### PR TITLE
Fixes issue #559

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
      * @private
      */
     function _dirtyFlagChangeHandler(event, doc) {
-        var $dirtyIndicators = $(".inlineEditor .dirty-indicator"),
+        var $dirtyIndicators = $(".inlineEditorHolder .dirty-indicator"),
             $indicator;
         
         $.each($dirtyIndicators, function (index, indicator) {


### PR DESCRIPTION
Updated class reference in _dirtyFlagChangeHandler() to "inlineEditorHolder" to restore dirty icon functionality

Fixes issue #559
