### PR TITLE
Header/toolbar layout & appearance

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -70,8 +70,7 @@ define(function main(require, exports, module) {
 
     /** Create the menu item "Go Live" */
     function _setupGoLiveButton() {
-        _btnGoLive = $("<a href=\"#\">Go Live </a>");
-        $(".nav").append($("<li>").append(_btnGoLive));
+        _btnGoLive = $("#toolbar-go-live");
         _btnGoLive.click(function onGoLive() {
             if (LiveDevelopment.status > 0) {
                 LiveDevelopment.close();
@@ -89,6 +88,7 @@ define(function main(require, exports, module) {
 
     /** Create the menu item "Highlight" */
     function _setupHighlightButton() {
+        // TODO: this should be moved into index.html like the Go Live button once it's re-enabled
         _btnHighlight = $("<a href=\"#\">Highlight </a>");
         $(".nav").append($("<li>").append(_btnHighlight));
         _btnHighlight.click(function onClick() {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -149,7 +149,9 @@ define(function (require, exports, module) {
         
         
         function initCommandHandlers() {
-            DocumentCommandHandlers.init($("#main-toolbar .title"));
+            var $titleWrapper = $("#main-toolbar .title-wrapper");
+            var $title = $(".title", $titleWrapper);
+            DocumentCommandHandlers.init($title, $titleWrapper);
         }
 
         function initKeyBindings() {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -149,9 +149,7 @@ define(function (require, exports, module) {
         
         
         function initCommandHandlers() {
-            var $titleWrapper = $("#main-toolbar .title-wrapper");
-            var $title = $(".title", $titleWrapper);
-            DocumentCommandHandlers.init($title, $titleWrapper);
+            DocumentCommandHandlers.init($("#main-toolbar"));
         }
 
         function initKeyBindings() {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -45,7 +45,9 @@ define(function (require, exports, module) {
             _title.attr("title", "");
         }
         
-        // CSS hack -- TODO: document this
+        // Set _titleWrapper to a fixed width just large enough to accomodate _title. This seems equivalent to what
+        // the browser would do automatically, but the CSS trick we use for layout requires _titleWrapper to have a
+        // fixed width set on it (see the "#main-toolbar.toolbar" CSS rule for details).
         _titleWrapper.css("width", "");
         var newWidth = _title.width();
         _titleWrapper.css("width", newWidth);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -35,6 +35,11 @@ define(function (require, exports, module) {
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     
+    /** @type {jQueryObject} Container for _titleWrapper; if changing title changes this element's height, must kick editor to resize */
+    var _titleContainerToolbar = null;
+    /** @type {Number} Last known height of _titleContainerToolbar */
+    var _lastToolbarHeight = null;
+    
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument();
         if (currentDoc) {
@@ -51,6 +56,14 @@ define(function (require, exports, module) {
         _titleWrapper.css("width", "");
         var newWidth = _title.width();
         _titleWrapper.css("width", newWidth);
+        
+        // Changing the width of the title may cause the toolbar layout to change height, which needs to resize the
+        // editor beneath it (toolbar changing height due to window resize is already caught by EditorManager).
+        var newToolbarHeight = _titleContainerToolbar.height();
+        if (_lastToolbarHeight !== newToolbarHeight) {
+            _lastToolbarHeight = newToolbarHeight;
+            EditorManager.resizeEditor();
+        }
     }
     
     function handleCurrentDocumentChange() {
@@ -595,9 +608,10 @@ define(function (require, exports, module) {
         });
     }
 
-    function init(title, titleWrapper) {
-        _title = title;
-        _titleWrapper = titleWrapper;
+    function init(titleContainerToolbar) {
+        _titleContainerToolbar = titleContainerToolbar;
+        _titleWrapper = $(".title-wrapper", _titleContainerToolbar);
+        _title = $(".title", _titleWrapper);
 
         // Register global commands
         CommandManager.register(Commands.FILE_OPEN, handleFileOpen);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -28,8 +28,10 @@ define(function (require, exports, module) {
      * Handlers for commands related to document handling (opening, saving, etc.)
      */
     
-    /** @type {jQueryObject} Container for label shown above editor */
+    /** @type {jQueryObject} Container for label shown above editor; must be an inline element */
     var _title = null;
+    /** @type {jQueryObject} Container for _title; need not be an inline element */
+    var _titleWrapper = null;
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     
@@ -40,6 +42,11 @@ define(function (require, exports, module) {
         } else {
             _title.text("");
         }
+        
+        // CSS hack -- TODO: document this
+        _titleWrapper.css("width", "");
+        var newWidth = _title.width();
+        _titleWrapper.css("width", newWidth);
     }
     
     function handleCurrentDocumentChange() {
@@ -584,8 +591,9 @@ define(function (require, exports, module) {
         });
     }
 
-    function init(title) {
+    function init(title, titleWrapper) {
         _title = title;
+        _titleWrapper = titleWrapper;
 
         // Register global commands
         CommandManager.register(Commands.FILE_OPEN, handleFileOpen);

--- a/src/index.html
+++ b/src/index.html
@@ -38,9 +38,7 @@
             <!-- Left-hand 'Project panel' -->
             <div id="projects" class="panel">
                 <div id="project-toolbar" class="toolbar">
-                    <div class="title-wrapper">
-                        <div id="project-title" class="title"></div>
-                    </div>
+                    <div id="project-title" class="title"></div>
                     <div class="buttons">
                         <button id="btn-open-project" class="btn">Open</button>
                     </div>
@@ -132,11 +130,15 @@
                     </li>
                 </ul>
                 
-                <div class="title-wrapper">
-                    <div class="title"></div>
+                <div class="buttons">
+                    <a href="#" id="toolbar-go-live">Go Live </a>
+                    <span id="gold-star">
+                        &#9733;
+                    </span>
                 </div>
-                <div id="gold-star">
-                    &#9733;
+                
+                <div class="title-wrapper">
+                    <span class="title"></span>
                 </div>
             </div>
             
@@ -156,7 +158,7 @@
                 <div class="toolbar">
                     <div class="title">Search Results</div>
                     <div class="title" id="search-result-summary"></div>
-                    <a href="#" class="close">&times;</a>
+                    <div class="buttons"><a href="#" class="close">&times;</a></div>
                 </div>
                 <div class="table-container"></div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -124,12 +124,6 @@
                             <li><a href="#" id="menu-debug-close-all-live-browsers">Close Browsers</a></li>
                         </ul>
                     </li>
-                    <li class="dropdown">
-                        <a href="#" class="dropdown-toggle">Experimental</a>
-                        <ul class="dropdown-menu">
-                            <!-- TODO -->
-                        </ul>
-                    </li>
                 </ul>
                 
                 <div class="buttons">

--- a/src/index.html
+++ b/src/index.html
@@ -32,45 +32,10 @@
 
 </head>
 <body>
-    <!-- Top bar for menus -->
-    <div class="topbar" data-dropdown="dropdown">
-        <div class="topbar-inner">
-            <a class="brand" href="#">Brackets</a>
-            <ul class="nav">
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle">File</a>
-                    <ul class="dropdown-menu">
-                        <li><a href="#" id="menu-file-new">New</a></li>
-                        <li><a href="#" id="menu-file-open">Open</a></li>
-                        <li><a href="#" id="menu-file-close">Close</a></li>
-                        <li><a href="#" id="menu-file-save">Save</a></li>
-                        <li><a href="#" id="menu-file-quit">Quit</a></li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle">Debug</a>
-                    <ul class="dropdown-menu">
-                        <li><a href="#" id="menu-debug-runtests">Run Tests</a></li>
-                        <!--<li><a href="#" id="menu-debug-wordwrap">Toggle Word Wrap</a></li>-->
-                        <li>
-                            <a href="#" id="menu-debug-jslint">
-                                Enable JSLint
-                                <span id="jslint-enabled-checkbox" style="float:right;">&#10003;</span>
-                            </a>
-                        </li>
-                        <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
-                        <li><a href="#" id="menu-debug-new-brackets-window">New Window</a></li>
-                        <li><a href="#" id="menu-debug-hide-sidebar">Hide Sidebar</a></li>
-                        <li><a href="#" id="menu-debug-close-all-live-browsers">Close Browsers</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-
     <!-- Main UI -->
     <div class="main-view">
         <div class="sidebar">
+            <!-- Left-hand 'Project panel' -->
             <div id="projects" class="panel">
                 <div id="project-toolbar" class="toolbar">
                     <div class="title-wrapper">
@@ -108,8 +73,65 @@
                 </div>
             </div>
         </div>
+        
+        <!-- Right-hand content: toolbar, editor, bottom panels -->
         <div class="content">
+            <!-- Toolbar containing menus, filename, and icons -->
             <div id="main-toolbar" class="toolbar">
+                <ul class="nav" data-dropdown="dropdown">
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">File</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="#" id="menu-file-new">New</a></li>
+                            <li><a href="#" id="menu-file-open">Open</a></li>
+                            <li><a href="#" id="menu-file-close">Close</a></li>
+                            <li><a href="#" id="menu-file-save">Save</a></li>
+                            <li><a href="#" id="menu-file-quit">Quit</a></li>
+                        </ul>
+                    </li>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">Edit</a>
+                        <ul class="dropdown-menu">
+                            <!-- TODO -->
+                        </ul>
+                    </li>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">Navigate</a>
+                        <ul class="dropdown-menu">
+                            <!-- TODO -->
+                        </ul>
+                    </li>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">View</a>
+                        <ul class="dropdown-menu">
+                            <!-- TODO -->
+                        </ul>
+                    </li>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">Debug</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="#" id="menu-debug-runtests">Run Tests</a></li>
+                            <!--<li><a href="#" id="menu-debug-wordwrap">Toggle Word Wrap</a></li>-->
+                            <li>
+                                <a href="#" id="menu-debug-jslint">
+                                    Enable JSLint
+                                    <span id="jslint-enabled-checkbox" style="float:right;">&#10003;</span>
+                                </a>
+                            </li>
+                            <li><a href="#" id="menu-debug-show-perf">Show Perf Data</a></li>
+                            <li><a href="#" id="menu-debug-new-brackets-window">New Window</a></li>
+                            <li><a href="#" id="menu-debug-hide-sidebar">Hide Sidebar</a></li>
+                            <li><a href="#" id="menu-debug-close-all-live-browsers">Close Browsers</a></li>
+                        </ul>
+                    </li>
+                    <li class="dropdown">
+                        <a href="#" class="dropdown-toggle">Experimental</a>
+                        <ul class="dropdown-menu">
+                            <!-- TODO -->
+                        </ul>
+                    </li>
+                </ul>
+                
                 <div class="title-wrapper">
                     <div class="title"></div>
                 </div>
@@ -117,11 +139,13 @@
                     &#9733;
                 </div>
             </div>
+            
             <div id="editorHolder">
                 <div id="notEditor">
                     <div id="notEditorContent">[&nbsp;&nbsp;]</div>
                 </div>
             </div>
+            
             <div id="jslint-results">
                 <div class="toolbar">
                     <div class="title">JSLint errors</div>

--- a/src/index.html
+++ b/src/index.html
@@ -37,8 +37,10 @@
         <div class="sidebar">
             <!-- Left-hand 'Project panel' -->
             <div id="projects" class="panel">
-                <div id="project-toolbar" class="toolbar">
-                    <div id="project-title" class="title"></div>
+                <div id="project-toolbar" class="toolbar simpleToolbarLayout">
+                    <div class="title-wrapper">
+                        <div id="project-title" class="title"></div>
+                    </div>
                     <div class="buttons">
                         <button id="btn-open-project" class="btn">Open</button>
                     </div>
@@ -149,16 +151,16 @@
             </div>
             
             <div id="jslint-results">
-                <div class="toolbar">
+                <div class="toolbar simpleToolbarLayout">
                     <div class="title">JSLint errors</div>
                 </div>
                 <div class="table-container"></div>
             </div>
             <div id="search-results">
-                <div class="toolbar">
+                <div class="toolbar simpleToolbarLayout">
                     <div class="title">Search Results</div>
                     <div class="title" id="search-result-summary"></div>
-                    <div class="buttons"><a href="#" class="close">&times;</a></div>
+                    <a href="#" class="close">&times;</a>
                 </div>
                 <div class="table-container"></div>
             </div>

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -107,7 +107,7 @@ a, img {
         padding-bottom: @base-padding / 2;
         .box-shadow(0 -1px 3px 0 fadeout(@bc-black, 70%));
         .title {
-            font-size: 14px;
+            font-size: @label-font-size;
             font-weight: bold;
         }
         .close {
@@ -145,7 +145,7 @@ a, img {
 #toolbar-go-live {
     color: @bc-black;
     font-weight: @font-weight-light;
-    padding-right: 10px;
+    padding-right: 8px;
     
     &:hover {
         text-decoration: none;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -45,28 +45,10 @@ body {
     
     /* This appears to be necessary in Firefox when body is set to display: box. */
     width: 100%;
-
-    .topbar {
-        position: static;
-    }
 }
 
 a, img {
     -webkit-user-drag: none;
-}
-
-.topbar-inner {
-    /* We don't want to use the default .container in here, 
-       so we need to .clearfix the children. */
-    .clearfix;
-
-    .brand {
-        .sane-box-model;
-        margin-left: 0;
-        width: 200px;
-        padding-left: @base-padding;
-        padding-right: @base-padding;
-    }
 }
 
 .main-view {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -110,9 +110,9 @@ a, img {
             font-size: 14px;
             font-weight: bold;
         }
-        .buttons {
-            // close button is not very tall
-            margin-top: 2px;
+        .close {
+            position: absolute;
+            right: 10px;
         }
     }
     
@@ -138,8 +138,7 @@ a, img {
 #gold-star {
     display: none;
     font-size: 1.2em;
-    color: lighten(@bc-yellow, @bc-color-step-size*2);
-    text-shadow: 0 -1px @bc-black;
+    color: #ffe13b;
 }
 
 // TODO: text styles here will go away once we have an icon
@@ -157,7 +156,11 @@ a, img {
 /* Project panel */
 
 #projects .toolbar {
-    // The "Open" button is much bigger than the editor toolbar buttons
+    .picker {
+        .box;
+        .box-flex(1);
+    }
+    // The "Open" button is unusually tall
     .buttons {
         margin: -2px 0 0 0;
     }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -105,12 +105,14 @@ a, img {
         height: auto;
         padding-top: @base-padding / 2;
         padding-bottom: @base-padding / 2;
-        font-size: 0.9em;
         .box-shadow(0 -1px 3px 0 fadeout(@bc-black, 70%));
-
-        .close {
-            position: absolute;
-            right: 10px;
+        .title {
+            font-size: 14px;
+            font-weight: bold;
+        }
+        .buttons {
+            // close button is not very tall
+            margin-top: 2px;
         }
     }
     
@@ -140,12 +142,24 @@ a, img {
     text-shadow: 0 -1px @bc-black;
 }
 
+// TODO: text styles here will go away once we have an icon
+#toolbar-go-live {
+    color: @bc-black;
+    font-weight: @font-weight-light;
+    padding-right: 10px;
+    
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+
 /* Project panel */
 
-#projects .toolbar {    
-    .picker {
-        .box;
-        .box-flex(1);
+#projects .toolbar {
+    // The "Open" button is much bigger than the editor toolbar buttons
+    .buttons {
+        margin: -2px 0 0 0;
     }
 }
 

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -13,7 +13,12 @@
 }
 
 
+/* Alternative weights */
+
+@font-weight-semibold: 500;
+
 @font-weight-light: 200;
+
 
 /* SourceSansLight */
 @font-face {

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -11,3 +11,18 @@
     font-weight: normal;
     font-style: normal;
 }
+
+
+@font-weight-light: 200;
+
+/* SourceSansLight */
+@font-face {
+    font-family: 'SourceSans';
+    src: url('styles/fonts/source-sans/sourcesans-light-webfont.eot');
+    src: url('styles/fonts/source-sans/sourcesans-light-webfont.eot?#iefix') format('embedded-opentype'),
+         url('styles/fonts/source-sans/sourcesans-light-webfont.woff') format('woff'),
+         url('styles/fonts/source-sans/sourcesans-light-webfont.ttf') format('truetype'),
+         url('styles/fonts/source-sans/sourcesans-light-webfont.svg#SourceSansRegular') format('svg');
+    font-weight: @font-weight-light;
+    font-style: normal;
+}

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -40,12 +40,19 @@
 }
 
 /* Editor toolbar layout
+
    CSS hack based on this code: http://jsfiddle.net/cD657/3/ (via StackOverflow)
    This center-aligns the title across the full width of the toolbar (ignoring the width of the nav floated
    left and buttons floated right), yet still have the browser automatically wrap the floats onto a 2nd row
    if they collide with the title. But the centered content must be a block element with fixed width. Since
    the editor title (filename) varies in width, we rely on JS code to update the width whenever the string
-   changes. */
+   changes.
+
+   Another wrinkle: wrapping to/from the two-line toolbar layout requires notifying the CodeMirror editor that
+   its height changed. Currently, we assume this can ONLY happen in two cases:
+    - the window resizes (handled by general listener in EditorManager)
+    - title content changes (the same JS code that sets .title-wrapper's fixed width is expected to handle this)
+*/
 #main-toolbar.toolbar {
     text-align: center;
     .nav {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -19,17 +19,23 @@
     border-right: 1px solid @bc-gray;
 }
 
+
+/* Toolbar-related styles */
+
 // Simple toolbar layout (project panel, find in files, etc.)
-.toolbar {
-    .nav {
-        float: left;
-    }
-    .title {
-        //float: left;
-        display: inline;
+// We don't set this directly on .toolbar because it'd be a pain to override all the pieces
+// if other code (e.g. #main-toolbar) wants to do a different layout
+.simpleToolbarLayout.toolbar {
+    .hbox;
+    .box-align(center);
+    .title-wrapper {
+        /* This is necessary because text-overflow: ellipsis doesn't work when it's set
+           directly on a flexing box in Chrome currently. */
+        .box-flex(1);
     }
     .buttons {
-        float: right;
+        .hbox;
+        margin-left: 4px;
     }
 }
 
@@ -41,20 +47,21 @@
         text-align: left;
     }
     .title {
-        display: inline;    // must be an inline for JS to measure text size
+        display: inline;  // must be an inline for JS to measure text size
         float: none;
     }
     .title-wrapper {
-        display: block; // must be a block for the fixed width applied by JS to be respected
+        display: block;  // must be a block for the fixed width applied by JS to be respected
         margin: 0px auto;
         // Also requires a hardcoded width, which is applied/updated by JavaScript in DocumentCommandHandlers
     }
     .buttons {
+        float: right;
         text-align: left;
     }
 }
 
-// Toolbar appearance
+// Toolbar appearance - shared by all toolbars
 .toolbar {
     
     // TODO: move this to .toolbar in brackets.less?

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -20,15 +20,43 @@
 }
 
 .toolbar {
+    /* TODO: in mockup, the menu & title are both SourceSansLight, which looks much thinner & grayer */
+    
     .hbox;
     .box-align(center);
     position: relative; // starts a new stacking group so that the drop shadow shows up on top of the code editor
 
-    height: 23px;
-    padding: @base-padding;
+    height: 27px;
+    padding: 4px 8px;
+    background-color: @bc-white;
+    color: @bc-black;
     border-bottom: 1px solid @bc-gray;
-    #gradient > .vertical(lighten(@bc-grey, @bc-color-step-size*6), lighten(@bc-grey, @bc-color-step-size*2));
     .box-shadow(0 1px 3px 0 fadeout(@bc-black, 70%));
+    
+    .nav {
+        /* TEMPORARY - misbehaves if menus collide with filename */
+        position: absolute;
+        left: 10px;
+        top: 0px;
+        /* TEMPORARY */
+        
+        a, a:hover {
+            color: @bc-black;
+            padding: 5px 10px;  // Bootstrap has a lot of vertical padding, limiting the min height of the menu bar
+        }
+        li:first-child a {
+            /* Want to be able to pack menu pretty close to left edge of toolbar, so the first menu shouldn't have the
+               usual symmetrical padding */
+            padding-left: 0px;
+        }
+        .dropdown-toggle:after { // no triangle icon after menu items
+            border: 0;
+            margin: 0;
+        }
+        .dropdown.open .dropdown-toggle {
+            color: @bc-black;
+        }
+    }
 
     .title-wrapper {
         /* This is necessary because text-overflow: ellipsis doesn't work when it's set
@@ -36,9 +64,12 @@
         .box-flex(1);
     }
     .title {
-        font-size: 1.1em;
-        font-weight: bold;
-        text-shadow: 0 1px @bc-white;        
+        /* TODO */
+        //margin: 0px auto;
+        
+        font-size: 18px;
+        line-height: normal;
+        font-weight: normal;
 
         white-space: nowrap;
         overflow: hidden;
@@ -50,6 +81,9 @@
         .hbox;
         margin-left: 4px;
     }
+}
+#main-toolbar.toolbar .title {
+    text-align: center;
 }
 
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -22,9 +22,9 @@
 
 /* Toolbar-related styles */
 
-// Simple toolbar layout (project panel, find in files, etc.)
-// We don't set this directly on .toolbar because it'd be a pain to override all the pieces
-// if other code (e.g. #main-toolbar) wants to do a different layout
+/* Simple toolbar layout (project panel, find in files, etc.)
+   We don't set this directly on .toolbar because it'd be a pain to override all the pieces
+   if other code (e.g. #main-toolbar) wants to do a different layout */
 .simpleToolbarLayout.toolbar {
     .hbox;
     .box-align(center);
@@ -39,7 +39,13 @@
     }
 }
 
-// Editor toolbar layout
+/* Editor toolbar layout
+   CSS hack based on this code: http://jsfiddle.net/cD657/3/ (via StackOverflow)
+   This center-aligns the title across the full width of the toolbar (ignoring the width of the nav floated
+   left and buttons floated right), yet still have the browser automatically wrap the floats onto a 2nd row
+   if they collide with the title. But the centered content must be a block element with fixed width. Since
+   the editor title (filename) varies in width, we rely on JS code to update the width whenever the string
+   changes. */
 #main-toolbar.toolbar {
     text-align: center;
     .nav {
@@ -47,13 +53,13 @@
         text-align: left;
     }
     .title {
-        display: inline;  // must be an inline for JS to measure text size
         float: none;
+        display: inline;  // must be an inline for JS to measure text size
     }
     .title-wrapper {
-        display: block;  // must be a block for the fixed width applied by JS to be respected
         margin: 0px auto;
-        // Also requires a hardcoded width, which is applied/updated by JavaScript in DocumentCommandHandlers
+        display: block;  // must be a block for the fixed width applied by JS to be respected
+        // width set in px is appled/updated by JavaScript in DocumentCommandHandlers
     }
     .buttons {
         float: right;
@@ -61,54 +67,54 @@
     }
 }
 
-// Toolbar appearance - shared by all toolbars
+/* Toolbar appearance - shared by all toolbars, independent of layout */
 .toolbar {
-    
-    // TODO: move this to .toolbar in brackets.less?
-    position: relative; // starts a new stacking group so that the drop shadow shows up on top of the code editor
-
-    font-size: 14px;
+    font-size: @label-font-size;
     padding: 4px 8px;
     background-color: @bc-white;
     color: @bc-black;
+    
+    position: relative; // starts a new stacking group so that the drop shadow shows up on top of the code editor
     .box-shadow(0 1px 3px 0 fadeout(@bc-black, 70%));
     
+    @toolbar-top-gap: 5px;
+    
     .nav {
-        margin: 5px 0px 0px 5px;
+        @menubar-item-h-padding: 10px;
+        
+        margin: @toolbar-top-gap 0px 0px (-@menubar-item-h-padding + 4);
         
         // Menubar item appearance
         .dropdown-toggle, .dropdown-toggle:hover, .dropdown.open .dropdown-toggle {
-            // Note: we need several selectors for this in order to match the specificity of all the various Bootstrap
-            // color rules we need to override (and Bootstrap has several selectors because the colors really differ
-            // in their defaults).
+            /* Note: we need several selectors for this in order to match the specificity of all the various Bootstrap
+               color rules we need to override (and Bootstrap has several selectors because the colors really differ
+               in their defaults). */
             color: @bc-black;
         }
         
         .dropdown-toggle {
             font-weight: @font-weight-light;
-            
-            // Bootstrap puts vertical padding on the individual menu item level; we'd rather have it at the toolbar level
-            // (and its padding is big, limiting the min height of the menu bar).
-            padding: 0px 10px;
+            padding: 0px @menubar-item-h-padding;  // no vertical padding; taken care of on the overall menubar (.nav)
         }
-        
-        li:first-child .dropdown-toggle {
-            /* Want to be able to pack menu pretty close to left edge of toolbar, so the first menu shouldn't have the
-               usual symmetrical padding (moving all padding to the right side would just mean we'd have this same problem
-               on the other end of the menubar, where it abuts the filename title) */
-            padding-left: 0px;
-        }
-        .dropdown-toggle:after { // no triangle icon after menu items
+
+        // no triangle icon after menu items
+        .dropdown-toggle:after {
             border: 0;
             margin: 0;
+        }
+        
+        // Bootstrap's default menu positioning is calibrated for a much taller menu bar
+        .dropdown-menu {
+            top: 25px;
         }
     }
     
     .title-wrapper {
-        padding: 2px 0px 3px 0px;
+        // Title is taller than menu text, so reduce top padding to keep its baseline aligned
+        padding: (@toolbar-top-gap - 3) 0px 3px 0px;
     }
     .title {
-        font-size: 18px;
+        font-size: @title-font-size;
         line-height: normal;
         font-weight: @font-weight-light;
 
@@ -118,8 +124,9 @@
         -o-text-overflow: ellipsis;
         text-overflow: ellipsis;
     }
+    
     .buttons {
-        margin: 5px 0px 0px 4px;
+        margin: @toolbar-top-gap 0px 0px 4px;
     }
 }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -84,12 +84,12 @@
     position: relative; // starts a new stacking group so that the drop shadow shows up on top of the code editor
     .box-shadow(0 1px 3px 0 fadeout(@bc-black, 70%));
     
-    @toolbar-top-gap: 5px;
+    @toolbar-top-gap-px: 5px;
     
     .nav {
         @menubar-item-h-padding: 10px;
         
-        margin: @toolbar-top-gap 0 0 (-@menubar-item-h-padding + 4);
+        margin: @toolbar-top-gap-px 0 0 (-@menubar-item-h-padding + 4);
         
         // Menubar item appearance
         .dropdown-toggle {
@@ -121,7 +121,7 @@
     
     .title-wrapper {
         // Title is taller than menu text, so reduce top padding to keep its baseline aligned
-        padding: (@toolbar-top-gap - 3) 0 3px 0;
+        padding: (@toolbar-top-gap-px - 3px) 0 3px 0;
     }
     .title {
         font-size: @title-font-size;
@@ -136,7 +136,7 @@
     }
     
     .buttons {
-        margin: @toolbar-top-gap 0 0 4px;
+        margin: @toolbar-top-gap-px 0 0 4px;
     }
 }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -19,57 +19,91 @@
     border-right: 1px solid @bc-gray;
 }
 
+// Simple toolbar layout (project panel, find in files, etc.)
 .toolbar {
-    /* TODO: in mockup, the menu & title are both SourceSansLight, which looks much thinner & grayer */
+    .nav {
+        float: left;
+    }
+    .title {
+        //float: left;
+        display: inline;
+    }
+    .buttons {
+        float: right;
+    }
+}
+
+// Editor toolbar layout
+#main-toolbar.toolbar {
+    text-align: center;
+    .nav {
+        float: left;
+        text-align: left;
+    }
+    .title {
+        display: inline;    // must be an inline for JS to measure text size
+        float: none;
+    }
+    .title-wrapper {
+        display: block; // must be a block for the fixed width applied by JS to be respected
+        margin: 0px auto;
+        // Also requires a hardcoded width, which is applied/updated by JavaScript in DocumentCommandHandlers
+    }
+    .buttons {
+        text-align: left;
+    }
+}
+
+// Toolbar appearance
+.toolbar {
     
-    .hbox;
-    .box-align(center);
+    // TODO: move this to .toolbar in brackets.less?
     position: relative; // starts a new stacking group so that the drop shadow shows up on top of the code editor
 
-    height: 27px;
+    font-size: 14px;
     padding: 4px 8px;
     background-color: @bc-white;
     color: @bc-black;
-    border-bottom: 1px solid @bc-gray;
     .box-shadow(0 1px 3px 0 fadeout(@bc-black, 70%));
     
     .nav {
-        /* TEMPORARY - misbehaves if menus collide with filename */
-        position: absolute;
-        left: 10px;
-        top: 0px;
-        /* TEMPORARY */
+        margin: 5px 0px 0px 5px;
         
-        a, a:hover {
+        // Menubar item appearance
+        .dropdown-toggle, .dropdown-toggle:hover, .dropdown.open .dropdown-toggle {
+            // Note: we need several selectors for this in order to match the specificity of all the various Bootstrap
+            // color rules we need to override (and Bootstrap has several selectors because the colors really differ
+            // in their defaults).
             color: @bc-black;
-            padding: 5px 10px;  // Bootstrap has a lot of vertical padding, limiting the min height of the menu bar
         }
-        li:first-child a {
+        
+        .dropdown-toggle {
+            font-weight: @font-weight-light;
+            
+            // Bootstrap puts vertical padding on the individual menu item level; we'd rather have it at the toolbar level
+            // (and its padding is big, limiting the min height of the menu bar).
+            padding: 0px 10px;
+        }
+        
+        li:first-child .dropdown-toggle {
             /* Want to be able to pack menu pretty close to left edge of toolbar, so the first menu shouldn't have the
-               usual symmetrical padding */
+               usual symmetrical padding (moving all padding to the right side would just mean we'd have this same problem
+               on the other end of the menubar, where it abuts the filename title) */
             padding-left: 0px;
         }
         .dropdown-toggle:after { // no triangle icon after menu items
             border: 0;
             margin: 0;
         }
-        .dropdown.open .dropdown-toggle {
-            color: @bc-black;
-        }
     }
-
+    
     .title-wrapper {
-        /* This is necessary because text-overflow: ellipsis doesn't work when it's set
-           directly on a flexing box in Chrome currently. */
-        .box-flex(1);
+        padding: 2px 0px 3px 0px;
     }
     .title {
-        /* TODO */
-        //margin: 0px auto;
-        
         font-size: 18px;
         line-height: normal;
-        font-weight: normal;
+        font-weight: @font-weight-light;
 
         white-space: nowrap;
         overflow: hidden;
@@ -78,12 +112,8 @@
         text-overflow: ellipsis;
     }
     .buttons {
-        .hbox;
-        margin-left: 4px;
+        margin: 5px 0px 0px 4px;
     }
-}
-#main-toolbar.toolbar .title {
-    text-align: center;
 }
 
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -64,7 +64,7 @@
         display: inline;  // must be an inline for JS to measure text size
     }
     .title-wrapper {
-        margin: 0px auto;
+        margin: 0 auto;
         display: block;  // must be a block for the fixed width applied by JS to be respected
         // width set in px is appled/updated by JavaScript in DocumentCommandHandlers
     }
@@ -89,10 +89,13 @@
     .nav {
         @menubar-item-h-padding: 10px;
         
-        margin: @toolbar-top-gap 0px 0px (-@menubar-item-h-padding + 4);
+        margin: @toolbar-top-gap 0 0 (-@menubar-item-h-padding + 4);
         
         // Menubar item appearance
-        .dropdown-toggle, .dropdown-toggle:hover, .dropdown.open .dropdown-toggle {
+        .dropdown-toggle {
+            color: fadeout(@bc-black, 25%);
+        }
+        .dropdown-toggle:hover, .dropdown.open .dropdown-toggle {
             /* Note: we need several selectors for this in order to match the specificity of all the various Bootstrap
                color rules we need to override (and Bootstrap has several selectors because the colors really differ
                in their defaults). */
@@ -101,7 +104,7 @@
         
         .dropdown-toggle {
             font-weight: @font-weight-light;
-            padding: 0px @menubar-item-h-padding;  // no vertical padding; taken care of on the overall menubar (.nav)
+            padding: 0 @menubar-item-h-padding;  // no vertical padding; taken care of on the overall menubar (.nav)
         }
 
         // no triangle icon after menu items
@@ -118,7 +121,7 @@
     
     .title-wrapper {
         // Title is taller than menu text, so reduce top padding to keep its baseline aligned
-        padding: (@toolbar-top-gap - 3) 0px 3px 0px;
+        padding: (@toolbar-top-gap - 3) 0 3px 0;
     }
     .title {
         font-size: @title-font-size;
@@ -133,7 +136,7 @@
     }
     
     .buttons {
-        margin: @toolbar-top-gap 0px 0px 4px;
+        margin: @toolbar-top-gap 0 0 4px;
     }
 }
 

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -2,3 +2,7 @@
 
 /* All paddings, gutters, etc. should be multiples of this */
 @base-padding: 10px;
+
+/* Common font sizes */
+@title-font-size: 18px;  // headings such as the editor titlebar
+@label-font-size: 14px;  // labels on buttons, menubar, etc.


### PR DESCRIPTION
- Eliminate black "top bar" & move menus into toolbar over editor
- New menu bar includes empty placeholder menus based on Ty's spec.
- Separates out the layout of Brackets' .toolbar instances into two buckets: the one atop the editor, with its fancy Northstar layout (#main-toolbar.toolbar), and all the others, with simpler layouts (.simpleToolbarLayout.toolbar).  The latter will probably eventually all get replaced with more official designs.
- The fancy layout uses a CSS hack that requires some JavaScript involvement to maintain a fixed width on the element that displays the editor title -- see comments in brackets_patterns_override.less and changes in DocumentCommandHandlers.
- Since the toolbar layout is variable-height, we also need code to kick CodeMirror when changes to its content (without a window resize) cause it to change height.  See same comments & code in DocumentCommandHandlers.
- Add the "light" weight of SourceSans to our set of fonts, with LESS constants so we don't have to remember the numeric weight values.
- Move "Go Live" button into static HTML instead of injecting programmatically; move it to the right side of the layout away from the menu bar.  _Note: Changing this into an icon will come as a later pull request._
- Tweak JSLint star to match the new visual design better.
