### PR TITLE
Hide project panel when reloading

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -172,6 +172,7 @@ define(function (require, exports, module) {
 
         // Instantiate tree widget
         // (jsTree is smart enough to replace the old tree if there's already one there)
+        $projectTreeContainer.hide();
         _projectTree = $projectTreeContainer
             .jstree(
                 {
@@ -259,6 +260,8 @@ define(function (require, exports, module) {
                         FileViewController.addToWorkingSetAndSelect(entry.fullPath);
                     }
                 });
+            
+            $projectTreeContainer.show();
         });
 
         return result;


### PR DESCRIPTION
Fixes issue #692.

The project tree was redrawing everything in black before loading the new data, causing an ugly flicker. To avoid this, hide the tree before loading data, and show it again once the old data has been cleared out.
