### PR TITLE
Allow empty files to be written again.

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
 
         // TODO (jasonsj): handle Blob data instead of string
         FileWriter.prototype.write = function (data) {
-            if (!data) {
+            if (data === null || data === undefined) {
                 throw new Error();
             }
 

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -578,12 +578,19 @@ define(function (require, exports, module) {
 
                 waitsFor(function () { return !!actualContents; }, 1000);
 
+                var rewriteComplete = false;
+                
                 runs(function () {
                     expect(actualContents).toEqual("FileWriter.write");
 
                     // reset file1 content
-                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8");
+                    // reset file1 content
+                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8", function () {
+                        rewriteComplete = true;
+                    });
                 });
+                
+                waitsFor(function () { return rewriteComplete; }, 1000);
             });
 
 
@@ -628,12 +635,18 @@ define(function (require, exports, module) {
 
                 waitsFor(function () { return (actualContents !== null); }, 1000);
 
+                var rewriteComplete = false;
+                
                 runs(function () {
                     expect(actualContents).toEqual("");
 
                     // reset file1 content
-                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8");
+                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8", function () {
+                        rewriteComplete = true;
+                    });
                 });
+                
+                waitsFor(function () { return rewriteComplete; }, 1000);
             });
 
             it("should report an error when writing to a file that cannot be read", function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -586,6 +586,56 @@ define(function (require, exports, module) {
                 });
             });
 
+
+            it("should write an empty file", function () {
+                var fileEntry = null;
+                var writeComplete = false;
+                var error = null;
+
+                runs(function () {
+                    var successCallback = function (entry) {
+                        fileEntry = entry;
+
+                        fileEntry.createWriter(function (fileWriter) {
+                            fileWriter.onwriteend = function (e) {
+                                writeComplete = true;
+                            };
+                            fileWriter.onerror = function (err) {
+                                writeComplete = true;
+                                error = err;
+                            };
+
+                            // TODO (jasonsj): BlobBulder
+                            fileWriter.write("");
+                        });
+                    };
+                    var errorCallback = function () {
+                        writeComplete = true;
+                    };
+
+                    this.nfs.getFile("file1", { create: false }, successCallback, errorCallback);
+                });
+
+                waitsFor(function () { return writeComplete && fileEntry; }, 1000);
+
+                var actualContents = null;
+
+                runs(function () {
+                    brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
+                        actualContents = contents;
+                    });
+                });
+
+                waitsFor(function () { return (actualContents !== null); }, 1000);
+
+                runs(function () {
+                    expect(actualContents).toEqual("");
+
+                    // reset file1 content
+                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8");
+                });
+            });
+
             it("should report an error when writing to a file that cannot be read", function () {
                 var complete = false;
                 var error = null;


### PR DESCRIPTION
My === null scrub the other day broke file save for empty files. This fixes it.
