### PR TITLE
fixes issue #140

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -442,8 +442,9 @@ define(function (require, exports, module) {
     NativeFileSystem.DirectoryEntry.prototype.getFile = function (path, options, successCallback, errorCallback) {
         var fileFullPath = path;
         
-        // assume relative paths are relative to this directory
-        if (path.charAt(0) !== '/') {
+        // resolve relative paths relative to the DirectoryEntry
+        // most abololute paths have a leading slash except Windows which has a driver letter followed by :/
+        if (path.charAt(0) !== '/' && path.charAt(1) != ":") {
             fileFullPath = this.fullPath + "/" + path;
         }
 


### PR DESCRIPTION
 NativeFileSystem.DirectoryEntry.prototype.getFile was incorrectly thinking Windows absolute paths where relative and was prepending the directory path.
