### PR TITLE
Fix for issue #49

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,7 +61,7 @@ define(function(require, exports, module) {
         $(".dialog-message", dlg).html(message);
 
         function dismissDialog(buttonId) {
-            dlg.one("hidden", function func() {
+            dlg.one("hidden", function() {
                 result.resolve(buttonId);
             });
             dlg.modal(true).hide();

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,10 +61,16 @@ define(function(require, exports, module) {
         $(".dialog-title", dlg).html(title);
         $(".dialog-message", dlg).html(message);
 
+        function dismissDialog(buttonId) {
+            dlg.on("hidden", function func() {
+                result.resolve(buttonId);
+                dlg.off("hidden", func);
+            });
+            dlg.modal(true).hide();
+        }
         // Click handler for buttons
         dlg.on("click", ".dialog-button", function(e) {
-            result.resolve($(this).attr("data-button-id"));
-            dlg.modal(true).hide();
+            dismissDialog($(this).attr("data-button-id"));
         });
 
         // Enter/Return handler for the primary button. Need to
@@ -81,8 +87,7 @@ define(function(require, exports, module) {
             if (e.keyCode === 13 && enterKeyPressed) {
                 var primaryBtn = dlg.find(".primary");
                 if (primaryBtn) {
-                    result.resolve(primaryBtn.attr("data-button-id"));
-                    dlg.modal(true).hide();
+                    dismissDialog(primaryBtn.attr("data-button-id"));
                 }
             }
             enterKeyPressed = false;
@@ -94,7 +99,7 @@ define(function(require, exports, module) {
             { backdrop: "static"
             , show: true
             }
-        ).on("hide", function(e) {
+        ).on("hidden", function(e) {
             // Remove all handlers in the .modal namespace
             $(document).off(".modal");
         });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,14 +61,13 @@ define(function(require, exports, module) {
         $(".dialog-message", dlg).html(message);
 
         function dismissDialog(buttonId) {
-            dlg.on("hidden", function func() {
+            dlg.one("hidden", function func() {
                 result.resolve(buttonId);
-                dlg.off("hidden", func);
             });
             dlg.modal(true).hide();
         }
         // Click handler for buttons
-        dlg.on("click", ".dialog-button", function(e) {
+        dlg.one("click", ".dialog-button", function(e) {
             dismissDialog($(this).attr("data-button-id"));
         });
 
@@ -98,7 +97,7 @@ define(function(require, exports, module) {
             { backdrop: "static"
             , show: true
             }
-        ).on("hidden", function(e) {
+        ).on("hide", function(e) {
             // Remove all handlers in the .modal namespace
             $(document).off(".modal");
         });


### PR DESCRIPTION
Don't resolve dialogs until the "hidden" event is sent. This is part 2 of the fix for issue #49 (part one is in the brackets-app repo: https://github.com/adobe/brackets-app/pull/22)

Note that this still doesn't completely fix issue #49. The dialog goes away before the open dialog is shown, but the modal background is still present. This is a bug in bootstrap, that can be resolved by either fixing the bug, or removing our fade on the modal backdrop.
