### PR TITLE
Fix issue #164 (Files with CRLF are rewritten to LF when saved)

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
     var NativeFileSystem    = require("NativeFileSystem").NativeFileSystem,
         ProjectManager      = require("ProjectManager"),
         PreferencesManager  = require("PreferencesManager"),
+        EditorUtils         = require("EditorUtils"),
         CommandManager      = require("CommandManager"),
         Commands            = require("Commands");
 
@@ -224,40 +225,6 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Asynchronously reads a file as UTF-8 encoded text.
-     * @return {Deferred} a jQuery Deferred that will be resolved with the 
-     *  file's text content plus its timestamp, or rejected with a FileError if
-     *  the file can not be read.
-     */
-    function readAsText(fileEntry) {
-        var result = new $.Deferred(),
-            reader = new NativeFileSystem.FileReader();
-
-        fileEntry.file(function (file) {
-            reader.onload = function (event) {
-                var text = event.target.result;
-                
-                fileEntry.getMetadata(
-                    function (metadata) {
-                        result.resolve(text, metadata.modificationTime);
-                    },
-                    function (error) {
-                        result.reject(error);
-                    }
-                );
-            };
-
-            reader.onerror = function (event) {
-                result.reject(event.target.error);
-            };
-
-            reader.readAsText(file, "utf8");
-        });
-
-        return result;
-    }
-    
-    /**
      * Closes the given document (which may or may not be the current document in the editor UI, and
      * may or may not be in the working set). Discards any unsaved changes if isDirty - it is
      * expected that the UI has already confirmed with the user before calling us.
@@ -325,56 +292,59 @@ define(function (require, exports, module) {
         allDocs.forEach(closeDocument);
     }
     
+    
     /**
-     * @private
-     * Preferences callback. Saves the document file paths for the working set.
+     * Asynchronously reads a file as UTF-8 encoded text.
+     * @return {Deferred} a jQuery Deferred that will be resolved with the 
+     *  file's text content plus its timestamp, or rejected with a FileError if
+     *  the file can not be read.
      */
-    function _savePreferences(storage) {
-        // save the working set file paths
-        var files       = [],
-            isActive    = false,
-            workingSet  = getWorkingSet(),
-            currentDoc  = getCurrentDocument();
+    function readAsText(fileEntry) {
+        var result = new $.Deferred(),
+            reader = new NativeFileSystem.FileReader();
 
-        workingSet.forEach(function (value, index) {
-            // flag the currently active editor
-            isActive = (value === currentDoc);
+        fileEntry.file(function (file) {
+            reader.onload = function (event) {
+                var text = event.target.result;
+                
+                fileEntry.getMetadata(
+                    function (metadata) {
+                        result.resolve(text, metadata.modificationTime);
+                    },
+                    function (error) {
+                        result.reject(error);
+                    }
+                );
+            };
 
-            files.push({
-                file: value.file.fullPath,
-                active: isActive
-            });
+            reader.onerror = function (event) {
+                result.reject(event.target.error);
+            };
+
+            reader.readAsText(file, "utf8");
         });
 
-        storage.files = files;
+        return result;
     }
+    
     
     /**
      * @constructor
      * A single editable document, e.g. an entry in the working set list. Documents are unique per
      * file, so it IS safe to compare them with '==' or '==='.
      * @param {!FileEntry} file  The file being edited. Need not lie within the project.
-     * @param {?CodeMirror} editor  Optional. The editor that will maintain the document state (current text
-     *          and undo stack). It is assumed that the editor text has already been initialized
-     *          with the file's contents. The editor may be null when the working set is restored
-     *          at initialization.
-     * @param {?Date} initialTimestamp  Timestamp of file at the time we read its contents from disk.
-     *          Required if editor is passed.
      */
-    function Document(file, editor, initialTimestamp) {
+    function Document(file) {
         if (!(this instanceof Document)) {  // error if constructor called without 'new'
             throw new Error("Document constructor must be called with 'new'");
         }
         if (getDocumentForFile(file)) {
-            throw new Error("Creating a document + editor when one already exists, for: " + file);
+            throw new Error("Creating a document when one already exists, for: " + file);
         }
         
         this.file = file;
-
-        if (editor) {
-            this._setEditor(editor, initialTimestamp);
-        }
     }
+    
     /**
      * The FileEntry for the document being edited.
      * @type {!FileEntry}
@@ -399,6 +369,7 @@ define(function (require, exports, module) {
      * @private
      * NOTE: this is actually "semi-private"; EditorManager also accesses this field. But no one
      * other than DocumentManager and EditorManager should access it.
+     *
      * The editor may be null in the case that the document working set was
      * restored from storage but an editor was not yet created.
      * TODO: we should close on whether private fields are declared on the prototype like this (vs.
@@ -406,14 +377,29 @@ define(function (require, exports, module) {
      * @type {?CodeMirror}
      */
     Document.prototype._editor = null;
+    
+    /**
+     * Null only of editor is not open yet. If a Document is created on empty text, or text with
+     * inconsistent line endings, the Document defaults to the current platform's standard endings.
+     * @type {null|EditorUtils.LINE_ENDINGS_CRLF|EditorUtils.LINE_ENDINGS_LF}
+     */
+    Document.prototype._lineEndings = null;
 
     /**
      * @private
+     * NOTE: this is actually "semi-private"; EditorManager also accesses this method. But no one
+     * other than DocumentManager and EditorManager should access it.
+     *
      * Initialize the editor instance for this file.
-     * @param {!CodeMirror} editor
-     * @param {!Date} initialTimestamp
+     * @param {!CodeMirror} editor  The editor that will maintain the document state (current text
+     *          and undo stack). It is assumed that the editor text has already been initialized
+     *          with the file's contents. The editor may be null when the working set is restored
+     *          at initialization.
+     * @param {!Date} initialTimestamp  Timestamp of file at the time we read its contents from disk.
+     *          Required if editor is passed.
+     * @perem {!string} rawText  Original text read from disk, beore handing to CodeMirror.
      */
-    Document.prototype._setEditor = function (editor, initialTimestamp) {
+    Document.prototype._setEditor = function (editor, initialTimestamp, rawText) {
         // Editor can only be assigned once per Document
         console.assert(!this._editor);
         
@@ -423,6 +409,12 @@ define(function (require, exports, module) {
         // Dirty-bit tracking
         editor.setOption("onChange", this._handleEditorChange.bind(this));
         this.isDirty = false;
+        
+        // Sniff line-ending style
+        this._lineEndings = EditorUtils.sniffLineEndings(rawText);
+        if (!this._lineEndings) {
+            this._lineEndings = EditorUtils.getPlatformLineEndings();
+        }
     };
     
     /**
@@ -431,11 +423,19 @@ define(function (require, exports, module) {
      *  created.
      */
     Document.prototype.getText = function () {
-        return this._editor.getValue();
+        // CodeMirror.getValue() always returns text with LF line endings; fix up to match line
+        // endings preferred by the document, if necessary
+        var codeMirrorText = this._editor.getValue();
+        if (this._lineEndings === EditorUtils.LINE_ENDINGS_LF) {
+            return codeMirrorText;
+        } else {
+            return codeMirrorText.replace(/\n/g, "\r\n");
+        }
     };
     
     /**
-     * Sets the contents of the document. Treated as an edit.
+     * Sets the contents of the document. Treated as an edit. Line endings will be rewritten to
+     * match the document's current line-ending style.
      * @param {!string} text The text to replace the contents of the document with.
      */
     Document.prototype.setText = function (text) {
@@ -444,7 +444,8 @@ define(function (require, exports, module) {
     
     /**
      * Sets the contents of the document. Treated as reloading the document from disk: the document
-     * will be marked clean with a new timestamp, and the undo/redo history is cleared.
+     * will be marked clean with a new timestamp, the undo/redo history is cleared, and we re-check
+     * the text's line-ending style.
      * @param {!string} text The text to replace the contents of the document with.
      * @param {!Date} newTimestamp Timestamp of file at the time we read its new contents from disk.
      */
@@ -454,6 +455,12 @@ define(function (require, exports, module) {
         
         this._markClean();
         this.diskTimestamp = newTimestamp;
+        
+        // Re-sniff line-ending style too
+        this._lineEndings = EditorUtils.sniffLineEndings(text);
+        if (!this._lineEndings) {
+            this._lineEndings = EditorUtils.getPlatformLineEndings();
+        }
     };
     
     /**
@@ -485,7 +492,9 @@ define(function (require, exports, module) {
         }
     };
     
-    /** Marks the document not dirty. Should be called after the document is saved to disk. */
+    /**
+     * @private
+     */
     Document.prototype._markClean = function () {
         if (!this._editor) {
             return;
@@ -496,8 +505,8 @@ define(function (require, exports, module) {
     };
     
     /** 
-     * Called when the document is saved (which currently happens in FileCommandHandlers). Updates the
-     * dirty bit and notifies listeners of the save.
+     * Called when the document is saved (which currently happens in FileCommandHandlers). Marks the
+     * document not dirty and notifies listeners of the save.
      */
     Document.prototype.notifySaved = function () {
         this._markClean();
@@ -523,6 +532,31 @@ define(function (require, exports, module) {
         return "[Document " + this.file.fullPath + " " + (this.isDirty ? "(dirty!)" : "(clean)") + "]";
     };
     
+    
+    /**
+     * @private
+     * Preferences callback. Saves the document file paths for the working set.
+     */
+    function _savePreferences(storage) {
+        // save the working set file paths
+        var files       = [],
+            isActive    = false,
+            workingSet  = getWorkingSet(),
+            currentDoc  = getCurrentDocument();
+
+        workingSet.forEach(function (value, index) {
+            // flag the currently active editor
+            isActive = (value === currentDoc);
+
+            files.push({
+                file: value.file.fullPath,
+                active: isActive
+            });
+        });
+
+        storage.files = files;
+    }
+
     /**
      * @private
      * Initializes the working set.
@@ -603,6 +637,7 @@ define(function (require, exports, module) {
             }
         });
     }
+
 
     // Define public API
     exports.Document = Document;

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -149,8 +149,9 @@ define(function (require, exports, module) {
      * Creates a new CodeMirror editor instance containing text from the 
      * specified fileEntry. The editor is not yet visible.
      * @param {!FileEntry} file  The file being edited. Need not lie within the project.
-     * @return {Deferred} a jQuery Deferred that will be resolved with the new editor and
-     *      the file's timestamp at the time it was read, or rejected if the file cannot be read.
+     * @return {Deferred} a jQuery Deferred that will be resolved with (the new editor, the file's
+     *      timestamp at the time it was read, the original text as read off disk); or rejected if
+     *      the file cannot be read.
      */
     function _createEditor(fileEntry) {
         var result = new $.Deferred(),
@@ -224,7 +225,7 @@ define(function (require, exports, module) {
             // Make sure we can't undo back to the empty state before setValue()
             editor.clearHistory();
 
-            result.resolve(editor, readTimestamp);
+            result.resolve(editor, readTimestamp, text);
         });
         reader.fail(function (error) {
             result.reject(error);
@@ -312,8 +313,8 @@ define(function (require, exports, module) {
         if (!document._editor) {
             var editorResult = _createEditor(document.file);
 
-            editorResult.done(function (editor, readTimestamp) {
-                document._setEditor(editor, readTimestamp);
+            editorResult.done(function (editor, readTimestamp, rawText) {
+                document._setEditor(editor, readTimestamp, rawText);
                 _doShow(document);
             });
             editorResult.fail(function (error) {
@@ -404,9 +405,10 @@ define(function (require, exports, module) {
         var result          = new $.Deferred(),
             editorResult    = _createEditor(fileEntry);
 
-        editorResult.done(function (editor, readTimestamp) {
+        editorResult.done(function (editor, readTimestamp, rawText) {
             // Create the Document wrapping editor & binding it to a file
-            var doc = new DocumentManager.Document(fileEntry, editor, readTimestamp);
+            var doc = new DocumentManager.Document(fileEntry);
+            doc._setEditor(editor, readTimestamp, rawText);
             result.resolve(doc);
         });
 

--- a/src/EditorUtils.js
+++ b/src/EditorUtils.js
@@ -2,7 +2,7 @@
  * Copyright 2011 Adobe Systems Incorporated. All Rights Reserved.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
 /*global define: false, PathUtils: false, FileError: false, brackets: false */
 
 /**
@@ -23,7 +23,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Given a file URL, determines the mode to use based
-     * off the files extensions.
+     * off the file's extension.
      * @param {string} fileUrl  A cannonical file URL to extract the extension from
      */
     function _getModeFromFileExtensions(fileUrl) {
@@ -70,6 +70,39 @@ define(function (require, exports, module) {
         editor.setOption("mode", mode);
     }
 
+    
+    /** @const */
+    var LINE_ENDINGS_CRLF = "CRLF";
+    /** @const */
+    var LINE_ENDINGS_LF = "LF";
+    
+    /**
+     * Returns the standard line endings for the current platform
+     * @return {LINE_ENDINGS_CRLF|LINE_ENDINGS_LF}
+     */
+    function getPlatformLineEndings() {
+        return brackets.isWin ? LINE_ENDINGS_CRLF : LINE_ENDINGS_LF;
+    }
+    
+    /**
+     * Scans the first 1000 chars of the text to determine how it encodes line endings. Returns
+     * null if usage is mixed or if no line endings found.
+     * @param {!string} text
+     * @return {null|LINE_ENDINGS_CRLF|LINE_ENDINGS_LF}
+     */
+    function sniffLineEndings(text) {
+        var subset = text.substr(0, 1000);  // (length is clipped to text.length)
+        var hasCRLF = /\r\n/.test(subset);
+        var hasLF = /[^\r]\n/.test(subset);
+        
+        if ((hasCRLF && hasLF) || (!hasCRLF && !hasLF)) {
+            return null;
+        } else {
+            return hasCRLF ? LINE_ENDINGS_CRLF : LINE_ENDINGS_LF;
+        }
+    }
+
+
     function getFileErrorString(code) {
         // There are a few error codes that we have specific error messages for. The rest are
         // displayed with a generic "(error N)" message.
@@ -102,6 +135,10 @@ define(function (require, exports, module) {
 
     // Define public API
     exports.setModeFromFileExtension = setModeFromFileExtension;
+    exports.LINE_ENDINGS_CRLF        = LINE_ENDINGS_CRLF;
+    exports.LINE_ENDINGS_LF          = LINE_ENDINGS_LF;
+    exports.getPlatformLineEndings   = getPlatformLineEndings;
+    exports.sniffLineEndings         = sniffLineEndings;
     exports.showFileOpenError        = showFileOpenError;
     exports.getFileErrorString       = getFileErrorString;
 });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -77,6 +77,10 @@ define(function (require, exports, module) {
     brackets.shellAPI = require("ShellAPI");
     
     brackets.inBrowser = !brackets.hasOwnProperty("fs");
+    
+    brackets.isWin = (global.navigator.userAgent.indexOf("Windows") !== -1);
+    brackets.isMac = !brackets.isWin;
+    
 
     brackets.DIALOG_BTN_CANCEL = "cancel";
     brackets.DIALOG_BTN_OK = "ok";


### PR DESCRIPTION
Fix issue #164 ("Files with CRLF are rewritten to LF when saved")

Since CodeMirror destroys line-ending info, we sniff and remember line endings when reading in a file, then swap in the correct endings again when saving.  If the file has mixed line endings or is blank/single-line, we default to the current platform's line endings.

This includes two small cleanups in DocumentManager, too:
- Documents constructor no longer takes optional editor & timeStamp args. We now always call _setEditor() directly to attach those.
- Relocate a few methods within DocumentManager to organize it better (no changes within those methods).
