### PR TITLE
Make windows unit tests run again.

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -6,12 +6,23 @@ define(function (require, exports, module) {
     var TEST_PREFERENCES_KEY = "com.adobe.brackets.test.preferences",
         testWindow;
 
+    function fixPath(path) {
+        // On Windows, when loading from a file, window.location.href has
+        // a leading '/'. Remove that here.
+        // TODO: Figure out a better way to handle this...
+        if (path[0] === '/' && path[2] === ":") {
+            path = path.substr(1);
+        }
+        
+        return path;
+    }
+    
     function getTestRoot() {
         // /path/to/brackets/test/SpecRunner.html
         var path = window.location.href;
         path = path.substr("file://".length);
         path = path.substr(0, path.lastIndexOf("/"));
-
+        path = fixPath(path);
         return path;
     }
     

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -10,7 +10,7 @@ define(function (require, exports, module) {
         // On Windows, when loading from a file, window.location.href has
         // a leading '/'. Remove that here.
         // TODO: Figure out a better way to handle this...
-        if (path[0] === '/' && path[2] === ":") {
+        if (path.length > 3 && path[0] === '/' && path[2] === ":") {
             path = path.substr(1);
         }
         


### PR DESCRIPTION
This is the brackets work to get Windows unit tests to run again. Note that this does _not_ fix all unit tests, it just makes it possible to run them.

This change removes the initial '/' from full path names on Windows. For example "/C:/Users/Glenn/.." is changed to "C:/Users/Glenn/..".

There is an associated pull request in brackets-app to fix a couple more issues. With both sets of changes, the number of unit test failures on Windows is reduced to 5 or 6 (6 with a clean pull, 5 on subsequent runs).
