### PR TITLE
Adding support for deleting lines 

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -156,7 +156,26 @@ define(function (require, exports, module) {
 
         return handled;
     }
-    
+
+    /**
+     * @private
+     * Deletes the current line if there is no selection or the lines for the selection
+     * (removing the end of line too)
+     * @param {!CodeMirror} instance CodeMirror instance
+     */
+    function _deleteCurrentLines(instance) {
+        var _from, _to, _sel;
+        _sel = instance.getCursor(true);
+        _from = {line: _sel.line, ch: 0};
+        _sel = instance.getCursor(false);
+        _to = {line: _sel.line + 1, ch: 0};
+        if (instance.lineCount() === _to.line && _from.line > 0) {
+            _from.line -= 1;
+            _from.ch = instance.getLine(_from.line).length;
+        }
+        instance.replaceRange("", _from, _to);
+    }
+
     /**
      * Checks if the user just typed a closing brace/bracket/paren, and considers automatically
      * back-indenting it if so.
@@ -273,7 +292,10 @@ define(function (require, exports, module) {
             "Ctrl-H": "replace",
             "Shift-Delete": "cut",
             "Ctrl-Insert": "copy",
-            "Shift-Insert": "paste"
+            "Shift-Insert": "paste",
+            "Ctrl-L": function (instance) {
+                _deleteCurrentLines(instance);
+            }
         };
         
         EditorManager.mergeExtraKeys(self, codeMirrorKeyMap, additionalKeys);


### PR DESCRIPTION
This enables people to delete either the current line (as defined by the cursor position when there is nothing selected) or the lines on which a selection has been made.

It deletes the end of line char too.

Few notes about the code:
- I used Ctrl-L because codemirror doesn't seem to support combination of Ctrl-Shift and a key
- Ctrl-K is already defined in codemirror. It deletes something but not the entire line (more like the end-of-line char if there is no chars to the right of the cursor or all the chars that are on the same line on the right-hand side of the cursor)
- killLine doesn't seem to do what I wanted
