### PR TITLE
Tweak border appearance of CSS rule list

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -370,6 +370,7 @@ a, img {
     /*-webkit-transition: width 0.15s ease-out;*/
     background: #f2f2f2;
     border-left: 1px solid #ccc;
+    box-shadow: -1px 0 0 0 #fff;
     
     @top-margin: 12px;
         
@@ -390,7 +391,6 @@ a, img {
         position: absolute;
         top: 0;
         left: 1px;
-        box-shadow: -1px 0 0 0 #fff;
         font-size: 12px;
         
         ul {


### PR DESCRIPTION
Cosmetic fix in CSS rule list: white vertical border line should be to the left of the darker line, and it should be the full height of the inline widget (not just the height of the rule list, which might be shorter).

(Per Garth's mockup)
