### PR TITLE
Integrate FileIndexManager with CSSManager

### DIFF
--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -3,7 +3,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, require: false, less: false */
+/*global define: false, $: false, require: false, less: false, FileError: false */
 
 /**
  * CSSManager
@@ -12,14 +12,26 @@ define(function (require, exports, module) {
     'use strict';
     
     // Dependencies
-    var NativeFileSystem = require("NativeFileSystem"),
-        FileUtils        = require("FileUtils");
+    var NativeFileSystem    = require("NativeFileSystem").NativeFileSystem,
+        FileIndexManager    = require("FileIndexManager"),
+        Async               = require("Async"),
+        FileUtils           = require("FileUtils");
     
     /**
      * Regex to match selector element values for ID '#', pseudo ':',
      * class name '.', attribute start '[' or digit.
      */
     var IDENTIFIER_REGEX = /^[#:\.\[\d]/;
+    
+    /**
+     * CSSManager instance for the current project
+     */
+    var _cssManager;
+    
+    /**
+     * Track CSS file modification times
+     */
+    var _cssFileMetadataMap = {};
     
     /**
      * Adapter for LESS RuleSet
@@ -39,7 +51,8 @@ define(function (require, exports, module) {
             children.forEach(function (value, index) {
                 _addRuleset(results, value, source);
             });
-        } else {
+        } else if (ruleset.selectors.length > 0) {
+            // only add rules with selectors
             results.push(new RuleSetInfo(ruleset, source));
         }
     }
@@ -62,18 +75,20 @@ define(function (require, exports, module) {
         // To be consistent with LESS, strip CR.
         // Remove this workaround and patch LESS parser to save accurate offset info.
         // There are current issues with CRLF replacement and token trimming.
-        var input = text.replace(/\r\n/g, '\n');
+        var input = text.replace(/\r\n/g, '\n').trimRight();
         
         // rulesets is an in-order traversal of the AST
         // work backwards to establish offset start and end values
         var i               = rulesets.length - 1,
             current         = null,
-            offsetEnd       = input.length,
+            offsetEnd       = input.length, // offset last non-white space char
+            elements        = null,
             firstElement    = null,
-            lines           = input;
+            lines           = input;        // complete file content
         
         while (i >= 0) {
             current = rulesets[i];
+            elements = current.ruleset.selectors[0].elements;
             
             // get offset end from the previous rule's offsetStart
             current.offsetEnd   = offsetEnd;
@@ -81,17 +96,24 @@ define(function (require, exports, module) {
             // HACK - Work backwards from the first element
             // Example: "div { color:red }"
             // The "div" Selector Element index returns 4 instead of 0
-            firstElement = current.ruleset.selectors[0].elements[0];
-            current.offsetStart = firstElement.index - firstElement.value.length - firstElement.combinator.value.length;
+            firstElement = elements[0];
+            current.offsetStart = firstElement.index - firstElement.value.length;
+            
+            // only subtract the first combinator if the selector has a single element
+            if ((elements.length === 1) && (firstElement.combinator.value === ' ')) {
+                current.offsetStart -= firstElement.combinator.value.length;
+            }
             
             // split the input up to the offset to find the lineStart and lineEnd
             current.lineEnd = _computeLineNumber(lines, current.offsetEnd);
-            lines = lines.substr(0, current.offsetEnd);
+            lines = lines.substr(0, current.offsetEnd).trimRight();
             
             current.lineStart = _computeLineNumber(lines, current.offsetStart);
-            lines = lines.substr(0, current.offsetStart);
             
-            offsetEnd = current.offsetStart - 1;
+            // the next rule (moving towards the top of the file) ends
+            // with the first non-whitespace char before this rule's offsetStart
+            lines = lines.substr(0, current.offsetStart).trimRight();
+            offsetEnd = lines.length;
             
             i--;
         }
@@ -179,6 +201,7 @@ define(function (require, exports, module) {
      *  objects for all rules parsed from the file.
      */
     CSSManager.prototype.loadFile = function (fileEntry) {
+        // TODO (jasonsj): Strategy for inline <style> blocks?
         var result = new $.Deferred(),
             textResult = FileUtils.readAsText(fileEntry),
             self = this,
@@ -197,8 +220,8 @@ define(function (require, exports, module) {
     /**
      * Remove a file from cache
      */
-    CSSManager.prototype.removeFile = function (fileEntry) {
-        delete this._rules[fileEntry.fullPath];
+    CSSManager.prototype.removeFile = function (fullPath) {
+        delete this._rules[fullPath];
     };
     
     /**
@@ -295,5 +318,150 @@ define(function (require, exports, module) {
         return matches;
     };
     
-    exports.CSSManager = CSSManager;
+    /*
+     * Check for CSS file deltas. Load and remove files as necessary.
+     */
+    function _syncFiles(cssFiles) {
+        // TODO (jasonsj): should FileIndexManager trigger add/change/remove events?
+        var deferred        = new $.Deferred(),
+            filesToLoad     = [],
+            filesToRemove   = {};
+        
+        // Copy the current loaded files into a new map. Remove keys
+        // from the map when the file is or will be loaded.
+        $.each(_cssFileMetadataMap, function (fullPath, value) {
+            filesToRemove[fullPath] = true;
+        });
+        
+        var compareFileTimestamp = function (fileInfo) {
+            var oneDeferred = new $.Deferred(),
+                fileEntry;
+            
+            var metadataSuccess = function (metadata) {
+                // compare to last timestamp
+                var previous = !_cssFileMetadataMap[fileInfo.fullPath],
+                    current = metadata.modificationTime;
+                
+                if ((previous === undefined) || (current !== previous)) {
+                    // new or changed file, load it
+                    filesToLoad.push(fileEntry);
+                }
+                
+                // update the timestamp
+                _cssFileMetadataMap[fileInfo.fullPath] = current;
+            
+                delete filesToRemove[fileInfo.fullPath];
+                
+                oneDeferred.resolve();
+            };
+            
+            var metadataError = function (fileError) {
+                // An entry will be left in currentFileMap
+                if (fileError.code !== FileError.NOT_FOUND_ERR) {
+                    // try to reload the file for any other errors
+                    filesToLoad.push(fileEntry);
+                    
+                    delete filesToRemove[fileInfo.fullPath];
+                }
+                
+                oneDeferred.resolve();
+            };
+            
+            // TODO (jasonsj): work with Ty to add FileEntry property to FileInfo
+            fileEntry = new NativeFileSystem.FileEntry(fileInfo.fullPath);
+            fileEntry.getMetadata(metadataSuccess, metadataError);
+            
+            return oneDeferred.promise();
+        };
+        
+        var compareResult = Async.doInParallel(cssFiles, compareFileTimestamp, false);
+        compareResult.done(function () {
+            // remove files
+            $.each(filesToRemove, function (fullPath) {
+                _cssManager.removeFile(fullPath);
+            });
+            
+            // load new/changed files
+            var loadFilesResult = Async.doInParallel(
+                filesToLoad,
+                function (value, index) {
+                    return _cssManager.loadFile(value);
+                },
+                false
+            );
+            
+            loadFilesResult.done(function () {
+                deferred.resolve();
+            });
+        });
+        
+        return deferred.promise();
+    }
+    
+    function findMatchingRules(selectorString) {
+        var deferred        = new $.Deferred(),
+            cssFilesResult  = FileIndexManager.getFileInfoList("css");
+        
+        cssFilesResult.done(function (fileInfos) {
+            _syncFiles(fileInfos).done(function () {
+                deferred.resolve(_cssManager.findMatchingRules(selectorString));
+            });
+        });
+        
+        return deferred.promise();
+    }
+    
+    /*
+     * Extract line text for each rule from the associated source file.
+     */
+    function _getTextForInfos(infos) {
+        var results = [],
+            deferred = new $.Deferred();
+        
+        var masterPromise = Async.doInParallel(infos, function (info) {
+            var oneFileResult = new $.Deferred();
+            var textResult = FileUtils.readAsText(info.source);
+        
+            textResult.done(function (content) {
+                content = content.replace(/\r\n/g, '\n');
+                var lines = content.split("\n").slice(info.lineStart, info.lineEnd + 1);
+                
+                results.push(lines.join("\n"));
+                oneFileResult.resolve();
+            });
+            
+            return oneFileResult;
+        });
+        
+        masterPromise.done(function () {
+            deferred.resolve(results);
+        });
+        
+        return deferred;
+    }
+    
+    function _logQuery(selectorString) {
+        var ruleInfo;
+
+        findMatchingRules(selectorString).done(function (ruleInfos) {
+            _getTextForInfos(ruleInfos).done(function (texts) {
+                texts.forEach(function (value, index) {
+                    ruleInfo = ruleInfos[index];
+                    console.log("result[" + index + "] line " +
+                        (ruleInfo.lineStart + 1) + ": " +
+                        ruleInfo.source.fullPath + "\n" + value);
+                });
+            });
+        });
+    }
+    
+    // Init
+    (function () {
+        _cssManager = new CSSManager();
+    }());
+    
+    exports.CSSManager          = CSSManager;
+    exports.findMatchingRules   = findMatchingRules;
+    exports._getTextForInfos    = _getTextForInfos;
+    exports._logQuery           = _logQuery;
 });

--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -398,6 +398,13 @@ define(function (require, exports, module) {
         return deferred.promise();
     }
     
+    /**
+     * Finds matching CSS rules in the current project, based on the tag,
+     * id and/or class name specified in the selectorString parameter. 
+     * @param {!string} selectorString A string formatted as a type name
+     *  "body", identifier "#myID" or class name ".myClass".
+     * @return {Array.<ResultSetInfo>}
+     */
     function findMatchingRules(selectorString) {
         var deferred        = new $.Deferred(),
             cssFilesResult  = FileIndexManager.getFileInfoList("css");
@@ -460,8 +467,8 @@ define(function (require, exports, module) {
         _cssManager = new CSSManager();
     }());
     
-    exports.CSSManager          = CSSManager;
     exports.findMatchingRules   = findMatchingRules;
+    exports._CSSManager         = CSSManager;
     exports._getTextForInfos    = _getTextForInfos;
     exports._logQuery           = _logQuery;
 });

--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -401,11 +401,15 @@ define(function (require, exports, module) {
             // show a dialog when parsing fails
             // TODO (jasonsj): log parsing errors in a panel?
             loadFilesResult.fail(function (errors) {
-                var files = "";
+                var files = "<ul>";
                 
                 errors.forEach(function (value, index) {
-                    files += "[" + index + "] " + value.item.fullPath + "\n";
+                    files += "<li>" + value.error.message +
+                        " " + value.item.fullPath + " line " + value.error.line +
+                        "</li>";
                 });
+                
+                files += "</ul>";
                 
                 var dialog = brackets.showModalDialog(
                     brackets.DIALOG_ID_ERROR,

--- a/src/CSSManager.js
+++ b/src/CSSManager.js
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
             deferred.resolve(results);
         });
         
-        return deferred;
+        return deferred.promise();
     }
     
     function _logQuery(selectorString) {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
         Commands                = require("Commands"),
         CommandManager          = require("CommandManager"),
         CodeHintManager         = require("CodeHintManager"),
-        PerfUtils               = require("PerfUtils");
+        PerfUtils               = require("PerfUtils"),
+        CSSManager              = require("CSSManager");
 
     // Define core brackets namespace if it isn't already defined
     //
@@ -66,7 +67,8 @@ define(function (require, exports, module) {
         DocumentManager         : DocumentManager,
         Commands                : Commands,
         WorkingSetView          : WorkingSetView,
-        CommandManager          : require("CommandManager")
+        CommandManager          : require("CommandManager"),
+        CSSManager              : CSSManager
     };
     
     // Uncomment the following line to force all low level file i/o routines to complete

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -41,7 +41,6 @@ define(function (require, exports, module) {
         PerfUtils               = require("PerfUtils"),
         CSSManager              = require("CSSManager"),
         FileIndexManager        = require("FileIndexManager"),
-        PerfUtils               = require("PerfUtils"),
         Menus                   = require("Menus");
     
     //Load modules the self-register and just need to get included in the main project

--- a/src/strings.js
+++ b/src/strings.js
@@ -60,6 +60,9 @@ define(function (require, exports, module) {
     // FileIndexManager error string
     exports.ERROR_MAX_FILES_TITLE             = "Error Indexing Files";
     exports.ERROR_MAX_FILES                   = "The maximum number of files have been indexed. Actions that look up files in the index may function incorrectly.";
+    
+    // CSSManager error strings
+    exports.ERROR_PARSE_TITLE                 = "Error parsing CSS file(s):";
 
     exports.SAVE_CLOSE_TITLE                  = "Save Changes";
     exports.SAVE_CLOSE_MESSAGE                = "Do you want to save the changes you made in the document \"{0}\"?";

--- a/test/spec/CSSManager-test-files/offsets.css
+++ b/test/spec/CSSManager-test-files/offsets.css
@@ -1,0 +1,11 @@
+a {
+    color: "red";
+}/*END*/
+a {
+    color: "orange";
+}/*END*/
+
+a { color: "yellow"; }/*END*/
+a:visited { color: "black"; }/*END*/
+
+a { color: "red"; }/*END*/a { color: "blue"; }/*END*/

--- a/test/spec/CSSManager-test.js
+++ b/test/spec/CSSManager-test.js
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
     };
     
     function init(spec, fileEntry) {
-        spec.cssManager = new CSSManager.CSSManager();
+        spec.cssManager = new CSSManager._CSSManager();
         
         if (fileEntry) {
             spec.addMatchers({toMatchLastSelector: toMatchLastSelector});
@@ -378,7 +378,7 @@ define(function (require, exports, module) {
          */
         var _match = function (cssCode, tagInfo) {
             try {
-                manager = new CSSManager.CSSManager();
+                manager = new CSSManager._CSSManager();
                 manager._loadString(cssCode);
             } catch (e) {
                 this.fail(e.message + ": " + cssCode);


### PR DESCRIPTION
- Refactor debug code from unit tests to CSSManager
- Fix bugs with RuleSetInfo offsetStart (fix assumption for selector index) and lineEnd (remove trailing whitespace)
- Check for file deltas and re-parse CSS files
- Add more unit tests for offsets and line numbers

CSSManager now has 2 entry points. (1) The module integrates with FileIndexManager, looking for CSS files in the current project. The module updates only when it detects delta's in the file index. (2) The CSSManager class can be used alone to load files and query for selectors without integrating with FileIndexManager. This is currently used only for unit tests.
