### PR TITLE
Fire "offsetTopChanged" when inline widget height changes

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -107,8 +107,8 @@ define(function (require, exports, module) {
         // editor, not general document changes.
         $(this.hostEditor).on("change", this._updateRelatedContainer);
         
-        // Listen to the editor's scroll event to reposition the relatedContainer.
-        $(this.hostEditor).on("scroll", this._updateRelatedContainer);
+        // Update relatedContainer when this widget's position changes
+        $(this).on("offsetTopChanged", this._updateRelatedContainer);
         
         // Listen for clicks directly on us, so we can set focus back to the editor
         this.$htmlContent.on("click", this._onClick);
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
         // remove resize handlers for relatedContainer
         $(this.hostEditor).off("change", this._updateRelatedContainer);
         $(this.editors[0]).off("change", this._updateRelatedContainer);
-        $(this.hostEditor).off("scroll", this._updateRelatedContainer);
+        $(this).off("offsetTopChanged", this._updateRelatedContainer);
     };
     
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -567,8 +567,8 @@ define(function (require, exports, module) {
         this._codeMirror.setOption("onScroll", function (instance) {
             $(self).triggerHandler("scroll", [self]);
         
-            // notify all following inline widgets of a position change
-            self._fireWidgetOffsetTopChanged(self.getFirstVisibleLine());
+            // notify all inline widgets of a position change
+            self._fireWidgetOffsetTopChanged(self.getFirstVisibleLine() - 1);
         });
     };
     
@@ -678,6 +678,7 @@ define(function (require, exports, module) {
         return (this._visibleRange ? this._visibleRange.endLine : this.lineCount() - 1);
     };
 
+    // FUTURE change to "hideLines()" API that hides a range of lines at once in a single operation, then fires offsetTopChanged afterwards.
     /* Hides the specified line number in the editor
      * @param {!number}
      */

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -30,7 +30,7 @@
  *    - lostContent -- When the backing Document changes in such a way that this Editor is no longer
  *          able to display accurate text. This occurs if the Document's file is deleted, or in certain
  *          Document->editor syncing edge cases that we do not yet support (the latter cause will
- *          eventually go away).
+ *          eventually go away). 
  *
  * The Editor also dispatches "change" events internally, but you should listen for those on
  * Documents, not Editors.
@@ -566,6 +566,9 @@ define(function (require, exports, module) {
         });
         this._codeMirror.setOption("onScroll", function (instance) {
             $(self).triggerHandler("scroll", [self]);
+        
+            // notify all following inline widgets of a position change
+            self._fireWidgetOffsetTopChanged(self.getFirstVisibleLine());
         });
     };
     
@@ -679,7 +682,12 @@ define(function (require, exports, module) {
      * @param {!number}
      */
     Editor.prototype.hideLine = function (lineNumber) {
-        return this._codeMirror.hideLine(lineNumber);
+        var value = this._codeMirror.hideLine(lineNumber);
+        
+        // when this line is hidden, notify all following inline widgets of a position change
+        this._fireWidgetOffsetTopChanged(lineNumber);
+        
+        return value;
     };
 
     /**
@@ -721,6 +729,9 @@ define(function (require, exports, module) {
         });
         this._inlineWidgets.push(inlineWidget);
         inlineWidget.onAdded();
+        
+        // once this widget is added, notify all following inline widgets of a position change
+        this._fireWidgetOffsetTopChanged(pos.line);
     };
     
     /**
@@ -728,8 +739,13 @@ define(function (require, exports, module) {
      * @param {number} inlineWidget The widget to remove.
      */
     Editor.prototype.removeInlineWidget = function (inlineWidget) {
+        var lineNum = this._getInlineWidgetLineNumber(inlineWidget);
+        
         // _removeInlineWidgetInternal will get called from the destroy callback in CodeMirror.
         this._codeMirror.removeInlineWidget(inlineWidget.id);
+        
+        // once this widget is removed, notify all following inline widgets of a position change
+        this._fireWidgetOffsetTopChanged(lineNum);
     };
     
     /**
@@ -762,9 +778,47 @@ define(function (require, exports, module) {
      * @param {boolean} ensureVisible Whether to scroll the entire widget into view.
      */
     Editor.prototype.setInlineWidgetHeight = function (inlineWidget, height, ensureVisible) {
+        var info = this._codeMirror.getInlineWidgetInfo(inlineWidget.id),
+            oldHeight = (info && info.height) || 0;
+        
         this._codeMirror.setInlineWidgetHeight(inlineWidget.id, height, ensureVisible);
+        
+        // update position for all following inline editors
+        if (oldHeight !== height) {
+            var lineNum = this._getInlineWidgetLineNumber(inlineWidget);
+            this._fireWidgetOffsetTopChanged(lineNum);
+        }
     };
     
+    /**
+     * @private
+     * Get the starting line number for an inline widget.
+     * @param {!InlineWidget} inlineWidget 
+     * @return {number} The line number of the widget or -1 if not found.
+     */
+    Editor.prototype._getInlineWidgetLineNumber = function (inlineWidget) {
+        var info = this._codeMirror.getInlineWidgetInfo(inlineWidget.id);
+        return (info && info.line) || -1;
+    };
+    
+    /**
+     * @private
+     * Fire "offsetTopChanged" events when inline editor positions change due to
+     * height changes of other inline editors.
+     * @param {!InlineWidget} inlineWidget 
+     */
+    Editor.prototype._fireWidgetOffsetTopChanged = function (lineNum) {
+        var self = this,
+            otherLineNum;
+        
+        this.getInlineWidgets().forEach(function (other) {
+            otherLineNum = self._getInlineWidgetLineNumber(other);
+            
+            if (otherLineNum > lineNum) {
+                $(other).triggerHandler("offsetTopChanged");
+            }
+        });
+    };
     
     /** Gives focus to the editor control */
     Editor.prototype.focus = function () {


### PR DESCRIPTION
All widgets below the modified widget will receive trigger an offsetTopChanged event. CSSInlineEditor uses this to update the rule list position.
