### PR TITLE
Usability tweaks for toolbar / Go Live

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -263,12 +263,24 @@ define(function LiveDevelopment(require, exports, module) {
         var doc = _getCurrentDocument();
         var browserStarted = false;
         var retryCount = 0;
+        
+        function showWrongDocError() {
+            Dialogs.showModalDialog(
+                Dialogs.DIALOG_ID_ERROR,
+                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
+                Strings.LIVE_DEV_NEED_HTML_MESSAGE
+            );
+        }
                 
-        if (doc && doc.root) {
+        if (!doc || !doc.root) {
+            showWrongDocError();
+            
+        } else {
             // For Sprint 6, we only open live development connections for HTML files
             // FUTURE: Remove this test when we support opening connections for different
             // file types.
             if (!doc.extension || doc.extension.indexOf('htm') !== 0) {
+                showWrongDocError();
                 return;
             }
             

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -22,6 +22,7 @@ define(function main(require, exports, module) {
     var DocumentManager = require("document/DocumentManager");
     var LiveDevelopment = require("LiveDevelopment/LiveDevelopment");
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
+    var Strings = require("strings");
 
     var config = {
         debug: true, // enable debug output and helpers
@@ -36,8 +37,10 @@ define(function main(require, exports, module) {
         }
     };
     var _checkMark = "✓"; // Check mark character
-    // Status styles are ordered: error, not connected, progress1, progress2, connected.
-    var _statusStyle = ["warning", "", "info", "info", "success"]; // Status label's CSS class
+    // Status labels and styles are ordered: error, not connected, progress1, progress2, connected.
+    var _statusTooltip = [Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED, Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED, Strings.LIVE_DEV_STATUS_TIP_PROGRESS1,
+                          Strings.LIVE_DEV_STATUS_TIP_PROGRESS2, Strings.LIVE_DEV_STATUS_TIP_CONNECTED];  // Status indicator tooltip
+    var _statusStyle = ["warning", "", "info", "info", "success"];  // Status indicator's CSS class
     var _allStatusStyles = _statusStyle.join(" ");
     
     var _btnGoLive; // reference to the GoLive button
@@ -58,8 +61,11 @@ define(function main(require, exports, module) {
         request.send(null);
     }
 
-    /** Change the appearance of a button. Omit text to remove any extra text; omit style to return to default styling. */
-    function _setLabel(btn, text, style) {
+    /**
+     * Change the appearance of a button. Omit text to remove any extra text; omit style to return to default styling;
+     * omit tooltip to leave tooltip unchanged.
+     */
+    function _setLabel(btn, text, style, tooltip) {
         // Clear text/styles from previous status
         $("span", btn).remove();
         btn.removeClass(_allStatusStyles);
@@ -72,6 +78,10 @@ define(function main(require, exports, module) {
             btn.append(label);
         } else {
             btn.addClass(style);
+        }
+        
+        if (tooltip) {
+            btn.attr("title", tooltip);
         }
     }
 
@@ -89,8 +99,11 @@ define(function main(require, exports, module) {
             // status starts at -1 (error), so add one when looking up name and style
             // See the comments at the top of LiveDevelopment.js for details on the 
             // various status codes.
-            _setLabel(_btnGoLive, null, _statusStyle[status + 1]);
+            _setLabel(_btnGoLive, null, _statusStyle[status + 1], _statusTooltip[status + 1]);
         });
+        
+        // Initialize tooltip for 'not connected' state
+        _setLabel(_btnGoLive, null, _statusStyle[1], _statusTooltip[1]);
     }
 
     /** Create the menu item "Highlight" */

--- a/src/index.html
+++ b/src/index.html
@@ -171,8 +171,9 @@
                 </ul>
                 
                 <div class="buttons">
-                    <a href="#" id="toolbar-go-live"></a>
-                    <span id="gold-star">
+                    <a href="#" id="toolbar-go-live"></a> <!-- tooltip for this is set in JS -->
+                    
+                    <span id="gold-star" title="No JSLint errors - good job!">
                         &#9733;
                     </span>
                 </div>

--- a/src/strings.js
+++ b/src/strings.js
@@ -73,7 +73,13 @@ define(function (require, exports, module) {
     exports.LIVE_DEVELOPMENT_ERROR_MESSAGE    = "A live development connection to Chrome could not be established. "
                                                 + "For live development to work, Chrome needs to be started with remote debugging enabled."
                                                 + "<br><br>Would you like to relaunch Chrome and enable remote debugging?";
-        
+    exports.LIVE_DEV_NEED_HTML_MESSAGE        = "Open an HTML file in order to launch live preview.";
+    
+    exports.LIVE_DEV_STATUS_TIP_NOT_CONNECTED = "Live File Preview";
+    exports.LIVE_DEV_STATUS_TIP_PROGRESS1     = "Live File Preview: Connecting...";
+    exports.LIVE_DEV_STATUS_TIP_PROGRESS2     = "Live File Preview: Initializing...";
+    exports.LIVE_DEV_STATUS_TIP_CONNECTED     = "Disconnect Live File Preview";
+    
     exports.SAVE_CLOSE_TITLE                  = "Save Changes";
     exports.SAVE_CLOSE_MESSAGE                = "Do you want to save the changes you made in the document \"{0}\"?";
     exports.SAVE_CLOSE_MULTI_MESSAGE          = "Do you want to save your changes to the following files?";


### PR DESCRIPTION
- Tooltip on JSLint star (for anyone new to the product, the icon is totally inexplicable)
- Tooltip on Go Live icon (changes based on status)
- Show error message instead of silently no-op if Go Live clicked when no doc or the wrong type of doc is open
