### PR TITLE
First pass at adding performance instrumentation

### DIFF
--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -19,7 +19,8 @@ define(function (require, exports, module) {
         EditorManager       = require("EditorManager"),
         EditorUtils         = require("EditorUtils"),
         Strings             = require("strings"),
-        PreferencesManager  = require("PreferencesManager");
+        PreferencesManager  = require("PreferencesManager"),
+        PerfUtils           = require("PerfUtils");
     
     /**
      * Handlers for commands related to file handling (opening, saving, etc.)
@@ -80,6 +81,11 @@ define(function (require, exports, module) {
             console.log("doOpen() called without fullPath");
             return result.reject();
         }
+        
+        PerfUtils.markStart("doOpen: " + fullPath);
+        result.always(function () {
+            PerfUtils.addMeasurement("doOpen: " + fullPath);
+        });
         
         var doc = DocumentManager.getDocumentForPath(fullPath);
         if (doc) {

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -82,9 +82,9 @@ define(function (require, exports, module) {
             return result.reject();
         }
         
-        PerfUtils.markStart("doOpen: " + fullPath);
+        PerfUtils.markStart("Open File: " + fullPath);
         result.always(function () {
-            PerfUtils.addMeasurement("doOpen: " + fullPath);
+            PerfUtils.addMeasurement("Open File: " + fullPath);
         });
         
         var doc = DocumentManager.getDocumentForPath(fullPath);

--- a/src/PerfUtils.js
+++ b/src/PerfUtils.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
         }
         
         activeTests[name] = {
-            startTime: brackets.app.getEllapsedMilliseconds()
+            startTime: brackets.app.getElapsedMilliseconds()
         };
     }
     
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
      * measured time is relative to app startup.
      */
     function addMeasurement(name) {
-        var elapsedTime = brackets.app.getEllapsedMilliseconds();
+        var elapsedTime = brackets.app.getElapsedMilliseconds();
         
         if (activeTests[name]) {
             elapsedTime -= activeTests[name].startTime;

--- a/src/PerfUtils.js
+++ b/src/PerfUtils.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 Adobe Systems Incorporated. All Rights Reserved.
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets */
+
+/**
+ * This is a collection of utility functions for gathering performance data.
+ */
+define(function (require, exports, module) {
+    'use strict';
+    
+    /**
+     * Peformance data is stored in this hash object. The key is the name of the
+     * test (passed to markStart/addMeasurement), and the value is the time, in 
+     * milliseconds, that it took to run the test. If multiple runs of the same test
+     * are made, the value is an Array with each run stored as an entry in the Array.
+     */
+    var perfData = {};
+    
+    /**
+     * Active tests. This is a hash of all tests that have had markStart() called,
+     * but have not yet had addMeasurement() called.
+     */
+    var activeTests = {};
+    
+    /**
+     * Start a new named timer. The name should be as descriptive as possible, since
+     * this name will appear as an entry in the performance report. 
+     * For example: "Open file: /Users/brackets/src/ProjectManager.js"
+     *
+     * Multiple timers can be opened simultaneously, but all open timers must have
+     * a unique name. 
+     */
+    function markStart(name) {
+        if (activeTests[name]) {
+            console.log("Recursive tests with the same name are not supported.");
+            return;
+        }
+        
+        activeTests[name] = {
+            startTime: brackets.app.getEllapsedMilliseconds()
+        };
+    }
+    
+    /**
+     * Stop a timer and add its measurements to the performance data.
+     *
+     * Multiple measurements can be stored for any given name. If there are
+     * multiple values for a name, they are stored in an Array.
+     *
+     * If the markStart() was not called for the specified timer, the
+     * measured time is relative to app startup.
+     */
+    function addMeasurement(name) {
+        var elapsedTime = brackets.app.getEllapsedMilliseconds();
+        
+        if (activeTests[name]) {
+            elapsedTime -= activeTests[name].startTime;
+            delete activeTests[name];
+        }
+        
+        if (perfData[name]) {
+            // We have existing data, add to it
+            if (Array.isArray(perfData[name])) {
+                perfData[name].push(elapsedTime);
+            } else {
+                // Current data is a number, convert to Array
+                perfData[name] = [perfData[name], elapsedTime];
+            }
+        } else {
+            perfData[name] = elapsedTime;
+        }
+    }
+    
+    exports.markStart       = markStart;
+    exports.addMeasurement  = addMeasurement;
+    exports.perfData        = perfData;
+});

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
         CommandManager      = require("CommandManager"),
         Commands            = require("Commands"),
         Strings             = require("strings"),
-        FileViewController  = require("FileViewController");
+        FileViewController  = require("FileViewController"),
+        PerfUtils           = require("PerfUtils");
     
     /**
      * @private
@@ -391,6 +392,8 @@ define(function (require, exports, module) {
                 rootPath = "DummyProject";
             }
         }
+        
+        PerfUtils.markStart("loadProject: " + rootPath);
 
         // Set title
         var projectName = rootPath.substring(rootPath.lastIndexOf("/") + 1);
@@ -418,6 +421,9 @@ define(function (require, exports, module) {
                     });
                     resultRenderTree.fail(function () {
                         result.reject();
+                    });
+                    resultRenderTree.always(function () {
+                        PerfUtils.addMeasurement("loadProject: " + rootPath);
                     });
                 },
                 function (error) {

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -393,7 +393,7 @@ define(function (require, exports, module) {
             }
         }
         
-        PerfUtils.markStart("loadProject: " + rootPath);
+        PerfUtils.markStart("Load Project: " + rootPath);
 
         // Set title
         var projectName = rootPath.substring(rootPath.lastIndexOf("/") + 1);
@@ -423,7 +423,7 @@ define(function (require, exports, module) {
                         result.reject();
                     });
                     resultRenderTree.always(function () {
-                        PerfUtils.addMeasurement("loadProject: " + rootPath);
+                        PerfUtils.addMeasurement("Load Project: " + rootPath);
                     });
                 },
                 function (error) {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -214,9 +214,6 @@ define(function (require, exports, module) {
 
     // Main Brackets initialization
     $(document).ready(function () {
-
-        PerfUtils.addMeasurement("Application Startup: beginning of $(document).ready()");
-
         var _enableJSLint = true;
         
         function initListeners() {
@@ -497,7 +494,7 @@ define(function (require, exports, module) {
             }
         });
         
-        PerfUtils.addMeasurement("Application Startup: end of $(document).ready()");
+        PerfUtils.addMeasurement("Application Startup");
     });
     
 });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -383,8 +383,9 @@ define(function (require, exports, module) {
                 
                 var perfBody = $("<div class='modal-body' style='padding: 0' />");
 
-                var data = $("<table class='zebra-striped condensed-table'>")
-                    .append("<tbody>")
+                var data = $("<table class='zebra-striped condensed-table' style='max-height: 600px; overflow: auto;'>")
+                    .append("<thead><th>Operation</th><th>Time (ms)</th></thead>")
+                    .append("<tbody />")
                     .appendTo(perfBody);
                 
                 var makeCell = function (content) {
@@ -400,7 +401,7 @@ define(function (require, exports, module) {
                         for (i = 0; i < entry.length; i++) {
                             sum += entry[i];
                         }
-                        return Math.floor(sum / entry.length);
+                        return String(Math.floor(sum / entry.length)) + " (avg)";
                     } else {
                         return entry;
                     }
@@ -418,7 +419,7 @@ define(function (require, exports, module) {
                     }
                 }
                                                              
-                var perfDlog = $("<div class='modal hide' style='width: 90%; left: 10%;' />")
+                var perfDlog = $("<div class='modal hide' />")
                     .append(perfHeader)
                     .append(perfBody)
                     .appendTo(document.body)

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,7 @@
                                 <span id="jslint-enabled-checkbox" style="float:right;">&#10003;</span>
                             </a>
                         </li>
+                        <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Add new PerfUtils module that has functions for adding performance instrumentation to code.

Add instrumentation for:
- App startup
- Project load
- File load

Basic results can be seen by selecting the Debug > Show Perf Data menu item. If a measurement was made more than once (for example, if you opened the same file multiple times), the average time is shown. (the internal data structures store the result for every call, it is just the UI that is displaying the average).

Note that the App startup times will be skewed if you reload the application - startup is always relative to native app start time, so reloading will show large app startup time.
