### PR TITLE
Editing in an inline syncs into a full-size editor

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -104,7 +104,8 @@ define(function (require, exports, module) {
 
     /**
      * Returns all documents that are open in editors: the union of the working set and the current
-     * document (which may not be in the working set if it is unmodified).
+     * document (which may not be in the working set if it is unmodified). Files viewed in inline
+     * editors are only included in this list if they've been modified.
      * @return {Array.<Document>}
      */
     function getAllOpenDocuments() {

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * The FileEntry for the document being edited.
+     * The FileEntry for the document being edited. Need not lie within the project.
      * @type {!FileEntry}
      */
     Document.prototype.file = null;

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -185,6 +185,21 @@ define(function (require, exports, module) {
         var fileEntry = new NativeFileSystem.FileEntry(fullPath);
         return getDocumentForFile(fileEntry);
     }
+    
+    /**
+     * Returns a Document for the given file: the existing Document if the given file is 'open' for
+     * editing, or creates a new one otherwise. This is the preferred way to create a new Document.
+     * @param {!string} fullPath
+     * @return {!Document}
+    */
+    function getOrCreateDocumentForPath(fullPath) {
+        var fileEntry = new NativeFileSystem.FileEntry(fullPath);
+        var doc = getDocumentForFile(fileEntry);
+        if (!doc) {
+            doc = new Document(fileEntry);
+        }
+        return doc;
+    }
 
     /** 
      * If the given file is 'open' for editing, return the contents of the editor (which could
@@ -621,6 +636,7 @@ define(function (require, exports, module) {
     // Define public API
     exports.Document = Document;
     exports.getCurrentDocument = getCurrentDocument;
+    exports.getOrCreateDocumentForPath = getOrCreateDocumentForPath;
     exports.getDocumentForPath = getDocumentForPath;
     exports.getDocumentForFile = getDocumentForFile;
     exports.getDocumentContents = getDocumentContents;

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -295,6 +295,16 @@ define(function (require, exports, module) {
         this._codeMirror.clearHistory();
     };
     
+    /**
+     * Copies the state of changedEditor into this editor.
+     * NOTE: for now, all we do is copy the contents from one editor to the other. The undo/redo
+     * history and other details will differ.
+     * @param {Editor} changedEditor
+     */
+    Editor.prototype.syncFrom = function (changedEditor) {
+        this._codeMirror.setValue( changedEditor._codeMirror.getValue() );
+    }
+    
     
     /**
      * Gets the current cursor position within the editor. If there is a selection, returns whichever

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -164,9 +164,9 @@ define(function (require, exports, module) {
      * DocumentManager.showInEditor().
      * @param {!Document} document  Document whose main/full Editor to create
      * @return {Deferred} a jQuery Deferred that will be resolved once Document.editor is populated,
-     *      or rejected with a FileError if the file cannot be read.
+     *      or rejected with a FileError if the file cannot be read. Does not show any error UI.
      */
-    function _realizeFullEditor(document) {
+    function createFullEditorForDocument(document) {
         var result = new $.Deferred(),
             reader = FileUtils.readAsText(document.file);
             
@@ -226,7 +226,7 @@ define(function (require, exports, module) {
             }
             
             if (!doc.editor) {
-                var editorResult = _realizeFullEditor(doc);
+                var editorResult = createFullEditorForDocument(doc);
                 
                 editorResult.done(function () {
                     // TODO: begin syncing from inline to full editor
@@ -380,21 +380,12 @@ define(function (require, exports, module) {
             _destroyEditorIfUnneeded(_currentEditorsDocument);
         }
 
-        // Lazily create editor for Documents that were restored on-init
+        // DocumentManager should have already ensured that we've created an Editor
         if (!document.editor) {
-            var editorResult = _realizeFullEditor(document);
-            editorResult.done(function () {
-                _doShow(document);
-            });
-            editorResult.fail(function (error) {
-                FileUtils.showFileOpenError(error.code, document.file.fullPath).done(function () {
-                    DocumentManager.closeDocument(document);
-                    focusEditor();
-                });
-            });
-        } else {
-            _doShow(document);
+            throw new Error("Trying to show a currentDocument without an Editor!");
         }
+        
+        _doShow(document);
     }
     
 
@@ -467,6 +458,7 @@ define(function (require, exports, module) {
     
     // Define public API
     exports.setEditorHolder = setEditorHolder;
+    exports.createFullEditorForDocument = createFullEditorForDocument;
     exports.createInlineEditorFromText = createInlineEditorFromText;
     exports.focusEditor = focusEditor;
     exports.resizeEditor = resizeEditor;

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -215,13 +215,11 @@ define(function (require, exports, module) {
         
         // Wire up to Document and its main full-size editor
         $(inlineEditor).on("change", function () {
-            // Add to working set, since it's about to become dirty
+            // Ensure there's a Document
             var doc = DocumentManager.getDocumentForFile(sourceFile);
             if (!doc) {
                 // File wasn't open before, so we must create a new document for it
                 doc = new DocumentManager.Document(sourceFile);
-                
-                DocumentManager.addToWorkingSet(doc);
             }
             
             // Sync the change into the Document's full editor

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -88,12 +88,7 @@ define(function (require, exports, module) {
             PerfUtils.addMeasurement("Open File: " + fullPath);
         });
         
-        var doc = DocumentManager.getDocumentForPath(fullPath);
-        if (!doc) {
-            // File wasn't open before, so we must create a new document for it
-            var fileEntry = new NativeFileSystem.FileEntry(fullPath);
-            doc = new DocumentManager.Document(fileEntry);
-        }
+        var doc = DocumentManager.getOrCreateDocumentForPath(fullPath);
         
         // This will load the file if it was never open before, and then switch to it
         DocumentManager.showInEditor(doc)

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -88,26 +88,21 @@ define(function (require, exports, module) {
         });
         
         var doc = DocumentManager.getDocumentForPath(fullPath);
-        if (doc) {
-            // File already open - don't need to load it, just switch to it in the UI
-            DocumentManager.showInEditor(doc);
-            result.resolve(doc);
-            
-        } else {
+        if (!doc) {
             // File wasn't open before, so we must create a new document for it
             var fileEntry = new NativeFileSystem.FileEntry(fullPath);
-            var docResult = EditorManager.createDocumentAndEditor(fileEntry);
-
-            docResult.done(function (doc) {
-                DocumentManager.showInEditor(doc);
-                result.resolve(doc);
-            });
-            
-            docResult.fail(function (error) {
-                FileUtils.showFileOpenError(error.code, fullPath);
-                result.reject();
-            });
+            doc = new DocumentManager.Document(fileEntry);
         }
+        
+        // This will load the file if it was never open before, and then switch to it
+        DocumentManager.showInEditor(doc);
+        
+        // FIXME: if the file needed to be loaded, it's actually wrong to resolve() this already!
+        // Need to move file loading from EditorManager into DocumentManager so showInEditor() can
+        // return a Deferred that tracks this... or have EditorManager fire an event once it's done
+        // responding to currentDocumentChange.
+        // The performance numbers above will be artificially low until this is fixed...
+        result.resolve(doc);
 
         return result;
     }

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -87,11 +87,8 @@ define(function (require, exports, module) {
                     startLine: startLine,
                     endLine: endLine
                 };
-                var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry.fullPath);
+                var inlineInfo = EditorManager.createInlineEditorFromText(parentEditor, text, range, fileEntry);
                 
-                // For Sprint 4, editor is a read-only view
-                inlineInfo.editor._codeMirror.setOption("readOnly", true);
-
                 result.resolve(inlineInfo);
             })
             .fail(function (fileError) {


### PR DESCRIPTION
This covers the first _two_ coding tasks of the user story (4.2 & 4.3).  We do not yet handle the backing editor getting closed or refreshed; we do not show a dirty affordance on the inline editor; and File > Save still only looks at the outer (full-size) editor.

Summary of code changes:
- When edits are made in an inline, EditorManager ensures that a Document and full-size editor exist for that file and mirrors the edits into the full-size editor
- Replace EditorManager._createEditorFromFile()/createDocumentAndEditor() with a public createFullEditorForDocument() that lets us create an Editor in the background (i.e. it doesn't support only the case where the editor is about to become current)
- Move responsibility for loading files (and related error UI) from EditorManager._showEditor()/FileCommandHandlers.doOpen() to DocumentManager.showInEditor(). EditorManager still creates the Editor once the file is loaded, however.
- Fixes #216 (Clean up Document construction & loading) - there is now only a single codepath for loading a file into an Editor
- Aside: This also lets showInEditor() return a Deferred so callers can reliably know when it is complete. (This will make implementing the future compound operation "open to go to line" MUCH easier)
- Also fix minor bug in File > Open: the last-used directory was not remembered if there was any kind of error opening the file.

Note: assuming Ty's pull #435 lands first, I'll need to merge that in here before this pull can be finished.
