### PR TITLE
Make clicks in dead space in inline CSS widget set focus back to the act...

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -7,7 +7,7 @@
 
 define(function (require, exports, module) {
     'use strict';
-
+    
     // Load dependent modules
     var DocumentManager     = require("document/DocumentManager"),
         HTMLUtils           = require("language/HTMLUtils"),
@@ -56,6 +56,7 @@ define(function (require, exports, module) {
 
         // Bind event handlers
         this._updateRelatedContainer = this._updateRelatedContainer.bind(this);
+        this._onClick = this._onClick.bind(this);
 
         // Create DOM to hold editors and related list
         this.$editorsDiv = $(document.createElement('div')).addClass("inlineEditorHolder");
@@ -108,6 +109,9 @@ define(function (require, exports, module) {
         
         // Listen to the editor's scroll event to reposition the relatedContainer.
         $(this.hostEditor).on("scroll", this._updateRelatedContainer);
+        
+        // Listen for clicks directly on us, so we can set focus back to the editor
+        this.$htmlContent.on("click", this._onClick);
 
         return (new $.Deferred()).resolve();
     };
@@ -191,6 +195,24 @@ define(function (require, exports, module) {
         $(this.hostEditor).off("change", this._updateRelatedContainer);
         $(this.editors[0]).off("change", this._updateRelatedContainer);
         $(this.hostEditor).off("scroll", this._updateRelatedContainer);
+    };
+    
+    /**
+     * Handle a click outside our child editor by setting focus back to it.
+     */
+    CSSInlineEditor.prototype._onClick = function (event) {
+        var childEditor = this.editors[0],
+            editorRoot = childEditor.getRootElement(),
+            editorPos = $(editorRoot).offset();
+        if (!$.contains(editorRoot, event.target)) {
+            childEditor.focus();
+            if (event.pageY < editorPos.top) {
+                childEditor.setCursorPos(0, 0);
+            } else if (event.pageY > editorPos.top + $(editorRoot).height()) {
+                var lastLine = childEditor.getLastVisibleLine();
+                childEditor.setCursorPos(lastLine, childEditor.getLineText(lastLine).length);
+            }
+        }
     };
     
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -357,14 +357,8 @@ define(function (require, exports, module) {
      * bugs in CodeMirror when lines are hidden.
      */
     Editor.prototype._selectAllVisible = function () {
-        var startLine, endLine;
-        if (this._visibleRange) {
-            startLine = this._visibleRange.startLine;
-            endLine = this._visibleRange.endLine;
-        } else {
-            startLine = 0;
-            endLine = this.lineCount() - 1;
-        }
+        var startLine = this.getFirstVisibleLine(),
+            endLine = this.getLastVisibleLine();
         this.setSelection({line: startLine, ch: 0},
                           {line: endLine, ch: this.getLineText(endLine).length});
     };
@@ -664,6 +658,22 @@ define(function (require, exports, module) {
     Editor.prototype.lineCount = function () {
         return this._codeMirror.lineCount();
     };
+    
+    /**
+     * Gets the number of the first visible line in the editor.
+     * @returns {number} The 0-based index of the first visible line.
+     */
+    Editor.prototype.getFirstVisibleLine = function () {
+        return (this._visibleRange ? this._visibleRange.startLine : 0);
+    };
+    
+    /**
+     * Gets the number of the last visible line in the editor.
+     * @returns {number} The 0-based index of the last visible line.
+     */
+    Editor.prototype.getLastVisibleLine = function () {
+        return (this._visibleRange ? this._visibleRange.endLine : this.lineCount() - 1);
+    };
 
     /* Hides the specified line number in the editor
      * @param {!number}
@@ -689,6 +699,13 @@ define(function (require, exports, module) {
         return this._codeMirror.getScrollerElement();
     };
     
+    /**
+     * Gets the root DOM node of the editor.
+     * @returns {Object} The editor's root DOM node.
+     */
+    Editor.prototype.getRootElement = function () {
+        return this._codeMirror.getWrapperElement();
+    };
     
     /**
      * Adds an inline widget below the given line. If any inline widget was already open for that


### PR DESCRIPTION
...ual editor and set the selection to the beginning/end

Fixes #543 (and refactors my fix for #461).
