### PR TITLE
Make sure in-memory changes to CSS docs are pushed when starting live development connection

### DIFF
--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -62,6 +62,11 @@ define(function CSSDocumentModule(require, exports, module) {
             // res = {styleSheet}
             this.rules = res.styleSheet.rules;
         }.bind(this));
+        
+        // If the CSS document is dirty, push the changes into the browser now
+        if (doc.isDirty) {
+            CSSAgent.reloadDocument(this.doc);
+        }
     };
 
     /** Close the document */


### PR DESCRIPTION
Fixes issue #550

You will see the on-disk styles applied first and then replaced with the in-memory styles. This is due to the delay between the time the initial document is displayed and the time our agents are attached.
