### PR TITLE
implement sort plugin to fix issue #146

### DIFF
--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -180,13 +180,13 @@ define(function (require, exports, module) {
                         // file because jsTree insists on loading one itself)
                     strings : { loading : "Loading ...", new_node : "New node" },
                     sort :  function (a, b) {
-                        if (brackets.platform === "mac") {
-                            return this.get_text(a).toLowerCase() > this.get_text(b).toLowerCase() ? 1 : -1;
-                        } else {
+                        if (brackets.platform === "win") {
                             // Windows: prepend folder names with a '0' and file names with a '1' so folders are listed first
                             var a1 = ($(a).hasClass("jstree-leaf") ? "1" : "0") + this.get_text(a).toLowerCase(),
                                 b1 = ($(b).hasClass("jstree-leaf") ? "1" : "0") + this.get_text(b).toLowerCase();
                             return (a1 > b1) ? 1 : -1;
+                        } else {
+                            return this.get_text(a).toLowerCase() > this.get_text(b).toLowerCase() ? 1 : -1;
                         }
                     }
                 }

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -184,14 +184,9 @@ define(function (require, exports, module) {
                             return this.get_text(a).toLowerCase() > this.get_text(b).toLowerCase() ? 1 : -1;
                         } else {
                             // Windows: prepend folder names with a '0' and file names with a '1' so folders are listed first
-                            var a1 = $(a),
-                                b1 = $(b);
-                            if (!a1 || !b1) {
-                                return 0;
-                            }
-                            var a2 = (a1.hasClass("jstree-open") || a1.hasClass("jstree-closed") ? "0" : "1") + this.get_text(a).toLowerCase(),
-                                b2 = (b1.hasClass("jstree-open") || b1.hasClass("jstree-closed") ? "0" : "1") + this.get_text(b).toLowerCase();
-                            return (a2 > b2) ? 1 : -1;
+                            var a1 = ($(a).hasClass("jstree-leaf") ? "1" : "0") + this.get_text(a).toLowerCase(),
+                                b1 = ($(b).hasClass("jstree-leaf") ? "1" : "0") + this.get_text(b).toLowerCase();
+                            return (a1 > b1) ? 1 : -1;
                         }
                     }
                 }

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -172,13 +172,28 @@ define(function (require, exports, module) {
         _projectTree = projectTreeContainer
             .jstree(
                 {
-                    plugins : ["ui", "themes", "json_data", "crrm"],
+                    plugins : ["ui", "themes", "json_data", "crrm", "sort"],
                     json_data : { data: treeDataProvider, correct_state: false },
                     core : { animation: 0 },
                     themes : { theme: "brackets", url: "styles/jsTreeTheme.css", dots: false, icons: false },
                         //(note: our actual jsTree theme CSS lives in brackets.less; we specify an empty .css
                         // file because jsTree insists on loading one itself)
-                    strings : { loading : "Loading ...", new_node : "New node" }
+                    strings : { loading : "Loading ...", new_node : "New node" },
+                    sort :  function (a, b) {
+                        if (brackets.platform === "mac") {
+                            return this.get_text(a).toLowerCase() > this.get_text(b).toLowerCase() ? 1 : -1;
+                        } else {
+                            // Windows: prepend folder names with a '0' and file names with a '1' so folders are listed first
+                            var a1 = $(a),
+                                b1 = $(b);
+                            if (!a1 || !b1) {
+                                return 0;
+                            }
+                            var a2 = (a1.hasClass("jstree-open") || a1.hasClass("jstree-closed") ? "0" : "1") + this.get_text(a).toLowerCase(),
+                                b2 = (b1.hasClass("jstree-open") || b1.hasClass("jstree-closed") ? "0" : "1") + this.get_text(b).toLowerCase();
+                            return (a2 > b2) ? 1 : -1;
+                        }
+                    }
                 }
             )
             .bind(


### PR DESCRIPTION
Implement sort plugin to fix issue #146.

Note that this changes the behavior when creating a new document, which starts with a name of "Untitled.js". Previously, the new file was placed as the first file inside of a selected folder or immediately following a selected file. Now, the new "Untitled.js" file is immediately sorted with any other files in the existing folder.
