### PR TITLE
updates for inline rule editor for what's shown before rules: comments, ...

### DIFF
--- a/src/CSSUtils.js
+++ b/src/CSSUtils.js
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
                         if (token === ";") {
                             inAtRule = false;
                         }
-                    } else if (token === "@charset" || token === "@import") {
+                    } else if (token.match(/@(charset|import|namespace)/i)) {
                         inAtRule = true;
                         currentPosition = -1;  // reset so we don't get @rules following comments
                         selectorGroupStartLine = -1;

--- a/src/CSSUtils.js
+++ b/src/CSSUtils.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
                         selectorGroupStartLine = -1;
                     } else {
                         // detect non-crlf whitespace, comments on same line as '}'
-                        if (currentPosition < 0 && (token !== " ") &&
+                        if (currentPosition < 0 && (token.trim() !== "") &&
                                 !(style === "comment" && stream.start > 0 && lines[i].substr(0, stream.start).indexOf('}') !== -1)) {
                              
                             // start of a new selector, or comment above selector

--- a/src/CSSUtils.js
+++ b/src/CSSUtils.js
@@ -29,10 +29,10 @@ define(function (require, exports, module) {
                                    starts that this selector (e.g. .baz) is part of. Particularly relevant for
                                    groups that are on multiple lines.
          selectorGroupStartChar:   column in line where the selector group starts.
-         ruleStartLine:            line where the rules for the selector start
-         ruleStartChar:            column in line where the rules for the selector start
-         ruleEndLine:              line where the rules for the selector end
-         ruleEndChar:              column in the line where the rules for the selector end
+         declListStartLine:        line where the declaration list for the rule starts
+         declListStartChar:        column in line where the declaration list for the rule starts
+         declListEndLine:          line where the declaration list for the rule ends
+         declListEndChar:          column in the line where the declaration list for the rule ends
      * @param text {!String} CSS text to extract from
      * @return {Array.<Object>} Array with objects specifying selectors.
      */
@@ -47,9 +47,9 @@ define(function (require, exports, module) {
         var currentSelector = "", currentPosition = -1, selectorStartLine;
         var token, style, stream, i, j;
 
-        var inRules = false;
+        var inDeclList = false, inAtRule = false;
         var selectorGroupStartLine = -1, selectorGroupStartChar = -1;
-        var ruleStartLine = -1, ruleStartChar = -1;
+        var declListStartLine = -1, declListStartChar = -1;
 
         for (i = 0; i < lineCount; ++i) {
             if (currentSelector.trim() !== "") {
@@ -64,27 +64,44 @@ define(function (require, exports, module) {
 
                 // DEBUG STATEMENT -- printer(token, style, i, stream.start, state.stack);
 
-                if (state.stack.indexOf("{") === -1 && // not in a rule
+                if (state.stack.indexOf("{") === -1 && // not in a declaration list
                         (state.stack.length === 0 || state.stack[state.stack.length - 1] !== "@media") && // not parsing a media query
-                        ((style === null && token !== "{" && token !== "}" && token !== ",") || (style !== null && style !== "comment" && style !== "meta"))) { // not at a non-selector token
-                    // we're parsing a selector!
-                    if (currentPosition < 0) { // start of a new selector
-                        currentPosition = stream.start;
-                        selectorStartLine = i;
-                        if (selectorGroupStartLine < 0) {
-                            // this is the start of a new comma-separated selector group
-                            // (whenever we start parsing rules, we set selectorGroupStartLine to -1)
-                            selectorGroupStartLine = selectorStartLine;
-                            selectorGroupStartChar = currentPosition;
+                        ((style === null && token !== "{" && token !== "}" && token !== ",") || (style !== null))) { // not at a non-selector token
+
+                    // check for these special cases:
+                    if (inAtRule) {
+                        // once we're in at @rule, consume tokens until next semi-colon
+                        if (token === ";") {
+                            inAtRule = false;
                         }
+                    } else if (token === "@charset" || token === "@import") {
+                        inAtRule = true;
+                        currentPosition = -1;  // reset so we don't get @rules following comments
+                        selectorGroupStartLine = -1;
+                    } else {
+                        // detect non-crlf whitespace, comments on same line as '}'
+                        if (currentPosition < 0 && (token !== " ") &&
+                                !(style === "comment" && stream.start > 0 && lines[i].substr(0, stream.start).indexOf('}') !== -1)) {
+                             
+                            // start of a new selector, or comment above selector
+                            currentSelector = "";
+                            currentPosition = stream.start;
+                            selectorStartLine = i;
+                            if (selectorGroupStartLine < 0) {
+                                // this is the start of a new comma-separated selector group
+                                // (whenever we start parsing a declaration list, we set selectorGroupStartLine to -1)
+                                selectorGroupStartLine = selectorStartLine;
+                                selectorGroupStartChar = currentPosition;
+                            }
+                        }
+                        currentSelector += token;
                     }
-                    currentSelector += token;
                 } else { // we aren't parsing a selector
                     if (currentSelector.trim() !== "") { // we have a selector, and we parsed something that is not part of a selector, so we just finished parsing a selector
                         selectors.push({selector: currentSelector.trim(),
                                         line: selectorStartLine,
                                         character: currentPosition,
-                                        ruleEndLine: -1,
+                                        declListEndLine: -1,
                                         selectorEndLine: i,
                                         selectorEndChar: stream.start - 1, // stream.start points to the first char of the non-selector token
                                         selectorGroupStartLine: selectorGroupStartLine,
@@ -94,27 +111,27 @@ define(function (require, exports, module) {
                     currentSelector = "";
                     currentPosition = -1;
 
-                    if (!inRules && state.stack.indexOf("{") > -1) { // just started parsing a rule
-                        inRules = true;
-                        ruleStartLine = i;
-                        ruleStartChar = stream.start;
+                    if (!inDeclList && state.stack.indexOf("{") > -1) { // just started parsing a declaration list
+                        inDeclList = true;
+                        declListStartLine = i;
+                        declListStartChar = stream.start;
 
-                        // Since we're now in a rule set, that means we also finished parsing the whole selector group.
+                        // Since we're now in a declartion list, that means we also finished parsing the whole selector group.
                         // Therefore, reset selectorGroupStartLine so that next time we parse a selector we know it's a new group
                         selectorGroupStartLine = -1;
                         selectorGroupStartChar = -1;
 
-                    } else if (inRules && state.stack.indexOf("{") === -1) {  // just finished parsing a rule
-                        inRules = false;
-                        // assign this rule position to every selector on the stack that doesn't have a rule start and end line
+                    } else if (inDeclList && state.stack.indexOf("{") === -1) {  // just finished parsing a declaration list
+                        inDeclList = false;
+                        // assign this declaration list position to every selector on the stack that doesn't have a declaration list start and end line
                         for (j = selectors.length - 1; j >= 0; j--) {
-                            if (selectors[j].ruleEndLine !== -1) {
+                            if (selectors[j].declListEndLine !== -1) {
                                 break;
                             } else {
-                                selectors[j].ruleStartLine = ruleStartLine;
-                                selectors[j].ruleStartChar = ruleStartChar;
-                                selectors[j].ruleEndLine = i;
-                                selectors[j].ruleEndChar = stream.pos - 1; // stream.pos actually points to the char after the }
+                                selectors[j].declListStartLine = declListStartLine;
+                                selectors[j].declListStartChar = declListStartChar;
+                                selectors[j].declListEndLine = i;
+                                selectors[j].declListEndChar = stream.pos - 1; // stream.pos actually points to the char after the }
                             }
                         }
                     }
@@ -159,7 +176,7 @@ define(function (require, exports, module) {
      *
      * @param text {!String} CSS text to search
      * @param selector {!String} selector to search for
-     * @return {Array.<{line:number, ruleEndLine:number}>} Array of objects containing the start
+     * @return {Array.<{line:number, declListEndLine:number}>} Array of objects containing the start
      *      and end line numbers (0-based, inclusive range) for each matched selector.
      */
     function _findAllMatchingSelectorsInText(text, selector) {
@@ -215,7 +232,7 @@ define(function (require, exports, module) {
      *
      * @param {!String} selector The selector to match. This can be a tag selector, class selector or id selector
      * @return {$.Promise} that will be resolved with an Array of objects containing the
-     *      source document, start line, and end line (0-based, inclusive range) for each matching rule.
+     *      source document, start line, and end line (0-based, inclusive range) for each matching declaration list.
      *      Does not addRef() the documents returned in the array.
      */
     function findMatchingRules(selector) {
@@ -235,7 +252,7 @@ define(function (require, exports, module) {
                         selectors.push({
                             document: doc,
                             lineStart: value.selectorGroupStartLine,
-                            lineEnd: value.ruleEndLine
+                            lineEnd: value.declListEndLine
                         });
                     });
                     result.resolve();

--- a/src/CSSUtils.js
+++ b/src/CSSUtils.js
@@ -75,6 +75,13 @@ define(function (require, exports, module) {
                             inAtRule = false;
                         }
                     } else if (token.match(/@(charset|import|namespace)/i)) {
+                        // This code only handles @rules in this format:
+                        //   @rule ... ;
+                        //
+                        // This code does not handle @rules that use this format:
+                        //    @rule ... { ... }
+                        // such as @media (which is handled elsewhere) @page,
+                        // @keyframes (also -webkit-keyframes, etc.), and @font-face.
                         inAtRule = true;
                         currentPosition = -1;  // reset so we don't get @rules following comments
                         selectorGroupStartLine = -1;

--- a/test/spec/CSSUtils-test-files/offsets.css
+++ b/test/spec/CSSUtils-test-files/offsets.css
@@ -9,3 +9,35 @@ a { color: "yellow"; }/*END*/
 a:visited { color: "black"; }/*END*/
 
 a { color: "red"; }/*END*/a { color: "blue"; }/*END*/
+
+/* Note: @charset and @import must be at top of style sheet, so
+ * examples are technically malformed, but parsing is the same
+ */
+@charset "UTF-8";
+/* comment after @rule should be included */
+a {
+	color: lime;
+}
+
+/* comment before @rule should be excluded */
+@import url("charset.css");
+a {
+	color: pink;
+}
+
+/* @media rule should be excluded */
+@media screen AND (max-width:320px) {
+    /* indented comment should be included */
+    a {
+        color: purple;
+    } /* comment on same line as previous rule should be excluded */
+    a {
+        color: purple;
+    }
+    
+    
+    a {
+        /* non-crlf whitespace before this rule should be excluded */
+        color: maroon;
+    }
+}

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -126,8 +126,10 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     expectRuleRanges(this, this.fileCssContent, "a", [
-                        {start: 0, end: 2}, {start: 3, end: 5 }, {start: 7, end: 7},
-                        {start: 8, end: 8}, {start: 10, end: 10}, {start: 10, end: 10}
+                        {start:  0, end:  2}, {start:  3, end:  5}, {start:  7, end:  7},
+                        {start:  8, end:  8}, {start: 10, end: 10}, {start: 10, end: 10},
+                        {start: 16, end: 19}, {start: 23, end: 25}, {start: 29, end: 32},
+                        {start: 33, end: 35}, {start: 38, end: 41}
                     ]);
                 });
             });

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
                 spec.expect(result.length).toEqual(ranges.length);
                 ranges.forEach(function (range, i) {
                     spec.expect(result[i].line).toEqual(range.start);
-                    spec.expect(result[i].ruleEndLine).toEqual(range.end);
+                    spec.expect(result[i].declListEndLine).toEqual(range.end);
                 });
             }
             
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
                 spec.expect(result.length).toEqual(ranges.length);
                 ranges.forEach(function (range, i) {
                     spec.expect(result[i].selectorGroupStartLine).toEqual(range.start);
-                    spec.expect(result[i].ruleEndLine).toEqual(range.end);
+                    spec.expect(result[i].declListEndLine).toEqual(range.end);
                 });
             }
             
@@ -211,7 +211,7 @@ define(function (require, exports, module) {
                 
                 expect(selectors[0]).not.toBe(null);
                 expect(selectors[0].line).toBe(292);
-                expect(selectors[0].ruleEndLine).toBe(301);
+                expect(selectors[0].declListEndLine).toBe(301);
             });
             
             it("should find all instances of the h2 selector", function () {
@@ -219,9 +219,9 @@ define(function (require, exports, module) {
                 expect(selectors.length).toBe(2);
                 
                 expect(selectors[0].line).toBe(292);
-                expect(selectors[0].ruleEndLine).toBe(301);
+                expect(selectors[0].declListEndLine).toBe(301);
                 expect(selectors[1].line).toBe(318);
-                expect(selectors[1].ruleEndLine).toBe(321);
+                expect(selectors[1].declListEndLine).toBe(321);
             });
             
             it("should return an empty array when findAllMatchingSelectors() can't find any matches", function () {


### PR DESCRIPTION
...no @rules, no whitespace.

This fixes Issues 403, 405, and an unreported issue with non-crlf whitespace.
