### PR TITLE
Fix unit tests

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -88,7 +88,9 @@ define(function (require, exports, module) {
         }
         
         // redraw selection
-        $projectTreeList.trigger("selectionChanged");
+        if ($projectTreeList) {
+            $projectTreeList.trigger("selectionChanged");
+        }
     };
 
     $(FileViewController).on("documentSelectionFocusChange", _documentSelectionFocusChange);


### PR DESCRIPTION
Selection triangle changes broke unit tests. Added a null check for projectTree UL list when currentDocumentChange fires before UI can update.
