### PR TITLE
Persist working set

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -386,14 +386,14 @@ define(function(require, exports, module) {
         //                 e.g. A file to restore no longer exists. Should we silently ignore
         //                 it or let the user be notified when they attempt to open the Document?
         var result = (function() {
-            var deferred    = new $.Deferred();
-            var fileCount   = prefs.files.length
-            ,   i           = 0;
+            var deferred        = new $.Deferred();
+            var fileCount       = prefs.files.length
+            ,   responseCount   = 0;
 
             function next() {
-                i++;
+                responseCount++;
 
-                if (i == fileCount) {
+                if (responseCount == fileCount) {
                     deferred.resolve();
                 }
             };
@@ -443,7 +443,6 @@ define(function(require, exports, module) {
             }
 
             if (activeDoc != null) {
-                console.log(activeDoc.file.fullPath);
                 showInEditor(activeDoc);
             }
         });

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -74,6 +74,8 @@ define(function(require, exports, module) {
      * @private
      * NOTE: this is actually "semi-private"; EditorManager also accesses this field. But no one
      * other than DocumentManager and EditorManager should access it.
+     * The editor may be null in the case that the document working set was
+     * restored from storage but an editor was not yet created.
      * TODO: we should close on whether private fields are declared on the prototype like this (vs.
      * just set in the constructor).
      * @type {!CodeMirror}
@@ -104,7 +106,9 @@ define(function(require, exports, module) {
     Document.prototype._savedUndoPosition = 0;
     
     /**
-     * @return {string} The editor's current contents; may not be saved to disk yet.
+     * @return {string} The editor's current contents; may not be saved to disk 
+     *  yet. Returns null if the file was not yet read and no editor was 
+     *  created.
      */
     Document.prototype.getText = function() {
         if (this._editor) {
@@ -112,7 +116,7 @@ define(function(require, exports, module) {
         }
         
         // TODO (jasonsj): is it worth adding an async call to readAsText()?
-        return "";
+        return null;
     }
     
     /**
@@ -148,7 +152,7 @@ define(function(require, exports, module) {
         if (this._editor == null) {
             return;
         }
-        
+
         this._savedUndoPosition = this._editor.historySize().undo;
         this._updateDirty();
     }

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -28,7 +28,9 @@ define(function(require, exports, module) {
 
     var NativeFileSystem    = require("NativeFileSystem").NativeFileSystem
     ,   ProjectManager      = require("ProjectManager")
-    ,   PreferencesManager  = require("PreferencesManager");
+    ,   PreferencesManager  = require("PreferencesManager")
+    ,   CommandManager      = require("CommandManager")
+    ,   Commands            = require("Commands");
 
     /**
      * Unique PreferencesManager clientID
@@ -502,7 +504,7 @@ define(function(require, exports, module) {
             }
 
             if (activeDoc != null) {
-                showInEditor(activeDoc);
+                CommandManager.execute(Commands.FILE_OPEN, activeDoc.file.fullPath);
             }
         });
     }
@@ -522,7 +524,7 @@ define(function(require, exports, module) {
     PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this);
 
     // Initialize after ProjectManager is loaded
-    $(ProjectManager).on("isFirstProjectOpen", function(event, projectRoot) {
+    $(ProjectManager).on("initializeComplete", function(event, projectRoot) {
         _init();
     });
 });

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -39,9 +39,10 @@ define(function(require, exports, module) {
      * A single editable document, e.g. an entry in the working set list. Documents are unique per
      * file, so it IS safe to compare them with '==' or '==='.
      * @param {!FileEntry} file  The file being edited. Need not lie within the project.
-     * @param {!CodeMirror} editor  The editor that will maintain the document state (current text
+     * @param {!CodeMirror} editor  Optional. The editor that will maintain the document state (current text
      *          and undo stack). It is assumed that the editor text has already been initialized
-     *          with the file's contents.
+     *          with the file's contents. The editor may be null when the working set is restored
+     *          at initialization.
      */
     function Document(file, editor) {
         if (!(this instanceof Document)) {  // error if constructor called without 'new'
@@ -343,7 +344,7 @@ define(function(require, exports, module) {
     
     /**
      * @private
-     * Preferences callback. Saves current project path.
+     * Preferences callback. Saves the document file paths for the working set.
      */
     function _savePreferences(storage) {
         // save the working set file paths

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -26,7 +26,8 @@
  */
 define(function(require, exports, module) {
 
-    var ProjectManager     = require("ProjectManager");
+    var ProjectManager     = require("ProjectManager")
+    ,   PreferencesManager = require("PreferencesManager");
 
     /**
      * Unique PreferencesManager clientID

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -29,6 +29,11 @@ define(function(require, exports, module) {
     var ProjectManager     = require("ProjectManager");
 
     /**
+     * Unique PreferencesManager clientID
+     */
+    var PREFERENCES_CLIENT_ID = "com.adobe.brackets.DocumentManager";
+
+    /**
      * @constructor
      * A single editable document, e.g. an entry in the working set list. Documents are unique per
      * file, so it IS safe to compare them with '==' or '==='.
@@ -323,7 +328,20 @@ define(function(require, exports, module) {
         // circumstances. See notes in EditorManager for more.
     }
     
-    
+    /**
+     * @private
+     * Preferences callback. Saves current project path.
+     */
+    function _savePreferences(storage) {
+        // save the working set file paths
+        var files = [];
+
+        $.each(_workingSet, function(index, value) {
+            files.push(value.file.fullPath);
+        });
+
+        storage.files = files;
+    }
     
     // Define public API
     exports.Document = Document;
@@ -333,5 +351,7 @@ define(function(require, exports, module) {
     exports.showInEditor = showInEditor;
     exports.addToWorkingSet = addToWorkingSet;
     exports.closeDocument = closeDocument;
-    
+
+    // Register preferences callback
+    PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this);
 });

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -91,6 +91,9 @@ define(function(require, exports, module) {
             return;
         }
         
+        // Editor can only be assigned once per Document
+        console.assert(this._editor === null);
+
         this._editor = editor;
         
         // Dirty-bit tracking
@@ -111,12 +114,9 @@ define(function(require, exports, module) {
      *  created.
      */
     Document.prototype.getText = function() {
-        if (this._editor) {
-            return this._editor.getValue();
-        }
-        
-        // TODO (jasonsj): is it worth adding an async call to readAsText()?
-        return null;
+        console.assert(this._editor != null);
+
+        return this._editor.getValue();
     }
     
     /**
@@ -149,7 +149,7 @@ define(function(require, exports, module) {
     
     /** Marks the document not dirty. Should be called after the document is saved to disk. */
     Document.prototype.markClean = function() {
-        if (this._editor == null) {
+        if (this._editor === null) {
             return;
         }
 
@@ -480,12 +480,8 @@ define(function(require, exports, module) {
             });
 
             // Initialize the active editor
-            if (activeDoc === null) {
-                var workingSet = getWorkingSet();
-
-                if (workingSet.length > 0) {
-                    activeDoc = _workingSet[0];   
-                }
+            if(activeDoc == null && _workingSet.length > 0) {
+                activeDoc = _workingSet[0]
             }
 
             if (activeDoc != null) {
@@ -508,7 +504,7 @@ define(function(require, exports, module) {
     PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this);
 
     // Initialize after ProjectManager is loaded
-    $(ProjectManager).on("initializeComplete", function(event, projectRoot) {
+    $(ProjectManager).on("isFirstProjectOpen", function(event, projectRoot) {
         _init();
     });
 });

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -347,12 +347,14 @@ define(function(require, exports, module) {
      */
     function _savePreferences(storage) {
         // save the working set file paths
-        var files = []
-        ,   isActive = false;
+        var files       = []
+        ,   isActive    = false
+        ,   workingSet  = getWorkingSet()
+        ,   currentDoc  = getCurrentDocument();
 
-        $.each(getWorkingSet(), function(index, value) {
+        workingSet.forEach(function(value, index) {
             // flag the currently active editor
-            isActive = (value === getCurrentDocument());
+            isActive = (value === currentDoc);
 
             files.push({
                 file: value.file.fullPath,
@@ -368,7 +370,6 @@ define(function(require, exports, module) {
      * Initializes the working set.
      */
     function _init() {
-        // TODO (jasonsj): check for project manager init?
         var prefs       = PreferencesManager.getPreferences(PREFERENCES_CLIENT_ID);
 
         if (prefs.files === undefined) {
@@ -381,6 +382,8 @@ define(function(require, exports, module) {
 
         // in parallel, check if files exist
         // TODO (jasonsj): delay validation until user requests the editor (like Eclipse)?
+        //                 e.g. A file to restore no longer exists. Should we silently ignore
+        //                 it or let the user be notified when they attempt to open the Document?
         var result = (function() {
             var deferred    = new $.Deferred();
             var fileCount   = prefs.files.length
@@ -394,7 +397,7 @@ define(function(require, exports, module) {
                 }
             };
 
-            $.each(prefs.files, function(index, value) {
+            prefs.files.forEach(function(value, index) {
                 // check if the file still exists
                 projectRoot.getFile(value.file, {}
                     , function(fileEntry) {
@@ -422,7 +425,7 @@ define(function(require, exports, module) {
             ,   doc;
 
             // Add all existing files to the working set
-            $.each(filesToOpen, function(index, value) {
+            filesToOpen.forEach(function(value, index) {
                 if (value) {
                     doc = new Document(value);
                     addToWorkingSet(doc);
@@ -438,8 +441,10 @@ define(function(require, exports, module) {
                 activeDoc = _workingSet[0];
             }
 
-            if (activeDoc != null)
+            if (activeDoc != null) {
+                console.log(activeDoc.file.fullPath);
                 showInEditor(activeDoc);
+            }
         });
     }
 

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -329,7 +329,7 @@ define(function(require, exports, module) {
                 // Edge case where (a) file exists at launch, (b) editor not 
                 // yet opened, and (c) file is deleted or permissions are 
                 // modified outside of Brackets
-                showFileOpenError(error.code, document.file.fullPath).done(function() {
+                EditorUtils.showFileOpenError(error.code, document.file.fullPath).done(function() {
                     DocumentManager.closeDocument(document);
                     focusEditor();
                 });
@@ -393,53 +393,10 @@ define(function(require, exports, module) {
         if (_currentEditor != null)
             _currentEditor.focus();
     }
-
-
-    function showFileOpenError(code, path) {
-        return brackets.showModalDialog(
-              brackets.DIALOG_ID_ERROR
-            , Strings.ERROR_OPENING_FILE_TITLE
-            , Strings.format(
-                    Strings.ERROR_OPENING_FILE
-                  , path
-                  , getErrorString(code))
-        );
-    }
-
-    function showSaveFileError(code, path) {
-        return brackets.showModalDialog(
-              brackets.DIALOG_ID_ERROR
-            , Strings.ERROR_SAVING_FILE_TITLE
-            , Strings.format(
-                    Strings.ERROR_SAVING_FILE
-                  , path
-                  , getErrorString(code))
-        );
-    }
-
-    function getErrorString(code) {
-        // There are a few error codes that we have specific error messages for. The rest are
-        // displayed with a generic "(error N)" message.
-        var result;
-
-        if (code == FileError.NOT_FOUND_ERR)
-            result = Strings.NOT_FOUND_ERR;
-        else if (code == FileError.NOT_READABLE_ERR)
-            result = Strings.NOT_READABLE_ERR;
-        else if (code == FileError.NO_MODIFICATION_ALLOWED_ERR)
-            result = Strings.NO_MODIFICATION_ALLOWED_ERR_FILE;
-        else
-            result = Strings.format(Strings.GENERIC_ERROR, code);
-
-        return result;
-    }
-    
     
     // Define public API
     exports.setEditorHolder = setEditorHolder;
     exports.createDocumentAndEditor = createDocumentAndEditor;
     exports.focusEditor = focusEditor;
-    exports.showFileOpenError = showFileOpenError;
-    exports.showSaveFileError = showSaveFileError;
     
 });

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -86,12 +86,13 @@ define(function(require, exports, module) {
     
     
     /**
-     * Creates a new CodeMirror editor instance containing the given text, and wraps it in a new
-     * Document tied to the given file. The editor is not yet visible; to display it in the main
+     * Creates a new CodeMirror editor instance containing text from the 
+     * specified fileEntry and wraps it in a new Document tied to the given 
+     * file. The editor is not yet visible; to display it in the main
      * editor UI area, ask DocumentManager to make this the current document.
      * @param {!FileEntry} file  The file being edited. Need not lie within the project.
-     * @param {!string} text  The initial contents of the editor, i.e. the contents of the file.
-     * @return {!Document}
+     * @return {Deferred} a jQuery Deferred that will be resolved with a new 
+     *  document for the fileEntry, or rejected if the file can not be read.
      */
     function createDocumentAndEditor(fileEntry) {
         var result          = new $.Deferred()
@@ -110,6 +111,15 @@ define(function(require, exports, module) {
         return result;
     }
 
+    /**
+     * Creates a new CodeMirror editor instance containing text from the 
+     * specified fileEntry and wraps it in a new Document tied to the given 
+     * file. The editor is not yet visible; to display it in the main
+     * editor UI area, ask DocumentManager to make this the current document.
+     * @param {!FileEntry} file  The file being edited. Need not lie within the project.
+     * @return {Deferred} a jQuery Deferred that will be resolved with a new 
+     *  editor for the fileEntry, or rejected if the file can not be read.
+     */
     function _createEditor(fileEntry) {
         var result = new $.Deferred()
         ,   reader = new NativeFileSystem.FileReader();
@@ -179,7 +189,8 @@ define(function(require, exports, module) {
     
     
     /**
-     * Make the given document's editor visible in the UI, hiding whatever was visible before.
+     * Make the given document's editor visible in the UI, hiding whatever was
+     * visible before. Creates a new editor if none is assigned.
      * @param {!Document} document
      */
     function _showEditor(document) {

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -191,9 +191,9 @@ define(function(require, exports, module) {
             _destroyEditorIfUnneeded(_currentEditorsDocument);
         }
 
-        // Create editor if necessary
+        // Lazily create editor for Documents that were restored on-init
         if (document._editor === null) {
-            var editorResult = _createEditor(document.fileEntry, text);
+            var editorResult = _createEditor(document.file);
 
             editorResult.done(function(editor) {
                 document._editor = editor;

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -126,9 +126,6 @@ define(function(require, exports, module) {
 
         fileEntry.file(function(file) {
             reader.onload = function(event) {
-                // FIXME (jasonsj): remove
-                console.log("create code mirror");
-
                 var editor = CodeMirror(_editorHolder.get(0), {
                     indentUnit : 4,
                     extraKeys: {

--- a/src/EditorUtils.js
+++ b/src/EditorUtils.js
@@ -62,6 +62,36 @@ define(function(require, exports, module) {
         }
     }
 
+    function showFileOpenError(code, path) {
+        return brackets.showModalDialog(
+              brackets.DIALOG_ID_ERROR
+            , Strings.ERROR_OPENING_FILE_TITLE
+            , Strings.format(
+                    Strings.ERROR_OPENING_FILE
+                  , path
+                  , getErrorString(code))
+        );
+    }
+
+    function getFileErrorString(code) {
+        // There are a few error codes that we have specific error messages for. The rest are
+        // displayed with a generic "(error N)" message.
+        var result;
+
+        if (code == FileError.NOT_FOUND_ERR)
+            result = Strings.NOT_FOUND_ERR;
+        else if (code == FileError.NOT_READABLE_ERR)
+            result = Strings.NOT_READABLE_ERR;
+        else if (code == FileError.NO_MODIFICATION_ALLOWED_ERR)
+            result = Strings.NO_MODIFICATION_ALLOWED_ERR_FILE;
+        else
+            result = Strings.format(Strings.GENERIC_ERROR, code);
+
+        return result;
+    }
+
     // Define public API
     exports.setModeFromFileExtension = setModeFromFileExtension;
+    exports.showFileOpenError        = showFileOpenError;
+    exports.getFileErrorString       = getFileErrorString;
 });

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -11,6 +11,7 @@ define(function(require, exports, module) {
     ,   ProjectManager      = require("ProjectManager")
     ,   DocumentManager     = require("DocumentManager")
     ,   EditorManager       = require("EditorManager")
+    ,   EditorUtils         = require("EditorUtils")
     ,   Strings             = require("strings");
     ;
      
@@ -81,6 +82,8 @@ define(function(require, exports, module) {
     function handleFileAddToWorkingSet(fullPath){
         handleFileOpen(fullPath).done(function(doc) {
             DocumentManager.addToWorkingSet(doc);
+            // jstree dblclick handling seems to steal focus from editor, so set focus again
+            EditorManager.focusEditor();
         });
     }
 
@@ -94,8 +97,8 @@ define(function(require, exports, module) {
 
     /**
      * @private
-     * Creates a document and editor for the specified file path. If no path
-     * is specified, a file prompt is provided for input.
+     * Creates a document and displays an editor for the specified file path. 
+     * If no path is specified, a file prompt is provided for input.
      * @return {Deferred} a jQuery Deferred that will be resolved with a new 
      *  document for the specified file path, or rejected if the file can not be read.
      */
@@ -122,7 +125,7 @@ define(function(require, exports, module) {
 
     /**
      * @private
-     * Creates a document and editor for the specified file path.
+     * Creates a document and displays an editor for the specified file path.
      * @return {Deferred} a jQuery Deferred that will be resolved with a new 
      *  document for the specified file path, or rejected if the file can not be read.
      */
@@ -152,7 +155,7 @@ define(function(require, exports, module) {
             });
             
             docResult.fail(function(error) {
-                EditorManager.showFileOpenError(error.code, fullPath);
+                EditorUtils.showFileOpenError(error.code, fullPath);
                 result.reject();
             });
         }
@@ -194,7 +197,7 @@ define(function(require, exports, module) {
             });
 
             result.fail( function fileError(error) { 
-                EditorManager.showSaveFileError(error.code, _currentFilePath);
+                showSaveFileError(error.code, _currentFilePath);
             });
 
             // TODO: we should implement something like NativeFileSystem.resolveNativeFileSystemURL() (similar
@@ -336,6 +339,17 @@ define(function(require, exports, module) {
         result.notify(baseFileName + fileExt , 1);
 
         return result;
+    }
+
+    function showSaveFileError(code, path) {
+        return brackets.showModalDialog(
+              brackets.DIALOG_ID_ERROR
+            , Strings.ERROR_SAVING_FILE_TITLE
+            , Strings.format(
+                    Strings.ERROR_SAVING_FILE
+                  , path
+                  , EditorUtils.getFileErrorString(code))
+        );
     }
 
     // Define public API

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -84,8 +84,6 @@ define(function(require, exports, module) {
     function handleFileAddToWorkingSet(fullPath){
         handleFileOpen(fullPath).done(function(doc) {
             DocumentManager.addToWorkingSet(doc);
-            // jstree dblclick handling seems to steal focus from editor, so set focus again
-            EditorManager.focusEditor();
         });
     }
 

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -79,8 +79,8 @@ define(function(require, exports, module) {
     }
     
     function handleFileAddToWorkingSet(fullPath){
-        handleFileOpen(fullPath).done(function() {
-            DocumentManager.addToWorkingSet(DocumentManager.getCurrentDocument());
+        handleFileOpen(fullPath).done(function(doc) {
+            DocumentManager.addToWorkingSet(doc);
         });
     }
 
@@ -92,6 +92,13 @@ define(function(require, exports, module) {
         return result;
     }
 
+    /**
+     * @private
+     * Creates a document and editor for the specified file path. If no path
+     * is specified, a file prompt is provided for input.
+     * @return {Deferred} a jQuery Deferred that will be resolved with a new 
+     *  document for the specified file path, or rejected if the file can not be read.
+     */
     function doOpenWithOptionalPath(fullPath) {
         var result;
         if (!fullPath) {
@@ -113,6 +120,12 @@ define(function(require, exports, module) {
         return result;
     }
 
+    /**
+     * @private
+     * Creates a document and editor for the specified file path.
+     * @return {Deferred} a jQuery Deferred that will be resolved with a new 
+     *  document for the specified file path, or rejected if the file can not be read.
+     */
     function doOpen(fullPath) {
         var result = new $.Deferred();
         if (!fullPath) {
@@ -124,18 +137,18 @@ define(function(require, exports, module) {
         // to what's in the standard file API) to get a FileEntry, rather than manually constructing it
         var fileEntry = new NativeFileSystem.FileEntry(fullPath);
 
-        var document = DocumentManager.getDocumentForFile(fileEntry);
-        if (document != null) {
+        var doc = DocumentManager.getDocumentForFile(fileEntry);
+        if (doc != null) {
             // File already open - don't need to load it, just switch to it in the UI
-            DocumentManager.showInEditor(document);
-            result.resolve();
+            DocumentManager.showInEditor(doc);
+            result.resolve(doc);
             
         } else {
             var docResult = EditorManager.createDocumentAndEditor(fileEntry);
 
             docResult.done(function(doc) {
                 DocumentManager.showInEditor(doc);
-                result.resolve();
+                result.resolve(doc);
             });
             
             docResult.fail(function(error) {

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -133,7 +133,8 @@ define(function(require, exports, module) {
         } else {
             var docResult = EditorManager.createDocumentAndEditor(fileEntry);
 
-            docResult.done(function() {
+            docResult.done(function(doc) {
+                DocumentManager.showInEditor(doc);
                 result.resolve();
             });
             

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -152,7 +152,7 @@ define(function(require, exports, module) {
             });
             
             docResult.fail(function(error) {
-                showFileOpenError(error.code, fullPath);
+                EditorManager.showFileOpenError(error.code, fullPath);
                 result.reject();
             });
         }
@@ -194,7 +194,7 @@ define(function(require, exports, module) {
             });
 
             result.fail( function fileError(error) { 
-                showSaveFileError(error.code, _currentFilePath);
+                EditorManager.showSaveFileError(error.code, _currentFilePath);
             });
 
             // TODO: we should implement something like NativeFileSystem.resolveNativeFileSystemURL() (similar
@@ -296,48 +296,6 @@ define(function(require, exports, module) {
             EditorManager.focusEditor();
             result.resolve();
         }
-        return result;
-    }
-
-    
-
-
-    function showFileOpenError(code, path) {
-        brackets.showModalDialog(
-              brackets.DIALOG_ID_ERROR
-            , Strings.ERROR_OPENING_FILE_TITLE
-            , Strings.format(
-                    Strings.ERROR_OPENING_FILE
-                  , path
-                  , getErrorString(code))
-        );
-    }
-
-    function showSaveFileError(code, path) {
-        brackets.showModalDialog(
-              brackets.DIALOG_ID_ERROR
-            , Strings.ERROR_SAVING_FILE_TITLE
-            , Strings.format(
-                    Strings.ERROR_SAVING_FILE
-                  , path
-                  , getErrorString(code))
-        );
-    }
-
-    function getErrorString(code) {
-        // There are a few error codes that we have specific error messages for. The rest are
-        // displayed with a generic "(error N)" message.
-        var result;
-
-        if (code == FileError.NOT_FOUND_ERR)
-            result = Strings.NOT_FOUND_ERR;
-        else if (code == FileError.NOT_READABLE_ERR)
-            result = Strings.NOT_READABLE_ERR;
-        else if (code == FileError.NO_MODIFICATION_ALLOWED_ERR)
-            result = Strings.NO_MODIFICATION_ALLOWED_ERR_FILE;
-        else
-            result = Strings.format(Strings.GENERIC_ERROR, code);
-
         return result;
     }
 

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -387,8 +387,11 @@ define(function(require, exports, module) {
      * @param {function(number)} errorCallback
      */
     NativeFileSystem.DirectoryEntry.prototype.getFile = function( path, options, successCallback, errorCallback ) {
-        // TODO (jasonsj): handle absolute paths
-        var fileFullPath = this.fullPath + "/" + path;
+        var fileFullPath = path;
+        
+        // assume relative paths are project-root relative
+        if (path.charAt(0) !== '/') 
+            fileFullPath = this.fullPath + "/" + path;
 
         var createFileEntry = function () {
             if ( successCallback ) {

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -389,7 +389,7 @@ define(function(require, exports, module) {
     NativeFileSystem.DirectoryEntry.prototype.getFile = function( path, options, successCallback, errorCallback ) {
         var fileFullPath = path;
         
-        // assume relative paths are project-root relative
+        // assume relative paths are relative to this directory
         if (path.charAt(0) !== '/') 
             fileFullPath = this.fullPath + "/" + path;
 

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -8,7 +8,8 @@
  * the file tree.
  *
  * This module dispatches 1 event:
- *    - initializeComplete -- When the ProjectManager initializes at application start-up.
+ *    - isFirstProjectOpen -- When the ProjectManager initializes the first 
+ *                            project at application start-up.
  *
  * These are jQuery events, so to listen for them you do something like this:
  *    $(ProjectManager).on("eventname", handler);
@@ -161,7 +162,8 @@ define(function(require, exports, module) {
      * Loads the given folder as a project. Normally, you would call openProject() instead to let the
      * user choose a folder.
      *
-     * @param {string} rootPath  Absolute path to the root folder of the project.
+     * @param {string} rootPath  Absolute path to the root folder of the project. 
+     *  If rootPath is undefined or null, the last open project will be restored.
      * @return {Deferred} A $.Deferred() object that will be resolved when the
      *  project is loaded and tree is rendered, or rejected if the project path
      *  fails to load.
@@ -173,12 +175,12 @@ define(function(require, exports, module) {
         var prefs = PreferencesManager.getPreferences(PREFERENCES_CLIENT_ID)
         ,   result = new $.Deferred()
         ,   resultRenderTree
-        ,   triggerInitEvent = false;
+        ,   isFirstProjectOpen = false;
 
         if (rootPath === null || rootPath === undefined) {
             // Load the last known project into the tree
             rootPath = prefs.projectPath;
-            triggerInitEvent = true;
+            isFirstProjectOpen = true;
 
             // TODO (jasonsj): handle missing paths, see issue #100
             _projectInitialLoad.previous = prefs.projectTreeState;
@@ -241,8 +243,8 @@ define(function(require, exports, module) {
         resultRenderTree.done(function () {
             result.resolve();
 
-            if (triggerInitEvent) {
-                $(exports).triggerHandler("initializeComplete", _projectRoot);
+            if (isFirstProjectOpen) {
+                $(exports).triggerHandler("isFirstProjectOpen", _projectRoot);
             }
         });
         resultRenderTree.fail(function () {
@@ -544,8 +546,6 @@ define(function(require, exports, module) {
             var entry = $(event.target).closest("li").data("entry");
             if (entry.isFile) {
                 CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, entry.fullPath);
-                // jstree dblclick handling seems to steal focus from editor, so set focus again
-                EditorManager.focusEditor();
             }
         });
 

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -8,7 +8,7 @@
  * the file tree.
  *
  * This module dispatches 1 event:
- *    - isFirstProjectOpen -- When the ProjectManager initializes the first 
+ *    - initializeComplete -- When the ProjectManager initializes the first 
  *                            project at application start-up.
  *
  * These are jQuery events, so to listen for them you do something like this:
@@ -255,7 +255,7 @@ define(function(require, exports, module) {
             result.resolve();
 
             if (isFirstProjectOpen) {
-                $(exports).triggerHandler("isFirstProjectOpen", _projectRoot);
+                $(exports).triggerHandler("initializeComplete", _projectRoot);
             }
         });
         resultRenderTree.fail(function () {
@@ -557,6 +557,8 @@ define(function(require, exports, module) {
             var entry = $(event.target).closest("li").data("entry");
             if (entry.isFile) {
                 CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, entry.fullPath);
+                // jstree dblclick handling seems to steal focus from editor, so set focus again
+                EditorManager.focusEditor();
             }
         });
 

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -1,6 +1,18 @@
 /*
  * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
  */
+
+/**
+ * ProjectManager is the model for the set of currently open project. It is responsible for
+ * creating and updating the project tree when projects are opened and when changes occur to
+ * the file tree.
+ *
+ * This module dispatches 1 event:
+ *    - initializeComplete -- When the ProjectManager initializes at application start-up.
+ *
+ * These are jQuery events, so to listen for them you do something like this:
+ *    $(ProjectManager).on("eventname", handler);
+ */
 define(function(require, exports, module) {
     // Load dependent non-module scripts
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");
@@ -546,12 +558,14 @@ define(function(require, exports, module) {
     exports.getSelectedItem = getSelectedItem;
     exports.createNewItem   = createNewItem;
 
-    // Register save callback
-    var loadedPath = window.location.pathname;
-    var bracketsSrc = loadedPath.substr(0, loadedPath.lastIndexOf("/"));
-    var defaults =
-        { projectPath:      bracketsSrc /* initialze to brackets source */
-        , projectTreeState: ""          /* TODO (jasonsj): jstree state */
-        };
-    PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this, defaults);
+    // Initialize now
+    (function() {
+        var loadedPath = window.location.pathname;
+        var bracketsSrc = loadedPath.substr(0, loadedPath.lastIndexOf("/"));
+        var defaults =
+            { projectPath:      bracketsSrc /* initialze to brackets source */
+            , projectTreeState: ""          /* TODO (jasonsj): jstree state */
+            };
+        PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this, defaults);
+    })();
 });

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -173,7 +173,7 @@ define(function(require, exports, module) {
         var prefs = PreferencesManager.getPreferences(PREFERENCES_CLIENT_ID)
         ,   result = new $.Deferred()
         ,   resultRenderTree
-        ,   triggerInitEvent = true;
+        ,   triggerInitEvent = false;
 
         if (rootPath === null || rootPath === undefined) {
             // Load the last known project into the tree

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -14,6 +14,11 @@ define(function(require, exports, module) {
     ;
 
     /**
+     * Unique PreferencesManager clientID
+     */
+    var PREFERENCES_CLIENT_ID = "com.adobe.brackets.ProjectManager";
+
+    /**
      * Returns the root folder of the currently loaded project, or null if no project is open (during
      * startup, or running outside of app shell).
      * @return {DirectoryEntry}
@@ -77,7 +82,7 @@ define(function(require, exports, module) {
      * @private
      * Preferences callback. Saves current project path.
      */
-    function savePreferences( storage ) {
+    function _savePreferences( storage ) {
         // save the current project
         storage.projectPath = _projectRoot.fullPath;
 
@@ -115,11 +120,6 @@ define(function(require, exports, module) {
         // Store the open nodes by their full path and persist to storage
         storage.projectTreeState = openNodes;
     }
-
-    /**
-     * Unique PreferencesManager clientID
-     */
-    var PREFERENCES_CLIENT_ID = "com.adobe.brackets.ProjectManager";
 
     /**
      * Displays a browser dialog where the user can choose a folder to load.
@@ -525,5 +525,5 @@ define(function(require, exports, module) {
         { projectPath:      bracketsSrc /* initialze to brackets source */
         , projectTreeState: ""          /* TODO (jasonsj): jstree state */
         };
-    PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, savePreferences, this, defaults);
+    PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this, defaults);
 });


### PR DESCRIPTION
@peterflynn 

Refactor EditorManager and DocumentManager to allow lazy init of editors.
Persist working set files and the current active editor.
Add "initializationComplete" event to ProjectManager. Hook DocumentManager to this new event to initialize the working set.
