### PR TITLE
Fix for #707 and #719

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -222,10 +222,7 @@ define(function (require, exports, module) {
         });
         
         // set dirty indicator state
-        // use setTimeout to allow filenameDiv to render first
-        setTimeout(function () {
-            _showDirtyIndicator($dirtyIndicatorDiv, doc.isDirty);
-        }, 0);
+        _showDirtyIndicator($dirtyIndicatorDiv, doc.isDirty);
     };
 
     /**

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
         var updateSelectionTriangle = function () {
             var scrollerOffset = $scrollerElement.offset(),
                 scrollerTop = scrollerOffset.top,
-                scrollerBottom = scrollerTop + $scrollerElement.get(0).clientHeight,
+                scrollerBottom = scrollerTop + $scrollerElement.outerHeight(),
                 scrollerLeft = scrollerOffset.left,
                 triangleTop = $selectionMarker.offset().top,
                 triangleHeight = $selectionTriangle.outerHeight(),


### PR DESCRIPTION
#707 remove setTimeout and immediately set visibility on dirty indicator.
#719 use of clientHeight was incorrect and clipping the selectionMarker too short, use outerHeight instead.
