### PR TITLE
Adds a Debug > New Window command to open a new Brackets window.

### DIFF
--- a/src/Commands.js
+++ b/src/Commands.js
@@ -24,5 +24,6 @@ define(function (require, exports, module) {
     exports.DEBUG_RUN_UNIT_TESTS = "debug.runUnitTests";
     exports.DEBUG_JSLINT = "debug.jslint";
     exports.DEBUG_SHOW_PERF_DATA = "debug.showPerfData";
+    exports.DEBUG_NEW_BRACKETS_WINDOW = "debug.newBracketsWindow";
 });
 

--- a/src/DebugCommandHandlers.js
+++ b/src/DebugCommandHandlers.js
@@ -89,7 +89,12 @@ define(function (require, exports, module) {
             });
     }
     
+    function _handleNewBracketsWindow() {
+        window.open(window.location.href);
+    }
+    
     CommandManager.register(Commands.DEBUG_JSLINT, _handleEnableJSLint);
     CommandManager.register(Commands.DEBUG_RUN_UNIT_TESTS, _handleRunUnitTests);
     CommandManager.register(Commands.DEBUG_SHOW_PERF_DATA, _handleShowPerfData);
+    CommandManager.register(Commands.DEBUG_NEW_BRACKETS_WINDOW, _handleNewBracketsWindow);
 });

--- a/src/Menus.js
+++ b/src/Menus.js
@@ -46,6 +46,10 @@ define(function (require, exports, module) {
         $("#menu-debug-show-perf").click(function () {
             CommandManager.execute(Commands.DEBUG_SHOW_PERF_DATA);
         });
+        
+        $("#menu-debug-new-brackets-window").click(function () {
+            CommandManager.execute(Commands.DEBUG_NEW_BRACKETS_WINDOW);
+        });
     }
 
     // Define public API

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,7 @@
                             </a>
                         </li>
                         <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
+                        <li><a href="#" id="menu-debug-new-brackets-window">New Window</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Quick hack to create a second Brackets window so that you can test new code in that window without disturbing your main Brackets dev window.
