### PR TITLE
Fix issue #350

### DIFF
--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
             .done(function (text) {
                 var range = {
                     startLine: startLine,
-                    endLine: endLine - 1   // rule.lineEnd is exclusive, range.endLine is inclusive
+                    endLine: endLine
                 };
                 var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
                 


### PR DESCRIPTION
Don't adjust endLine on inline editors.

This may cause the editor to show an additional line, but that is better than crashing (and Jason will be fixing that soon).
