### PR TITLE
Added proper default shortcuts for Find Next/Find Prev/Replace on Windows

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -146,7 +146,10 @@ define(function(require, exports, module) {
                     "Delete" : function(instance) {
                         if (!_handleSoftTabNavigation(instance, 1, "deleteH"))
                             CodeMirror.commands.delCharRight(instance);
-                    }
+                    },
+                    "F3": "findNext", 
+                    "Shift-F3": "findPrev", 
+                    "Ctrl-H": "replace"
                 }
             });
             


### PR DESCRIPTION
@gruehle 

For #142, added F3/Shift-F3/Ctrl-H as the proper default shortcuts for Find Next/Find Prev/Replace on Windows. Note that I just added these to extraKeys--I didn't unbind the CodeMirror defaults for these since it seems harmless to leave them in for now. That said, one could make the argument that the CodeMirror Windows keymap defaults are just wrong and should be replaced in the core code...but I'd like to avoid random changes to core CodeMirror code for now.
