### PR TITLE
Quick fix for issue #666, tab handling not working

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -277,6 +277,7 @@ define(function (require, exports, module) {
         
         // Editor supplies some standard keyboard behavior extensions of its own
         var codeMirrorKeyMap = {
+            "Tab" : _handleTabKey,
             "Left" : function (instance) {
                 if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
                     CodeMirror.commands.goCharLeft(instance);
@@ -929,8 +930,10 @@ define(function (require, exports, module) {
     CommandManager.register(Commands.EDIT_REPLACE, _replace);
     CommandManager.register(Commands.EDIT_FIND_PREVIOUS, _findPrevious);
     CommandManager.register(Commands.EDIT_SELECT_ALL, _handleSelectAll);
-    CommandManager.register(Commands.EDIT_INDENT, _handleTabKey);
-    CommandManager.register(Commands.EDIT_UNINDENT, _handleTabKey);
+
+    // TODO: code mirror handles 
+    // CommandManager.register(Commands.EDIT_INDENT, _handleTabKey);
+    // CommandManager.register(Commands.EDIT_UNINDENT, _handleTabKey);
 
     // Define public API
     exports.Editor = Editor;


### PR DESCRIPTION
This restores the old behavior so the keyboard shortcut will work, but the menu will not.
I have a full fix in the works to get the menus working, but wanted to quickly restore the key handling so the team is not impacted

fixes issue #666
