### PR TITLE
Insert a delay between opening and closing a live connection

### DIFF
--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -95,6 +95,9 @@ define(function (require, exports, module) {
                     var doc = DocumentManager.getOpenDocumentForPath(testPath + "/simple1.html");
                     //expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
                 });
+                
+                // Let things settle down before trying to close the connection.
+                waits(1000);
             });
             
             it("should should not start a browser connection for an opened css file", function () {


### PR DESCRIPTION
@gruehle 

The first live edit unit test was hitting a race condition where it was trying to close a connection immediately after opening one. This inserts a small delay to avoid this condition. This condition could conceivably be hit in the real app if you're very unlucky, but we've been unable to reproduce it there.
