### PR TITLE
Fix refresh issue #721

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -210,10 +210,6 @@ define(function (require, exports, module) {
                 FileIndexManager.markDirty();
             });
             
-            $(window).unload(function () {
-                CommandManager.execute(Commands.FILE_CLOSE_WINDOW);
-            });
-            
             $(window).contextmenu(function (e) {
                 e.preventDefault();
             });


### PR DESCRIPTION
Removing unload event handler since it is not really needed to capture unsaved changes and it is closing the app. I have verified that we're still prompting users for unsaved changes in editor windows without this event handler.
