### PR TITLE
Fix some indent problems

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -204,7 +204,7 @@ define(function (require, exports, module) {
                                 // This is the same timeout value used by the
                                 // electricChars feature in CodeMirror.
                                 setTimeout(function () {
-                                    instance.indentLine(lineNum, "smart");
+                                    instance.indentLine(lineNum);
                                 }, 75);
                             }
                         }

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
                 },
                 onKeyEvent: function (instance, event) {
                     if (event.type === "keypress") {
-                        var keyStr = String.fromCharCode(event.keyCode);
+                        var keyStr = String.fromCharCode(event.which || event.keyCode);
                         if (/[\]\}\)]/.test(keyStr)) {
                             // If the whole line is whitespace, auto-indent it
                             var lineNum = instance.getCursor().line;
@@ -204,7 +204,7 @@ define(function (require, exports, module) {
                                 // This is the same timeout value used by the
                                 // electricChars feature in CodeMirror.
                                 setTimeout(function () {
-                                    instance.indentLine(lineNum);
+                                    instance.indentLine(lineNum, "smart");
                                 }, 75);
                             }
                         }

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -62,10 +62,10 @@ define(function (require, exports, module) {
         }
 
         if (indentAuto) {
-            var currentWS = line.search(/\S/);
+            var currentLength = line.length;
             CodeMirror.commands.indentAuto(instance);
             // If the amount of whitespace didn't change, insert another tab
-            if (instance.getLine(from.line).search(/\S/) === currentWS) {
+            if (instance.getLine(from.line).length === currentLength) {
                 insertTab = true;
                 to.ch = 0;
             }
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
             } else {
                 var i, ins = "", numSpaces = instance.getOption("tabSize");
                 numSpaces -= to.ch % numSpaces;
-                for (i = 0; i < numSpaces + 1; i++) {
+                for (i = 0; i < numSpaces; i++) {
                     ins += " ";
                 }
                 instance.replaceSelection(ins, "end");
@@ -160,6 +160,7 @@ define(function (require, exports, module) {
             // NOTE: CodeMirror doesn't actually require calling 'new',
             // but jslint does require it because of the capital 'C'
             var editor = new CodeMirror(_editorHolder.get(0), {
+                electricChars: false,
                 indentUnit : 4,
                 lineNumbers: true,
                 extraKeys: {
@@ -188,6 +189,27 @@ define(function (require, exports, module) {
                     "Shift-F3": "findPrev",
                     "Ctrl-H": "replace",
                     "Shift-Delete": "cut"
+                },
+                onKeyEvent: function (instance, event) {
+                    if (event.type === "keypress") {
+                        var keyStr = String.fromCharCode(event.keyCode);
+                        if (/[\]\}\)]/.test(keyStr)) {
+                            // If the whole line is whitespace, auto-indent it
+                            var lineStr = instance.getLine(instance.getCursor().line);
+                            
+                            if (!/\S/.test(lineStr)) {
+                                // Need to do the auto-indent on a timeout to ensure
+                                // the keypress is handled before auto-indenting.
+                                // This is the same timeout value used by the
+                                // electricChars feature in CodeMirror.
+                                setTimeout(function () {
+                                    CodeMirror.commands.indentAuto(instance);
+                                }, 75);
+                            }
+                        }
+                    }
+                    
+                    return false;
                 }
             });
             

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -195,7 +195,8 @@ define(function (require, exports, module) {
                         var keyStr = String.fromCharCode(event.keyCode);
                         if (/[\]\}\)]/.test(keyStr)) {
                             // If the whole line is whitespace, auto-indent it
-                            var lineStr = instance.getLine(instance.getCursor().line);
+                            var lineNum = instance.getCursor().line;
+                            var lineStr = instance.getLine(lineNum);
                             
                             if (!/\S/.test(lineStr)) {
                                 // Need to do the auto-indent on a timeout to ensure
@@ -203,7 +204,7 @@ define(function (require, exports, module) {
                                 // This is the same timeout value used by the
                                 // electricChars feature in CodeMirror.
                                 setTimeout(function () {
-                                    CodeMirror.commands.indentAuto(instance);
+                                    instance.indentLine(lineNum);
                                 }, 75);
                             }
                         }


### PR DESCRIPTION
@njx 
- Pressing the TAB key on an empty line no longer inserts an additional tab.
- Fixed problem that occasionally added an additional space character when typing a tab.
- Disable built-in "electric chars" feature and replace with a less heavy-handed version. The new version does the following:
  - Only runs when closing braces are typed: "]", "}", or ")"
  - Only runs if the line is all whitespace (except the closing brace)
    This should eliminate the majority of the odd and unpredictable auto-indent behaviors.

This fixes issues #155 and #193.
