### PR TITLE
Turn off text selectability for UI elements

### DIFF
--- a/src/brackets.less
+++ b/src/brackets.less
@@ -32,6 +32,7 @@ html, body {
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;
+    -ms-user-select: none;
     -o-user-select: none;
     user-select: none;
     

--- a/src/brackets.less
+++ b/src/brackets.less
@@ -27,6 +27,16 @@
 html, body {
     height: 100%;
     overflow: hidden;
+    
+    /* Turn off selection for UI elements */
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+    
+    /* And make sure we get a pointer cursor even over text */
+    cursor: default;
 }
 
 body {


### PR DESCRIPTION
Fix for issue #50. This seems to work for turning off UI element selectability, while still allowing selection in the code editor and in input fields (like in the Find overlay).
