### PR TITLE
Infrastructure for unit tests with offset-based fixtures

### DIFF
--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -459,6 +459,7 @@ define(function (require, exports, module) {
     window.addEventListener("resize", _updateEditorSize, true);
     
     // Define public API
+    exports._openInlineWidget = _openInlineWidget;
     exports.setEditorHolder = setEditorHolder;
     exports.createFullEditorForDocument = createFullEditorForDocument;
     exports.createInlineEditorFromText = createInlineEditorFromText;

--- a/src/FileUtils.js
+++ b/src/FileUtils.js
@@ -46,7 +46,32 @@ define(function (require, exports, module) {
             reader.readAsText(file, "utf8");
         });
 
-        return result;
+        return result.promise();
+    }
+    
+    /**
+     * Asynchronously writes a file as UTF-8 encoded text.
+     * @param {!FileEntry} fileEntry
+     * @param {!string} text
+     * @return {Deferred} a jQuery Deferred that will be resolved when
+     * file writing completes, or rejected with a FileError.
+     */
+    function writeText(fileEntry, text) {
+        var result = new $.Deferred();
+        
+        fileEntry.createWriter(function (fileWriter) {
+            fileWriter.onwriteend = function (e) {
+                result.resolve();
+            };
+            fileWriter.onerror = function (err) {
+                result.reject(err);
+            };
+
+            // TODO (issue #241): NativeFileSystem.BlobBulder
+            fileWriter.write(text);
+        });
+        
+        return result.promise();
     }
 
     /** @const */

--- a/src/FileUtils.js
+++ b/src/FileUtils.js
@@ -159,5 +159,6 @@ define(function (require, exports, module) {
     exports.showFileOpenError        = showFileOpenError;
     exports.getFileErrorString       = getFileErrorString;
     exports.readAsText               = readAsText;
+    exports.writeText                = writeText;
     exports.convertToNativePath      = convertToNativePath;
 });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
         FileCommandHandlers     : FileCommandHandlers,
         FileViewController      : FileViewController,
         DocumentManager         : DocumentManager,
+        EditorManager           : EditorManager,
         Commands                : Commands,
         WorkingSetView          : WorkingSetView,
         CommandManager          : require("CommandManager"),

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
     localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
 
     // Load test specs
-    require("spec/LowLevelFileIO-test.js");
+    /*require("spec/LowLevelFileIO-test.js");
     require("spec/FileCommandHandlers-test.js");
     require("spec/NativeFileSystem-test.js");
     require("spec/PreferencesManager-test.js");
@@ -26,7 +26,8 @@ define(function (require, exports, module) {
     require("spec/KeyMap-test.js");
     require("spec/FileIndexManager-test.js");
     require("spec/CodeHintUtils-test.js");
-    require("spec/CSSUtils-test.js");
+    require("spec/CSSUtils-test.js");*/
+    require("spec/InlineEditorProviders-test.js");
 
     // Clean up preferencesKey
     $(window).unload(function () {

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
     localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
 
     // Load test specs
-    /*require("spec/LowLevelFileIO-test.js");
+    require("spec/LowLevelFileIO-test.js");
     require("spec/FileCommandHandlers-test.js");
     require("spec/NativeFileSystem-test.js");
     require("spec/PreferencesManager-test.js");
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
     require("spec/KeyMap-test.js");
     require("spec/FileIndexManager-test.js");
     require("spec/CodeHintUtils-test.js");
-    require("spec/CSSUtils-test.js");*/
+    require("spec/CSSUtils-test.js");
     require("spec/InlineEditorProviders-test.js");
 
     // Clean up preferencesKey

--- a/test/spec/InlineEditorProviders-test-files/test1.css
+++ b/test/spec/InlineEditorProviders-test-files/test1.css
@@ -1,0 +1,8 @@
+div {
+    margin: 0;
+    padding: 0;
+}
+
+.foo {
+    color: #f00;
+}

--- a/test/spec/InlineEditorProviders-test-files/test1.css
+++ b/test/spec/InlineEditorProviders-test-files/test1.css
@@ -1,8 +1,8 @@
-div {
+{{0}}div {
     margin: 0;
     padding: 0;
 }
 
-.foo {
+{{1}}.foo {
     color: #f00;
 }

--- a/test/spec/InlineEditorProviders-test-files/test1.html
+++ b/test/spec/InlineEditorProviders-test-files/test1.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+    <title>test</title>
+    <link rel="stylesheet" href="test1.css">
+</head>
+<body>
+    <div{{0}} class="{{1}}foo">{{2}}</div>
+    <!--<div{{3}}>-->
+</body>
+</html>

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -51,11 +51,7 @@ define(function (require, exports, module) {
                 waitsFor(function () { return info && !err; }, "FILE_OPEN timeout", 1000);
                 
                 runs(function () {
-                    var offset0 = info.offsets[0];
-                    editor.setCursorPos(offset0.line, offset0.ch);
-                    
-                    // TODO (jasonsj): refactor CMD+E as a Command instead of a CodeMirror key binding?
-                    EditorManager._openInlineWidget(editor);
+                    SpecRunnerUtils.openInlineEditorAtOffset(editor, info.offsets[0]);
                 });
                 
                 waitsFor(function () {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012 Adobe Systems Incorporated. All Rights Reserved.
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define: false, describe: false, it: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    var Commands,       // loaded from brackets.test
+        EditorManager,  // loaded from brackets.test
+        SpecRunnerUtils = require("./SpecRunnerUtils.js");
+
+    describe("InlineEditorProviders", function () {
+
+        var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
+            testWindow;
+
+        beforeEach(function () {
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow      = w;
+                Commands        = testWindow.brackets.test.Commands;
+                EditorManager   = testWindow.brackets.test.EditorManager;
+            });
+        });
+
+        afterEach(function () {
+            SpecRunnerUtils.closeTestWindow();
+        });
+
+        describe("htmlToCSSProvider", function () {
+
+            it("TODO", function () {
+                var info        = null,
+                    editor      = null,
+                    err         = false,
+                    inlineData  = null;
+                
+                runs(function () {
+                    SpecRunnerUtils.openFileWithOffsets(testPath + "/test1.html")
+                        .done(function (result) {
+                            info = result;
+                            editor = info.document.editor;
+                        })
+                        .fail(function () {
+                            err = true;
+                        });
+                });
+                
+                waitsFor(function () { return info && !err; }, "FILE_OPEN timeout", 1000);
+                
+                runs(function () {
+                    var offset0 = info.offsets[0];
+                    editor.setCursorPos(offset0.line, offset0.ch);
+                    
+                    // TODO (jasonsj): refactor CMD+E as a Command instead of a CodeMirror key binding?
+                    EditorManager._openInlineWidget(editor);
+                });
+                
+                waitsFor(function () {
+                    return editor.getInlineWidgets().length > 0;
+                }, "inline editor timeout", 1000);
+                
+                runs(function () {
+                    inlineData = editor.getInlineWidgets()[0].data;
+                });
+            });
+        });
+    });
+});

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -77,12 +77,26 @@ define(function (require, exports, module) {
                     return docs["test1.html"].editor.getInlineWidgets().length > 0;
                 }, "inline editor timeout", 1000);
                 
+                var widgetHeight;
                 runs(function () {
                     inlineData = test1html.editor.getInlineWidgets()[0].data;
+                    widgetHeight = inlineData.editor.totalHeight(true);
                     var inlinePos = inlineData.editor.getCursorPos();
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
+                    expect(inlineData.editor.lineCount()).toBe(8);
                 });
+
+                // verify widget resizes when contents is changed
+                runs(function () {
+                    var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
+                    inlineData.editor.setText(inlineData.editor.getText() + newLines);
+                    expect(inlineData.editor.lineCount()).toBe(13);
+                    expect(inlineData.editor.totalHeight(true)).toBeGreaterThan(widgetHeight);
+                });
+
+
             });
+
         });
     });
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
             }
         }
         
-        return {offsets: offsets, text: output.join("")};
+        return {offsets: offsets, text: output.join(""), original: text};
     }
     
     /**
@@ -187,6 +187,30 @@ define(function (require, exports, module) {
             });
         
         return result.promise();
+    }
+    
+    function saveFileWithoutOffsets(path) {
+        var result = new $.Deferred(),
+            fileEntry = new NativeFileSystem.FileEntry(path);
+        
+        parseOffsetsFromFile(fileEntry).done(function (info) {
+            // Write TODO
+            result.resolve(info);
+        });
+        
+        return result.promise();
+    }
+    
+    /**
+     * Set editor cursor position to the given offset then activate an inline editor.
+     * @param {!Editor} editor
+     * @param {!{{line:number, ch:number}}} 
+     */
+    function openInlineEditorAtOffset(editor, offset) {
+        editor.setCursorPos(offset.line, offset.ch);
+        
+        // TODO (jasonsj): refactor CMD+E as a Command instead of a CodeMirror key binding?
+        testWindow.brackets.test.EditorManager._openInlineWidget(editor);
     }
 
     exports.TEST_PREFERENCES_KEY    = TEST_PREFERENCES_KEY;


### PR DESCRIPTION
@chrisbank 
- One unit test for htmlToCSSProvider inline editor
- Parsing offset markup (e.g. {{0}}) in test fixtures
- Unit test utils to open an array of files in the currently loaded project
