### PR TITLE
sizeInlineEditorToContents() updated to account for line wrapping

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -360,16 +360,6 @@ define(function (require, exports, module) {
         return this._codeMirror.totalHeight(includePadding);
     };
 
-
-    /**
-     * Gets the total number of displayed lines for the document (not the viewport).
-     * This function accounts for extra lines due to word wrapping if wordWrapping is enabled.
-     * @returns {!number} height in lines
-     */
-    Editor.prototype.heightInLines = function () {
-        return this._codeMirror.heightInLines();
-    };
-
     /**
      * Gets the scroller element from the editor.
      * @returns {!HTMLDivElement} scroller

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -360,6 +360,16 @@ define(function (require, exports, module) {
         return this._codeMirror.totalHeight(includePadding);
     };
 
+
+    /**
+     * Gets the total number of displayed lines for the document (not the viewport).
+     * This function accounts for extra lines due to word wrapping if wordWrapping is enabled.
+     * @returns {!number} height in lines
+     */
+    Editor.prototype.heightInLines = function () {
+        return this._codeMirror.heightInLines();
+    };
+
     /**
      * Gets the scroller element from the editor.
      * @returns {!HTMLDivElement} scroller

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -209,14 +209,13 @@ define(function (require, exports, module) {
         var inlineEditor = _createEditorFromText(text, fileNameToSelectMode, inlineContent, closeThisInline);
 
         // Update the inline editor's height when the number of lines change
-        var prevLineCount;
+        var prevHeight;
         function sizeInlineEditorToContents() {
-            var lineCount = inlineEditor.lineCount();
-            if (lineCount !== prevLineCount) {
-                prevLineCount = lineCount;
-                var widgetHeight = inlineEditor.totalHeight(true);
-                hostEditor.setInlineWidgetHeight(myInlineId, widgetHeight, true);
-                $(inlineEditor.getScrollerElement()).height(widgetHeight);
+            var height = inlineEditor.totalHeight(true);
+            if (height !== prevHeight) {
+                prevHeight = height;
+                hostEditor.setInlineWidgetHeight(myInlineId, height, true);
+                $(inlineEditor.getScrollerElement()).height(height);
                 inlineEditor.refresh();
             }
         }


### PR DESCRIPTION
- changed sizeInlineEditorToContents() back to using totalHeight() instead of lineCount() to handle word wrap. Initially totalHeight() was thought to be too heavy to do on every change, but after further inspection this function just multiplies doc.height times the cached font height and adds padding. Inline editors don't have nested editors, so the inline loop is not executed. Therefore this function runs in constant time and is pretty light weight to call on every change.
- note: word wrapping is off by default and is not yet accessible via the UI, but I tested the resizing code with word wrap temporarily turned on.
