### PR TITLE
Added keyboard shortcut for hiding sidebar (Ctrl+Shift+H). 

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -162,6 +162,7 @@ define(function (require, exports, module) {
                     {"Ctrl-W": Commands.FILE_CLOSE},
                     {"Ctrl-Shift-O": Commands.FILE_QUICK_NAVIGATE},
                     {"Ctrl-Shift-F": Commands.FIND_IN_FILES},
+                    {"Ctrl-Shift-H": Commands.DEBUG_HIDE_SIDEBAR},
                     {"Ctrl-R": Commands.FILE_RELOAD, "platform": "mac"},
                     {"F5"    : Commands.FILE_RELOAD, "platform": "win"}
                 ],


### PR DESCRIPTION
In this case H stands for "hide". It's also a right handed key which I thought made it easy to press with Ctrl+Shift. 
