### PR TITLE
Fix inline editor breakage

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -23,6 +23,7 @@ define(function (require, exports, module) {
     var FileUtils           = require("file/FileUtils"),
         DocumentManager     = require("document/DocumentManager"),
         Editor              = require("editor/Editor").Editor,
+        InlineTextEditor    = require("editor/InlineTextEditor").InlineTextEditor,
         EditorUtils         = require("editor/EditorUtils"),
         Strings             = require("strings");
     
@@ -178,13 +179,13 @@ define(function (require, exports, module) {
     function getInlineEditors(hostEditor) {
         var inlineEditors = [];
         hostEditor.getInlineWidgets().forEach(function (widget) {
-            if (widget.data.editor) {
-                inlineEditors.push(widget.data.editor);
+            if (widget.data instanceof InlineTextEditor) {
+                inlineEditors.concat(widget.data.editors);
             }
         });
         return inlineEditors;
     }
-    
+
     
     
     /**
@@ -408,8 +409,12 @@ define(function (require, exports, module) {
             
             // See if any inlines have focus
             _currentEditor.getInlineWidgets().forEach(function (widget) {
-                if (widget.data.editor && widget.data.editor.hasFocus()) {
-                    focusedInline = widget.data.editor;
+                if (widget.data instanceof InlineTextEditor) {
+                    widget.data.editors.forEach(function (editor) {
+                        if (editor.hasFocus()) {
+                            focusedInline = editor;
+                        }
+                    });
                 }
             });
             

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -185,7 +185,7 @@ define(function (require, exports, module) {
         });
         return inlineEditors;
     }
-
+    
     
     
     /**

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
-                    var inlinePos = inlineData.editor.getCursorPos();
+                    var inlinePos = inlineData.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
-                    var inlinePos = inlineData.editor.getCursorPos();
+                    var inlinePos = inlineData.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[1]);
@@ -244,7 +244,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
-                    var inlinePos = inlineData.editor.getCursorPos();
+                    var inlinePos = inlineData.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[2]);
@@ -260,7 +260,7 @@ define(function (require, exports, module) {
                     fullEditor =  EditorManager.getCurrentFullEditor();
                     savedPos = fullEditor.getCursorPos();
                     inlineWidget = fullEditor.getInlineWidgets()[0];
-                    inlinePos = inlineWidget.data.editor.getCursorPos();
+                    inlinePos = inlineWidget.data.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
@@ -300,7 +300,7 @@ define(function (require, exports, module) {
                 var inlineEditor, widgetHeight;
                 
                 runs(function () {
-                    inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                    inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                     widgetHeight = inlineEditor.totalHeight(true);
                     
                     // verify original line count
@@ -328,7 +328,7 @@ define(function (require, exports, module) {
                 var inlineEditor, widgetHeight;
                 
                 runs(function () {
-                    inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                    inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                     widgetHeight = inlineEditor.totalHeight(true);
                     
                     // verify original line count
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
-                    inlineEditor = hostEditor.getInlineWidgets()[0].data.editor;
+                    inlineEditor = hostEditor.getInlineWidgets()[0].data.editors[0];
                     
                     // insert text at the inline editor's cursor position
                     // can't mutate document directly at this point
@@ -415,7 +415,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
-                    inlineEditor = hostEditor.getInlineWidgets()[0].data.editor;
+                    inlineEditor = hostEditor.getInlineWidgets()[0].data.editors[0];
                     
                     // insert text at the host editor's cursor position
                     hostEditor._codeMirror.replaceRange(newHostText, hostEditor.getCursorPos());
@@ -474,7 +474,7 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 0);
                     
                     runs(function () {
-                        var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
+                        // var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
                         var i = DocumentManager.findInWorkingSet(this.infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(-1);
                     });
@@ -486,7 +486,7 @@ define(function (require, exports, module) {
                     var inlineEditor, widgetHeight;
                     
                     runs(function () {
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         widgetHeight = inlineEditor.totalHeight(true);
                         
                         // change inline editor content
@@ -517,7 +517,7 @@ define(function (require, exports, module) {
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         
                         // edit the inline editor
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         inlineEditor._codeMirror.replaceRange(
                             newInlineText,
                             inlineEditor.getCursorPos()
@@ -563,7 +563,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         cssPath = this.infos["test1.css"].fileEntry.fullPath;
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         
                         // activate the full editor
                         DocumentManager.setCurrentDocument(cssDoc);
@@ -636,7 +636,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         cssPath = this.infos["test1.css"].fileEntry.fullPath;
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         
                         // activate the full editor
                         DocumentManager.setCurrentDocument(cssDoc);
@@ -699,7 +699,7 @@ define(function (require, exports, module) {
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         
                         // edit the inline editor
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         
                         // activate the full editor
                         DocumentManager.setCurrentDocument(cssDoc);
@@ -730,7 +730,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         cssPath = this.infos["test1.css"].fileEntry.fullPath;
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         
                         // activate the full editor
                         DocumentManager.setCurrentDocument(cssDoc);
@@ -759,7 +759,7 @@ define(function (require, exports, module) {
                         htmlPath = this.infos["test1.html"].fileEntry.fullPath;
                         cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         
-                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editor;
+                        inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data.editors[0];
                         originalText = inlineEditor._codeMirror.getValue();
                         
                         // edit the inline editor

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -474,7 +474,6 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 0);
                     
                     runs(function () {
-                        // var inlineData = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].data;
                         var i = DocumentManager.findInWorkingSet(this.infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(-1);
                     });


### PR DESCRIPTION
This fixes breakage from recent changes that allow multiple Editors per inline widget:
- 15 unit tests were failing trying to get the inline Editor.
- Saving while focus is in an inline was broken. EditorManager.getFocusedEditor() now needs nested loops to look at all the Editors.
- Gutter width syncing was subtly broken. Similar bug as above but in EditorManager.getInlineEditors().
