### PR TITLE
CSSUtils and InlineEditorProvider work with in-memory content

### DIFF
--- a/src/CSSUtils.js
+++ b/src/CSSUtils.js
@@ -14,7 +14,6 @@ define(function (require, exports, module) {
     var Async               = require("Async"),
         DocumentManager     = require("DocumentManager"),
         FileIndexManager    = require("FileIndexManager"),
-        FileUtils           = require("FileUtils"),
         NativeFileSystem    = require("NativeFileSystem").NativeFileSystem;
 
     /*
@@ -194,38 +193,27 @@ define(function (require, exports, module) {
         var result          = new $.Deferred(),
             cssFilesResult  = FileIndexManager.getFileInfoList("css"),
             selectors       = [];
-    
-        function _scanText(fileEntry, content) {
-            // Scan for selectors
-            var localResults = _findAllMatchingSelectorsInText(content, selector);
-            
-            localResults.forEach(function (value) {
-                selectors.push({
-                    source: fileEntry,
-                    lineStart: value.line,
-                    lineEnd: value.ruleEndLine
-                });
-            });
-        }
         
         function _loadFileAndScan(fullPath, selector) {
-            var fileEntry = new NativeFileSystem.FileEntry(fullPath),
-                result = new $.Deferred(),
-                document = DocumentManager.getDocumentForFile(fileEntry);
+            var result = new $.Deferred();
             
-            if (document) {
-                _scanText(fileEntry, document.getText());
-                result.resolve();
-            } else {
-                FileUtils.readAsText(fileEntry)
-                    .done(function (content) {
-                        _scanText(fileEntry, content);
-                        result.resolve();
-                    })
-                    .fail(function (error) {
-                        result.reject(error);
+            DocumentManager.getDocumentContents(fullPath)
+                .done(function (content) {
+                    var localResults = _findAllMatchingSelectorsInText(content, selector);
+                    var fileEntry = new NativeFileSystem.FileEntry(fullPath);
+                    
+                    localResults.forEach(function (value) {
+                        selectors.push({
+                            source: fileEntry,
+                            lineStart: value.line,
+                            lineEnd: value.ruleEndLine
+                        });
                     });
-            }
+                    result.resolve();
+                })
+                .fail(function (error) {
+                    result.reject(error);
+                });
         
             return result.promise();
         }

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -182,6 +182,28 @@ define(function (require, exports, module) {
         return getDocumentForFile(fileEntry);
     }
 
+    /** 
+     * If the given file is 'open' for editing, return the contents of the editor (which could
+     * be different from the contents of the file, if the editor contains unsaved changes). If
+     * the given file is not open for editing, read the contents off disk.
+     * @param {!string} fullPath
+     * @return {Deferred} A Deferred object that will be resolved with the contents of the document
+     */
+    function getDocumentContents(fullPath) {
+        var doc = getDocumentForPath(fullPath);
+        
+        if (doc) {
+            var result = new $.Deferred();
+            
+            result.resolve(doc.getText());
+            return result;
+        } else {
+            var fileEntry = new NativeFileSystem.FileEntry(fullPath);
+            
+            return FileUtils.readAsText(fileEntry);
+        }
+    }
+    
     /**
      * Displays the given file in the editor pane. May also add the item to the working set list.
      * This changes the value of getCurrentDocument(), which will trigger listeners elsewhere in the
@@ -627,6 +649,7 @@ define(function (require, exports, module) {
     exports.getCurrentDocument = getCurrentDocument;
     exports.getDocumentForPath = getDocumentForPath;
     exports.getDocumentForFile = getDocumentForFile;
+    exports.getDocumentContents = getDocumentContents;
     exports.getWorkingSet = getWorkingSet;
     exports.findInWorkingSet = findInWorkingSet;
     exports.getAllOpenDocuments = getAllOpenDocuments;

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -79,37 +79,28 @@ define(function (require, exports, module) {
      * @param {!Number} endLine The last line to be shown in the inline editor
      */
     function _showTextRangeInInlineEditor(parentEditor, fileEntry, startLine, endLine) {
-        var result = new $.Deferred(),
-            document = DocumentManager.getDocumentForFile(fileEntry);
+        var result = new $.Deferred();
         
-        function createEditor(text) {
-            var range = {
-                startLine: startLine,
-                endLine: endLine
-            };
-            var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
-            
-            var inlineEditor = inlineInfo.editor;
-            
-            // For Sprint 4, editor is a read-only view
-            inlineEditor.setOption("readOnly", true);
-            
-            return inlineInfo;
-        }
-        
-        if (document) {
-            result.resolve(createEditor(document.getText()));
-        } else {
-            FileUtils.readAsText(fileEntry)
-                .done(function (text) {
-                    result.resolve(createEditor(text));
-                })
-                .fail(function (fileError) {
-                    console.log("Error reading as text: ", fileError);
-                    result.reject();
-                });
-        }
-    
+        DocumentManager.getDocumentContents(fileEntry.fullPath)
+            .done(function (text) {
+                var range = {
+                    startLine: startLine,
+                    endLine: endLine
+                };
+                var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
+                
+                var inlineEditor = inlineInfo.editor;
+                
+                // For Sprint 4, editor is a read-only view
+                inlineEditor.setOption("readOnly", true);
+
+                result.resolve(inlineInfo);
+            })
+            .fail(function (fileError) {
+                console.log("Error getting document contents: ", fileError);
+                result.reject();
+            });
+
         return result.promise();
     }
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -75,7 +75,8 @@ define(function (require, exports, module) {
         Commands                : Commands,
         WorkingSetView          : WorkingSetView,
         CommandManager          : require("CommandManager"),
-        FileIndexManager        : FileIndexManager
+        FileIndexManager        : FileIndexManager,
+        CSSUtils                : require("CSSUtils")
     };
     
     // Uncomment the following line to force all low level file i/o routines to complete

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1019,7 +1019,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     var doc = DocumentManager.getCurrentDocument();
                     
-                    // Add several blank lines at the beginning of the text
+                    // Add a new selector to the file
                     doc.setText(doc.getText() + "\n\n.TESTSELECTOR {\n    font-size: 12px;\n}\n");
                     
                     // Look for the selector we just created


### PR DESCRIPTION
This change adds a new DocumentManager.getDocumentContents() function that returns the in-memory representation of the document (if the document is currently loaded), or the disk representation if the content is not loaded.

CSSUtils and InlineEditorProvider now call getDocumentContents() instead of FileUtils.readAsText(). This means that any unsaved changes in the document will be reflected in the inlined editor (this only happens when the inline editor is initially shown for now. Updating the contents after the editor is opened is part of the document synchronization user story).

Add unit tests to make sure CSSUtils reads in-memory content.
