### PR TITLE
Fix dirty bit appearance in inline editor

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -27,9 +27,8 @@ define(function (require, exports, module) {
      */
     function _showDirtyIndicator($indicatorDiv, isDirty) {
         // Show or hide the dirty indicator by adjusting
-        // the width of the div. The "hidden" width is 
-        // 4 pixels to make the padding look correct.
-        $indicatorDiv.css("width", isDirty ? 16 : 4);
+        // the width of the div.
+        $indicatorDiv.css("width", isDirty ? 16 : 0);
     }
     
     /**

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -353,7 +353,7 @@ a, img {
         .dirty-indicator {
             .bracketSprite;
             display: inline-block;
-            background-position: 0 0;
+            background-position: -32px 0;
             padding-top: 3px;
         }
         


### PR DESCRIPTION
@gruehle @jason-sanjose 

I noticed that in master the appearance of the inline editor title is messed up:
- When the inline file isn't dirty, a little bit of schmutz shows up to the left of the title.
- When the inline file is dirty, the icon shows the "x" instead of the bullet.

This pull request fixes those issues. I'm guessing it broke when Glenn checked in a new bullet sprite.
