### PR TITLE
making readEntires more asynchronouser, and deal with treeRenderer taking awhile to create

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -229,47 +229,8 @@ define(function(require, exports, module) {
         var projectName = rootPath.substring(rootPath.lastIndexOf("/") + 1);
         $("#project-title").html(projectName);
 
-        // Populate file tree
-        if (brackets.inBrowser) {
-            // Hardcoded dummy data for local testing, in jsTree JSON format
-            // (we leave _projectRoot null)
-            var subfolderInner = { data:"Folder_inner", children:[
-                { data: "subsubfile_1" }, { data: "subsubfile_2" }
-            ] };
-            var treeJSONData = [
-                { data: "Dummy tree content:" },
-                { data:"Folder_1", children:[
-                    { data: "subfile_1" }, { data: "subfile_2" }, { data: "subfile_3" }
-                ] },
-                { data:"Folder_2", children:[
-                    { data: "subfile_4" }, subfolderInner, { data: "subfile_5" }
-                ] },
-                { data: "file_1" },
-                { data: "file_2" }
-            ];
-
-            // Show file list in UI
-            resultRenderTree = _renderTree(treeJSONData, result);
-
-            // NOTE: These two functions contain duplicated code from the code
-            // below. However, this code will go away when we're no longer
-            // rendering a fake tree for the browser. So, this code isn't
-            // being refactored
-
-            resultRenderTree.done(function () {
-                result.resolve();
-
-                if (isFirstProjectOpen) {
-                    $(exports).triggerHandler("initializeComplete", _projectRoot);
-                }
-            });
-            resultRenderTree.fail(function () {
-                result.reject();
-            });
-
-            // END duplicated code
-
-        } else {
+        // Populate file tree as long as we aren't running in the browser
+        if (!brackets.inBrowser) {
             // Point at a real folder structure on local disk
             NativeFileSystem.requestNativeFileSystem(rootPath,
                 function(rootEntry) {

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -251,6 +251,17 @@ define(function(require, exports, module) {
             // Show file list in UI
             resultRenderTree = _renderTree(treeJSONData, result);
 
+            resultRenderTree.done(function () {
+                result.resolve();
+
+                if (isFirstProjectOpen) {
+                    $(exports).triggerHandler("initializeComplete", _projectRoot);
+                }
+            });
+            resultRenderTree.fail(function () {
+                result.reject();
+            });
+
         } else {
             // Point at a real folder structure on local disk
             NativeFileSystem.requestNativeFileSystem(rootPath,
@@ -262,6 +273,17 @@ define(function(require, exports, module) {
                     // go idle until a node is expanded - at which time it'll call us again to fetch the node's
                     // immediate children, and so on.
                     resultRenderTree = _renderTree(_treeDataProvider);
+
+                    resultRenderTree.done(function () {
+                        result.resolve();
+
+                        if (isFirstProjectOpen) {
+                            $(exports).triggerHandler("initializeComplete", _projectRoot);
+                        }
+                    });
+                    resultRenderTree.fail(function () {
+                        result.reject();
+                    });
                 },
                 function(error) {
                     brackets.showModalDialog(
@@ -273,17 +295,6 @@ define(function(require, exports, module) {
                 }
             );
         }
-
-        resultRenderTree.done(function () {
-            result.resolve();
-
-            if (isFirstProjectOpen) {
-                $(exports).triggerHandler("initializeComplete", _projectRoot);
-            }
-        });
-        resultRenderTree.fail(function () {
-            result.reject();
-        });
 
         return result;
     }

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -251,6 +251,11 @@ define(function(require, exports, module) {
             // Show file list in UI
             resultRenderTree = _renderTree(treeJSONData, result);
 
+            // NOTE: These two functions contain duplicated code from the code
+            // below. However, this code will go away when we're no longer
+            // rendering a fake tree for the browser. So, this code isn't
+            // being refactored
+
             resultRenderTree.done(function () {
                 result.resolve();
 
@@ -261,6 +266,8 @@ define(function(require, exports, module) {
             resultRenderTree.fail(function () {
                 result.reject();
             });
+
+            // END duplicated code
 
         } else {
             // Point at a real folder structure on local disk


### PR DESCRIPTION
This is a fix for issues #130 and #132.

It seems that fixing these two items at the same time is necessary, since making readEntries better about being asynchronous will potentially allow other code to execute between when the treeRenderer is created and when event handlers are bound to it.

Initially, this change was causing unit tests to fail on my machine. However, deleting my cefCache fixed the failing unit tests.
