### PR TITLE
Fix rule list layout to avoid overlap/clipping issues

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -174,6 +174,21 @@ define(function (require, exports, module) {
         var borderThickness = (this.$htmlContent.outerHeight() - this.$htmlContent.innerHeight()) / 2;
         this.$relatedContainer.css("top", this.$htmlContent.offset().top + borderThickness);
         this.$relatedContainer.height(this.$htmlContent.height());
+        
+        // Because we're using position: fixed, we need to explicitly clip the rule list if it crosses
+        // out of the top or bottom of the scroller area.
+        var hostScroller = this.hostEditor._codeMirror.getScrollerElement(),
+            rcTop = this.$relatedContainer.offset().top,
+            rcHeight = this.$relatedContainer.outerHeight(),
+            rcBottom = rcTop + rcHeight,
+            scrollerTop = $(hostScroller).offset().top,
+            scrollerBottom = scrollerTop + hostScroller.clientHeight;
+        if (rcTop < scrollerTop || rcBottom > scrollerBottom) {
+            this.$relatedContainer.css("clip", "rect(" + Math.max(scrollerTop - rcTop, 0) + "px, auto, " +
+                                       (rcHeight - Math.max(rcBottom - scrollerBottom, 0)) + "px, auto)");
+        } else {
+            this.$relatedContainer.css("clip", "");
+        }
     };
 
     /**

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
         
         // Container to hold all editors
         var self = this,
+            hostScroller = hostEditor._codeMirror.getScrollerElement(),
             $ruleItem,
             $location;
 
@@ -50,6 +51,9 @@ define(function (require, exports, module) {
         
         // Outer container for border-left and scrolling
         this.$relatedContainer = $(document.createElement("div")).addClass("relatedContainer");
+        // Position immediately to the left of the main editor's scrollbar.
+        var rightOffset = $(document.body).outerWidth() - ($(hostScroller).offset().left + $(hostScroller).get(0).clientWidth);
+        this.$relatedContainer.css("right", rightOffset + "px");
         
         // List "selection" highlight
         this.$selectedMarker = $(document.createElement("div")).appendTo(this.$relatedContainer).addClass("selection");

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -366,7 +366,6 @@ a, img {
     /*width: 0;*/
     font-family: sans-serif;
     position: fixed;
-    right: 0;
     width: 250px;
     overflow: auto;
     /*-webkit-transition: width 0.15s ease-out;*/


### PR DESCRIPTION
@peterflynn (since @jason-sanjose is out--though Jason, if you have time to look at this, that would be good)

Two fixes to the rule list layout that should make it appear to behave properly now:
- The rule list insets itself to the left to avoid overlapping the vertical editor scrollbar.
- The rule list clips itself to the vertical range of the editor area, so it doesn't overlap other areas of the UI when it scrolls out of the editor area.

Note that there's one leftover issue this doesn't yet address: if the content of the inline editor is long enough, it will go underneath the rule list, and you won't be able to scroll to see it. To fix this, we'd need to increase the horizontal scroll area of the overall editor by the width of the rule list whenever a CSS inline is open. I can look at fixing that next, but wanted to get these changes into master since they make the rule list feel less flaky.
