### PR TITLE
Fix problems when switching between html documents while live development is enabled

### DIFF
--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -109,6 +109,16 @@ define(function Inspector(require, exports, module) {
      * @param {object} the method signature
      */
     function _send(method, signature, varargs) {
+        if (!_socket) {
+            // FUTURE: Our current implementation closes and re-opens an inspector connection whenever
+            // a new HTML file is selected. If done quickly enough, pending requests from the previous
+            // connection could come in before the new socket connection is established. For now we 
+            // simply ignore this condition. 
+            // This race condition will go away once we support multiple inspector connections and turn
+            // off auto re-opening when a new HTML file is selected.
+            return;
+        }
+        
         console.assert(_socket, "You must connect to the WebSocket before sending messages.");
         var id, callback, args, i, params = {};
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -252,7 +252,7 @@ define(function LiveDevelopment(require, exports, module) {
             // For Sprint 6, we only open live development connections for HTML files
             // FUTURE: Remove this test when we support opening connections for different
             // file types.
-            if (doc.extension.indexOf('htm') !== 0) {
+            if (doc.extension && doc.extension.indexOf('htm') !== 0) {
                 return;
             }
             
@@ -342,7 +342,7 @@ define(function LiveDevelopment(require, exports, module) {
                 _openDocument(doc, editor);
             } else {
                 /* FUTURE: support live connections for docments other than html */
-                if (doc.extension.indexOf('htm') === 0) {
+                if (doc.extension && doc.extension.indexOf('htm') === 0) {
                     close();
                     setTimeout(open);
                 }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -252,7 +252,7 @@ define(function LiveDevelopment(require, exports, module) {
             // For Sprint 6, we only open live development connections for HTML files
             // FUTURE: Remove this test when we support opening connections for different
             // file types.
-            if (doc.extension && doc.extension.indexOf('htm') !== 0) {
+            if (!doc.extension || doc.extension.indexOf('htm') !== 0) {
                 return;
             }
             


### PR DESCRIPTION
Fixes issue #534

This is a band-aid fix for the most common problem that occurs when switching between html documents while live development is enabled. The problems occur when asynchronous callbacks from the old connection come back before the new connection is established. When that happens, we simply ignore all inspector requests until the new connection is made. 

We have a backlog item to support multiple connections, and to disable the auto-connect when switching between documents. When either of these are done, this fix becomes unnecessary. 

The pull request also fixes an unreported null reference error when selecting a file that doesn't have an extension.
