### PR TITLE
Allow inline editor to open when selection is not an insertion point.

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -490,13 +490,15 @@ define(function (require, exports, module) {
             return null;
         }
         
-        // Only provide CSS editor if the selection is an insertion point
+        // Only provide CSS editor if the selection is within a single line
         var sel = hostEditor.getSelection(false);
-        if (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch) {
+        if (sel.start.line !== sel.end.line) {
             return null;
         }
         
-        var selectorName = _getSelectorName(hostEditor, pos);
+        // Always use the selection start for determining selector name. The pos
+        // parameter is usually the selection end.        
+        var selectorName = _getSelectorName(hostEditor, hostEditor.getSelection(false).start);
         if (selectorName === "") {
             return null;
         }


### PR DESCRIPTION
Fixes issue #688

The selection start position is used to determine the selector to open in an inline editor. If the selection spans multiple classes, or if it starts in a class/tag and extends outside the class/tag, the starting position is used and the rest of the selection is ignored.

The only constraint is the selection must be on a single line.
