### PR TITLE
Scrolling fixes for inline editors

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -219,6 +219,15 @@ define(function (require, exports, module) {
         
         // Add extra padding to the right edge of the widget to account for the rule list.
         this.$htmlContent.css("padding-right", this.$relatedContainer.outerWidth() + "px");
+        
+        // Set the minimum width of the widget (which doesn't include the padding) to the width
+        // of CodeMirror's linespace, so that the total width will be at least as large as the
+        // width of the host editor's code plus the padding for the rule list. This is a bit of a 
+        // hack since it relies on knowing some detail about the innards of CodeMirror.
+        var lineSpaceParent = $(".CodeMirror-lines", this.hostEditor._codeMirror.getScrollerElement()).get(0),
+            lineSpace = $(lineSpaceParent).children().get(0),
+            minWidth = $(lineSpace).offset().left - this.$htmlContent.offset().left + $(lineSpace).width();
+        this.$htmlContent.css("min-width", minWidth + "px");
     };
 
     /**

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -216,6 +216,9 @@ define(function (require, exports, module) {
         } else {
             this.$relatedContainer.css("clip", "");
         }
+        
+        // Add extra padding to the right edge of the widget to account for the rule list.
+        this.$htmlContent.css("padding-right", this.$relatedContainer.outerWidth() + "px");
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -717,6 +717,14 @@ define(function (require, exports, module) {
         var lineSpaceParent = $(".CodeMirror-lines", this.getScrollerElement()).get(0);
         return $(lineSpaceParent).children().get(0);
     };
+    
+    /**
+     * Returns the current scroll position of the editor.
+     * @returns {{x:number, y:number}} The x,y scroll position.
+     */
+    Editor.prototype.getScrollPos = function () {
+        return this._codeMirror.scrollPos();
+    };
 
     /**
      * Adds an inline widget below the given line. If any inline widget was already open for that

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -333,7 +333,7 @@ define(function (require, exports, module) {
     Editor.prototype.destroy = function () {
         // CodeMirror docs for getWrapperElement() say all you have to do is "Remove this from your
         // tree to delete an editor instance."
-        $(this._codeMirror.getWrapperElement()).remove();
+        $(this.getRootElement()).remove();
         
         // Disconnect from Document
         this.document.releaseRef();
@@ -708,6 +708,17 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Gets the lineSpace element within the editor (the container around the individual lines of code).
+     * FUTURE: This is fairly CodeMirror-specific. Logic that depends on this may break if we switch
+     * editors.
+     * @returns {Object} The editor's lineSpace element.
+     */
+    Editor.prototype.getLineSpaceElement = function () {
+        var lineSpaceParent = $(".CodeMirror-lines", this.getScrollerElement()).get(0);
+        return $(lineSpaceParent).children().get(0);
+    };
+
+    /**
      * Adds an inline widget below the given line. If any inline widget was already open for that
      * line, it is closed without warning.
      * @param {!{line:number, ch:number}} pos  Position in text to anchor the inline.
@@ -773,7 +784,7 @@ define(function (require, exports, module) {
     /** Returns true if the editor has focus */
     Editor.prototype.hasFocus = function () {
         // The CodeMirror instance wrapper has a "CodeMirror-focused" class set when focused
-        return $(this._codeMirror.getWrapperElement()).hasClass("CodeMirror-focused");
+        return $(this.getRootElement()).hasClass("CodeMirror-focused");
     };
     
     /**
@@ -789,7 +800,7 @@ define(function (require, exports, module) {
      * @param {boolean} show true to show the editor, false to hide it
      */
     Editor.prototype.setVisible = function (show) {
-        $(this._codeMirror.getWrapperElement()).css("display", (show ? "" : "none"));
+        $(this.getRootElement()).css("display", (show ? "" : "none"));
         this._codeMirror.refresh();
         if (show) {
             this._inlineWidgets.forEach(function (inlineWidget) {
@@ -803,7 +814,7 @@ define(function (require, exports, module) {
      * visible, and has a non-zero width/height.
      */
     Editor.prototype.isFullyVisible = function () {
-        return $(this._codeMirror.getWrapperElement()).is(":visible");
+        return $(this.getRootElement()).is(":visible");
     };
     
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -722,7 +722,7 @@ define(function (require, exports, module) {
      * editors.
      * @returns {Object} The editor's lineSpace element.
      */
-    Editor.prototype.getLineSpaceElement = function () {
+    Editor.prototype._getLineSpaceElement = function () {
         var lineSpaceParent = $(".CodeMirror-lines", this.getScrollerElement()).get(0);
         return $(lineSpaceParent).children().get(0);
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -742,13 +742,12 @@ define(function (require, exports, module) {
     /**
      * Sets the height of an inline widget in this editor. 
      * @param {!InlineWidget} inlineWidget The widget whose height should be set.
-     * @param {!height} height The height of the widget.
+     * @param {!number} height The height of the widget.
      * @param {boolean} ensureVisible Whether to scroll the entire widget into view.
      */
     Editor.prototype.setInlineWidgetHeight = function (inlineWidget, height, ensureVisible) {
         this._codeMirror.setInlineWidgetHeight(inlineWidget.id, height, ensureVisible);
     };
-    
     
     /** Gives focus to the editor control */
     Editor.prototype.focus = function () {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -321,7 +321,6 @@ a, img {
 .InlineWidget {
     border-top:         1px solid #C0C0C0;
     border-bottom:      1px solid #C0C0C0;
-    min-width:          100%;
     background-color:   #eaeaea;
     
     .filename {


### PR DESCRIPTION
@jason-sanjose 

**Note**: this requires the CodeMirror branch https://github.com/adobe/CodeMirror2/pull/51

This pull request fixes two issues.
- Makes it so that the scrollable width of the host editor is always large enough to encompass the width of the code in the inline widget plus the width of the rule list, so you can always scroll to see the entire code in the inline widget. 

The main bit that achieves this is the addition of padding to the inline widget to account for the space taken up by the rule list. However, in order for that to work, we can no longer just have min-width set to 100% on the inline widget, because the padding is added onto that width, which would then push out the width of the parent, which would then increase what the 100% is referring to. So we have to explicitly calculate the min-width based on the parent's code width.

Note that in some cases we add too much horizontal space to the scroll area, because we always tack on the width of the rule list to the width of the host editor's code. I tried to make it so that we subtract the width of the rule list from the host editor's code width, but for some reason that led to problems with the calculation of the overall scroll width (the scroll width would bounce back and forth as you type). Just using box-sizing: border-box to make the min-width include the padding had a similar issue. I'm guessing there are some bugs with min-width in the browser. At this point I think we should treat the extra scroll area as a low-priority bug.
- Fixes issue #533, so that if you arrow around horizontally or vertically in the inline editor, the cursor should always stay visible.

There are a couple of cases here. Horizontally, the cursor needs to stay visible even if you arrow underneath the rule list. In order to deal with that, we add the width of the rule list to the current horizontal cursor position, and ask the host editor to ensure that's visible. That has the effect of pushing everything over so that the actual cursor position is visible to the left of the rule list.

Vertically, we just need to translate the cursor position into a position in the host editor's scroll region.
