### PR TITLE
Auto size inline editor

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -335,6 +335,23 @@ define(function (require, exports, module) {
     Editor.prototype.setSelection = function (start, end) {
         this._codeMirror.setSelection(start, end);
     };
+
+    /**
+     * Gets the height of the editor.
+     * @param {!boolean} includePadding
+     * @returns {!number} height
+     */
+    Editor.prototype.totalHeight = function (includePadding) {
+        return this._codeMirror.totalHeight(includePadding);
+    }
+
+    /**
+    * Gets the scroller element from the editor.
+    * @returns {!HTMLDivElement} scroller
+    */
+    Editor.prototype.getScrollerElement = function () {
+        return this._codeMirror.getScrollerElement();
+    }
     
     
     /**
@@ -391,6 +408,16 @@ define(function (require, exports, module) {
     Editor.prototype.getInlineWidgets = function () {
         return this._inlineWidgets;
     };
+
+    /**
+     * Sets the height of the inline widget for this editor. The inline editor is identified by id.
+     * @param {!number} id
+     * @param {!height} height
+     * @param {boolean} ensureVisible
+     */
+    Editor.prototype.setInlineWidgetHeight = function (id, height, ensureVisible) {
+        this._codeMirror.setInlineWidgetHeight(id, height, ensureVisible);
+    }
     
     
     /** Gives focus to the editor control */
@@ -398,6 +425,12 @@ define(function (require, exports, module) {
         this._codeMirror.focus();
     };
     
+    /**
+     * Refreshes the editor control
+     */
+    Editor.prototype.refresh = function () {
+        this._codeMirror.refresh();
+    }
     
     
     /**

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -337,22 +337,46 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Gets the height of the editor.
+     * Gets the total number of lines in the the document (includes lines not visible in the viewport)
+     * @returns {!number}
+     */
+    Editor.prototype.lineCount = function () {
+        return this._codeMirror.lineCount();
+    };
+
+    /* Hides the specified line number in the editor
+     * @param {!number}
+     */
+    Editor.prototype.hideLine = function (lineNumber) {
+        return this._codeMirror.hideLine(lineNumber);
+    };
+
+    /**
+     * Gets the total height of the document in pixels (not the viewport)
      * @param {!boolean} includePadding
-     * @returns {!number} height
+     * @returns {!number} height in pixels
      */
     Editor.prototype.totalHeight = function (includePadding) {
         return this._codeMirror.totalHeight(includePadding);
-    }
+    };
 
     /**
-    * Gets the scroller element from the editor.
-    * @returns {!HTMLDivElement} scroller
-    */
+     * Gets the scroller element from the editor.
+     * @returns {!HTMLDivElement} scroller
+     */
     Editor.prototype.getScrollerElement = function () {
         return this._codeMirror.getScrollerElement();
-    }
+    };
     
+    /**
+     * Returns the provided function wrapped in a code mirror closure so that the function
+     * can operate on code mirror internal structures
+     * @param {!function}
+     * @returns {!function}
+     */
+    Editor.prototype.operation = function (func) {
+        return this._codeMirror.operation(func);
+    };
     
     /**
      * Adds an inline widget below the given line. If any inline widget was already open for that
@@ -417,7 +441,7 @@ define(function (require, exports, module) {
      */
     Editor.prototype.setInlineWidgetHeight = function (id, height, ensureVisible) {
         this._codeMirror.setInlineWidgetHeight(id, height, ensureVisible);
-    }
+    };
     
     
     /** Gives focus to the editor control */
@@ -430,7 +454,7 @@ define(function (require, exports, module) {
      */
     Editor.prototype.refresh = function () {
         this._codeMirror.refresh();
-    }
+    };
     
     
     /**

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -368,15 +368,6 @@ define(function (require, exports, module) {
         return this._codeMirror.getScrollerElement();
     };
     
-    /**
-     * Returns the provided function wrapped in a code mirror closure so that the function
-     * can operate on code mirror internal structures
-     * @param {!function}
-     * @returns {!function}
-     */
-    Editor.prototype.operation = function (func) {
-        return this._codeMirror.operation(func);
-    };
     
     /**
      * Adds an inline widget below the given line. If any inline widget was already open for that

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -229,7 +229,7 @@ define(function (require, exports, module) {
             // text itself so that the editor still shows accurate line numbers.
             var didHideLines  = false;
             if (range) {
-                inlineEditor.operation(function () {
+                inlineEditor._codeMirror.operation(function () {
                     var i;
                     for (i = 0; i < range.startLine; i++) {
                         didHideLines  = true;
@@ -248,7 +248,7 @@ define(function (require, exports, module) {
             // If we haven't hidden any lines (which would have caused an update already), 
             // force the editor to update its display so we measure the correct height below
             // in totalHeight().
-            if (!didHideLines ) {
+            if (!didHideLines) {
                 inlineEditor.refresh();
             }
             

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -88,9 +88,6 @@ define(function (require, exports, module) {
                     endLine: endLine
                 };
                 var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
-                
-                // For Sprint 4, editor is a read-only view
-                inlineInfo.editor._codeMirror.setOption("readOnly", true);
 
                 result.resolve(inlineInfo);
             })
@@ -156,7 +153,7 @@ define(function (require, exports, module) {
         var filenameDiv = $('<div class="filename" style="visibility: hidden"/>').text(filename);
         
         // add inline editor styling
-        $(editor._codeMirror.getScrollerElement())
+        $(editor.getScrollerElement())
             .append('<div class="shadow top"/>')
             .append('<div class="shadow bottom"/>')
             .append(filenameDiv);


### PR DESCRIPTION
- removed code that set inline editors to readonly. 
- added sizeInlineEditorToContents to createInlineEditorFromText to handle resizing the editor to the right size as the modifies the inline editor text
- added additional functions to Editor.js to proxy CodeMirror APIs
