### PR TITLE
Fix issue #687 (Win: Dirty indicator dot in editor titlebar looks bad with SourceSans font)

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -40,11 +40,16 @@ define(function (require, exports, module) {
     /** @type {Number} Last known height of _titleContainerToolbar */
     var _lastToolbarHeight = null;
     
+    var DIRTY_INDICATOR = " <span class='dirty-dot'>\u2022</span>";
+    
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument();
         if (currentDoc) {
-            _title.text(_currentTitlePath + (currentDoc.isDirty ? " \u2022" : ""));
+            _title.text(_currentTitlePath);
             _title.attr("title", currentDoc.file.fullPath);
+            if (currentDoc.isDirty) {
+                _title.append(DIRTY_INDICATOR);
+            }
         } else {
             _title.text("");
             _title.attr("title", "");

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -110,6 +110,11 @@
         line-height: normal;
         font-weight: @font-weight-light;
 
+        // On Win, the size+weight combo used above does not look good for the bullet character
+        .dirty-dot {
+            font-weight: normal;
+        }
+        
         white-space: nowrap;
         overflow: hidden;
         -ms-text-overflow: ellipsis;


### PR DESCRIPTION
Fix issue #687 (Win: Dirty indicator dot in editor titlebar looks bad with SourceSans font):

Give the dot a heavier weight than the rest of the titlebar text. It renders fine on Win at anything other than Light, and this weight change doesn't noticeably affect the appearance on Mac.
