### PR TITLE
TODO cleanup

### DIFF
--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
     /** @type {jQueryObject} */
     var _title;
     /** @type {string} */
-    var _currentFilePath;  // TODO: eliminate this and just use getCurrentDocument().file.fullPath
+    var _currentFilePath;  // TODO: (issue #271) eliminate this and just use getCurrentDocument().file.fullPath
     /** @type {string} */
     var _currentTitlePath;
     
@@ -305,7 +305,7 @@ define(function (require, exports, module) {
      * Saves all unsaved documents. Returns a Promise that will be resolved once ALL the save
      * operations have been completed. If any ONE save operation fails, an error dialog is immediately
      * shown and the promise fails.
-     * TODO: But subsequent save operations continue in the background, and if more fail the error
+     * TODO: (issue #272) But subsequent save operations continue in the background, and if more fail the error
      * dialogs will stack up on top of the old one.
      *
      * @return {$.Promise}
@@ -358,7 +358,7 @@ define(function (require, exports, module) {
             doc = DocumentManager.getCurrentDocument();
         }
         
-        // No-op if called when nothing is open; TODO: should command be grayed out instead?
+        // No-op if called when nothing is open; TODO: (issue #273) should command be grayed out instead?
         if (!doc) {
             return;
         }
@@ -530,7 +530,7 @@ define(function (require, exports, module) {
         // Register global commands
         CommandManager.register(Commands.FILE_OPEN, handleFileOpen);
         CommandManager.register(Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
-        // TODO: For now, hook up File > New to the "new in project" handler. Eventually
+        // TODO: (issue #274) For now, hook up File > New to the "new in project" handler. Eventually
         // File > New should open a new blank tab, and handleFileNewInProject should
         // be called from a "+" button in the project
         CommandManager.register(Commands.FILE_NEW, handleFileNewInProject);

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -10,7 +10,7 @@
  * dependencies (or dependencies thereof), initializes the UI, and binds global menus & keyboard
  * shortcuts to their Commands.
  *
- * TODO: break out the definition of brackets into a separate module from the application controller logic
+ * TODO: (issue #264) break out the definition of brackets into a separate module from the application controller logic
  *
  * Unlike other modules, this one can be accessed without an explicit require() because it exposes
  * a global object, window.brackets.
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
         global.brackets = {};
     }
     
-    // TODO: Make sure the "test" object is not included in final builds
+    // TODO: (issue #265) Make sure the "test" object is not included in final builds
     // All modules that need to be tested from the context of the application
     // must to be added to this object. The unit tests cannot just pull
     // in the modules since they would run in context of the unit test window,
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
     // brackets.forceAsyncCallbacks = true;
 
     // Load native shell when brackets is run in a native shell rather than the browser
-    // TODO: load conditionally
+    // TODO: (issue #266) load conditionally
     brackets.shellAPI = require("ShellAPI");
     
     brackets.inBrowser = !brackets.hasOwnProperty("fs");
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
     // Main Brackets initialization
     $(document).ready(function () {
 
-        var _enableJSLint = true; // TODO: Decide if this should be opt-in or opt-out.
+        var _enableJSLint = true;
         
         function initListeners() {
             // Prevent unhandled drag and drop of files into the browser from replacing 
@@ -376,7 +376,7 @@ define(function (require, exports, module) {
 
         function initKeyBindings() {
             // Register keymaps and install the keyboard handler
-            // TODO: show keyboard equivalents in the menus
+            // TODO: (issue #268) show keyboard equivalents in the menus
             var _globalKeymap = new KeyMap({
                 "Ctrl-O": Commands.FILE_OPEN,
                 "Ctrl-S": Commands.FILE_SAVE,
@@ -403,7 +403,7 @@ define(function (require, exports, module) {
         }
         
         function initWindowListeners() {
-            // TODO: to support IE, need to listen to document instead (and even then it may not work when focus is in an input field?)
+            // TODO: (issue 269) to support IE, need to listen to document instead (and even then it may not work when focus is in an input field?)
             $(window).focus(function () {
                 FileSyncManager.syncOpenDocuments();
             });
@@ -412,8 +412,6 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_CLOSE_WINDOW);
             });
             
-            //TODO: for now disable all the default context menus until we decide what we
-            //actually want to put in them
             $(window).contextmenu(function (e) {
                 e.preventDefault();
             });


### PR DESCRIPTION
Filed bugs for TODOs in brackets.js and FileCommandHandlers.js. I also removed two TODOs that I thought were unnecessary:
- one that said we should decide whether to opt in or out of JSLint. Since this is just a debug feature for now, and we want it on by default, we don't have to worry about this. If/when we go to make it a real feature, we'll decide as part of that how we want to default it.
- one that said we're disabling context menus for now until we decide what to put in them. At the point if/when we want a context menu, we'll add it, so I don't think we need to track this in the code.
