### PR TITLE
Fix for issue 211, show all files types on file open

### DIFF
--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -136,7 +136,7 @@ define(function (require, exports, module) {
             // Prompt the user with a dialog
             // TODO (issue #117): we're relying on this to not be asynchronous--is that safe?
             NativeFileSystem.showOpenDialog(false, false, Strings.OPEN_FILE, _defaultOpenDialogFullPath,
-                ["htm", "html", "js", "css"], function (files) {
+                null, function (files) {
                     if (files.length > 0) {
                         result = doOpen(files[0])
                             .done(function updateDefualtOpenDialogFullPath(doc) {


### PR DESCRIPTION
For File > Open NativeFileSystem.showOpenDialog(...) passes in null for allowed file types to indicate all file types should be shown

This should be merged with the pull request of the same name in adobe/brackets-app

fixes issue #211
