### PR TITLE
Fix Tab key handling.

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -107,7 +107,17 @@ define(function(require, exports, module) {
     $(document).ready(function() {
 
         var editorElt = $('#editor')
-        ,   editor = CodeMirror(editorElt.get(0), { indentUnit : 4 });
+        ,   editor = CodeMirror(editorElt.get(0), {
+                indentUnit : 4, 
+                extraKeys: { 
+                    "Tab" : function(instance) {
+                         if (instance.somethingSelected())
+                            CodeMirror.commands.indentMore(instance);
+                         else
+                            CodeMirror.commands.insertTab(instance);
+                    }
+                }
+            });
     
         // CodeMirror expects to be resized by having its inner "CodeMirror-scroll" area be resized.
         // We need to do this programmatically.


### PR DESCRIPTION
The default CodeMirror behavior for Tab key handling always indents the current line. This fix inserts a tab character (or the appropriate number of spaces) if there is no selection, and indents the selected line(s) if there is a selection.

I thought this was a CodeMirror bug, so I logged it here:
https://github.com/marijnh/CodeMirror2/issues/328

Turns out this is expected behavior, so this is a change we need to make in Brackets.
