### PR TITLE
Clean up TODOs in DocumentManager & FileSyncManager

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
      */
     function getWorkingSet() {
         return _workingSet;
-        // TODO: return a clone to prevent meddling?
+        // TODO: (issue #297) return a clone to prevent meddling?
     }
 
     /** 
@@ -178,10 +178,7 @@ define(function (require, exports, module) {
      * @return {?Document}
     */
     function getDocumentForPath(fullPath) {
-        // TODO: we should implement something like NativeFileSystem.resolveNativeFileSystemURL() (similar
-        // to what's in the standard file API) to get a FileEntry, rather than manually constructing it
         var fileEntry = new NativeFileSystem.FileEntry(fullPath);
-
         return getDocumentForFile(fileEntry);
     }
 
@@ -285,9 +282,6 @@ define(function (require, exports, module) {
      * unsaved changes, so the UI should confirm with the user before calling this.
      */
     function closeAll() {
-        // TODO: could be more efficient by clearing working set in bulk instead of via
-        // individual notifications, and ensuring we don't switch editors while closing...
-        
         var allDocs = getAllOpenDocuments();
         
         allDocs.forEach(closeDocument);
@@ -373,8 +367,6 @@ define(function (require, exports, module) {
      *
      * The editor may be null in the case that the document working set was
      * restored from storage but an editor was not yet created.
-     * TODO: we should close on whether private fields are declared on the prototype like this (vs.
-     * just set in the constructor).
      * @type {?CodeMirror}
      */
     Document.prototype._editor = null;
@@ -513,10 +505,7 @@ define(function (require, exports, module) {
         this._markClean();
         $(exports).triggerHandler("documentSaved", this);
         
-        // TODO: this introduces two race conditions: (a) if user leaves app & returns before this
-        // async op finishes, we'll think file was modified externally when it wasn't; (b) if ext
-        // app overwrites file in between when we saved and when this op finishes, we'll miss the
-        // fact that it was modified externally
+        // TODO: (issue #295) fetching timestamp async creates race conditions (albeit unlikely ones)
         var thisDoc = this;
         this.file.getMetadata(
             function (metadata) {
@@ -574,9 +563,7 @@ define(function (require, exports, module) {
             activeFile;
 
         // in parallel, check if files exist
-        // TODO (jasonsj): delay validation until user requests the editor (like Eclipse)?
-        //                 e.g. A file to restore no longer exists. Should we silently ignore
-        //                 it or let the user be notified when they attempt to open the Document?
+        // TODO: (issue #298) delay this check until it becomes the current document?
         function checkOneFile(value, index) {
             var oneFileResult = new $.Deferred();
             

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -117,7 +117,6 @@ define(function (require, exports, module) {
     
     /**
      * Reloads the Document's contents from disk, discarding any unsaved changes in the editor.
-     * TODO: move this into FileCommandHandlers as the impl of a Revert command?
      *
      * @param {!Document} doc
      * @return {$.Deferred} Resolved after editor has been refreshed; rejected if unable to load the
@@ -171,7 +170,6 @@ define(function (require, exports, module) {
     function closeDeletedDocs() {
         toClose.forEach(function (doc) {
             DocumentManager.closeDocument(doc);
-            // TODO: remove from file tree view also
         });
     }
     
@@ -295,11 +293,6 @@ define(function (require, exports, module) {
         //  4) Prompt about any editors that are dirty (if file changed/deleted on disk)
         // Each phase fully completes (asynchronously) before the next one begins.
         
-        // TODO: like most of our file operations, this is probably full of race conditions where
-        // the user can go into the UI and break our state while we're still in mid-operation. We
-        // need a way to block user input while this is going on, at least in the browser-hosted
-        // version where APIs are truly async.
-
         // 1) Check for external modifications
         var allDocs = DocumentManager.getAllOpenDocuments();
         


### PR DESCRIPTION
- Tagged some with issue #s
- In cases where it didn't seem necessary to keep a placeholder in the code, I just deleted the TODO after filing an issue.
- A few seemed unimportant enough that I deleted them without filing any issue (e.g. the TODO on Document._editor, since we seem to be ok with it as-is now).
