### PR TITLE
Adding a couple experimental extensions

### DIFF
--- a/src/extensions/disabled/InlineImageViewer/InlineImageViewer.js
+++ b/src/extensions/disabled/InlineImageViewer/InlineImageViewer.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets, $, window */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Load Brackets modules
+    var InlineWidget        = brackets.getModule("editor/InlineWidget").InlineWidget;
+    
+    function InlineImageViewer(fileName, fullPath) {
+        this.fileName = fileName;
+        this.fullPath = fullPath;
+        InlineWidget.call(this);
+    }
+    InlineImageViewer.prototype = new InlineWidget();
+    InlineImageViewer.prototype.constructor = InlineImageViewer;
+    InlineImageViewer.prototype.parentClass = InlineWidget.prototype;
+    
+    InlineImageViewer.prototype.fileName = null;
+    InlineImageViewer.prototype.fullPath = null;
+    InlineImageViewer.prototype.$wrapperDiv = null;
+    InlineImageViewer.prototype.$image = null;
+    
+    InlineImageViewer.prototype.load = function (hostEditor) {
+        this.parentClass.load.call(this, hostEditor);
+            
+        // Header
+        var $filenameDiv = $("<div/>")
+            .addClass("filename")
+            .append($("<span></span>").text(this.fileName));
+
+        // Image
+        this.$image = $("<img/>")
+            .css("display", "block")
+            .css("margin", "20px auto")
+            .css("opacity", 0)
+            .attr("src", this.fullPath);
+         
+        // Wrapper
+        this.$wrapperDiv = $("<div/>")
+            .append($filenameDiv)
+            .append(this.$image);
+        
+        this.$htmlContent.append(this.$wrapperDiv);
+        this.$htmlContent.click(this.close.bind(this));
+    };
+
+    InlineImageViewer.prototype.close = function () {
+        this.hostEditor.removeInlineWidget(this);
+    };
+    
+    InlineImageViewer.prototype.onAdded = function () {
+        window.setTimeout(this._sizeEditorToContent.bind(this));
+    };
+    
+    InlineImageViewer.prototype._sizeEditorToContent = function () {
+        this.hostEditor.setInlineWidgetHeight(this, this.$wrapperDiv.height() + 20, true);
+        this.$image.css("opacity", 1);
+    };
+    
+    module.exports = InlineImageViewer;
+});

--- a/src/extensions/disabled/InlineImageViewer/main.js
+++ b/src/extensions/disabled/InlineImageViewer/main.js
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
         }
         
         // Check for valid file extensions
-        if (!/(.png|.jpg|.jpeg|.svg)$/i.test(fileName)) {
+        if (!/(.png|.jpg|.jpeg|.gif|.svg)$/i.test(fileName)) {
             return null;
         }
 

--- a/src/extensions/disabled/InlineImageViewer/main.js
+++ b/src/extensions/disabled/InlineImageViewer/main.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, brackets, $ */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Brackets modules
+    var EditorManager           = brackets.getModule("editor/EditorManager"),
+        ProjectManager          = brackets.getModule("project/ProjectManager");
+    
+    // Local modules
+    var InlineImageViewer       = require("InlineImageViewer");
+    
+    /**
+     * Return the token string that is at the specified position.
+     *
+     * @param hostEditor {!Editor} editor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {String} token string at the specified position
+     */
+    function _getStringAtPos(hostEditor, pos) {
+        var token = hostEditor._codeMirror.getTokenAt(pos);
+        
+        // If the pos is at the beginning of a name, token will be the 
+        // preceding whitespace or dot. In that case, try the next pos.
+        if (token.string.trim().length === 0 || token.string === ".") {
+            token = hostEditor._codeMirror.getTokenAt({line: pos.line, ch: pos.ch + 1});
+        }
+        
+        if (token.className === "string") {
+            var string = token.string;
+            
+            // Strip quotes
+            if (string[0] === "\"") {
+                string = string.substr(1);
+            }
+            if (string[string.length - 1] === "\"") {
+                string = string.substr(0, string.length - 1);
+            }
+            
+            return string;
+        }
+        
+        return "";
+    }
+    
+    /**
+     * This function is registered with EditManager as an inline editor provider. It creates an inline editor
+     * when cursor is on a JavaScript function name, find all functions that match the name
+     * and show (one/all of them) in an inline editor.
+     *
+     * @param {!Editor} editor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {$.Promise} a promise that will be resolved with an InlineWidget
+     *      or null if we're not going to provide anything.
+     */
+    function inlineImageViewerProvider(hostEditor, pos) {
+        
+        // Only provide image viewer if the selection is within a single line
+        var sel = hostEditor.getSelection(false);
+        if (sel.start.line !== sel.end.line) {
+            return null;
+        }
+        
+        // Always use the selection start for determining the image file name. The pos
+        // parameter is usually the selection end.        
+        var fileName = _getStringAtPos(hostEditor, hostEditor.getSelection(false).start);
+        if (fileName === "") {
+            return null;
+        }
+        
+        // Check for valid file extensions
+        if (!/(.png|.jpg|.jpeg|.svg)$/i.test(fileName)) {
+            return null;
+        }
+
+        // TODO: Check for relative path
+        var fullPath = ProjectManager.getProjectRoot().fullPath + fileName;
+        var result = new $.Deferred();
+
+        var imageViewer = new InlineImageViewer(fileName, fullPath);
+        imageViewer.load(hostEditor);
+        
+        result.resolve(imageViewer);
+        
+        return result.promise();
+    }
+
+    EditorManager.registerInlineEditProvider(inlineImageViewerProvider);
+});

--- a/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, PathUtils */
+
+/**
+ * Set of utilities for simple parsing of JS text.
+ */
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Load brackets modules
+    var Async               = brackets.getModule("utils/Async"),
+        DocumentManager     = brackets.getModule("document/DocumentManager"),
+        FileIndexManager    = brackets.getModule("project/FileIndexManager"),
+        NativeFileSystem    = brackets.getModule("file/NativeFileSystem").NativeFileSystem;
+    
+    // Return an Array with names and offsets for all functions in the specified text
+    function _findAllFunctionsInText(text) {
+        var result = [];
+        var regexA = new RegExp(/(function\b)(.+)\b\(.*?\)/gi);  // recognizes the form: function functionName()
+        var regexB = new RegExp(/(\w+)\s*=\s*function\s*(\(.*?\))/gi); // recognizes the form: functionName = function()
+        var regexC = new RegExp(/((\w+)\s*:\s*function\s*\(.*?\))/gi); // recognizes the form: functionName: function()
+        var match;
+        
+        while ((match = regexA.exec(text)) !== null) {
+            result.push({
+                functionName: match[2].trim(),
+                offset: match.index
+            });
+        }
+        
+        while ((match = regexB.exec(text)) !== null) {
+            result.push({
+                functionName: match[1].trim(),
+                offset: match.index
+            });
+        }
+        
+        while ((match = regexC.exec(text)) !== null) {
+            result.push({
+                functionName: match[2].trim(),
+                offset: match.index
+            });
+        }
+        
+        return result;
+    }
+    
+    // Simple scanner to determine the end offset for the function (the closing "}") 
+    function _getFunctionEndOffset(text, offsetStart) {
+        var curOffset = text.indexOf("{", offsetStart) + 1;
+        var length = text.length;
+        var blockCount = 1;
+        
+        // Brute force scan to look for closing curly match
+        // NOTE: This does *not* handle comments.
+        while (curOffset < length) {
+            if (text[curOffset] === "{") {
+                blockCount++;
+            } else if (text[curOffset] === "}") {
+                blockCount--;
+            }
+            
+            curOffset++;
+            
+            if (blockCount <= 0) {
+                return curOffset;
+            }
+        }
+        
+        // Shouldn't get here, but if we do, return the end of the text as the offset
+        return length;
+    }
+    
+    function _offsetToLineNum(text, offset) {
+        return text.substr(0, offset).split("\n").length - 1;
+    }
+    
+    // Search function list for a specific function. If found, extract info about the function
+    // (line start, line end, etc.) and return.
+    function _findAllMatchingFunctions(fileInfo, functions, functionName) {
+        var result = new $.Deferred();
+        var foundMatch = false;
+        
+        functions.forEach(function (funcEntry) {
+            if (funcEntry.functionName === functionName) {
+                var matchingFunctions = [];
+                
+                DocumentManager.getDocumentForPath(fileInfo.fullPath)
+                    .done(function (doc) {
+                        var text = doc.getText();
+                        
+                        functions.forEach(function (funcEntry) {
+                            if (funcEntry.functionName === functionName) {
+                                var endOffset = _getFunctionEndOffset(text, funcEntry.offset);
+                                matchingFunctions.push({
+                                    document: doc,
+                                    name: funcEntry.functionName,
+                                    lineStart: _offsetToLineNum(text, funcEntry.offset),
+                                    lineEnd: _offsetToLineNum(text, endOffset)
+                                });
+                            }
+                        });
+                        
+                        result.resolve(matchingFunctions);
+                    })
+                    .fail(function (error) {
+                        result.reject(error);
+                    });
+            }
+        });
+        
+        if (!foundMatch) {
+            result.resolve([]);
+        }
+        
+        return result.promise();
+    }
+    
+    // Read a file and build a function list. Result is cached in fileInfo.
+    function _readFileAndGetFunctionList(fileInfo, result) {
+        
+        DocumentManager.getDocumentForPath(fileInfo.fullPath)
+            .done(function (doc) {
+                var allFunctions = _findAllFunctionsInText(doc.getText());
+                
+                // Cache the result in the fileInfo object
+                fileInfo.JSUtils = {};
+                fileInfo.JSUtils.functions = allFunctions;
+                fileInfo.JSUtils.timestamp = doc.diskTimestamp;
+                
+                result.resolve(allFunctions);
+            })
+            .fail(function (error) {
+                result.reject(error);
+            });
+    }
+    
+    // Resolves with an Array of all function names and offsets for the specified file. Results
+    // may be cached.
+    function _getFunctionListForFile(fileInfo) {
+        var result = new $.Deferred();
+        var needToRead = false;
+        
+        // Always read if we have no cached data
+        if (!fileInfo.JSUtils) {
+            needToRead = true;
+        }
+        
+        // If the document is dirty, we need to read it
+        if (!needToRead) {
+            var openDocs = DocumentManager.getAllOpenDocuments();
+            openDocs.forEach(function (doc) {
+                if (doc.file.fullPath === fileInfo.fullPath && doc.isDirty) {
+                    needToRead = true;
+                }
+            });
+        }
+        
+        // Finally, see if we have missing or stale cache data
+        if (!needToRead) {
+            var file = new NativeFileSystem.FileEntry(fileInfo.fullPath);
+            
+            file.getMetadata(
+                function (metadata) {
+                    if (fileInfo.JSUtils.timestamp !== metadata.diskTimestamp) {
+                        _readFileAndGetFunctionList(fileInfo, result);
+                    } else {
+                        // Return cached data 
+                        result.resolve(fileInfo.JSUtils.functions);
+                    }
+                },
+                function (error) {
+                    result.reject(error);
+                }
+            );
+        } else {
+            _readFileAndGetFunctionList(fileInfo, result);
+        }
+                        
+        return result.promise();
+    }
+        
+    // Search for all matching functions in a file
+    function _getMatchingFunctionsInFile(fileInfo, functionName, resultFunctions) {
+        var oneFileResult = new $.Deferred();
+        var fullPath = fileInfo.fullPath;
+        
+        // Only scan JS files
+        var ext = PathUtils.filenameExtension(fullPath);
+        
+        if (!/^\.js/i.test(ext)) {
+            oneFileResult.resolve();
+            return oneFileResult.promise();
+        }
+        
+        _getFunctionListForFile(fileInfo)
+            .done(function (functionList) {
+                _findAllMatchingFunctions(fileInfo, functionList, functionName)
+                    .done(function (matches) {
+                        matches.forEach(function (functionInfo) {
+                            resultFunctions.push(functionInfo);
+                        });
+                        oneFileResult.resolve();
+                    })
+                    .fail(function (error) {
+                        oneFileResult.reject(error);
+                    });
+            })
+            .fail(function (error) {
+                oneFileResult.reject(error);
+            });
+        
+    
+        return oneFileResult.promise();
+    }
+    
+    /**
+     * Return all functions that have the specified name.
+     *
+     * @param {!String} functionName The name to match. 
+     * @return {$.Promise} that will be resolved with an Array of objects containing the
+     *      source document, start line, and end line (0-based, inclusive range) for each matching function list.
+     *      Does not addRef() the documents returned in the array.
+     */
+    function findMatchingFunctions(functionName) {
+        var result          = new $.Deferred(),
+            resultFunctions = [],
+            jsFilesResult   = FileIndexManager.getFileInfoList("all");
+        
+        // Load index of all CSS files; then process each CSS file in turn (see above)
+        jsFilesResult.done(function (fileInfos) {
+            Async.doInParallel(fileInfos, function (fileInfo, number) {
+                return _getMatchingFunctionsInFile(fileInfo, functionName, resultFunctions);
+            })
+                .done(function () {
+                    result.resolve(resultFunctions);
+                })
+                .fail(function (error) {
+                    result.reject(error);
+                });
+        });
+        
+        return result.promise();
+    }
+    
+    exports.findMatchingFunctions = findMatchingFunctions;
+});

--- a/src/extensions/disabled/JavaScriptInlineEditor/main.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/main.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets, $ */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Brackets modules
+    var MultiRangeInlineEditor  = brackets.getModule("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
+        EditorManager           = brackets.getModule("editor/EditorManager");
+    
+    // Local modules
+    var JSUtils         = require("JSUtils");
+    
+    /**
+     * Return the token string that is at the specified position.
+     *
+     * @param hostEditor {!Editor} editor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {String} token string at the specified position
+     */
+    function _getFunctionName(hostEditor, pos) {
+        var token = hostEditor._codeMirror.getTokenAt(pos);
+        
+        // If the pos is at the beginning of a name, token will be the 
+        // preceding whitespace or dot. In that case, try the next pos.
+        if (token.string.trim().length === 0 || token.string === ".") {
+            token = hostEditor._codeMirror.getTokenAt({line: pos.line, ch: pos.ch + 1});
+        }
+        
+        return token.string;
+    }
+    
+    /**
+     * This function is registered with EditManager as an inline editor provider. It creates an inline editor
+     * when cursor is on a JavaScript function name, find all functions that match the name
+     * and show (one/all of them) in an inline editor.
+     *
+     * @param {!Editor} editor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {$.Promise} a promise that will be resolved with an InlineWidget
+     *      or null if we're not going to provide anything.
+     */
+    function javaScriptFunctionProvider(hostEditor, pos) {
+        // Only provide a JavaScript editor when cursor is in JavaScript content
+        if (hostEditor._codeMirror.getOption("mode") !== "javascript") {
+            return null;
+        }
+        
+        // Only provide JavaScript editor if the selection is within a single line
+        var sel = hostEditor.getSelection(false);
+        if (sel.start.line !== sel.end.line) {
+            return null;
+        }
+        
+        // Always use the selection start for determining the function name. The pos
+        // parameter is usually the selection end.        
+        var functionName = _getFunctionName(hostEditor, hostEditor.getSelection(false).start);
+        if (functionName === "") {
+            return null;
+        }
+
+        var result = new $.Deferred();
+
+        JSUtils.findMatchingFunctions(functionName)
+            .done(function (functions) {
+                if (functions && functions.length > 0) {
+                    var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                    jsInlineEditor.load(hostEditor);
+                    
+                    result.resolve(jsInlineEditor);
+                } else {
+                    // No matching functions were found
+                    result.reject();
+                }
+            })
+            .fail(function () {
+                result.reject();
+            });
+        
+        return result.promise();
+    }
+
+    EditorManager.registerInlineEditProvider(javaScriptFunctionProvider);
+});


### PR DESCRIPTION
These extensions are early experiments and are **not** full featured (although they are pretty useful as-is...)
# Inline Editor for JavaScript functions

When in a JavaScript file, put the cursor (or selection) on a function name and press Cmd/Ctrl-E. If the function can be found it is displayed in an inline editor. If multiple functions with the same name are found, they can be navigated in the same way that multiple CSS rules can be navigated.

This extension searches **all** JavaScript files in your project, regardless of whether they are used or not.

Note: performance can be pretty slow, especially if you have lots of JavaScript files in your project.
# Inline Image Viewer

If the cursor (or selection) is in a string that is an image filename (basically any string that ends with .jpg, .jpeg, .png, .gif, or .svg), the image is displayed in an inline widget.

Click anywhere on the inline widget to close it.
# How to enable

These extensions are being checked in to the `extensions/disabled` directory, which means they are _not_ enabled by default. To use them, copy the folder to the `extentions/user` directory (the `extensions/user` directory is ignored by git, so copying the extensions there won't affect your git working directory)
