### PR TITLE
fixes issue #758, remove benign menu shortcut warning

### DIFF
--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -132,9 +132,6 @@ define(function (require, exports, module) {
             } else if (finalMap[normalizedKey]) {
                 console.log("KeyMap _normalizeMap() - Rejecting key because it was defined twice: " + ele + " (value: " + val + ")");
             } else {
-                if (normalizedKey !== ele) {
-                    console.log("KeyMap _normalizeMap() - Corrected a malformed key: " + ele + " (value: " + val + ")");
-                }
                 finalMap[normalizedKey] = val;
             }
         });


### PR DESCRIPTION
Remove "corrected a malformed key" warning as this is benign and expected as part of the key normalization process. The docs for _normalizeKeyDescriptorString indicate that key descriptors are tolerated in any order

fixes issue #758
