### PR TITLE
Prefixed vars that refer to jQuery objects with $

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -64,8 +64,8 @@ define(function main(require, exports, module) {
     var _statusStyle = ["warning", "", "info", "info", "success"];  // Status indicator's CSS class
     var _allStatusStyles = _statusStyle.join(" ");
     
-    var _btnGoLive; // reference to the GoLive button
-    var _btnHighlight; // reference to the HighlightButton
+    var _$btnGoLive; // reference to the GoLive button
+    var _$btnHighlight; // reference to the HighlightButton
 
     /** Load Live Development LESS Style */
     function _loadStyles() {
@@ -75,8 +75,8 @@ define(function main(require, exports, module) {
             var parser = new less.Parser();
             parser.parse(request.responseText, function onParse(err, tree) {
                 console.assert(!err, err);
-                var style = $("<style>" + tree.toCSS() + "</style>");
-                $(window.document.head).append(style);
+                $("<style>" + tree.toCSS() + "</style>")
+                    .appendTo(window.document.head);
             });
         };
         request.send(null);
@@ -86,23 +86,23 @@ define(function main(require, exports, module) {
      * Change the appearance of a button. Omit text to remove any extra text; omit style to return to default styling;
      * omit tooltip to leave tooltip unchanged.
      */
-    function _setLabel(btn, text, style, tooltip) {
+    function _setLabel($btn, text, style, tooltip) {
         // Clear text/styles from previous status
-        $("span", btn).remove();
-        btn.removeClass(_allStatusStyles);
+        $("span", $btn).remove();
+        $btn.removeClass(_allStatusStyles);
         
         // Set text/styles for new status
         if (text && text.length > 0) {
-            var label = $("<span class=\"label\">");
-            label.addClass(style);
-            label.text(text);
-            btn.append(label);
+            $("<span class=\"label\">")
+                .addClass(style)
+                .text(text)
+                .appendTo($btn);
         } else {
-            btn.addClass(style);
+            $btn.addClass(style);
         }
         
         if (tooltip) {
-            btn.attr("title", tooltip);
+            $btn.attr("title", tooltip);
         }
     }
 
@@ -119,37 +119,37 @@ define(function main(require, exports, module) {
 
     /** Create the menu item "Go Live" */
     function _setupGoLiveButton() {
-        _btnGoLive = $("#toolbar-go-live");
-        _btnGoLive.click(function onGoLive() {
+        _$btnGoLive = $("#toolbar-go-live");
+        _$btnGoLive.click(function onGoLive() {
             _handleGoLiveCommand();
         });
         $(LiveDevelopment).on("statusChange", function statusChange(event, status) {
             // status starts at -1 (error), so add one when looking up name and style
             // See the comments at the top of LiveDevelopment.js for details on the 
             // various status codes.
-            _setLabel(_btnGoLive, null, _statusStyle[status + 1], _statusTooltip[status + 1]);
+            _setLabel(_$btnGoLive, null, _statusStyle[status + 1], _statusTooltip[status + 1]);
         });
         
         // Initialize tooltip for 'not connected' state
-        _setLabel(_btnGoLive, null, _statusStyle[1], _statusTooltip[1]);
+        _setLabel(_$btnGoLive, null, _statusStyle[1], _statusTooltip[1]);
     }
 
     /** Create the menu item "Highlight" */
     function _setupHighlightButton() {
         // TODO: this should be moved into index.html like the Go Live button once it's re-enabled
-        _btnHighlight = $("<a href=\"#\">Highlight </a>");
-        $(".nav").append($("<li>").append(_btnHighlight));
-        _btnHighlight.click(function onClick() {
+        _$btnHighlight = $("<a href=\"#\">Highlight </a>");
+        $(".nav").append($("<li>").append(_$btnHighlight));
+        _$btnHighlight.click(function onClick() {
             config.highlight = !config.highlight;
             if (config.highlight) {
-                _setLabel(_btnHighlight, _checkMark, "success");
+                _setLabel(_$btnHighlight, _checkMark, "success");
             } else {
-                _setLabel(_btnHighlight);
+                _setLabel(_$btnHighlight);
                 LiveDevelopment.hideHighlight();
             }
         });
         if (config.highlight) {
-            _setLabel(_btnHighlight, _checkMark, "success");
+            _setLabel(_$btnHighlight, _checkMark, "success");
         }
     }
 

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -60,16 +60,16 @@ define(function (require, exports, module) {
     }
     
     function _handleShowPerfData() {
-        var perfHeader = $("<div class='modal-header' />")
+        var $perfHeader = $("<div class='modal-header' />")
             .append("<a href='#' class='close'>&times;</a>")
             .append("<h1 class='dialog-title'>Performance Data</h1>");
         
-        var perfBody = $("<div class='modal-body' style='padding: 0' />");
+        var $perfBody = $("<div class='modal-body' style='padding: 0' />");
 
-        var data = $("<table class='zebra-striped condensed-table' style='max-height: 600px; overflow: auto;'>")
+        var $data = $("<table class='zebra-striped condensed-table' style='max-height: 600px; overflow: auto;'>")
             .append("<thead><th>Operation</th><th>Time (ms)</th></thead>")
             .append("<tbody />")
-            .appendTo(perfBody);
+            .appendTo($perfBody);
         
         var makeCell = function (content) {
             return $("<td/>").text(content);
@@ -95,16 +95,16 @@ define(function (require, exports, module) {
         for (testName in perfData) {
             if (perfData.hasOwnProperty(testName)) {
                 // Add row to error table
-                var row = $("<tr/>")
+                $("<tr/>")
                     .append(makeCell(testName))
                     .append(makeCell(getValue(perfData[testName])))
-                    .appendTo(data);
+                    .appendTo($data);
             }
         }
                                                      
-        var perfDlog = $("<div class='modal hide' />")
-            .append(perfHeader)
-            .append(perfBody)
+        $("<div class='modal hide' />")
+            .append($perfHeader)
+            .append($perfBody)
             .appendTo(window.document.body)
             .modal({
                 backdrop: "static",

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -49,15 +49,15 @@ define(function (require, exports, module) {
      */
     
     /** @type {jQueryObject} Container for label shown above editor; must be an inline element */
-    var _title = null;
-    /** @type {jQueryObject} Container for _title; need not be an inline element */
-    var _titleWrapper = null;
+    var _$title = null;
+    /** @type {jQueryObject} Container for _$title; need not be an inline element */
+    var _$titleWrapper = null;
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     
-    /** @type {jQueryObject} Container for _titleWrapper; if changing title changes this element's height, must kick editor to resize */
-    var _titleContainerToolbar = null;
-    /** @type {Number} Last known height of _titleContainerToolbar */
+    /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
+    var _$titleContainerToolbar = null;
+    /** @type {Number} Last known height of _$titleContainerToolbar */
     var _lastToolbarHeight = null;
     
     var DIRTY_INDICATOR = " <span class='dirty-dot'>\u2022</span>";
@@ -65,26 +65,26 @@ define(function (require, exports, module) {
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument();
         if (currentDoc) {
-            _title.text(_currentTitlePath);
-            _title.attr("title", currentDoc.file.fullPath);
+            _$title.text(_currentTitlePath);
+            _$title.attr("title", currentDoc.file.fullPath);
             if (currentDoc.isDirty) {
-                _title.append(DIRTY_INDICATOR);
+                _$title.append(DIRTY_INDICATOR);
             }
         } else {
-            _title.text("");
-            _title.attr("title", "");
+            _$title.text("");
+            _$title.attr("title", "");
         }
         
-        // Set _titleWrapper to a fixed width just large enough to accomodate _title. This seems equivalent to what
-        // the browser would do automatically, but the CSS trick we use for layout requires _titleWrapper to have a
+        // Set _$titleWrapper to a fixed width just large enough to accomodate _$title. This seems equivalent to what
+        // the browser would do automatically, but the CSS trick we use for layout requires _$titleWrapper to have a
         // fixed width set on it (see the "#main-toolbar.toolbar" CSS rule for details).
-        _titleWrapper.css("width", "");
-        var newWidth = _title.width();
-        _titleWrapper.css("width", newWidth);
+        _$titleWrapper.css("width", "");
+        var newWidth = _$title.width();
+        _$titleWrapper.css("width", newWidth);
         
         // Changing the width of the title may cause the toolbar layout to change height, which needs to resize the
         // editor beneath it (toolbar changing height due to window resize is already caught by EditorManager).
-        var newToolbarHeight = _titleContainerToolbar.height();
+        var newToolbarHeight = _$titleContainerToolbar.height();
         if (_lastToolbarHeight !== newToolbarHeight) {
             _lastToolbarHeight = newToolbarHeight;
             EditorManager.resizeEditor();
@@ -642,10 +642,10 @@ define(function (require, exports, module) {
         });
     }
 
-    function init(titleContainerToolbar) {
-        _titleContainerToolbar = titleContainerToolbar;
-        _titleWrapper = $(".title-wrapper", _titleContainerToolbar);
-        _title = $(".title", _titleWrapper);
+    function init($titleContainerToolbar) {
+        _$titleContainerToolbar = $titleContainerToolbar;
+        _$titleWrapper = $(".title-wrapper", _$titleContainerToolbar);
+        _$title = $(".title", _$titleWrapper);
 
         // Register global commands
         CommandManager.register(Commands.FILE_OPEN, handleFileOpen);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -223,9 +223,9 @@ define(function (require, exports, module) {
             codeMirror.execCommand("find");
 
             // Prepopulate the search field with the current selection, if any
-            var findBarTextField = $(".CodeMirror-dialog input[type='text']");
-            findBarTextField.attr("value", codeMirror.getSelection());
-            findBarTextField.get(0).select();
+            $(".CodeMirror-dialog input[type='text']")
+                .attr("value", codeMirror.getSelection())
+                .get(0).select();
         }
     }
 
@@ -766,8 +766,7 @@ define(function (require, exports, module) {
      * @returns {Object} The editor's lineSpace element.
      */
     Editor.prototype._getLineSpaceElement = function () {
-        var lineSpaceParent = $(".CodeMirror-lines", this.getScrollerElement()).get(0);
-        return $(lineSpaceParent).children().get(0);
+        return $(".CodeMirror-lines", this.getScrollerElement()).children().get(0);
     };
     
     /**

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -98,9 +98,9 @@ define(function (require, exports, module) {
         
         var maxWidth = 0;
         allHostedEditors.forEach(function (editor) {
-            var gutter = $(editor._codeMirror.getGutterElement());
-            gutter.css("min-width", "");
-            var curWidth = gutter.width();
+            var $gutter = $(editor._codeMirror.getGutterElement());
+            $gutter.css("min-width", "");
+            var curWidth = $gutter.width();
             if (curWidth > maxWidth) {
                 maxWidth = curWidth;
             }

--- a/src/extensions/disabled/quickopen_example/main.js
+++ b/src/extensions/disabled/quickopen_example/main.js
@@ -62,6 +62,7 @@ define(function (require, exports, module) {
     * Creates a dialog div floating on top of the current code mirror editor
     */
     QuickNavigateDialog.prototype._createDialogDiv = function (template) {
+        // FUTURE: consider using jQuery for all the DOM manipulation here
         var wrap = $("#editorHolder")[0];
         this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
@@ -105,10 +106,10 @@ define(function (require, exports, module) {
                 var dialogHTML = 'Quick Open: <input type="text" autocomplete="off" id="quickFileOpenSearch" style="width: 30em">';
                 that._createDialogDiv(dialogHTML);
                 var closed = false;
-                var searchField = $('input#quickFileOpenSearch');
+                var $searchField = $('input#quickFileOpenSearch');
                 
-                searchField.attr("value", initialString || "");
-                searchField.get(0).select();
+                $searchField.attr("value", initialString || "");
+                $searchField.get(0).select();
 
                 // auto suggest list helper function
                 function _handleResultsFormatter(path) {
@@ -147,7 +148,7 @@ define(function (require, exports, module) {
                 }
 
                 // Create the auto suggest list of filenames
-                searchField.smartAutoComplete({
+                $searchField.smartAutoComplete({
                     source: fileInfoList,
                     maxResults: 10,
                     forceSelect: false,
@@ -156,7 +157,7 @@ define(function (require, exports, module) {
                     resultFormatter: _handleResultsFormatter
                 });
         
-                searchField.bind({
+                $searchField.bind({
                     // close the dialog when the user selects an item
                     itemSelect: function (ev, selected_item) {
                         var value = decodeURIComponent($(selected_item).attr("data-fullpath"));
@@ -164,7 +165,7 @@ define(function (require, exports, module) {
                     },
         
                     keydown: function (e) {
-                        var query = searchField.val();
+                        var query = $searchField.val();
 
                         // close the dialog when the ENTER (23) or ESC (27) key is pressed
                         if ((e.keyCode === 13 && query.charAt(0) === ":") || e.keyCode === 27) {
@@ -184,7 +185,7 @@ define(function (require, exports, module) {
         
                 });
         
-                searchField.focus();
+                $searchField.focus();
             });
 
         return this.result.promise();

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -50,8 +50,8 @@ define(function (require, exports, module) {
     function run() {
         var currentDoc = DocumentManager.getCurrentDocument();
         var ext = currentDoc ? PathUtils.filenameExtension(currentDoc.file.fullPath) : "";
-        var lintResults = $("#jslint-results");
-        var goldStar = $("#gold-star");
+        var $lintResults = $("#jslint-results");
+        var $goldStar = $("#gold-star");
         
         if (getEnabled() && /^(\.js|\.htm|\.html)$/i.test(ext)) {
             var text = currentDoc.getText();
@@ -70,9 +70,9 @@ define(function (require, exports, module) {
             var result = JSLINT(text, null);
             
             if (!result) {
-                var errorTable = $("<table class='zebra-striped condensed-table'>")
+                var $errorTable = $("<table class='zebra-striped condensed-table'>")
                                    .append("<tbody>");
-                var selectedRow;
+                var $selectedRow;
                 
                 JSLINT.errors.forEach(function (item, i) {
                     if (item) {
@@ -81,18 +81,18 @@ define(function (require, exports, module) {
                         };
                         
                         // Add row to error table
-                        var row = $("<tr/>")
+                        var $row = $("<tr/>")
                             .append(makeCell(item.line))
                             .append(makeCell(item.reason))
                             .append(makeCell(item.evidence || ""))
-                            .appendTo(errorTable);
+                            .appendTo($errorTable);
                         
-                        row.click(function () {
-                            if (selectedRow) {
-                                selectedRow.removeClass("selected");
+                        $row.click(function () {
+                            if ($selectedRow) {
+                                $selectedRow.removeClass("selected");
                             }
-                            row.addClass("selected");
-                            selectedRow = row;
+                            $row.addClass("selected");
+                            $selectedRow = $row;
                             
                             var editor = EditorManager.getCurrentFullEditor();
                             editor.setCursorPos(item.line - 1, item.character - 1);
@@ -103,18 +103,18 @@ define(function (require, exports, module) {
 
                 $("#jslint-results .table-container")
                     .empty()
-                    .append(errorTable);
-                lintResults.show();
-                goldStar.hide();
+                    .append($errorTable);
+                $lintResults.show();
+                $goldStar.hide();
             } else {
-                lintResults.hide();
-                goldStar.show();
+                $lintResults.hide();
+                $goldStar.show();
             }
         } else {
             // JSLint is disabled or does not apply to the current file, hide
             // both the results and the gold star
-            lintResults.hide();
-            goldStar.hide();
+            $lintResults.hide();
+            $goldStar.hide();
         }
         
         EditorManager.resizeEditor();

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -84,18 +84,18 @@ define(function (require, exports, module) {
      * @param {bool} canClose
      */
     function _updateFileStatusIcon(listElement, isDirty, canClose) {
-        var fileStatusIcon = listElement.find(".file-status-icon");
+        var $fileStatusIcon = listElement.find(".file-status-icon");
         var showIcon = isDirty || canClose;
 
         // remove icon if its not needed
-        if (!showIcon && fileStatusIcon.length !== 0) {
-            fileStatusIcon.remove();
-            fileStatusIcon = null;
+        if (!showIcon && $fileStatusIcon.length !== 0) {
+            $fileStatusIcon.remove();
+            $fileStatusIcon = null;
             
         // create icon if its needed and doesn't exist
-        } else if (showIcon && fileStatusIcon.length === 0) {
+        } else if (showIcon && $fileStatusIcon.length === 0) {
             
-            fileStatusIcon = $("<div class='file-status-icon'></div>")
+            $fileStatusIcon = $("<div class='file-status-icon'></div>")
                 .prependTo(listElement)
                 .click(function () {
                     // Clicking the "X" button is equivalent to File > Close; it doesn't merely
@@ -106,10 +106,10 @@ define(function (require, exports, module) {
         }
 
         // Set icon's class
-        if (fileStatusIcon) {
+        if ($fileStatusIcon) {
             // cast to Boolean needed because toggleClass() distinguishes true/false from truthy/falsy
-            fileStatusIcon.toggleClass("dirty", Boolean(isDirty));
-            fileStatusIcon.toggleClass("canClose", Boolean(canClose));
+            $fileStatusIcon.toggleClass("dirty", Boolean(isDirty));
+            $fileStatusIcon.toggleClass("canClose", Boolean(canClose));
         }
     }
     
@@ -141,24 +141,24 @@ define(function (require, exports, module) {
         var curDoc = DocumentManager.getCurrentDocument();
 
         // Create new list item with a link
-        var link = $("<a href='#'></a>").text(file.name);
-        var newItem = $("<li></li>")
-            .append(link)
+        var $link = $("<a href='#'></a>").text(file.name);
+        var $newItem = $("<li></li>")
+            .append($link)
             .data(_FILE_KEY, file);
 
-        $openFilesContainer.find("ul").append(newItem);
+        $openFilesContainer.find("ul").append($newItem);
         
         // working set item might never have been opened; if so, then it's definitely not dirty
 
         // Update the listItem's apperance
-        _updateFileStatusIcon(newItem, isOpenAndDirty(file), false);
-        _updateListItemSelection(newItem, curDoc);
+        _updateFileStatusIcon($newItem, isOpenAndDirty(file), false);
+        _updateListItemSelection($newItem, curDoc);
 
-        newItem.click(function () {
+        $newItem.click(function () {
             FileViewController.openAndSelectDocument(file.fullPath, FileViewController.WORKING_SET_VIEW);
         });
 
-        newItem.hover(
+        $newItem.hover(
             function () {
                 _updateFileStatusIcon($(this), isOpenAndDirty(file), true);
             },
@@ -230,9 +230,9 @@ define(function (require, exports, module) {
         if (file) {
             var items = $openFilesContainer.find("ul").children();
             items.each(function () {
-                var listItem = $(this);
-                if (listItem.data(_FILE_KEY).fullPath === file.fullPath) {
-                    result = listItem;
+                var $listItem = $(this);
+                if ($listItem.data(_FILE_KEY).fullPath === file.fullPath) {
+                    result = $listItem;
                     return false;
                     // breaks each
                 }
@@ -247,9 +247,9 @@ define(function (require, exports, module) {
      * @param {FileEntry} file 
      */
     function _handleFileRemoved(file) {
-        var listItem = _findListItemFromFile(file);
-        if (listItem) {
-            listItem.remove();
+        var $listItem = _findListItemFromFile(file);
+        if ($listItem) {
+            $listItem.remove();
         }
 
         _updateOpenFilesContainer();

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -67,6 +67,7 @@ define(function (require, exports, module) {
     * Creates a dialog div floating on top of the current code mirror editor
     */
     FindInFilesDialog.prototype._createDialogDiv = function (template) {
+        // FUTURE: consider using jQuery for all the DOM manipulation here
         var wrap = $("#editorHolder")[0];
         this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
@@ -96,18 +97,18 @@ define(function (require, exports, module) {
         var dialogHTML = 'Find in Files: <input type="text" id="findInFilesInput" style="width: 10em"> <span style="color: #888">(Use /re/ syntax for regexp search)</span>';
         this.result = new $.Deferred();
         this._createDialogDiv(dialogHTML);
-        var searchField = $('input#findInFilesInput');
+        var $searchField = $('input#findInFilesInput');
         var that = this;
         
-        searchField.attr("value", initialString || "");
-        searchField.get(0).select();
+        $searchField.attr("value", initialString || "");
+        $searchField.get(0).select();
         
-        searchField.bind("keydown", function (event) {
+        $searchField.bind("keydown", function (event) {
             if (event.keyCode === 13 || event.keyCode === 27) {  // Enter/Return key or Esc key
                 event.stopPropagation();
                 event.preventDefault();
                 
-                var query = searchField.val();
+                var query = $searchField.val();
                 
                 if (event.keyCode === 27) {
                     query = null;
@@ -169,7 +170,7 @@ define(function (require, exports, module) {
         var $searchResultsDiv = $("#search-results");
         
         if (searchResults && searchResults.length) {
-            var resultTable = $("<table class='zebra-striped condensed-table'>")
+            var $resultTable = $("<table class='zebra-striped condensed-table'>")
                                 .append("<tbody>");
             
             // Count the total number of matches
@@ -205,18 +206,18 @@ define(function (require, exports, module) {
                     // Add row for file name
                     $("<tr/>")
                         .append("<td colspan='3'>File: <b>" + item.fullPath + "</b></td>")
-                        .appendTo(resultTable);
+                        .appendTo($resultTable);
                     
                     // Add row for each match in file
                     item.matches.forEach(function (match) {
                         if (resultsDisplayed < 100) {
-                            var row = $("<tr/>")
+                            var $row = $("<tr/>")
                                 .append(makeCell(" "))      // Indent
                                 .append(makeCell("line: " + (match.start.line + 1)))
                                 .append(makeCell(highlightMatch(match.line, match.start.ch, match.end.ch)))
-                                .appendTo(resultTable);
+                                .appendTo($resultTable);
                             
-                            row.click(function () {
+                            $row.click(function () {
                                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: item.fullPath})
                                     .done(function (doc) {
                                         // Opened document is now the current main editor
@@ -232,7 +233,7 @@ define(function (require, exports, module) {
             
             $("#search-results .table-container")
                 .empty()
-                .append(resultTable);
+                .append($resultTable);
             
             $("#search-results .close")
                 .one("click", function () {

--- a/src/search/QuickFileOpen.js
+++ b/src/search/QuickFileOpen.js
@@ -62,6 +62,7 @@ define(function (require, exports, module) {
     * Creates a dialog div floating on top of the current code mirror editor
     */
     QuickNavigateDialog.prototype._createDialogDiv = function (template) {
+        // FUTURE: consider using jQuery for all the DOM manipulation here
         var wrap = $("#editorHolder")[0];
         this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
@@ -105,10 +106,10 @@ define(function (require, exports, module) {
                 var dialogHTML = 'Quick Open: <input type="text" autocomplete="off" id="quickFileOpenSearch" style="width: 30em">';
                 that._createDialogDiv(dialogHTML);
                 var closed = false;
-                var searchField = $('input#quickFileOpenSearch');
+                var $searchField = $('input#quickFileOpenSearch');
                 
-                searchField.attr("value", initialString || "");
-                searchField.get(0).select();
+                $searchField.attr("value", initialString || "");
+                $searchField.get(0).select();
 
                 // auto suggest list helper function
                 function _handleResultsFormatter(path) {
@@ -147,7 +148,7 @@ define(function (require, exports, module) {
                 }
 
                 // Create the auto suggest list of filenames
-                searchField.smartAutoComplete({
+                $searchField.smartAutoComplete({
                     source: fileInfoList,
                     maxResults: 10,
                     forceSelect: false,
@@ -156,7 +157,7 @@ define(function (require, exports, module) {
                     resultFormatter: _handleResultsFormatter
                 });
         
-                searchField.bind({
+                $searchField.bind({
                     // close the dialog when the user selects an item
                     itemSelect: function (ev, selected_item) {
                         var value = decodeURIComponent($(selected_item).attr("data-fullpath"));
@@ -164,7 +165,7 @@ define(function (require, exports, module) {
                     },
         
                     keydown: function (e) {
-                        var query = searchField.val();
+                        var query = $searchField.val();
 
                         // close the dialog when the ENTER (23) or ESC (27) key is pressed
                         if ((e.keyCode === 13 && query.charAt(0) === ":") || e.keyCode === 27) {
@@ -184,7 +185,7 @@ define(function (require, exports, module) {
         
                 });
         
-                searchField.focus();
+                $searchField.focus();
             });
 
         return this.result.promise();

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -123,29 +123,29 @@ define(function (require, exports, module) {
         // type happen to show up, they can appear at the same time. (This is an edge case that
         // shouldn't happen often, but we can't prevent it from happening since everything is
         // asynchronous.)
-        var dlg = $("." + dlgClass + ".template")
+        var $dlg = $("." + dlgClass + ".template")
             .clone()
             .removeClass("template")
             .addClass("instance")
             .appendTo(window.document.body);
         
-        if (dlg.length === 0) {
+        if ($dlg.length === 0) {
             throw new Error("Dialog id " + dlgClass + " does not exist");
         }
 
         // Set title and message
         if (title) {
-            $(".dialog-title", dlg).html(title);
+            $(".dialog-title", $dlg).html(title);
         }
         if (message) {
-            $(".dialog-message", dlg).html(message);
+            $(".dialog-message", $dlg).html(message);
         }
 
-        var handleKeyDown = _handleKeyDown.bind(dlg);
+        var handleKeyDown = _handleKeyDown.bind($dlg);
 
         // Pipe dialog-closing notification back to client code
-        dlg.one("hidden", function () {
-            var buttonId = dlg.data("buttonId");
+        $dlg.one("hidden", function () {
+            var buttonId = $dlg.data("buttonId");
             if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
                 buttonId = DIALOG_BTN_CANCEL;
             }
@@ -158,14 +158,14 @@ define(function (require, exports, module) {
             }, 0);
             
             // Remove the dialog instance from the DOM.
-            dlg.remove();
+            $dlg.remove();
 
             // Remove keydown event handler
             window.document.body.removeEventListener("keydown", handleKeyDown, true);
             KeyBindingManager.setEnabled(true);
         }).one("shown", function () {
             // Set focus to the default button
-            var primaryBtn = dlg.find(".primary");
+            var primaryBtn = $dlg.find(".primary");
 
             if (primaryBtn) {
                 primaryBtn.focus();
@@ -177,12 +177,12 @@ define(function (require, exports, module) {
         });
         
         // Click handler for buttons
-        dlg.one("click", ".dialog-button", function (e) {
-            _dismissDialog(dlg, $(this).attr("data-button-id"));
+        $dlg.one("click", ".dialog-button", function (e) {
+            _dismissDialog($dlg, $(this).attr("data-button-id"));
         });
 
         // Run the dialog
-        dlg.modal({
+        $dlg.modal({
             backdrop: "static",
             show: true,
             keyboard: true

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -95,10 +95,10 @@ define(function (require, exports, module) {
         it("should add a list item when a file is dirtied", function () {
             // check if files are added to work set and dirty icons are present
             runs(function () {
-                var listItems = testWindow.$("#open-files-container > ul").children();
-                expect(listItems.length).toBe(2);
-                expect(listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
-                expect(listItems.find(".file-status-icon").length).toBe(2);
+                var $listItems = testWindow.$("#open-files-container > ul").children();
+                expect($listItems.length).toBe(2);
+                expect($listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
+                expect($listItems.find(".file-status-icon").length).toBe(2);
             });
         });
         
@@ -127,9 +127,9 @@ define(function (require, exports, module) {
                 var secondItem =  $($("#open-files-container > ul").children()[1]);
                 secondItem.trigger('click');
                 
-                var listItems = $("#open-files-container > ul").children();
-                expect($(listItems[0]).hasClass("selected")).not.toBeTruthy();
-                expect($(listItems[1]).hasClass("selected")).toBeTruthy();
+                var $listItems = $("#open-files-container > ul").children();
+                expect($($listItems[0]).hasClass("selected")).not.toBeTruthy();
+                expect($($listItems[1]).hasClass("selected")).toBeTruthy();
             });
         });
         
@@ -153,28 +153,28 @@ define(function (require, exports, module) {
                 testWindow = w;
             });
             
-            var listItems;
+            var $listItems;
             
             // wait for working set to populate
             waitsFor(
                 function () {
                     // check working set UI list content
-                    listItems = testWindow.$("#open-files-container > ul").children();
-                    return listItems.length > 0;
+                    $listItems = testWindow.$("#open-files-container > ul").children();
+                    return $listItems.length > 0;
                 },
                 1000
             );
 
             // files should be in the working set
             runs(function () {
-                expect(listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
-                expect(listItems.find("a").get(1).text === "file_two.js").toBeTruthy();
+                expect($listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
+                expect($listItems.find("a").get(1).text === "file_two.js").toBeTruthy();
 
                 // files should be clean
-                expect(listItems.find(".file-status-icon dirty").length).toBe(0);
+                expect($listItems.find(".file-status-icon dirty").length).toBe(0);
 
                 // file_two.js should be active
-                expect($(listItems[1]).hasClass("selected")).toBeTruthy();
+                expect($($listItems[1]).hasClass("selected")).toBeTruthy();
             });
         });
         
@@ -210,9 +210,9 @@ define(function (require, exports, module) {
             waitsFor(function () { return didClose; }, "click on working set close icon timeout", 1000);
                             
             runs(function () {
-                var listItems = $("#open-files-container > ul").children();
-                expect(listItems.length).toBe(1);
-                expect(listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
+                var $listItems = $("#open-files-container > ul").children();
+                expect($listItems.length).toBe(1);
+                expect($listItems.find("a").get(0).text === "file_one.js").toBeTruthy();
             });
         });
         


### PR DESCRIPTION
Fixes #421.

In most cases this was straightforward. In a couple of places the variable didn't seem necessary since it wasn't used later; in other cases I replaced it with a chained call.

I also noticed some duplicated code in various places that create a semi-modal dialog similar to the Find UI. I added a comment but left them alone since I know we'll be refactoring that eventually.

To find all the places where this might apply, I did a Find in Files for "= $(". In a few places this was a red herring, because the expression ended up calling a method that returned something other than a jQuery object, but in most cases it was something that needed to be replaced. It's possible that this missed some cases, so if we see more cases in the future we should fix them opportunistically.

Unit tests pass and I did some light sanity testing. Everything looks ok.
