### PR TITLE
Let CodeMirror do its own refreshing on resize

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -420,20 +420,11 @@ define(function (require, exports, module) {
     
     /**
      * NJ's editor-resizing fix. Whenever the window resizes, we immediately adjust the editor's
-     * height; somewhat less than once per resize event, we also kick it to do a full re-layout.
+     * height.
      * @see #resizeEditor()
      */
     function _updateEditorSize() {
-        // Don't refresh every single time
-        if (!_resizeTimeout) {
-            _resizeTimeout = setTimeout(function () {
-                _resizeTimeout = null;
-                
-                if (_currentEditor) {
-                    _currentEditor.refresh();
-                }
-            }, 100);
-        }
+        // The editor itself will call refresh() when it gets the window resize event.
         if (_currentEditor) {
             $(_currentEditor.getScrollerElement()).height(_editorHolder.height());
         }
@@ -581,7 +572,9 @@ define(function (require, exports, module) {
     // Initialize: register listeners
     $(DocumentManager).on("currentDocumentChange", _onCurrentDocumentChange);
     $(DocumentManager).on("workingSetRemove", _onWorkingSetRemove);
-    $(window).resize(_updateEditorSize);
+    // Add this as a capture handler so we're guaranteed to run it before the editor does its own
+    // refresh on resize.
+    window.addEventListener("resize", _updateEditorSize, true);
     
     // Define public API
     exports.setEditorHolder = setEditorHolder;


### PR DESCRIPTION
@gruehle 

My original window resize handler assumed that we needed to refresh CodeMirror when we change the editor height. However, it turns out CodeMirror always refreshes itself whenever the window resizes, so we were updating the editor twice. Now we just set the height in a capture handler for window resize, and let CodeMirror refresh itself later.

https://github.com/adobe/CodeMirror2/pull/29 makes it so CodeMirror does the timeout itself, so it only refreshes itself once every 100ms during resizes.
