### PR TITLE
Account for %20 encoding for paths gotten from windows.location.pathname

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -162,10 +162,10 @@ define(function (require, exports, module) {
      */
     function convertToNativePath(path) {
         if (path.indexOf(":") !== -1 && path[0] === "/") {
-            return path.substr(1);
+            path = path.substr(1);
         }
         
-        return path;
+        return window.unescape(path);
     }
     
     // Define public API


### PR DESCRIPTION
Fix for first launch from a folder with a space in it where window.location.pathname was used as the default project path.

Fixes adobe/brackets-app#84
