### PR TITLE
Simplify dirty bit management

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -99,7 +99,7 @@ define(function(require, exports, module) {
         this._editor = editor;
         
         // Dirty-bit tracking
-        editor.setOption("onChange", this._updateDirty.bind(this));
+        editor.setOption("onChange", this._handleEditorChange.bind(this));
         this.isDirty = false;
     }
     
@@ -109,8 +109,6 @@ define(function(require, exports, module) {
      *  created.
      */
     Document.prototype.getText = function() {
-        console.assert(this._editor != null);
-
         return this._editor.getValue();
     }
     
@@ -119,15 +117,13 @@ define(function(require, exports, module) {
      * @param {!string} text The text to replace the contents of the document with.
      */
     Document.prototype.setText = function(text) {
-        console.assert(this._editor != null);
-        
         this._editor.setValue(text);
     }
         
     /**
      * @private
      */
-    Document.prototype._updateDirty = function() {
+    Document.prototype._handleEditorChange = function() {
         if (this._editor == null) {
             return;
         }
@@ -136,13 +132,12 @@ define(function(require, exports, module) {
         // undo back to the last saved state, we mark the file clean.
         var wasDirty = this.isDirty;
         this.isDirty = true;
-            
-        // Dispatch event
-        $(exports).triggerHandler("dirtyFlagChange", this);
-            
-        // If file just became dirty, add it to working set (if not already there)
-        if (!wasDirty)
+
+        // If file just became dirty, notify listeners, and add it to working set (if not already there)
+        if (!wasDirty) {
+            $(exports).triggerHandler("dirtyFlagChange", this);
             addToWorkingSet(this);
+        }
     }
     
     /** Marks the document not dirty. Should be called after the document is saved to disk. */

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -100,7 +100,7 @@ define(function(require, exports, module) {
         
         // Dirty-bit tracking
         editor.setOption("onChange", this._updateDirty.bind(this));
-        _isDirty = false;
+        this.isDirty = false;
     }
     
     /**

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -146,32 +146,6 @@ define(function(require, exports, module) {
 
         describe("Dirty File Handling", function() {
 
-            // This test is not currently valid. For issue 152, we have temporarily decided to make it so
-            // the file is always dirty as soon as you make a change, regardless of whether you undo back to
-            // its last saved state.
-/*
-            it("should report not dirty after undo", function() {
-                var didOpen = false, gotError = false;
-
-                runs(function() {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"})
-                        .done(function() { didOpen = true; })
-                        .fail(function() { gotError = true; });
-                });
-                waitsFor(function() { return didOpen && !gotError; }, "FILE_OPEN timeout", 1000);
-
-                runs(function() {
-                    // change editor content, followed by undo
-                    var editor = DocumentManager.getCurrentDocument()._editor;
-                    editor.setValue(TEST_JS_NEW_CONTENT);
-                    editor.undo();
-                    
-                    // verify Document dirty status
-                    expect(editor.getValue()).toBe(TEST_JS_CONTENT);
-                    expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
-                });
-            });
-*/
             beforeEach(function() {
                 var didOpen = false, gotError = false;
 
@@ -234,6 +208,24 @@ define(function(require, exports, module) {
                     expect(document.isDirty).toBe(false);
                 });
             });
+
+            // This test is not currently valid. For issue 152, we have temporarily decided to make it so
+            // the file is always dirty as soon as you make a change, regardless of whether you undo back to
+            // its last saved state. In the future, we might restore this behavior.
+/*
+            it("should report not dirty after undo", function() {
+                runs(function() {
+                    // change editor content, followed by undo
+                    var editor = DocumentManager.getCurrentDocument()._editor;
+                    editor.setValue(TEST_JS_NEW_CONTENT);
+                    editor.undo();
+                    
+                    // verify Document dirty status
+                    expect(editor.getValue()).toBe(TEST_JS_CONTENT);
+                    expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
+                });
+            });
+*/
         });
 
         // TODO (jasonsj): experiment with mocks instead of real UI

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -146,6 +146,10 @@ define(function(require, exports, module) {
 
         describe("Dirty File Handling", function() {
 
+            // This test is not currently valid. For issue 152, we have temporarily decided to make it so
+            // the file is always dirty as soon as you make a change, regardless of whether you undo back to
+            // its last saved state.
+/*
             it("should report not dirty after undo", function() {
                 var didOpen = false, gotError = false;
 
@@ -167,8 +171,8 @@ define(function(require, exports, module) {
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
                 });
             });
-
-            it("should report dirty when modified", function() {
+*/
+            beforeEach(function() {
                 var didOpen = false, gotError = false;
 
                 runs(function() {
@@ -177,7 +181,15 @@ define(function(require, exports, module) {
                         .fail(function() { gotError = true; });
                 });
                 waitsFor(function() { return didOpen && !gotError; }, "FILE_OPEN timeout", 1000);
+            });
 
+            it("should report clean immediately after opening a file", function() {
+                runs(function() {
+                    expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
+                });
+            });
+            
+            it("should report dirty when modified", function() {
                 runs(function() {
                     // change editor content
                     var editor = DocumentManager.getCurrentDocument()._editor;
@@ -199,15 +211,6 @@ define(function(require, exports, module) {
             });
 
             it("should report dirty after undo and redo", function() {
-                var didOpen = false, gotError = false;
-
-                runs(function() {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"})
-                        .done(function() { didOpen = true; })
-                        .fail(function() { gotError = true; });
-                });
-                waitsFor(function() { return didOpen && !gotError; }, "FILE_OPEN timeout", 1000);
-
                 runs(function() {
                     // change editor content, followed by undo and redo
                     var editor = DocumentManager.getCurrentDocument()._editor;
@@ -220,6 +223,15 @@ define(function(require, exports, module) {
                     editor.redo();
                     expect(editor.getValue()).toBe(TEST_JS_NEW_CONTENT);
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(true);
+                });
+            });
+            
+            it("should report clean after being marked clean", function() {
+                runs(function() {
+                    var document = DocumentManager.getCurrentDocument();
+                    document.setText(TEST_JS_NEW_CONTENT);
+                    document.markClean();
+                    expect(document.isDirty).toBe(false);
                 });
             });
         });


### PR DESCRIPTION
Issue #152 exposed a problem with our dirty bit management, which was relying on CodeMirror's undo history. Because CodeMirror limits the size of its undo history, our logic for figuring out when to clear the dirty bit due to an undo was incorrect.

The real fix for this would be to add the dirty bit tracking to CodeMirror. For now, we're simplifying the dirty bit management so that we simply mark documents as dirty as soon as you make a change, and only mark them clean again on save. If you undo back to your previous save state, the document is still marked dirty. This avoids the data loss issue from 152, but is not as good from the user's point of view. We'll add a user story to the product backlog to get back to the previous functionality.
