### PR TITLE
Support for opening an inline editor within an outer editor

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
             inlineEditor.focus();
         }
         
-        return { content: inlineContent, editor: inlineEditor, height: 1, onAdded: afterAdded };
+        return { content: inlineContent, editor: inlineEditor, height: 0, onAdded: afterAdded };
     }
     
     

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -269,7 +269,17 @@ define(function (require, exports, module) {
     }
     
     function _closeInlineWidget(hostEditor, inlineId) {
+        // Place cursor back on the line just above the inline (the line from which it was opened)
+        // If cursor's already on that line, leave it be to preserve column position
+        var widgetLine = hostEditor.getInlineWidgetInfo(inlineId).line;
+        var cursorLine = hostEditor.getCursor().line;
+        if (cursorLine !== widgetLine) {
+            hostEditor.setCursor({ line: widgetLine, pos: 0 });
+        }
+        
         hostEditor.removeInlineWidget(inlineId);
+        
+        hostEditor.focus();
     }
     
     function registerInlineEditProvider(provider) {
@@ -314,6 +324,7 @@ define(function (require, exports, module) {
     function createInlineEditorFromText(hostEditor, text, range, fileNameToSelectMode) {
         // Container to hold editor & render its stylized frame
         var inlineContent = document.createElement('div');
+        $(inlineContent).addClass("inlineCodeEditor");
         
         var myInlineId; // won't be populated until our afterAdded() callback is run
         function closeThisInline() {
@@ -322,23 +333,11 @@ define(function (require, exports, module) {
         
         var inlineEditor = _createEditorFromText(text, fileNameToSelectMode, inlineContent, closeThisInline);
         
-        // Auto-size editor to its content, clamped to a max of 150px
-        function editorHeight(nLines) {
-            // TODO: need a real API for this; currently hacked up based on CodeMirror's totalHeight() impl
-            var lineHeight = 18; // what our current stylesheet yields
-            var padding = 12;    // ditto
-            return nLines * lineHeight + padding;
-        }
-        var nLines = range ? (range.endLine - range.startLine + 1) : inlineEditor.lineCount();
-        var textTotalHeight = editorHeight(nLines);
-        var widgetHeight = Math.min(textTotalHeight, 150);
+        var MAX_INLINE_HEIGHT = 150;
         
         // Some tasks have to wait until we've been parented into the outer editor
         function afterAdded(inlineId) {
             myInlineId = inlineId;
-            
-            $(inlineEditor.getScrollerElement()).height(widgetHeight);
-            inlineEditor.refresh();
             
             // Hide all lines other than those we want to show. We do this rather than trimming the
             // text itself so that the editor still shows accurate line numbers.
@@ -354,20 +353,20 @@ define(function (require, exports, module) {
                     }
                 });
                 inlineEditor.setCursor(range.startLine, 0);
-                
-                // CodeMirror has bugs where the gutter line numbers are wrong if the first line
-                // is hidden, so for now when trimming text down to a range we show NO line numbers
-                inlineEditor.setOption("gutter", true);
-                inlineEditor.setOption("lineNumbers", false);
             }
             
-            inlineEditor.focus();
+            // Auto-size editor to its remaining content, clamped to a max
+            var totalTextHeight = inlineEditor.totalHeight(true);
+            var widgetHeight = Math.min(totalTextHeight, MAX_INLINE_HEIGHT);
+
+            hostEditor.setInlineWidgetHeight(inlineId, widgetHeight);
+            $(inlineEditor.getScrollerElement()).height(widgetHeight);
+            inlineEditor.refresh();
             
-            // Set late because CodeMirror.addInlineWidget() blows away any CSS classes we set earlier
-            $(inlineContent).addClass("inlineCodeEditor");
+            inlineEditor.focus();
         }
         
-        return { content: inlineContent, editor: inlineEditor, height: widgetHeight, onAdded: afterAdded };
+        return { content: inlineContent, editor: inlineEditor, height: MAX_INLINE_HEIGHT, onAdded: afterAdded };
     }
     
     

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -342,11 +342,11 @@ define(function (require, exports, module) {
             if (range) {
                 inlineEditor.operation(function () {
                     var i;
-                    for(i = 0; i < range.startLine; i++) {
+                    for (i = 0; i < range.startLine; i++) {
                         inlineEditor.hideLine(i);
                     }
                     var lineCount = inlineEditor.lineCount();
-                    for(i = range.endLine + 1; i < lineCount; i++) {
+                    for (i = range.endLine + 1; i < lineCount; i++) {
                         inlineEditor.hideLine(i);
                     }
                 });

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -333,8 +333,6 @@ define(function (require, exports, module) {
         
         var inlineEditor = _createEditorFromText(text, fileNameToSelectMode, inlineContent, closeThisInline);
         
-        var MAX_INLINE_HEIGHT = 150;
-        
         // Some tasks have to wait until we've been parented into the outer editor
         function afterAdded(inlineId) {
             myInlineId = inlineId;
@@ -355,9 +353,8 @@ define(function (require, exports, module) {
                 inlineEditor.setCursor(range.startLine, 0);
             }
             
-            // Auto-size editor to its remaining content, clamped to a max
-            var totalTextHeight = inlineEditor.totalHeight(true);
-            var widgetHeight = Math.min(totalTextHeight, MAX_INLINE_HEIGHT);
+            // Auto-size editor to its remaining content
+            var widgetHeight = inlineEditor.totalHeight(true);
 
             hostEditor.setInlineWidgetHeight(inlineId, widgetHeight);
             $(inlineEditor.getScrollerElement()).height(widgetHeight);
@@ -366,7 +363,7 @@ define(function (require, exports, module) {
             inlineEditor.focus();
         }
         
-        return { content: inlineContent, editor: inlineEditor, height: MAX_INLINE_HEIGHT, onAdded: afterAdded };
+        return { content: inlineContent, editor: inlineEditor, height: 1, onAdded: afterAdded };
     }
     
     

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -315,10 +315,14 @@ define(function (require, exports, module) {
                                 } else {
                                     // We're really done!
                                     _alreadyChecking = false;
-                                    EditorManager.focusEditor();
+                                    
+                                    // If we showed a dialog, restore focus to editor
+                                    if (editConflicts.length > 0 || deleteConflicts.length > 0) {
+                                        EditorManager.focusEditor();
+                                    }
                                     
                                     // (Any errors that ocurred during presentConflicts() have already
-                                    // shown UI & been dismissed, so there's no fail() processing here)
+                                    // shown UI & been dismissed, so there's no fail() handler here)
                                 }
                             });
                     });

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012 Adobe Systems Incorporated. All Rights Reserved.
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define: false, $: false, CodeMirror: false */
+
+/**
+ * InlineEditorProviders contains providers for Brackets' various built-in code editors. "Provider"
+ * essentially means "a function that you pass to EditorManager.registerInlineEditProvider()".
+ */
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Load dependent modules
+    var EditorManager       = require("EditorManager"),
+        DocumentManager     = require("DocumentManager"),
+        ProjectManager      = require("ProjectManager"),
+        NativeFileSystem    = require("NativeFileSystem").NativeFileSystem;
+    
+    
+    /**
+     * Today: When cursor is within any HTML content, open a dummy CSS 'file' in an inline editor.
+     * TODO: When cursor is on an HTML tag name, class attribute, or id attribute, find associated
+     * CSS rules and show (one/all of them) in an inline editor.
+     *
+     * @param {!CodeMirror} editor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {$.Promise} a promise that will be resolved with:
+     *      {{inlineContent:DOMElement, height:Number, onAdded:function(inlineId:Number)}}
+     *      or null if we're not going to provide anything.
+     */
+    function htmlToCSSProvider(editor, pos) {
+        // Only provide a CSS editor when cursor is in HTML content
+        if (editor.getOption("mode") !== "htmlmixed") {
+            return null;
+        }
+        var htmlmixedState = editor.getTokenAt(pos).state;
+        if (htmlmixedState.mode !== "html") {
+            return null;
+        }
+        
+        var result = new $.Deferred();
+        
+        // TODO: use 'pos' to form a CSSManager query, and go find an actual relevant CSS rule
+        
+        // Load a project file at random
+        var arbitraryFile = "todos.css";
+        var fileEntry = new NativeFileSystem.FileEntry(ProjectManager.getProjectRoot().fullPath + arbitraryFile);
+        DocumentManager.readAsText(fileEntry)
+            .done(function (text) {
+                // var dummyRange = { startLine: 18, endLine: 22 };    // small rule
+                var dummyRange = { startLine: 218, endLine: 255 };    // tall rule
+                var inlineInfo = EditorManager.createInlineEditorFromText(editor, text, dummyRange, arbitraryFile);
+                
+                var inlineEditor = inlineInfo.editor;
+                
+                // For Sprint 4, editor is a read-only view
+                inlineEditor.setOption("readOnly", true);
+                
+                result.resolve(inlineInfo);
+            })
+            .fail(function (fileError) {
+                console.log("Error in dummy htmlToCSSProvider(): ", fileError);
+            });
+        
+        return result.promise();
+    }
+
+
+    /** Initialize: register listeners */
+    function init() {
+        EditorManager.registerInlineEditProvider(htmlToCSSProvider);
+    }
+    
+    // Define public API
+    exports.init = init;
+});

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
     var ProjectManager          = require("ProjectManager"),
         DocumentManager         = require("DocumentManager"),
         EditorManager           = require("EditorManager"),
+        InlineEditorProviders   = require("InlineEditorProviders"),
         WorkingSetView          = require("WorkingSetView"),
         FileCommandHandlers     = require("FileCommandHandlers"),
         FileViewController      = require("FileViewController"),
@@ -473,6 +474,7 @@ define(function (require, exports, module) {
 
 
         EditorManager.setEditorHolder($('#editorHolder'));
+        InlineEditorProviders.init();
     
         initListeners();
         initProject();

--- a/src/brackets.less
+++ b/src/brackets.less
@@ -310,6 +310,12 @@ a, img {
     .code-font();
 }
 
+/* Styles for inline editors */
+.inlineCodeEditor {
+    border-top:    1px solid #A0A0A0;
+    border-bottom: 1px solid #A0A0A0;
+}
+
 /* Styles for the search dialog--this is temporary, only for debugging */
 
 .CodeMirror-dialog {

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -38,3 +38,31 @@
 
 div.CodeMirror span.CodeMirror-matchingbracket {color: @accent-bracket; background-color: @background-color-2;}
 div.CodeMirror span.CodeMirror-nonmatchingbracket {color: @accent-bracket;}
+
+
+/*
+    CodeMirror's use of descendant selectors for certain styling causes problems when editors are
+    nested because, for items in the inner editor, the left-hand clause in the selector will now
+    match either the actual containing CodeMirror instance *OR* the outer "host" CodeMirror instance.
+    
+    TODO (issue #324): We'll still have problems if editors can be nested more than one level deep,
+    or if any other descendant-selector-driven CM styles can differ between inner & outer editors
+    (potential problem areas include line wrap and coloring theme: basically, anything in codemirror.css
+    that uses a descandant selector where the CSS class name to the left of the space is something
+    other than a vanilla .CodeMirror)
+ */
+.CodeMirror {
+    .CodeMirror pre.CodeMirror-cursor {
+        visibility: hidden;
+    }
+    .CodeMirror.CodeMirror-focused pre.CodeMirror-cursor {
+        visibility: visible;
+    }
+    
+    .CodeMirror div.CodeMirror-selected {
+        background: #d9d9d9;
+    }
+    .CodeMirror.CodeMirror-focused div.CodeMirror-selected {
+        background: #d2dcf8;
+    }
+}


### PR DESCRIPTION
- Refactor EditorManager to support creating editors that won't be shown in the main top-level editor area
- Add utility method for creating an inline editor, adding borders, auto-sizing its height, and showing only a chosen text range.
- Add Ctrl+E binding to editors to open an inline editor (if in an outer editor) or close the inline editor (if in the inline editor itself).  Generic mechanism lets us keep a registry of inline-editor providers that apply to different contexts (CSS displayed from HTML file being the only context we're implementing in this sprint).
- Dummy inline-editor provider for testing, which reads a hardcoded range of content from a file called "todos.css" and shows it (if cursor is in HTML content when invoked).
- Reorder a few methods in EditorManager for cleanliness
- Fix one case of issue #301 that causes inline editors to lose focus whenever the window is activated (due to FileSyncManager).
