### PR TITLE
Option to use tab characters instead of spaces

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
     exports.DEBUG_NEW_BRACKETS_WINDOW = "debug.newBracketsWindow";
 
     exports.DEBUG_CLOSE_ALL_LIVE_BROWSERS = "debug.closeAllLiveBrowsers";
+    exports.DEBUG_USE_TAB_CHARS = "debug.useTabChars";
 
 
 });

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -59,7 +59,8 @@ define(function (require, exports, module) {
 
         // Experimental
         "menu-experimental-new-brackets-window": Commands.DEBUG_NEW_BRACKETS_WINDOW,
-        "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS
+        "menu-experimental-close-all-live-browsers": Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS,
+        "menu-experimental-usetab": Commands.DEBUG_USE_TAB_CHARS
     };
 
     var _codeMirrorInternal = [Commands.EDIT_SELECT_ALL, Commands.EDIT_UNDO];

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -10,6 +10,7 @@ define(function (require, exports, module) {
     
     var Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
+        Editor                  = require("editor/Editor").Editor,
         JSLintUtils             = require("language/JSLintUtils"),
         PerfUtils               = require("utils/PerfUtils"),
         NativeApp               = require("utils/NativeApp");
@@ -19,6 +20,7 @@ define(function (require, exports, module) {
         JSLintUtils.run();
         $("#menu-debug-jslint").toggleClass("selected", JSLintUtils.getEnabled());
     }
+    
     
     // Implements the 'Run Tests' menu to bring up the Jasmine unit test window
     var _testWindow = null;
@@ -115,10 +117,18 @@ define(function (require, exports, module) {
         });
     }
     
+    function _handleUseTabChars() {
+        Editor.setUseTabChar(!Editor.getUseTabChar());
+        $("#menu-experimental-usetab").toggleClass("selected", Editor.getUseTabChar());
+    }
+    
+    
+    // Register all the command handlers
     CommandManager.register(Commands.DEBUG_JSLINT, _handleEnableJSLint);
     CommandManager.register(Commands.DEBUG_RUN_UNIT_TESTS, _handleRunUnitTests);
     CommandManager.register(Commands.DEBUG_SHOW_PERF_DATA, _handleShowPerfData);
     CommandManager.register(Commands.DEBUG_NEW_BRACKETS_WINDOW, _handleNewBracketsWindow);
     CommandManager.register(Commands.DEBUG_HIDE_SIDEBAR, _handleHideSidebar);
     CommandManager.register(Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS, _handleCloseAllLiveBrowsers);
+    CommandManager.register(Commands.DEBUG_USE_TAB_CHARS, _handleUseTabChars);
 });

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -232,6 +232,20 @@ define(function (require, exports, module) {
         }
     }
     
+    
+    
+    /**
+     * List of all current (non-destroy()ed) Editor instances. Needed when changing global preferences
+     * that affect all editors, e.g. tabbing or color scheme settings.
+     * @type {Array.<Editor>}
+     */
+    var _instances = [];
+    
+    /** @type {boolean}  Global setting: When inserting new text, use tab characters? (instead of spaces) */
+    var _useTabChar = false;
+    
+    
+    
     /**
      * @constructor
      *
@@ -257,6 +271,8 @@ define(function (require, exports, module) {
     function Editor(document, makeMasterEditor, mode, container, additionalKeys, range) {
         var self = this;
         
+        _instances.push(this);
+        
         // Attach to document: add ref & handlers
         this.document = document;
         document.addRef();
@@ -277,6 +293,7 @@ define(function (require, exports, module) {
         
         // Editor supplies some standard keyboard behavior extensions of its own
         var codeMirrorKeyMap = {
+            "Tab"  : _handleTabKey,
             "Left" : function (instance) {
                 if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
                     CodeMirror.commands.goCharLeft(instance);
@@ -315,7 +332,8 @@ define(function (require, exports, module) {
         // (note: CodeMirror doesn't actually require using 'new', but jslint complains without it)
         this._codeMirror = new CodeMirror(container, {
             electricChars: false,   // we use our own impl of this to avoid CodeMirror bugs; see _checkElectricChars()
-            indentUnit : 4,
+            indentUnit: 4,
+            indentWithTabs: _useTabChar,
             lineNumbers: true,
             matchBrackets: true,
             extraKeys: codeMirrorKeyMap
@@ -376,6 +394,8 @@ define(function (require, exports, module) {
         // CodeMirror docs for getWrapperElement() say all you have to do is "Remove this from your
         // tree to delete an editor instance."
         $(this.getRootElement()).remove();
+        
+        _instances.splice(_instances.indexOf(this), 1);
         
         // Disconnect from Document
         this.document.releaseRef();
@@ -922,8 +942,29 @@ define(function (require, exports, module) {
      * @type {?TextRange}
      */
     Editor.prototype._visibleRange = null;
+    
+    
+    // Global settings that affect all Editor instances (both currently open Editors as well as those created
+    // in the future)
+
+    /**
+     * Sets whether to use tab characters (vs. spaces) when inserting new text. Affects all Editors.
+     * @param {boolean} value
+     */
+    Editor.setUseTabChar = function (value) {
+        _useTabChar = value;
+        _instances.forEach(function (editor) {
+            editor._codeMirror.setOption("indentWithTabs", _useTabChar);
+        });
+    };
+    
+    /** @type {boolean}  Gets whether all Editors use tab characters (vs. spaces) when inserting new text */
+    Editor.getUseTabChar = function (value) {
+        return _useTabChar;
+    };
 
     
+    // Global commands that affect the currently focused Editor instance, wherever it may be
     CommandManager.register(Commands.EDIT_FIND, _launchFind);
     CommandManager.register(Commands.EDIT_FIND_NEXT, _findNext);
     CommandManager.register(Commands.EDIT_REPLACE, _replace);

--- a/src/index.html
+++ b/src/index.html
@@ -162,6 +162,7 @@
                             <li><a class="menu-disabled" href="#">Experimental:</a></li>
                             <li><a href="#" id="menu-experimental-new-brackets-window">New Window</a></li>
                             <li><a href="#" id="menu-experimental-close-all-live-browsers">Close Browsers</a></li>
+                            <li><a href="#" id="menu-experimental-usetab">Use Tab Characters</a></li>
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
**Bonus/experimental feature** -- from feedback in PhoneGap hack-a-thon.
- Use Debug menu item to toggle; affects all running Editor instances.
- Setting is NOT persisted between launches.
- This includes new code in Editor to track all Editor instances. This seems generally useful because we'll want other global settings (e.g. code coloring scheme) to get pushed out to all Editor instances when changed too.
