### PR TITLE
don't show the working set files initially, wait until a file is added

### DIFF
--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -28,11 +28,9 @@ define(function (require, exports, module) {
 
     function _hideShowOpenFileHeader() {
         if (DocumentManager.getWorkingSet().length === 0) {
-            $("#open-files-header").hide();
-            $("#open-files-divider").hide();
+            $("#open-files-section").hide();
         } else {
-            $("#open-files-header").show();
-            $("#open-files-divider").show();
+            $("#open-files-section").show();
         }
     }
     

--- a/src/brackets.less
+++ b/src/brackets.less
@@ -158,7 +158,7 @@ a, img {
     }
 }
 
-#project-file-area {
+#file-section {
     .vbox;
     .box-flex(1);
     margin: 5px 0px 5px 0px;
@@ -217,6 +217,11 @@ a, img {
             }             
         }        
     }
+}
+
+//Initially start with the open files hidden, they will get show as files are added
+#open-files-section {
+    display:none;
 }
 
 #project-files-container {

--- a/src/index.html
+++ b/src/index.html
@@ -76,29 +76,32 @@
                     <!-- <select class="picker"></select>  -->
                 </div>
                 
-                <div id="project-file-area">
-                    <div id="open-files-header" class="project-file-header-area">
-                        <span id="open-files-disclosure-arrow" class="disclosure-arrow-opened"></span>
-                        <span>Open Files</span>
-                    </div>   
-                    
-                    <div id="open-files-container">
-                        <!-- This will contain a dynamically generated <ul> at runtime -->
-                        <ul>
-                        </ul>
-                    </div>
-                    
-                    <div id="open-files-divider" class="file-list-divider"></div>
-                    
-                    <div id="project-files-header" class="project-file-header-area">
-                        <div id="project-files-disclosure-arrow" class="disclosure-arrow-opened">
+                <div id="file-section">
+                    <div id="open-files-section">
+                        <div id="open-files-header" class="project-file-header-area">
+                            <span id="open-files-disclosure-arrow" class="disclosure-arrow-opened"></span>
+                            <span>Open Files</span>
+                        </div>   
+                        
+                        <div id="open-files-container">
+                            <!-- This will contain a dynamically generated <ul> at runtime -->
+                            <ul>
+                            </ul>
                         </div>
-                        <span>Project Files</span>
-                    </div>
-                    <div id="project-files-container">
-                    <!-- This will contain a dynamically generated <ul> hierarchy at runtime -->
+                        
+                        <div id="open-files-divider" class="file-list-divider"></div>
                     </div>
                     
+                    <div id="project-file-section">
+                        <div id="project-files-header" class="project-file-header-area">
+                            <div id="project-files-disclosure-arrow" class="disclosure-arrow-opened">
+                            </div>
+                            <span>Project Files</span>
+                        </div>
+                        <div id="project-files-container">
+                        <!-- This will contain a dynamically generated <ul> hierarchy at runtime -->
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This fixes issue #129 by not showing the working files on launch and waiting until we add files. The index.html didn't diff well, but I basically just wrapped the working files and project files sections in a div show I could show and hide them together. 
