### PR TITLE
Ignore readFile() errors in FileWriter constructor.

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -198,7 +198,10 @@ define(function (require, exports, module) {
             var self = this;
 
             brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
-                // Ignore error. It's okay if the file doesn't exist yet.
+                // Ignore FILE_NOT_FOUND errors. It's okay if the file doesn't exist yet.
+                if (err !== brackets.fs.ERR_NOT_FOUND) {
+                    self._err = err;
+                }
                 
                 if (contents) {
                     self._length = contents.length;

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -198,8 +198,8 @@ define(function (require, exports, module) {
             var self = this;
 
             brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
-                self._err = err;
-
+                // Ignore error. It's okay if the file doesn't exist yet.
+                
                 if (contents) {
                     self._length = contents.length;
                 }

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
             var self = this;
 
             brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
-                // Ignore FILE_NOT_FOUND errors. It's okay if the file doesn't exist yet.
+                // Ignore "file not found" errors. It's okay if the file doesn't exist yet.
                 if (err !== brackets.fs.ERR_NOT_FOUND) {
                     self._err = err;
                 }


### PR DESCRIPTION
The FileWriter constructer calls readFile to get the current file length. If the file doesn't exist, readFile returns an error. This is okay since the subsequent writeFile will create the file if needed.

Fixes adobe/brackets-app#42
