### PR TITLE
Fix #205

### DIFF
--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -186,7 +186,10 @@ define(function (require, exports, module) {
 
                     // TODO (jasonsj): edit menu undo/redo commands
                     editor.undo();
+                    expect(doc.getText()).toBe(TEST_JS_CONTENT);
+                    
                     editor.redo();
+                    expect(doc.getText()).toBe(TEST_JS_NEW_CONTENT);
                     
                     expect(doc.isDirty).toBe(true);
                 });

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -171,11 +171,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     // change editor content
                     editor.setValue(TEST_JS_NEW_CONTENT);
-                });
-                
-                waitsFor(function () { return editor.getValue() === TEST_JS_NEW_CONTENT; }, 1000);
-                
-                runs(function () {
+                    
                     // verify Document dirty status
                     expect(doc.isDirty).toBe(true);
                 });
@@ -190,13 +186,8 @@ define(function (require, exports, module) {
                     editor.setValue(TEST_JS_NEW_CONTENT);
 
                     editor.undo();
-                });
-                
-                waitsFor(function () { return editor.getValue() === TEST_JS_CONTENT; }, 1000);
-                
-                runs(function () {
-                    // verify Document dirty status
                     editor.redo();
+                    
                     expect(editor.getValue()).toBe(TEST_JS_NEW_CONTENT);
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(true);
                 });
@@ -209,11 +200,6 @@ define(function (require, exports, module) {
                 runs(function () {
                     doc.setText(TEST_JS_NEW_CONTENT);
                     doc._markClean();
-                });
-                
-                waitsFor(function () { return editor.getValue() === TEST_JS_NEW_CONTENT; }, 1000);
-                
-                runs(function () {
                     expect(doc.isDirty).toBe(false);
                 });
             });

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -166,11 +166,10 @@ define(function (require, exports, module) {
             
             it("should report dirty when modified", function () {
                 var doc = DocumentManager.getCurrentDocument();
-                var editor = doc._editor;
                 
                 runs(function () {
                     // change editor content
-                    editor.setValue(TEST_JS_NEW_CONTENT);
+                    doc.setText(TEST_JS_NEW_CONTENT);
                     
                     // verify Document dirty status
                     expect(doc.isDirty).toBe(true);
@@ -183,19 +182,18 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     // change editor content, followed by undo and redo
-                    editor.setValue(TEST_JS_NEW_CONTENT);
+                    doc.setText(TEST_JS_NEW_CONTENT);
 
+                    // TODO (jasonsj): edit menu undo/redo commands
                     editor.undo();
                     editor.redo();
                     
-                    expect(editor.getValue()).toBe(TEST_JS_NEW_CONTENT);
-                    expect(DocumentManager.getCurrentDocument().isDirty).toBe(true);
+                    expect(doc.isDirty).toBe(true);
                 });
             });
             
-            it("should report clean after being marked clean", function () {
+            it("should report not dirty after explicit clean", function () {
                 var doc = DocumentManager.getCurrentDocument();
-                var editor = doc._editor;
                 
                 runs(function () {
                     doc.setText(TEST_JS_NEW_CONTENT);

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -165,35 +165,36 @@ define(function (require, exports, module) {
             });
             
             it("should report dirty when modified", function () {
+                var doc = DocumentManager.getCurrentDocument();
+                var editor = doc._editor;
+                
                 runs(function () {
                     // change editor content
-                    var editor = DocumentManager.getCurrentDocument()._editor;
                     editor.setValue(TEST_JS_NEW_CONTENT);
-
+                });
+                
+                waitsFor(function () { return editor.getValue() === TEST_JS_NEW_CONTENT; }, 1000);
+                
+                runs(function () {
                     // verify Document dirty status
-                    expect(editor.getValue()).toBe(TEST_JS_NEW_CONTENT);
-                    expect(DocumentManager.getCurrentDocument().isDirty).toBe(true);
-
-                    // FIXME (jasonsj): Even with the main app window reloaded, and
-                    // proper jasmine async handling, some state is being held.
-                    // Without this undo, *any* immediate test will timeout for
-                    // Commands.FILE_OPEN. I had to re-order this suite so that
-                    // this bug has minimal impact. This *does not* appear to be an
-                    // issue with the FileCommandHandlers module.
-                    // FIXME (jasonsj): editor.clearHistory() doesn't work either.
-                    editor.undo();
+                    expect(doc.isDirty).toBe(true);
                 });
             });
 
             it("should report dirty after undo and redo", function () {
+                var doc = DocumentManager.getCurrentDocument();
+                var editor = doc._editor;
+                
                 runs(function () {
                     // change editor content, followed by undo and redo
-                    var editor = DocumentManager.getCurrentDocument()._editor;
                     editor.setValue(TEST_JS_NEW_CONTENT);
 
                     editor.undo();
-                    expect(editor.getValue()).toBe(TEST_JS_CONTENT);
-
+                });
+                
+                waitsFor(function () { return editor.getValue() === TEST_JS_CONTENT; }, 1000);
+                
+                runs(function () {
                     // verify Document dirty status
                     editor.redo();
                     expect(editor.getValue()).toBe(TEST_JS_NEW_CONTENT);
@@ -202,11 +203,18 @@ define(function (require, exports, module) {
             });
             
             it("should report clean after being marked clean", function () {
+                var doc = DocumentManager.getCurrentDocument();
+                var editor = doc._editor;
+                
                 runs(function () {
-                    var document = DocumentManager.getCurrentDocument();
-                    document.setText(TEST_JS_NEW_CONTENT);
-                    document.markClean();
-                    expect(document.isDirty).toBe(false);
+                    doc.setText(TEST_JS_NEW_CONTENT);
+                    doc.markClean();
+                });
+                
+                waitsFor(function () { return editor.getValue() === TEST_JS_NEW_CONTENT; }, 1000);
+                
+                runs(function () {
+                    expect(doc.isDirty).toBe(false);
                 });
             });
 

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -41,20 +41,11 @@ define(function (require, exports, module) {
     function closeTestWindow() {
         // debug-only to see testWindow state before closing
         // waits(500);
-        var testWindowClosed = false;
         
         runs(function () {
-            // unload callback
-            testWindow.$(testWindow).unload(function () {
-                testWindowClosed = true;
-            });
-            
             testWindow.close();
-            
             testWindow = null;
         });
-        
-        waitsFor(function () { return testWindowClosed; }, "testWindow.close()", 1000);
     }
 
     function createTestWindowAndRun(spec, callback) {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -38,9 +38,26 @@ define(function (require, exports, module) {
         return path.join("/");
     }
 
-    function createTestWindowAndRun(spec, callback) {
-        var isReady = false;
+    function closeTestWindow() {
+        // debug-only to see testWindow state before closing
+        // waits(500);
+        var testWindowClosed = false;
+        
+        runs(function () {
+            // unload callback
+            testWindow.$(testWindow).unload(function () {
+                testWindowClosed = true;
+            });
+            
+            testWindow.close();
+            
+            testWindow = null;
+        });
+        
+        waitsFor(function () { return testWindowClosed; }, "testWindow.close()", 1000);
+    }
 
+    function createTestWindowAndRun(spec, callback) {
         runs(function () {
             testWindow = window.open(getBracketsSourceRoot() + "/index.html");
         });
@@ -56,15 +73,6 @@ define(function (require, exports, module) {
         runs(function () {
             // callback allows specs to query the testWindow before they run
             callback.call(spec, testWindow);
-        });
-    }
-
-    function closeTestWindow() {
-        // debug-only to see testWindow state before closing
-        // waits(500);
-
-        runs(function () {
-            testWindow.close();
         });
     }
 

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -39,8 +39,6 @@ define(function (require, exports, module) {
     }
 
     function createTestWindowAndRun(spec, callback) {
-        var isReady = false;
-
         runs(function () {
             testWindow = window.open(getBracketsSourceRoot() + "/index.html");
         });

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -112,18 +112,34 @@ define(function (require, exports, module) {
             runs(function () {
                 localStorage.setItem("doLoadPreferences", true);
             });
+            
+            // remove temporary unit test preferences with a single-spec after() 
+            this.after(function () {
+                localStorage.removeItem("doLoadPreferences");
+            });
 
-            // close test window while working set has 2 files
+            // close test window while working set has 2 files (see beforeEach())
             SpecRunnerUtils.closeTestWindow();
 
-            // reopen without loading a project
+            // reopen brackets test window to initialize unit test working set
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
             });
+            
+            var listItems;
+            
+            // wait for working set to populate
+            waitsFor(
+                function () {
+                    // check working set UI list content
+                    listItems = testWindow.$("#open-files-container > ul").children();
+                    return listItems.length > 0;
+                },
+                1000
+            );
 
             // files should be in the working set
             runs(function () {
-                var listItems = testWindow.$("#open-files-container > ul").children();
                 expect(listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
                 expect(listItems.find("a").get(1).text === "file_two.js").toBeTruthy();
 
@@ -132,8 +148,6 @@ define(function (require, exports, module) {
 
                 // file_two.js should be active
                 expect($(listItems[1]).hasClass("selected")).toBeTruthy();
-
-                localStorage.removeItem("doLoadPreferences", true);
             });
         });
         


### PR DESCRIPTION
Fix timing issue in working set unit tests. Add waitsFor() block to wait for working set UI to be fully initialized before validation.
Use single-spec after() to cleanup temporary preferences.
Cleanup FileCommandHandlers dirty bit unit tests, remove stale comments.
