### PR TITLE
Fix filename tab font on Windows

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -76,7 +76,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: @accent-bracket;}
         top: 0;
         background: #FFF;
         padding: 0px 4px 3px;
-        font-family: "Lucida Grande";
+        font-family: "Lucida Grande", Helvetica, Arial, sans-serif;
         font-size: 12px;
         border: solid #C0C0C0;
         border-width: 0px 1px 1px;


### PR DESCRIPTION
The filename tab was appearing as a serifed font on Windows because Lucida Grande is only on Mac. This adds font fallbacks for Windows.
