### PR TITLE
focus editor when closing find in files, fixes issue #709

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -82,9 +82,8 @@ define(function (require, exports, module) {
         }
         
         this.closed = true;
-            
         this.dialog.parentNode.removeChild(this.dialog);
-
+        EditorManager.focusEditor();
         this.result.resolve(value);
     };
         


### PR DESCRIPTION
- calls EditorManager.focusEditor() when closing the find in files ui

fixes issue #709
