### PR TITLE
make the default code font smaller

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -65,15 +65,12 @@
 
 .code-font() {
     color: @content-color;
-    font-size: 15px;
+    font-size: 14px;
     font-family: InconsolataMedium;
 
-    // Note: Large changes in font-size will also require setting
-    // a <pre> element line-height. That can be done like this:
-    //
-    // pre {
-    //     line-height: 50px;
-    // }
+    pre {
+        line-height: 15px;
+    }
 }
 
 .code-cursor() {


### PR DESCRIPTION
Would people like a smaller code font? @gruehle and @peterflynn would.

Limited scenario testing suggests that changing the code font size doesn't break anything. But, if it does, it's probably better to catch it now rather than later and fix it.
