### PR TITLE
Fix for issue #541

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -161,7 +161,8 @@ define(function (require, exports, module) {
         // Cursor activity in the inline editor may cause us to horizontally scroll.
         $(this.editors[0]).on("cursorActivity", this._ensureCursorVisible);
 
-        this.sizeInlineWidgetToContents(true);
+        // ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a view
+        this.sizeInlineWidgetToContents(true, false);
         this._updateRelatedContainer();
 
         // scroll the selection to the ruleItem, use setTimeout to wait for DOM updates
@@ -353,13 +354,15 @@ define(function (require, exports, module) {
     /**
      * Sizes the inline widget height to be the maximum between the rule list height and the editor height
      * @overide 
+     * @param {boolean} force the editor to resize
+     * @param {boolean} ensureVisibility makes the parent editor scroll to display the inline editor when true
      */
-    CSSInlineEditor.prototype.sizeInlineWidgetToContents = function (force) {
+    CSSInlineEditor.prototype.sizeInlineWidgetToContents = function (force, ensureVisibility) {
         // Size the code mirror editors height to the editor content
         this.parentClass.sizeInlineWidgetToContents.call(this, force);
         // Size the widget height to the max between the editor content and the related rules list
         var widgetHeight = Math.max(this.$relatedContainer.find(".related").height(), this.$editorsDiv.height());
-        this.hostEditor.setInlineWidgetHeight(this, widgetHeight, true);
+        this.hostEditor.setInlineWidgetHeight(this, widgetHeight, ensureVisibility);
 
         // The related rules container size itself based on htmlContent which is set by setInlineWidgetHeight above.
         this._updateRelatedContainer();

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -217,13 +217,15 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Handle a click outside our child editor by setting focus back to it.
+     * Prevent clicks in the dead areas of the inlineWidget from changing the focus and insertion point in the editor.
+     * This is done by detecting clicks in the inlineWidget that are not inside the editor or the rule list and
+     * restoring focus and the insertion point.
      */
     CSSInlineEditor.prototype._onClick = function (event) {
         var childEditor = this.editors[0],
             editorRoot = childEditor.getRootElement(),
             editorPos = $(editorRoot).offset();
-        if (!$.contains(editorRoot, event.target)) {
+        if (!$.contains(editorRoot, event.target) && !$.contains(this.$relatedContainer, event.target)) {
             childEditor.focus();
             if (event.pageY < editorPos.top) {
                 childEditor.setCursorPos(0, 0);

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
 
         
         this.editors[0].refresh();
-		// ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a vie
+        // ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a view
         this.sizeInlineWidgetToContents(true, false);
         this._updateRelatedContainer();
 
@@ -272,13 +272,16 @@ define(function (require, exports, module) {
         var childEditor = this.editors[0],
             editorRoot = childEditor.getRootElement(),
             editorPos = $(editorRoot).offset();
-        if (!$.contains(editorRoot, event.target) && this.$relatedContainer.find(event.target).length === 0) {
+        if ($(editorRoot).find(event.target).length === 0) {
             childEditor.focus();
-            if (event.pageY < editorPos.top) {
-                childEditor.setCursorPos(0, 0);
-            } else if (event.pageY > editorPos.top + $(editorRoot).height()) {
-                var lastLine = childEditor.getLastVisibleLine();
-                childEditor.setCursorPos(lastLine, childEditor.getLineText(lastLine).length);
+            // Only set the cursor if the click isn't in the rule list.
+            if (this.$relatedContainer.find(event.target).length === 0) {
+                if (event.pageY < editorPos.top) {
+                    childEditor.setCursorPos(0, 0);
+                } else if (event.pageY > editorPos.top + $(editorRoot).height()) {
+                    var lastLine = childEditor.getLastVisibleLine();
+                    childEditor.setCursorPos(lastLine, childEditor.getLineText(lastLine).length);
+                }
             }
         }
     };
@@ -400,9 +403,9 @@ define(function (require, exports, module) {
 
     /**
      * Sizes the inline widget height to be the maximum between the rule list height and the editor height
-     * @overide 
+     * @override 
      * @param {boolean} force the editor to resize
-     * @param {boolean} ensureVisibility makes the parent editor scroll to display the inline editor when true
+     * @param {boolean} ensureVisibility makes the parent editor scroll to display the inline editor. Default true.
      */
     CSSInlineEditor.prototype.sizeInlineWidgetToContents = function (force, ensureVisibility) {
         // Size the code mirror editors height to the editor content

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
         var childEditor = this.editors[0],
             editorRoot = childEditor.getRootElement(),
             editorPos = $(editorRoot).offset();
-        if (!$.contains(editorRoot, event.target) && !$.contains(this.$relatedContainer, event.target)) {
+        if (!$.contains(editorRoot, event.target) && this.$relatedContainer.find(event.target).length === 0) {
             childEditor.focus();
             if (event.pageY < editorPos.top) {
                 childEditor.setCursorPos(0, 0);

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -163,7 +163,9 @@ define(function (require, exports, module) {
         _syncGutterWidths(this.hostEditor);
         
         // Set initial size
-        this.sizeInlineWidgetToContents();
+        // Note that the second argument here (ensureVisibility) is only used by CSSInlineEditor.
+        // FUTURE: Should clean up this API so it's consistent between the two.
+        this.sizeInlineWidgetToContents(true, true);
         
         this.editors[0].focus();
     };


### PR DESCRIPTION
Prevents the host editor from scrolling in the follow cases:
- when selecting a rule. setSelectedRule() now passes false for ensureVisibility to sizeInlineWidgetToContents() since the host editor should not scroll when select a rule
- when clicking outside the editor and not on a rule. There was a bug in _onClick where it would restore focus when clicking in the rule list. The code now avoids this case. Note: there was one oddity. I had to use this.$relatedContainer.find(event.target).length === 0 because !$.contains(this.$relatedContainer, event.target) was not working. $.contains was returning true saying the file label was in the relatedContainer. I don't know why. They intersect visually, but one is not inside the other.

Note: This pull request must be merged with the pull request in the code mirror repro. The branches have the same name

Fix for issue #541
