### PR TITLE
Better fix for issue 84: remove jstree's double-click handler

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -26,9 +26,7 @@ define(function(require, exports, module) {
     ,   CommandManager      = require("CommandManager")
     ,   Commands            = require("Commands")
     ,   Strings             = require("strings")
-    ,   EditorManager       = require("EditorManager")
     ,   FileViewController  = require("FileViewController")
-    ,   DocumentManager     = require("DocumentManager")
     ;
     
     $(FileViewController).on("documentSelectionFocusChange", function(event) {

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -578,17 +578,24 @@ define(function(require, exports, module) {
                 result.resolve();
             }
         })
-        .bind("dblclick.jstree", function(event) {
 
-            var entry = $(event.target).closest("li").data("entry");
-            if (entry.isFile){
-                FileViewController.addToWorkingSetAndSelect( entry.fullPath);
-                
-                // jstree dblclick handling seems to steal focus from editor, so set focus again
-                EditorManager.focusEditor();
-            }
+        // jstree has a default event handler for dblclick that attempts to clear the
+        // global window selection (presumably because it doesn't want text within the tree
+        // to be selected). This ends up messing up CodeMirror, and we don't need this anyway
+        // since we've turned off user selection of UI text globally. So we just unbind it,
+        // and add our own double-click handler here.
+        // Filed this bug against jstree at https://github.com/vakata/jstree/issues/163
+        _projectTree.bind("init.jstree", function() {
+            _projectTree
+                .unbind("dblclick.jstree")
+                .bind("dblclick.jstree", function(event) {
+                    var entry = $(event.target).closest("li").data("entry");
+                    if (entry.isFile){
+                        FileViewController.addToWorkingSetAndSelect(entry.fullPath);
+                    }
+                });
         });
-
+        
         return result;
     };
 


### PR DESCRIPTION
@peterflynn 

Fix for #84.

jstree adds a double-click handler that clears the selection. We don't need this, and it interferes with codemirror. So we unbind the built-in double-click handler.

Because the handler gets attached by jstree in its init method (which is called asynchronously), we unbind it in an init handler. I moved the initialization of our own double-click handler into this new handler as well, after we unbind jstree's (so we don't end up unbinding our own).

I also removed the previous fix attempt (which sets focus to the editor) since it's not necessary (FileCommandHandlers.handleFileOpen() does this already).
