### PR TITLE
Pass 'enableRemoteDebugging' flag to openLiveBrowser

### DIFF
--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -4,7 +4,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, WebSocket */
+/*global define, $, WebSocket, FileError */
 
  /**
  * Inspector manages the connection to Chrome/Chromium's remote debugger.
@@ -287,7 +287,7 @@ define(function Inspector(require, exports, module) {
                     return;
                 }
             }
-            deferred.reject();
+            deferred.reject(FileError.ERR_NOT_FOUND); // Reject with a "not found" error
         });
         promise.fail(function onFail(err) {
             deferred.reject(err);

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -304,8 +304,15 @@ define(function LiveDevelopment(require, exports, module) {
                 retryCount++;
                 
                 if (!browserStarted && exports.status !== -1) {
+                    // If err === FileError.ERR_NOT_FOUND, it means a remote debugger connection
+                    // is available, but the requested URL is not loaded in the browser. In that
+                    // case we want to launch the live browser (to open the url in a new tab)
+                    // without using the --remote-debugging-port flag. This works around issues
+                    // on Windows where Chrome can't be opened more than once with the
+                    // --remote-debugging-port flag set.
                     NativeApp.openLiveBrowser(
-                        doc.root.url
+                        doc.root.url,
+                        err !== FileError.ERR_NOT_FOUND
                     )
                         .done(function () {
                             browserStarted = true;

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -26,10 +26,10 @@ define(function (require, exports, module) {
      * @param {string} url
      * @return {$.Promise} 
      */
-    function openLiveBrowser(url, successCallback, errorCallback) {
+    function openLiveBrowser(url, enableRemoteDebugging, successCallback, errorCallback) {
         var result = new $.Deferred();
         
-        brackets.app.openLiveBrowser(url, function onRun(err) {
+        brackets.app.openLiveBrowser(url, enableRemoteDebugging, function onRun(err) {
             if (!err) {
                 result.resolve();
             } else {


### PR DESCRIPTION
This is the brackets fix for issue #603. Corresponding pull request adobe/brackets-app#90 needs to be done at the same time.

When opening a live connection, distinguish between "don't have a live connection" and "have a live connection, but the requested url isn't loaded" errors. With this information, we pass a new 'enableRemoteDebugging' flag to openLiveBrowser(). 
