### PR TITLE
css color keywords should not be in quotes

### DIFF
--- a/test/spec/CSSUtils-test-files/offsets.css
+++ b/test/spec/CSSUtils-test-files/offsets.css
@@ -1,14 +1,14 @@
 a {
-    color: "red";
+    color: red;
 }/*END*/
 a {
-    color: "orange";
+    color: orange;
 }/*END*/
 
-a { color: "yellow"; }/*END*/
-a:visited { color: "black"; }/*END*/
+a { color: yellow; }/*END*/
+a:visited { color: black; }/*END*/
 
-a { color: "red"; }/*END*/a { color: "blue"; }/*END*/
+a { color: red; }/*END*/a { color: blue; }/*END*/
 
 /* Note: @charset and @import must be at top of style sheet, so
  * examples are technically malformed, but parsing is the same


### PR DESCRIPTION
I noticed that css color keywords were quoted in this test file. This test is for rule extraction offsets, so it does not affect the test, so this is low priority.
