### PR TITLE
Fix live development for inline editors when there is a space in the project pathname

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -172,7 +172,7 @@ define(function LiveDevelopment(require, exports, module) {
                 path = path.slice(1);
             }
         }
-        return path;
+        return decodeURI(path);
     }
 
     /** Open a live document


### PR DESCRIPTION
Call decodeURI() when converting from URL to path name. This fixes issue #611.

The brackets-scenario repo has a project with a space in the folder name -- "samples/backbone todos" -- which can be used to test/regress this issue.
