### PR TITLE
Tvoliter/menus

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -162,9 +162,11 @@ define(function (require, exports, module) {
                     {"Ctrl-O": Commands.FILE_OPEN},
                     {"Ctrl-S": Commands.FILE_SAVE},
                     {"Ctrl-W": Commands.FILE_CLOSE},
+                    {"Ctrl-Alt-P": Commands.FILE_LIVE_FILE_PREVIEW},
                     {"Ctrl-Q": Commands.FILE_QUIT},
 
-                    // EDIT
+                    // EDIT 
+                    // disabled until the menu items are connected to the commands. Keyboard shortcuts work via CodeMirror
                     //{"Ctrl-Z": Commands.EDIT_UNDO},
                     //{"Ctrl-Y": Commands.EDIT_REDO},
                     //{"Ctrl-X": Commands.EDIT_CUT},

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -24,15 +24,23 @@ define(function (require, exports, module) {
         }
         
         var keyDescriptor = [];
-        if (hasCtrl) {
-            keyDescriptor.push("Ctrl");
-        }
+       
         if (hasAlt) {
             keyDescriptor.push("Alt");
         }
         if (hasShift) {
             keyDescriptor.push("Shift");
         }
+
+        if (hasCtrl) {
+            // Windows display Ctrl first, Mac displays Command symbol last
+            if (brackets.platform === "win") {
+                keyDescriptor.unshift("Ctrl");
+            } else {
+                keyDescriptor.push("Ctrl");
+            }
+        }
+
         keyDescriptor.push(key);
         
         return keyDescriptor.join("-");

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -62,7 +62,6 @@ define(function (require, exports, module) {
         "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS
     };
 
-    var _codeMirrorInternal = [Commands.EDIT_SELECT_ALL, Commands.EDIT_UNDO];
 
     function init() {
         var cmdToIdMap = {}; // used to swap the values and keys for fast look up

--- a/src/index.html
+++ b/src/index.html
@@ -101,12 +101,14 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle">Edit</a>
                         <ul class="dropdown-menu">
+                            <!-- disabled until the menu items are connected to the commands. Keyboard shortcuts work via CodeMirror
                             <li><a href="#" id="menu-edit-undo">Undo</a></li>
                             <li><a href="#" id="menu-edit-redo">Redo</a></li>
                             <li><hr class="divider"></li>
                             <li><a href="#" id="menu-edit-cut">Cut</a></li>
                             <li><a href="#" id="menu-edit-copy">Copy</a></li>
-                            <li><a href="#" id="menu-edit-paste">Paste</a></li>
+                            <li><a href="#" id="menu-edit-paste">Paste</a></li> 
+                            -->
                             <li><a href="#" id="menu-edit-select-all">Select All</a></li>
                             <li><hr class="divider"></li>
                             <li><a href="#" id="menu-edit-find">Find</a></li>


### PR DESCRIPTION
- added key command for File > File Live Preview
- fixes issue #658 (integrated Ryan's pull into this one)
- disables cut/copy/paste/undo/redo menus since they don't work yet and were moved to a user story. Keyboard shortcuts still work
