### PR TITLE
Changes Brackets keydown handling to use event capture

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -196,8 +196,8 @@ define(function (require, exports, module) {
                     if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
                         event.stopPropagation();
                     }
-                }),
-                true;
+                },
+                true);
         }
         
         function initWindowListeners() {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -197,7 +197,8 @@ define(function (require, exports, module) {
                         event.stopPropagation();
                     }
                 },
-                true);
+                true
+            );
         }
         
         function initWindowListeners() {

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -190,11 +190,14 @@ define(function (require, exports, module) {
             });
             KeyBindingManager.installKeymap(_globalKeymap);
 
-            $(document.body).keydown(function (event) {
-                if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
-                    event.preventDefault();
-                }
-            });
+            document.body.addEventListener(
+                "keydown",
+                function (event) {
+                    if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
+                        event.stopPropagation();
+                    }
+                }),
+                true;
         }
         
         function initWindowListeners() {

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -193,7 +193,7 @@ define(function (require, exports, module) {
         //As that will let us use keys like then function keys "F5" for commands. The
         //full set of values we can use is here
         //http://www.w3.org/TR/2007/WD-DOM-Level-3-Events-20071221/keyset.html#KeySet-Set
-        var ident = event.originalEvent.keyIdentifier;
+        var ident = event.keyIdentifier;
         if (ident) {
             if (ident.charAt(0) === "U" && ident.charAt(1) === "+") {
                 //This is a unicode code point like "U+002A", get the 002A and use that


### PR DESCRIPTION
Prevents both Brackets and CodeMirror from handling the same event. Brackets uses event capture which goes before the bubbling event phase that code mirror uses. If Brackets handles the command it calls stopPropigation() this preventing CodeMirror from handling the event.

fixes issue #686
