### PR TITLE
Fix exception when creating an inline widget

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -386,7 +386,7 @@ define(function (require, exports, module) {
         var i;
         for (i = 0; i < this._inlineWidgets.length; i++) {
             var info = this._codeMirror.getInlineWidgetInfo(this._inlineWidgets[i].id);
-            if (info.line === pos.line) {
+            if (!info || (info.line === pos.line)) {
                 this.removeInlineWidget(this._inlineWidgets[i].id);
                 break;
             }

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -391,8 +391,9 @@ define(function (require, exports, module) {
      */
     Editor.prototype.addInlineWidget = function (pos, domContent, initialHeight, data) {
         // If any other inline widget is alrady open on this line, CodeMirror will automatically
-        // close it. We don't want to leak an _inlineWidgets entry, so check for this case and
-        // remove it manually instead.
+        // close it. Also, CodeMirror may have already disposed of one of the existing widgets due
+        // to an edit. We don't want to leak an _inlineWidgets entry, so check for these cases and
+        // remove it manually instead. When we fix issue #426 this should no longer be necessary here.
         var i;
         for (i = 0; i < this._inlineWidgets.length; i++) {
             var info = this._codeMirror.getInlineWidgetInfo(this._inlineWidgets[i].id);


### PR DESCRIPTION
@peterflynn 

If a widget has already been destroyed by CodeMirror, we would throw an exception when deciding whether to remove that widget from our list in the course of adding a new widget. This fixes it so we just remove it from our list in that case.

This is just an interim solution--it would be eventually fixed by a fix for #426.
