### PR TITLE
Converted functions that return a Deferred to return a Promise instead

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -40,8 +40,8 @@ define(function (require, exports, module) {
      * @param {string} id The ID of the command.
      * @param {function(...)} command The function to call when the command is executed. Any arguments passed to
      *     execute() (after the id) are passed as arguments to the function. If the function is asynchronous,
-     *     it must return a jQuery Deferred that is resolved when the command completes. Otherwise, the
-     *     CommandManager will assume it is synchronous, and return a Deferred that is already resolved.
+     *     it must return a jQuery promise that is resolved when the command completes. Otherwise, the
+     *     CommandManager will assume it is synchronous, and return a promise that is already resolved.
      */
     function register(id, command) {
         if (_commands[id]) {

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -57,19 +57,19 @@ define(function (require, exports, module) {
      * Runs a global command. Additional arguments are passed to the command.
      *
      * @param {string} id The ID of the command to run.
-     * @return {Deferred} a jQuery Deferred that will be resolved when the command completes.
+     * @return {$.Promise} a jQuery promise that will be resolved when the command completes.
      */
     function execute(id) {
         var command = _commands[id];
         if (command) {
             var result = command.apply(null, Array.prototype.slice.call(arguments, 1));
             if (!result) {
-                return (new $.Deferred()).resolve();
+                return (new $.Deferred()).resolve().promise();
             } else {
                 return result;
             }
         } else {
-            return (new $.Deferred()).reject();
+            return (new $.Deferred()).reject().promise();
         }
     }
 

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -121,15 +121,16 @@ define(function (require, exports, module) {
      * @private
      * Creates a document and displays an editor for the specified file path.
      * @param {!string} fullPath
-     * @return {Deferred} a jQuery Deferred that will be resolved with a
+     * @return {$.Promise} a jQuery promise that will be resolved with a
      *  document for the specified file path, or rejected if the file can not be read.
      */
     function doOpen(fullPath) {
         
-        var result = new $.Deferred();
+        var result = new $.Deferred(), promise = result.promise();
         if (!fullPath) {
             console.log("doOpen() called without fullPath");
-            return result.reject();
+            result.reject();
+            return promise;
         }
         
         PerfUtils.markStart("Open File: " + fullPath);
@@ -150,7 +151,7 @@ define(function (require, exports, module) {
                 });
             });
 
-        return result;
+        return promise;
     }
     
     /**
@@ -164,7 +165,7 @@ define(function (require, exports, module) {
      * Creates a document and displays an editor for the specified file path. 
      * If no path is specified, a file prompt is provided for input.
      * @param {?string} fullPath - The path of the file to open; if it's null we'll prompt for it
-     * @return {Deferred} a jQuery Deferred that will be resolved with a new 
+     * @return {$.Promise} a jQuery promise that will be resolved with a new 
      *  document for the specified file path, or rejected if the file can not be read.
      */
     function _doOpenWithOptionalPath(fullPath) {
@@ -193,7 +194,7 @@ define(function (require, exports, module) {
             result = doOpen(fullPath);
         }
         if (!result) {
-            result = (new $.Deferred()).reject();
+            result = (new $.Deferred()).reject().promise();
         }
         return result;
     }
@@ -220,6 +221,8 @@ define(function (require, exports, module) {
      * @param {string} dir  The directory to use
      * @param {string} baseFileName  The base to start with, "-n" will get appened to make unique
      * @param {string} fileExt  The file extension
+     * @return {$.Promise} a jQuery promise that will be resolved with a unique name starting with 
+     *   the given base name
      */
     function _getUntitledFileSuggestion(dir, baseFileName, fileExt) {
         var result = new $.Deferred();
@@ -251,7 +254,7 @@ define(function (require, exports, module) {
         //kick it off
         result.notify(baseFileName + fileExt, 1);
 
-        return result;
+        return result.promise();
     }
 
     function handleFileNewInProject() {
@@ -291,7 +294,7 @@ define(function (require, exports, module) {
         );
     }
     
-    /** Note: if there is an error, the Deferred is not rejected until the user has dimissed the dialog */
+    /** Note: if there is an error, the promise is not rejected until the user has dimissed the dialog */
     function doSave(docToSave) {
         var result = new $.Deferred();
         
@@ -333,13 +336,13 @@ define(function (require, exports, module) {
         result.always(function () {
             EditorManager.focusEditor();
         });
-        return result;
+        return result.promise();
     }
     
     /**
      * Saves the given file. If no file specified, assumes the current document.
      * @param {?{doc: Document}} commandData  Document to close, or null
-     * @return {$.Deferred}
+     * @return {$.Promise} a promise that is resolved after the save completes
      */
     function handleFileSave(commandData) {
         // Default to current document if doc is null
@@ -380,7 +383,7 @@ define(function (require, exports, module) {
                     return doSave(doc);
                 } else {
                     // working set entry that was never actually opened - ignore
-                    return (new $.Deferred()).resolve();
+                    return (new $.Deferred()).resolve().promise();
                 }
             },
             false
@@ -422,7 +425,8 @@ define(function (require, exports, module) {
      *      promptOnly - If true, only displays the relevant confirmation UI and does NOT actually
      *          close the document. This is useful when chaining file-close together with other user
      *          prompts that may be cancelable.
-     * @return {$.Deferred}
+     * @return {$.Promise} a promise that is resolved when the file is closed, or if no file is open.
+     *      FUTURE: should we reject the promise if no file is open?
      */
     function handleFileClose(commandData) {
         var file = null;
@@ -441,7 +445,7 @@ define(function (require, exports, module) {
         }
         
         
-        var result = new $.Deferred();
+        var result = new $.Deferred(), promise = result.promise();
         
         // Default to current document if doc is null
         if (!file) {
@@ -452,7 +456,8 @@ define(function (require, exports, module) {
         
         // No-op if called when nothing is open; TODO: (issue #273) should command be grayed out instead?
         if (!file) {
-            return;
+            result.resolve();
+            return promise;
         }
         
         var doc = DocumentManager.getOpenDocumentForPath(file.fullPath);
@@ -502,7 +507,7 @@ define(function (require, exports, module) {
             EditorManager.focusEditor();
             result.resolve();
         }
-        return result;
+        return promise;
     }
     
     /**
@@ -511,7 +516,7 @@ define(function (require, exports, module) {
      * @param {?{promptOnly: boolean}}  If true, only displays the relevant confirmation UI and does NOT
      *          actually close any documents. This is useful when chaining close-all together with
      *          other user prompts that may be cancelable.
-     * @return {$.Deferred}
+     * @return {$.Promise} a promise that is resolved when all files are closed
      */
     function handleFileCloseAll(commandData) {
         var result = new $.Deferred();
@@ -579,7 +584,7 @@ define(function (require, exports, module) {
             }
         });
         
-        return result;
+        return result.promise();
     }
     
     /**
@@ -595,7 +600,7 @@ define(function (require, exports, module) {
     function _handleWindowGoingAway(commandData, postCloseHandler) {
         if (_windowGoingAway) {
             //if we get called back while we're closing, then just return
-            return (new $.Deferred()).resolve();
+            return (new $.Deferred()).resolve().promise();
         }
         
         //prevent the default action of closing the window until we can save all the files

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -609,7 +609,7 @@ define(function (require, exports, module) {
      * refs and listeners for that Editor UI).
      *
      * @param {!string} fullPath
-     * @return {Deferred} A Deferred object that will be resolved with the Document, or rejected
+     * @return {$.Promise} A promise object that will be resolved with the Document, or rejected
      *      with a FileError if the file is not yet open and can't be read from disk.
      */
     function getDocumentForPath(fullPath) {
@@ -628,7 +628,7 @@ define(function (require, exports, module) {
                     result.reject(fileError);
                 });
         }
-        return result;
+        return result.promise();
     }
     
     /**
@@ -729,7 +729,7 @@ define(function (require, exports, module) {
                     oneFileResult.resolve();
                 });
             
-            return oneFileResult;
+            return oneFileResult.promise();
         }
 
         var result = Async.doInParallel(prefs.files, checkOneFile, false);

--- a/src/extensions/disabled/quickopen_example/main.js
+++ b/src/extensions/disabled/quickopen_example/main.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
     /**
     * Shows the search dialog and initializes the auto suggestion list with filenames from the current project
     * @param {?string} initialString Default text to prepopulate the search field with
-    * @returns {$.Promise} a promise that is resolved when the dialgo closes with the string value from the search field
+    * @returns {$.Promise} a promise that is resolved when the dialog closes with the string value from the search field
     */
     QuickNavigateDialog.prototype.showDialog = function (initialString) {
         var that = this;
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
                 searchField.focus();
             });
 
-        return this.result;
+        return this.result.promise();
     };
 
 

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
     
     /**
      * Asynchronously reads a file as UTF-8 encoded text.
-     * @return {Deferred} a jQuery Deferred that will be resolved with the 
+     * @return {$.Promise} a jQuery promise that will be resolved with the 
      *  file's text content plus its timestamp, or rejected with a FileError if
      *  the file can not be read.
      */
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      * Asynchronously writes a file as UTF-8 encoded text.
      * @param {!FileEntry} fileEntry
      * @param {!string} text
-     * @return {Deferred} a jQuery Deferred that will be resolved when
+     * @return {$.Promise} a jQuery promise that will be resolved when
      * file writing completes, or rejected with a FileError.
      */
     function writeText(fileEntry, text) {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -609,7 +609,7 @@ define(function (require, exports, module) {
                         }
                     });
                     
-                    return deferred;
+                    return deferred.promise();
                 }, true);
 
                 // We want the error callback to get called after some timeout (in case some deferreds don't return).

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
      *  deleteConflicts - deleted on disk; also dirty in Brackets
      *
      * @param {!Array.<Document>} docs
-     * @return {$.Deferred}  Resolved when all scanning done, or rejected immediately if there's any
+     * @return {$.Promise}  Resolved when all scanning done, or rejected immediately if there's any
      *      error while reading file timestamps. Errors are logged but no UI is shown.
      */
     function findExternalChanges(docs) {
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
      * Reloads the Document's contents from disk, discarding any unsaved changes in the editor.
      *
      * @param {!Document} doc
-     * @return {$.Deferred} Resolved after editor has been refreshed; rejected if unable to load the
+     * @return {$.Promise} Resolved after editor has been refreshed; rejected if unable to load the
      *      file's new content. Errors are logged but no UI is shown.
      */
     function reloadDoc(doc) {
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
     /**
      * Reloads all the documents in "toReload" silently (no prompts). The operations are all run
      * in parallel.
-     * @return {$.Deferred} Resolved/rejected after all reloads done; will be rejected if any one
+     * @return {$.Promise} Resolved/rejected after all reloads done; will be rejected if any one
      *      file's reload failed. Errors are logged (by reloadDoc()) but no UI is shown.
      */
     function reloadChangedDocs() {
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
     /**
      * @param {FileError} error
      * @param {!Document} doc
-     * @return {$.Deferred}
+     * @return {$.Promise}
      */
     function showReloadError(error, doc) {
         return Dialogs.showModalDialog(
@@ -235,7 +235,7 @@ define(function (require, exports, module) {
      * about each one. Processing is sequential: if the user chooses to reload a document, the next
      * prompt is not shown until after the reload has completed.
      *
-     * @return {$.Deferred} Resolved/rejected after all documents have been prompted and (if
+     * @return {$.Promise} Resolved/rejected after all documents have been prompted and (if
      *      applicable) reloaded (and any resulting error UI has been dismissed). Rejected if any
      *      one reload failed.
      */
@@ -244,12 +244,12 @@ define(function (require, exports, module) {
         var allConflicts = editConflicts.concat(deleteConflicts);
         
         function presentConflict(doc, i) {
-            var result = new $.Deferred();
+            var result = new $.Deferred(), promise = result.promise();
             
             // If window has been re-focused, skip all remaining conflicts so the sync can bail & restart
             if (_restartPending) {
                 result.resolve();
-                return result;
+                return promise;
             }
             
             var message;
@@ -306,7 +306,7 @@ define(function (require, exports, module) {
                     }
                 });
             
-            return result;
+            return promise;
         }
         
         // Begin walking through the conflicts, one at a time

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
      * fileSelectionFocus
      * @param {!fullPath}
      * @param {string} - must be either WORKING_SET_VIEW or PROJECT_MANAGER
-     * @returns {!Deferred}
+     * @returns {$.Promise}
      */
     function openAndSelectDocument(fullPath, fileSelectionFocus) {
         var result;
@@ -118,7 +118,7 @@ define(function (require, exports, module) {
             $(exports).triggerHandler("documentSelectionFocusChange");
             // Ensure the editor has focus even though we didn't open a new file.
             EditorManager.focusEditor();
-            result = (new $.Deferred()).resolve();
+            result = (new $.Deferred()).resolve().promise();
         } else {
             result = CommandManager.execute(Commands.FILE_OPEN, {fullPath: fullPath});
         }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -346,7 +346,7 @@ define(function (require, exports, module) {
             $projectTreeContainer.show();
         });
 
-        return result;
+        return result.promise();
     }
     
     /** @param {Entry} entry File or directory to filter */
@@ -483,7 +483,7 @@ define(function (require, exports, module) {
      *
      * @param {string} rootPath  Absolute path to the root folder of the project. 
      *  If rootPath is undefined or null, the last open project will be restored.
-     * @return {Deferred} A $.Deferred() object that will be resolved when the
+     * @return {$.Promise} A promise object that will be resolved when the
      *  project is loaded and tree is rendered, or rejected if the project path
      *  fails to load.
      */
@@ -572,7 +572,7 @@ define(function (require, exports, module) {
                 );
         }
 
-        return result;
+        return result.promise();
     }
 
     /**
@@ -629,7 +629,7 @@ define(function (require, exports, module) {
      * @param baseDir {string} Full path of the directory where the item should go
      * @param initialName {string} Initial name for the item
      * @param skipRename {boolean} If true, don't allow the user to rename the item
-     * @return {Deferred} A $.Deferred() object that will be resolved with the FileEntry
+     * @return {$.Promise} A promise object that will be resolved with the FileEntry
      *  of the created object, or rejected if the user cancelled or entered an illegal
      *  filename.
      */
@@ -775,7 +775,7 @@ define(function (require, exports, module) {
         renameInput.css({ left: "17px", height: "24px"})
             .parent().css({ height: "26px"});
 
-        return result;
+        return result.promise();
     }
 
     // Define public API

--- a/src/search/QuickFileOpen.js
+++ b/src/search/QuickFileOpen.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
     /**
     * Shows the search dialog and initializes the auto suggestion list with filenames from the current project
     * @param {?string} initialString Default text to prepopulate the search field with
-    * @returns {$.Promise} a promise that is resolved when the dialgo closes with the string value from the search field
+    * @returns {$.Promise} a promise that is resolved when the dialog closes with the string value from the search field
     */
     QuickNavigateDialog.prototype.showDialog = function (initialString) {
         var that = this;
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
                 searchField.focus();
             });
 
-        return this.result;
+        return this.result.promise();
     };
 
 

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
      *      the HTML template is used unchanged.
      * @param {string=} message The message to display in the error dialog. Can contain HTML markup. If
      *      unspecified, body in the HTML template is used unchanged.
-     * @return {Deferred} a $.Deferred() that will be resolved with the ID of the clicked button when the dialog
+     * @return {$.Promise} a promise that will be resolved with the ID of the clicked button when the dialog
      *     is dismissed. Never rejected.
      */
     function showModalDialog(dlgClass, title, message) {
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
             show: true,
             keyboard: true
         });
-        return result;
+        return result.promise();
     }
     
     /**


### PR DESCRIPTION
@peterflynn 

Fixes #320.

The only small functional change I made was to `DocumentCommandHandlers.handleFileClose()`. Originally this returned a promise in most cases, but returned nothing in the case where no file was already open. CommandManager handled this by creating its own resolved promise, so it worked fine, but it seemed more consistent to always return a promise. 

(It seems to me like we should actually reject the promise in this case, but that would actually be a semantic change and would break an existing unit test.)

In some cases functions were already returning a promise, but the comments for the function hadn't been updated to reflect this.

Unit tests pass and basic functionality seems to work fine. Once we have a good sanity test, I'll run it :)
