### PR TITLE
Add a comment to LESS explaining how to change code line height

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -67,6 +67,13 @@
     color: @content-color;
     font-size: 15px;
     font-family: InconsolataMedium;
+
+    // Note: Large changes in font-size will also require setting
+    // a <pre> element line-height. That can be done like this:
+    //
+    // pre {
+    //     line-height: 50px;
+    // }
 }
 
 .code-cursor() {


### PR DESCRIPTION
@njx 

I spent far too much time today trying to figure out how to make the font big in CodeMirror and have it still work properly (not for Brackets, for something else).

It turns out that, if one makes the font relatively large, the "pre" tag line height isn't big enough and all the code lines overlap.

So, I added a comment to the appropriate place in the LESS files about how to change the "pre" height. Using this change, one can make, e.g., the font 30px high and the line height 50px high, and everything works.

As we contribute to CodeMirror, we should probably test that adjusting "pre" height doesn't break things.

Let me know if there's another place I should document this.
