### PR TITLE
Temporary fix for global key bindings and dialogs

### DIFF
--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -97,21 +97,22 @@ define(function (require, exports, module) {
         // type happen to show up, they can appear at the same time. (This is an edge case that
         // shouldn't happen often, but we can't prevent it from happening since everything is
         // asynchronous.)
-        var dlg = $("." + dlgClass + ".template")
+        var $dlg = $("." + dlgClass + ".template")
             .clone()
             .removeClass("template")
             .addClass("instance")
             .appendTo(document.body);
 
         // Set title and message
-        $(".dialog-title", dlg).html(title);
-        $(".dialog-message", dlg).html(message);
+        $(".dialog-title", $dlg).html(title);
+        $(".dialog-message", $dlg).html(message);
 
-        var handleKeyDown = _handleKeyDown.bind(dlg);
+        var handleKeyDown = _handleKeyDown.bind($dlg),
+            $primaryBtn = $dlg.find(".primary");
 
         // Pipe dialog-closing notification back to client code
-        dlg.one("hidden", function () {
-            var buttonId = dlg.data("buttonId");
+        $dlg.one("hidden", function () {
+            var buttonId = $dlg.data("buttonId");
             if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
                 buttonId = DIALOG_BTN_CANCEL;
             }
@@ -124,29 +125,33 @@ define(function (require, exports, module) {
             }, 0);
             
             // Remove the dialog instance from the DOM.
-            dlg.remove();
+            $dlg.remove();
 
             // Remove keydown event handler
             document.body.removeEventListener("keydown", handleKeyDown, true);
         }).one("shown", function () {
             // Set focus to the default button
-            var primaryBtn = dlg.find(".primary");
-
-            if (primaryBtn) {
-                primaryBtn.focus();
+            if ($primaryBtn) {
+                $primaryBtn.focus();
             }
 
             // Listen for dialog keyboard shortcuts
             document.body.addEventListener("keydown", handleKeyDown, true);
         });
         
+        // prevent focus from leaving the dialog
+        $dlg.bind("focusout", function (e) {
+            $primaryBtn.focus();
+            return false;
+        });
+        
         // Click handler for buttons
-        dlg.one("click", ".dialog-button", function (e) {
-            _dismissDialog(dlg, $(this).attr("data-button-id"));
+        $dlg.one("click", ".dialog-button", function (e) {
+            _dismissDialog($dlg, $(this).attr("data-button-id"));
         });
 
         // Run the dialog
-        dlg.modal({
+        $dlg.modal({
             backdrop: "static",
             show: true,
             keyboard: true

--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -10,6 +10,8 @@
  */
 define(function (require, exports, module) {
     'use strict';
+    
+    var KeyBindingManager = require("KeyBindingManager");
 
     var DIALOG_BTN_CANCEL = "cancel",
         DIALOG_BTN_OK = "ok",
@@ -128,6 +130,7 @@ define(function (require, exports, module) {
 
             // Remove keydown event handler
             document.body.removeEventListener("keydown", handleKeyDown, true);
+            KeyBindingManager.setEnabled(true);
         }).one("shown", function () {
             // Set focus to the default button
             var primaryBtn = dlg.find(".primary");
@@ -138,6 +141,7 @@ define(function (require, exports, module) {
 
             // Listen for dialog keyboard shortcuts
             document.body.addEventListener("keydown", handleKeyDown, true);
+            KeyBindingManager.setEnabled(false);
         });
         
         // Click handler for buttons

--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -97,22 +97,21 @@ define(function (require, exports, module) {
         // type happen to show up, they can appear at the same time. (This is an edge case that
         // shouldn't happen often, but we can't prevent it from happening since everything is
         // asynchronous.)
-        var $dlg = $("." + dlgClass + ".template")
+        var dlg = $("." + dlgClass + ".template")
             .clone()
             .removeClass("template")
             .addClass("instance")
             .appendTo(document.body);
 
         // Set title and message
-        $(".dialog-title", $dlg).html(title);
-        $(".dialog-message", $dlg).html(message);
+        $(".dialog-title", dlg).html(title);
+        $(".dialog-message", dlg).html(message);
 
-        var handleKeyDown = _handleKeyDown.bind($dlg),
-            $primaryBtn = $dlg.find(".primary");
+        var handleKeyDown = _handleKeyDown.bind(dlg);
 
         // Pipe dialog-closing notification back to client code
-        $dlg.one("hidden", function () {
-            var buttonId = $dlg.data("buttonId");
+        dlg.one("hidden", function () {
+            var buttonId = dlg.data("buttonId");
             if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
                 buttonId = DIALOG_BTN_CANCEL;
             }
@@ -125,33 +124,29 @@ define(function (require, exports, module) {
             }, 0);
             
             // Remove the dialog instance from the DOM.
-            $dlg.remove();
+            dlg.remove();
 
             // Remove keydown event handler
             document.body.removeEventListener("keydown", handleKeyDown, true);
         }).one("shown", function () {
             // Set focus to the default button
-            if ($primaryBtn) {
-                $primaryBtn.focus();
+            var primaryBtn = dlg.find(".primary");
+
+            if (primaryBtn) {
+                primaryBtn.focus();
             }
 
             // Listen for dialog keyboard shortcuts
             document.body.addEventListener("keydown", handleKeyDown, true);
         });
         
-        // prevent focus from leaving the dialog
-        $dlg.bind("focusout", function (e) {
-            $primaryBtn.focus();
-            return false;
-        });
-        
         // Click handler for buttons
-        $dlg.one("click", ".dialog-button", function (e) {
-            _dismissDialog($dlg, $(this).attr("data-button-id"));
+        dlg.one("click", ".dialog-button", function (e) {
+            _dismissDialog(dlg, $(this).attr("data-button-id"));
         });
 
         // Run the dialog
-        $dlg.modal({
+        dlg.modal({
             backdrop: "static",
             show: true,
             keyboard: true

--- a/src/KeyBindingManager.js
+++ b/src/KeyBindingManager.js
@@ -47,6 +47,7 @@ define(function (require, exports, module) {
     }
     
 
+    // TODO (issue #414): Replace this temporary fix with a more robust solution to handle focus and modality
     /**
      * Enable or disable key bindings. Clients such as dialogs may wish to disable 
      * global key bindings temporarily.

--- a/src/KeyBindingManager.js
+++ b/src/KeyBindingManager.js
@@ -17,6 +17,11 @@ define(function (require, exports, module) {
      * The currently installed keymap.
      */
     var _keymap = null;
+    
+    /**
+     * Allow clients to toggle key binding
+     */
+    var _enabled = true;
 
     /**
      * Install the specified keymap as the current keymap, overwriting the existing keymap.
@@ -34,15 +39,28 @@ define(function (require, exports, module) {
      * @return {boolean} true if the key was processed, false otherwise
      */
     function handleKey(key) {
-        if (_keymap && _keymap.map[key]) {
+        if (_enabled && _keymap && _keymap.map[key]) {
             CommandManager.execute(_keymap.map[key]);
             return true;
         }
         return false;
+    }
+    
+
+    /**
+     * Enable or disable key bindings. Clients such as dialogs may wish to disable 
+     * global key bindings temporarily.
+     *
+     * @param {string} A key-description string.
+     * @return {boolean} true if the key was processed, false otherwise
+     */
+    function setEnabled(value) {
+        _enabled = value;
     }
 
     
     // Define public API
     exports.installKeymap = installKeymap;
     exports.handleKey = handleKey;
+    exports.setEnabled = setEnabled;
 });


### PR DESCRIPTION
Fixes issue #427

Dialogs now disable key bindings when open. More robust focus handling should be handled by issue #414.
