### PR TITLE
Use clean, empty preferences for unit test runs

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -19,4 +19,8 @@ define(function(require, exports, module) {
     require("spec/ProjectManager-test.js");
     require("spec/WorkingSetView-test.js");
 
+    // Clean up preferencesKey
+    $(window).unload(function () {
+        localStorage.removeItem("preferencesKey");
+    });
 });

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -8,8 +8,7 @@ define(function(require, exports, module) {
     var SpecRunnerUtils = require("spec/SpecRunnerUtils.js");
 
     // Unique key for unit testing
-    var PreferencesManager = require("PreferencesManager");
-    PreferencesManager._setStorageKey( SpecRunnerUtils.TEST_PREFERENCES_KEY );
+    localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
 
     // Load test specs
     require("spec/LowLevelFileIO-test.js");

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -31,16 +31,25 @@ define(function(require, exports, module) {
             testWindow = window.open( getBracketsSourceRoot() + "/index.html" );
         });
 
+        // FIXME (jasonsj): Need an event or something a little more reliable...
         waitsFor(function() {
             return testWindow.brackets && testWindow.brackets.test;
         }, 5000); 
 
         runs(function() {
             // all test windows should use unit test preferences
-            testWindow.brackets.test.PreferencesManager._setStorageKey( TEST_PREFERENCES_KEY );
+            // unless we explicitly skip
+            setTestPreferencesKey(testWindow);
 
             // callback allows specs to query the testWindow before they run
             callback.call( spec, testWindow );
+        });
+    }
+
+    function setTestPreferencesKey(loadAgain) {
+        runs(function() {
+            var again = (loadAgain && true);
+            testWindow.brackets.test.PreferencesManager._setStorageKey( TEST_PREFERENCES_KEY, again );
         });
     }
 
@@ -76,4 +85,5 @@ define(function(require, exports, module) {
     exports.createTestWindowAndRun  = createTestWindowAndRun;
     exports.closeTestWindow         = closeTestWindow;
     exports.loadProjectInTestWindow = loadProjectInTestWindow;
+    exports.setTestPreferencesKey   = setTestPreferencesKey;
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -37,19 +37,8 @@ define(function(require, exports, module) {
         }, 5000); 
 
         runs(function() {
-            // all test windows should use unit test preferences
-            // unless we explicitly skip
-            setTestPreferencesKey(testWindow);
-
             // callback allows specs to query the testWindow before they run
             callback.call( spec, testWindow );
-        });
-    }
-
-    function setTestPreferencesKey(loadAgain) {
-        runs(function() {
-            var again = (loadAgain && true);
-            testWindow.brackets.test.PreferencesManager._setStorageKey( TEST_PREFERENCES_KEY, again );
         });
     }
 
@@ -85,5 +74,4 @@ define(function(require, exports, module) {
     exports.createTestWindowAndRun  = createTestWindowAndRun;
     exports.closeTestWindow         = closeTestWindow;
     exports.loadProjectInTestWindow = loadProjectInTestWindow;
-    exports.setTestPreferencesKey   = setTestPreferencesKey;
 });

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -26,7 +26,7 @@ define(function(require, exports, module) {
                 // Open a directory
                 SpecRunnerUtils.loadProjectInTestWindow( testPath );
             });
-            
+
             var didOpen = false, gotError = false;
             
             var openAndMakeDirty = function (path){
@@ -99,11 +99,32 @@ define(function(require, exports, module) {
                            
         });
         
-        
-        // TODO Ty: Can't write this test yet until Jason's persistant work is complete    
-        // it("should rebuild the ui from the model correctly", function() {
-        //                 
-        // });
+        it("should rebuild the ui from the model correctly", function() {
+            // force the test window to initialize to unit test preferences
+            // for just this test
+            SpecRunnerUtils.setTestPreferencesKey(testWindow, true);
+
+            // close test window while working set has 2 files
+            SpecRunnerUtils.closeTestWindow();
+
+            // reopen without loading a project
+            SpecRunnerUtils.createTestWindowAndRun( this, function( w ) {
+                testWindow = w;
+            });
+
+            // files should be in the working set
+            runs(function(){
+                var listItems = testWindow.$("#open-files-container > ul").children();
+                expect( listItems.find("a").get(0).text == "file_one.js" ).toBeTruthy();
+                expect( listItems.find("a").get(1).text == "file_two.js" ).toBeTruthy();
+
+                // files should be clean
+                expect( listItems.find(".file-status-icon dirty").length).toBe(0);
+
+                // file_two.js should be active
+                expect( $(listItems[1]).hasClass("selected") ).toBeTruthy();
+            });
+        });
         
         it("should close a file when the user clicks the close button", function() {
             var $ = testWindow.$;

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -102,7 +102,9 @@ define(function(require, exports, module) {
         it("should rebuild the ui from the model correctly", function() {
             // force the test window to initialize to unit test preferences
             // for just this test
-            SpecRunnerUtils.setTestPreferencesKey(testWindow, true);
+            runs(function() {
+                localStorage.setItem("doLoadPreferences", true);
+            });
 
             // close test window while working set has 2 files
             SpecRunnerUtils.closeTestWindow();
@@ -123,6 +125,8 @@ define(function(require, exports, module) {
 
                 // file_two.js should be active
                 expect( $(listItems[1]).hasClass("selected") ).toBeTruthy();
+
+                localStorage.removeItem("doLoadPreferences", true);
             });
         });
         


### PR DESCRIPTION
Updated setStorageKey() to allow unit test preferences to persist within a single test.
Added working set unit test to verify working set UI is restored after close+reopen
