### PR TITLE
Hook up inline CSS display 

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -206,6 +206,9 @@ define(function (require, exports, module) {
                 "Shift-Insert": "paste",
                 "Ctrl-E" : function (instance) {
                     onInlineGesture(instance);
+                },
+                "Cmd-E" : function (instance) {
+                    onInlineGesture(instance);
                 }
             },
             onKeyEvent: function (instance, event) {
@@ -344,11 +347,11 @@ define(function (require, exports, module) {
             if (range) {
                 inlineEditor.operation(function () {
                     var i;
-                    for(i = 0; i < range.startLine; i++) {
+                    for (i = 0; i < range.startLine; i++) {
                         inlineEditor.hideLine(i);
                     }
                     var lineCount = inlineEditor.lineCount();
-                    for(i = range.endLine + 1; i < lineCount; i++) {
+                    for (i = range.endLine + 1; i < lineCount; i++) {
                         inlineEditor.hideLine(i);
                     }
                 });

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -43,6 +43,14 @@ define(function (require, exports, module) {
         var tagInfo = CodeHintUtils.getTagInfo(editor, pos);
         var selectorName = "";
         
+        // Only provide CSS editor if the selection is an insertion point
+        var selStart = editor.getCursor(false),
+            selEnd = editor.getCursor(true);
+        
+        if (selStart.line !== selEnd.line || selStart.ch !== selEnd.ch) {
+            return null;
+        }
+        
         if (tagInfo.hint.type === CodeHintUtils.TAG_NAME) {
             // Type selector
             selectorName = tagInfo.tagName;
@@ -61,10 +69,20 @@ define(function (require, exports, module) {
                         startIndex === -1 ? 0 : startIndex + 1,
                         endIndex === -1 ? attributeValue.length : endIndex
                     );
+                
+                // If the insertion point is surrounded by space, selectorName is "."
+                // Check for that here
+                if (selectorName === ".") {
+                    selectorName = "";
+                }
             } else if (tagInfo.attr.name === "id") {
                 // ID selector
                 selectorName = "#" + tagInfo.attr.value;
             }
+        }
+        
+        if (selectorName === "") {
+            return null;
         }
 
         var result = new $.Deferred();

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -16,12 +16,12 @@ define(function (require, exports, module) {
     var EditorManager       = require("EditorManager"),
         DocumentManager     = require("DocumentManager"),
         ProjectManager      = require("ProjectManager"),
-        NativeFileSystem    = require("NativeFileSystem").NativeFileSystem;
+        NativeFileSystem    = require("NativeFileSystem").NativeFileSystem,
+        CodeHintUtils       = require("CodeHintUtils");
     
     
     /**
-     * Today: When cursor is within any HTML content, open a dummy CSS 'file' in an inline editor.
-     * TODO: When cursor is on an HTML tag name, class attribute, or id attribute, find associated
+     * When cursor is on an HTML tag name, class attribute, or id attribute, find associated
      * CSS rules and show (one/all of them) in an inline editor.
      *
      * @param {!CodeMirror} editor
@@ -37,6 +37,22 @@ define(function (require, exports, module) {
         }
         var htmlmixedState = editor.getTokenAt(pos).state;
         if (htmlmixedState.mode !== "html") {
+            return null;
+        }
+        
+        var tagInfo = CodeHintUtils.getTagInfoForValueHint(editor, pos);
+        var selectorName = "";
+        if (tagInfo.attr.name === "class") {
+            // Class selector
+            selectorName = "." + tagInfo.attr.value;
+        } else if (tagInfo.attr.name === "id") {
+            // ID selector
+            selectorName = "#" + tagInfo.attr.value;
+        } else if (tagInfo.tagName !== "" && tagInfo.attr.name === "") {
+            // Type selector
+            selectorName = tagInfo.tagName;
+        } else {
+            // Cursor is not in a tag name, or class/id attribute
             return null;
         }
         

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -52,14 +52,14 @@ define(function (require, exports, module) {
                 // that includes the insertion point. For example, if
                 // the attribute is: 
                 //   class="error-dialog modal hide"
-                // And the insertion point is inside "modal", we want ".modal"
+                // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
                 var startIndex = attributeValue.substr(0, tagInfo.hint.offset).lastIndexOf(" ");
                 var endIndex = attributeValue.indexOf(" ", tagInfo.hint.offset);
-                selectorName = "." + 
+                selectorName = "." +
                     attributeValue.substring(
-                        startIndex === -1 ? 0 : startIndex, endIndex === -1 ? 
-                        attributeValue.length : endIndex
+                        startIndex === -1 ? 0 : startIndex + 1,
+                        endIndex === -1 ? attributeValue.length : endIndex
                     );
             } else if (tagInfo.attr.name === "id") {
                 // ID selector

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -40,9 +40,6 @@ define(function (require, exports, module) {
             return null;
         }
         
-        var tagInfo = CodeHintUtils.getTagInfo(editor, pos);
-        var selectorName = "";
-        
         // Only provide CSS editor if the selection is an insertion point
         var selStart = editor.getCursor(false),
             selEnd = editor.getCursor(true);
@@ -50,11 +47,14 @@ define(function (require, exports, module) {
         if (selStart.line !== selEnd.line || selStart.ch !== selEnd.ch) {
             return null;
         }
+                
+        var tagInfo = CodeHintUtils.getTagInfo(editor, pos),
+            selectorName = "";
         
-        if (tagInfo.hint.type === CodeHintUtils.TAG_NAME) {
+        if (tagInfo.position.type === CodeHintUtils.TAG_NAME) {
             // Type selector
             selectorName = tagInfo.tagName;
-        } else if (tagInfo.hint.type === CodeHintUtils.ATTR_VALUE) {
+        } else if (tagInfo.position.type === CodeHintUtils.ATTR_VALUE) {
             if (tagInfo.attr.name === "class") {
                 // Class selector. We only look for the class name
                 // that includes the insertion point. For example, if
@@ -62,8 +62,8 @@ define(function (require, exports, module) {
                 //   class="error-dialog modal hide"
                 // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
-                var startIndex = attributeValue.substr(0, tagInfo.hint.offset).lastIndexOf(" ");
-                var endIndex = attributeValue.indexOf(" ", tagInfo.hint.offset);
+                var startIndex = attributeValue.substr(0, tagInfo.position.offset).lastIndexOf(" ");
+                var endIndex = attributeValue.indexOf(" ", tagInfo.position.offset);
                 selectorName = "." +
                     attributeValue.substring(
                         startIndex === -1 ? 0 : startIndex + 1,

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -16,6 +16,7 @@ define(function (require, exports, module) {
     var CodeHintUtils       = require("CodeHintUtils"),
         CSSManager          = require("CSSManager"),
         EditorManager       = require("EditorManager"),
+        FileUtils           = require("FileUtils"),
         ProjectManager      = require("ProjectManager");
     
     /**
@@ -87,9 +88,27 @@ define(function (require, exports, module) {
 
         CSSManager.findMatchingRules(selectorName)
             .done(function (rules) {
-                if (rules && rules.length() > 0) {
-                    //var inlineInfo = EditorManager.createInlineEditorFromText();
-                    var foo = 42;
+                if (rules && rules.length > 0) {
+                    var rule = rules[0];  // For Sprint 4 we use the first match only
+                    
+                    FileUtils.readAsText(rule.source)
+                        .done(function (text) {
+                            var range = { startLine: rule.lineStart, endLine: rule.lineEnd - 1 }; // rule.lineEnd is exclusive, range.endLine is inclusive
+                            var inlineInfo = EditorManager.createInlineEditorFromText(editor, text, range, rule.source.fullPath);
+                            
+                            var inlineEditor = inlineInfo.editor;
+                            
+                            // For Sprint 4, editor is a read-only view
+                            inlineEditor.setOption("readOnly", true);
+                            
+                            result.resolve(inlineInfo);
+                        })
+                        .fail(function (fileError) {
+                            console.log("Error in dummy htmlToCSSProvider(): ", fileError);
+                            result.reject();
+                        });
+                } else {
+                    result.reject();
                 }
             })
             .fail(function () {

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -13,12 +13,10 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var EditorManager       = require("EditorManager"),
-        FileUtils           = require("FileUtils"),
-        ProjectManager      = require("ProjectManager"),
-        NativeFileSystem    = require("NativeFileSystem").NativeFileSystem,
-        CodeHintUtils       = require("CodeHintUtils");
-    
+    var CodeHintUtils       = require("CodeHintUtils"),
+        CSSManager          = require("CSSManager"),
+        EditorManager       = require("EditorManager"),
+        ProjectManager      = require("ProjectManager");
     
     /**
      * When cursor is on an HTML tag name, class attribute, or id attribute, find associated
@@ -86,9 +84,20 @@ define(function (require, exports, module) {
         }
 
         var result = new $.Deferred();
+
+        CSSManager.findMatchingRules(selectorName)
+            .done(function (rules) {
+                if (rules && rules.length() > 0) {
+                    //var inlineInfo = EditorManager.createInlineEditorFromText();
+                    var foo = 42;
+                }
+            })
+            .fail(function () {
+                console.log("Error in CSSManager.findMatchingRules()");
+                result.reject();
+            });
         
-        // TODO: use 'pos' to form a CSSManager query, and go find an actual relevant CSS rule
-        
+        /*
         // Load a project file at random
         var arbitraryFile = "todos.css";
         var fileEntry = new NativeFileSystem.FileEntry(ProjectManager.getProjectRoot().fullPath + arbitraryFile);
@@ -108,6 +117,7 @@ define(function (require, exports, module) {
             .fail(function (fileError) {
                 console.log("Error in dummy htmlToCSSProvider(): ", fileError);
             });
+        */
         
         return result.promise();
     }

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -18,6 +18,40 @@ define(function (require, exports, module) {
         EditorManager       = require("EditorManager"),
         FileUtils           = require("FileUtils"),
         ProjectManager      = require("ProjectManager");
+
+    /**
+     * Show a range of text in an inline editor.
+     * 
+     * @param {!CodeMirror} parentEditor The parent editor that will contain the inline editor
+     * @param {!FileEntry} fileEntry File containing inline content
+     * @param {!Number} startLine The first line to be shown in the inline editor 
+     * @param {!Number} endLine The last line to be shown in the inline editor
+     */
+    function _showTextRangeInInlineEditor(parentEditor, fileEntry, startLine, endLine) {
+        var result = new $.Deferred();
+        
+        FileUtils.readAsText(fileEntry)
+            .done(function (text) {
+                var range = {
+                    startLine: startLine,
+                    endLine: endLine - 1   // rule.lineEnd is exclusive, range.endLine is inclusive
+                };
+                var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
+                
+                var inlineEditor = inlineInfo.editor;
+                
+                // For Sprint 4, editor is a read-only view
+                inlineEditor.setOption("readOnly", true);
+                
+                result.resolve(inlineInfo);
+            })
+            .fail(function (fileError) {
+                console.log("Error reading as text: ", fileError);
+                result.reject();
+            });
+    
+        return result.promise();
+    }
     
     /**
      * When cursor is on an HTML tag name, class attribute, or id attribute, find associated
@@ -91,23 +125,11 @@ define(function (require, exports, module) {
                 if (rules && rules.length > 0) {
                     var rule = rules[0];  // For Sprint 4 we use the first match only
                     
-                    FileUtils.readAsText(rule.source)
-                        .done(function (text) {
-                            var range = {
-                                startLine: rule.lineStart,
-                                endLine: rule.lineEnd - 1   // rule.lineEnd is exclusive, range.endLine is inclusive
-                            };
-                            var inlineInfo = EditorManager.createInlineEditorFromText(editor, text, range, rule.source.fullPath);
-                            
-                            var inlineEditor = inlineInfo.editor;
-                            
-                            // For Sprint 4, editor is a read-only view
-                            inlineEditor.setOption("readOnly", true);
-                            
+                    _showTextRangeInInlineEditor(editor, rule.source, rule.lineStart, rule.lineEnd)
+                        .done(function (inlineInfo) {
                             result.resolve(inlineInfo);
                         })
-                        .fail(function (fileError) {
-                            console.log("Error reading as text: ", fileError);
+                        .fail(function () {
                             result.reject();
                         });
                 } else {

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
      * @param {!CodeMirror} editor
      * @param {!{line:Number, ch:Number}} pos
      * @return {$.Promise} a promise that will be resolved with:
-     *      {{inlineContent:DOMElement, height:Number, onAdded:function(inlineId:Number)}}
+     *      {{content:DOMElement, height:Number, onAdded:function(inlineId:Number)}}
      *      or null if we're not going to provide anything.
      */
     function htmlToCSSProvider(editor, pos) {

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -51,10 +51,10 @@ define(function (require, exports, module) {
         var tagInfo = CodeHintUtils.getTagInfo(editor, pos),
             selectorName = "";
         
-        if (tagInfo.position.type === CodeHintUtils.TAG_NAME) {
+        if (tagInfo.position.tokenType === CodeHintUtils.TAG_NAME) {
             // Type selector
             selectorName = tagInfo.tagName;
-        } else if (tagInfo.position.type === CodeHintUtils.ATTR_VALUE) {
+        } else if (tagInfo.position.tokenType === CodeHintUtils.ATTR_VALUE) {
             if (tagInfo.attr.name === "class") {
                 // Class selector. We only look for the class name
                 // that includes the insertion point. For example, if

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -93,7 +93,10 @@ define(function (require, exports, module) {
                     
                     FileUtils.readAsText(rule.source)
                         .done(function (text) {
-                            var range = { startLine: rule.lineStart, endLine: rule.lineEnd - 1 }; // rule.lineEnd is exclusive, range.endLine is inclusive
+                            var range = {
+                                startLine: rule.lineStart,
+                                endLine: rule.lineEnd - 1   // rule.lineEnd is exclusive, range.endLine is inclusive
+                            };
                             var inlineInfo = EditorManager.createInlineEditorFromText(editor, text, range, rule.source.fullPath);
                             
                             var inlineEditor = inlineInfo.editor;
@@ -104,10 +107,11 @@ define(function (require, exports, module) {
                             result.resolve(inlineInfo);
                         })
                         .fail(function (fileError) {
-                            console.log("Error in dummy htmlToCSSProvider(): ", fileError);
+                            console.log("Error reading as text: ", fileError);
                             result.reject();
                         });
                 } else {
+                    // No matching rules were found.
                     result.reject();
                 }
             })
@@ -115,28 +119,6 @@ define(function (require, exports, module) {
                 console.log("Error in CSSManager.findMatchingRules()");
                 result.reject();
             });
-        
-        /*
-        // Load a project file at random
-        var arbitraryFile = "todos.css";
-        var fileEntry = new NativeFileSystem.FileEntry(ProjectManager.getProjectRoot().fullPath + arbitraryFile);
-        FileUtils.readAsText(fileEntry)
-            .done(function (text) {
-                // var dummyRange = { startLine: 18, endLine: 22 };    // small rule
-                var dummyRange = { startLine: 218, endLine: 255 };    // tall rule
-                var inlineInfo = EditorManager.createInlineEditorFromText(editor, text, dummyRange, arbitraryFile);
-                
-                var inlineEditor = inlineInfo.editor;
-                
-                // For Sprint 4, editor is a read-only view
-                inlineEditor.setOption("readOnly", true);
-                
-                result.resolve(inlineInfo);
-            })
-            .fail(function (fileError) {
-                console.log("Error in dummy htmlToCSSProvider(): ", fileError);
-            });
-        */
         
         return result.promise();
     }


### PR DESCRIPTION
This pull request hooks up all the various pieces for inline display of CSS rules.

When viewing an HTML file, pressing Cmd/Ctrl+E does the following:
- checks to see if the selection is an insertion point
- calls CodeHintUtils to get the tag/attribute at the insertion point
- if the insertion point is in a tag name, use the tag name as the selector name
- if the insertion point is in an id attribute value, use "#" + the value as the selector name
- if the insertion point is in a class attribute value, use the word containing the insertion point as the class name, and prepend "." for the selector name

If the selector can be found within a .css file in your project, it will be displayed in an inline view. 

To close an inline editor, set the insertion point anywhere inside the inline editor and press Cmd/Ctrl+E.
