### PR TITLE
parallelize directory reading, and also make directory reading work for empty directories

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -12,6 +12,11 @@ define(function (require, exports, module) {
 
     var NativeFileSystem = {
         
+        /** Amount of time we wait for async calls to return (in milliseconds)
+         * TODO: Not all async calls are wrapped with something that times out and calls the error callback
+         * @const
+         * @type {number}
+         */
         ASYNC_TIMEOUT: 2000,
         
         /** showOpenDialog

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -3,7 +3,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50*/
-/*global define: false, brackets: true, FileError: false, InvalidateStateError: false */
+/*global $: false, define: false, brackets: true, FileError: false, InvalidateStateError: false */
 
 define(function (require, exports, module) {
     'use strict';
@@ -517,36 +517,47 @@ define(function (require, exports, module) {
      * @param {function(...)} errorCallback
      * @returns {Array.<Entry>}
      */
-    // TODO: Parallelize the XHRs using something like Promises?
     NativeFileSystem.DirectoryReader.prototype.readEntries = function (successCallback, errorCallback) {
         var rootPath = this._directory.fullPath;
         brackets.fs.readdir(rootPath, function (err, filelist) {
             if (!err) {
-                var entries = [];
-                var filelistIterator = function (i) {
-                    if (i >= filelist.length) {
-                        successCallback(entries);
-                    } else {
-                        var item = filelist[i];
-                        var itemFullPath = rootPath + "/" + item;
-                        brackets.fs.stat(itemFullPath, function (statErr, statData) {
-                            if (!statErr) {
-    
-                                if (statData.isDirectory()) {
-                                    entries.push(new NativeFileSystem.DirectoryEntry(itemFullPath));
-                                } else if (statData.isFile()) {
-                                    entries.push(new NativeFileSystem.FileEntry(itemFullPath));
-                                }
-    
-                                filelistIterator(i + 1);
-                            } else if (errorCallback) {
-                                errorCallback(NativeFileSystem._nativeToFileError(statErr));
-                            }
-                        });
-                    }
+                var i, entries = [], d, deferreds = [];
+
+                // create the function that will be used to create inidividual functions
+                // for each deferred that add the entry in the right place in the entries array
+                var genAddToArrayFunction = function (a, i) {
+                    return function (v) { entries[i] = v; };
                 };
-                filelistIterator(0);
-            } else {
+
+                // the function that stats individual entires.
+                // takes the item's full path and the deferred to resolve with
+                var statEntry = function (itemFullPath, d) {
+                    brackets.fs.stat(itemFullPath, function (statErr, statData) {
+                        if (!statErr) {
+                            if (statData.isDirectory()) {
+                                d.resolve(new NativeFileSystem.DirectoryEntry(itemFullPath));
+                            } else if (statData.isFile()) {
+                                d.resolve(new NativeFileSystem.FileEntry(itemFullPath));
+                            }
+                        } else if (errorCallback) {
+                            d.reject(NativeFileSystem._nativeToFileError(statErr));
+                        }
+                    });
+                };
+                
+                // create all the deferreds, and start the work executing!
+                for (i = 0; i < filelist.length; i++) {
+                    d = new $.Deferred();
+                    d.done(genAddToArrayFunction(entries, i));
+                    deferreds.push(d);
+                    statEntry(rootPath + "/" + filelist[i], d);
+                }
+
+                // wait until they're all done or an error occurs.
+                $.when.apply(this, deferreds).then(function () { successCallback(entries); },
+                                                   function (err) { errorCallback(err); });
+
+            } else { // there was an error reading the initial directory
                 errorCallback(NativeFileSystem._nativeToFileError(err));
             }
         });

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -524,26 +524,26 @@ define(function (require, exports, module) {
             if (!err) {
                 var entries = [];
                 var filelistIterator = function (i) {
-                    var item = filelist[i];
-                    var itemFullPath = rootPath + "/" + item;
-                    brackets.fs.stat(itemFullPath, function (statErr, statData) {
-                        if (!statErr) {
-
-                            if (statData.isDirectory()) {
-                                entries.push(new NativeFileSystem.DirectoryEntry(itemFullPath));
-                            } else if (statData.isFile()) {
-                                entries.push(new NativeFileSystem.FileEntry(itemFullPath));
-                            }
-
-                            if (i < filelist.length - 1) {
+                    if (i >= filelist.length) {
+                        successCallback(entries);
+                    } else {
+                        var item = filelist[i];
+                        var itemFullPath = rootPath + "/" + item;
+                        brackets.fs.stat(itemFullPath, function (statErr, statData) {
+                            if (!statErr) {
+    
+                                if (statData.isDirectory()) {
+                                    entries.push(new NativeFileSystem.DirectoryEntry(itemFullPath));
+                                } else if (statData.isFile()) {
+                                    entries.push(new NativeFileSystem.FileEntry(itemFullPath));
+                                }
+    
                                 filelistIterator(i + 1);
-                            } else {
-                                successCallback(entries);
+                            } else if (errorCallback) {
+                                errorCallback(NativeFileSystem._nativeToFileError(statErr));
                             }
-                        } else if (errorCallback) {
-                            errorCallback(NativeFileSystem._nativeToFileError(statErr));
-                        }
-                    });
+                        });
+                    }
                 };
                 filelistIterator(0);
             } else {

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -75,9 +75,7 @@ define(function (require, exports, module) {
         },
 
         _nativeToFileError: function (nativeErr) {
-            // The HTML file spec says SECURITY_ERR is a catch-all to be used in situations
-            // not covered by other error codes. 
-            var error = FileError.SECURITY_ERR;
+            var error;
 
             switch (nativeErr) {
                 // We map ERR_UNKNOWN and ERR_INVALID_PARAMS to SECURITY_ERR,
@@ -537,8 +535,8 @@ define(function (require, exports, module) {
                 // This function is used to create individual functions for each deferred. 
                 // These generated functions will add the async result to the right place 
                 // in the entries array.
-                var genAddToArrayFunction = function (arr, i) {
-                    return function (value) { arr[i] = value; };
+                var genAddToEntriesArrayFunction = function (index) {
+                    return function (value) { entries[index] = value; };
                 };
 
                 // This function is called to initiate the stat on individual entires.
@@ -562,7 +560,7 @@ define(function (require, exports, module) {
                 // Create all the deferreds, and start the work executing!
                 for (i = 0; i < filelist.length; i++) {
                     d = new $.Deferred();
-                    d.done(genAddToArrayFunction(entries, i));
+                    d.done(genAddToEntriesArrayFunction(i));
                     deferreds.push(d);
                     statEntry(rootPath + "/" + filelist[i], d);
                 }

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -57,18 +57,18 @@ define(function (require, exports, module) {
                     var errorCallback = function () { readComplete = true; gotError = true; };
 
                     reader.readEntries(successCallback, errorCallback);
-
-                    waitsFor(function () { return readComplete; }, 1000);
-
-                    runs(function () {
-                        expect(gotError).toBe(false);
-                        expect(entries).toContainDirectoryWithName("dir1");
-                        expect(entries).toContainFileWithName("file1");
-                        expect(entries).not.toContainFileWithName("file2");
-                    });
                 }
                 
                 var nfs = NativeFileSystem.requestNativeFileSystem(this.path, requestNativeFileSystemSuccessCB);
+                
+                waitsFor(function () { return readComplete; }, 1000);
+
+                runs(function () {
+                    expect(gotError).toBe(false);
+                    expect(entries).toContainDirectoryWithName("dir1");
+                    expect(entries).toContainFileWithName("file1");
+                    expect(entries).not.toContainFileWithName("file2");
+                });
             });
 
             it("should return an error if the directory doesn't exist", function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -48,20 +48,20 @@ define(function (require, exports, module) {
 
             it("should read a directory from disk", function () {
                 var entries = null;
-                var readComplete = false;
+                var readComplete = false, gotError = false;
                 
                 function requestNativeFileSystemSuccessCB(nfs) {
                     var reader = nfs.createReader();
 
                     var successCallback = function (e) { entries = e; readComplete = true; };
-                    // TODO: not sure what parameters error callback will take because it's not implemented yet
-                    var errorCallback = function () { readComplete = true; };
+                    var errorCallback = function () { readComplete = true; gotError = true; };
 
                     reader.readEntries(successCallback, errorCallback);
 
                     waitsFor(function () { return readComplete; }, 1000);
 
                     runs(function () {
+                        expect(gotError).toBe(false);
                         expect(entries).toContainDirectoryWithName("dir1");
                         expect(entries).toContainFileWithName("file1");
                         expect(entries).not.toContainFileWithName("file2");
@@ -122,6 +122,29 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(entries).not.toBe(null);
                 });
+            });
+            
+            it("can read an empty folder", function () {
+                var entries = null;
+                var readComplete = false, gotError = false;
+                
+                function requestNativeFileSystemSuccessCB(nfs) {
+                    var reader = nfs.createReader();
+
+                    var successCallback = function (e) { entries = e; readComplete = true; };
+                    var errorCallback = function () { readComplete = true; gotError = true; };
+
+                    reader.readEntries(successCallback, errorCallback);
+
+                    waitsFor(function () { return readComplete; }, 1000);
+
+                    runs(function () {
+                        expect(gotError).toBe(false);
+                        expect(entries).toEqual([]);
+                    });
+                }
+                
+                var nfs = NativeFileSystem.requestNativeFileSystem(this.path + "/emptydir", requestNativeFileSystemSuccessCB);
             });
         });
 

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -125,8 +125,13 @@ define(function (require, exports, module) {
             });
             
             it("can read an empty folder", function () {
-                // FIXME: (joelrbrandt) if we add NativeFileSystem commands to create a folder, we should
-                // change this test to simply create a new folder (rather than remove a placeholder, etc.)
+                // FIXME: (joelrbrandt) We need an empty folder for testing in this spec. Unfortunately, it's impossible
+                // to check an empty folder in to git, and we don't have low level fs calls to create an emtpy folder.
+                // So, for now, we have a folder called "emptydir" which contains a single 0-length file called
+                // "placeholder". We delete that file at the beginning of each test, and then recreate it at the end.
+                //
+                // If we add NativeFileSystem commands to create a folder, we should change this test to simply create
+                // a new folder (rather than remove a placeholder, etc.)
                 var entries = null;
                 var accessedFolder = false, placeholderDeleted = false, readComplete = false, gotErrorReadingContents = false, placeholderRecreated = false;
 

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -193,6 +193,38 @@ define(function (require, exports, module) {
                     expect(placeholderRecreated).toBe(true);
                 });
             });
+            
+            it("should timeout with error when reading dir if low-level stat call takes too long", function () {
+                var statCalled = false, readComplete = false, gotError = false, theError = null;
+                var oldStat = brackets.fs.stat;
+                this.after(function () { brackets.fs.stat = oldStat; });
+                
+                function requestNativeFileSystemSuccessCB(nfs) {
+                    var reader = nfs.createReader();
+                    
+                    var successCallback = function (e) { readComplete = true; };
+                    var errorCallback = function (error) { readComplete = true; gotError = true; theError = error; };
+
+                    // mock up new low-level stat that never calls the callback
+                    brackets.fs.stat = function (path, callback) {
+                        statCalled = true;
+                    };
+                    
+                    reader.readEntries(successCallback, errorCallback);
+                    
+                }
+                
+                var nfs = NativeFileSystem.requestNativeFileSystem(this.path, requestNativeFileSystemSuccessCB);
+
+                waitsFor(function () { return readComplete; }, NativeFileSystem.ASYNC_TIMEOUT * 2);
+                    
+                runs(function () {
+                    expect(readComplete).toBe(true);
+                    expect(statCalled).toBe(true);
+                    expect(gotError).toBe(true);
+                    expect(theError.code).toBe(FileError.SECURITY_ERR);
+                });
+            });
         });
 
         describe("Reading a file", function () {


### PR DESCRIPTION
@njx 

builds on pull #206 which addresses issue #203

Differences from pull #206:
- async calls to read directory items is now parallelized
- still works for empty directories (not a difference, actually)
- unit test works with what's checked in to git. The unit test deletes a placeholder file to yield an actually empty dir, then reads the dir, then recreates the placeholder
