### PR TITLE
changing how we load the core namespace in brackets.js

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -28,9 +28,12 @@ define(function (require, exports, module) {
         Commands                = require("Commands"),
         CommandManager          = require("CommandManager");
 
-    // Define core brackets namespace
-    brackets = window.brackets || {};
-
+    // Define core brackets namespace                                                                                                                         
+    if (!window.brackets) {
+        window.brackets = {};
+    }
+    var brackets = window.brackets;
+    
     // TODO: Make sure the "test" object is not included in final builds
     // All modules that need to be tested from the context of the application
     // must to be added to this object. The unit tests cannot just pull

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -30,10 +30,10 @@ define(function (require, exports, module) {
 
     // Define core brackets namespace if it isn't already defined
     //
-    // We can't simply refer do 'brackets = {}' to define it in the global namespace because
+    // We can't simply do 'brackets = {}' to define it in the global namespace because
     // we're in "use strict" mode. Most likely, 'window' will always point to the global
-    // object when this code is running. However, in case it isn't (e.g. running inside
-    // Node for CI testing) we use this trick to get the global object.
+    // object when this code is running. However, in case it isn't (e.g. if we're running 
+    // inside Node for CI testing) we use this trick to get the global object.
     //
     // Taken from:
     //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         Commands                = require("Commands"),
         CommandManager          = require("CommandManager");
 
-    // Define core brackets namespace                                                                                                                         
+    // Define core brackets namespace
     if (!window.brackets) {
         window.brackets = {};
     }

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -28,11 +28,19 @@ define(function (require, exports, module) {
         Commands                = require("Commands"),
         CommandManager          = require("CommandManager");
 
-    // Define core brackets namespace
-    if (!window.brackets) {
-        window.brackets = {};
+    // Define core brackets namespace if it isn't already defined
+    //
+    // We can't simply refer do 'brackets = {}' to define it in the global namespace because
+    // we're in "use strict" mode. Most likely, 'window' will always point to the global
+    // object when this code is running. However, in case it isn't (e.g. running inside
+    // Node for CI testing) we use this trick to get the global object.
+    //
+    // Taken from:
+    //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
+    var Fn = Function, global = (new Fn('return this'))();
+    if (!global.brackets) {
+        global.brackets = {};
     }
-    var brackets = window.brackets;
     
     // TODO: Make sure the "test" object is not included in final builds
     // All modules that need to be tested from the context of the application


### PR DESCRIPTION
@gruehle I think this was a bug that was masked by something going on with brackets-app's JS interface.

the old code didn't work when running brackets in the browser. also, the old code created the intended-to-be-local variable "brackets" without "var", which didn't pop up as a jslint error because "brackets" is set to be a global in the jslint options.

anyway, the old version of the code didn't work properly (i.e. didn't create window.brackets) when running brackets in the browser. My (unconfirmed) hypothesis is that brackets-app creates window.brackets before brackets.js is loaded.

the new code works both in brackets-app and in the browser.
