### PR TITLE
Fix small refactoring issue #271 (Remove FileCommandHandlers._currentFilePath)

### DIFF
--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -27,11 +27,9 @@ define(function (require, exports, module) {
      * Handlers for commands related to file handling (opening, saving, etc.)
      */
     
-    /** @type {jQueryObject} */
+    /** @type {jQueryObject} Container for label shown above editor */
     var _title;
-    /** @type {string} */
-    var _currentFilePath;  // TODO: (issue #271) eliminate this and just use getCurrentDocument().file.fullPath
-    /** @type {string} */
+    /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath;
     
     function updateTitle() {
@@ -49,14 +47,12 @@ define(function (require, exports, module) {
         if (newDocument) {
             var fullPath = newDocument.file.fullPath;
     
-            _currentFilePath = _currentTitlePath = fullPath;
-
             // In the main toolbar, show the project-relative path (if the file is inside the current project)
             // or the full absolute path (if it's not in the project).
             _currentTitlePath = ProjectManager.makeProjectRelativeIfPossible(fullPath);
             
         } else {
-            _currentFilePath = _currentTitlePath = null;
+            _currentTitlePath = null;
         }
         
         // Update title text & "dirty dot" display
@@ -64,7 +60,9 @@ define(function (require, exports, module) {
     }
     
     function handleDirtyChange(event, changedDoc) {
-        if (changedDoc.file.fullPath === _currentFilePath) {
+        var currentDoc = DocumentManager.getCurrentDocument();
+        
+        if (currentDoc && changedDoc.file.fullPath === currentDoc.file.fullPath) {
             updateTitle();
         }
     }

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -28,9 +28,9 @@ define(function (require, exports, module) {
      */
     
     /** @type {jQueryObject} Container for label shown above editor */
-    var _title;
+    var _title = null;
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
-    var _currentTitlePath;
+    var _currentTitlePath = null;
     
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument();


### PR DESCRIPTION
Issue #271:
Remove unneeded _currentFilePath state -- use the FileEntry from DocumentManager.getCurrentDocument() instead.
