### PR TITLE
Ensure that the new widget is scrolled into view after its height is set

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -361,7 +361,7 @@ define(function (require, exports, module) {
             // Auto-size editor to its remaining content
             var widgetHeight = inlineEditor.totalHeight(true);
 
-            hostEditor.setInlineWidgetHeight(inlineId, widgetHeight);
+            hostEditor.setInlineWidgetHeight(inlineId, widgetHeight, true);
             $(inlineEditor.getScrollerElement()).height(widgetHeight);
             inlineEditor.refresh();
             


### PR DESCRIPTION
@gruehle or @peterflynn 

Fixes #383. 

Requires this CodeMirror pull request: https://github.com/adobe/CodeMirror2/pull/31
