### PR TITLE
Adding save/restore of scrollbar state when hiding/showing editor.

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -82,6 +82,14 @@ define(function(require, exports, module) {
      * @type {number}
      */
     Document.prototype._savedUndoPosition = 0;
+
+    /**
+     * @private
+
+     * Used to store the scrollbar position of the editor whenever the editor is hidden / shown
+     * @type {number}
+     */
+    Document.prototype._scrollPosition = 0;
     
     /**
      * @return {string} The editor's current contents; may not be saved to disk yet.
@@ -90,6 +98,15 @@ define(function(require, exports, module) {
         return this._editor.getValue();
     }
 
+    /**
+     * Saves the editor's scroll position. This should be called before hiding the
+     * editor. Hiding and then showing an editor causes the scrollbar's 'scrollTop'
+     * property to change to zero, which causes the editor's scroll position to
+     * be reset when 'refresh' is called on the editor.
+     *
+     * @see Document.restoreScrollPosition
+     * @see EditorManager._showEditor
+     */
     Document.prototype.saveScrollPosition = function() {
         // this terrible hack to get the scrollbar element is taken directly
         // from codemirror.js lines 40-47 (which contains the comment "I've
@@ -98,6 +115,13 @@ define(function(require, exports, module) {
         this._scrollPosition = scrollbar.scrollTop;
     }
 
+    /**
+     * Restores an editor's scrolling position. This should be called after
+     * re-displaying an editor, but before calling 'refresh'.
+     *
+     * @see Document.saveScrollPosition
+     * @see EditorManager._showEditor
+     */
     Document.prototype.restoreScrollPosition = function() {
         // this terrible hack to get the scrollbar element is taken directly
         // from codemirror.js lines 40-47 (which contains the comment "I've
@@ -108,7 +132,6 @@ define(function(require, exports, module) {
         }
     }
 
-    
     
     /**
      * @private

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -89,6 +89,26 @@ define(function(require, exports, module) {
     Document.prototype.getText = function() {
         return this._editor.getValue();
     }
+
+    Document.prototype.saveScrollPosition = function() {
+        // this terrible hack to get the scrollbar element is taken directly
+        // from codemirror.js lines 40-47 (which contains the comment "I've
+        // never seen more elegant code in my life.")
+        var scrollbar = this._editor.getWrapperElement().firstChild.nextSibling;
+        this._scrollPosition = scrollbar.scrollTop;
+    }
+
+    Document.prototype.restoreScrollPosition = function() {
+        // this terrible hack to get the scrollbar element is taken directly
+        // from codemirror.js lines 40-47 (which contains the comment "I've
+        // never seen more elegant code in my life.")
+        var scrollbar = this._editor.getWrapperElement().firstChild.nextSibling;
+        if (this._scrollPosition !== undefined) {
+            scrollbar.scrollTop = this._scrollPosition;
+        }
+    }
+
+    
     
     /**
      * @private

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -85,7 +85,6 @@ define(function(require, exports, module) {
 
     /**
      * @private
-
      * Used to store the scrollbar position of the editor whenever the editor is hidden / shown
      * @type {number}
      */

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -271,6 +271,7 @@ define(function(require, exports, module) {
         if (_currentEditor == null) {
             $("#notEditor").css("display","none");
         } else {
+            _currentEditorsDocument.saveScrollPosition();
             $(_currentEditor.getWrapperElement()).css("display","none");
             _destroyEditorIfUnneeded(_currentEditorsDocument);
         }
@@ -279,7 +280,8 @@ define(function(require, exports, module) {
         _currentEditorsDocument = document;
         _currentEditor = document._editor;
         $(_currentEditor.getWrapperElement()).css("display", "");
-        
+
+        _currentEditorsDocument.restoreScrollPosition();        
         // Window may have been resized since last time editor was visible, so kick it now
         // (see _updateEditorSize() handler below)
         $('.CodeMirror-scroll', _editorHolder).height(_editorHolder.height());

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -271,6 +271,7 @@ define(function(require, exports, module) {
         if (_currentEditor == null) {
             $("#notEditor").css("display","none");
         } else {
+            // hiding and then showing an editor causes its scrollbar to reset to zero
             _currentEditorsDocument.saveScrollPosition();
             $(_currentEditor.getWrapperElement()).css("display","none");
             _destroyEditorIfUnneeded(_currentEditorsDocument);
@@ -281,7 +282,9 @@ define(function(require, exports, module) {
         _currentEditor = document._editor;
         $(_currentEditor.getWrapperElement()).css("display", "");
 
-        _currentEditorsDocument.restoreScrollPosition();        
+        // hiding and then showing an editor causes its scrollbar to reset to zero
+        _currentEditorsDocument.restoreScrollPosition();
+        
         // Window may have been resized since last time editor was visible, so kick it now
         // (see _updateEditorSize() handler below)
         $('.CodeMirror-scroll', _editorHolder).height(_editorHolder.height());


### PR DESCRIPTION
@njx @peterflynn 

This addresses issue 112 -- preserving scrolling state when switching editors.

The hack is pretty gross to get access to the scrollbar. But, it is exactly what is done in the codemirror.js code.
