### PR TITLE
Jason sanjose/persistance

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -2,9 +2,9 @@
  * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
  */
 define(function(require, exports, module) {
-    
+
     // TODO: Determine proper public/private API for this module, splitting into separate modules as needed
-    
+
     var NativeFileSystem = {
 
         /** showOpenDialog
@@ -107,6 +107,8 @@ define(function(require, exports, module) {
         this.isDirectory = isDirectory;
         this.isFile = !isDirectory;
         // IMPLEMENT LATER void      getMetadata (MetadataCallback successCallback, optional ErrorCallback errorCallback);
+
+        // TODO (jasonsj): PATH_SEPARATOR per native OS
         this.fullPath = fullPath;
 
         // Extract name from fullPath
@@ -656,7 +658,7 @@ define(function(require, exports, module) {
     NativeFileSystem.FileError = function( code ) {
         this.code = code || 0;
     };
-    
+
     // Define public API
     exports.NativeFileSystem = NativeFileSystem;
 });

--- a/src/PreferencesManager.js
+++ b/src/PreferencesManager.js
@@ -7,8 +7,7 @@
  *
  */
 define(function(require, exports, module) {
-    var PREFERENCES_KEY = "com.adobe.brackets.preferences"
-    ,   TEST_PREFERENCES_KEY = "com.adobe.brackets.test.preferences";
+    var PREFERENCES_KEY = "com.adobe.brackets.preferences";
 
     // Private Properties
     var preferencesKey      = PREFERENCES_KEY
@@ -120,11 +119,23 @@ define(function(require, exports, module) {
         persistentStorage.setItem( preferencesKey, JSON.stringify( prefStorage ) );
     }
 
+    /**
+     * @private
+     * Redirects preference storage to another key in persistent storage. 
+     * Allows unit test preferences to be stored in the same mechanism as
+     * production preferences without clobbering.
+     * 
+     * @return {string} Previous key
+     */
     function _setStorageKey( key ) {
+        var oldKey = preferencesKey;
+
         preferencesKey = key;
 
         // re-init in-memory prefs when changing keys
         _initStorage( persistentStorage );
+
+        return oldKey;
     }
 
     /**
@@ -154,14 +165,6 @@ define(function(require, exports, module) {
         persistentStorage.setItem( preferencesKey, JSON.stringify( prefStorage ) );
     }
 
-    /**
-     * @private
-     * Accessor to persistent storage implementation.
-     */
-    function _getStorage( storage ) {
-        return persistentStorage;
-    }
-
     // Public API
     exports.getPreferences          = getPreferences;
     exports.addPreferencesClient    = addPreferencesClient;
@@ -170,8 +173,5 @@ define(function(require, exports, module) {
     // Internal Use Only
     exports._reset                  = _reset;
     exports._setStorageKey          = _setStorageKey;
-    exports._getStorage             = _getStorage;
-    exports._initStorage            = _initStorage;
     exports._PREFERENCES_KEY        = PREFERENCES_KEY;
-    exports._TEST_PREFERENCES_KEY   = TEST_PREFERENCES_KEY;
 });

--- a/src/PreferencesManager.js
+++ b/src/PreferencesManager.js
@@ -7,13 +7,17 @@
  *
  */
 define(function(require, exports, module) {
-    var PREFERENCES_KEY = "com.adobe.brackets.preferences";
+    var PREFERENCES_KEY = "com.adobe.brackets.preferences"
+    ,   TEST_PREFERENCES_KEY = "com.adobe.brackets.test.preferences";
 
-    var callbacks           = {}
+    // Private Properties
+    var preferencesKey      = PREFERENCES_KEY
+    ,   callbacks           = {}
+    ,   prefStorage         = {}
     ,   persistentStorage;
 
-    // TODO (jasonsj): interface for different storage (localStorage vs. hosted)
-    _setStorage( localStorage );
+    // Use localStorage by default
+    _initStorage( localStorage );
 
     /**
      * Retrieves preference object for the specified client.
@@ -105,22 +109,29 @@ define(function(require, exports, module) {
      */
     function saveToPersistentStorage() {
         // save all preferences
-        persistentStorage.setItem( PREFERENCES_KEY, JSON.stringify( prefStorage ) );
+        persistentStorage.setItem( preferencesKey, JSON.stringify( prefStorage ) );
+    }
+
+    function _setStorageKey( key ) {
+        preferencesKey = key;
+
+        // re-init in-memory prefs when changing keys
+        _initStorage( persistentStorage );
     }
 
     /**
      * @private
-     * Initialize persistent storage implementation. Also used for unit tests.
-     * TODO (jasonsj): expose for other persistent storage implementations.
+     * Initialize persistent storage implementation
      */
-    function _setStorage( storage ) {
-        persistentStorage   = storage;
-        prefStorage         = JSON.parse( persistentStorage.getItem( PREFERENCES_KEY ) );
+    function _initStorage( storage ) {
+        persistentStorage = storage;
+
+        prefStorage = JSON.parse( persistentStorage.getItem( preferencesKey ) );
 
         if ( !prefStorage ) {
             // initialize empty preferences
             prefStorage = {};
-            persistentStorage.setItem( PREFERENCES_KEY, JSON.stringify( prefStorage ) );
+            persistentStorage.setItem( preferencesKey, JSON.stringify( prefStorage ) );
         }
     }
 
@@ -138,7 +149,9 @@ define(function(require, exports, module) {
     exports.savePreferences         = savePreferences;
 
     // Internal Use Only
-    exports._getStorage              = _getStorage;
-    exports._setStorage              = _setStorage;
-    exports._PREFERENCES_KEY         = PREFERENCES_KEY;
+    exports._setStorageKey          = _setStorageKey;
+    exports._getStorage             = _getStorage;
+    exports._initStorage            = _initStorage;
+    exports._PREFERENCES_KEY        = PREFERENCES_KEY;
+    exports._TEST_PREFERENCES_KEY   = TEST_PREFERENCES_KEY;
 });

--- a/src/PreferencesManager.js
+++ b/src/PreferencesManager.js
@@ -7,19 +7,13 @@
  *
  */
 define(function(require, exports, module) {
-    var callbacks = [];
-
     var PREFERENCES_KEY = "com.adobe.brackets.preferences";
 
-    // TODO (jasonsj): interface for different storage (localStorage vs. hosted)
-    var persistentStorage = localStorage;
-    var prefStorage = JSON.parse( persistentStorage.getItem( PREFERENCES_KEY ) );
+    var callbacks           = {}
+    ,   persistentStorage;
 
-    if ( !prefStorage ) {
-        // initialize empty preferences
-        prefStorage = {};
-        persistentStorage.setItem( PREFERENCES_KEY, JSON.stringify( prefStorage ) );
-    }
+    // TODO (jasonsj): interface for different storage (localStorage vs. hosted)
+    _setStorage( localStorage );
 
     /**
      * Retrieves preference object for the specified client.
@@ -75,20 +69,19 @@ define(function(require, exports, module) {
                            , instance: instance };
 
         // add to callbacks list
-        callbacks.push( callbackData );
+        callbacks[ clientID ] = callbackData;
     }
 
     /**
      * Save all participants.
      */
     function savePreferences() {
-        var max = callbacks.length
-        ,   data
+        var data
         ,   storage;
 
-        // iterate over all save participants
-        for( var i = 0; i < max; i++ ) {
-            data = callbacks[i];
+        // iterate over all preference clients
+        $.each( callbacks, function( index, value ) {
+            data = callbacks[ index ];
             storage = prefStorage[ data.clientID ];
 
             // fire callback with thisArg and preference storage
@@ -101,18 +94,51 @@ define(function(require, exports, module) {
 
             // save client preferences
             prefStorage[ data.clientID ] = storage;
-        }
+        });
 
         saveToPersistentStorage();
     }
 
+    /**
+     * Saves to persistent storage.
+     * TODO (jasonsj): local and/or hosted
+     */
     function saveToPersistentStorage() {
         // save all preferences
         persistentStorage.setItem( PREFERENCES_KEY, JSON.stringify( prefStorage ) );
+    }
+
+    /**
+     * @private
+     * Initialize persistent storage implementation. Also used for unit tests.
+     * TODO (jasonsj): expose for other persistent storage implementations.
+     */
+    function _setStorage( storage ) {
+        persistentStorage   = storage;
+        prefStorage         = JSON.parse( persistentStorage.getItem( PREFERENCES_KEY ) );
+
+        if ( !prefStorage ) {
+            // initialize empty preferences
+            prefStorage = {};
+            persistentStorage.setItem( PREFERENCES_KEY, JSON.stringify( prefStorage ) );
+        }
+    }
+
+    /**
+     * @private
+     * Accessor to persistent storage implementation.
+     */
+    function _getStorage( storage ) {
+        return persistentStorage;
     }
 
     // Public API
     exports.getPreferences          = getPreferences;
     exports.addPreferencesClient    = addPreferencesClient;
     exports.savePreferences         = savePreferences;
+
+    // Internal Use Only
+    exports._getStorage              = _getStorage;
+    exports._setStorage              = _setStorage;
+    exports._PREFERENCES_KEY         = PREFERENCES_KEY;
 });

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -71,7 +71,6 @@ define(function(require, exports, module) {
 
                 // Determine depth of the node by counting path separators.
                 // Children at the root have depth of zero.
-                // TODO (jasonsj): PATH_SEPARATOR per native OS
                 depth = shortPath.split("/").length - 1;
 
                 // Map tree depth to list of open nodes

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -26,7 +26,8 @@ define(function(require, exports, module) {
     // in the modules since they would run in context of the unit test window,
     // and would not have access to the app html/css.
     brackets.test =
-        { ProjectManager        : ProjectManager
+        { PreferencesManager    : PreferencesManager
+        , ProjectManager        : ProjectManager
         , FileCommandHandlers   : FileCommandHandlers
         , Commands              : Commands
         , CommandManager        : require("CommandManager")

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -5,11 +5,11 @@ require.config({
 
 define(function(require, exports, module) {
     // Utility dependency
-    require("spec/SpecRunnerUtils.js");
+    var SpecRunnerUtils = require("spec/SpecRunnerUtils.js");
 
     // Unique key for unit testing
     var PreferencesManager = require("PreferencesManager");
-    PreferencesManager._setStorageKey( PreferencesManager._TEST_PREFERENCES_KEY );
+    PreferencesManager.setStorageKey( SpecRunnerUtils.TEST_PREFERENCES_KEY );
 
     // Load test specs
     require("spec/Editor-test.js");

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -7,7 +7,9 @@ define(function(require, exports, module) {
     // Utility dependency
     require("spec/SpecRunnerUtils.js");
 
-    // FIXME (jasonsj): PreferencesManager mock persistent storage
+    // Unique key for unit testing
+    var PreferencesManager = require("PreferencesManager");
+    PreferencesManager._setStorageKey( PreferencesManager._TEST_PREFERENCES_KEY );
 
     // Load test specs
     require("spec/Editor-test.js");

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -1,4 +1,4 @@
-// Set the baseUrl to brackets/src 
+// Set the baseUrl to brackets/src
 require.config({
     baseUrl: "../src"
 });
@@ -6,11 +6,14 @@ require.config({
 define(function(require, exports, module) {
     // Utility dependency
     require("spec/SpecRunnerUtils.js");
-    
+
+    // FIXME (jasonsj): PreferencesManager mock persistent storage
+
     // Load test specs
     require("spec/Editor-test.js");
     require("spec/NativeFileSystem-test.js");
     require("spec/LowLevelFileIO-test.js");
     require("spec/ProjectManager-test.js");
     require("spec/FileCommandHandlers-test.js");
+    require("spec/PreferencesManager-test.js");
 });

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -8,33 +8,20 @@ define(function(require, exports, module) {
 
     describe("PreferencesManager", function() {
 
-        beforeEach(function() {
-            // TODO (jasonsj): configure PreferencesManager for unit testing
-            //                 localStorage will be the same for SpecRunner and
-            //                 brackets/src (same origin).
-
-            // keep default storage impl to restore after testing
-            this.persistentStorage = PreferencesManager._getStorage();
-
-            // reset session storage
-            sessionStorage.clear();
-        });
-
-        afterEach(function() {
-            // restore persistent storage
-            PreferencesManager._setStorage( this.persistentStorage );
-        });
-
-        function initTestData() {
+        function initTestPreferences( data ) {
             // mock preferences
             var prefs = {};
-            prefs[ PREFERENCES_CLIENT_ID ] = { test: "dummy data" };
-            sessionStorage.setItem( PreferencesManager._PREFERENCES_KEY, JSON.stringify( prefs ) );
-            PreferencesManager._setStorage( sessionStorage );
+            prefs[ PREFERENCES_CLIENT_ID ] = data;
+
+            var storage = PreferencesManager._getStorage();
+            storage.setItem( PreferencesManager._TEST_PREFERENCES_KEY, JSON.stringify( prefs ) );
+
+            // init storage, update in-memory data
+            PreferencesManager._initStorage( storage );
         };
 
         it("should load preferences from storage", function() {
-            initTestData();
+            initTestPreferences( { test: "dummy data" } );
 
             var actual = PreferencesManager.getPreferences( PREFERENCES_CLIENT_ID );
             expect( actual.test ).toBe( "dummy data" );

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -1,0 +1,71 @@
+define(function(require, exports, module) {
+    // Load dependent modules
+    var PreferencesManager      = require("PreferencesManager")
+    ,   SpecRunnerUtils         = require("./SpecRunnerUtils.js")
+    ;
+
+    var PREFERENCES_CLIENT_ID = "PreferencesManager-test";
+
+    describe("PreferencesManager", function() {
+
+        beforeEach(function() {
+            // TODO (jasonsj): configure PreferencesManager for unit testing
+            //                 localStorage will be the same for SpecRunner and
+            //                 brackets/src (same origin).
+
+            // keep default storage impl to restore after testing
+            this.persistentStorage = PreferencesManager._getStorage();
+
+            // reset session storage
+            sessionStorage.clear();
+        });
+
+        afterEach(function() {
+            // restore persistent storage
+            PreferencesManager._setStorage( this.persistentStorage );
+        });
+
+        function initTestData() {
+            // mock preferences
+            var prefs = {};
+            prefs[ PREFERENCES_CLIENT_ID ] = { test: "dummy data" };
+            sessionStorage.setItem( PreferencesManager._PREFERENCES_KEY, JSON.stringify( prefs ) );
+            PreferencesManager._setStorage( sessionStorage );
+        };
+
+        it("should load preferences from storage", function() {
+            initTestData();
+
+            var actual = PreferencesManager.getPreferences( PREFERENCES_CLIENT_ID );
+            expect( actual.test ).toBe( "dummy data" );
+        });
+
+        it("should register clients", function() {
+
+        });
+
+        it("should register clients without duplicates", function() {
+
+        });
+
+        it("should use default preferences", function() {
+
+        });
+
+        it("should save preferences to localStorage", function() {
+
+        });
+
+        it("should get preferences from localStorage", function() {
+
+        });
+
+        it("should throw an error when the client is not found", function() {
+
+        });
+
+        it("should fail when storing an invalid JSON object", function() {
+
+        });
+    });
+});

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -15,25 +15,6 @@ define(function(require, exports, module) {
             PreferencesManager._reset();
         });
 
-        function initTestPreferences( data, newStorage ) {
-            // mock persistent preference data to load
-            var prefs = {};
-            prefs[ CLIENT_ID ] = data;
-
-            var storage = PreferencesManager._getStorage();
-            storage.setItem( PreferencesManager._TEST_PREFERENCES_KEY, JSON.stringify( prefs ) );
-
-            // init storage, update in-memory data
-            PreferencesManager._initStorage( storage );
-        };
-
-        it("should load preferences from storage", function() {
-            initTestPreferences( { test: "dummy data" } );
-
-            var actual = PreferencesManager.getPreferences( CLIENT_ID );
-            expect( actual.test ).toBe( "dummy data" );
-        });
-
         it("should register clients", function() {
             var pass1 = false
             ,   pass2 = false;

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -17,10 +17,8 @@ define(function(require, exports, module) {
             ProjectManager = this.app.brackets.test.ProjectManager;
             PreferencesManager = this.app.brackets.test.PreferencesManager;
 
-            // Swap persistent storage implementation
-            this.persistentStorage = PreferencesManager._getStorage();
-            sessionStorage.clear();
-            PreferencesManager._setStorage( sessionStorage );
+            // Temporarily use test key in the main app window
+            PreferencesManager._setStorageKey( PreferencesManager._TEST_PREFERENCES_KEY );
 
             this.app.location.reload();
             this.testPath = SpecRunnerUtils.getTestPath("/spec/ProjectManager-test-files");
@@ -32,8 +30,8 @@ define(function(require, exports, module) {
         });
 
         afterEach(function() {
-            // restore persistent storage
-            PreferencesManager._setStorage( this.persistentStorage );
+            // restore main app window preferences key
+            PreferencesManager._setStorageKey( PreferencesManager.PREFERENCES_KEY );
         });
 
         describe("createNewItem", function() {

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -1,9 +1,10 @@
 define(function(require, exports, module) {
     // Load dependent modules
     var ProjectManager      // Load from brackets.test
+    ,   PreferencesManager  // Load from brackets.test
     ,   SpecRunnerUtils     = require("./SpecRunnerUtils.js")
     ;
-    
+
     // FIXME (jasonsj): these tests are ommitted when launching in the main app window
     if (window.opener) { // (function(){
 
@@ -11,10 +12,16 @@ define(function(require, exports, module) {
 
         beforeEach(function() {
             this.app = window.opener;
-            
+
             // Load module instances from brackets.test
-            ProjectManager = this.app.brackets.test.ProjectManager; 
-            
+            ProjectManager = this.app.brackets.test.ProjectManager;
+            PreferencesManager = this.app.brackets.test.PreferencesManager;
+
+            // Swap persistent storage implementation
+            this.persistentStorage = PreferencesManager._getStorage();
+            sessionStorage.clear();
+            PreferencesManager._setStorage( sessionStorage );
+
             this.app.location.reload();
             this.testPath = SpecRunnerUtils.getTestPath("/spec/ProjectManager-test-files");
             var isReady = false;
@@ -22,6 +29,11 @@ define(function(require, exports, module) {
                 isReady = true;
             });
             waitsFor(function() { return isReady; }, 5000);
+        });
+
+        afterEach(function() {
+            // restore persistent storage
+            PreferencesManager._setStorage( this.persistentStorage );
         });
 
         describe("createNewItem", function() {

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -18,7 +18,7 @@ define(function(require, exports, module) {
             PreferencesManager = this.app.brackets.test.PreferencesManager;
 
             // Temporarily use test key in the main app window
-            PreferencesManager._setStorageKey( PreferencesManager._TEST_PREFERENCES_KEY );
+            this.oldKey = PreferencesManager._setStorageKey( SpecRunnerUtils.TEST_PREFERENCES_KEY );
 
             this.app.location.reload();
             this.testPath = SpecRunnerUtils.getTestPath("/spec/ProjectManager-test-files");
@@ -31,7 +31,7 @@ define(function(require, exports, module) {
 
         afterEach(function() {
             // restore main app window preferences key
-            PreferencesManager._setStorageKey( PreferencesManager.PREFERENCES_KEY );
+            PreferencesManager._setStorageKey( this.oldKey );
         });
 
         describe("createNewItem", function() {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -1,5 +1,7 @@
 define(function(require, exports, module) {
     
+    var TEST_PREFERENCES_KEY = "com.adobe.brackets.test.preferences";
+
     function getTestRoot() {
         // /path/to/brackets/test/SpecRunner.html
         var path = window.location.href;
@@ -20,6 +22,8 @@ define(function(require, exports, module) {
         path.push("src");
         return path.join("/");
     }
+
+    exports.TEST_PREFERENCES_KEY    = TEST_PREFERENCES_KEY;
     
     exports.getTestRoot             = getTestRoot;
     exports.getTestPath             = getTestPath;


### PR DESCRIPTION
- Refactor PreferencesManager to allow unit tests preferences to live in a sandbox, side-by-side with production preferences. 
- Update unit tests to use the new preferences key so that unit test modifications don't affect the production workspace.
- Ensure uniqueness of preference clients
- Return defensive copy of preferences to enforce save callback pattern
