### PR TITLE
Prevent re-entrancy into handleFileNewInProject(), fixes issue #738

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -258,17 +258,18 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Prevent re-entrancy into handleFileNewInProject()
+     * Prevents re-entrancy into handleFileNewInProject()
      *
      * handleFileNewInProject() first prompts the user to name a file and then asynchronously writes the file when the
      * filename field loses focus. This boolean prevent additional calls to handleFileNewInProject() when an existing
      * file creation call is outstanding
      */
     var fileNewInProgress = false;
+
     function handleFileNewInProject() {
 
         if (fileNewInProgress) {
-            ProjectManager.closeRenameInput();
+            ProjectManager.forceFinishRename();
             return;
         }
         fileNewInProgress = true;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -260,18 +260,18 @@ define(function (require, exports, module) {
     /**
      * Prevent re-entrancy into handleFileNewInProject()
      *
-     * handleFileNewInProject() first prompts users to name a file and then asynchronously writes the file when the
-     * file name field loses focus. This boolean prevent additional calls to handleFileNewInProject() when an exist
+     * handleFileNewInProject() first prompts the user to name a file and then asynchronously writes the file when the
+     * filename field loses focus. This boolean prevent additional calls to handleFileNewInProject() when an existing
      * file creation call is outstanding
      */
-    var isCreatingNewFile = false;
+    var fileNewInProgress = false;
     function handleFileNewInProject() {
 
-        if (isCreatingNewFile) {
+        if (fileNewInProgress) {
             ProjectManager.closeRenameInput();
             return;
         }
-        isCreatingNewFile = true;
+        fileNewInProgress = true;
 
         // Determine the directory to put the new file
         // If a file is currently selected, put it next to it.
@@ -291,7 +291,7 @@ define(function (require, exports, module) {
         var createWithSuggestedName = function (suggestedName) {
             ProjectManager.createNewItem(baseDir, suggestedName, false)
                 .pipe(deferred.resolve, deferred.reject, deferred.notify)
-                .always(function () { isCreatingNewFile = false; });
+                .always(function () { fileNewInProgress = false; });
         };
 
         deferred.done(createWithSuggestedName);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -782,7 +782,7 @@ define(function (require, exports, module) {
      * Forces createNewItem() to complete by removing focus from the rename field which causes
      * the new file to be written to disk
      */
-    function closeRenameInput() {
+    function forceFinishRename() {
         $(".jstree-rename-input").blur();
     }
 
@@ -794,7 +794,7 @@ define(function (require, exports, module) {
     exports.loadProject     = loadProject;
     exports.getSelectedItem = getSelectedItem;
     exports.createNewItem   = createNewItem;
-    exports.closeRenameInput = closeRenameInput;
+    exports.forceFinishRename = forceFinishRename;
 
     // Initialize now
     (function () {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -778,6 +778,14 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
+    /**
+     * Forces createNewItem() to complete by removing focus from the rename field which causes
+     * the new file to be written to disk
+     */
+    function closeRenameInput() {
+        $(".jstree-rename-input").blur();
+    }
+
     // Define public API
     exports.getProjectRoot  = getProjectRoot;
     exports.isWithinProject = isWithinProject;
@@ -786,6 +794,7 @@ define(function (require, exports, module) {
     exports.loadProject     = loadProject;
     exports.getSelectedItem = getSelectedItem;
     exports.createNewItem   = createNewItem;
+    exports.closeRenameInput = closeRenameInput;
 
     // Initialize now
     (function () {


### PR DESCRIPTION
handleFileNewInProject() initiates a two step process where the user is first prompted to name a file and then it is written asynchronously to disk. This process must complete before a new file is generated. This change prevents reentrancy and also closes the rename field when the user chooses "new file" during a rename.

I earlier tried a fancier approach that queue up user requests for new files. This got overly complex plus in the future "new file" is likely to create a new in-memory file rather than one on disk. In which case this code will change.

Fixes issue #738
