### PR TITLE
Set focus to the editor when switching docs, even if it's a no-op

### DIFF
--- a/src/FileViewController.js
+++ b/src/FileViewController.js
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
     // Load dependent modules
     var DocumentManager     = require("DocumentManager"),
         CommandManager      = require("CommandManager"),
+        EditorManager       = require("EditorManager"),
         Commands            = require("Commands");
 
     /** 
@@ -97,6 +98,8 @@ define(function (require, exports, module) {
         var curDoc = DocumentManager.getCurrentDocument();
         if (curDoc && curDoc === doc) {
             $(exports).triggerHandler("documentSelectionFocusChange");
+            // Ensure the editor has focus even though we didn't open a new file.
+            EditorManager.focusEditor();
             result = (new $.Deferred()).resolve();
         } else {
             result = CommandManager.execute(Commands.FILE_OPEN, {fullPath: fullPath});


### PR DESCRIPTION
@peterflynn 

For #127, when switching documents in FileViewController.openAndSelectDocument(), force focus back to the editor even if we're switching to the current document.

Not entirely sure this is the right place to fix this, but it makes sense to me that the semantics of this function should guarantee that the editor is focused afterwards.
