### PR TITLE
Implements menu spec for brackets

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
 
             // Open project button
             $("#btn-open-project").click(function () {
-                ProjectManager.openProject();
+                CommandManager.execute(Commands.FILE_OPEN_FOLDER);
             });
 
 
@@ -157,14 +157,39 @@ define(function (require, exports, module) {
             // TODO: (issue #268) show keyboard equivalents in the menus
             var _globalKeymap = KeyMap.create({
                 "bindings": [
+                    // FILE
+                    {"Ctrl-N": Commands.FILE_NEW},
                     {"Ctrl-O": Commands.FILE_OPEN},
                     {"Ctrl-S": Commands.FILE_SAVE},
                     {"Ctrl-W": Commands.FILE_CLOSE},
+                    {"Ctrl-Q": Commands.FILE_QUIT},
+
+                    // EDIT
+                    {"Ctrl-Z": Commands.EDIT_UNDO},
+                    {"Ctrl-Y": Commands.EDIT_REDO},
+                    // {"Ctrl-X": Commands.EDIT_CUT},
+                    // {"Ctrl-C": Commands.EDIT_COPY}, 
+                    // {"Ctrl-P": Commands.EDIT_PASTE},
+
+                    {"Ctrl-A": Commands.EDIT_SELECT_ALL},
+                    {"Ctrl-F": Commands.EDIT_FIND},
+                    {"Ctrl-Shift-F": Commands.EDIT_FIND_IN_FILES},
+                    {"Ctrl-G": Commands.EDIT_FIND_NEXT, "platform": "mac"},
+                    {"F3": Commands.EDIT_FIND_NEXT, "platform": "win"},
+                    {"Ctrl-Shift-G": Commands.EDIT_FIND_PREVIOUS, "platform": "mac"},
+                    {"Shift-F3": Commands.EDIT_FIND_PREVIOUS, "platform": "win"},
+                    //{"Ctrl-Tab": Commands.EDIT_INDENT},
+                    //{"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},
+
+                    // DEBUG
+                    {"F5": Commands.DEBUG_REFRESH_WINDOW, "platform": "win"},
+                    {"Ctrl-R": Commands.DEBUG_REFRESH_WINDOW, "platform": "mac"},
+
+
                     {"Ctrl-Shift-O": Commands.FILE_QUICK_NAVIGATE},
-                    {"Ctrl-Shift-F": Commands.FIND_IN_FILES},
-                    {"Ctrl-Shift-H": Commands.DEBUG_HIDE_SIDEBAR},
-                    {"Ctrl-R": Commands.FILE_RELOAD, "platform": "mac"},
-                    {"F5"    : Commands.FILE_RELOAD, "platform": "win"}
+                    {"Ctrl-Shift-H": Commands.DEBUG_HIDE_SIDEBAR}
+
+
                 ],
                 "platform": brackets.platform
             });
@@ -201,9 +226,9 @@ define(function (require, exports, module) {
     
         initListeners();
         initProject();
-        Menus.init();
         initCommandHandlers();
         initKeyBindings();
+        Menus.init(); // key bindings should be initialized first
         initWindowListeners();
 
         // Load extensions

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
                     {"F3": Commands.EDIT_FIND_NEXT, "platform": "win"},
                     {"Ctrl-Shift-G": Commands.EDIT_FIND_PREVIOUS, "platform": "mac"},
                     {"Shift-F3": Commands.EDIT_FIND_PREVIOUS, "platform": "win"},
-                    {"Ctrl-G": Commands.EDIT_REPLACE, "platform": "mac"},
+                    {"Ctrl-Alt-F": Commands.EDIT_REPLACE, "platform": "mac"},
                     {"Ctrl-H": Commands.EDIT_REPLACE, "platform": "win"},
                     //{"Ctrl-Tab": Commands.EDIT_INDENT},
                     //{"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -165,19 +165,21 @@ define(function (require, exports, module) {
                     {"Ctrl-Q": Commands.FILE_QUIT},
 
                     // EDIT
-                    {"Ctrl-Z": Commands.EDIT_UNDO},
-                    {"Ctrl-Y": Commands.EDIT_REDO},
-                    // {"Ctrl-X": Commands.EDIT_CUT},
-                    // {"Ctrl-C": Commands.EDIT_COPY}, 
-                    // {"Ctrl-P": Commands.EDIT_PASTE},
+                    //{"Ctrl-Z": Commands.EDIT_UNDO},
+                    //{"Ctrl-Y": Commands.EDIT_REDO},
+                    //{"Ctrl-X": Commands.EDIT_CUT},
+                    //{"Ctrl-C": Commands.EDIT_COPY}, 
+                    //{"Ctrl-V": Commands.EDIT_PASTE},
 
-                    {"Ctrl-A": Commands.EDIT_SELECT_ALL},
+                    //{"Ctrl-A": Commands.EDIT_SELECT_ALL},
                     {"Ctrl-F": Commands.EDIT_FIND},
                     {"Ctrl-Shift-F": Commands.EDIT_FIND_IN_FILES},
                     {"Ctrl-G": Commands.EDIT_FIND_NEXT, "platform": "mac"},
                     {"F3": Commands.EDIT_FIND_NEXT, "platform": "win"},
                     {"Ctrl-Shift-G": Commands.EDIT_FIND_PREVIOUS, "platform": "mac"},
                     {"Shift-F3": Commands.EDIT_FIND_PREVIOUS, "platform": "win"},
+                    {"Ctrl-G": Commands.EDIT_REPLACE, "platform": "mac"},
+                    {"Ctrl-H": Commands.EDIT_REPLACE, "platform": "win"},
                     //{"Ctrl-Tab": Commands.EDIT_INDENT},
                     //{"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},
 

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -183,12 +183,14 @@ define(function (require, exports, module) {
                     //{"Ctrl-Tab": Commands.EDIT_INDENT},
                     //{"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},
 
+                    // Navigate
+                    {"Ctrl-Shift-O": Commands.NAVIGATE_QUICK_OPEN},
+                    //{"Ctrl-E", Commands.TODO}
+
                     // DEBUG
                     {"F5": Commands.DEBUG_REFRESH_WINDOW, "platform": "win"},
                     {"Ctrl-R": Commands.DEBUG_REFRESH_WINDOW, "platform": "mac"},
 
-
-                    {"Ctrl-Shift-O": Commands.FILE_QUICK_NAVIGATE},
                     {"Ctrl-Shift-H": Commands.DEBUG_HIDE_SIDEBAR}
 
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -24,6 +24,8 @@ define(function (require, exports, module) {
     exports.FILE_QUIT           = "file.quit";
 
     // EDIT
+    exports.EDIT_UNDO           = "edit.undo";
+    exports.EDIT_REDO           = "edit.redo";
     exports.EDIT_CUT            = "edit.cut";
     exports.EDIT_COPY           = "edit.copy";
     exports.EDIT_PASTE          = "edit.paste";
@@ -48,7 +50,6 @@ define(function (require, exports, module) {
     exports.DEBUG_HIDE_SIDEBAR  = "debug.hideSidebar";
     exports.DEBUG_CLOSE_ALL_LIVE_BROWSERS = "debug.closeAllLiveBrowsers";
 
-    exports.EDIT_UNDO           = "edit.undo";
-    exports.EDIT_REDO           = "edit.redo";
+
 });
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
     exports.EDIT_FIND_IN_FILES  = "edit.findInFiles";
     exports.EDIT_FIND_NEXT      = "edit.findNext";
     exports.EDIT_FIND_PREVIOUS  = "edit.findPrevious";
+    exports.EDIT_REPLACE        = "edit.replace"
     exports.EDIT_INDENT         = "edit.indent";
     exports.EDIT_UNINDENT       = "edit.unindent";
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     exports.EDIT_FIND_IN_FILES  = "edit.findInFiles";
     exports.EDIT_FIND_NEXT      = "edit.findNext";
     exports.EDIT_FIND_PREVIOUS  = "edit.findPrevious";
-    exports.EDIT_REPLACE        = "edit.replace"
+    exports.EDIT_REPLACE        = "edit.replace";
     exports.EDIT_INDENT         = "edit.indent";
     exports.EDIT_UNINDENT       = "edit.unindent";
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -22,7 +22,6 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_WINDOW   = "file.close_window";
     exports.FILE_ADD_TO_WORKING_SET = "file.addToWorkingSet";
     exports.FILE_QUIT           = "file.quit";
-    exports.FILE_QUICK_NAVIGATE = "file.quickNaviate";
 
     // EDIT
     exports.EDIT_CUT            = "edit.cut";
@@ -36,6 +35,9 @@ define(function (require, exports, module) {
     exports.EDIT_REPLACE        = "edit.replace"
     exports.EDIT_INDENT         = "edit.indent";
     exports.EDIT_UNINDENT       = "edit.unindent";
+
+    // Navigate
+    exports.NAVIGATE_QUICK_OPEN = "navigate.quickOpen";
 
     exports.DEBUG_REFRESH_WINDOW = "debug.refreshWindow";
     exports.DEBUG_SHOW_DEVELOPER_TOOLS = "debug.showDeveloperTools";

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -11,22 +11,41 @@ define(function (require, exports, module) {
     /**
      * List of constants for global command IDs.
      */
-    exports.FILE_OPEN   = "file.open";
-    exports.FILE_NEW    = "file.new";
-    exports.FILE_SAVE   = "file.save";
-    exports.FILE_CLOSE  = "file.close";
-    exports.FILE_CLOSE_ALL = "file.close_all";
-    exports.FILE_CLOSE_WINDOW = "file.close_window";
+
+    // FILE
+    exports.FILE_NEW             = "file.new";
+    exports.FILE_OPEN           = "file.open";
+    exports.FILE_OPEN_FOLDER    = "file.openFolder";
+    exports.FILE_SAVE           = "file.save";
+    exports.FILE_CLOSE          = "file.close";
+    exports.FILE_CLOSE_ALL      = "file.close_all";
+    exports.FILE_CLOSE_WINDOW   = "file.close_window";
     exports.FILE_ADD_TO_WORKING_SET = "file.addToWorkingSet";
-    exports.FILE_RELOAD = "file.reload";
-    exports.FILE_QUIT = "file.quit";
+    exports.FILE_QUIT           = "file.quit";
     exports.FILE_QUICK_NAVIGATE = "file.quickNaviate";
-    exports.FIND_IN_FILES = "findInFiles";
+
+    // EDIT
+    exports.EDIT_CUT            = "edit.cut";
+    exports.EDIT_COPY           = "edit.copy";
+    exports.EDIT_PASTE          = "edit.paste";
+    exports.EDIT_SELECT_ALL     = "edit.selectAll";
+    exports.EDIT_FIND           = "edit.find";
+    exports.EDIT_FIND_IN_FILES  = "edit.findInFiles";
+    exports.EDIT_FIND_NEXT      = "edit.findNext";
+    exports.EDIT_FIND_PREVIOUS  = "edit.findPrevious";
+    exports.EDIT_INDENT         = "edit.indent";
+    exports.EDIT_UNINDENT       = "edit.unindent";
+
+    exports.DEBUG_REFRESH_WINDOW = "debug.refreshWindow";
+    exports.DEBUG_SHOW_DEVELOPER_TOOLS = "debug.showDeveloperTools";
     exports.DEBUG_RUN_UNIT_TESTS = "debug.runUnitTests";
-    exports.DEBUG_JSLINT = "debug.jslint";
+    exports.DEBUG_JSLINT        = "debug.jslint";
     exports.DEBUG_SHOW_PERF_DATA = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW = "debug.newBracketsWindow";
-    exports.DEBUG_HIDE_SIDEBAR = "debug.hideSidebar";
+    exports.DEBUG_HIDE_SIDEBAR  = "debug.hideSidebar";
     exports.DEBUG_CLOSE_ALL_LIVE_BROWSERS = "debug.closeAllLiveBrowsers";
+
+    exports.EDIT_UNDO           = "edit.undo";
+    exports.EDIT_REDO           = "edit.redo";
 });
 

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -33,6 +33,14 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Returns a copy of the keymap
+     * @returns {KeyMap}
+     */
+    function getKeymap() {
+        return $.extend({}, _keymap.map);
+    }
+
+    /**
      * Process the keybinding for the current key.
      *
      * @param {string} A key-description string.
@@ -62,6 +70,7 @@ define(function (require, exports, module) {
     
     // Define public API
     exports.installKeymap = installKeymap;
+    exports.getKeymap = getKeymap;
     exports.handleKey = handleKey;
     exports.setEnabled = setEnabled;
 });

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -3,7 +3,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false */
+/*global define: false. $ */
 
 /**
  * Manages the mapping of keyboard inputs to commands.

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -14,10 +14,10 @@ define(function (require, exports, module) {
         EditorManager           = require("editor/EditorManager"),
         CommandManager          = require("command/CommandManager");
     
-        /**
-         * Maps the dom id's of menus to command strings in Commands.js 
-         * @type {Object.<string, string>}
-         */
+    /**
+     * Maps the dom id's of menus to command strings in Commands.js 
+     * @type {Object.<string, string>}
+     */
     var menuMap = {
         // File
         "menu-file-new": Commands.FILE_NEW,
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
             };
         }
 
-        // create click handles and populate cmdToIdMap
+        // create click handlers and populate cmdToIdMap
         var menuID;
         var commandStr;
         for (menuID in menuMap) {
@@ -96,6 +96,8 @@ define(function (require, exports, module) {
                 menuID = cmdToIdMap[commandStr];
                 if (menuID) {
                     var shortcut = keyCmd.replace(/-/, "+");
+
+                    // TODO TY: put in platform specific keys
                     $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");
                 }
             }

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
             "menu-edit-find-in-files": Commands.EDIT_FIND_IN_FILES,
             "menu-edit-find-next": Commands.EDIT_FIND_NEXT,
             "menu-edit-find-previous": Commands.EDIT_FIND_PREVIOUS,
+            "menu-edit-replace": Commands.EDIT_REPLACE,
             
 
             // View
@@ -58,6 +59,8 @@ define(function (require, exports, module) {
             "menu-experimental-new-brackets-window": Commands.DEBUG_NEW_BRACKETS_WINDOW,
             "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS,
         };
+
+        var _codeMirrorInternal = [Commands.EDIT_SELECT_ALL, Commands.EDIT_UNDO];
 
     function init() {
         var cmdToIdMap = {}; // used to swap the values and keys for fast look up

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -10,54 +10,94 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Commands                = require("command/Commands"),
+        KeyBindingManager       = require("command/KeyBindingManager"),
+        EditorManager           = require("editor/EditorManager"),
         CommandManager          = require("command/CommandManager");
     
-    function init() {
-        // Implements the File menu items
-        $("#menu-file-new").click(function () {
-            CommandManager.execute(Commands.FILE_NEW);
-        });
-        $("#menu-file-open").click(function () {
-            CommandManager.execute(Commands.FILE_OPEN);
-        });
-        $("#menu-file-close").click(function () {
-            CommandManager.execute(Commands.FILE_CLOSE);
-        });
-        $("#menu-file-save").click(function () {
-            CommandManager.execute(Commands.FILE_SAVE);
-        });
-        $("#menu-file-quit").click(function () {
-            CommandManager.execute(Commands.FILE_QUIT);
-        });
+        /**
+         * Maps the dom id's of menus to command strings in Commands.js 
+         * @type {Object.<string, string>}
+         */
+        var menuMap = {
+            // File
+            "menu-file-new": Commands.FILE_NEW,
+            "menu-file-open": Commands.FILE_OPEN,
+            "menu-file-open-folder": Commands.FILE_OPEN_FOLDER,
+            "menu-file-close": Commands.FILE_CLOSE,
+            "menu-file-save": Commands.FILE_SAVE,
+            "menu-file-quit": Commands.FILE_QUIT,
 
-        $("#menu-debug-runtests").click(function () {
-            CommandManager.execute(Commands.DEBUG_RUN_UNIT_TESTS);
-        });
+            // Edit
+            "menu-edit-undo": Commands.EDIT_UNDO,
+            "menu-edit-redo": Commands.EDIT_REDO,
+            "menu-edit-cut": Commands.EDIT_CUT,
+            "menu-edit-copy": Commands.EDIT_COPY,
+            "menu-edit-paste": Commands.EDIT_PASTE,
+
+            "menu-edit-select-all": Commands.EDIT_SELECT_ALL,
+            "menu-edit-find": Commands.EDIT_FIND,
+            "menu-edit-find-in-files": Commands.EDIT_FIND_IN_FILES,
+            "menu-edit-find-next": Commands.EDIT_FIND_NEXT,
+            "menu-edit-find-previous": Commands.EDIT_FIND_PREVIOUS,
+            
+
+            // View
+            "menu-view-hide-sidebar": Commands.DEBUG_HIDE_SIDEBAR,
+
+            // Navigate
+
+            // Debug
+            "menu-debug-refresh-window": Commands.DEBUG_REFRESH_WINDOW,
+            "menu-debug-show-developer-tools": Commands.DEBUG_SHOW_DEVELOPER_TOOLS,
+            "menu-debug-jslint": Commands.DEBUG_JSLINT,
+            "menu-debug-runtests": Commands.DEBUG_RUN_UNIT_TESTS,
+            "menu-debug-show-perf": Commands.DEBUG_SHOW_PERF_DATA,
+
+
+            // Experimental
+            "menu-experimental-new-brackets-window": Commands.DEBUG_NEW_BRACKETS_WINDOW,
+            "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS,
+        };
+
+    function init() {
+        var cmdToIdMap = {}; // used to swap the values and keys for fast look up
+
+        function createExecFunc(commandStr) {
+            return function() {
+                // TODO TY: should flash menu here
+                //console.log(commandStr);
+
+                EditorManager.focusEditor();
+                CommandManager.execute(commandStr);
+            }
+        }
+
+        // create click handles and populate cmdToIdMap
+        for(var menuID in menuMap) {
+            var commandStr = menuMap[menuID];
+            $("#" + menuID).click( createExecFunc(commandStr) );
+            cmdToIdMap[commandStr] = menuID;
+        }
+
+        // Add shortcut key text to menu items in UI
+        var menuBindings = KeyBindingManager.getKeymap();
+        for(var keyCmd in menuBindings) {
+            var commandStr = menuBindings[keyCmd];
+            var menuID = cmdToIdMap[commandStr];
+            if ( menuID ) {
+                var shortcut = keyCmd.replace(/-/, "+");
+                $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");
+            }
+        }
+
         
-        // Other debug menu items
+// Other debug menu items
 //            $("#menu-debug-wordwrap").click(function() {
 //                editor.setOption("lineWrapping", !(editor.getOption("lineWrapping")));
 //            });     
         
-        $("#menu-debug-jslint").click(function () {
-            CommandManager.execute(Commands.DEBUG_JSLINT);
-        });
-        
-        $("#menu-debug-show-perf").click(function () {
-            CommandManager.execute(Commands.DEBUG_SHOW_PERF_DATA);
-        });
-        
-        $("#menu-debug-new-brackets-window").click(function () {
-            CommandManager.execute(Commands.DEBUG_NEW_BRACKETS_WINDOW);
-        });
-        
-        $("#menu-debug-hide-sidebar").click(function () {
-            CommandManager.execute(Commands.DEBUG_HIDE_SIDEBAR);
-        });
-        
-        $("#menu-debug-close-all-live-browsers").click(function () {
-            CommandManager.execute(Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS);
-        });
+                
+   
     }
 
     // Define public API

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -18,79 +18,86 @@ define(function (require, exports, module) {
          * Maps the dom id's of menus to command strings in Commands.js 
          * @type {Object.<string, string>}
          */
-        var menuMap = {
-            // File
-            "menu-file-new": Commands.FILE_NEW,
-            "menu-file-open": Commands.FILE_OPEN,
-            "menu-file-open-folder": Commands.FILE_OPEN_FOLDER,
-            "menu-file-close": Commands.FILE_CLOSE,
-            "menu-file-save": Commands.FILE_SAVE,
-            "menu-file-quit": Commands.FILE_QUIT,
+    var menuMap = {
+        // File
+        "menu-file-new": Commands.FILE_NEW,
+        "menu-file-open": Commands.FILE_OPEN,
+        "menu-file-open-folder": Commands.FILE_OPEN_FOLDER,
+        "menu-file-close": Commands.FILE_CLOSE,
+        "menu-file-save": Commands.FILE_SAVE,
+        "menu-file-quit": Commands.FILE_QUIT,
 
-            // Edit
-            "menu-edit-undo": Commands.EDIT_UNDO,
-            "menu-edit-redo": Commands.EDIT_REDO,
-            "menu-edit-cut": Commands.EDIT_CUT,
-            "menu-edit-copy": Commands.EDIT_COPY,
-            "menu-edit-paste": Commands.EDIT_PASTE,
+        // Edit
+        "menu-edit-undo": Commands.EDIT_UNDO,
+        "menu-edit-redo": Commands.EDIT_REDO,
+        "menu-edit-cut": Commands.EDIT_CUT,
+        "menu-edit-copy": Commands.EDIT_COPY,
+        "menu-edit-paste": Commands.EDIT_PASTE,
 
-            "menu-edit-select-all": Commands.EDIT_SELECT_ALL,
-            "menu-edit-find": Commands.EDIT_FIND,
-            "menu-edit-find-in-files": Commands.EDIT_FIND_IN_FILES,
-            "menu-edit-find-next": Commands.EDIT_FIND_NEXT,
-            "menu-edit-find-previous": Commands.EDIT_FIND_PREVIOUS,
-            "menu-edit-replace": Commands.EDIT_REPLACE,
-            
+        "menu-edit-select-all": Commands.EDIT_SELECT_ALL,
+        "menu-edit-find": Commands.EDIT_FIND,
+        "menu-edit-find-in-files": Commands.EDIT_FIND_IN_FILES,
+        "menu-edit-find-next": Commands.EDIT_FIND_NEXT,
+        "menu-edit-find-previous": Commands.EDIT_FIND_PREVIOUS,
+        "menu-edit-replace": Commands.EDIT_REPLACE,
+        
 
-            // View
-            "menu-view-hide-sidebar": Commands.DEBUG_HIDE_SIDEBAR,
+        // View
+        "menu-view-hide-sidebar": Commands.DEBUG_HIDE_SIDEBAR,
 
-            // Navigate
-            "menu-navigate-quick-open": Commands.NAVIGATE_QUICK_OPEN,
+        // Navigate
+        "menu-navigate-quick-open": Commands.NAVIGATE_QUICK_OPEN,
 
-            // Debug
-            "menu-debug-refresh-window": Commands.DEBUG_REFRESH_WINDOW,
-            "menu-debug-show-developer-tools": Commands.DEBUG_SHOW_DEVELOPER_TOOLS,
-            "menu-debug-jslint": Commands.DEBUG_JSLINT,
-            "menu-debug-runtests": Commands.DEBUG_RUN_UNIT_TESTS,
-            "menu-debug-show-perf": Commands.DEBUG_SHOW_PERF_DATA,
+        // Debug
+        "menu-debug-refresh-window": Commands.DEBUG_REFRESH_WINDOW,
+        "menu-debug-show-developer-tools": Commands.DEBUG_SHOW_DEVELOPER_TOOLS,
+        "menu-debug-jslint": Commands.DEBUG_JSLINT,
+        "menu-debug-runtests": Commands.DEBUG_RUN_UNIT_TESTS,
+        "menu-debug-show-perf": Commands.DEBUG_SHOW_PERF_DATA,
 
 
-            // Experimental
-            "menu-experimental-new-brackets-window": Commands.DEBUG_NEW_BRACKETS_WINDOW,
-            "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS,
-        };
+        // Experimental
+        "menu-experimental-new-brackets-window": Commands.DEBUG_NEW_BRACKETS_WINDOW,
+        "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS
+    };
 
-        var _codeMirrorInternal = [Commands.EDIT_SELECT_ALL, Commands.EDIT_UNDO];
+    var _codeMirrorInternal = [Commands.EDIT_SELECT_ALL, Commands.EDIT_UNDO];
 
     function init() {
         var cmdToIdMap = {}; // used to swap the values and keys for fast look up
 
         function createExecFunc(commandStr) {
-            return function() {
+            return function () {
                 // TODO TY: should flash menu here
                 //console.log(commandStr);
 
                 EditorManager.focusEditor();
                 CommandManager.execute(commandStr);
-            }
+            };
         }
 
         // create click handles and populate cmdToIdMap
-        for(var menuID in menuMap) {
-            var commandStr = menuMap[menuID];
-            $("#" + menuID).click( createExecFunc(commandStr) );
-            cmdToIdMap[commandStr] = menuID;
+        var menuID;
+        var commandStr;
+        for (menuID in menuMap) {
+            if (menuMap.hasOwnProperty(menuID)) {
+                commandStr = menuMap[menuID];
+                $("#" + menuID).click(createExecFunc(commandStr));
+                cmdToIdMap[commandStr] = menuID;
+            }
         }
 
         // Add shortcut key text to menu items in UI
         var menuBindings = KeyBindingManager.getKeymap();
-        for(var keyCmd in menuBindings) {
-            var commandStr = menuBindings[keyCmd];
-            var menuID = cmdToIdMap[commandStr];
-            if ( menuID ) {
-                var shortcut = keyCmd.replace(/-/, "+");
-                $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");
+        var keyCmd;
+        for (keyCmd in menuBindings) {
+            if (menuBindings.hasOwnProperty(keyCmd)) {
+                commandStr = menuBindings[keyCmd];
+                menuID = cmdToIdMap[commandStr];
+                if (menuID) {
+                    var shortcut = keyCmd.replace(/-/, "+");
+                    $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");
+                }
             }
         }
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -46,6 +46,7 @@ define(function (require, exports, module) {
             "menu-view-hide-sidebar": Commands.DEBUG_HIDE_SIDEBAR,
 
             // Navigate
+            "menu-navigate-quick-open": Commands.NAVIGATE_QUICK_OPEN,
 
             // Debug
             "menu-debug-refresh-window": Commands.DEBUG_REFRESH_WINDOW,

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -101,10 +101,10 @@ define(function (require, exports, module) {
         var currentWidth = $(".sidebar").width();
         if (currentWidth > 0) {
             $(".sidebar").width(0);
-            $("#menu-view-hide-sidebar").text("Show Sidebar");
+            $("#menu-view-hide-sidebar span").first().text("Show Sidebar");
         } else {
             $(".sidebar").width(200);
-            $("#menu-view-hide-sidebar").text("Hide Sidebar");
+            $("#menu-view-hide-sidebar span").first().text("Hide Sidebar");
         }
         
     }

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -101,10 +101,10 @@ define(function (require, exports, module) {
         var currentWidth = $(".sidebar").width();
         if (currentWidth > 0) {
             $(".sidebar").width(0);
-            $("#menu-debug-hide-sidebar").text("Show Sidebar");
+            $("#menu-view-hide-sidebar").text("Show Sidebar");
         } else {
             $(".sidebar").width(200);
-            $("#menu-debug-hide-sidebar").text("Hide Sidebar");
+            $("#menu-view-hide-sidebar").text("Hide Sidebar");
         }
         
     }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -576,6 +576,10 @@ define(function (require, exports, module) {
         });
         // if fail, don't exit: user canceled (or asked us to save changes first, but we failed to do so)
     }
+
+    function handleShowDeveloperTools(commandData) {
+        brackets.app.showDeveloperTools();
+    }
     
      /** Does a full reload of the browser window */
     function handleFileReload(commandData) {
@@ -599,7 +603,8 @@ define(function (require, exports, module) {
         CommandManager.register(Commands.FILE_CLOSE_ALL, handleFileCloseAll);
         CommandManager.register(Commands.FILE_CLOSE_WINDOW, handleFileCloseWindow);
         CommandManager.register(Commands.FILE_QUIT, handleFileQuit);
-        CommandManager.register(Commands.FILE_RELOAD, handleFileReload);
+        CommandManager.register(Commands.DEBUG_REFRESH_WINDOW, handleFileReload);
+        CommandManager.register(Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
         
         
         $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -187,7 +187,6 @@ define(function (require, exports, module) {
         }
     }
 
-        // TY TODO
     function _handleSelectAll() {
         var editor = EditorManager.getFocusedEditor();
         if (editor) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -41,8 +41,10 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var EditorManager    = require("editor/EditorManager");
-    var TextRange        = require("document/TextRange").TextRange;
+    var EditorManager    = require("editor/EditorManager"),
+        Commands         = require("command/Commands"),
+        CommandManager   = require("command/CommandManager"),
+        TextRange        = require("document/TextRange").TextRange;
     
     
     /**
@@ -184,15 +186,23 @@ define(function (require, exports, module) {
     }
     
     /** Launches CodeMirror's basic Find-within-single-editor feature */
-    function _launchFind(codeMirror) {
-        // Bring up CodeMirror's existing search bar UI
-        codeMirror.execCommand("find");
-        
-        // Prepopulate the search field with the current selection, if any
-        var findBarTextField = $(".CodeMirror-dialog input[type='text']");
-        findBarTextField.attr("value", codeMirror.getSelection());
-        findBarTextField.get(0).select();
+    function _launchFind() {
+        var editor = EditorManager.getFocusedEditor();
+        if (editor) {
+            var codeMirror = editor._codeMirror;
+
+            // Bring up CodeMirror's existing search bar UI
+            codeMirror.execCommand("find");
+
+
+            
+            // Prepopulate the search field with the current selection, if any
+            var findBarTextField = $(".CodeMirror-dialog input[type='text']");
+            findBarTextField.attr("value", codeMirror.getSelection());
+            findBarTextField.get(0).select();
+        }
     }
+
     
     /**
      * @constructor
@@ -887,6 +897,11 @@ define(function (require, exports, module) {
      * @type {?TextRange}
      */
     Editor.prototype._visibleRange = null;
+
+    
+    CommandManager.register( Commands.EDIT_FIND, _launchFind);
+    CommandManager.register( Commands.EDIT_INDENT, _handleTabKey);
+    
 
     // Define public API
     exports.Editor = Editor;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -47,6 +47,8 @@ define(function (require, exports, module) {
         TextRange        = require("document/TextRange").TextRange;
     
     
+
+
     /**
      * @private
      * Handle Tab key press.
@@ -184,6 +186,14 @@ define(function (require, exports, module) {
             }
         }
     }
+
+        // TY TODO
+    function _handleSelectAll() {
+        var editor = EditorManager.getFocusedEditor();
+        if (editor) {
+            editor._codeMirror.execCommand("selectAll");
+        }
+    }
     
     /** Launches CodeMirror's basic Find-within-single-editor feature */
     function _launchFind() {
@@ -194,8 +204,6 @@ define(function (require, exports, module) {
             // Bring up CodeMirror's existing search bar UI
             codeMirror.execCommand("find");
 
-
-            
             // Prepopulate the search field with the current selection, if any
             var findBarTextField = $(".CodeMirror-dialog input[type='text']");
             findBarTextField.attr("value", codeMirror.getSelection());
@@ -203,6 +211,26 @@ define(function (require, exports, module) {
         }
     }
 
+    function _findNext() {
+        var editor = EditorManager.getFocusedEditor();
+        if (editor) {
+            editor._codeMirror.execCommand("findNext");
+        }
+    }
+
+    function _findPrevious() {
+        var editor = EditorManager.getFocusedEditor();
+        if (editor) {
+            editor._codeMirror.execCommand("findPrev");
+        }
+    }
+
+    function _replace() {
+        var editor = EditorManager.getFocusedEditor();
+        if (editor) {
+            editor._codeMirror.execCommand("replace");
+        }
+    }
     
     /**
      * @constructor
@@ -899,9 +927,12 @@ define(function (require, exports, module) {
     Editor.prototype._visibleRange = null;
 
     
-    CommandManager.register( Commands.EDIT_FIND, _launchFind);
-    CommandManager.register( Commands.EDIT_INDENT, _handleTabKey);
-    
+    CommandManager.register(Commands.EDIT_FIND, _launchFind);
+    CommandManager.register(Commands.EDIT_FIND_NEXT, _findNext);
+    CommandManager.register(Commands.EDIT_REPLACE, _replace);
+    CommandManager.register(Commands.EDIT_FIND_PREVIOUS, _findPrevious);
+    CommandManager.register(Commands.EDIT_INDENT, _handleTabKey);
+    CommandManager.register(Commands.EDIT_SELECT_ALL, _handleSelectAll);
 
     // Define public API
     exports.Editor = Editor;

--- a/src/extensions/disabled/quickopen_example/main.js
+++ b/src/extensions/disabled/quickopen_example/main.js
@@ -7,7 +7,7 @@
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.
-* Uses FileIndexManger to supply the file list and registers Commands.FILE_QUICK_NAVIGATE with Brackets.
+* Uses FileIndexManger to supply the file list and registers Commands.NAVIGATE_QUICK_OPEN with Brackets.
 * 
 * TODO (issue 333) - currently jquery smart auto complete is used for the popup list. While it mostly works
 * it has several issues, so it should be replace with an alternative. Issues:
@@ -201,5 +201,5 @@ define(function (require, exports, module) {
             });
     }
 
-    CommandManager.register(Commands.FILE_QUICK_NAVIGATE, doFileSearch);
+    CommandManager.register(Commands.NAVIGATE_QUICK_OPEN, doFileSearch);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -83,7 +83,9 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle">View</a>
                     <ul class="dropdown-menu">
-                        <li><a href="#" id="menu-view-hide-sidebar">Hide Sidebar</a></li>
+                        <!-- wrap menu name in span for show/hide sidebar so we can programmatically change the text independent 
+                        of the keyboard shortcut -->
+                        <li><a href="#" id="menu-view-hide-sidebar"><span>Hide Sidebar</span></a></li>
                         <!--<li><a href="#" id="menu-view-wordwrap">Word Wrap</a></li>-->
                         <!--<li><a href="#" id="menu-view-invisible-characters">Invisible Characters</a></li>-->
                         <!--<li><a href="#" id="menu-view-code-folding">Code Folding</a></li>-->
@@ -119,7 +121,7 @@
                         </li>
                         <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
                         <li><hr class="divider"></li>
-                        <li><a href="#">Experimental:</a></li>
+                        <li><a class="menu-disabled" href="#">Experimental:</a></li>
                         <li><a href="#" id="menu-experimental-new-brackets-window">New Window</a></li>
                         <li><a href="#" id="menu-experimental-close-all-live-browsers">Close Browsers</a></li>
                     </ul>

--- a/src/index.html
+++ b/src/index.html
@@ -118,13 +118,8 @@
                             </a>
                         </li>
                         <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
-                    </ul>
-                </li>
-
-                <!-- Experimental menu -->
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle">Experimental</a>
-                    <ul class="dropdown-menu">
+                        <li><hr class="divider"></li>
+                        <li><a href="#">Experimental:</a></li>
                         <li><a href="#" id="menu-experimental-new-brackets-window">New Window</a></li>
                         <li><a href="#" id="menu-experimental-close-all-live-browsers">Close Browsers</a></li>
                     </ul>

--- a/src/index.html
+++ b/src/index.html
@@ -37,21 +37,80 @@
         <div class="topbar-inner">
             <a class="brand" href="#">Brackets</a>
             <ul class="nav">
+                <!-- File menu -->
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle">File</a>
                     <ul class="dropdown-menu">
                         <li><a href="#" id="menu-file-new">New</a></li>
                         <li><a href="#" id="menu-file-open">Open</a></li>
+                        <li><a href="#" id="menu-file-open-folder">Open Folder</a></li>
                         <li><a href="#" id="menu-file-close">Close</a></li>
+                        <li><hr class="divider"></li>
                         <li><a href="#" id="menu-file-save">Save</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-file-live-file-preview">Live File Preview</a></li>
+                        <li><hr class="divider"></li>
                         <li><a href="#" id="menu-file-quit">Quit</a></li>
+
                     </ul>
                 </li>
+
+                <!-- Edit menu -->
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle">Edit</a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#" id="menu-edit-undo">Undo</a></li>
+                        <li><a href="#" id="menu-edit-redo">Redo</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-edit-cut">Cut</a></li>
+                        <li><a href="#" id="menu-edit-copy">Copy</a></li>
+                        <li><a href="#" id="menu-edit-paste">Paste</a></li>
+                        <li><a href="#" id="menu-edit-select-all">Select All</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-edit-find">Find</a></li>
+                        <li><a href="#" id="menu-edit-find-in-files">Find in Files</a></li>
+                        <li><a href="#" id="menu-edit-find-next">Find Next</a></li>
+                        <li><a href="#" id="menu-edit-find-previous">Find Previous</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-edit-replace">Replace</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-edit-indent">Indent</a></li>
+                        <li><a href="#" id="menu-edit-unindent">Unindent</a></li>
+                    </ul>
+                </li>
+
+                <!-- View menu -->
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle">View</a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#" id="menu-view-hide-sidebar">Hide Sidebar</a></li>
+                        <!--<li><a href="#" id="menu-view-wordwrap">Word Wrap</a></li>-->
+                        <!--<li><a href="#" id="menu-view-invisible-characters">Invisible Characters</a></li>-->
+                        <!--<li><a href="#" id="menu-view-code-folding">Code Folding</a></li>-->
+                    </ul>
+                </li>
+
+                <!-- Navigate menu -->
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle">Navigate</a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#" id="menu-navigate-quick-open">Quick Open</a></li>
+                        <li><a href="#" id="menu-navigate-go-to-line">Go to Line</a></li>
+                        <li><a href="#" id="menu-navigate-go-to-symbol">Go to Symbol</a></li>
+                        <li><hr class="divider"></li>
+                        <li><a href="#" id="menu-navigate-show-inline-editor">Show Inline Editor</a></li>
+                        <li><a href="#" id="menu-navigate-next-css-rule">Next CSS Rule</a></li>
+                        <li><a href="#" id="menu-navigate-previous-css-rulle">Previous CSS Rule</a></li>
+                    </ul>
+                </li>
+
+                <!-- Debug menu -->
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle">Debug</a>
                     <ul class="dropdown-menu">
+                        <li><a href="#" id="menu-debug-refresh-window">Refresh Window</a></li>
+                        <li><a href="#" id="menu-debug-show-developer-tools">Show Developer Tools</a></li>
                         <li><a href="#" id="menu-debug-runtests">Run Tests</a></li>
-                        <!--<li><a href="#" id="menu-debug-wordwrap">Toggle Word Wrap</a></li>-->
                         <li>
                             <a href="#" id="menu-debug-jslint">
                                 Enable JSLint
@@ -59,9 +118,15 @@
                             </a>
                         </li>
                         <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
-                        <li><a href="#" id="menu-debug-new-brackets-window">New Window</a></li>
-                        <li><a href="#" id="menu-debug-hide-sidebar">Hide Sidebar</a></li>
-                        <li><a href="#" id="menu-debug-close-all-live-browsers">Close Browsers</a></li>
+                    </ul>
+                </li>
+
+                <!-- Experimental menu -->
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle">Experimental</a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#" id="menu-experimental-new-brackets-window">New Window</a></li>
+                        <li><a href="#" id="menu-experimental-close-all-live-browsers">Close Browsers</a></li>
                     </ul>
                 </li>
             </ul>

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -709,5 +709,7 @@ define(function (require, exports, module) {
             projectTreeState: ""
         };
         PreferencesManager.addPreferencesClient(PREFERENCES_CLIENT_ID, _savePreferences, this, defaults);
+
+        CommandManager.register(Commands.FILE_OPEN_FOLDER, openProject);
     }());
 });

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -303,5 +303,5 @@ define(function (require, exports, module) {
             });
     }
 
-    CommandManager.register(Commands.FIND_IN_FILES, doFindInFiles);
+    CommandManager.register(Commands.EDIT_FIND_IN_FILES, doFindInFiles);
 });

--- a/src/search/QuickFileOpen.js
+++ b/src/search/QuickFileOpen.js
@@ -7,7 +7,7 @@
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.
-* Uses FileIndexManger to supply the file list and registers Commands.FILE_QUICK_NAVIGATE with Brackets.
+* Uses FileIndexManger to supply the file list and registers Commands.NAVIGATE_QUICK_OPEN with Brackets.
 * 
 * TODO (issue 333) - currently jquery smart auto complete is used for the popup list. While it mostly works
 * it has several issues, so it should be replace with an alternative. Issues:
@@ -201,5 +201,5 @@ define(function (require, exports, module) {
             });
     }
 
-    CommandManager.register(Commands.FILE_QUICK_NAVIGATE, doFileSearch);
+    CommandManager.register(Commands.NAVIGATE_QUICK_OPEN, doFileSearch);
 });

--- a/src/styles/bootstrap/patterns.less
+++ b/src/styles/bootstrap/patterns.less
@@ -204,6 +204,9 @@
       background-color: #222;
       border-color: #444;
     }
+    .menu-shortcut {
+      float: right;
+    }
   }
 }
 
@@ -248,7 +251,7 @@ a.menu:after,
   top: 40px;
   z-index: 900;
   min-width: 160px;
-  max-width: 220px;
+  max-width: 400px;
   _width: 160px;
   margin-left: 0; // override default ul styles
   margin-right: 0;


### PR DESCRIPTION
This change implements the majority of the the Brackets menu spec. See https://zerowing.corp.adobe.com/pages/viewpage.action?pageId=650023563. Some details are still being worked out and will be finalized through the testing phase of this user story.

Changes:
- adds new top level menus with appropriate menus and menu items
- does not yet address menu appearance or shortcuts overlapping menu items (this is another story)
- hooks up most of the menu items to their associated commands.

The following menus are not hooked up yet due to issues with focus or difficulties hooking up to the appropriate command. These will be addressed in a later pull request
Cut/Copy/Paste
Undo/Redo
Select All
Indent/Unindent
Show Inline Editor/Next CSS Rule/Previous CSS Rule

Note: this pull request has a related pull request with the same branch name on brackets/app. Both must be pulled together
