### PR TITLE
Added the ability to hide the sidebar from the debug menu.

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -22,9 +22,10 @@ define(function (require, exports, module) {
     exports.FILE_QUIT = "file.quit";
     exports.FILE_QUICK_NAVIGATE = "file.quickNaviate";
     exports.FIND_IN_FILES = "findInFiles";
+    exports.HIDE_SIDEBAR = "hideSidebar";
     exports.DEBUG_RUN_UNIT_TESTS = "debug.runUnitTests";
-    exports.DEBUG_JSLINT = "debug.jslint";
     exports.DEBUG_SHOW_PERF_DATA = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW = "debug.newBracketsWindow";
+    exports.DEBUG_HIDE_SIDEBAR = "debug.hideSidebar";
 });
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -50,6 +50,10 @@ define(function (require, exports, module) {
         $("#menu-debug-new-brackets-window").click(function () {
             CommandManager.execute(Commands.DEBUG_NEW_BRACKETS_WINDOW);
         });
+
+        $("#menu-debug-hide-sidebar").click(function () {
+            CommandManager.execute(Commands.DEBUG_HIDE_SIDEBAR);
+        });
     }
 
     // Define public API

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -93,8 +93,24 @@ define(function (require, exports, module) {
         window.open(window.location.href);
     }
     
+    /* TODO: Support arbitrary widths with grabber
+        When the new theme lands with the CSS, potentially
+        adjust how this is done. */
+    function _handleHideSidebar() {
+        var currentWidth = $(".sidebar").width();
+        if (currentWidth > 0) {
+            $(".sidebar").width(0);
+            $("#menu-debug-hide-sidebar").text("Show Sidebar");
+        } else {
+            $(".sidebar").width(200);
+            $("#menu-debug-hide-sidebar").text("Hide Sidebar");
+        }
+        
+    }
+
     CommandManager.register(Commands.DEBUG_JSLINT, _handleEnableJSLint);
     CommandManager.register(Commands.DEBUG_RUN_UNIT_TESTS, _handleRunUnitTests);
     CommandManager.register(Commands.DEBUG_SHOW_PERF_DATA, _handleShowPerfData);
     CommandManager.register(Commands.DEBUG_NEW_BRACKETS_WINDOW, _handleNewBracketsWindow);
+    CommandManager.register(Commands.DEBUG_HIDE_SIDEBAR, _handleHideSidebar);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,3 @@
-<!doctype html>
-
 <!-- Copyright 2011 Adobe Systems Incorporated. All Rights Reserved. -->
 
 <html>
@@ -60,6 +58,7 @@
                         </li>
                         <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
                         <li><a href="#" id="menu-debug-new-brackets-window">New Window</a></li>
+                        <li><a href="#" id="menu-debug-hide-sidebar">Hide Sidebar</a></li>
                     </ul>
                 </li>
             </ul>

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -21,9 +21,9 @@
  * The opposite is true for a dark background -- background-color-3 should be
  * the darkest, -2 should be lighter, and -1 should be lighter still.
  */
-@background-color-1: darken(@bc-white, @bc-color-step-size*2);
-@background-color-2: darken(@bc-white, @bc-color-step-size);
-@background-color-3: @bc-white;
+@background-color-1: lighten(@bc-black, @bc-color-step-size*2);
+@background-color-2: lighten(@bc-black, @bc-color-step-size);
+@background-color-3: @bc-black;
 
 /*
  * @content-color-stronger should be should be further away from the
@@ -32,9 +32,9 @@
  * @content-color-weaker should be closer to the background color
  * than @content-color (i.e. less contrasty).
  */
-@content-color: lighten(@bc-black, @bc-color-step-size*2);
-@content-color-stronger: @bc-black;
-@content-color-weaker: lighten(@bc-black, @bc-color-step-size*6);
+@content-color: darken(@bc-white, @bc-color-step-size*2);
+@content-color-stronger: @bc-white;
+@content-color-weaker: darken(@bc-white, @bc-color-step-size*6);
 
 /* Code Styling */
 
@@ -107,7 +107,7 @@
     // border: none !important;
 
     // to make an I-cursor, use something like this:
-    border-left: 1px solid black !important;
+    border-left: 1px solid white !important;
 
 }
 


### PR DESCRIPTION
Added the initial code to show/hide the sidebar in the editor. Created a menu item under "debug" and set it up so that it should work with the theme when the new one lands. I talked to Garth about making sure it would work as he adds CSS animations.

Next step is enable dragging of the panel so the user can set width by dragging. Ultimately this will probably be in a view menu as well and register a shortcut key. 

Also, made sure this passed JSLint. 
