### PR TITLE
Connecting additional menu items to commands

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -79,11 +79,7 @@ define(function main(require, exports, module) {
     function _setupGoLiveButton() {
         _btnGoLive = $("#toolbar-go-live");
         _btnGoLive.click(function onGoLive() {
-            if (LiveDevelopment.status > 0) {
-                LiveDevelopment.close();
-            } else {
-                LiveDevelopment.open();
-            }
+            _handleGoLiveCommand();
         });
         $(LiveDevelopment).on("statusChange", function statusChange(event, status) {
             // status starts at -1 (error), so add one when looking up name and style
@@ -92,6 +88,18 @@ define(function main(require, exports, module) {
             _setLabel(_btnGoLive, null, _statusStyle[status + 1]);
         });
     }
+
+    function _handleGoLiveCommand() {
+        if (LiveDevelopment.status > 0) {
+            LiveDevelopment.close();
+            $("#menu-file-live-file-preview").first().text("Stop Live File Preview");
+        } else {
+            LiveDevelopment.open();
+            $("#menu-file-live-file-preview").first().text("Live File Preview");
+        }
+    }
+
+    CommandManager.register(Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
 
     /** Create the menu item "Highlight" */
     function _setupHighlightButton() {

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -19,9 +19,11 @@
 define(function main(require, exports, module) {
     'use strict';
 
-    var DocumentManager = require("document/DocumentManager");
-    var LiveDevelopment = require("LiveDevelopment/LiveDevelopment");
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
+    var DocumentManager = require("document/DocumentManager"),
+        Commands        = require("command/Commands"),
+        LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
+        Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        CommandManager  = require("command/CommandManager");
 
     var config = {
         debug: true, // enable debug output and helpers
@@ -75,6 +77,17 @@ define(function main(require, exports, module) {
         }
     }
 
+    /** Toggles LiveDevelopment and synchronizes the state of UI elements that reports LiveDevelopment status */
+    function _handleGoLiveCommand() {
+        if (LiveDevelopment.status > 0) {
+            LiveDevelopment.close();
+            // TODO Ty: when checkmark support lands, remove checkmark
+        } else {
+            LiveDevelopment.open();
+            // TODO Ty: when checkmark support lands, add checkmark
+        }
+    }
+
     /** Create the menu item "Go Live" */
     function _setupGoLiveButton() {
         _btnGoLive = $("#toolbar-go-live");
@@ -88,18 +101,6 @@ define(function main(require, exports, module) {
             _setLabel(_btnGoLive, null, _statusStyle[status + 1]);
         });
     }
-
-    function _handleGoLiveCommand() {
-        if (LiveDevelopment.status > 0) {
-            LiveDevelopment.close();
-            $("#menu-file-live-file-preview").first().text("Stop Live File Preview");
-        } else {
-            LiveDevelopment.open();
-            $("#menu-file-live-file-preview").first().text("Live File Preview");
-        }
-    }
-
-    CommandManager.register(Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
 
     /** Create the menu item "Highlight" */
     function _setupHighlightButton() {
@@ -139,6 +140,8 @@ define(function main(require, exports, module) {
         }
     }
     setTimeout(init);
+
+    CommandManager.register(Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
 
     // Export public functions
     exports.init = init;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
                     //{"Ctrl-C": Commands.EDIT_COPY}, 
                     //{"Ctrl-V": Commands.EDIT_PASTE},
 
-                    //{"Ctrl-A": Commands.EDIT_SELECT_ALL},
+                    {"Ctrl-A": Commands.EDIT_SELECT_ALL},
                     {"Ctrl-F": Commands.EDIT_FIND},
                     {"Ctrl-Shift-F": Commands.EDIT_FIND_IN_FILES},
                     {"Ctrl-G": Commands.EDIT_FIND_NEXT, "platform": "mac"},
@@ -180,16 +180,16 @@ define(function (require, exports, module) {
                     {"Shift-F3": Commands.EDIT_FIND_PREVIOUS, "platform": "win"},
                     {"Ctrl-Alt-F": Commands.EDIT_REPLACE, "platform": "mac"},
                     {"Ctrl-H": Commands.EDIT_REPLACE, "platform": "win"},
-                    //{"Ctrl-Tab": Commands.EDIT_INDENT},
-                    //{"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},
+                    {"Ctrl-Tab": Commands.EDIT_INDENT},
+                    {"Ctrl-Shift-Tab": Commands.EDIT_UNINDENT},
 
                     // Navigate
                     {"Ctrl-Shift-O": Commands.NAVIGATE_QUICK_OPEN},
                     //{"Ctrl-E", Commands.TODO}
 
                     // DEBUG
-                    {"F5": Commands.DEBUG_REFRESH_WINDOW, "platform": "win"},
-                    {"Ctrl-R": Commands.DEBUG_REFRESH_WINDOW, "platform": "mac"},
+                    {"F5": Commands.VIEW_REFRESH_WINDOW, "platform": "win"},
+                    {"Ctrl-R": Commands.VIEW_REFRESH_WINDOW, "platform": "mac"},
 
                     {"Ctrl-Shift-H": Commands.DEBUG_HIDE_SIDEBAR}
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_ALL      = "file.close_all";
     exports.FILE_CLOSE_WINDOW   = "file.close_window";
     exports.FILE_ADD_TO_WORKING_SET = "file.addToWorkingSet";
-    exports.FILE_LIVE_FILE_PREVIEW = "file.liveFilePreview"
+    exports.FILE_LIVE_FILE_PREVIEW = "file.liveFilePreview";
     exports.FILE_QUIT           = "file.quit";
 
     // EDIT

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -21,6 +21,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_ALL      = "file.close_all";
     exports.FILE_CLOSE_WINDOW   = "file.close_window";
     exports.FILE_ADD_TO_WORKING_SET = "file.addToWorkingSet";
+    exports.FILE_LIVE_FILE_PREVIEW = "file.liveFilePreview"
     exports.FILE_QUIT           = "file.quit";
 
     // EDIT
@@ -38,16 +39,19 @@ define(function (require, exports, module) {
     exports.EDIT_INDENT         = "edit.indent";
     exports.EDIT_UNINDENT       = "edit.unindent";
 
+    // VIEW
+    exports.DEBUG_HIDE_SIDEBAR  = "view.hideSidebar";
+
     // Navigate
     exports.NAVIGATE_QUICK_OPEN = "navigate.quickOpen";
 
-    exports.DEBUG_REFRESH_WINDOW = "debug.refreshWindow";
+    exports.VIEW_REFRESH_WINDOW = "debug.refreshWindow";
     exports.DEBUG_SHOW_DEVELOPER_TOOLS = "debug.showDeveloperTools";
     exports.DEBUG_RUN_UNIT_TESTS = "debug.runUnitTests";
     exports.DEBUG_JSLINT        = "debug.jslint";
     exports.DEBUG_SHOW_PERF_DATA = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW = "debug.newBracketsWindow";
-    exports.DEBUG_HIDE_SIDEBAR  = "debug.hideSidebar";
+
     exports.DEBUG_CLOSE_ALL_LIVE_BROWSERS = "debug.closeAllLiveBrowsers";
 
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
         "menu-navigate-quick-open": Commands.NAVIGATE_QUICK_OPEN,
 
         // Debug
-        "menu-debug-refresh-window": Commands.DEBUG_REFRESH_WINDOW,
+        "menu-debug-refresh-window": Commands.VIEW_REFRESH_WINDOW,
         "menu-debug-show-developer-tools": Commands.DEBUG_SHOW_DEVELOPER_TOOLS,
         "menu-debug-jslint": Commands.DEBUG_JSLINT,
         "menu-debug-runtests": Commands.DEBUG_RUN_UNIT_TESTS,
@@ -97,7 +97,6 @@ define(function (require, exports, module) {
                 if (menuID) {
                     var shortcut = keyCmd.replace(/-/, "+");
 
-                    // TODO TY: put in platform specific keys
                     $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");
                 }
             }

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
         "menu-file-open-folder": Commands.FILE_OPEN_FOLDER,
         "menu-file-close": Commands.FILE_CLOSE,
         "menu-file-save": Commands.FILE_SAVE,
+        "menu-file-live-file-preview": Commands.FILE_LIVE_FILE_PREVIEW,
         "menu-file-quit": Commands.FILE_QUIT,
 
         // Edit

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -3,7 +3,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*global define: false, $: false, brackets */
 
 define(function (require, exports, module) {
     'use strict';
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
 
         // Add shortcut key text to menu items in UI
         var menuBindings = KeyBindingManager.getKeymap();
-        var keyCmd;
+        var keyCmd, shortcut;
         for (keyCmd in menuBindings) {
             if (menuBindings.hasOwnProperty(keyCmd)) {
                 commandStr = menuBindings[keyCmd];
@@ -98,12 +98,12 @@ define(function (require, exports, module) {
                 if (menuID) {
                     // Convert normalized key representation to display appropriate for platform
                     if (brackets.platform === "mac") {
-                        var shortcut = keyCmd.replace(/-/g, "");        // remove dashes
+                        shortcut = keyCmd.replace(/-/g, "");        // remove dashes
                         shortcut = shortcut.replace("Ctrl", "&#8984");  // Ctrl > command symbol
                         shortcut = shortcut.replace("Shift", "&#8679"); // Shift > shift symbol
                         shortcut = shortcut.replace("Alt", "&#8997");   // Alt > option symbol
                     } else {
-                        var shortcut = keyCmd.replace(/-/g, "+");
+                        shortcut = keyCmd.replace(/-/g, "+");
                     }
 
                     $("#" + menuID).append("<span class='menu-shortcut'>" + shortcut + "</span>");

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -629,7 +629,7 @@ define(function (require, exports, module) {
         CommandManager.register(Commands.FILE_CLOSE_ALL, handleFileCloseAll);
         CommandManager.register(Commands.FILE_CLOSE_WINDOW, handleFileCloseWindow);
         CommandManager.register(Commands.FILE_QUIT, handleFileQuit);
-        CommandManager.register(Commands.DEBUG_REFRESH_WINDOW, handleFileReload);
+        CommandManager.register(Commands.VIEW_REFRESH_WINDOW, handleFileReload);
         CommandManager.register(Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
         
         

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -277,7 +277,6 @@ define(function (require, exports, module) {
         
         // Editor supplies some standard keyboard behavior extensions of its own
         var codeMirrorKeyMap = {
-            "Tab"  : _handleTabKey,
             "Left" : function (instance) {
                 if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
                     CodeMirror.commands.goCharLeft(instance);
@@ -298,17 +297,6 @@ define(function (require, exports, module) {
                     CodeMirror.commands.delCharRight(instance);
                 }
             },
-            "Ctrl-A": function () {
-                self._selectAllVisible();
-            },
-            "Cmd-A": function () {
-                self._selectAllVisible();
-            },
-            "Ctrl-F": _launchFind,
-            "Cmd-F": _launchFind,
-            "F3": "findNext",
-            "Shift-F3": "findPrev",
-            "Ctrl-H": "replace",
             "Shift-Delete": "cut",
             "Ctrl-Insert": "copy",
             "Shift-Insert": "paste"
@@ -940,8 +928,9 @@ define(function (require, exports, module) {
     CommandManager.register(Commands.EDIT_FIND_NEXT, _findNext);
     CommandManager.register(Commands.EDIT_REPLACE, _replace);
     CommandManager.register(Commands.EDIT_FIND_PREVIOUS, _findPrevious);
-    CommandManager.register(Commands.EDIT_INDENT, _handleTabKey);
     CommandManager.register(Commands.EDIT_SELECT_ALL, _handleSelectAll);
+    CommandManager.register(Commands.EDIT_INDENT, _handleTabKey);
+    CommandManager.register(Commands.EDIT_UNINDENT, _handleTabKey);
 
     // Define public API
     exports.Editor = Editor;


### PR DESCRIPTION
Hooks up the following menu items to their associated commands:
- File > Live File Preview
- Edit > Indent / Unindent
- Edit > Select All

Also fixes issue #646
