### PR TITLE
Turn off draggability of elements in webkit 

### DIFF
--- a/src/brackets.less
+++ b/src/brackets.less
@@ -51,6 +51,10 @@ body {
     }
 }
 
+a, img {
+    -webkit-user-drag: none;
+}
+
 .topbar-inner {
     /* We don't want to use the default .container in here, 
        so we need to .clearfix the children. */


### PR DESCRIPTION
While reviewing the fix for turning off selectability, Joel noticed that elements like <a> and <img> are draggable as well. This fix turns that off in WebKit browsers. (For Firefox, it's not as easy to fix because you have to actually set a property on each element.)
