### PR TITLE
Fix for issue #191 (UI left unusable if two dialogs are shown too close together in time)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -77,8 +77,14 @@ define(function (require, exports, module) {
 
         function dismissDialog(buttonId) {
             dlg.one("hidden", function () {
-                result.resolve(buttonId);
+                // Let call stack return before notifying that dialog has closed; this avoids issue #191
+                // if the handler we're triggering might show another dialog (as long as there's no
+                // fade-out animation)
+                setTimeout(function () {
+                    result.resolve(buttonId);
+                }, 0);
             });
+            
             dlg.modal(true).hide();
         }
         // Click handler for buttons

--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,7 @@
     </div>
 
     <!-- Modal Windows -->
-    <div id="error-dialog" class="modal hide fade">
+    <div id="error-dialog" class="modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Error</h3>
@@ -138,7 +138,7 @@
             <a href="#" class="dialog-button btn primary" data-button-id="ok">OK</a>
         </div>
     </div>
-    <div id="save-close-dialog" class="modal hide fade">
+    <div id="save-close-dialog" class="modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Save Changes</h3>

--- a/src/widgets/bootstrap-modal.js
+++ b/src/widgets/bootstrap-modal.js
@@ -144,15 +144,13 @@
   }
 
   function hideModal (that) {
-    this.$element.hide()
+    this.$element
+      .hide()
+      .trigger('hidden')
+
     backdrop.call(this)
-    
-    // pflynn: Moved this after the backdrop.call(). If the client code's 'hidden' event listener
-    // might try to open another dialog, we really want to be 100% finished with closing this one
-    // before we let that code run.
-    this.$element.trigger('hidden')
   }
-  
+
   function backdrop ( callback ) {
     var that = this
       , animate = this.$element.hasClass('fade') ? 'fade' : ''

--- a/src/widgets/bootstrap-modal.js
+++ b/src/widgets/bootstrap-modal.js
@@ -144,13 +144,15 @@
   }
 
   function hideModal (that) {
-    this.$element
-      .hide()
-      .trigger('hidden')
-
+    this.$element.hide()
     backdrop.call(this)
+    
+    // pflynn: Moved this after the backdrop.call(). If the client code's 'hidden' event listener
+    // might try to open another dialog, we really want to be 100% finished with closing this one
+    // before we let that code run.
+    this.$element.trigger('hidden')
   }
-
+  
   function backdrop ( callback ) {
     var that = this
       , animate = this.$element.hasClass('fade') ? 'fade' : ''


### PR DESCRIPTION
Bootstrap has numerous timing issues where dialogs break if one is shown while another's fade-out animation is still playing. We can avoid most of those by removing the "fade" CSS style that causes the animation from all our dialogs.

There's still one remaining Bootstrap bug, if a dialog is shown synchronously after another one was hidden. The last notification that Bootstrap sends out when closing a dialog is "hidden" - but that's not the last task it performs. So anyone who responds to "hidden" by showing another dialog will try to show it while Bootstrap is still in the midst of hiding the last one. The fix is to reorder Bootstrap's hideModal() so that dispatching "hidden" is truly the very last thing that happens.

Note: this still leaves issue #187 unfixed (showModalDialog() breaks if dialogs are ever stacked or shown sequentially too quickly). The only way around that is to rearchitect our dialogs so that two instances of the same type of dialog don't share the same chunk of the DOM.
