### PR TITLE
Change working set from list of Documents -> list of files

### DIFF
--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -547,7 +547,7 @@ define(function (require, exports, module) {
     /* (pretty toString(), to aid debugging) */
     Document.prototype.toString = function () {
         var dirtyInfo = (this.isDirty ? " (dirty!)" : " (clean)");
-        var editorInfo = (this._masterEditor ? " Editable" : " Non-editable");
+        var editorInfo = (this._masterEditor ? " (Editable)" : " (Non-editable)");
         var refInfo = " refs:" + this._refCount;
         return "[Document " + this.file.fullPath + dirtyInfo + editorInfo + refInfo + "]";
     };

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -261,7 +261,6 @@ define(function (require, exports, module) {
             // Switch editor to next document (or blank it out)
             if (nextFile) {
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: nextFile.fullPath });
-                // TODO: need to async wait for this? what if there's an error opening it?
             } else {
                 _clearCurrentDocument();
             }
@@ -339,7 +338,7 @@ define(function (require, exports, module) {
     /**
      * What we expect the file's timestamp to be on disk. If the timestamp differs from this, then
      * it means the file was modified by an app other than Brackets.
-     * @type {?Date}
+     * @type {!Date}
      */
     Document.prototype.diskTimestamp = null;
     

--- a/src/DocumentManager.js
+++ b/src/DocumentManager.js
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
     
     
     /**
-     * Adds the given document to the end of the working set list, if it is not already in the list.
+     * Adds the given file to the end of the working set list, if it is not already in the list.
      * Does not change which document is currently open in the editor.
      * @param {!FileEntry} file
      */
@@ -162,8 +162,8 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Removes the given document from the working set list, if it was in the list. Does not change
-     * the editor even if this document is the one currently open;.
+     * Removes the given file from the working set list, if it was in the list. Does not change
+     * the current editor even if it's for this file.
      * @param {!FileEntry} file
      */
     function _removeFromWorkingSet(file) {
@@ -228,9 +228,9 @@ define(function (require, exports, module) {
      *
      * Changes currentDocument if this file was the current document (may change to null).
      *
-     * TODO: disentangle the notion of closing the main editor vs. totally destroying a Document (e.g.
-     * because it has been deleted on disk). The latter can happen even when there's no main editor,
-     * and not in the working set.
+     * TODO (issue #474): disentangle the notion of closing the main editor vs. totally destroying a
+     * Document (e.g. because it has been deleted on disk). The latter can happen even when there's
+     * no main editor, and not in the working set.
      *
      * @param {!FileEntry} file
      */
@@ -655,7 +655,7 @@ define(function (require, exports, module) {
                     filesToOpen[index] = null;
                     oneFileResult.resolve();
                 });
-                        
+            
             return oneFileResult;
         }
 

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -199,6 +199,8 @@ define(function (require, exports, module) {
     function Editor(document, makeMasterEditor, mode, container, additionalKeys) {
         var self = this;
         
+        console.log("Creating Editor for "+document);
+        
         // Attach to document
         this.document = document;
         document.addRef();

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -199,8 +199,6 @@ define(function (require, exports, module) {
     function Editor(document, makeMasterEditor, mode, container, additionalKeys) {
         var self = this;
         
-        console.log("Creating Editor for "+document);
-        
         // Attach to document
         this.document = document;
         document.addRef();

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -313,7 +313,7 @@ define(function (require, exports, module) {
         
         // If outgoing editor is no longer needed, dispose it
         var isCurrentDocument = (DocumentManager.getCurrentDocument() === document);
-        var isInWorkingSet = (DocumentManager.findInWorkingSet(document.file) !== -1);
+        var isInWorkingSet = (DocumentManager.findInWorkingSet(document.file.fullPath) !== -1);
         if (!isCurrentDocument && !isInWorkingSet) {
             // Destroy the editor widget (which un-refs the Document and reverts it to read-only mode)
             editor.destroy();

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -303,7 +303,6 @@ define(function (require, exports, module) {
         
         // Called any time inline was closed, whether manually (via closeThisInline()) or automatically
         function afterClosed() {
-            //console.log("Inline editor is being destroyed!");
             _syncGutterWidths(hostEditor);
             inlineEditor.destroy(); //release ref on Document
         }

--- a/src/EditorManager.js
+++ b/src/EditorManager.js
@@ -312,7 +312,9 @@ define(function (require, exports, module) {
         }
         
         // If outgoing editor is no longer needed, dispose it
-        if (DocumentManager.getCurrentDocument() !== document && DocumentManager.findInWorkingSet(document.file.fullPath) === -1) {
+        var isCurrentDocument = (DocumentManager.getCurrentDocument() === document);
+        var isInWorkingSet = (DocumentManager.findInWorkingSet(document.file) !== -1);
+        if (!isCurrentDocument && !isInWorkingSet) {
             // Destroy the editor widget (which un-refs the Document and reverts it to read-only mode)
             editor.destroy();
             
@@ -423,23 +425,27 @@ define(function (require, exports, module) {
     }
     
     /** Handles removals from DocumentManager's working set list */
-    function _onWorkingSetRemove(event, removedDoc) {
+    function _onWorkingSetRemove(event, removedFile) {
         // There's one case where an editor should be disposed even though the current document
         // didn't change: removing a document from the working set (via the "X" button). (This may
         // also cover the case where the document WAS current, if the editor-swap happens before the
         // removal from the working set.
-        _destroyEditorIfUnneeded(removedDoc);
+        var doc = DocumentManager.getOpenDocumentForPath(removedFile.fullPath);
+        if (doc) {
+            _destroyEditorIfUnneeded(doc);
+        }
+        // else, file was listed in working set but never shown in the editor - ignore
     }
     // Note: there are several paths that can lead to an editor getting destroyed
-    //  - file was in working set, but not open; then closed (via working set "X" button)
+    //  - file was in working set, but not in current editor; then closed (via working set "X" button)
     //      --> handled by _onWorkingSetRemove()
-    //  - file was open, but not in working set; then navigated away from
+    //  - file was in current editor, but not in working set; then navigated away from
     //      --> handled by _onCurrentDocumentChange()
-    //  - file was open, but not in working set; then closed (via File > Close) (and thus implicitly
-    //    navigated away from)
+    //  - file was in current editor, but not in working set; then closed (via File > Close) (and thus
+    //    implicitly navigated away from)
     //      --> handled by _onCurrentDocumentChange()
-    //  - file was open AND in working set; then closed (via File > Close OR working set "X" button)
-    //    (and thus implicitly navigated away from)
+    //  - file was in current editor AND in working set; then closed (via File > Close OR working set
+    //    "X" button) (and thus implicitly navigated away from)
     //      --> handled by _onWorkingSetRemove() currently, but could be _onCurrentDocumentChange()
     //      just as easily (depends on the order of events coming from DocumentManager)
     

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -425,9 +425,12 @@ define(function (require, exports, module) {
     function handleFileCloseAll(commandData) {
         var result = new $.Deferred();
         
-        var unsavedDocs = DocumentManager.getWorkingSet().filter(function (file) {
+        var unsavedDocs = [];
+        DocumentManager.getWorkingSet().forEach(function (file) {
             var doc = DocumentManager.getOpenDocumentForPath(file.fullPath);
-            return (doc && doc.isDirty);
+            if (doc && doc.isDirty) {
+                unsavedDocs.push(doc);
+            }
         });
         
         if (unsavedDocs.length === 0) {

--- a/src/FileCommandHandlers.js
+++ b/src/FileCommandHandlers.js
@@ -324,8 +324,8 @@ define(function (require, exports, module) {
         // Do in serial because doSave shows error UI for each file, and we don't want to stack
         // multiple dialogs on top of each other
         return Async.doSequentially(
-            DocumentManager.getWorkingSet(), 
-            function(file) {
+            DocumentManager.getWorkingSet(),
+            function (file) {
                 var doc = DocumentManager.getOpenDocumentForPath(file.fullPath);
                 if (doc) {
                     return doSave(doc);
@@ -334,7 +334,8 @@ define(function (require, exports, module) {
                     return (new $.Deferred()).resolve();
                 }
             },
-            false);
+            false
+        );
     }
     
 
@@ -357,7 +358,7 @@ define(function (require, exports, module) {
         function doClose(doc) {
             if (!commandData || !commandData.promptOnly) {
                 // This selects a different document if the working set has any other options
-                DocumentManager.closeDocument(doc);
+                DocumentManager.closeFullEditor(doc.file);
             
                 EditorManager.focusEditor();
             }

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -169,7 +169,8 @@ define(function (require, exports, module) {
      */
     function closeDeletedDocs() {
         toClose.forEach(function (doc) {
-            DocumentManager.closeDocument(doc);
+            // TODO: should be Document.destroy() or something instead
+            DocumentManager.closeFullEditor(doc.file);
         });
     }
     
@@ -223,7 +224,8 @@ define(function (require, exports, module) {
                     if (id === Dialogs.DIALOG_BTN_DONTSAVE) {
                         if (toClose) {
                             // Discard - close editor
-                            DocumentManager.closeDocument(doc);
+                            // TODO: should be Document.destroy() or something instead
+                            DocumentManager.closeFullEditor(doc.file);
                             result.resolve();
                         } else {
                             // Discard - load changes from disk
@@ -294,6 +296,7 @@ define(function (require, exports, module) {
         // Each phase fully completes (asynchronously) before the next one begins.
         
         // 1) Check for external modifications
+        // TODO: actually need to check the UNION of this & the working set list!!!
         var allDocs = DocumentManager.getAllOpenDocuments();
         
         findExternalChanges(allDocs)

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
                     }
                 }
             );
-            return result;
+            return result.promise();
         }
         
         // Check all docs in parallel
@@ -110,6 +110,10 @@ define(function (require, exports, module) {
         return Async.doInParallel(docs, checkDoc, true);
     }
     
+    /**
+     * Scans all the files in the working set that do not have Documents (and thus were not scanned
+     * by findExternalChanges()). If any were deleted on disk, removes them from the working set.
+     */
     function syncUnopenWorkingSet() {
         // We only care about working set entries that have never been open (have no Document).
         var unopenWorkingSetFiles = DocumentManager.getWorkingSet().filter(function (wsFile) {
@@ -136,7 +140,7 @@ define(function (require, exports, module) {
                     }
                 }
             );
-            return result;
+            return result.promise();
         }
         
         // Check all these files in parallel
@@ -198,7 +202,7 @@ define(function (require, exports, module) {
      */
     function closeDeletedDocs() {
         toClose.forEach(function (doc) {
-            // TODO: should be Document.destroy() or something instead
+            // TODO (issue #474): should be Document.destroy() or something instead
             DocumentManager.closeFullEditor(doc.file);
         });
     }
@@ -253,7 +257,7 @@ define(function (require, exports, module) {
                     if (id === Dialogs.DIALOG_BTN_DONTSAVE) {
                         if (toClose) {
                             // Discard - close editor
-                            // TODO: should be Document.destroy() or something instead
+                            // TODO (issue #474): should be Document.destroy() or something instead
                             DocumentManager.closeFullEditor(doc.file);
                             result.resolve();
                         } else {
@@ -328,7 +332,6 @@ define(function (require, exports, module) {
         
         
         // 1) Check for external modifications
-        // TODO: actually need to check the UNION of this & the working set list!!!
         var allDocs = DocumentManager.getAllOpenDocuments();
         
         findExternalChanges(allDocs)

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
     function syncUnopenWorkingSet() {
         // We only care about working set entries that have never been open (have no Document).
         var unopenWorkingSetFiles = DocumentManager.getWorkingSet().filter(function (wsFile) {
-           return !DocumentManager.getOpenDocumentForPath(wsFile.fullPath);
+            return !DocumentManager.getOpenDocumentForPath(wsFile.fullPath);
         });
         
         function checkWorkingSetFile(file) {

--- a/src/FileSyncManager.js
+++ b/src/FileSyncManager.js
@@ -73,45 +73,74 @@ define(function (require, exports, module) {
         function checkDoc(doc) {
             var result = new $.Deferred();
             
-            // Docs restored from last launch aren't really "open" yet, so skip those
-            if (!doc.diskTimestamp) {
-                result.resolve();
-            } else {
-                doc.file.getMetadata(
-                    function (metadata) {
-                        // Does file's timestamp differ from last sync time on the Document?
-                        if (metadata.modificationTime.getTime() !== doc.diskTimestamp.getTime()) {
-                            if (doc.isDirty) {
-                                editConflicts.push(doc);
-                            } else {
-                                toReload.push(doc);
-                            }
-                        }
-                        result.resolve();
-                    },
-                    function (error) {
-                        // File has been deleted externally
-                        if (error.code === FileError.NOT_FOUND_ERR) {
-                            if (doc.isDirty) {
-                                deleteConflicts.push(doc);
-                            } else {
-                                toClose.push(doc);
-                            }
-                            result.resolve();
+            // Check file timestamp / existence
+            doc.file.getMetadata(
+                function (metadata) {
+                    // Does file's timestamp differ from last sync time on the Document?
+                    if (metadata.modificationTime.getTime() !== doc.diskTimestamp.getTime()) {
+                        if (doc.isDirty) {
+                            editConflicts.push(doc);
                         } else {
-                            // Some other error fetching metadata: treat as a real error
-                            console.log("Error checking modification status of " + doc.file.fullPath, error.code);
-                            result.reject();
+                            toReload.push(doc);
                         }
                     }
-                );
-            }
+                    result.resolve();
+                },
+                function (error) {
+                    // File has been deleted externally
+                    if (error.code === FileError.NOT_FOUND_ERR) {
+                        if (doc.isDirty) {
+                            deleteConflicts.push(doc);
+                        } else {
+                            toClose.push(doc);
+                        }
+                        result.resolve();
+                    } else {
+                        // Some other error fetching metadata: treat as a real error
+                        console.log("Error checking modification status of " + doc.file.fullPath, error.code);
+                        result.reject();
+                    }
+                }
+            );
             return result;
         }
         
         // Check all docs in parallel
         // (fail fast b/c we won't continue syncing if there was any error fetching timestamps)
         return Async.doInParallel(docs, checkDoc, true);
+    }
+    
+    function syncUnopenWorkingSet() {
+        // We only care about working set entries that have never been open (have no Document).
+        var unopenWorkingSetFiles = DocumentManager.getWorkingSet().filter(function (wsFile) {
+           return !DocumentManager.getOpenDocumentForPath(wsFile.fullPath);
+        });
+        
+        function checkWorkingSetFile(file) {
+            var result = new $.Deferred();
+            
+            file.getMetadata(
+                function (metadata) {
+                    // File still exists
+                    result.resolve();
+                },
+                function (error) {
+                    // File has been deleted externally
+                    if (error.code === FileError.NOT_FOUND_ERR) {
+                        DocumentManager.closeFullEditor(file);
+                        result.resolve();
+                    } else {
+                        // Some other error fetching metadata: treat as a real error
+                        console.log("Error checking for deletion of " + file.fullPath, error.code);
+                        result.reject();
+                    }
+                }
+            );
+            return result;
+        }
+        
+        // Check all these files in parallel
+        return Async.doInParallel(unopenWorkingSetFiles, checkWorkingSetFile, false);
     }
     
     
@@ -289,11 +318,14 @@ define(function (require, exports, module) {
         
         
         // Syncing proceeds in four phases:
-        //  1) Check all files for external modifications
-        //  2) Refresh all editors that are clean (if file changed on disk)
-        //  3) Close all editors that are clean (if file deleted on disk)
-        //  4) Prompt about any editors that are dirty (if file changed/deleted on disk)
+        //  1) Check all open files for external modifications
+        //  2) Check any other working set entries (that are not open) for deletion, and remove
+        //     from working set if deleted
+        //  3) Refresh all Documents that are clean (if file changed on disk)
+        //  4) Close all Documents that are clean (if file deleted on disk)
+        //  5) Prompt about any Documents that are dirty (if file changed/deleted on disk)
         // Each phase fully completes (asynchronously) before the next one begins.
+        
         
         // 1) Check for external modifications
         // TODO: actually need to check the UNION of this & the working set list!!!
@@ -301,40 +333,47 @@ define(function (require, exports, module) {
         
         findExternalChanges(allDocs)
             .done(function () {
-                // 2) Reload clean docs as needed
-                reloadChangedDocs()
+                // 2) Check un-open working set entries for deletion (& "close" if needed)
+                syncUnopenWorkingSet()
                     .always(function () {
-                        // 3) Close clean docs as needed
-                        // This phase completes synchronously
-                        closeDeletedDocs();
+                        // If we were unable to check any un-open files for deletion, silently ignore
+                        // (after logging to console). This doesn't have any bearing on syncing truly
+                        // open Documents (which we've already successfully checked).
                         
-                        // 4) Prompt for dirty editors (conflicts)
-                        presentConflicts()
+                        // 3) Reload clean docs as needed
+                        reloadChangedDocs()
                             .always(function () {
-                                if (_restartPending) {
-                                    // Restart the sync if needed
-                                    _restartPending = false;
-                                    _alreadyChecking = false;
-                                    syncOpenDocuments();
-                                } else {
-                                    // We're really done!
-                                    _alreadyChecking = false;
-                                    
-                                    // If we showed a dialog, restore focus to editor
-                                    if (editConflicts.length > 0 || deleteConflicts.length > 0) {
-                                        EditorManager.focusEditor();
-                                    }
-                                    
-                                    // (Any errors that ocurred during presentConflicts() have already
-                                    // shown UI & been dismissed, so there's no fail() handler here)
-                                }
+                                // 4) Close clean docs as needed
+                                // This phase completes synchronously
+                                closeDeletedDocs();
+                                
+                                // 5) Prompt for dirty editors (conflicts)
+                                presentConflicts()
+                                    .always(function () {
+                                        if (_restartPending) {
+                                            // Restart the sync if needed
+                                            _restartPending = false;
+                                            _alreadyChecking = false;
+                                            syncOpenDocuments();
+                                        } else {
+                                            // We're really done!
+                                            _alreadyChecking = false;
+                                            
+                                            // If we showed a dialog, restore focus to editor
+                                            if (editConflicts.length > 0 || deleteConflicts.length > 0) {
+                                                EditorManager.focusEditor();
+                                            }
+                                            
+                                            // (Any errors that ocurred during presentConflicts() have already
+                                            // shown UI & been dismissed, so there's no fail() handler here)
+                                        }
+                                    });
                             });
+                            // Note: if any auto-reloads failed, we silently ignore (after logging to console)
+                            // and we still continue onto phase 4 and try to process those files anyway.
+                            // (We'll retry the auto-reloads next time window is activated... and evenually
+                            // we'll also be double checking before each Save).
                     });
-                    // Note: if any auto-reloads failed, we silently ignore (after logging to console)
-                    // and we still continue onto phase 4 and try to process those files anyway.
-                    // (We'll retry the auto-reloads next time window is activated... and evenually
-                    // we'll also be double checking before each Save).
-                    
             }).fail(function () {
                 // Unable to fetch timestamps for some reason - silently ignore (after logging to console)
                 // (We'll retry next time window is activated... and evenually we'll also be double

--- a/src/FileViewController.js
+++ b/src/FileViewController.js
@@ -6,7 +6,7 @@
 /*global define: false, $: false */
 
 /**
- * Responsible for coordinating file seletion between views by permitting only one view
+ * Responsible for coordinating file selection between views by permitting only one view
  * to show the current file selection at a time. Currently, only WorkingSetView and 
  * ProjectManager can show file selection. In general the WorkingSetView takes higher
  * priority until the user selects a file in the ProjectManager.
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
     /** 
      * Change the doc selection to the working set when ever a new file is added to the working set
      */
-    $(DocumentManager).on("workingSetAdd", function (event, addedDoc) {
+    $(DocumentManager).on("workingSetAdd", function (event, addedFile) {
         _fileSelectionFocus = WORKING_SET_VIEW;
         $(exports).triggerHandler("documentSelectionFocusChange");
     });

--- a/src/ProjectManager.js
+++ b/src/ProjectManager.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
                 }
                 return false;
             });
-        } else if( _projectTree !== null ) {
+        } else if (_projectTree !== null) {
             _projectTree.jstree("deselect_all");
         }
     });

--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
      * @param {bool} canClose
      */
     function _updateFileStatusIcon(listElement, isDirty, canClose) {
+        
         var fileStatusIcon = listElement.find(".file-status-icon");
         var showIcon = isDirty || canClose;
 
@@ -111,11 +112,9 @@ define(function (require, exports, module) {
         $("#open-files-container > ul").append(newItem);
         
         // working set item might never have been opened; if so, then it's definitely not dirty
-        var docIfOpen = DocumentManager.getOpenDocumentForPath(file.fullPath);
-        var isDirty = (docIfOpen && docIfOpen.isDirty);
 
         // Update the listItem's apperance
-        _updateFileStatusIcon(newItem, isDirty, false);
+        _updateFileStatusIcon(newItem, isOpenAndDirty(file), false);
         _updateListItemSelection(newItem, curDoc);
 
         newItem.click(function () {
@@ -124,12 +123,17 @@ define(function (require, exports, module) {
 
         newItem.hover(
             function () {
-                _updateFileStatusIcon($(this), isDirty, true);
+                _updateFileStatusIcon($(this), isOpenAndDirty(file), true);
             },
             function () {
-                _updateFileStatusIcon($(this), isDirty, false);
+                _updateFileStatusIcon($(this), isOpenAndDirty(file), false);
             }
         );
+    }
+    
+    function isOpenAndDirty(file) {
+        var docIfOpen = DocumentManager.getOpenDocumentForPath(file.fullPath);
+        return (docIfOpen && docIfOpen.isDirty);
     }
     
     /** 

--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -49,7 +49,6 @@ define(function (require, exports, module) {
      * @param {bool} canClose
      */
     function _updateFileStatusIcon(listElement, isDirty, canClose) {
-        
         var fileStatusIcon = listElement.find(".file-status-icon");
         var showIcon = isDirty || canClose;
 
@@ -77,8 +76,9 @@ define(function (require, exports, module) {
 
         // Set icon's class
         if (fileStatusIcon) {
-            fileStatusIcon.toggleClass("dirty", isDirty);
-            fileStatusIcon.toggleClass("canClose", canClose);
+            // cast to Boolean needed because toggleClass() distinguishes true/false from truthy/falsy
+            fileStatusIcon.toggleClass("dirty", Boolean(isDirty));
+            fileStatusIcon.toggleClass("canClose", Boolean(canClose));
         }
     }
     
@@ -90,7 +90,9 @@ define(function (require, exports, module) {
      */
     function _updateListItemSelection(listItem, selectedDoc) {
         var shouldBeSelected = (selectedDoc && $(listItem).data(_FILE_KEY).fullPath === selectedDoc.file.fullPath);
-        $(listItem).toggleClass("selected", shouldBeSelected);
+        
+        // cast to Boolean needed because toggleClass() distinguishes true/false from truthy/falsy
+        $(listItem).toggleClass("selected", Boolean(shouldBeSelected));
     }
 
     function isOpenAndDirty(file) {

--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -93,6 +93,11 @@ define(function (require, exports, module) {
         $(listItem).toggleClass("selected", shouldBeSelected);
     }
 
+    function isOpenAndDirty(file) {
+        var docIfOpen = DocumentManager.getOpenDocumentForPath(file.fullPath);
+        return (docIfOpen && docIfOpen.isDirty);
+    }
+    
     /** 
      * Builds the UI for a new list item and inserts in into the end of the list
      * @private
@@ -128,11 +133,6 @@ define(function (require, exports, module) {
                 _updateFileStatusIcon($(this), isOpenAndDirty(file), false);
             }
         );
-    }
-    
-    function isOpenAndDirty(file) {
-        var docIfOpen = DocumentManager.getOpenDocumentForPath(file.fullPath);
-        return (docIfOpen && docIfOpen.isDirty);
     }
     
     /** 

--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -68,7 +68,9 @@ define(function (require, exports, module) {
                     if (doc) {
                         CommandManager.execute(Commands.FILE_CLOSE, {doc: doc});
                     } else {
-                        // FIXME: still must remove from working set!
+                        // No need for confirmation prompt here: no doc for this file
+                        // TODO: roll this functionality into FILE_CLOSE?
+                        DocumentManager.closeFullEditor(file);
                     }
                 });
         }

--- a/src/WorkingSetView.js
+++ b/src/WorkingSetView.js
@@ -70,7 +70,6 @@ define(function (require, exports, module) {
                         CommandManager.execute(Commands.FILE_CLOSE, {doc: doc});
                     } else {
                         // No need for confirmation prompt here: no doc for this file
-                        // TODO: roll this functionality into FILE_CLOSE?
                         DocumentManager.closeFullEditor(file);
                     }
                 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -91,12 +91,12 @@ define(function (require, exports, module) {
         runs(function () {
             //we need to mark the documents as not dirty before we close
             //or the window will stay open prompting to save
-            var workingSet = testWindow.brackets.test.DocumentManager.getAllOpenDocuments();
-            workingSet.forEach(function resetDoc(ele, i, array) {
-                if (ele.isDirty) {
+            var openDocs = testWindow.brackets.test.DocumentManager.getAllOpenDocuments();
+            openDocs.forEach(function resetDoc(doc) {
+                if (doc.isDirty) {
                     //just refresh it back to it's current text. This will mark it
                     //clean to save
-                    ele.refreshText(ele.getText(), ele.diskTimestamp);
+                    doc.refreshText(doc.getText(), doc.diskTimestamp);
                 }
             });
             testWindow.close();

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
             
             runs(function () {
                 // Initialize: register listeners
-                testWindow.$(DocumentManager).on("workingSetAdd", function (event, addedDoc) {
+                testWindow.$(DocumentManager).on("workingSetAdd", function (event, addedFile) {
                     workingSetCount++;
                 });
             });
@@ -163,13 +163,15 @@ define(function (require, exports, module) {
             var didClose = false;
                     
             // make 2nd doc clean
-            var docList = DocumentManager.getWorkingSet();
+            var fileList = DocumentManager.getWorkingSet();
 
             runs(function () {
-                docList[1]._markClean();
+                var doc0 = DocumentManager.getOpenDocumentForPath(fileList[0].fullPath);
+                var doc1 = DocumentManager.getOpenDocumentForPath(fileList[1].fullPath);
+                doc1._markClean();
                                 
                 // make the first one active
-                DocumentManager.setCurrentDocument(docList[0]);
+                DocumentManager.setCurrentDocument(doc0);
                                 
                 // hover over and click on close icon of 2nd list item
                 var secondItem =  $($("#open-files-container > ul").children()[1]);
@@ -178,7 +180,7 @@ define(function (require, exports, module) {
                 expect(closeIcon.length).toBe(1);
                                 
                 // simulate click
-                $(DocumentManager).on("workingSetRemove", function (event, removedDoc) {
+                $(DocumentManager).on("workingSetRemove", function (event, removedFile) {
                     didClose = true;
                 });
 
@@ -197,8 +199,10 @@ define(function (require, exports, module) {
         it("should remove dirty icon when file becomes clean", function () {
             runs(function () {
                 // check that dirty icon is removed when docs are cleaned
-                var docList = DocumentManager.getWorkingSet();
-                docList[0]._markClean();
+                var fileList = DocumentManager.getWorkingSet();
+                var doc0 = DocumentManager.getOpenDocumentForPath(fileList[0].fullPath);
+                doc0._markClean();
+                
                 var listItems = testWindow.$("#open-files-container > ul").children();
                 expect(listItems.find(".file-status-icon dirty").length).toBe(0);
             });


### PR DESCRIPTION
This fixes a performance regression from the big Editor/Document refactoring, where we were forced to load the contents of all working set entries on startup (since Documents no longer lazily load their content).
- Renames DocumentManager.closeDocument() -> closeFullEditor(), since it may be used to close things in the working set which don't have a Document.  (This is still a somewhat awkward API, and I think it may go away entirely once we disentangle the UI/user notion of "close" from the notion of "destroy Document" - see issue #474).
- Fixes bug #468 (many currentDocumentChange notifications on startup), which was a side effect of the way we were loading Documents for the working set on startup.
- Adds one more stage to FileSyncManager, for checking the status of files that are in the working set but are do not have an associated Document -- we still want to see if these files have been deleted, and remove them from the working set if so.  (Note: this file's diff is much easier to view with whitespace diffs ignored -- add `?w=1` to the URL).
