### PR TITLE
"Go Live" toolbar icon

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -36,9 +36,10 @@ define(function main(require, exports, module) {
         }
     };
     var _checkMark = "✓"; // Check mark character
-    // Status names and styles are ordered: error, not connected, progress1, progress2, connected.
-    var _statusNames = ["X", "", ".", "..", _checkMark]; // Status label name
-    var _statusStyle = ["warning", "", "info", "info", "success"]; // Status label class
+    // Status styles are ordered: error, not connected, progress1, progress2, connected.
+    var _statusStyle = ["warning", "", "info", "info", "success"]; // Status label's CSS class
+    var _allStatusStyles = _statusStyle.join(" ");
+    
     var _btnGoLive; // reference to the GoLive button
     var _btnHighlight; // reference to the HighlightButton
 
@@ -57,14 +58,20 @@ define(function main(require, exports, module) {
         request.send(null);
     }
 
-    /** Change the status of a button */
+    /** Change the appearance of a button. Omit text to remove any extra text; omit style to return to default styling. */
     function _setLabel(btn, text, style) {
+        // Clear text/styles from previous status
         $("span", btn).remove();
+        btn.removeClass(_allStatusStyles);
+        
+        // Set text/styles for new status
         if (text && text.length > 0) {
             var label = $("<span class=\"label\">");
             label.addClass(style);
             label.text(text);
             btn.append(label);
+        } else {
+            btn.addClass(style);
         }
     }
 
@@ -82,7 +89,7 @@ define(function main(require, exports, module) {
             // status starts at -1 (error), so add one when looking up name and style
             // See the comments at the top of LiveDevelopment.js for details on the 
             // various status codes.
-            _setLabel(_btnGoLive, _statusNames[status + 1], _statusStyle[status + 1]);
+            _setLabel(_btnGoLive, null, _statusStyle[status + 1]);
         });
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -127,7 +127,7 @@
                 </ul>
                 
                 <div class="buttons">
-                    <a href="#" id="toolbar-go-live">Go Live </a>
+                    <a href="#" id="toolbar-go-live"></a>
                     <span id="gold-star">
                         &#9733;
                     </span>

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -141,14 +141,25 @@ a, img {
     color: #ffe13b;
 }
 
-// TODO: text styles here will go away once we have an icon
 #toolbar-go-live {
-    color: @bc-black;
-    font-weight: @font-weight-light;
     padding-right: 8px;
     
+    // Default icon is for the 'disconnected' state
+    // The 'connecting failed' (.warning) state also maps here
+    .spriteIcon(0,0, 22px,11px, "styles/images/live_development_sprites.svg");
     &:hover {
-        text-decoration: none;
+        .spriteSwap(0,11px);
+    }
+    // 'Connected' state
+    &.success {
+        .spriteSwap(0,22px);
+    }
+    &.success:hover {
+        .spriteSwap(0,33px);
+    }
+    // 'Connection in progress' state
+    &.info {
+        .spriteSwap(0,44px);
     }
 }
 

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -65,14 +65,14 @@
 /* Sets the background to the given offset in the spritesheet. Typically, the element you set this on requires
    a fixed size so that other parts of the spritesheet don't show. */
 .sprite(@xOffset, @yOffset, @spriteSheet) {
-    background:url(@spriteSheet) -@xOffset -@yOffset no-repeat;
+    background: url(@spriteSheet) -@xOffset -@yOffset no-repeat;
 }
 
 /* Turns the given element into an icon showing the given rectangle in the spritesheet. Can be used on empty elements
    (e.g. a link with no text) or on the :before/:after selector of elements that have content. */
 .spriteIcon(@xOffset, @yOffset, @width, @height, @spriteSheet) {
     content: "";
-    background: url(@spriteSheet) -@xOffset -@yOffset no-repeat;
+    .sprite(@xOffset, @yOffset, @spriteSheet);
     display: inline-block;
     width: @width;
     height: @height;

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -37,3 +37,25 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
+
+/* Sets the background to the given offset in the sprite sheet. Typically, the element you set this on requires
+   a fixed size so that other parts of the sprite sheet don't show. */
+.sprite(@xOffset, @yOffset, @spriteSheet) {
+    background:url(@spriteSheet) -@xOffset -@yOffset no-repeat;
+}
+
+/* Turns the given element into an icon showing the given rectangle in the sprite sheet. Can be used on empty elements
+   (e.g. a link with no text) or on the :before/:after selector of elements that have content. */
+.spriteIcon(@xOffset, @yOffset, @width, @height, @spriteSheet) {
+    content: "";
+    background: url(@spriteSheet) -@xOffset -@yOffset no-repeat;
+    display: inline-block;
+    width: @width;
+    height: @height;
+}
+
+/* Changes an element that's already showing one area of a sprite sheet to show a different area of the same size.
+   Should be used with an element whose base styling applies .sprite() or .spriteIcon() */
+.spriteSwap(@xOffset, @yOffset) {
+    background-position: -@xOffset -@yOffset;
+}


### PR DESCRIPTION
Change "Go Live" button to an icon with no text. Icon changes to indicate connection status.

Also add some helper LESS mixins for general use with spritesheets (see brackets_mixins.less).
