### PR TITLE
Set z-index: auto for JSLint and Search Results toolbars.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -113,6 +113,7 @@ a, img {
         height: auto;
         padding-top: @base-padding / 2;
         padding-bottom: @base-padding / 2;
+        z-index: auto;
         .box-shadow(0 -1px 3px 0 fadeout(@bc-black, 70%));
         .title {
             font-size: @label-font-size;


### PR DESCRIPTION
Fixes issue #649
