### PR TITLE
making Consolas the first font (for use on Windows) -- issue 440

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -66,7 +66,7 @@
 .code-font() {
     color: @content-color;
     font-size: 14px;
-    font-family: InconsolataMedium;
+    font-family: Consolas, InconsolataMedium;
 
     pre {
         line-height: 15px;


### PR DESCRIPTION
addresses issue #440 (hopefully)

@peterflynn can you verify that this looks good on your Windows box?
