### PR TITLE
Initial error dialogs

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -34,7 +34,10 @@ ProjectManager.openProject = function() {
                     ProjectManager.loadProject( files[0] );
             },
             function(error) {
-                console.log(error);     // TODO: real error handling
+                brackets.showErrorDialog(
+					  brackets.strings.ERROR_LOADING_PROJECT
+					, brackets.strings.format(brackets.strings.OPEN_DIALOG_ERROR, error.code)
+				);
             }
         );
     }
@@ -86,7 +89,10 @@ ProjectManager.loadProject = function(rootPath) {
                 ProjectManager._renderTree(ProjectManager._treeDataProvider);
             },
             function(error) {
-                console.log(error);     // TODO: real error handling
+                brackets.showErrorDialog(
+					  brackets.strings.ERROR_LOADING_PROJECT
+					, brackets.strings.format(brackets.strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR, rootPath, error.code)
+				);
             }
         );
         
@@ -120,7 +126,10 @@ ProjectManager._treeDataProvider = function(treeNode, jsTreeCallback) {
             jsTreeCallback(subtreeJSON);
         },
         function(error) {
-            console.log(error);     // TODO: real error handling
+            brackets.showErrorDialog(
+				  brackets.strings.ERROR_LOADING_PROJECT
+				, brackets.strings.format(brackets.strings.READ_DIRECTORY_ENTRIES_ERROR, dirEntry.fullPath, error.code)
+			);
         }
     );
     

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -35,9 +35,9 @@ ProjectManager.openProject = function() {
             },
             function(error) {
                 brackets.showErrorDialog(
-					  brackets.strings.ERROR_LOADING_PROJECT
-					, brackets.strings.format(brackets.strings.OPEN_DIALOG_ERROR, error.code)
-				);
+                      brackets.strings.ERROR_LOADING_PROJECT
+                    , brackets.strings.format(brackets.strings.OPEN_DIALOG_ERROR, error.code)
+                );
             }
         );
     }
@@ -90,9 +90,9 @@ ProjectManager.loadProject = function(rootPath) {
             },
             function(error) {
                 brackets.showErrorDialog(
-					  brackets.strings.ERROR_LOADING_PROJECT
-					, brackets.strings.format(brackets.strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR, rootPath, error.code)
-				);
+                      brackets.strings.ERROR_LOADING_PROJECT
+                    , brackets.strings.format(brackets.strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR, rootPath, error.code)
+                );
             }
         );
         
@@ -127,9 +127,9 @@ ProjectManager._treeDataProvider = function(treeNode, jsTreeCallback) {
         },
         function(error) {
             brackets.showErrorDialog(
-				  brackets.strings.ERROR_LOADING_PROJECT
-				, brackets.strings.format(brackets.strings.READ_DIRECTORY_ENTRIES_ERROR, dirEntry.fullPath, error.code)
-			);
+                  brackets.strings.ERROR_LOADING_PROJECT
+                , brackets.strings.format(brackets.strings.READ_DIRECTORY_ENTRIES_ERROR, dirEntry.fullPath, error.code)
+            );
         }
     );
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -10,51 +10,51 @@ brackets.inBrowser = !brackets.hasOwnProperty("fs");
 
 $(document).ready(function() {
 
-	/**
-	 * General purpose modal error dialog. 
-	 *
-	 * @param {string} title The title of the error dialog. Can contain HTML markup.
-	 * @param {string} message The message to display in the error dialog. Can contain HTML markup.
-	 */
-	brackets.showErrorDialog = function(title, message) {
-		var dlg = $("#error-dialog");
-		
-		// Set title and message
-		$("#error-dialog-title").html(title);
-		$("#error-dialog-message").html(message);
-		
-		// Click handler for OK button
-		dlg.delegate("#error-dialog-ok", "click", function(e) {
-			dlg.modal(true).hide();
-		});
-		
-		// Run the dialog
-		dlg.modal(
-			{ backdrop: "static" 
-			, show: true
-			}
-		);
-	}
+    /**
+     * General purpose modal error dialog. 
+     *
+     * @param {string} title The title of the error dialog. Can contain HTML markup.
+     * @param {string} message The message to display in the error dialog. Can contain HTML markup.
+     */
+    brackets.showErrorDialog = function(title, message) {
+        var dlg = $("#error-dialog");
+        
+        // Set title and message
+        $("#error-dialog-title").html(title);
+        $("#error-dialog-message").html(message);
+        
+        // Click handler for OK button
+        dlg.delegate("#error-dialog-ok", "click", function(e) {
+            dlg.modal(true).hide();
+        });
+        
+        // Run the dialog
+        dlg.modal(
+            { backdrop: "static" 
+            , show: true
+            }
+        );
+    }
 
     var myCodeMirror = CodeMirror($('#editor').get(0), {
         value: 'var myResponse="Yes, it will be!"\n'
     });
 
-	// Load a default project into the tree
-	if (brackets.inBrowser) {
-	    // In browser: dummy folder tree (hardcoded in ProjectManager)
-		ProjectManager.loadProject("DummyProject");
-	} else {
-	    // In app shell: load Brackets itself
-	    var loadedPath = window.location.pathname;
-	    var bracketsSrc = loadedPath.substr(0, loadedPath.lastIndexOf("/"));
-	    ProjectManager.loadProject(bracketsSrc);
-	}
-	
-	// Open project button
-	$("#btn-open-project").click(function() {
-		ProjectManager.openProject();
-	});
+    // Load a default project into the tree
+    if (brackets.inBrowser) {
+        // In browser: dummy folder tree (hardcoded in ProjectManager)
+        ProjectManager.loadProject("DummyProject");
+    } else {
+        // In app shell: load Brackets itself
+        var loadedPath = window.location.pathname;
+        var bracketsSrc = loadedPath.substr(0, loadedPath.lastIndexOf("/"));
+        ProjectManager.loadProject(bracketsSrc);
+    }
+    
+    // Open project button
+    $("#btn-open-project").click(function() {
+        ProjectManager.openProject();
+    });
     
     
     // Implements the 'Run Tests' menu to bring up the Jasmine unit test window

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -10,6 +10,32 @@ brackets.inBrowser = !brackets.hasOwnProperty("fs");
 
 $(document).ready(function() {
 
+	/**
+	 * General purpose modal error dialog. 
+	 *
+	 * @param {string} title The title of the error dialog. Can contain HTML markup.
+	 * @param {string} message The message to display in the error dialog. Can contain HTML markup.
+	 */
+	brackets.showErrorDialog = function(title, message) {
+		var dlg = $("#error-dialog");
+		
+		// Set title and message
+		$("#error-dialog-title").html(title);
+		$("#error-dialog-message").html(message);
+		
+		// Click handler for OK button
+		dlg.delegate("#error-dialog-ok", "click", function(e) {
+			dlg.modal(true).hide();
+		});
+		
+		// Run the dialog
+		dlg.modal(
+			{ backdrop: "static" 
+			, show: true
+			}
+		);
+	}
+
     var myCodeMirror = CodeMirror($('#editor').get(0), {
         value: 'var myResponse="Yes, it will be!"\n'
     });
@@ -47,5 +73,4 @@ $(document).ready(function() {
             testWindow.location.reload(); // if it was opened before, we need to reload because it will be cached
         }
     });
-
 });

--- a/src/index.html
+++ b/src/index.html
@@ -17,11 +17,13 @@
 	
 	<script src="thirdparty/jquery-1.7.min.js"></script>
 	<script src="widgets/bootstrap-dropdown.js"></script>
+	<script src="widgets/bootstrap-modal.js"></script>
 	<script src="thirdparty/jstree_pre1.0_fix_1/jquery.jstree.js"></script>
 	
 	<script src="NativeFileSystem.js"></script>	
 	<script src="brackets.js"></script>
 	<script src="ProjectManager.js"></script>
+	<script src="strings.js"></script>
 </head>
 <body>
 	<!-- TODO: LESS won't work directly from Chrome when run locally (unless you launch it with -allow-file-access-from-files)
@@ -75,6 +77,20 @@
 			</div>			
 			<div id="editor"></div>
 		</div>
+	</div>
+	
+	<!-- Modal Windows -->
+	<div id="error-dialog" class="modal hide fade">
+		<div class="modal-header">
+			<a href="#" class="close">&times;</a>
+			<h3 id="error-dialog-title">Error</h3>
+		</div>
+		<div class="modal-body">
+			<p id="error-dialog-message">Message goes here</p>
+		</div>
+		<div class="modal-footer">
+			<a id="error-dialog-ok" href="#" class="btn primary">OK</a>
+		</div>		
 	</div>
 </body>
 </html>

--- a/src/strings.js
+++ b/src/strings.js
@@ -32,7 +32,7 @@ if (!brackets.strings)
     
     // Project error strings
     s.ERROR_LOADING_PROJECT = "Error loading project";
-    s.OPEN_DIALOG_ERROR = "An error occured when showing the open file dialog. (error {0})";
-    s.REQUEST_NATIVE_FILE_SYSTEM_ERROR = "An error occured when trying to load the directory '{0}'. (error {1})";
-    s.READ_DIRECTORY_ENTRIES_ERROR = "An error occured when reading the contents of the directory '{0}'. (error {1})";
+    s.OPEN_DIALOG_ERROR = "An error occurred when showing the open file dialog. (error {0})";
+    s.REQUEST_NATIVE_FILE_SYSTEM_ERROR = "An error occurred when trying to load the directory '{0}'. (error {1})";
+    s.READ_DIRECTORY_ENTRIES_ERROR = "An error occurred when reading the contents of the directory '{0}'. (error {1})";
 })();

--- a/src/strings.js
+++ b/src/strings.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
+ */
+
+if (!brackets.strings)
+    brackets.strings = {};
+
+(function() {
+    var s = brackets.strings;
+
+    /**
+     * Format a string by replacing placeholder symbols with passed in arguments.
+     *
+     * Example: var formatted = brackets.string.format("Hello {0}", "World");
+     *
+     * @param {string} str The base string
+     * @param {string} ... Arguments to be subsituted into the string
+     *
+     * @return {string} Formatted string
+     */
+    s.format = function(str) {
+        var args = arguments;
+        return str.replace(/{(\d+)}/g, function(match, num) {
+            // args[0] is the string, so we need to adjust index values here
+            // "num" is a string
+            var i = Number(num);
+            return typeof args[i + 1] !== 'undefined' ? args[i + 1] : match;
+        });
+    }
+    
+    // General file io error strings
+    
+    // Project error strings
+    s.ERROR_LOADING_PROJECT = "Error loading project";
+    s.OPEN_DIALOG_ERROR = "An error occured when showing the open file dialog. (error {0})";
+    s.REQUEST_NATIVE_FILE_SYSTEM_ERROR = "An error occured when trying to load the directory '{0}'. (error {1})";
+    s.READ_DIRECTORY_ENTRIES_ERROR = "An error occured when reading the contents of the directory '{0}'. (error {1})";
+})();

--- a/src/strings.js
+++ b/src/strings.js
@@ -11,10 +11,10 @@ if (!brackets.strings)
     /**
      * Format a string by replacing placeholder symbols with passed in arguments.
      *
-     * Example: var formatted = brackets.string.format("Hello {0}", "World");
+     * Example: var formatted = brackets.strings.format("Hello {0}", "World");
      *
      * @param {string} str The base string
-     * @param {string} ... Arguments to be subsituted into the string
+     * @param {string} ... Arguments to be substituted into the string
      *
      * @return {string} Formatted string
      */


### PR DESCRIPTION
This commit adds basic error dialog and string infrastructure.

The `brackets.showErrorDialog()` method displays a Bootstrap Modal window, and takes `title` and `message` parameters.

Error strings are all placed in a new `brackets.strings` namespace, in strings.js.

All string constants should be added to the new strings.js file.
