### PR TITLE
Add full path to hover text

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -37,8 +37,10 @@ define(function (require, exports, module) {
         var currentDoc = DocumentManager.getCurrentDocument();
         if (currentDoc) {
             _title.text(_currentTitlePath + (currentDoc.isDirty ? " \u2022" : ""));
+            _title.attr("title", currentDoc.file.fullPath);
         } else {
             _title.text("");
+            _title.attr("title", "");
         }
     }
     


### PR DESCRIPTION
Currently when you open a file, you get only a partial path/filename in the editor, for example: foo.js. What this does is use the TITLE attribute of the node to include the full path. When you mouseover and pause, you will see the path.
