### PR TITLE
Add .gitignore file to make 'git status' less noisy on Win

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Thumbs.db


### PR DESCRIPTION
I sent an email about the .gitignore file a few days ago and didn't hear any objections, so I went ahead and set it up.  Anyone want to give this a quick review?
