### PR TITLE
Fix #533 (gutter width syncing no longer working, impacting inline editor H scrolling in certain cases)

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -184,8 +184,8 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Given a host editor, return a list of all its open inline Editors. (Ignoring any other
-     * inline widgets that might be open).
+     * Given a host editor, return a list of all Editors in all its open inline widgets. (Ignoring
+     * any other inline widgets that might be open but don't contain Editors).
      * @param {!Editor} hostEditor
      * @return {Array.<Editor>}
      *
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
         var inlineEditors = [];
         hostEditor.getInlineWidgets().forEach(function (widget) {
             if (widget instanceof InlineTextEditor) {
-                inlineEditors.concat(widget.editors);
+                inlineEditors = inlineEditors.concat(widget.editors);
             }
         });
         return inlineEditors;

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -71,17 +71,9 @@ define(function (require, exports, module) {
      * @private
      */
     function _syncGutterWidths(hostEditor) {
-        var inlines = EditorManager.getInlineEditors(hostEditor),
-            allHostedEditors = [];
+        var allHostedEditors = EditorManager.getInlineEditors(hostEditor);
         
-        // add all Editor instances of each InlineTextEditor
-        inlines.forEach(function (inline) {
-            if (inline instanceof InlineTextEditor) {
-                Array.push.apply(allHostedEditors, inline.editors);
-            }
-        });
-        
-        // add the host to the list and go through them all
+        // add the host itself to the list too
         allHostedEditors.push(hostEditor);
         
         var maxWidth = 0;


### PR DESCRIPTION
Two bugs from the InlineEditorProviders -> CSSInlineEditor/InlineTextEditor both meant that _syncGutterWidths() was always getting an empty array for the list of open inline editors.
