### PR TITLE
Addresses selection bug -- Issue #56

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -1,6 +1,17 @@
 /* Brackets / CodeMirror Code Formatting */
 
-.content {
+
+body {
+    /* TODO: Setting code backround color should probably be deeper in the 
+             DOM hierarchy than "body". Right now there's a bug that if you 
+             change the background color of .content (probably the right place)
+             then selection gets drawn underneath the color, so you can't see
+             the selection.
+             
+             This is due to the fact that the div containing the selection is
+             absolutely positioned with a z-order of -1, and so is drawn
+             below EVERYTHING else that doesn't have a "position" property.
+    */
     background-color: @background-color-3;
 }
 


### PR DESCRIPTION
Problem was that how we draw selection changed in codemirror to use a absolutely positioned div with z-index: -1. This drew selection below the .content div, which is what the new LESS was changing the background color of to set the code editor color.
