### PR TITLE
Make File > Save work on the currently focused editor

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -451,6 +451,12 @@ define(function (require, exports, module) {
         this._codeMirror.focus();
     };
     
+    /** Returns true if the editor has focus */
+    Editor.prototype.hasFocus = function () {
+        // The CodeMirror instance wrapper has a "CodeMirror-focused" class set when focused
+        return $(this._codeMirror.getWrapperElement()).hasClass("CodeMirror-focused");
+    };
+    
     /**
      * Refreshes the editor control
      */

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
      * @param {!FileEntry} sourceFile  The file from which the text was drawn. Ties the inline editor
      *      back to the full editor from which edits can be saved; also determines the editor's mode.
      *
-     * @returns {{content:DOMElement, height:Number, onAdded:function(inlineId:Number)}}
+     * @returns {{content:DOMElement, editor:Editor, source: FileEntry, height:Number, onAdded:function(inlineId:Number)}}
      */
     function createInlineEditorFromText(hostEditor, text, range, sourceFile) {
         // Container to hold editor & render its stylized frame
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
             inlineEditor.focus();
         }
         
-        return { content: inlineContent, editor: inlineEditor, height: 0, onAdded: afterAdded };
+        return { content: inlineContent, editor: inlineEditor, source: sourceFile, height: 0, onAdded: afterAdded };
     }
     
     
@@ -451,6 +451,33 @@ define(function (require, exports, module) {
         _editorHolder = holder;
     }
     
+    /**
+     * Returns the currently focused editor instance.
+     * @returns {{editor:Editor, source:FileEntry}}
+     */
+    function getFocusedEditor() {
+        if (_currentEditor) {
+            var focusedInline;
+            
+            // See if any inlines have focus
+            _currentEditor.getInlineWidgets().forEach(function (widget) {
+                if (widget.data.editor.hasFocus()) {
+                    focusedInline = { editor: widget.data.editor, source: widget.data.source };
+                }
+            });
+            
+            if (focusedInline) {
+                return focusedInline;
+            }
+            
+            if (_currentEditor.hasFocus()) {
+                return { editor: _currentEditor, source: _currentEditorsDocument.file };
+            }
+        }
+        
+        return null;
+    }
+    
     // Initialize: register listeners
     $(DocumentManager).on("currentDocumentChange", _onCurrentDocumentChange);
     $(DocumentManager).on("workingSetRemove", _onWorkingSetRemove);
@@ -463,6 +490,7 @@ define(function (require, exports, module) {
     exports.createFullEditorForDocument = createFullEditorForDocument;
     exports.createInlineEditorFromText = createInlineEditorFromText;
     exports.focusEditor = focusEditor;
+    exports.getFocusedEditor = getFocusedEditor;
     exports.resizeEditor = resizeEditor;
     exports.registerInlineEditProvider = registerInlineEditProvider;
 });

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -461,7 +461,7 @@ define(function (require, exports, module) {
             
             // See if any inlines have focus
             _currentEditor.getInlineWidgets().forEach(function (widget) {
-                if (widget.data.editor.hasFocus()) {
+                if (widget.data.editor && widget.data.editor.hasFocus()) {
                     focusedInline = { editor: widget.data.editor, source: widget.data.source };
                 }
             });

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
      * @param {!FileEntry} sourceFile  The file from which the text was drawn. Ties the inline editor
      *      back to the full editor from which edits can be saved; also determines the editor's mode.
      *
-     * @returns {{content:DOMElement, editor:Editor, source: FileEntry, height:Number, onAdded:function(inlineId:Number)}}
+     * @returns {{content:DOMElement, editor:Editor, source:FileEntry, height:Number, onAdded:function(inlineId:Number)}}
      */
     function createInlineEditorFromText(hostEditor, text, range, sourceFile) {
         // Container to hold editor & render its stylized frame

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -297,7 +297,11 @@ define(function (require, exports, module) {
             doc = commandData.doc;
         }
         if (!doc) {
-            doc = DocumentManager.getCurrentDocument();
+            var focusedEditor = EditorManager.getFocusedEditor();
+            
+            if (focusedEditor) {
+                doc = DocumentManager.getDocumentForFile(focusedEditor.source);
+            }
         }
         
         return doSave(doc);

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -302,6 +302,9 @@ define(function (require, exports, module) {
             if (focusedEditor) {
                 doc = DocumentManager.getDocumentForFile(focusedEditor.source);
             }
+            
+            // The doSave() method called below does a null check on doc and makes sure the
+            // document is dirty before saving.
         }
         
         return doSave(doc);

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -59,5 +59,29 @@ define(function (require, exports, module) {
                 expect(mode).toEqual("");
             });
         });
+        
+        describe("Focus", function () {
+            var myEditor;
+            
+            beforeEach(function () {
+                // init Editor instance (containing a CodeMirror instance)
+                $("body").append("<div id='editor'/>");
+                myEditor = new Editor(content, "", $("#editor").get(0), {});
+            });
+
+            afterEach(function () {
+                $("#editor").remove();
+                myEditor = null;
+            });
+
+            it("should not have focus until explicitly set", function () {
+                expect(myEditor.hasFocus()).toBe(false);
+            });
+            
+            it("should be able to detect when it has focus", function () {
+                myEditor.focus();
+                expect(myEditor.hasFocus()).toBe(true);
+            });
+        });
     });
 });


### PR DESCRIPTION
@peterflynn 

This change has a few small parts:
1. Add isFocused() method to Editor
2. Add "source" property to the object returned by EditorManager.createInlineEditorFromText()
3. Add EditorManager.getFocusedEditor() method
4. Update FileCommandHandlers.handleFileSave() to save the document associated with the currently focused editor.

The only part I'm not sure about is #2. We now have an anonymous object floating around that ties together a document and an editor. This is probably fine for now, but will need to be changed once we have proper Document <--> Editor mapping in place.
