### PR TITLE
Fix bug #755 (Hard to quit Brackets if unsaved file deleted/renamed on disk)

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -429,14 +429,9 @@ define(function (require, exports, module) {
      *      FUTURE: should we reject the promise if no file is open?
      */
     function handleFileClose(commandData) {
-        var file = null;
-        if (commandData) {
-            file = commandData.file;
-        }
-        var promptOnly = false;
-        if (commandData) {
-            promptOnly = commandData.promptOnly;
-        }
+        // If not specified, file defaults to null; promptOnly defaults to falsy
+        var file       = commandData && commandData.file,
+            promptOnly = commandData && commandData.promptOnly;
         
         // utility function for handleFileClose: closes document & removes from working set
         function doClose(file) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -433,10 +433,14 @@ define(function (require, exports, module) {
         if (commandData) {
             file = commandData.file;
         }
+        var promptOnly = false;
+        if (commandData) {
+            promptOnly = commandData.promptOnly;
+        }
         
         // utility function for handleFileClose: closes document & removes from working set
         function doClose(file) {
-            if (!commandData || !commandData.promptOnly) {
+            if (!promptOnly) {
                 // This selects a different document if the working set has any other options
                 DocumentManager.closeFullEditor(file);
             
@@ -489,8 +493,9 @@ define(function (require, exports, module) {
                     // copy of whatever's on disk.
                     doClose(file);
                     
-                    // Only reload from disk if other views still exist
-                    if (DocumentManager.getOpenDocumentForPath(file.fullPath)) {
+                    // Only reload from disk if we've executed the Close for real,
+                    // *and* if at least one other view still exists
+                    if (!promptOnly && DocumentManager.getOpenDocumentForPath(file.fullPath)) {
                         doRevert(doc)
                             .pipe(result.resolve, result.reject);
                     } else {


### PR DESCRIPTION
Fix bug #755 (Unable to quit Brackets while discarding unsaved changes, if unsaved file was deleted/renamed on disk) -- If we're in "promptOnly" mode we're not actually closing the file, so we shouldn't try to reload its contents from disk.

This bug afflicted several cases: quit/window-close, reload, and switching folders. (Switching folders is especially key, because you should be able to cancel the subsequent folder picker and remain on the old folder without all your files now being closed/reverted).
