### PR TITLE
Clone HTML for dialogs

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -190,8 +190,8 @@ define(function (require, exports, module) {
     };
     
     /**
-     * If the dialog is visible, immediately closes it. The dialog callback will be called with the
-     * special buttonId brackets.DIALOG_CANCELED (note: callback is run asynchronously).
+     * Immediately closes any dialog instances with the given class. The dialog callback for each instance will 
+     * be called with the special buttonId brackets.DIALOG_CANCELED (note: callback is run asynchronously).
      */
     brackets.cancelModalDialogIfOpen = function (dlgClass) {
         $("." + dlgClass + ".instance").each(function (dlg) {

--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,7 @@
     </div>
 
     <!-- Modal Windows -->
-    <div id="error-dialog" class="modal hide">
+    <div class="error-dialog template modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Error</h3>
@@ -138,7 +138,7 @@
             <a href="#" class="dialog-button btn primary" data-button-id="ok">OK</a>
         </div>
     </div>
-    <div id="save-close-dialog" class="modal hide">
+    <div class="save-close-dialog template modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Save Changes</h3>
@@ -152,7 +152,7 @@
             <a href="#" class="dialog-button btn primary" data-button-id="ok">Save</a>
         </div>
     </div>
-    <div id="ext-changed-dialog" class="modal hide">
+    <div class="ext-changed-dialog template modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Title goes here</h3>
@@ -165,7 +165,7 @@
             <a href="#" class="dialog-button btn primary" data-button-id="cancel">Keep Changes in Editor</a>
         </div>
     </div>
-    <div id="ext-deleted-dialog" class="modal hide">
+    <div class="ext-deleted-dialog template modal hide">
         <div class="modal-header">
             <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Title goes here</h3>


### PR DESCRIPTION
@peterflynn 

For #187, we now no longer directly show the original dialog DOM nodes. Instead, we clone them each time showModalDialog() is invoked. As part of this change, the original dialog templates are now addressed by a class name rather than by ID, and the marker class "template" is assumed to be applied to them.
