### PR TITLE
Correctly handle scenario where no document is active.

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -333,10 +333,12 @@ define(function LiveDevelopment(require, exports, module) {
     /** Triggered by a document change from the DocumentManager */
     function _onDocumentChange() {
         var doc = _getCurrentDocument();
+        if (!doc) {
+            return;
+        }
+        
         if (Inspector.connected()) {
-            if (!doc) {
-                close();
-            } else if (agents.network && agents.network.wasURLRequested(doc.url)) {
+            if (agents.network && agents.network.wasURLRequested(doc.url)) {
                 _closeDocument();
                 var editor = EditorManager.getCurrentFullEditor();
                 _openDocument(doc, editor);


### PR DESCRIPTION
Fixes issue #545

If a live development connection is active and the user closes the last document in the working set, don't close the live connection.
