### PR TITLE
Factor out an Editor wrapper object

### DIFF
--- a/src/CodeHintManager.js
+++ b/src/CodeHintManager.js
@@ -58,6 +58,8 @@ define(function (require, exports, module) {
     
     // Register our listeners
     // Commenting out the code hinting for now. Uncomment this line to re-enable.
+    // NOTE: this has gone stale a bit; individual Editors now dispatch a keyEvent event; there is
+    // no global EditorManager event
     //$(EditorManager).on("onKeyEvent", _onKeyEvent);
     
     // Define public API

--- a/src/CodeHintUtils.js
+++ b/src/CodeHintUtils.js
@@ -252,13 +252,13 @@ define(function (require, exports, module) {
      *      className:          string:"="
      *      className:string    string:""open-files-disclosure-arrow""
      *      className:tag       string:"></span>"
-     * @param {CodeMirror} editor An instance of a CodeMirror editor
+     * @param {Editor} editor An instance of a Brackets editor
      * @param {{ch: number, line: number}} pos  A CM pos (likely from editor.getCursor())
      * @return {{tagName:string, attr{name:string, value:string}, hint:{type:{string}, offset{number}}}}
      *              A tagInfo object with some context about the current tag hint.
      */
     function getTagInfo(editor, pos) {
-        var ctx = _getInitialContext(editor, pos),
+        var ctx = _getInitialContext(editor._codeMirror, pos),
             offset = _offsetInToken(ctx),
             tagInfo,
             tokenType;

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
         this.diskTimestamp = initialTimestamp;
         
         // Dirty-bit tracking
-        $(editor).on("onChange", this._handleEditorChange.bind(this));
+        $(editor).on("change", this._handleEditorChange.bind(this));
         this.isDirty = false;
         
         // Sniff line-ending style

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -383,40 +383,6 @@ define(function (require, exports, module) {
     };
     
     /**
-     * @private
-     * NOTE: this is actually "semi-private"; EditorManager also accesses this method. But no one
-     * other than DocumentManager and EditorManager should access it.
-     *
-     * Adds to the list of inline editors
-     * @param {!Editor} inlineEditor
-     */
-    Document.prototype._addInlineEditor = function (inlineEditor) {
-        this._inlineEditors.push(inlineEditor);
-    };
-    
-    /**
-     * @private
-     * NOTE: this is actually "semi-private"; EditorManager also accesses this method. But no one
-     * other than DocumentManager and EditorManager should access it.
-     *
-     * Removes the inline editor from our list
-     * @param {!Editor} inlineEditor
-     */
-    Document.prototype._removeInlineEditor = function (inlineEditor) {
-        var i = this._inlineEditors.indexOf(inlineEditor);
-        if (i >= 0) {
-            this._inlineEditors.splice(i, 1);
-        }
-    };
-    
-    /**
-     * @return {!Array.<Editor>} an array of inline editors
-     */
-    Document.prototype.getInlineEditors = function () {
-        return this._inlineEditors;
-    };
-    
-    /**
      * @return {string} The document's current contents; may not be saved to disk 
      *  yet. Returns null if the file was not yet read and no editor was 
      *  created.

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -329,14 +329,12 @@ define(function (require, exports, module) {
     /**
      * @private
      * NOTE: this is actually "semi-private"; EditorManager also accesses this field. But no one
-     * other than DocumentManager and EditorManager should access it.
+     * other than DocumentManager and EditorManager should access it. -- TODO: is this still true?
      *
      * The editor may be null in the case that the document working set was
      * restored from storage but an editor was not yet created.
-     * @type {?CodeMirror}
+     * @type {?Editor}
      */
-    Document.prototype._editor = null;
-    
     Document.prototype.editor = null;
 
     /**
@@ -371,7 +369,6 @@ define(function (require, exports, module) {
         console.assert(!this.editor);
         
         this.editor = editor;
-        this._editor = editor._editor;
         this.diskTimestamp = initialTimestamp;
         
         // Dirty-bit tracking
@@ -391,7 +388,7 @@ define(function (require, exports, module) {
      * other than DocumentManager and EditorManager should access it.
      *
      * Adds to the list of inline editors
-     * @param {!CodeMirror} inlineEditor
+     * @param {!Editor} inlineEditor
      */
     Document.prototype._addInlineEditor = function (inlineEditor) {
         this._inlineEditors.push(inlineEditor);
@@ -403,7 +400,7 @@ define(function (require, exports, module) {
      * other than DocumentManager and EditorManager should access it.
      *
      * Removes the inline editor from our list
-     * @param {!CodeMirror} inlineEditor
+     * @param {!Editor} inlineEditor
      */
     Document.prototype._removeInlineEditor = function (inlineEditor) {
         var i = this._inlineEditors.indexOf(inlineEditor);
@@ -413,7 +410,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * @return [{!CodeMirror}] an array of inline editors
+     * @return {!Array.<Editor>} an array of inline editors
      */
     Document.prototype.getInlineEditors = function () {
         return this._inlineEditors;

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -349,12 +349,10 @@ define(function (require, exports, module) {
     Document.prototype.diskTimestamp = null;
     
     /**
-     * @private
-     * NOTE: this is actually "semi-private"; EditorManager also accesses this field. But no one
-     * other than DocumentManager and EditorManager should access it. -- TODO: is this still true?
-     *
-     * The editor may be null in the case that the document working set was
-     * restored from storage but an editor was not yet created.
+     * Editor object representing the full-size editor UI for this document. Null if Document was
+     * restored from persisted working set but hasn'r been opened in the UI yet.
+     * Note: where Document and Editor APIs overlap, prefer Document. Only use Editor directly for
+     * UI-related actions that Document does not provide any APIs for.
      * @type {?Editor}
      */
     Document.prototype.editor = null;

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -193,7 +193,7 @@ define(function (require, exports, module) {
     function getDocumentContents(fullPath) {
         var doc = getDocumentForPath(fullPath);
         
-        if (doc) {
+        if (doc && doc.editor) {
             var result = new $.Deferred();
             
             result.resolve(doc.getText());

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -338,13 +338,6 @@ define(function (require, exports, module) {
     Document.prototype.editor = null;
 
     /**
-     * @private
-     * List of the open inline editors in this document
-     * @type [{!CodeMirror}]
-     */
-    Document.prototype._inlineEditors = [];
-
-    /**
      * Null only of editor is not open yet. If a Document is created on empty text, or text with
      * inconsistent line endings, the Document defaults to the current platform's standard endings.
      * @type {null|FileUtils.LINE_ENDINGS_CRLF|FileUtils.LINE_ENDINGS_LF}

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2012 Adobe Systems Incorporated. All Rights Reserved.
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define: false, $: false, CodeMirror: false */
+
+/**
+ * Editor is a 1-to-1 wrapper for a CodeMirror editor instance. It layers on Brackets-specific
+ * functionality and provides APIs that cleanly pass through the bits of CodeMirror that the rest
+ * of our codebase may want to interact with.
+ *
+ * For now, direct access to the underlying CodeMirror object is provided -- but this is considered
+ * deprecated.
+ *  
+ * The Editor object dispatches several events:
+ *    - onChange -- When the text of the editor changes (including due to undo/redo)
+ *    - xxxxxxx -- When a Document's changes have been saved. The 2nd arg to the listener is the 
+ *      Document that has been saved.
+ *
+ * These are jQuery events, so to listen for them you do something like this:
+ *    $(editorInstance).on("eventname", handler);
+ */
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Load dependent modules
+    // var FileUtils           = require("FileUtils"),
+    //     DocumentManager     = require("DocumentManager"),
+    //     EditorUtils         = require("EditorUtils"),
+    //     Strings             = require("strings");
+    
+    
+    /**
+     * @private
+     * Handle Tab key press.
+     * @param {!CodeMirror} instance CodeMirror instance.
+     */
+    function _handleTabKey(instance) {
+        // Tab key handling is done as follows:
+        // 1. If the selection is before any text and the indentation is to the left of 
+        //    the proper indentation then indent it to the proper place. Otherwise,
+        //    add another tab. In either case, move the insertion point to the 
+        //    beginning of the text.
+        // 2. If the selection is after the first non-space character, and is not an 
+        //    insertion point, indent the entire line(s).
+        // 3. If the selection is after the first non-space character, and is an 
+        //    insertion point, insert a tab character or the appropriate number 
+        //    of spaces to pad to the nearest tab boundary.
+        var from = instance.getCursor(true),
+            to = instance.getCursor(false),
+            line = instance.getLine(from.line),
+            indentAuto = false,
+            insertTab = false;
+        
+        if (from.line === to.line) {
+            if (line.search(/\S/) > to.ch || to.ch === 0) {
+                indentAuto = true;
+            }
+        }
+
+        if (indentAuto) {
+            var currentLength = line.length;
+            CodeMirror.commands.indentAuto(instance);
+            // If the amount of whitespace didn't change, insert another tab
+            if (instance.getLine(from.line).length === currentLength) {
+                insertTab = true;
+                to.ch = 0;
+            }
+        } else if (instance.somethingSelected()) {
+            CodeMirror.commands.indentMore(instance);
+        } else {
+            insertTab = true;
+        }
+        
+        if (insertTab) {
+            if (instance.getOption("indentWithTabs")) {
+                CodeMirror.commands.insertTab(instance);
+            } else {
+                var i, ins = "", numSpaces = instance.getOption("tabSize");
+                numSpaces -= to.ch % numSpaces;
+                for (i = 0; i < numSpaces; i++) {
+                    ins += " ";
+                }
+                instance.replaceSelection(ins, "end");
+            }
+        }
+    }
+    
+    /**
+     * @private
+     * Handle left arrow, right arrow, backspace and delete keys when soft tabs are used.
+     * @param {!CodeMirror} instance CodeMirror instance 
+     * @param {number} direction Direction of movement: 1 for forward, -1 for backward
+     * @param {function} functionName name of the CodeMirror function to call
+     * @return {boolean} true if key was handled
+     */
+    function _handleSoftTabNavigation(instance, direction, functionName) {
+        var handled = false;
+        if (!instance.getOption("indentWithTabs")) {
+            var cursor = instance.getCursor(),
+                tabSize = instance.getOption("tabSize"),
+                jump = cursor.ch % tabSize,
+                line = instance.getLine(cursor.line);
+
+            if (direction === 1) {
+                jump = tabSize - jump;
+
+                if (cursor.ch + jump > line.length) { // Jump would go beyond current line
+                    return false;
+                }
+
+                if (line.substr(cursor.ch, jump).search(/\S/) === -1) {
+                    instance[functionName](jump, "char");
+                    handled = true;
+                }
+            } else {
+                // Quick exit if we are at the beginning of the line
+                if (cursor.ch === 0) {
+                    return false;
+                }
+                
+                // If we are on the tab boundary, jump by the full amount, 
+                // but not beyond the start of the line.
+                if (jump === 0) {
+                    jump = tabSize;
+                }
+
+                // Search backwards to the first non-space character
+                var offset = line.substr(cursor.ch - jump, jump).search(/\s*$/g);
+
+                if (offset !== -1) { // Adjust to jump to first non-space character
+                    jump -= offset;
+                }
+
+                if (jump > 0) {
+                    instance[functionName](-jump, "char");
+                    handled = true;
+                }
+            }
+        }
+
+        return handled;
+    }
+    
+
+    /**
+     * Creates a new CodeMirror editor instance containing the given text. The editor's mode is set
+     * based on the given filename's extension (the actual file on disk is never examined).
+     *
+     * @param {!string} text  The text content of the editor.
+     * @param {!string} mode  Syntax-highlighting language mode.
+     *          See {@link EditorUtils#getModeFromFileExtension()}.
+     * @param {!jQueryObject} container  Container to add the editor to.
+     * @param {!Object<string, function(CodeMirror)} additionalKeys  ...TODO...
+     * @return {CodeMirror} the newly created editor.
+     */
+    function Editor(text, mode, container, additionalKeys) {
+        var self = this;
+        
+        var codeMirrorKeyMap = {
+            "Tab"  : _handleTabKey,
+            "Left" : function (instance) {
+                if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
+                    CodeMirror.commands.goCharLeft(instance);
+                }
+            },
+            "Right" : function (instance) {
+                if (!_handleSoftTabNavigation(instance, 1, "moveH")) {
+                    CodeMirror.commands.goCharRight(instance);
+                }
+            },
+            "Backspace" : function (instance) {
+                if (!_handleSoftTabNavigation(instance, -1, "deleteH")) {
+                    CodeMirror.commands.delCharLeft(instance);
+                }
+            },
+            "Delete" : function (instance) {
+                if (!_handleSoftTabNavigation(instance, 1, "deleteH")) {
+                    CodeMirror.commands.delCharRight(instance);
+                }
+            },
+            "F3": "findNext",
+            "Shift-F3": "findPrev",
+            "Ctrl-H": "replace",
+            "Shift-Delete": "cut",
+            "Ctrl-Insert": "copy",
+            "Shift-Insert": "paste",
+        };
+        for (var key in additionalKeys) {
+            if (codeMirrorKeyMap.hasOwnProperty(key)) {
+                console.log("Warning: overwriting standard Editor shortcut "+key);
+            }
+            codeMirrorKeyMap[key] = function(instance) {
+                additionalKeys[key](self);
+            }
+        }
+        
+        // NOTE: CodeMirror doesn't actually require calling 'new',
+        // but jslint does require it because of the capital 'C'
+        var editor = new CodeMirror(container, {
+            electricChars: false,
+            indentUnit : 4,
+            lineNumbers: true,
+            matchBrackets: true,
+            extraKeys: codeMirrorKeyMap,
+            onKeyEvent: function (instance, event) {
+                if (event.type === "keypress") {
+                    var keyStr = String.fromCharCode(event.which || event.keyCode);
+                    if (/[\]\}\)]/.test(keyStr)) {
+                        // If the whole line is whitespace, auto-indent it
+                        var lineNum = instance.getCursor().line;
+                        var lineStr = instance.getLine(lineNum);
+                        
+                        if (!/\S/.test(lineStr)) {
+                            // Need to do the auto-indent on a timeout to ensure
+                            // the keypress is handled before auto-indenting.
+                            // This is the same timeout value used by the
+                            // electricChars feature in CodeMirror.
+                            setTimeout(function () {
+                                instance.indentLine(lineNum);
+                            }, 75);
+                        }
+                    }
+                }
+                
+                
+                $(exports).triggerHandler("onKeyEvent", [instance, event]);
+                return false;
+            }
+        });
+        
+        this._editor = editor;
+        
+        this._installEditorListeners();
+        
+        // Set code-coloring mode BEFORE populating with text, to avoid a flash of uncolored text
+        editor.setOption("mode", mode);
+        
+        // Initially populate with text. This will send a spurious change event, but that's ok
+        // because no one's listening yet (and we clear the undo stack below)
+        this.resetText(text);
+    }
+    
+    Editor.prototype._installEditorListeners = function() {
+        var self = this;
+        
+        this._editor.setOption("onChange", function () {
+            $(self).triggerHandler("onChange");
+        });
+    }
+    
+    
+    /**
+     * @return {string} The editor's current contents
+     */
+    Editor.prototype.getText = function() {
+        return this._editor.getValue();
+    }
+    /**
+     * Sets the contents of the editor. Treated as an edit, so it adds an undo step and dispatches
+     * onChange. Note: all line endings will be changed to LFs.
+     * @param {!string} text
+     */
+    Editor.prototype.setText = function(text) {
+        this._editor.setValue(text);
+    }
+    /**
+     * Sets the contents of the editor and clears the undo/redo history. Dispatches onChange.
+     * @param {!string} text
+     */
+    Editor.prototype.resetText = function(text) {
+        // This *will* fire a change event, but we clear the undo immediately afterward
+        this._editor.setValue(text);
+        
+        // Make sure we can't undo back to the empty state before setValue()
+        this._editor.clearHistory();
+    }
+    
+    
+    /**
+     * Gets the current cursor position within the editor. If there is a selection, returns ...TODO
+     * @return !{line:number, ch:number}
+     */
+    Editor.prototype.getCursorPos = function() {
+        return this._editor.getCursor();
+    }
+    /**
+     * Sets the cursor position within the editor. Removes any selection.
+     * @param {number} line The 0 based line number.
+     * @param {number} ch   The 0 based character position.
+     */
+    Editor.prototype.setCursorPos = function(line, ch) {
+        this._editor.setCursor(line, ch);
+    }
+    
+    
+    
+    Editor.prototype._editor = null;
+
+
+
+    // Define public API
+    exports.Editor = Editor;
+    // exports.setEditorHolder = setEditorHolder;
+    // exports.createDocumentAndEditor = createDocumentAndEditor;
+    // exports.createInlineEditorFromText = createInlineEditorFromText;
+    // exports.focusEditor = focusEditor;
+    // exports.resizeEditor = resizeEditor;
+    // exports.registerInlineEditProvider = registerInlineEditProvider;
+});

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
     // Load dependent modules
     var FileUtils           = require("FileUtils"),
         DocumentManager     = require("DocumentManager"),
+        Editor              = require("Editor").Editor,
         EditorUtils         = require("EditorUtils"),
         Strings             = require("strings");
     
@@ -46,118 +47,6 @@ define(function (require, exports, module) {
     var _inlineEditProviders = [];
     
     /**
-     * @private
-     * Handle Tab key press.
-     * @param {!CodeMirror} instance CodeMirror instance.
-     */
-    function _handleTabKey(instance) {
-        // Tab key handling is done as follows:
-        // 1. If the selection is before any text and the indentation is to the left of 
-        //    the proper indentation then indent it to the proper place. Otherwise,
-        //    add another tab. In either case, move the insertion point to the 
-        //    beginning of the text.
-        // 2. If the selection is after the first non-space character, and is not an 
-        //    insertion point, indent the entire line(s).
-        // 3. If the selection is after the first non-space character, and is an 
-        //    insertion point, insert a tab character or the appropriate number 
-        //    of spaces to pad to the nearest tab boundary.
-        var from = instance.getCursor(true),
-            to = instance.getCursor(false),
-            line = instance.getLine(from.line),
-            indentAuto = false,
-            insertTab = false;
-        
-        if (from.line === to.line) {
-            if (line.search(/\S/) > to.ch || to.ch === 0) {
-                indentAuto = true;
-            }
-        }
-
-        if (indentAuto) {
-            var currentLength = line.length;
-            CodeMirror.commands.indentAuto(instance);
-            // If the amount of whitespace didn't change, insert another tab
-            if (instance.getLine(from.line).length === currentLength) {
-                insertTab = true;
-                to.ch = 0;
-            }
-        } else if (instance.somethingSelected()) {
-            CodeMirror.commands.indentMore(instance);
-        } else {
-            insertTab = true;
-        }
-        
-        if (insertTab) {
-            if (instance.getOption("indentWithTabs")) {
-                CodeMirror.commands.insertTab(instance);
-            } else {
-                var i, ins = "", numSpaces = instance.getOption("tabSize");
-                numSpaces -= to.ch % numSpaces;
-                for (i = 0; i < numSpaces; i++) {
-                    ins += " ";
-                }
-                instance.replaceSelection(ins, "end");
-            }
-        }
-    }
-    
-    /**
-     * @private
-     * Handle left arrow, right arrow, backspace and delete keys when soft tabs are used.
-     * @param {!CodeMirror} instance CodeMirror instance 
-     * @param {number} direction Direction of movement: 1 for forward, -1 for backward
-     * @param {function} functionName name of the CodeMirror function to call
-     * @return {boolean} true if key was handled
-     */
-    function _handleSoftTabNavigation(instance, direction, functionName) {
-        var handled = false;
-        if (!instance.getOption("indentWithTabs")) {
-            var cursor = instance.getCursor(),
-                tabSize = instance.getOption("tabSize"),
-                jump = cursor.ch % tabSize,
-                line = instance.getLine(cursor.line);
-
-            if (direction === 1) {
-                jump = tabSize - jump;
-
-                if (cursor.ch + jump > line.length) { // Jump would go beyond current line
-                    return false;
-                }
-
-                if (line.substr(cursor.ch, jump).search(/\S/) === -1) {
-                    instance[functionName](jump, "char");
-                    handled = true;
-                }
-            } else {
-                // Quick exit if we are at the beginning of the line
-                if (cursor.ch === 0) {
-                    return false;
-                }
-                
-                // If we are on the tab boundary, jump by the full amount, 
-                // but not beyond the start of the line.
-                if (jump === 0) {
-                    jump = tabSize;
-                }
-
-                // Search backwards to the first non-space character
-                var offset = line.substr(cursor.ch - jump, jump).search(/\s*$/g);
-
-                if (offset !== -1) { // Adjust to jump to first non-space character
-                    jump -= offset;
-                }
-
-                if (jump > 0) {
-                    instance[functionName](-jump, "char");
-                    handled = true;
-                }
-            }
-        }
-
-        return handled;
-    }
-    
-    /**
      * Creates a new CodeMirror editor instance containing the given text. The editor's mode is set
      * based on the given filename's extension (the actual file on disk is never examined). The
      * editor is not yet visible.
@@ -167,88 +56,21 @@ define(function (require, exports, module) {
      * @param {!jQueryObject} container  Container to add the editor to.
      * @param {!function} onInlineGesture  Handler for Ctrl+E command (open/close inline, depending
                 on context)
-     * @return {CodeMirror} the newly created editor.
+     * @return {Editor} the newly created editor.
      */
     function _createEditorFromText(text, fileNameToSelectMode, container, onInlineGesture) {
-        // NOTE: CodeMirror doesn't actually require calling 'new',
-        // but jslint does require it because of the capital 'C'
-        var editor = new CodeMirror(container, {
-            electricChars: false,
-            indentUnit : 4,
-            lineNumbers: true,
-            matchBrackets: true,
-            extraKeys: {
-                "Tab"  : _handleTabKey,
-                "Left" : function (instance) {
-                    if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
-                        CodeMirror.commands.goCharLeft(instance);
-                    }
-                },
-                "Right" : function (instance) {
-                    if (!_handleSoftTabNavigation(instance, 1, "moveH")) {
-                        CodeMirror.commands.goCharRight(instance);
-                    }
-                },
-                "Backspace" : function (instance) {
-                    if (!_handleSoftTabNavigation(instance, -1, "deleteH")) {
-                        CodeMirror.commands.delCharLeft(instance);
-                    }
-                },
-                "Delete" : function (instance) {
-                    if (!_handleSoftTabNavigation(instance, 1, "deleteH")) {
-                        CodeMirror.commands.delCharRight(instance);
-                    }
-                },
-                "F3": "findNext",
-                "Shift-F3": "findPrev",
-                "Ctrl-H": "replace",
-                "Shift-Delete": "cut",
-                "Ctrl-Insert": "copy",
-                "Shift-Insert": "paste",
-                "Ctrl-E" : function (instance) {
-                    onInlineGesture(instance);
-                },
-                "Cmd-E" : function (instance) {
-                    onInlineGesture(instance);
-                }
+        var mode = EditorUtils.getModeFromFileExtension(fileNameToSelectMode);
+        
+        var extraKeys = {
+            "Ctrl-E" : function (editor) {
+                onInlineGesture(editor);
             },
-            onKeyEvent: function (instance, event) {
-                if (event.type === "keypress") {
-                    var keyStr = String.fromCharCode(event.which || event.keyCode);
-                    if (/[\]\}\)]/.test(keyStr)) {
-                        // If the whole line is whitespace, auto-indent it
-                        var lineNum = instance.getCursor().line;
-                        var lineStr = instance.getLine(lineNum);
-                        
-                        if (!/\S/.test(lineStr)) {
-                            // Need to do the auto-indent on a timeout to ensure
-                            // the keypress is handled before auto-indenting.
-                            // This is the same timeout value used by the
-                            // electricChars feature in CodeMirror.
-                            setTimeout(function () {
-                                instance.indentLine(lineNum);
-                            }, 75);
-                        }
-                    }
-                }
-                
-                
-                $(exports).triggerHandler("onKeyEvent", [instance, event]);
-                return false;
+            "Cmd-E" : function (editor) {
+                onInlineGesture(editor);
             }
-        });
-        
-        // Set code-coloring mode
-        EditorUtils.setModeFromFileExtension(editor, fileNameToSelectMode);
-        
-        // Initially populate with text. This will send a spurious change event, but that's ok
-        // because no one's listening yet (and we clear the undo stack below)
-        editor.setValue(text);
-        
-        // Make sure we can't undo back to the empty state before setValue()
-        editor.clearHistory();
-        
-        return editor;
+        };
+
+        return new Editor(text, mode, container, extraKeys);
     }
     
     /**
@@ -269,20 +91,20 @@ define(function (require, exports, module) {
     }
     
     /** Bound to Ctrl+E on outermost editors */
-    function _openInlineWidget(instance) {
+    function _openInlineWidget(editor) {
         // Run through inline-editor providers until one responds
-        var pos = instance.getCursor();
+        var pos = editor.getCursorPos();
         var inlinePromise;
         var i;
         for (i = 0; i < _inlineEditProviders.length && !inlinePromise; i++) {
             var provider = _inlineEditProviders[i];
-            inlinePromise = provider(instance, pos);
+            inlinePromise = provider(editor._editor, pos);
         }
         
         // If one of them will provide a widget, show it inline once ready
         if (inlinePromise) {
             inlinePromise.done(function (inlineContent) {
-                var inlineId = instance.addInlineWidget(pos, inlineContent.content, inlineContent.height);
+                var inlineId = editor._editor.addInlineWidget(pos, inlineContent.content, inlineContent.height);
                 inlineContent.onAdded(inlineId);
             });
         }
@@ -365,8 +187,8 @@ define(function (require, exports, module) {
             reader = FileUtils.readAsText(fileEntry);
             
         reader.done(function (text, readTimestamp) {
-            var editor = _createEditorFromText(text, fileEntry.fullPath, container, _openInlineWidget);
-            result.resolve(editor, readTimestamp, text);
+            var editorWrapper = _createEditorFromText(text, fileEntry.fullPath, container, _openInlineWidget);
+            result.resolve(editorWrapper, readTimestamp, text);
         });
         reader.fail(function (error) {
             result.reject(error);
@@ -393,16 +215,17 @@ define(function (require, exports, module) {
         $(inlineContent).addClass("inlineCodeEditor");
         
         var myInlineId; // won't be populated until our afterAdded() callback is run
-        function closeThisInline(instance) {
+        function closeThisInline(editor) {
             _closeInlineWidget(hostEditor, myInlineId);
             var doc = _getDocumentForEditor(hostEditor);
             if (doc) {
-                doc._removeInlineEditor(instance);
+                doc._removeInlineEditor(editor._editor);
             }
             _syncGutterWidths(hostEditor);
         }
         
-        var inlineEditor = _createEditorFromText(text, fileNameToSelectMode, inlineContent, closeThisInline);
+        var editorWrapper = _createEditorFromText(text, fileNameToSelectMode, inlineContent, closeThisInline);
+        var inlineEditor = editorWrapper._editor;
         
         // Some tasks have to wait until we've been parented into the outer editor
         function afterAdded(inlineId) {
@@ -481,6 +304,7 @@ define(function (require, exports, module) {
     }
 
     /** Focus the currently visible editor. If no editor visible, does nothing. */
+    // TODO: rename to focusMainEditor()
     function focusEditor() {
         if (_currentEditor) {
             _currentEditor.focus();
@@ -543,11 +367,11 @@ define(function (require, exports, module) {
         }
 
         // Lazily create editor for Documents that were restored on-init
-        if (!document._editor) {
+        if (!document.editor) {
             var editorResult = _createEditorFromFile(document.file, _editorHolder.get(0));
 
-            editorResult.done(function (editor, readTimestamp, rawText) {
-                document._setEditor(editor, readTimestamp, rawText);
+            editorResult.done(function (editorWrapper, readTimestamp, rawText) {
+                document._setEditor(editorWrapper, readTimestamp, rawText);
                 _doShow(document);
             });
             editorResult.fail(function (error) {
@@ -638,10 +462,10 @@ define(function (require, exports, module) {
         var result          = new $.Deferred(),
             editorResult    = _createEditorFromFile(fileEntry, _editorHolder.get(0));
 
-        editorResult.done(function (editor, readTimestamp, rawText) {
+        editorResult.done(function (editorWrapper, readTimestamp, rawText) {
             // Create the Document wrapping editor & binding it to a file
             var doc = new DocumentManager.Document(fileEntry);
-            doc._setEditor(editor, readTimestamp, rawText);
+            doc._setEditor(editorWrapper, readTimestamp, rawText);
             result.resolve(doc);
         });
 

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
         
         hostEditor.removeInlineWidget(inlineId);
         
-        hostEditor._codeMirror.focus();
+        hostEditor.focus();
     }
     
     function registerInlineEditProvider(provider) {
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
             $(inlineEditorCM.getScrollerElement()).height(widgetHeight);
             inlineEditorCM.refresh();
             
-            inlineEditorCM.focus();
+            inlineEditor.focus();
         }
         
         return { content: inlineContent, editor: inlineEditor, height: 0, onAdded: afterAdded };
@@ -282,7 +282,7 @@ define(function (require, exports, module) {
     /** Focus the currently visible editor. If no editor visible, does nothing. */
     function focusEditor() {
         if (_currentEditor) {
-            _currentEditor._codeMirror.focus();
+            _currentEditor.focus();
         }
     }
     

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -280,7 +280,6 @@ define(function (require, exports, module) {
     }
 
     /** Focus the currently visible editor. If no editor visible, does nothing. */
-    // TODO: rename to focusMainEditor()
     function focusEditor() {
         if (_currentEditor) {
             _currentEditor._codeMirror.focus();

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -14,10 +14,7 @@
  * not a pure headless model. Each Document encapsulates an editor instance, and thus EditorManager
  * must have some knowledge about Document's internal state (we access its _editor property).
  *
- * This module dispatches several events:
- *    - onKeyEvent ({CodeMirror}, {KeyboardEvent}) -- When any key event happens in the editor. The event 
- *          provides the instance of the editor where the event occurred and the raw event. Most likely 
- *          this should get filtered for event.type === "keypress"
+ * This module does not dispatch any events.
  */
 define(function (require, exports, module) {
     'use strict';
@@ -139,7 +136,7 @@ define(function (require, exports, module) {
         
         var maxWidth = 0;
         editors.forEach(function (editor) {
-            var gutter = $(editor._codeMirror.getGutterElement())
+            var gutter = $(editor._codeMirror.getGutterElement());
             gutter.css("min-width", "");
             var curWidth = gutter.width();
             if (curWidth > maxWidth) {
@@ -174,8 +171,8 @@ define(function (require, exports, module) {
             reader = FileUtils.readAsText(fileEntry);
             
         reader.done(function (text, readTimestamp) {
-            var editorWrapper = _createEditorFromText(text, fileEntry.fullPath, container, _openInlineWidget);
-            result.resolve(editorWrapper, readTimestamp, text);
+            var editor = _createEditorFromText(text, fileEntry.fullPath, container, _openInlineWidget);
+            result.resolve(editor, readTimestamp, text);
         });
         reader.fail(function (error) {
             result.reject(error);
@@ -349,8 +346,8 @@ define(function (require, exports, module) {
         if (!document.editor) {
             var editorResult = _createEditorFromFile(document.file, _editorHolder.get(0));
 
-            editorResult.done(function (editorWrapper, readTimestamp, rawText) {
-                document._setEditor(editorWrapper, readTimestamp, rawText);
+            editorResult.done(function (editor, readTimestamp, rawText) {
+                document._setEditor(editor, readTimestamp, rawText);
                 _doShow(document);
             });
             editorResult.fail(function (error) {
@@ -441,10 +438,10 @@ define(function (require, exports, module) {
         var result          = new $.Deferred(),
             editorResult    = _createEditorFromFile(fileEntry, _editorHolder.get(0));
 
-        editorResult.done(function (editorWrapper, readTimestamp, rawText) {
+        editorResult.done(function (editor, readTimestamp, rawText) {
             // Create the Document wrapping editor & binding it to a file
             var doc = new DocumentManager.Document(fileEntry);
-            doc._setEditor(editorWrapper, readTimestamp, rawText);
+            doc._setEditor(editor, readTimestamp, rawText);
             result.resolve(doc);
         });
 

--- a/src/EditorUtils.js
+++ b/src/EditorUtils.js
@@ -24,7 +24,7 @@ define(function (require, exports, module) {
      * off the file's extension.
      * @param {string} fileUrl  A cannonical file URL to extract the extension from
      */
-    function _getModeFromFileExtensions(fileUrl) {
+    function getModeFromFileExtension(fileUrl) {
         var ext = PathUtils.filenameExtension(fileUrl);
         //incase the arg is just the ext
         if (!ext) {
@@ -58,16 +58,16 @@ define(function (require, exports, module) {
         }
     }
 
-    /**
-     * Change the current mode of the editor based on file extension 
-     * @param {object} editor  An instance of a CodeMirror editor
-     * @param {string} fileUrl  A cannonical file URL to extract the extension from
-     */
-    function setModeFromFileExtension(editor, fileUrl) {
-        var mode = _getModeFromFileExtensions(fileUrl);
-        editor.setOption("mode", mode);
-    }
+    // /**
+    //  * Change the current mode of the editor based on file extension 
+    //  * @param {object} editor  An instance of a CodeMirror editor
+    //  * @param {string} fileUrl  A cannonical file URL to extract the extension from
+    //  */
+    // function setModeFromFileExtension(editor, fileUrl) {
+    //     var mode = _getModeFromFileExtensions(fileUrl);
+    //     
+    // }
 
     // Define public API
-    exports.setModeFromFileExtension = setModeFromFileExtension;
+    exports.getModeFromFileExtension = getModeFromFileExtension;
 });

--- a/src/EditorUtils.js
+++ b/src/EditorUtils.js
@@ -58,16 +58,6 @@ define(function (require, exports, module) {
         }
     }
 
-    // /**
-    //  * Change the current mode of the editor based on file extension 
-    //  * @param {object} editor  An instance of a CodeMirror editor
-    //  * @param {string} fileUrl  A cannonical file URL to extract the extension from
-    //  */
-    // function setModeFromFileExtension(editor, fileUrl) {
-    //     var mode = _getModeFromFileExtensions(fileUrl);
-    //     
-    // }
-
     // Define public API
     exports.getModeFromFileExtension = getModeFromFileExtension;
 });

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
     /**
      * Show a range of text in an inline editor.
      * 
-     * @param {!CodeMirror} parentEditor The parent editor that will contain the inline editor
+     * @param {!Editor} parentEditor The parent editor that will contain the inline editor
      * @param {!FileEntry} fileEntry File containing inline content
      * @param {!Number} startLine The first line to be shown in the inline editor 
      * @param {!Number} endLine The last line to be shown in the inline editor
@@ -88,10 +88,8 @@ define(function (require, exports, module) {
                 };
                 var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
                 
-                var inlineEditor = inlineInfo.editor;
-                
                 // For Sprint 4, editor is a read-only view
-                inlineEditor.setOption("readOnly", true);
+                inlineInfo.editor._codeMirror.setOption("readOnly", true);
                 
                 result.resolve(inlineInfo);
             })
@@ -106,6 +104,7 @@ define(function (require, exports, module) {
     /**
      * Given a position in an HTML editor, returns the relevant selector for the attribute/tag
      * surrounding that position, or "" if none is found.
+     * @param {!Editor} editor
      * @private
      */
     function _getSelectorName(editor, pos) {
@@ -148,6 +147,7 @@ define(function (require, exports, module) {
     
     /**
      * Create the shadowing and filename tab for an inline editor.
+     * TODO: move to createInlineEditorFromText()
      * @private
      */
     function _createInlineEditorDecorations(editor, filename) {
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
         var filenameDiv = $('<div class="filename" style="visibility: hidden"/>').text(filename);
         
         // add inline editor styling
-        $(editor.getScrollerElement())
+        $(editor._codeMirror.getScrollerElement())
             .append('<div class="shadow top"/>')
             .append('<div class="shadow bottom"/>')
             .append(filenameDiv);
@@ -172,7 +172,7 @@ define(function (require, exports, module) {
      * When cursor is on an HTML tag name, class attribute, or id attribute, find associated
      * CSS rules and show (one/all of them) in an inline editor.
      *
-     * @param {!CodeMirror} editor
+     * @param {!Editor} editor
      * @param {!{line:Number, ch:Number}} pos
      * @return {$.Promise} a promise that will be resolved with:
      *      {{content:DOMElement, height:Number, onAdded:function(inlineId:Number)}}
@@ -180,19 +180,17 @@ define(function (require, exports, module) {
      */
     function htmlToCSSProvider(editor, pos) {
         // Only provide a CSS editor when cursor is in HTML content
-        if (editor.getOption("mode") !== "htmlmixed") {
+        if (editor._codeMirror.getOption("mode") !== "htmlmixed") {
             return null;
         }
-        var htmlmixedState = editor.getTokenAt(pos).state;
+        var htmlmixedState = editor._codeMirror.getTokenAt(pos).state;
         if (htmlmixedState.mode !== "html") {
             return null;
         }
         
         // Only provide CSS editor if the selection is an insertion point
-        var selStart = editor.getCursor(false),
-            selEnd = editor.getCursor(true);
-        
-        if (selStart.line !== selEnd.line || selStart.ch !== selEnd.ch) {
+        var sel = editor.getSelection(false);
+        if (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch) {
             return null;
         }
         

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
     
     /**
      * Create the shadowing and filename tab for an inline editor.
-     * TODO: move to createInlineEditorFromText()
+     * TODO (issue #424): move to createInlineEditorFromText()
      * @private
      */
     function _createInlineEditorDecorations(editor, filename) {

--- a/src/JSLint.js
+++ b/src/JSLint.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
                             }
                             row.addClass("selected");
                             selectedRow = row;
-                            currentDoc.setCursor(item.line - 1, item.character - 1);
+                            currentDoc.editor.setCursor(item.line - 1, item.character - 1);
                             EditorManager.focusEditor();
                         });
                     }

--- a/src/JSLint.js
+++ b/src/JSLint.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
                             }
                             row.addClass("selected");
                             selectedRow = row;
-                            currentDoc.editor.setCursor(item.line - 1, item.character - 1);
+                            currentDoc.editor.setCursorPos(item.line - 1, item.character - 1);
                             EditorManager.focusEditor();
                         });
                     }

--- a/src/QuickFileOpen.js
+++ b/src/QuickFileOpen.js
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
                     if (query.charAt(0) === ":") {
                         var lineNumber = parseInt(query.slice(1, query.length), 10);
                         if (!isNaN(lineNumber)) {
-                            DocumentManager.getCurrentDocument().setCursor(lineNumber - 1, 0);
+                            DocumentManager.getCurrentDocument().editor.setCursor(lineNumber - 1, 0);
                         }
                     } else {
                         CommandManager.execute(Commands.FILE_OPEN, {fullPath: query});

--- a/src/QuickFileOpen.js
+++ b/src/QuickFileOpen.js
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
                     if (query.charAt(0) === ":") {
                         var lineNumber = parseInt(query.slice(1, query.length), 10);
                         if (!isNaN(lineNumber)) {
-                            DocumentManager.getCurrentDocument().editor.setCursor(lineNumber - 1, 0);
+                            DocumentManager.getCurrentDocument().editor.setCursorPos(lineNumber - 1, 0);
                         }
                     } else {
                         CommandManager.execute(Commands.FILE_OPEN, {fullPath: query});

--- a/src/index.html
+++ b/src/index.html
@@ -27,9 +27,6 @@
 
 </head>
 <body>
-    <!-- TODO (Issue #279): LESS won't work directly from Chrome when run locally (unless you launch it with -allow-file-access-from-files)
-    due to annoying security restrictions. This will work in the shell app, or in other browsers like Safari. -->
-
     <!-- Top bar for menus -->
     <div class="topbar" data-dropdown="dropdown">
         <div class="topbar-inner">

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -9,21 +9,20 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var CodeHintUtils = require("CodeHintUtils");
+    var CodeHintUtils = require("CodeHintUtils"),
+        Editor        = require("Editor").Editor;
     
     //Use a clean version of the editor each time
-    var myCodeMirror;
+    var myEditor;
     beforeEach(function () {
         // init CodeMirror instance
         $("body").append("<div id='editor'/>");
-        myCodeMirror = new CodeMirror($("#editor").get(0), {
-            value: ""
-        });
+        myEditor = new Editor("", "", $("#editor").get(0), {});
     });
 
     afterEach(function () {
         $("#editor").remove();
-        myCodeMirror = null;
+        myEditor = null;
     });
     
     function getContentAndUpdatePos(pos, linesBefore, hintLineBefore, hintLineAfter, linesAfter) {
@@ -44,12 +43,12 @@ define(function (require, exports, module) {
             beforeEach(function () {
                 // tell CodeMirror this is html content as the mode is
                 //used in determining the hints
-                myCodeMirror.setOption("mode", "htmlmixed");
+                myEditor._codeMirror.setOption("mode", "htmlmixed");
             });
     
             it("should not find attribute hints in an empty editor", function () {
                 var pos = {"ch": 0, "line": 0};
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo());
             });
             
@@ -59,8 +58,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<p class="');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 0, "p", "class"));
             });
             
@@ -71,8 +70,8 @@ define(function (require, exports, module) {
                     '<p id="', '>test</p>',
                     [ '</div>', '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 0, "p", "id"));
             });
             
@@ -83,8 +82,8 @@ define(function (require, exports, module) {
                     '<p id="one', '>test</p>',
                     [ '</div>', '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 3, "p", "id", "one"));
             });
             
@@ -95,8 +94,8 @@ define(function (require, exports, module) {
                     '<p id="foo">tricky="', '</p>',
                     [ '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo());
             });
             
@@ -107,8 +106,8 @@ define(function (require, exports, module) {
                     '<p class="foo"', '></p>',
                     [ '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 3, "p", "class", "foo"));
             });
             
@@ -119,8 +118,8 @@ define(function (require, exports, module) {
                     '<p class="foo', ' bar"></p>',
                     [ '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 3, "p", "class", "foo bar"));
             });
             
@@ -131,8 +130,8 @@ define(function (require, exports, module) {
                     '<p class = "foo"', '></p>',
                     [ '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 3, "p", "class", "foo"));
             });
             
@@ -143,8 +142,8 @@ define(function (require, exports, module) {
                     '<p class=', '"foo"></p>',
                     [ '</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_VALUE, 0, "p", "class", "foo"));
             });
             
@@ -154,8 +153,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<di');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.TAG_NAME, 2, "di"));
             });
             
@@ -165,8 +164,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<p>test</p><');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.TAG_NAME));
             });
             
@@ -176,8 +175,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<div><span');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.TAG_NAME, 4, "span"));
             });
             
@@ -187,8 +186,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<div><li  ', '  id="foo"');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_NAME, 0, "li"));
             });
             
@@ -198,8 +197,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<div><span ');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo(CodeHintUtils.ATTR_NAME, 0, "span"));
             });
             
@@ -209,8 +208,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>'],
                     '<div><span>');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo());
             });
             
@@ -221,8 +220,8 @@ define(function (require, exports, module) {
                     '<div><span></span>', '</div>',
                     ['</body>', '</html>']);
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo());
             });
             
@@ -232,8 +231,8 @@ define(function (require, exports, module) {
                     ['<html>', '<body>', '<div id="test" class="foo"></div>'],
                     '</body></ht', 'ml>');
                 
-                myCodeMirror.setValue(content);
-                var tag = CodeHintUtils.getTagInfo(myCodeMirror, pos);
+                myEditor.setText(content);
+                var tag = CodeHintUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(CodeHintUtils.createTagInfo());
             });
         });

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -8,56 +8,55 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var EditorUtils = require("EditorUtils");
+    var Editor      = require("Editor").Editor,
+        EditorUtils = require("EditorUtils");
 
     describe("Editor", function () {
         var content = 'Brackets is going to be awesome!\n';
 
-        describe("CodeMirror", function () {
-            var myCodeMirror;
+        describe("Editor wrapper", function () {
+            var myEditor;
 
             beforeEach(function () {
-                // init CodeMirror instance
+                // init Editor instance (containing a CodeMirror instance)
                 $("body").append("<div id='editor'/>");
-                myCodeMirror = new CodeMirror($("#editor").get(0), {
-                    value: content
-                });
+                myEditor = new Editor(content, "", $("#editor").get(0), {});
             });
 
             afterEach(function () {
                 $("#editor").remove();
-                myCodeMirror = null;
+                myEditor = null;
             });
 
             it("should initialize with content", function () {
                 // verify editor content
-                expect(myCodeMirror.getValue()).toEqual(content);
+                expect(myEditor.getText()).toEqual(content);
+            });
+        });
+            
+        describe("File extension to mode mapping", function () {
+            it("should switch to the HTML mode for files ending in .html", function () {
+                // verify editor content
+                var mode = EditorUtils.getModeFromFileExtension("file:///only/testing/the/path.html");
+                expect(mode).toEqual("htmlmixed");
             });
             
-            describe("Modes", function () {
-                it("should switch to the HTML mode for files ending in .html", function () {
-                    // verify editor content
-                    EditorUtils.setModeFromFileExtension(myCodeMirror, "file:///only/testing/the/path.html");
-                    expect(myCodeMirror.getOption("mode")).toEqual("htmlmixed");
-                });
-                
-                it("should switch modes even if the url has a query string", function () {
-                    // verify editor content
-                    EditorUtils.setModeFromFileExtension(myCodeMirror, "http://only.org/testing/the/path.css?v=2");
-                    expect(myCodeMirror.getOption("mode")).toEqual("css");
-                });
-                
-                it("should accecpt just a file name too", function () {
-                    // verify editor content
-                    EditorUtils.setModeFromFileExtension(myCodeMirror, "path.js");
-                    expect(myCodeMirror.getOption("mode")).toEqual("javascript");
-                });
+            it("should switch modes even if the url has a query string", function () {
+                // verify editor content
+                var mode = EditorUtils.getModeFromFileExtension("http://only.org/testing/the/path.css?v=2");
+                expect(mode).toEqual("css");
+            });
+            
+            it("should accecpt just a file name too", function () {
+                // verify editor content
+                var mode = EditorUtils.getModeFromFileExtension("path.js");
+                expect(mode).toEqual("javascript");
+            });
 
-                it("should default to plaintext for unknown file extensions", function () {
-                    // verify editor content
-                    EditorUtils.setModeFromFileExtension(myCodeMirror, "test.foo");
-                    expect(myCodeMirror.getOption("mode")).toEqual("");
-                });
+            it("should default to plaintext for unknown file extensions", function () {
+                // verify editor content
+                var mode = EditorUtils.getModeFromFileExtension("test.foo");
+                expect(mode).toEqual("");
             });
         });
     });

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -176,7 +176,7 @@ define(function (require, exports, module) {
 
             it("should report dirty after undo and redo", function () {
                 var doc = DocumentManager.getCurrentDocument();
-                var editor = doc._codeMirror;
+                var editor = doc.editor._codeMirror;
                 
                 runs(function () {
                     // change editor content, followed by undo and redo
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
                 runs(function() {
                     // change editor content, followed by undo
                     var doc = DocumentManager.getCurrentDocument();
-                    var editor = doc._codeMirror;
+                    var editor = doc.editor._codeMirror;
                     
                     doc.getText(TEST_JS_NEW_CONTENT);
                     editor.undo();

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -176,7 +176,7 @@ define(function (require, exports, module) {
 
             it("should report dirty after undo and redo", function () {
                 var doc = DocumentManager.getCurrentDocument();
-                var editor = doc._editor;
+                var editor = doc._codeMirror;
                 
                 runs(function () {
                     // change editor content, followed by undo and redo
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
                 runs(function() {
                     // change editor content, followed by undo
                     var doc = DocumentManager.getCurrentDocument();
-                    var editor = doc._editor;
+                    var editor = doc._codeMirror;
                     
                     doc.getText(TEST_JS_NEW_CONTENT);
                     editor.undo();

--- a/test/spec/FileCommandHandlers-test.js
+++ b/test/spec/FileCommandHandlers-test.js
@@ -102,8 +102,7 @@ define(function (require, exports, module) {
                 var didOpen     = false,
                     didSave     = false,
                     gotError    = false,
-                    filePath    = testPath + "/test.js",
-                    editor;
+                    filePath    = testPath + "/test.js";
 
                 runs(function () {
                     CommandManager.execute(Commands.FILE_OPEN, {fullPath: filePath})
@@ -114,8 +113,7 @@ define(function (require, exports, module) {
 
                 // modify and save
                 runs(function () {
-                    editor = DocumentManager.getCurrentDocument()._editor;
-                    editor.setValue(TEST_JS_NEW_CONTENT);
+                    DocumentManager.getCurrentDocument().setText(TEST_JS_NEW_CONTENT);
 
                     CommandManager.execute(Commands.FILE_SAVE)
                         .done(function () { didSave = true; })
@@ -211,12 +209,14 @@ define(function (require, exports, module) {
             it("should report not dirty after undo", function() {
                 runs(function() {
                     // change editor content, followed by undo
-                    var editor = DocumentManager.getCurrentDocument()._editor;
-                    editor.setValue(TEST_JS_NEW_CONTENT);
+                    var doc = DocumentManager.getCurrentDocument();
+                    var editor = doc._editor;
+                    
+                    doc.getText(TEST_JS_NEW_CONTENT);
                     editor.undo();
                     
                     // verify Document dirty status
-                    expect(editor.getValue()).toBe(TEST_JS_CONTENT);
+                    expect(doc.getText()).toBe(TEST_JS_CONTENT);
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
                 });
             });


### PR DESCRIPTION
Fixes architecture/cleanup issue #372.

Editor packages up a bunch of CodeMirror-management code, some old, some new:
- Instantiating CodeMirror and applying all of our tab/auto-indent fixes (moved from EditorManager)
- Ability to register multiple listeners for a single CodeMirror event
- Track the set of inline widgets currently open on an editor (moved from Document & improved)
- Get/set/reset text (moved from Document & EditorManager)
- Cleaner cursor/selection APIs
- Ability to add mixin CodeMirror key bindings (currently used only for the inline editor open/close shortcut)

Most code that used to pass around CodeMirror instances now passes around Editor instances instead.  There are still a few references to the underlying CodeMirror instance, via Editor._codeMirror (most notably in EditorManager and CodeHintUtils).

We could push harder on the cleanup here, e.g. factoring more of the resizing code into Editor or stripping out more of the references to _codeMirror...  But I feel like there'll be enough churn from the upcoming inline-editor stories that we may want to hold back and reassess what's best after that stuff has all landed.

Note: this pull request also includes a fix for issue #412 (Exception opening inline editor if CSS file is in working set but not yet opened).  See change to DocumentManager.getDocumentContents().
