### PR TITLE
Set default indentation to 4 spaces

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -103,7 +103,7 @@ define(function(require, exports, module) {
     $(document).ready(function() {
 
         var editorElt = $('#editor')
-        ,   editor = CodeMirror(editorElt.get(0));
+        ,   editor = CodeMirror(editorElt.get(0), { indentUnit : 4 });
     
         // CodeMirror expects to be resized by having its inner "CodeMirror-scroll" area be resized.
         // We need to do this programmatically.


### PR DESCRIPTION
For #63, set the default indentation in Brackets to 4 spaces, since that's the default for our code. In future, we'll make this configurable.
