### PR TITLE
Don't re-open a connection to the same HTML document.

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -64,7 +64,8 @@ define(function LiveDevelopment(require, exports, module) {
         */
     };
 
-    var _liveDocument; // the live HTML document
+    var _htmlDocumentPath; // the path of the html file open for live development
+    var _liveDocument; // the document open for live editing.
     var _relatedDocuments; // CSS and JS documents that are used by the live HTML document
 
     /** Augments the given Brackets document with information that's useful for live development. */
@@ -359,9 +360,10 @@ define(function LiveDevelopment(require, exports, module) {
                 _openDocument(doc, editor);
             } else {
                 /* FUTURE: support live connections for docments other than html */
-                if (doc.extension && doc.extension.indexOf('htm') === 0) {
+                if (doc.extension && doc.extension.indexOf('htm') === 0 && doc.file.fullPath !== _htmlDocumentPath) {
                     close();
                     setTimeout(open);
+                    _htmlDocumentPath = doc.file.fullPath;
                 }
             }
         } else if (exports.config.autoconnect) {


### PR DESCRIPTION
Fixes issue #579, and other intermittent cases where selecting the HTML file causes it to be reloaded in the live connection.
