### PR TITLE
Fix issue #229

### DIFF
--- a/src/FileUtils.js
+++ b/src/FileUtils.js
@@ -110,6 +110,22 @@ define(function (require, exports, module) {
         );
     }
 
+    /**
+     * Convert a URI path to a native path.
+     * On the mac, this is a no-op
+     * On windows, URI paths start with a "/", but have a drive letter ("C:"). In this
+     * case, remove the initial "/".
+     * @param {!string} path
+     * @return {string}
+     */
+    function convertToNativePath(path) {
+        if (path.indexOf(":") !== -1 && path[0] === "/") {
+            return path.substr(1);
+        }
+        
+        return path;
+    }
+    
     // Define public API
     exports.LINE_ENDINGS_CRLF        = LINE_ENDINGS_CRLF;
     exports.LINE_ENDINGS_LF          = LINE_ENDINGS_LF;
@@ -118,4 +134,5 @@ define(function (require, exports, module) {
     exports.showFileOpenError        = showFileOpenError;
     exports.getFileErrorString       = getFileErrorString;
     exports.readAsText               = readAsText;
+    exports.convertToNativePath      = convertToNativePath;
 });

--- a/src/NativeFileSystem.js
+++ b/src/NativeFileSystem.js
@@ -9,7 +9,6 @@ define(function (require, exports, module) {
     'use strict';
     
     var Async = require("Async");
-    
 
     var NativeFileSystem = {
         
@@ -469,9 +468,19 @@ define(function (require, exports, module) {
     NativeFileSystem.DirectoryEntry.prototype.getFile = function (path, options, successCallback, errorCallback) {
         var fileFullPath = path;
         
+        function isRelativePath(path) {
+            // If the path contains a colons it must be a full path on Windows (colons are
+            // not valid path characters on mac or in URIs)
+            if (path.indexOf(":") !== -1) {
+                return false;
+            }
+            
+            // For everyone else, absolute paths start with a "/"
+            return path[0] !== "/";
+        }
+
         // resolve relative paths relative to the DirectoryEntry
-        // most absolute paths have a leading slash except Windows which has a drive letter followed by :/
-        if (path.charAt(0) !== '/' && path.charAt(1) !== ":") {
+        if (isRelativePath(path)) {
             fileFullPath = this.fullPath + path;
         }
 

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         Dialogs             = require("Dialogs"),
         Strings             = require("strings"),
         FileViewController  = require("FileViewController"),
-        PerfUtils           = require("PerfUtils");
+        PerfUtils           = require("PerfUtils"),
+        FileUtils           = require("FileUtils");
     
     /**
      * @private
@@ -366,13 +367,8 @@ define(function (require, exports, module) {
         var loadedPath = window.location.pathname;
         var bracketsSrc = loadedPath.substr(0, loadedPath.lastIndexOf("/"));
         
-        // On Windows, when loading from a file, window.location.pathname has
-        // a leading '/'. Remove that here.
-        // TODO (issue #267): This will be obsolete when Brackets can support no project
-        if (bracketsSrc[0] === '/' && bracketsSrc[2] === ":") {
-            bracketsSrc = bracketsSrc.substr(1);
-        }
-
+        bracketsSrc = FileUtils.convertToNativePath(bracketsSrc);
+        
         return bracketsSrc;
     }
     

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -3,26 +3,16 @@
 define(function (require, exports, module) {
     'use strict';
     
+    var FileUtils   = require("FileUtils");
+    
     var TEST_PREFERENCES_KEY = "com.adobe.brackets.test.preferences",
         testWindow;
-
-    function fixPath(path) {
-        // On Windows, when loading from a file, window.location.href has
-        // a leading '/'. Remove that here.
-        // TODO (issue #281): Figure out a better way to handle this...
-        if (path.length > 3 && path[0] === '/' && path[2] === ":") {
-            path = path.substr(1);
-        }
-        
-        return path;
-    }
     
     function getTestRoot() {
         // /path/to/brackets/test/SpecRunner.html
-        var path = window.location.href;
-        path = path.substr("file://".length);
+        var path = window.location.pathname;
         path = path.substr(0, path.lastIndexOf("/"));
-        path = fixPath(path);
+        path = FileUtils.convertToNativePath(path);
         return path;
     }
     
@@ -31,8 +21,8 @@ define(function (require, exports, module) {
     }
     
     function getBracketsSourceRoot() {
-        var path = window.location.href;
-        path = path.substr("file://".length).split("/");
+        var path = window.location.pathname;
+        path = path.split("/");
         path = path.slice(0, path.length - 2);
         path.push("src");
         return path.join("/");


### PR DESCRIPTION
Add new FileUtils.convertToNativePath() method and call it from places that were doing explicit checks for windows style path names.

Add new "isRelativePath" inner function in NativeFileSystem. I considered adding it to FileUtils, but that would create a circular dependency between FileUtils and NativeFileSystem. This function is only used once in NativeFileSystem anyway.
