### PR TITLE
add color transition and delay for issue 632

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -442,6 +442,7 @@ a, img {
             
             .selected {
                 color: @inline-color-3;
+                -webkit-transition: color 0.1s ease-out .15s;
             }
         }
     }


### PR DESCRIPTION
Delay text color change in CSS inline editor rule list to animate after the selection highlight transition. See #632.
