### PR TITLE
Performance improvements for inline editors

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
         this._rules.forEach(function (rule, i) {
             $ruleItem = $(document.createElement("li")).appendTo($ruleList);
             $ruleItem.text(rule.selector + " ");
-            $ruleItem.click(function () {
+            $ruleItem.mousedown(function () {
                 self.setSelectedRule(i);
             });
             
@@ -123,6 +123,10 @@ define(function (require, exports, module) {
     CSSInlineEditor.prototype.setSelectedRule = function (index) {
         var newIndex = Math.min(Math.max(0, index), this._rules.length - 1);
         
+        if (newIndex === this._selectedRuleIndex) {
+            return;
+        }
+
         this._selectedRuleIndex = newIndex;
         var $ruleItem = this._ruleItems[this._selectedRuleIndex];
 
@@ -154,6 +158,8 @@ define(function (require, exports, module) {
         // editor, not general document changes.
         $(this.editors[0]).on("change", this._updateRelatedContainer);
 
+        
+        this.editors[0].refresh();
         this.sizeInlineWidgetToContents(true);
         this._updateRelatedContainer();
 

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -190,7 +190,6 @@ define(function (require, exports, module) {
         // create the filename div
         var wrapperDiv = document.createElement("div");
         var $wrapperDiv = $(wrapperDiv);
-        container.appendChild(wrapperDiv);
         
         // dirty indicator followed by filename
         var $filenameDiv = $(document.createElement("div")).addClass("filename");
@@ -207,6 +206,7 @@ define(function (require, exports, module) {
         
         var inlineInfo = EditorManager.createInlineEditorForDocument(doc, range, wrapperDiv, closeThisInline, additionalKeys);
         this.editors.push(inlineInfo.editor);
+        container.appendChild(wrapperDiv);
 
         // Size editor to content whenever it changes (via edits here or any other view of the doc)
         $(inlineInfo.editor).on("change", function () {


### PR DESCRIPTION
This request adds a couple performance improvements for inline editors, and partially fixes issue #571

(a separate CodeMirror pull request, adobe/CodeMirror2#52, has a much larger impact on performance)

Improvements in this pull request:
- InlineTextEditor.createInlineFromText() adds the wrapperDiv to the DOM after the editor is created
- Change selection on mouse down instead of click
- setSelectedRule returns early if the selected index isn't changed
