### PR TITLE
Fix for #67: Add width: 100% to body to make layout work in Firefox

### DIFF
--- a/src/brackets.less
+++ b/src/brackets.less
@@ -32,6 +32,7 @@ html, body {
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;
+    -ms-user-select: none;
     -o-user-select: none;
     user-select: none;
     

--- a/src/brackets.less
+++ b/src/brackets.less
@@ -27,6 +27,16 @@
 html, body {
     height: 100%;
     overflow: hidden;
+    
+    /* Turn off selection for UI elements */
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+    
+    /* And make sure we get a pointer cursor even over text */
+    cursor: default;
 }
 
 body {

--- a/src/brackets.less
+++ b/src/brackets.less
@@ -42,6 +42,9 @@ html, body {
 
 body {
     .vbox;
+    
+    /* This appears to be necessary in Firefox when body is set to display: box. */
+    width: 100%;
 
     .topbar {
         position: static;


### PR DESCRIPTION
This fixes issue #67. In Firefox, if you set body to be display: box, you apparently need to explicitly set its width to 100% to get it to stay the width of the browser. This isn't necessary for WebKit, but doesn't appear to hurt anything. (IE doesn't support flexbox yet.)
