### PR TITLE
Fix exception when cancelling open dialogs

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -164,9 +164,9 @@ define(function (require, exports, module) {
      * be called with the special buttonId DIALOG_CANCELED (note: callback is run asynchronously).
      */
     function cancelModalDialogIfOpen(dlgClass) {
-        $("." + dlgClass + ".instance").each(function (dlg) {
-            if (dlg.is(":visible")) {   // Bootstrap breaks if try to hide dialog that's already hidden
-                _dismissDialog(dlg, DIALOG_CANCELED);
+        $("." + dlgClass + ".instance").each(function (index, dlg) {
+            if ($(dlg).is(":visible")) {   // Bootstrap breaks if try to hide dialog that's already hidden
+                _dismissDialog($(dlg), DIALOG_CANCELED);
             }
         });
     }


### PR DESCRIPTION
@peterflynn 

Fixes #554.

In addition to correctly specifying the arguments to `$(selector).each()`, it turns out that `each()` in this case returns the actual DOM nodes, not jQuery objects for each element.
