### PR TITLE
FOR REVIEW: Work around as part of investigating bugs #99 and #149

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -293,6 +293,18 @@ define(function (require, exports, module) {
                 _projectInitialLoad.fullPathToIdMap[entry.fullPath] = jsonEntry.attr.id;
             }
         }
+
+        // FIXME: (joelrbrandt) Right now, this is a hack to put something in the
+        // subtree for empty directories
+        if (jsonEntryList.length === 0) {
+            jsonEntryList.push({
+                data: "Empty directory",
+                attr: { id: "node" + _projectInitialLoad.id++ },
+                metadata: { entry: { isDirectory: false, isFile: false } }
+            });
+        }
+        // END OF HACK
+        
         return jsonEntryList;
     }
 


### PR DESCRIPTION
This patch adds a work-around for displaying empty folders in the project tree.

Whenever there is an empty folder, it creates a new child node of that folder in the UI that says "Empty Folder". This element is set to return false for both isFile and isDirectory.

Other than the fact that we don't want this item in the tree, it appears to fix bugs #99 and #149. When this is present, expanding the empty folder works without error and new files can be created in the empty folder.
