### PR TITLE
Re-fix issue #403 (Show comment immediately above CSS rule if there is one)

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -281,7 +281,7 @@ define(function (require, exports, module) {
                         selectors.push({
                             selector: value.selector,
                             document: doc,
-                            lineStart: value.selectorGroupStartLine,
+                            lineStart: value.ruleStartLine,
                             lineEnd: value.declListEndLine
                         });
                     });

--- a/test/spec/CSSUtils-test-files/issue-403-test.css
+++ b/test/spec/CSSUtils-test-files/issue-403-test.css
@@ -1,0 +1,13 @@
+#ruleBeforeIssue403 {
+    color: red;
+}
+
+/* comment before rule - include */
+#issue403 {
+    color: green;
+}
+/* comment after rule - exclude */
+
+#ruleAfterIssue403 {
+    color: red;
+}

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1019,6 +1019,41 @@ define(function (require, exports, module) {
         }); // describe("Known Issues")    
 
 
+        describe("Working with real public CSSUtils API", function () {
+            var CSSUtils;
+            
+            beforeEach(function () {
+                SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
+                    // Load module instances from brackets.test
+                    CSSUtils = testWindow.brackets.test.CSSUtils;
+                    
+                    // Load test project
+                    var testPath = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files");
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                });
+            });
+            afterEach(function () {
+                SpecRunnerUtils.closeTestWindow();
+            });
+            
+            it("should include comment preceding selector (issue #403)", function () {
+                var rules;
+                runs(function () {
+                    CSSUtils.findMatchingRules("#issue403")
+                        .done(function (result) { rules = result; });
+                });
+                waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
+                
+                runs(function () {
+                    expect(rules.length).toBe(1);
+                    expect(rules[0].lineStart).toBe(4);
+                    expect(rules[0].lineEnd).toBe(7);
+                });
+            });
+            
+        });
+        
+        
         describe("Working with unsaved changes", function () {
             var testPath = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
                 CSSUtils,


### PR DESCRIPTION
- Fix issue #403 (Show comment immediately above CSS rule if there is one), which had regressed due to pull #496 changing the meaning of selectorGroupStartLine in CSSUtils
- Since this has regressed once already, add a unit test for it too
