### PR TITLE
Fix unit test failure on windows

### DIFF
--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
             lines = lines.substr(0, current.offsetEnd);
             
             current.lineStart = _computeLineNumber(lines, current.offsetStart);
-            text.substr(0, current.offsetStart);
+            lines = lines.substr(0, current.offsetStart);
             
             offsetEnd = current.offsetStart - 1;
             

--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
             
             // split the input up to the offset to find the lineStart and lineEnd
             current.lineEnd = _computeLineNumber(lines, current.offsetEnd);
-            lines = text.substr(0, current.offsetEnd);
+            lines = lines.substr(0, current.offsetEnd);
             
             current.lineStart = _computeLineNumber(lines, current.offsetStart);
             text.substr(0, current.offsetStart);

--- a/test/spec/CSSManager-test.js
+++ b/test/spec/CSSManager-test.js
@@ -152,6 +152,13 @@ define(function (require, exports, module) {
                 waitsFor(function () { return styleRules; }, 1000);
                 
                 runs(function () {
+                    expect(styleRules[0].lineStart).toBe(0);
+                    expect(styleRules[1].lineStart).toBe(4);
+                    expect(styleRules[2].lineStart).toBe(8);
+                    expect(styleRules[3].lineStart).toBe(12);
+                    expect(styleRules[4].lineStart).toBe(16);
+                    expect(styleRules[5].lineStart).toBe(20);
+                    
                     // use lineStart and lineEnd to index into file content
                     getTextForInfos(styleRules).done(function (texts) {
                         ruleTexts = texts;


### PR DESCRIPTION
_computeOffsets was using the original string input without carriage returns stripped. This explains why this failed on windows only.
