### PR TITLE
Remove 'browser' setting from JSLint options

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define */
 
 /**

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, XMLHttpRequest */
 
 /**
  * DOMAgent constructs and maintains a tree of {DOMNode}s that represents the

--- a/src/LiveDevelopment/Agents/DOMHelpers.js
+++ b/src/LiveDevelopment/Agents/DOMHelpers.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Agents/DOMNode.js
+++ b/src/LiveDevelopment/Agents/DOMNode.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Agents/EditAgent.js
+++ b/src/LiveDevelopment/Agents/EditAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, setTimeout */
 
 /**
  * GotoAgent constructs and responds to the in-browser goto dialog.

--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, setTimeout */
+/*global define, $, window */
 
 /**
  * GotoAgent constructs and responds to the in-browser goto dialog.
@@ -141,7 +141,7 @@ define(function GotoAgent(require, exports, module) {
         }
         codeMirror.setCursor(location);
         codeMirror.setLineClass(location.line, "flash");
-        setTimeout(codeMirror.setLineClass.bind(codeMirror, location.line), 1000);
+        window.setTimeout(codeMirror.setLineClass.bind(codeMirror, location.line), 1000);
     }
 
     /** Open the editor at the given url and editor location

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define */
 
 /**

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, XMLHttpRequest */
 
 /**
  * RemoteAgent defines and provides an interface for custom remote functions

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, document, setTimeout */
+/*global define, $, window */
 
 /**
  * RemoteFunctions define the functions to be executed in the browser. This
@@ -33,7 +33,7 @@
 function RemoteFunctions() {
     'use strict';
 
-    var _body = document.getElementsByTagName("body")[0]; // the document body
+    var _body = window.document.getElementsByTagName("body")[0]; // the document body
     var _sourceHighlight; // the highlighted element in the source
     var _highlight = []; // the highlighted elements
     var _dialog; // the active dialog
@@ -78,7 +78,7 @@ function RemoteFunctions() {
         var width = element.offsetWidth;
 
         // create the container
-        _dialog = document.createElement("div");
+        _dialog = window.document.createElement("div");
         _dialog.style.setProperty("z-index", 2147483647);
         _dialog.style.setProperty("position", "absolute");
         _dialog.style.setProperty("left", x + "px");
@@ -113,7 +113,7 @@ function RemoteFunctions() {
         if (value !== undefined && value !== null) {
             element.setAttribute(key, value);
             if (autoRemove) {
-                setTimeout(element.removeAttribute.bind(element, key));
+                window.setTimeout(element.removeAttribute.bind(element, key));
             }
         } else {
             element.removeAttribute(key);
@@ -154,7 +154,7 @@ function RemoteFunctions() {
     function _showEdit(text) {
         _editText = text;
         var dialog = _createDialog(_target);
-        _editor = document.createElement("input");
+        _editor = window.document.createElement("input");
         _editor.setAttribute("value", text);
         _editor.setAttribute("width", _target.attributes.width);
         _editor.addEventListener("keyup", _onEditKeyUp);
@@ -237,7 +237,7 @@ function RemoteFunctions() {
         var i, target, row, file;
         for (i in targets) {
             target = targets[i];
-            row = document.createElement("div");
+            row = window.document.createElement("div");
             row.style.setProperty("padding", "6px 12px");
             row.style.setProperty("display", "block");
             row.style.setProperty("border-bottom", "1px solid #ccc");
@@ -248,7 +248,7 @@ function RemoteFunctions() {
             row.addEventListener("mouseover", _onGotoMouse.bind(undefined, row, target.type));
             row.addEventListener("mouseout", _onGotoMouse.bind(undefined, row, target.type));
             if (target.file) {
-                file = document.createElement("i");
+                file = window.document.createElement("i");
                 file.style.setProperty("float", "right");
                 file.style.setProperty("margin-left", "12px");
                 file.innerHTML = " " + target.file;
@@ -279,7 +279,7 @@ function RemoteFunctions() {
     // highlight a rule
     function highlightRule(rule) {
         hideHighlight();
-        var i, nodes = document.querySelectorAll(rule);
+        var i, nodes = window.document.querySelectorAll(rule);
         for (i = 0; i < nodes.length; i++) {
             highlight(nodes[i]);
         }
@@ -289,9 +289,9 @@ function RemoteFunctions() {
     function insertNode(payload, parent, index) {
         var node;
         if (payload.value) {
-            node = document.createTextNode(payload.value);
+            node = window.document.createTextNode(payload.value);
         } else {
-            node = document.createElement(payload.nodeName);
+            node = window.document.createElement(payload.nodeName);
         }
         var sibling;
         if (index !== undefined) {
@@ -316,12 +316,12 @@ function RemoteFunctions() {
     // install event listeners
     
     /* FUTURE
-    document.addEventListener("keyup", _onKeyUp);
-    document.addEventListener("mousemove", _onMouse);
-    document.addEventListener("mouseout", _onMouse);
-    document.addEventListener("mousedown", _preventEventWhenMeta, true);
-    document.addEventListener("mouseup", _preventEventWhenMeta, true);
-    document.addEventListener("click", _onClick, true);
+    window.document.addEventListener("keyup", _onKeyUp);
+    window.document.addEventListener("mousemove", _onMouse);
+    window.document.addEventListener("mouseout", _onMouse);
+    window.document.addEventListener("mousedown", _preventEventWhenMeta, true);
+    window.document.addEventListener("mouseup", _preventEventWhenMeta, true);
+    window.document.addEventListener("click", _onClick, true);
     */
     
     return {

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, document, setTimeout */
 
 /**
  * RemoteFunctions define the functions to be executed in the browser. This

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $ */
 
 /**

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -23,8 +23,8 @@
 
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, WebSocket, FileError */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, WebSocket, FileError, setTimeout, XMLHttpRequest */
 
  /**
  * Inspector manages the connection to Chrome/Chromium's remote debugger.

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -24,7 +24,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, WebSocket, FileError, setTimeout, XMLHttpRequest */
+/*global define, $, WebSocket, FileError, window, XMLHttpRequest */
 
  /**
  * Inspector manages the connection to Chrome/Chromium's remote debugger.
@@ -105,7 +105,7 @@ define(function Inspector(require, exports, module) {
         var i, handlers = _handlers[name];
         var args = Array.prototype.slice.call(arguments, 1);
         for (i in handlers) {
-            setTimeout(_triggerHandler.bind(undefined, handlers[i], args));
+            window.setTimeout(_triggerHandler.bind(undefined, handlers[i], args));
         }
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, FileError, brackets, setTimeout */
+/*global define, $, FileError, brackets, window */
 
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument
@@ -320,7 +320,7 @@ define(function LiveDevelopment(require, exports, module) {
                             NativeApp.closeLiveBrowser()
                                 .done(function () {
                                     browserStarted = false;
-                                    setTimeout(open);
+                                    window.setTimeout(open);
                                 })
                                 .fail(function (err) {
                                     // Report error?
@@ -366,7 +366,7 @@ define(function LiveDevelopment(require, exports, module) {
                 }
                 
                 if (exports.status !== -1) {
-                    setTimeout(function retryConnect() {
+                    window.setTimeout(function retryConnect() {
                         Inspector.connectToURL(doc.root.url).fail(onConnectFail);
                     }, 500);
                 }
@@ -399,12 +399,12 @@ define(function LiveDevelopment(require, exports, module) {
                 /* FUTURE: support live connections for docments other than html */
                 if (doc.extension && doc.extension.indexOf('htm') === 0 && doc.file.fullPath !== _htmlDocumentPath) {
                     close();
-                    setTimeout(open);
+                    window.setTimeout(open);
                     _htmlDocumentPath = doc.file.fullPath;
                 }
             }
         } else if (exports.config.autoconnect) {
-            setTimeout(open);
+            window.setTimeout(open);
         }
     }
     

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, FileError, brackets */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, FileError, brackets, setTimeout */
 
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, less */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, less, document, window, setTimeout, XMLHttpRequest */
 
 /**
  * main integrates LiveDevelopment into Brackets

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, less, document, window, setTimeout, XMLHttpRequest */
+/*global define, $, less, window, XMLHttpRequest */
 
 /**
  * main integrates LiveDevelopment into Brackets
@@ -76,7 +76,7 @@ define(function main(require, exports, module) {
             parser.parse(request.responseText, function onParse(err, tree) {
                 console.assert(!err, err);
                 var style = $("<style>" + tree.toCSS() + "</style>");
-                $(document.head).append(style);
+                $(window.document.head).append(style);
             });
         };
         request.send(null);
@@ -171,7 +171,7 @@ define(function main(require, exports, module) {
             _setupDebugHelpers();
         }
     }
-    setTimeout(init);
+    window.setTimeout(init);
 
     CommandManager.register(Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
 

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets: true, $, PathUtils, document, window, navigator */
+/*global define, brackets: true, $, PathUtils, window, navigator */
 
 /**
  * brackets is the root of the Brackets codebase. This file pulls in all other modules as
@@ -128,13 +128,13 @@ define(function (require, exports, module) {
     brackets.platform = (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") ? "mac" : "win";
 
     // Main Brackets initialization
-    $(document).ready(function () {
+    $(window.document).ready(function () {
         
         function initListeners() {
             // Prevent unhandled drag and drop of files into the browser from replacing 
             // the entire Brackets app. This doesn't prevent children from choosing to
             // handle drops.
-            $(document.body)
+            $(window.document.body)
                 .on("dragover", function (event) {
                     if (event.originalEvent.dataTransfer.files) {
                         event.stopPropagation();
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
             });
             KeyBindingManager.installKeymap(_globalKeymap);
 
-            document.body.addEventListener(
+            window.document.body.addEventListener(
                 "keydown",
                 function (event) {
                     if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
@@ -295,7 +295,7 @@ define(function (require, exports, module) {
         var osxMatch = /Mac OS X 10\D([\d+])\D/.exec(navigator.userAgent);
         if (osxMatch && osxMatch[1] && Number(osxMatch[1]) >= 7) {
             // test a scrolling div for scrollbars
-            var $testDiv = $("<div style='position:fixed;left:-50px;width:50px;height:50px;overflow:auto;'><div style='width:100px;height:100px;'/></div>").appendTo(document.body);
+            var $testDiv = $("<div style='position:fixed;left:-50px;width:50px;height:50px;overflow:auto;'><div style='width:100px;height:100px;'/></div>").appendTo(window.document.body);
             
             if ($testDiv.outerWidth() === $testDiv.get(0).clientWidth) {
                 $(".sidebar").removeClass("quiet-scrollbars");

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, brackets: true, $: false, PathUtils: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets: true, $, PathUtils, document, window, navigator */
 
 /**
  * brackets is the root of the Brackets codebase. This file pulls in all other modules as

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
  /**
   * Manages global application commands that can be called from menu items, key bindings, or subparts

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 /**
  * Manages the mapping of keyboard inputs to commands.

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, brackets */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, brackets */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window, document */
+/*global define, $, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
         var perfDlog = $("<div class='modal hide' />")
             .append(perfHeader)
             .append(perfBody)
-            .appendTo(document.body)
+            .appendTo(window.document.body)
             .modal({
                 backdrop: "static",
                 show: true

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false*/
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, window, document */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, brackets: false, PathUtils: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, PathUtils, window */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 /**
  * DocumentManager maintains a list of currently 'open' Documents. It also owns the list of files in

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror */
 
 /**
  */

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, CodeMirror, document, window, setTimeout */
+/*global define, $, CodeMirror, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -112,10 +112,10 @@ define(function (require, exports, module) {
         this._onClick = this._onClick.bind(this);
 
         // Create DOM to hold editors and related list
-        this.$editorsDiv = $(document.createElement('div')).addClass("inlineEditorHolder");
+        this.$editorsDiv = $(window.document.createElement('div')).addClass("inlineEditorHolder");
         
         // Outer container for border-left and scrolling
-        this.$relatedContainer = $(document.createElement("div")).addClass("relatedContainer");
+        this.$relatedContainer = $(window.document.createElement("div")).addClass("relatedContainer");
         this._relatedContainerInserted = false;
         this._relatedContainerInsertedHandler = this._relatedContainerInsertedHandler.bind(this);
         
@@ -123,19 +123,19 @@ define(function (require, exports, module) {
         this.$relatedContainer.on("DOMNodeInserted", this._relatedContainerInsertedHandler);
         
         // List "selection" highlight
-        this.$selectedMarker = $(document.createElement("div")).appendTo(this.$relatedContainer).addClass("selection");
+        this.$selectedMarker = $(window.document.createElement("div")).appendTo(this.$relatedContainer).addClass("selection");
         
         // Inner container
-        var $related = $(document.createElement("div")).appendTo(this.$relatedContainer).addClass("related");
+        var $related = $(window.document.createElement("div")).appendTo(this.$relatedContainer).addClass("related");
         
         // Rule list
-        var $ruleList = $(document.createElement("ul")).appendTo($related);
+        var $ruleList = $(window.document.createElement("ul")).appendTo($related);
         
         // create rule list & add listeners for rule textrange changes
         var ruleItemText;
         this._rules.forEach(function (rule, i) {
             // Create list item UI
-            var $ruleItem = $(document.createElement("li")).appendTo($ruleList);
+            var $ruleItem = $(window.document.createElement("li")).appendTo($ruleList);
             updateRuleLabel($ruleItem, rule);
             $ruleItem.mousedown(function () {
                 self.setSelectedRule(i);
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
         this.$htmlContent.append(this.$editorsDiv).append(this.$relatedContainer);
         
         // initialize position based on the main #editorHolder
-        setTimeout(this._updateRelatedContainer, 0);
+        window.setTimeout(this._updateRelatedContainer, 0);
         
         // Changes to the host editor should update the relatedContainer
         // Note: normally it's not kosher to listen to changes on a specific editor,
@@ -236,7 +236,7 @@ define(function (require, exports, module) {
 
         // scroll the selection to the ruleItem, use setTimeout to wait for DOM updates
         var self = this;
-        setTimeout(function () {
+        window.setTimeout(function () {
             var containerHeight = self.$relatedContainer.height(),
                 itemTop = $ruleItem.position().top,
                 scrollTop = self.$relatedContainer.scrollTop();
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
             scrollerTop = scrollerOffset.top,
             scrollerBottom = scrollerTop + hostScroller.clientHeight,
             scrollerLeft = scrollerOffset.left,
-            rightOffset = $(document.body).outerWidth() - (scrollerLeft + hostScroller.clientWidth);
+            rightOffset = $(window.document.body).outerWidth() - (scrollerLeft + hostScroller.clientWidth);
         if (rcTop < scrollerTop || rcBottom > scrollerBottom) {
             this.$relatedContainer.css("clip", "rect(" + Math.max(scrollerTop - rcTop, 0) + "px, auto, " +
                                        (rcHeight - Math.max(rcBottom - scrollerBottom, 0)) + "px, auto)");
@@ -375,7 +375,7 @@ define(function (require, exports, module) {
      * scroll position of the host editor to ensure that the cursor is visible.
      */
     CSSInlineEditor.prototype._ensureCursorVisible = function () {
-        if ($.contains(this.editors[0].getRootElement(), document.activeElement)) {
+        if ($.contains(this.editors[0].getRootElement(), window.document.activeElement)) {
             var cursorCoords = this.editors[0]._codeMirror.cursorCoords(),
                 lineSpaceOffset = $(this.editors[0]._getLineSpaceElement()).offset(),
                 ruleListOffset = this.$relatedContainer.offset();

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, document, window, setTimeout */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, setTimeout */
+/*global define, $, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
         if (keyboardEvent.type !== "keypress") {
             return;
         }
-        setTimeout(function () { _checkForHint(editor); }, 40);
+        window.setTimeout(function () { _checkForHint(editor); }, 40);
     }
     
     // Register our listeners

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, setTimeout */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, setTimeout */
 
 /**
  * Editor is a 1-to-1 wrapper for a CodeMirror editor instance. It layers on Brackets-specific

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, CodeMirror, setTimeout */
+/*global define, $, CodeMirror, window */
 
 /**
  * Editor is a 1-to-1 wrapper for a CodeMirror editor instance. It layers on Brackets-specific
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
                     // the keypress is handled before auto-indenting.
                     // This is the same timeout value used by the
                     // electricChars feature in CodeMirror.
-                    setTimeout(function () {
+                    window.setTimeout(function () {
                         instance.indentLine(lineNum);
                     }, 75);
                 }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, window */
 
 /**
  * EditorManager owns the UI for the editor area. This essentially mirrors the 'current document'

--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define: false, PathUtils: false, FileError: false, brackets: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, PathUtils, FileError, brackets */
 
 /**
  * Set of utilites for working with the code editor

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, document */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, CodeMirror, document */
+/*global define, $, CodeMirror, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -202,14 +202,14 @@ define(function (require, exports, module) {
         }
         
         // create the filename div
-        var wrapperDiv = document.createElement("div");
+        var wrapperDiv = window.document.createElement("div");
         var $wrapperDiv = $(wrapperDiv);
         
         // dirty indicator followed by filename
-        var $filenameDiv = $(document.createElement("div")).addClass("filename");
+        var $filenameDiv = $(window.document.createElement("div")).addClass("filename");
         
         // save file path data to dirty-indicator
-        var $dirtyIndicatorDiv = $(document.createElement("div"))
+        var $dirtyIndicatorDiv = $(window.document.createElement("div"))
             .addClass("dirty-indicator")
             .width(0); // initialize indicator as hidden
         $dirtyIndicatorDiv.data("fullPath", doc.file.fullPath);

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, document */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, CodeMirror, document */
+/*global define, $, CodeMirror, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
      */
     function InlineWidget() {
         // create the outer wrapper div
-        this.htmlContent = document.createElement("div");
+        this.htmlContent = window.document.createElement("div");
         this.$htmlContent = $(this.htmlContent).addClass("InlineWidget");
         this.$htmlContent.append('<div class="shadow top"/>')
             .append('<div class="shadow bottom"/>');

--- a/src/extensions/disabled/circular_dependency_test/main.js
+++ b/src/extensions/disabled/circular_dependency_test/main.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $ */
 
 define(function (require, exports, module) {

--- a/src/extensions/disabled/circular_dependency_test/secondary.js
+++ b/src/extensions/disabled/circular_dependency_test/secondary.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define, $, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
 
     exports.bar = function bar() {
         console.log("in bar in secondary!");
-        setTimeout(function () { require("main").bar(); }, 300);
+        window.setTimeout(function () { require("main").bar(); }, 300);
     };
 
 });

--- a/src/extensions/disabled/circular_dependency_test/secondary.js
+++ b/src/extensions/disabled/circular_dependency_test/secondary.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $ */
 
 define(function (require, exports, module) {

--- a/src/extensions/disabled/quickopen_example/main.js
+++ b/src/extensions/disabled/quickopen_example/main.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, brackets: false, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets, $, document */
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.

--- a/src/extensions/disabled/quickopen_example/main.js
+++ b/src/extensions/disabled/quickopen_example/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, document */
+/*global define, brackets, $, window */
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     */
     QuickNavigateDialog.prototype._createDialogDiv = function (template) {
         var wrap = $("#editorHolder")[0];
-        this.dialog = wrap.insertBefore(document.createElement("div"), wrap.firstChild);
+        this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
         this.dialog.innerHTML = '<div style=\'background-image:url(' + require.toUrl("./ty.jpg") + ')\'>' + template + '</div>';
     };

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, FileError, brackets, unescape */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, $, FileError, brackets, unescape, window */
 
 /**
  * Set of utilites for working with files and text content.

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50*/
-/*global $: false, define: false, brackets: false, FileError: false, InvalidateStateError: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50*/
+/*global $, define, brackets, FileError, InvalidateStateError */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror */
 
 /**
  * Set of utilities for simple parsing of CSS text.

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, JSLINT: false, PathUtils: false*/
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, JSLINT, PathUtils */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 /**
  * PreferenceStorage defines an interface for persisting preference data as

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, localStorage */
 
 /**
  * PreferencesManager

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, brackets, PathUtils */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, PathUtils */
 
 /*
  * Manages a collection of FileIndexes where each index maintains a list of information about

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $, brackets, FileError */
 
 /**

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 /**
  * Responsible for coordinating file selection between views by permitting only one view

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, brackets: false, FileError: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, FileError, window */
 
 /**
  * ProjectManager is the model for the set of currently open project. It is responsible for

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: true  */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $  */
 
 /**
  * WorkingSetView generates the UI for the list of the files user is editing based on the model provided by EditorManager.

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, PathUtils, document */
+/*global define, $, PathUtils, window */
 
 /*
  * Adds a "find in files" command to allow the user to find all occurances of a string in all files in
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     */
     FindInFilesDialog.prototype._createDialogDiv = function (template) {
         var wrap = $("#editorHolder")[0];
-        this.dialog = wrap.insertBefore(document.createElement("div"), wrap.firstChild);
+        this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
         this.dialog.innerHTML = '<div>' + template + '</div>';
     };

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, PathUtils */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, $, PathUtils, document */
 
 /*
  * Adds a "find in files" command to allow the user to find all occurances of a string in all files in

--- a/src/search/QuickFileOpen.js
+++ b/src/search/QuickFileOpen.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, document */
+/*global define, $, window */
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     */
     QuickNavigateDialog.prototype._createDialogDiv = function (template) {
         var wrap = $("#editorHolder")[0];
-        this.dialog = wrap.insertBefore(document.createElement("div"), wrap.firstChild);
+        this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
         this.dialog.innerHTML = '<div>' + template + '</div>';
     };

--- a/src/search/QuickFileOpen.js
+++ b/src/search/QuickFileOpen.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, document */
 
 /*
 * Displays an auto suggest popup list of files to allow the user to quickly navigate to a file.

--- a/src/strings.js
+++ b/src/strings.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
 
 define(function (require, exports, module) {
     

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, setTimeout, clearTimeout */
 
 /**
  * Utilities for working with Deferred, Promise, and other asynchronous processes.

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, setTimeout, clearTimeout */
+/*global define, $, window */
 
 /**
  * Utilities for working with Deferred, Promise, and other asynchronous processes.
@@ -262,11 +262,11 @@ define(function (require, exports, module) {
     function withTimeout(promise, timeout) {
         var wrapper = new $.Deferred();
         
-        var timer = setTimeout(function () {
+        var timer = window.setTimeout(function () {
             wrapper.reject(ERROR_TIMEOUT);
         }, timeout);
         promise.always(function () {
-            clearTimeout(timer);
+            window.clearTimeout(timer);
         });
         
         // If the wrapper was already rejected due to timeout, the Promise's calls to resolve/reject

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, CodeMirror: false, brackets: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror, brackets */
 
 /**
  * ExtensionLoader searches the filesystem for extensions, then creates a new context for each one and loads it

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50*/
-/*global $: false, define: false, brackets: false, FileError: false, InvalidateStateError: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50*/
+/*global $, define, brackets, FileError */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -21,8 +21,7 @@
  * 
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, brackets */
 
 /**

--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, document */
 
  /**
   * This is JavaScript API exposed to the native shell when Brackets is run in a native shell rather than a browser.

--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, document */
+/*global define, $, window */
 
  /**
   * This is JavaScript API exposed to the native shell when Brackets is run in a native shell rather than a browser.
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
      * calling Brackets commands from the native shell.
      */
     function executeCommand(eventName) {
-        var evt = document.createEvent("Event");
+        var evt = window.document.createEvent("Event");
         evt.initEvent(eventName, false, true);
         
         CommandManager.execute(eventName, {evt: evt});

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, document, window */
+/*global define, $, window */
 
 define(function (require, exports, module) {
     'use strict';
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
         var $findShadow = $displayElement.find(".scrollerShadow." + position);
 
         if ($findShadow.length === 0) {
-            $findShadow = $(document.createElement("div")).addClass("scrollerShadow " + position);
+            $findShadow = $(window.document.createElement("div")).addClass("scrollerShadow " + position);
             $displayElement.append($findShadow);
         }
         
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
             showTriangle = true;
         
         // build selectionMarker and position absolute within the scroller
-        $selectionMarker = $(document.createElement("div")).addClass("sidebarSelection");
+        $selectionMarker = $(window.document.createElement("div")).addClass("sidebarSelection");
         $scrollerElement.prepend($selectionMarker);
         
         // enable scrolling
@@ -196,7 +196,7 @@ define(function (require, exports, module) {
         $scrollerElement.css("position", "relative");
         
         // build selectionTriangle and position fixed to the window
-        $selectionTriangle = $(document.createElement("div")).addClass("sidebarSelectionTriangle");
+        $selectionTriangle = $(window.document.createElement("div")).addClass("sidebarSelectionTriangle");
         $fileSection.append($selectionTriangle);
         
         selectedClassName = "." + (selectedClassName || "selected");

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, document, window */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -21,8 +21,8 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false*/
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
 
 define(function (require, exports, module) {
     'use strict';

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, document, setTimeout */
+/*global define, $, brackets, window */
 
 /**
  * Utilities for creating and managing standard modal dialogs.
@@ -127,7 +127,7 @@ define(function (require, exports, module) {
             .clone()
             .removeClass("template")
             .addClass("instance")
-            .appendTo(document.body);
+            .appendTo(window.document.body);
         
         if (dlg.length === 0) {
             throw new Error("Dialog id " + dlgClass + " does not exist");
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             // Let call stack return before notifying that dialog has closed; this avoids issue #191
             // if the handler we're triggering might show another dialog (as long as there's no
             // fade-out animation)
-            setTimeout(function () {
+            window.setTimeout(function () {
                 result.resolve(buttonId);
             }, 0);
             
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
             dlg.remove();
 
             // Remove keydown event handler
-            document.body.removeEventListener("keydown", handleKeyDown, true);
+            window.document.body.removeEventListener("keydown", handleKeyDown, true);
             KeyBindingManager.setEnabled(true);
         }).one("shown", function () {
             // Set focus to the default button
@@ -172,7 +172,7 @@ define(function (require, exports, module) {
             }
 
             // Listen for dialog keyboard shortcuts
-            document.body.addEventListener("keydown", handleKeyDown, true);
+            window.document.body.addEventListener("keydown", handleKeyDown, true);
             KeyBindingManager.setEnabled(false);
         });
         

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -22,8 +22,8 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, $: false, brackets: false */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, document, setTimeout */
 
 /**
  * Utilities for creating and managing standard modal dialogs.


### PR DESCRIPTION
Issue #459

This pull request removes the 'browser' setting from the default JSLint options at the top of our source files. The 'browser' setting allows all browser globals, including `document`, to be accepted. This can cause false positives if you use `document` as a property name on an object.

Where needed, a 'window' global directive was added. Global properties and functions like `document`, `setTimeout()`, etc. are now accessed as `window.document`, `window.setTimeout()`, etc.
