### PR TITLE
Add dirty indicator to inline editor tab

### DIFF
--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -70,6 +70,9 @@ define(function (require, exports, module) {
         
         _htmlToCSSProviderContent.forEach(function (value) {
             var $filenameDiv = $(value).find(".filename");
+            // This only checks filename here. If there are multiple documents with the same filename
+            // (in different directories), this test will fail.
+            // This needs to be fixed once we have proper document<-->editor mapping.
             if ($filenameDiv.text() === doc.file.name) {
                 _showDirtyIndicator($filenameDiv.find(".dirty-indicator"), doc.isDirty);
             }

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -37,7 +37,10 @@ define(function (require, exports, module) {
      * @private
      */
     function _showDirtyIndicator($indicatorDiv, isDirty) {
-        $indicatorDiv.css("visibility", isDirty ? "" : "hidden");
+        // Show or hide the dirty indicator by adjusting
+        // the width of the div. The "hidden" width is 
+        // 4 pixels to make the padding look correct.
+        $indicatorDiv.css("width", isDirty ? 16 : 4);
     }
     
     /**
@@ -178,7 +181,7 @@ define(function (require, exports, module) {
     function _createInlineEditorDecorations(editor, fileEntry) {
         // create the filename div
         var filenameDiv = $('<div class="filename" style="visibility: hidden"/>')
-            .append('<div class="dirty-indicator" style="visibility: hidden"/>')
+            .append('<div class="dirty-indicator"/>')
             .append(fileEntry.name);
         
         // add inline editor styling

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -33,6 +33,14 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Shows or hides the dirty indicator
+     * @private
+     */
+    function _showDirtyIndicator($indicatorDiv, isDirty) {
+        $indicatorDiv.css("visibility", isDirty ? "" : "hidden");
+    }
+    
+    /**
      * Returns editor holder width (not CodeMirror's width).
      * @private
      */
@@ -54,6 +62,21 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Respond to dirty flag change event. If the dirty flag is associated with an inline editor,
+     * show (or hide) the dirty indicator.
+     * @private
+     */
+    function _dirtyFlagChangeHandler(event, doc) {
+        
+        _htmlToCSSProviderContent.forEach(function (value) {
+            var $filenameDiv = $(value).find(".filename");
+            if ($filenameDiv.text() === doc.file.name) {
+                _showDirtyIndicator($filenameDiv.find(".dirty-indicator"), doc.isDirty);
+            }
+        });
+    }
+    
+    /**
      * Stops tracking an editor after being removed from the document.
      * @private
      */
@@ -66,7 +89,8 @@ define(function (require, exports, module) {
         
         // stop listening for resize when all inline editors are closed
         if (_htmlToCSSProviderContent.length === 0) {
-            $(window).unbind("resize", _updateAllFilenames);
+            $(window).off("resize", _updateAllFilenames);
+            $(DocumentManager).off("dirtyFlagChange", _dirtyFlagChangeHandler);
         }
     }
 
@@ -148,9 +172,11 @@ define(function (require, exports, module) {
      * TODO (issue #424): move to createInlineEditorFromText()
      * @private
      */
-    function _createInlineEditorDecorations(editor, filename) {
+    function _createInlineEditorDecorations(editor, fileEntry) {
         // create the filename div
-        var filenameDiv = $('<div class="filename" style="visibility: hidden"/>').text(filename);
+        var filenameDiv = $('<div class="filename" style="visibility: hidden"/>')
+            .append('<div class="dirty-indicator" style="visibility: hidden"/>')
+            .append(fileEntry.name);
         
         // add inline editor styling
         $(editor.getScrollerElement())
@@ -161,7 +187,9 @@ define(function (require, exports, module) {
         // update the current inline editor immediately
         // use setTimeout to allow filenameDiv to render first
         setTimeout(function () {
+            var document = DocumentManager.getDocumentForFile(fileEntry);
             _updateInlineEditorFilename(_editorHolderWidth(), filenameDiv);
+            _showDirtyIndicator(filenameDiv.find(".dirty-indicator"), document.isDirty);
             filenameDiv.css("visibility", "");
         }, 0);
     }
@@ -208,14 +236,15 @@ define(function (require, exports, module) {
                         .done(function (inlineInfo) {
                             // track inlineEditor content removal
                             inlineInfo.content.addEventListener("DOMNodeRemovedFromDocument", _inlineEditorRemoved);
-                            _createInlineEditorDecorations(inlineInfo.editor, rule.source.name);
+                            _createInlineEditorDecorations(inlineInfo.editor, rule.source);
                             
                             _htmlToCSSProviderContent.push(inlineInfo.content);
                             
                             // Manaully position filename div's. Can't use CSS positioning in this case
                             // since the label is relative to the window boundary, not CodeMirror.
                             if (_htmlToCSSProviderContent.length > 0) {
-                                $(window).bind("resize", _updateAllFilenames);
+                                $(window).on("resize", _updateAllFilenames);
+                                $(DocumentManager).on("dirtyFlagChange", _dirtyFlagChangeHandler);
                             }
                             
                             result.resolve(inlineInfo);

--- a/src/InlineEditorProviders.js
+++ b/src/InlineEditorProviders.js
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
         setTimeout(function () {
             var document = DocumentManager.getDocumentForFile(fileEntry);
             _updateInlineEditorFilename(_editorHolderWidth(), filenameDiv);
-            _showDirtyIndicator(filenameDiv.find(".dirty-indicator"), document.isDirty);
+            _showDirtyIndicator(filenameDiv.find(".dirty-indicator"), document ? document.isDirty : false);
             filenameDiv.css("visibility", "");
         }, 0);
     }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -76,7 +76,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: @accent-bracket;}
         #font > .sans-serif(normal, 12px, auto);
         top: 0;
         background: #FFF;
-        padding: 0 6px 0 0;
+        padding: 2px 6px 0 2px;
         border: solid #C0C0C0;
         border-width: 0px 1px 1px;
         border-bottom-right-radius: 3px 5px;

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -76,12 +76,19 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: @accent-bracket;}
         #font > .sans-serif(normal, 12px, auto);
         top: 0;
         background: #FFF;
-        padding: 0px 4px 3px;
+        padding: 0 6px 0 0;
         border: solid #C0C0C0;
         border-width: 0px 1px 1px;
         border-bottom-right-radius: 3px 5px;
         border-bottom-left-radius: 3px 5px;
         z-index: 11;
+        
+        .dirty-indicator {
+            .bracketSprite;
+            display: inline-block;
+            background-position: 0 0;
+            padding-top: 3px;
+        }
     }
     .shadow {
         display: block;


### PR DESCRIPTION
Listen for document dirty flag changes and update the dirty indicator accordingly.

There is no mapping between an inline editor UI and it's associated editor or document, so we fall back on basic filename matching. This means we could have incorrect matching if the filename is the same but the directories are different. 

This code will change once we have proper document<-->editor mapping (and is likely to change again once we finalize our UI).
