### PR TITLE
Cleaning up the loop within 'removeInlineWidgetInternal'.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -824,7 +824,9 @@ define(function (require, exports, module) {
      * @param {number} inlineId  id returned by addInlineWidget().
      */
     Editor.prototype._removeInlineWidgetInternal = function (inlineId) {
-        for(var i = 0; i < this._inlineWidgets.length; i++) {
+        var i;
+        var l = this._inlineWidgets.length;
+        for (i = 0; i < l; i++) {
             if (this._inlineWidgets[i].id === inlineId) {
                 this._inlineWidgets.splice(i, 1);
                 break;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -824,8 +824,7 @@ define(function (require, exports, module) {
      * @param {number} inlineId  id returned by addInlineWidget().
      */
     Editor.prototype._removeInlineWidgetInternal = function (inlineId) {
-        var l = this._inlineWidgets.length;
-        for (var i = 0; i < l; i++) {
+        for(var i = 0; i < this._inlineWidgets.length; i++) {
             if (this._inlineWidgets[i].id === inlineId) {
                 this._inlineWidgets.splice(i, 1);
                 break;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -824,8 +824,8 @@ define(function (require, exports, module) {
      * @param {number} inlineId  id returned by addInlineWidget().
      */
     Editor.prototype._removeInlineWidgetInternal = function (inlineId) {
-        var i;
-        for (i = 0; i < this._inlineWidgets.length; i++) {
+        var l = this._inlineWidgets.length;
+        for (var i = 0; i < l; i++) {
             if (this._inlineWidgets[i].id === inlineId) {
                 this._inlineWidgets.splice(i, 1);
                 break;


### PR DESCRIPTION
Moving length check of the widget list to outside of the loop to speed up iteration duration.
