### PR TITLE
Don't assume we have at least one entry when reading a directory

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -524,26 +524,26 @@ define(function (require, exports, module) {
             if (!err) {
                 var entries = [];
                 var filelistIterator = function (i) {
-                    var item = filelist[i];
-                    var itemFullPath = rootPath + "/" + item;
-                    brackets.fs.stat(itemFullPath, function (statErr, statData) {
-                        if (!statErr) {
-
-                            if (statData.isDirectory()) {
-                                entries.push(new NativeFileSystem.DirectoryEntry(itemFullPath));
-                            } else if (statData.isFile()) {
-                                entries.push(new NativeFileSystem.FileEntry(itemFullPath));
-                            }
-
-                            if (i < filelist.length - 1) {
+                    if (i >= filelist.length) {
+                        successCallback(entries);
+                    } else {
+                        var item = filelist[i];
+                        var itemFullPath = rootPath + "/" + item;
+                        brackets.fs.stat(itemFullPath, function (statErr, statData) {
+                            if (!statErr) {
+    
+                                if (statData.isDirectory()) {
+                                    entries.push(new NativeFileSystem.DirectoryEntry(itemFullPath));
+                                } else if (statData.isFile()) {
+                                    entries.push(new NativeFileSystem.FileEntry(itemFullPath));
+                                }
+    
                                 filelistIterator(i + 1);
-                            } else {
-                                successCallback(entries);
+                            } else if (errorCallback) {
+                                errorCallback(NativeFileSystem._nativeToFileError(statErr));
                             }
-                        } else if (errorCallback) {
-                            errorCallback(NativeFileSystem._nativeToFileError(statErr));
-                        }
-                    });
+                        });
+                    }
                 };
                 filelistIterator(0);
             } else {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -48,20 +48,20 @@ define(function (require, exports, module) {
 
             it("should read a directory from disk", function () {
                 var entries = null;
-                var readComplete = false;
+                var readComplete = false, gotError = false;
                 
                 function requestNativeFileSystemSuccessCB(nfs) {
                     var reader = nfs.createReader();
 
                     var successCallback = function (e) { entries = e; readComplete = true; };
-                    // TODO: not sure what parameters error callback will take because it's not implemented yet
-                    var errorCallback = function () { readComplete = true; };
+                    var errorCallback = function () { readComplete = true; gotError = true; };
 
                     reader.readEntries(successCallback, errorCallback);
 
                     waitsFor(function () { return readComplete; }, 1000);
 
                     runs(function () {
+                        expect(gotError).toBe(false);
                         expect(entries).toContainDirectoryWithName("dir1");
                         expect(entries).toContainFileWithName("file1");
                         expect(entries).not.toContainFileWithName("file2");
@@ -122,6 +122,29 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(entries).not.toBe(null);
                 });
+            });
+            
+            it("can read an empty folder", function () {
+                var entries = null;
+                var readComplete = false, gotError = false;
+                
+                function requestNativeFileSystemSuccessCB(nfs) {
+                    var reader = nfs.createReader();
+
+                    var successCallback = function (e) { entries = e; readComplete = true; };
+                    var errorCallback = function () { readComplete = true; gotError = true; };
+
+                    reader.readEntries(successCallback, errorCallback);
+
+                    waitsFor(function () { return readComplete; }, 1000);
+
+                    runs(function () {
+                        expect(gotError).toBe(false);
+                        expect(entries).toEqual([]);
+                    });
+                }
+                
+                var nfs = NativeFileSystem.requestNativeFileSystem(this.path + "/emptydir", requestNativeFileSystemSuccessCB);
             });
         });
 


### PR DESCRIPTION
@joelrbrandt 

The new code in readEntries() that handles asynchronicity better assumes that there's at least one entry in the folder. This fixes that.

I'm not totally sure if this is the best way to fix the logic. A slightly less invasive fix would have been to simply check early if there are no file entries, and return [] in that case. However, I thought it might be better to make the iterator stop when it gets "past the end", instead of when it's right before the end. But I don't really know if this is more or less elegant.

(Unfortunately the diff is hard to read. The effective change was to move the test for whether to call the successCallback from after processing the entry to before processing it. Probably better to just look at the function in its entirety rather than the diff.)

I also added a unit test for this case, but can't test it because the unit tests are failing on Windows and (for me) crashing on the Mac. So if this gets pulled next week while I'm out, please verify that my unit test seems correct too.
