### PR TITLE
Better fix for #649

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -113,7 +113,7 @@ a, img {
         height: auto;
         padding-top: @base-padding / 2;
         padding-bottom: @base-padding / 2;
-        z-index: auto;
+        z-index: 19;
         .box-shadow(0 -1px 3px 0 fadeout(@bc-black, 70%));
         .title {
             font-size: @label-font-size;


### PR DESCRIPTION
@njx 

The original fix for #649 (pull request #685) had a small cosmetic problem - the shadow above the JSLint/SearchResults header was under the gutter. This is a better fix.
