### PR TITLE
moved all less/css includes before all js includes in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,24 +6,29 @@
 <head>
     <meta charset="utf-8">
     <title>Brackets</title>
-    
+
+    <!-- CSS/LESS -->
+
+    <!-- CSS for CodeMirror search support, currently for debugging only -->
+    <link rel="stylesheet" href="thirdparty/CodeMirror2/lib/util/dialog.css">
+    <!-- TODO (Issue #278): switch between runtime LESS compilation in dev mode and precompiled version -->
+    <link rel="stylesheet/less" href="brackets.less">
+    <script src="thirdparty/less-1.1.5.min.js"></script>
+    <!-- <link rel="stylesheet" href="brackets.min.css"> -->
+
+    <!-- JavaScript -->
+
     <!-- Pre-load third party scripts that cannot be async loaded. -->
     <script src="thirdparty/jquery-1.7.min.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
     
-    <!-- CodeMirror search support, currently for debugging only -->
-    <link rel="stylesheet" href="thirdparty/CodeMirror2/lib/util/dialog.css">
+    <!-- JS for CodeMirror search support, currently for debugging only -->
     <script src="thirdparty/CodeMirror2/lib/util/dialog.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/search.js"></script>
     
     <!-- All other scripts are loaded through require. -->
     <script src="thirdparty/require.js" data-main="brackets"></script>
-    
-    <!-- TODO (Issue #278): switch between runtime LESS compilation in dev mode and precompiled version -->
-    <link rel="stylesheet/less" href="brackets.less">
-    <script src="thirdparty/less-1.1.5.min.js"></script>
-    <!-- <link rel="stylesheet" href="brackets.min.css"> -->
 
 </head>
 <body>


### PR DESCRIPTION
While doing some performance testing today, I ran into a weird race condition where code would sometimes get drawn into the wrong place in the codemirror div right at load time.

The race condition was very hard to reproduce -- it happened once out of every 10 loads or so. Resizing the window (forcing the editor to redraw) would always fix the problem.

I suspect that it might have something to do with the way that codemirror detects the size of characters for its layout math, and the fact that LESS runs asynchronously.

I reordered index.html to include all CSS first, and then all JS. Since scripts execute in order, this means that the LESS->CSS conversion happens before codemirror.js runs.

I haven't seen the issue since (after 50+ reloads)
