### PR TITLE
JSLint cleanup

### DIFF
--- a/src/CommandManager.js
+++ b/src/CommandManager.js
@@ -3,13 +3,14 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false */
+/*global define: false, $: false */
 
  /**
   * Manages global application commands that can be called from menu items, key bindings, or subparts
   * of the application.
   */
-define(function(require, exports, module) {
+define(function (require, exports, module) {
+    'use strict';
     
     var _commands = {};
 
@@ -41,13 +42,10 @@ define(function(require, exports, module) {
             var result = command.apply(null, Array.prototype.slice.call(arguments, 1));
             if (result === undefined) {
                 return (new $.Deferred()).resolve();
-            }
-            else {
+            } else {
                 return result;
             }
-        }
-        else {
-            console.log("Attempted to call unregistered command: " + id);
+        } else {
             return (new $.Deferred()).reject();
         }
     }

--- a/src/Commands.js
+++ b/src/Commands.js
@@ -5,7 +5,9 @@
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define: false */
 
-define(function(require, exports, module) {
+define(function (require, exports, module) {
+    'use strict';
+    
     /**
      * List of constants for global command IDs.
      */

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -2,23 +2,24 @@
  * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false */
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, undef: true, indent: 4, maxerr: 50 */
+/*global define: false, $: false, brackets: false */
 
-define(function(require, exports, module) {
+define(function (require, exports, module) {
+    'use strict';
+    
     require("thirdparty/path-utils/path-utils.min");
     
     // Load dependent modules
-    var CommandManager      = require("CommandManager")
-    ,   Commands            = require("Commands")
-    ,   NativeFileSystem    = require("NativeFileSystem").NativeFileSystem
-    ,   ProjectManager      = require("ProjectManager")
-    ,   DocumentManager     = require("DocumentManager")
-    ,   EditorManager       = require("EditorManager")
-    ,   EditorUtils         = require("EditorUtils")
-    ,   Strings             = require("strings");
-    ;
-     
+    var CommandManager      = require("CommandManager"),
+        Commands            = require("Commands"),
+        NativeFileSystem    = require("NativeFileSystem").NativeFileSystem,
+        ProjectManager      = require("ProjectManager"),
+        DocumentManager     = require("DocumentManager"),
+        EditorManager       = require("EditorManager"),
+        EditorUtils         = require("EditorUtils"),
+        Strings             = require("strings");
+    
     /**
      * Handlers for commands related to file handling (opening, saving, etc.)
      */
@@ -48,12 +49,12 @@ define(function(require, exports, module) {
         
         $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
         $(DocumentManager).on("currentDocumentChange", handleCurrentDocumentChange);
-    };
+    }
 
     function handleCurrentDocumentChange() {
         var newDocument = DocumentManager.getCurrentDocument();
         
-        if (newDocument != null) {
+        if (newDocument) {
             var fullPath = newDocument.file.fullPath;
     
             _currentFilePath = _currentTitlePath = fullPath;
@@ -71,7 +72,7 @@ define(function(require, exports, module) {
     }
     
     function handleDirtyChange(event, changedDoc) {
-        if (changedDoc.file.fullPath == _currentFilePath) {
+        if (changedDoc.file.fullPath === _currentFilePath) {
             updateTitle();
         }
     }
@@ -79,25 +80,26 @@ define(function(require, exports, module) {
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument();
         if (currentDoc) {
-            _title.text( _currentTitlePath + (currentDoc.isDirty ? " \u2022" : "") );
+            _title.text(_currentTitlePath + (currentDoc.isDirty ? " \u2022" : ""));
         } else {
             _title.text("");
         }
     }
     
-    function handleFileAddToWorkingSet(commandData){
-        handleFileOpen(commandData).done(function(doc) {
+    function handleFileAddToWorkingSet(commandData) {
+        handleFileOpen(commandData).done(function (doc) {
             DocumentManager.addToWorkingSet(doc);
         });
     }
 
     function handleFileOpen(commandData) {
         var fullPath = null;
-        if( commandData )
+        if (commandData) {
             fullPath = commandData.fullPath;
+        }
         
         var result = doOpenWithOptionalPath(fullPath);
-        result.always(function() {
+        result.always(function () {
             EditorManager.focusEditor();
         });
         return result;
@@ -116,18 +118,18 @@ define(function(require, exports, module) {
             // Prompt the user with a dialog
             // TODO: we're relying on this to not be asynchronous--is that safe?
             NativeFileSystem.showOpenDialog(false, false, Strings.OPEN_FILE, ProjectManager.getProjectRoot().fullPath,
-                ["htm", "html", "js", "css"], function(files) {
+                ["htm", "html", "js", "css"], function (files) {
                     if (files.length > 0) {
                         result = doOpen(files[0]);
                         return;
                     }
                 });
-        }
-        else {
+        } else {
             result = doOpen(fullPath);
         }
-        if (!result)
+        if (!result) {
             result = (new $.Deferred()).reject();
+        }
         return result;
     }
 
@@ -146,7 +148,7 @@ define(function(require, exports, module) {
         }
         
         var doc = DocumentManager.getDocumentForPath(fullPath);
-        if (doc != null) {
+        if (doc) {
             // File already open - don't need to load it, just switch to it in the UI
             DocumentManager.showInEditor(doc);
             result.resolve(doc);
@@ -156,12 +158,12 @@ define(function(require, exports, module) {
             var fileEntry = new NativeFileSystem.FileEntry(fullPath);
             var docResult = EditorManager.createDocumentAndEditor(fileEntry);
 
-            docResult.done(function(doc) {
+            docResult.done(function (doc) {
                 DocumentManager.showInEditor(doc);
                 result.resolve(doc);
             });
             
-            docResult.fail(function(error) {
+            docResult.fail(function (error) {
                 EditorUtils.showFileOpenError(error.code, fullPath);
                 result.reject();
             });
@@ -175,28 +177,29 @@ define(function(require, exports, module) {
         // If a file is currently selected, put it next to it.
         // If a directory is currently selected, put it in it.
         // If nothing is selected, put it at the root of the project
-        var baseDir, 
+        var baseDir,
             selected = ProjectManager.getSelectedItem() || ProjectManager.getProjectRoot();
         
         baseDir = selected.fullPath;
-        if (selected.isFile) 
+        if (selected.isFile) {
             baseDir = baseDir.substr(0, baseDir.lastIndexOf("/"));
+        }
         
         // Create the new node. The createNewItem function does all the heavy work
         // of validating file name, creating the new file and selecting.
         var deferred = _getUntitledFileSuggestion(baseDir, "Untitled", ".js");
-        var createWithSuggestedName = function ( suggestedName ) {
-            ProjectManager.createNewItem(baseDir, suggestedName, false).pipe( deferred.resolve, deferred.reject, deferred.notify );
+        var createWithSuggestedName = function (suggestedName) {
+            ProjectManager.createNewItem(baseDir, suggestedName, false).pipe(deferred.resolve, deferred.reject, deferred.notify);
         };
 
-        deferred.done( createWithSuggestedName );
-        deferred.fail( function createWithDefault() { createWithSuggestedName( "Untitled.js" ); } );
+        deferred.done(createWithSuggestedName);
+        deferred.fail(function createWithDefault() { createWithSuggestedName("Untitled.js"); });
         return deferred;
     }
     
     
     function handleFileSave() {
-        return doSave( DocumentManager.getCurrentDocument() );
+        return doSave(DocumentManager.getCurrentDocument());
     }
     
     function doSave(docToSave) {
@@ -206,35 +209,34 @@ define(function(require, exports, module) {
             var fileEntry = docToSave.file;
             
             //setup our resolve and reject handlers
-            result.done( function fileSaved() { 
+            result.done(function fileSaved() {
                 docToSave.notifySaved();
             });
 
-            result.fail( function fileError(error) { 
+            result.fail(function fileError(error) {
                 showSaveFileError(error.code, fileEntry.fullPath);
             });
 
             fileEntry.createWriter(
-                function(writer) {
-                    writer.onwriteend = function() {
+                function (writer) {
+                    writer.onwriteend = function () {
                         result.resolve();
-                    }
-                    writer.onerror = function(error) {
+                    };
+                    writer.onerror = function (error) {
                         result.reject(error);
-                    }
+                    };
 
                     // TODO (jasonsj): Blob instead of string
-                    writer.write( docToSave.getText() );
+                    writer.write(docToSave.getText());
                 },
-                function(error) {
+                function (error) {
                     result.reject(error);
                 }
             );
-        }
-        else {
+        } else {
             result.resolve();
         }
-        result.always(function() {
+        result.always(function () {
             EditorManager.focusEditor();
         });
         return result;
@@ -252,8 +254,8 @@ define(function(require, exports, module) {
     function saveAll() {
         var saveResults = [];
         
-        DocumentManager.getWorkingSet().forEach(function(doc) {
-            saveResults.push( doSave(doc) );
+        DocumentManager.getWorkingSet().forEach(function (doc) {
+            saveResults.push(doSave(doc));
         });
         
         // Aggregate all the file-save Deferreds into one master
@@ -275,8 +277,9 @@ define(function(require, exports, module) {
      */
     function handleFileClose(commandData) {
         var doc = null;
-        if(commandData)
+        if (commandData) {
             doc = commandData.doc;
+        }
         
         // utility function for handleFileClose: closes document & removes from working set
         function doClose(doc) {
@@ -292,44 +295,44 @@ define(function(require, exports, module) {
         var result = new $.Deferred();
         
         // Default to current document if doc is null
-        if (!doc)
-            doc =  DocumentManager.getCurrentDocument();
+        if (!doc) {
+            doc = DocumentManager.getCurrentDocument();
+        }
+        
         // No-op if called when nothing is open; TODO: should command be grayed out instead?
-        if (!doc)
+        if (!doc) {
             return;
+        }
         
         if (doc.isDirty) {
             var filename = PathUtils.parseUrl(doc.file.fullPath).filename;
             
             brackets.showModalDialog(
-                  brackets.DIALOG_ID_SAVE_CLOSE
-                , Strings.SAVE_CLOSE_TITLE
-                , Strings.format(Strings.SAVE_CLOSE_MESSAGE, filename )
-            ).done(function(id) {
+                brackets.DIALOG_ID_SAVE_CLOSE,
+                Strings.SAVE_CLOSE_TITLE,
+                Strings.format(Strings.SAVE_CLOSE_MESSAGE, filename)
+            ).done(function (id) {
                 if (id === brackets.DIALOG_BTN_CANCEL) {
                     result.reject();
-                }
-                else if (id === brackets.DIALOG_BTN_OK) {
+                } else if (id === brackets.DIALOG_BTN_OK) {
                     doSave(doc)
-                        .done(function() {
+                        .done(function () {
                             doClose(doc);
                             result.resolve();
                         })
-                        .fail(function() {
+                        .fail(function () {
                             result.reject();
                         });
-                }
-                else {
+                } else {
                     // This is the "Don't Save" case--we can just go ahead and close the file.
                     doClose(doc);
                     result.resolve();
                 }
             });
-            result.always(function() {
+            result.always(function () {
                 EditorManager.focusEditor();
             });
-        }
-        else {
+        } else {
             // Doc is not dirty, just close
             doClose(doc);
             EditorManager.focusEditor();
@@ -349,21 +352,21 @@ define(function(require, exports, module) {
     function handleFileCloseAll(commandData) {
         var result = new $.Deferred();
         
-        var unsavedDocs = DocumentManager.getWorkingSet().filter( function(doc) {
+        var unsavedDocs = DocumentManager.getWorkingSet().filter(function (doc) {
             return doc.isDirty;
         });
         
-        if (unsavedDocs.length == 0) {
+        if (unsavedDocs.length === 0) {
             // No unsaved changes, so we can proceed without a prompt
             result.resolve();
             
-        } else if (unsavedDocs.length == 1) {
+        } else if (unsavedDocs.length === 1) {
             // Only one unsaved file: show the usual single-file-close confirmation UI
             var fileCloseArgs = { doc: unsavedDocs[0], promptOnly: promptOnly };
-            handleFileClose(fileCloseArgs).done( function() {
+            handleFileClose(fileCloseArgs).done(function () {
                 // still need to close any other, non-unsaved documents
                 result.resolve();
-            }).fail( function() {
+            }).fail(function () {
                 result.reject();
             });
             
@@ -372,28 +375,26 @@ define(function(require, exports, module) {
             var message = Strings.SAVE_CLOSE_MULTI_MESSAGE;
             
             message += "<ul>";
-            unsavedDocs.forEach(function(doc) {
+            unsavedDocs.forEach(function (doc) {
                 message += "<li>" + ProjectManager.makeProjectRelativeIfPossible(doc.file.fullPath) + "</li>";
             });
             message += "</ul>";
             
             brackets.showModalDialog(
-                  brackets.DIALOG_ID_SAVE_CLOSE
-                , Strings.SAVE_CLOSE_TITLE
-                , message
-            ).done(function(id) {
+                brackets.DIALOG_ID_SAVE_CLOSE,
+                Strings.SAVE_CLOSE_TITLE,
+                message
+            ).done(function (id) {
                 if (id === brackets.DIALOG_BTN_CANCEL) {
                     result.reject();
-                }
-                else if (id === brackets.DIALOG_BTN_OK) {
+                } else if (id === brackets.DIALOG_BTN_OK) {
                     // Save all unsaved files, then if that succeeds, close all
-                    saveAll().done( function() {
+                    saveAll().done(function () {
                         result.resolve();
-                    }).fail( function() {
+                    }).fail(function () {
                         result.reject();
                     });
-                }
-                else {
+                } else {
                     // "Don't Save" case--we can just go ahead and close all  files.
                     result.resolve();
                 }
@@ -403,9 +404,10 @@ define(function(require, exports, module) {
         // If all the unsaved-changes confirmations pan out above, then go ahead & close all editors
         // NOTE: this still happens before any done() handlers added by our caller, because jQ
         // guarantees that handlers run in the order they are added.
-        result.done(function() {
-            if (!commandData || !commandData.promptOnly)
+        result.done(function () {
+            if (!commandData || !commandData.promptOnly) {
                 DocumentManager.closeAll();
+            }
         });
         
         return result;
@@ -416,9 +418,9 @@ define(function(require, exports, module) {
     function handleFileQuit() {
         var closeAllArgs = { promptOnly: false };
         handleFileCloseAll(closeAllArgs)
-        .done(function() {
-            window.close();  // TODO: call a native API to quit the whole app
-        });
+            .done(function () {
+                window.close();  // TODO: call a native API to quit the whole app
+            });
         // if fail, don't exit: user canceled (or asked us to save changes first, but we failed to do so)
     }
 
@@ -429,46 +431,48 @@ define(function(require, exports, module) {
      * @param {string} baseFileName  The base to start with, "-n" will get appened to make unique
      * @param {string} fileExt  The file extension
      */
-    function _getUntitledFileSuggestion( dir, baseFileName, fileExt ) {
+    function _getUntitledFileSuggestion(dir, baseFileName, fileExt) {
         var result = new $.Deferred();
         var suggestedName = baseFileName + fileExt;
         var dirEntry = new NativeFileSystem.DirectoryEntry(dir);
 
-        result.progress( function attemptNewName( suggestedName, nextIndexToUse ) {
-            if( nextIndexToUse > 99 ) {
+        result.progress(function attemptNewName(suggestedName, nextIndexToUse) {
+            if (nextIndexToUse > 99) {
                 //we've tried this enough
                 result.reject();
                 return;
             }
 
             //check this name
-            dirEntry.getFile( suggestedName
-                            , {}
-                            , function successCallback(entry){
-                                //file exists, notify to the next progress
-                                result.notify(baseFileName + "-" + nextIndexToUse + fileExt , nextIndexToUse + 1);
-                                }
-                             , function errorCallback(error) {
-                                //most likely error is FNF, user is better equiped to handle the rest
-                                result.resolve(suggestedName);
-                                }
-                            );
+            dirEntry.getFile(
+                suggestedName,
+                {},
+                function successCallback(entry) {
+                    //file exists, notify to the next progress
+                    result.notify(baseFileName + "-" + nextIndexToUse + fileExt, nextIndexToUse + 1);
+                },
+                function errorCallback(error) {
+                    //most likely error is FNF, user is better equiped to handle the rest
+                    result.resolve(suggestedName);
+                }
+            );
         });
 
         //kick it off
-        result.notify(baseFileName + fileExt , 1);
+        result.notify(baseFileName + fileExt, 1);
 
         return result;
     }
 
     function showSaveFileError(code, path) {
         return brackets.showModalDialog(
-              brackets.DIALOG_ID_ERROR
-            , Strings.ERROR_SAVING_FILE_TITLE
-            , Strings.format(
-                    Strings.ERROR_SAVING_FILE
-                  , path
-                  , EditorUtils.getFileErrorString(code))
+            brackets.DIALOG_ID_ERROR,
+            Strings.ERROR_SAVING_FILE_TITLE,
+            Strings.format(
+                Strings.ERROR_SAVING_FILE,
+                path,
+                EditorUtils.getFileErrorString(code)
+            )
         );
     }
 

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -2,7 +2,7 @@
  * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, undef: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define: false, $: false, brackets: false, PathUtils: false */
 
 define(function (require, exports, module) {

--- a/src/KeyBindingManager.js
+++ b/src/KeyBindingManager.js
@@ -5,8 +5,10 @@
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define: false */
 
-define(function(require, exports, module) {
-    CommandManager = require("CommandManager");
+define(function (require, exports, module) {
+    'use strict';
+    
+    var CommandManager = require("CommandManager");
 
     // TODO: Move KeyMap into separate module
     
@@ -24,7 +26,7 @@ define(function(require, exports, module) {
          *
          * @param {KeyMap} keymap The keymap to install.
          */
-        installKeymap: function(keymap) {
+        installKeymap: function (keymap) {
             this._keymap = keymap;
         },
 
@@ -34,11 +36,11 @@ define(function(require, exports, module) {
          * @param {string} A key-description string.
          * @return {boolean} true if the key was processed, false otherwise
          */
-        handleKey: function(key) {
+        handleKey: function (key) {
             if (this._keymap && this._keymap.map[key]) {
                 CommandManager.execute(this._keymap.map[key]);
                 return true;
-            }        
+            }
             return false;
         }
     };
@@ -60,10 +62,10 @@ define(function(require, exports, module) {
      * @constructor
      * @param {map} map An object mapping key-description strings to command IDs.
      */
-    var KeyMap = function(map) {
+    var KeyMap = function (map) {
         if (map === undefined) {
             throw new Error("All parameters to the KeyMap constructor must be specified");
-        }    
+        }
         this.map = map;
     };
     


### PR DESCRIPTION
@gruehle 

Mostly just whitespace issues, but I also did a fair amount of reordering in FileCommandHandlers.js, which makes the diffs a bit hard to read.

There was also one bona-fide bug that @peterflynn should probably look at. On FileCommandHandlers.js line 396, it used to set `promptOnly: promptOnly`, but it looks like a refactoring occurred at some point and this should have been changed to `promptOnly: commandData.promptOnly`. I went ahead and changed it--please double-check that this is ok.
