### PR TITLE
Change 'Show Inline Editor' menu item to 'Quick Edit'

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
 
         // Navigate
         "menu-navigate-quick-open": Commands.NAVIGATE_QUICK_OPEN,
-        "menu-navigate-show-inline-editor": Commands.SHOW_INLINE_EDITOR,
+        "menu-navigate-quick-edit": Commands.SHOW_INLINE_EDITOR,
         "menu-navigate-next-css-rule": Commands.NEXT_CSS_RULE,
         "menu-navigate-previous-css-rule": Commands.PREVIOUS_CSS_RULE,
 

--- a/src/index.html
+++ b/src/index.html
@@ -122,7 +122,7 @@
                             <li><a href="#" id="menu-navigate-go-to-line">Go to Line</a></li>
                             <li><a href="#" id="menu-navigate-go-to-symbol">Go to Symbol</a></li>
                             <li><hr class="divider"></li>
-                            <li><a href="#" id="menu-navigate-show-inline-editor">Show Inline Editor</a></li>
+                            <li><a href="#" id="menu-navigate-quick-edit">Quick Edit</a></li>
                             <li><a href="#" id="menu-navigate-previous-css-rule">Previous CSS Rule</a></li>
                             <li><a href="#" id="menu-navigate-next-css-rule">Next CSS Rule</a></li>
                         </ul>


### PR DESCRIPTION
We decided to change the name to something more general (and catchy :)). This has the side-effect of obsoleting bug #698. (We do still need to make closing inline editors more discoverable--that's a separate issue.)
