### PR TITLE
Fix issue #251 (Close button in dialogs doesn't work as expected)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -127,6 +127,10 @@ define(function (require, exports, module) {
         // Pipe dialog-closing notification back to client code
         dlg.one("hidden", function () {
             var buttonId = dlg.data("buttonId");
+            if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
+                buttonId = brackets.DIALOG_BTN_CANCEL;
+            }
+            
             // Let call stack return before notifying that dialog has closed; this avoids issue #191
             // if the handler we're triggering might show another dialog (as long as there's no
             // fade-out animation)

--- a/src/index.html
+++ b/src/index.html
@@ -154,7 +154,6 @@
     </div>
     <div class="ext-changed-dialog template modal hide">
         <div class="modal-header">
-            <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Title goes here</h3>
         </div>
         <div class="modal-body">
@@ -167,7 +166,6 @@
     </div>
     <div class="ext-deleted-dialog template modal hide">
         <div class="modal-header">
-            <a href="#" class="close">&times;</a>
             <h3 class="dialog-title">Title goes here</h3>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
Fixes issue #251:
- Map close button to Cancel automatically (rather than handing an undefined buttonId to the dialog's callback)
- Remove close button from external-changes dialogs, since it's not clear to user what it would mean (there's no button clearly labeled "Cancel")
