### PR TITLE
Bottom scroll shadow

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -340,7 +340,7 @@ define(function (require, exports, module) {
         
         this._installEditorListeners();
         
-        ViewUtils.installScrollShadow($("#editor-scroll-shadow"), this);
+        ViewUtils.scrollerShadow($("#editorHolder"), this);
         
         $(this)
             .on("keyEvent", _checkElectricChars)
@@ -376,7 +376,7 @@ define(function (require, exports, module) {
             document._makeEditable(this);
         }
         
-        // Add a "scrollTop" property to this object for the scroll shadow code to use
+        // Add scrollTop property to this object for the scroll shadow code to use
         Object.defineProperty(this, "scrollTop", {
             get: function () {
                 return this._codeMirror.scrollPos().y;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -340,8 +340,6 @@ define(function (require, exports, module) {
         
         this._installEditorListeners();
         
-        ViewUtils.scrollerShadow($("#editorHolder"), this);
-        
         $(this)
             .on("keyEvent", _checkElectricChars)
             .on("change", this._handleEditorChange.bind(this));

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
         Editor              = require("editor/Editor").Editor,
         InlineTextEditor    = require("editor/InlineTextEditor").InlineTextEditor,
         EditorUtils         = require("editor/EditorUtils"),
+        ViewUtils           = require("utils/ViewUtils"),
         Strings             = require("strings");
     
     /** @type {jQueryObject} DOM node that contains all editors (visible and hidden alike) */
@@ -209,6 +210,9 @@ define(function (require, exports, module) {
         // Create editor; make it initially invisible
         var container = _editorHolder.get(0);
         var editor = _createEditorForDocument(document, true, container, _openInlineWidget);
+        
+        ViewUtils.scrollerShadow(container, editor);
+        
         editor.setVisible(false);
     }
     

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -210,9 +210,6 @@ define(function (require, exports, module) {
         // Create editor; make it initially invisible
         var container = _editorHolder.get(0);
         var editor = _createEditorForDocument(document, true, container, _openInlineWidget);
-        
-        ViewUtils.addScrollerShadow(container, editor);
-        
         editor.setVisible(false);
     }
     
@@ -363,12 +360,19 @@ define(function (require, exports, module) {
 
     /** Handles changes to DocumentManager.getCurrentDocument() */
     function _onCurrentDocumentChange() {
-        var doc = DocumentManager.getCurrentDocument();
+        var doc = DocumentManager.getCurrentDocument(),
+            container = _editorHolder.get(0);
+        
+        // Remove scrollerShadow from the current editor
+        if (_currentEditor) {
+            ViewUtils.removeScrollerShadow(container, _currentEditor);
+        }
         
         // Update the UI to show the right editor (or nothing), and also dispose old editor if no
         // longer needed.
         if (doc) {
             _showEditor(doc);
+            ViewUtils.addScrollerShadow(container, _currentEditor);
         } else {
             _showNoEditor();
         }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -211,7 +211,7 @@ define(function (require, exports, module) {
         var container = _editorHolder.get(0);
         var editor = _createEditorForDocument(document, true, container, _openInlineWidget);
         
-        ViewUtils.scrollerShadow(container, editor);
+        ViewUtils.addScrollerShadow(container, editor);
         
         editor.setVisible(false);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -168,8 +168,6 @@
                 <div id="notEditor">
                     <div id="notEditorContent">[&nbsp;&nbsp;]</div>
                 </div>
-                <div id="editor-scroll-shadow">
-                </div>
             </div>
             
             <div id="jslint-results">

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -97,7 +97,10 @@ define(function (require, exports, module) {
         if ($projectTreeList) {
             $projectTreeList.triggerHandler("selectionChanged");
             
-            // in-lieu of resize events, manually trigger contentChanged to update scroll shadows on jstree
+            // in-lieu of resize events, manually trigger contentChanged for every
+            // FileViewController focus change. This event triggers scroll shadows
+            // on the jstree to update. documentSelectionFocusChange fires when
+            // a new file is added and removed (causing a new selection) from the working set
             _projectTree.triggerHandler("contentChanged");
         }
     };
@@ -279,7 +282,7 @@ define(function (require, exports, module) {
         // Filed this bug against jstree at https://github.com/vakata/jstree/issues/163
         _projectTree.bind("init.jstree", function () {
             // install scroller shadows
-            ViewUtils.scrollerShadow(_projectTree.get(0));
+            ViewUtils.addScrollerShadow(_projectTree.get(0));
             
             _projectTree
                 .unbind("dblclick.jstree")

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -95,7 +95,10 @@ define(function (require, exports, module) {
         
         // redraw selection
         if ($projectTreeList) {
-            $projectTreeList.trigger("selectionChanged");
+            $projectTreeList.triggerHandler("selectionChanged");
+            
+            // in-lieu of resize events, manually trigger contentChanged to update scroll shadows on jstree
+            _projectTree.triggerHandler("contentChanged");
         }
     };
 
@@ -261,7 +264,10 @@ define(function (require, exports, module) {
                 "loaded.jstree open_node.jstree close_node.jstree",
                 function (event, data) {
                     ViewUtils.updateChildrenToParentScrollwidth($("#project-files-container"));
+                    
+                    // update when tree display state changes
                     _savePreferences();
+                    _projectTree.triggerHandler("contentChanged");
                 }
             );
 
@@ -273,7 +279,7 @@ define(function (require, exports, module) {
         // Filed this bug against jstree at https://github.com/vakata/jstree/issues/163
         _projectTree.bind("init.jstree", function () {
             // install scroller shadows
-            ViewUtils.installScrollShadow(_projectTree[0]);
+            ViewUtils.scrollerShadow(_projectTree.get(0));
             
             _projectTree
                 .unbind("dblclick.jstree")

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -28,7 +28,18 @@ define(function (require, exports, module) {
     var _FILE_KEY = "file",
         $openFilesContainer = $("#open-files-container"),
         $openFilesList = $openFilesContainer.find("ul");
+    
+    /**
+     * @private
+     */
+    function _updateScrollShadow() {
+        // in-lieu of resize events, manually trigger contentChanged to update scroll shadows
+        $openFilesContainer.triggerHandler("contentChanged");
+    }
 
+    /**
+     * @private
+     */
     function _hideShowOpenFileHeader() {
         if (DocumentManager.getWorkingSet().length === 0) {
             $openFilesContainer.hide();
@@ -37,6 +48,9 @@ define(function (require, exports, module) {
         }
         
         ViewUtils.updateChildrenToParentScrollwidth($openFilesContainer);
+        
+        // redraw shadows
+        _updateScrollShadow();
     }
     
     /** 
@@ -251,12 +265,15 @@ define(function (require, exports, module) {
         _handleDocumentSelectionChange();
         
         // redraw selection
-        $openFilesList.trigger("selectionChanged");
+        $openFilesList.triggerHandler("selectionChanged");
+        
+        // redraw shadows
+        _updateScrollShadow();
     });
 
     _hideShowOpenFileHeader();
 
     // Show scroller shadows when open-files-container scrolls
-    ViewUtils.installScrollShadow($openFilesContainer[0]);
+    ViewUtils.scrollerShadow($openFilesContainer[0], null, true);
     ViewUtils.sidebarList($openFilesContainer);
 });

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -274,6 +274,6 @@ define(function (require, exports, module) {
     _hideShowOpenFileHeader();
 
     // Show scroller shadows when open-files-container scrolls
-    ViewUtils.scrollerShadow($openFilesContainer[0], null, true);
+    ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);
     ViewUtils.sidebarList($openFilesContainer);
 });

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -57,7 +57,7 @@ a, img {
 
     .sidebar {
         .vbox;
-        width: 200px;
+        width: @sidebar-width;
     }
 
     .content {
@@ -256,6 +256,7 @@ a, img {
 
 .sidebarSelectionTriangle {
     position: fixed;
+    z-index: 20; /* scrollerShadow appears above this triangle */
     
     margin-top: -@triangle-size;
     
@@ -283,15 +284,31 @@ a, img {
     }
 }
 
+.sidebar .scrollerShadow {
+    max-width: @sidebar-width;  /* width is clobbered by ViewUtils.updateChildrenToParentScrollwidth() */
+}
+
+#editorHolder .scrollerShadow {
+    width: 100%;
+}
+
 .scrollerShadow {
-    /* top shadow */
-    #gradient.vertical(rgba(0,0,0,0.10), rgba(0, 0, 0, 0));
-    
-    /* hide the shadow on init */
-    background-position: 0px -9999px;
-    
-    background-size: 100% 4px;
+    background-size: 100% 5px;
     background-repeat: no-repeat;
+    height: 5px;
+    position: fixed;
+    z-index: 21;
+    
+    &.top {
+        #gradient.vertical(rgba(0,0,0,0.1), rgba(0,0,0,0));
+        background-position: 0px -5px;
+    }
+    
+    &.bottom {
+        #gradient.vertical(rgba(0,0,0,0), rgba(0,0,0,0.1));
+        background-position: 0px 5px;
+        background-color: transparent; /* override background-color: @endColor from #gradient.vertical */
+    }
 }
 
 @spriteSize18: 18px;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -92,14 +92,6 @@ a, img {
             opacity: 0.30;
         }
     }
-    
-    /* Scroll shadow */
-    #editor-scroll-shadow {
-        position: fixed;
-        height: 4px;
-        width: 100%;
-        z-index: 12;
-    }
 }
     
 #jslint-results, #search-results {
@@ -301,12 +293,12 @@ a, img {
     
     &.top {
         #gradient.vertical(rgba(0,0,0,0.1), rgba(0,0,0,0));
-        background-position: 0px -5px;
+        background-position: 0 -5px;
     }
     
     &.bottom {
         #gradient.vertical(rgba(0,0,0,0), rgba(0,0,0,0.1));
-        background-position: 0px 5px;
+        background-position: 0 5px;
         background-color: transparent; /* override background-color: @endColor from #gradient.vertical */
     }
 }

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -10,3 +10,6 @@
 
 /* CSS triangle */
 @triangle-size: 10px;
+
+/* sidebar */
+@sidebar-width: 200px;

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -85,11 +85,8 @@ define(function (require, exports, module) {
      * @param {?boolean} showBottom optionally show the bottom shadow
      */
     function addScrollerShadow(displayElement, scrollElement, showBottom) {
-        var sharedDisplayElement    = true;
-
         if (!scrollElement) {
             scrollElement = displayElement;
-            sharedDisplayElement = false;
         }
         
         // update shadows when the scrolling element is scrolled
@@ -103,17 +100,33 @@ define(function (require, exports, module) {
             _updateScrollerShadow($displayElement, $scrollElement, $shadowTop, $shadowBottom);
         };
         
-        $scrollElement.on("scroll", doUpdate);
-
-        if (sharedDisplayElement) {
-            $scrollElement.on("blur", function () { $scrollElement.off("scroll", doUpdate); });
-            $scrollElement.on("focus", function () { $scrollElement.on("scroll", doUpdate); });
-        }
-
-        $displayElement.on("contentChanged", doUpdate);
+        $scrollElement.on("scroll.scrollerShadow", doUpdate);
+        $displayElement.on("contentChanged.scrollerShadow", doUpdate);
         
         // update immediately
         doUpdate();
+    }
+    
+    /**
+     * Remove scrollerShadow effect.
+     * @param {!DOMElement} displayElement the DOMElement that displays the shadow
+     * @param {?Object} scrollElement the object that is scrolled
+     */
+    function removeScrollerShadow(displayElement, scrollElement) {
+        if (!scrollElement) {
+            scrollElement = displayElement;
+        }
+        
+        var $displayElement = $(displayElement),
+            $scrollElement = $(scrollElement);
+        
+        // remove scrollerShadow elements from DOM
+        $(displayElement).find(".scrollerShadow.top").remove();
+        $(displayElement).find(".scrollerShadow.bottom").remove();
+        
+        // remove event handlers
+        $scrollElement.off("scroll.scrollerShadow");
+        $displayElement.off("contentChanged.scrollerShadow");
     }
     
     /** 
@@ -238,5 +251,6 @@ define(function (require, exports, module) {
     
     exports.updateChildrenToParentScrollwidth = updateChildrenToParentScrollwidth;
     exports.addScrollerShadow = addScrollerShadow;
+    exports.removeScrollerShadow = removeScrollerShadow;
     exports.sidebarList = sidebarList;
 });

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -78,10 +78,13 @@ define(function (require, exports, module) {
 
     /** 
      * Installs event handlers for updatng shadow background elements to indicate vertical scrolling.
-     * @param {!DOMElement} displayElement the DOMElement that displays the shadow
-     * @param {?Object} scrollElement the object that is scrolled. If null, the displayElement is used.
+     * @param {!DOMElement} displayElement the DOMElement that displays the shadow. Must fire
+     *  "contentChanged" events when the element is resized or repositioned.
+     * @param {?Object} scrollElement the object that is scrolled. Must fire "scroll" events
+     *  when the element is scrolled. If null, the displayElement is used.
+     * @param {?boolean} showBottom optionally show the bottom shadow
      */
-    function scrollerShadow(displayElement, scrollElement, showBottom) {
+    function addScrollerShadow(displayElement, scrollElement, showBottom) {
         var sharedDisplayElement    = true;
 
         if (!scrollElement) {
@@ -156,11 +159,10 @@ define(function (require, exports, module) {
                 triangleHeight = $selectionTriangle.outerHeight(),
                 triangleOffsetYBy = $selectionMarker.height() / 2,
                 triangleClipOffsetYBy = Math.floor(($selectionMarker.height() - triangleHeight) / 2),
-                triangleBottom = triangleTop + triangleHeight + triangleClipOffsetYBy,
-                rightOffset = $scrollerElement.outerWidth() - $scrollerElement.get(0).clientWidth;
+                triangleBottom = triangleTop + triangleHeight + triangleClipOffsetYBy;
             
             $selectionTriangle.css("top", triangleTop + triangleOffsetYBy);
-            $selectionTriangle.css("left", $fileSection.width() - $selectionTriangle.outerWidth() - rightOffset);
+            $selectionTriangle.css("left", $fileSection.width() - $selectionTriangle.outerWidth());
             
             if (triangleTop < scrollerTop || triangleBottom > scrollerBottom) {
                 $selectionTriangle.css("clip", "rect(" + Math.max(scrollerTop - triangleTop - triangleClipOffsetYBy, 0) + "px, auto, " +
@@ -235,6 +237,6 @@ define(function (require, exports, module) {
     exports.SCROLL_SHADOW_HEIGHT = SCROLL_SHADOW_HEIGHT;
     
     exports.updateChildrenToParentScrollwidth = updateChildrenToParentScrollwidth;
-    exports.scrollerShadow = scrollerShadow;
+    exports.addScrollerShadow = addScrollerShadow;
     exports.sidebarList = sidebarList;
 });

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -15,13 +15,14 @@ define(function (require, exports, module) {
         When the new theme lands with the CSS, potentially
         adjust how this is done. */
     function _handleHideSidebar() {
-        var currentWidth = $(".sidebar").width();
-        if (currentWidth > 0) {
-            $(".sidebar").width(0);
-            $("#menu-view-hide-sidebar span").first().text("Show Sidebar");
-        } else {
-            $(".sidebar").width(200);
+        var $sidebar = $(".sidebar");
+        
+        if ($sidebar.css("display") === "none") {
+            $sidebar.show();
             $("#menu-view-hide-sidebar span").first().text("Hide Sidebar");
+        } else {
+            $sidebar.hide();
+            $("#menu-view-hide-sidebar span").first().text("Show Sidebar");
         }
         
     }

--- a/test/spec/ViewUtils-test.js
+++ b/test/spec/ViewUtils-test.js
@@ -47,14 +47,14 @@ define(function (require, exports, module) {
             }
         
             it("should not show the top shadow when no scrolling is available", function () {
-                ViewUtils.installScrollShadow(fixture);
+                ViewUtils.scrollerShadow(fixture);
                 
                 expect(fixture.scrollTop).toEqual(0);
                 expect(backgroundY()).toEqual(-ViewUtils.SCROLL_SHADOW_HEIGHT);
             });
         
             it("should partially reveal the shadow", function () {
-                ViewUtils.installScrollShadow($fixture[0]);
+                ViewUtils.scrollerShadow($fixture[0]);
                 scrollTop(3);
                 
                 expect(backgroundY()).toEqual(3 - ViewUtils.SCROLL_SHADOW_HEIGHT);
@@ -62,13 +62,13 @@ define(function (require, exports, module) {
         
             it("should update shadow position when installed", function () {
                 scrollTop(100);
-                ViewUtils.installScrollShadow($fixture[0]);
+                ViewUtils.scrollerShadow($fixture[0]);
                 
                 expect(backgroundY()).toEqual(0);
             });
         
             it("should fully reveal the shadow at the bottommost scroll position", function () {
-                ViewUtils.installScrollShadow($fixture[0]);
+                ViewUtils.scrollerShadow($fixture[0]);
                 scrollTop(900);
                 
                 expect(backgroundY()).toEqual(0);

--- a/test/spec/ViewUtils-test.js
+++ b/test/spec/ViewUtils-test.js
@@ -26,7 +26,7 @@ define(function (require, exports, module) {
             
             beforeEach(function () {
                 /* 100% x 100px scroller with 100px x 1000px content */
-                $fixture = $("<div style='overflow:auto;height:100px'><div style='width:100px;height:1000px'></div></div>");
+                $fixture = $("<div style='overflow:auto;height:100px'><div id='content' style='width:100px;height:1000px'></div></div>");
                 fixture = $fixture[0];
                 $(document.body).append($fixture);
             });
@@ -42,36 +42,43 @@ define(function (require, exports, module) {
                 $fixture.trigger("scroll");
             }
             
-            function backgroundY() {
-                return parseInt($fixture.css("background-position").split(" ")[1], 10);
+            function backgroundY(position) {
+                return parseInt($fixture.find(".scrollerShadow." + position).css("background-position").split(" ")[1], 10);
             }
         
             it("should not show the top shadow when no scrolling is available", function () {
-                ViewUtils.scrollerShadow(fixture);
+                $fixture.find("#content").height(50); // make height shorter than the viewport
+                ViewUtils.scrollerShadow(fixture, null, true);
                 
                 expect(fixture.scrollTop).toEqual(0);
-                expect(backgroundY()).toEqual(-ViewUtils.SCROLL_SHADOW_HEIGHT);
+                expect(backgroundY("top")).toEqual(-ViewUtils.SCROLL_SHADOW_HEIGHT);
+                expect(backgroundY("bottom")).toEqual(ViewUtils.SCROLL_SHADOW_HEIGHT);
             });
         
             it("should partially reveal the shadow", function () {
-                ViewUtils.scrollerShadow($fixture[0]);
+                ViewUtils.scrollerShadow(fixture, null, true);
                 scrollTop(3);
+                expect(backgroundY("top")).toEqual(3 - ViewUtils.SCROLL_SHADOW_HEIGHT);
+                expect(backgroundY("bottom")).toEqual(0);
                 
-                expect(backgroundY()).toEqual(3 - ViewUtils.SCROLL_SHADOW_HEIGHT);
+                scrollTop(899);
+                expect(backgroundY("top")).toEqual(0);
+                expect(backgroundY("bottom")).toEqual(4);
             });
         
             it("should update shadow position when installed", function () {
                 scrollTop(100);
-                ViewUtils.scrollerShadow($fixture[0]);
+                ViewUtils.scrollerShadow(fixture, null, true);
                 
-                expect(backgroundY()).toEqual(0);
+                expect(backgroundY("top")).toEqual(0);
             });
         
             it("should fully reveal the shadow at the bottommost scroll position", function () {
-                ViewUtils.scrollerShadow($fixture[0]);
+                ViewUtils.scrollerShadow(fixture, null, true);
                 scrollTop(900);
                 
-                expect(backgroundY()).toEqual(0);
+                expect(backgroundY("top")).toEqual(0);
+                expect(backgroundY("bottom")).toEqual(ViewUtils.SCROLL_SHADOW_HEIGHT);
             });
         
         });


### PR DESCRIPTION
@gruehle 
- Re-implement scroller shadows to use position:fixed
- Fix z-index issues when shadow and selection triangle overlap
- Remove extra markup in editorHolder
- Update unit tests
- Position selection triangle adjacent to vscrollbar instead of overlapping
