### PR TITLE
Use current project root as the initial directory when selecting a new project folder.

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -485,7 +485,7 @@ define(function (require, exports, module) {
         CommandManager.execute(Commands.FILE_CLOSE_ALL, { promptOnly: true })
             .done(function () {
                 // Pop up a folder browse dialog
-                NativeFileSystem.showOpenDialog(false, true, "Choose a folder", null, null,
+                NativeFileSystem.showOpenDialog(false, true, "Choose a folder", _projectRoot.fullPath, null,
                     function (files) {
                         // If length == 0, user canceled the dialog; length should never be > 1
                         if (files.length > 0) {


### PR DESCRIPTION
This is part of the fix for adobe/brackets-app#75
