### PR TITLE
Fix issue #149

### DIFF
--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -124,9 +124,11 @@ define(function (require, exports, module) {
         this.isDirectory = isDirectory;
         this.isFile = !isDirectory;
         
-        var lastChar = fullPath.length - 1;
-        if (isDirectory && fullPath.charAt(lastChar) === "/") {
-            fullPath = fullPath.substr(0, lastChar);
+        if (fullPath) {
+            var lastChar = fullPath.length - 1;
+            if (isDirectory && fullPath.charAt(lastChar) === "/") {
+                fullPath = fullPath.substr(0, lastChar);
+            }
         }
         
         this.fullPath = fullPath;

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -585,7 +585,7 @@ define(function (require, exports, module) {
                     d = new $.Deferred();
                     d.done(genAddToEntriesArrayFunction(i));
                     deferreds.push(d);
-                    statEntry(rootPath + "/" + filelist[i], d);
+                    statEntry(rootPath + filelist[i], d);
                 }
 
                 // FIXME (issue #213): -- once we have an async library, it would be good

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -133,11 +133,12 @@ define(function (require, exports, module) {
         
         this.fullPath = fullPath;
 
-        // Extract name from fullPath
         this.name = null; // default if extraction fails
         if (fullPath) {
             var pathParts = fullPath.split("/");
-            if (pathParts.length > 0) {
+            
+            // Extract name from the end of the fullPath (account for trailing slash(es))
+            while (!this.name && pathParts.length) {
                 this.name = pathParts.pop();
             }
         }

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -126,7 +126,8 @@ define(function (require, exports, module) {
         
         if (fullPath) {
             var lastChar = fullPath.length - 1;
-            if (isDirectory && fullPath.charAt(lastChar) === "/") {
+            // only trim off the trailing slash for directories, skip system root
+            if (isDirectory && (lastChar > 0) && (fullPath.charAt(lastChar) === "/")) {
                 fullPath = fullPath.substr(0, lastChar);
             }
         }

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -469,7 +469,7 @@ define(function (require, exports, module) {
         // resolve relative paths relative to the DirectoryEntry
         // most absolute paths have a leading slash except Windows which has a drive letter followed by :/
         if (path.charAt(0) !== '/' && path.charAt(1) !== ":") {
-            fileFullPath = this.fullPath + "/" + path;
+            fileFullPath = this.fullPath + path;
         }
 
         var createFileEntry = function () {

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -125,10 +125,9 @@ define(function (require, exports, module) {
         this.isFile = !isDirectory;
         
         if (fullPath) {
-            var lastChar = fullPath.length - 1;
-            // only trim off the trailing slash for directories, skip system root
-            if (isDirectory && (lastChar > 0) && (fullPath.charAt(lastChar) === "/")) {
-                fullPath = fullPath.substr(0, lastChar);
+            // add trailing "/" to directory paths
+            if (isDirectory && (fullPath.charAt(fullPath.length - 1) !== '/')) {
+                fullPath = fullPath.concat("/");
             }
         }
         

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -123,6 +123,12 @@ define(function (require, exports, module) {
     NativeFileSystem.Entry = function (fullPath, isDirectory) {
         this.isDirectory = isDirectory;
         this.isFile = !isDirectory;
+        
+        var lastChar = fullPath.length - 1;
+        if (isDirectory && fullPath.charAt(lastChar) === "/") {
+            fullPath = fullPath.substr(0, lastChar);
+        }
+        
         this.fullPath = fullPath;
 
         // Extract name from fullPath

--- a/src/PreferencesManager.js
+++ b/src/PreferencesManager.js
@@ -44,7 +44,6 @@ define(function (require, exports, module) {
 
     /**
      * Saves to persistent storage.
-     * TODO (jasonsj): local and/or hosted
      */
     function saveToPersistentStorage() {
         // save all preferences

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -133,11 +133,11 @@ define(function (require, exports, module) {
             if (entry.fullPath) {
                 fullPath = entry.fullPath;
 
-                // Truncate project path prefix
-                shortPath = fullPath.slice(projectPathLength);
+                // Truncate project path prefix, remove the trailing slash
+                shortPath = fullPath.slice(projectPathLength, -1);
 
                 // Determine depth of the node by counting path separators.
-                // Children at the root have depth of zero.
+                // Children at the root have depth of zero
                 depth = shortPath.split("/").length - 1;
 
                 // Map tree depth to list of open nodes

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -96,10 +96,7 @@ define(function (require, exports, module) {
      * FIXME (issue #263): Does not support paths containing ".."
      */
     function isWithinProject(absPath) {
-        // DirectoryEntry.fullPath does not end with trailing "/"
-        var rootPath = _projectRoot.fullPath + "/";
-        
-        return (absPath.indexOf(rootPath) === 0);
+        return (absPath.indexOf(_projectRoot.fullPath) === 0);
     }
     /**
      * If absPath lies within the project, returns a project-relative path. Else returns absPath
@@ -108,8 +105,7 @@ define(function (require, exports, module) {
      */
     function makeProjectRelativeIfPossible(absPath) {
         if (isWithinProject(absPath)) {
-            // fullPath does not include trailing '/', add 1 here
-            return absPath.slice(_projectRoot.fullPath.length + 1);
+            return absPath.slice(_projectRoot.fullPath.length);
         }
         return absPath;
     }
@@ -124,7 +120,7 @@ define(function (require, exports, module) {
 
         // save jstree state
         var openNodes = [],
-            projectPathLength = _projectRoot.fullPath.length + 1,
+            projectPathLength = _projectRoot.fullPath.length,
             entry,
             fullPath,
             shortPath,

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -316,11 +316,16 @@ define(function (require, exports, module) {
                     wasNodeOpen = false,
                     emptyDirectory = (subtreeJSON.length === 0);
                 
-                if (!isProjectRoot && emptyDirectory) {
-                    wasNodeOpen = treeNode.hasClass("jstree-open");
+                if (emptyDirectory) {
+                    if (!isProjectRoot) {
+                        wasNodeOpen = treeNode.hasClass("jstree-open");
+                    } else {
+                        // project root is a special case, add a placeholder
+                        subtreeJSON.push({});
+                    }
                 }
                 
-                jsTreeCallback(_convertEntriesToJSON(entries));
+                jsTreeCallback(subtreeJSON);
                 
                 if (!isProjectRoot && emptyDirectory) {
                     // If the directory is empty, force it to appear as an open or closed node.
@@ -392,12 +397,9 @@ define(function (require, exports, module) {
             if (brackets.inBrowser) {
                 // In browser: dummy folder tree (hardcoded in ProjectManager)
                 rootPath = "DummyProject";
+                $("#project-title").html(rootPath);
             }
         }
-
-        // Set title
-        var projectName = rootPath.substring(rootPath.lastIndexOf("/") + 1);
-        $("#project-title").html(projectName);
 
         // Populate file tree as long as we aren't running in the browser
         if (!brackets.inBrowser) {
@@ -406,6 +408,9 @@ define(function (require, exports, module) {
                 function (rootEntry) {
                     // Success!
                     _projectRoot = rootEntry;
+
+                    // Set title
+                    $("#project-title").html(_projectRoot.name);
 
                     // The tree will invoke our "data provider" function to populate the top-level items, then
                     // go idle until a node is expanded - at which time it'll call us again to fetch the node's

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -302,11 +302,12 @@ define(function (require, exports, module) {
      * @param {function(Array)} jsTreeCallback  jsTree callback to provide children to
      */
     function _treeDataProvider(treeNode, jsTreeCallback) {
-        var dirEntry;
+        var dirEntry, isProjectRoot = false;
 
         if (treeNode === -1) {
             // Special case: root of tree
             dirEntry = _projectRoot;
+            isProjectRoot = true;
         } else {
             // All other nodes: the DirectoryEntry is saved as jQ data in the tree (by _convertEntriesToJSON())
             dirEntry = treeNode.data("entry");
@@ -316,15 +317,16 @@ define(function (require, exports, module) {
         dirEntry.createReader().readEntries(
             function (entries) {
                 var subtreeJSON = _convertEntriesToJSON(entries),
-                    wasNodeOpen = false;
+                    wasNodeOpen = false,
+                    emptyDirectory = (subtreeJSON.length === 0);
                 
-                if (subtreeJSON.length === 0) {
+                if (!isProjectRoot && emptyDirectory) {
                     wasNodeOpen = treeNode.hasClass("jstree-open");
                 }
                 
                 jsTreeCallback(_convertEntriesToJSON(entries));
                 
-                if (subtreeJSON.length === 0) {
+                if (!isProjectRoot && emptyDirectory) {
                     // If the directory is empty, force it to appear as an open or closed node.
                     // This is a workaround for issue #149 where jstree would show this node as a leaf.
                     var classToAdd = (wasNodeOpen) ? "jstree-closed" : "jstree-open";


### PR DESCRIPTION
@joelrbrandt 

Use an empty child list instead of placeholder child data when the directory is empty. Since jstree treats empty directories as leaves, manually manage styles when necessary.
