### PR TITLE
Set horizontal scrolling region based on visible lines in inline editor

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -50,7 +50,11 @@
  *    - lostContent -- When the backing Document changes in such a way that this Editor is no longer
  *          able to display accurate text. This occurs if the Document's file is deleted, or in certain
  *          Document->editor syncing edge cases that we do not yet support (the latter cause will
- *          eventually go away). 
+ *          eventually go away).
+ *    - desiredWidthChange -- When the maximum width of the longest line in the currently visible content
+ *          changes. Note that this is only dispatched if the editor is restricted to a specific visible
+ *          range (by passing a range argument to the constructor). The desired width can be retrieved
+ *          using getDesiredWidth().
  *
  * The Editor also dispatches "change" events internally, but you should listen for those on
  * Documents, not Editors.
@@ -495,6 +499,20 @@ define(function (require, exports, module) {
         }
     };
     
+    Editor.prototype._checkMaxWidth = function () {
+        var oldWidth;
+                        
+        // Whenever the document is being changed (even if it's due to our own editor), check if we
+        // need to update the maximum line width.
+        if (this._visibleRange) {
+            oldWidth = this._maxWidthInfo ? this._maxWidthInfo.width : -1;
+            this._recomputeMaxWidth();
+            if (this._maxWidthInfo.width !== oldWidth) {
+                $(this).triggerHandler("desiredWidthChange");
+            }
+        }
+    };
+    
     /**
      * Responds to changes in the CodeMirror editor's text, syncing the changes to the Document.
      * There are several cases where we want to ignore a CodeMirror change:
@@ -508,6 +526,8 @@ define(function (require, exports, module) {
         if (this._duringSync) {
             return;
         }
+        
+        this._checkMaxWidth();
         
         // Secondary editor: force creation of "master" editor backing the model, if doesn't exist yet
         if (!this.document._masterEditor) {
@@ -550,8 +570,6 @@ define(function (require, exports, module) {
      *    the document an editor change that originated with us
      */
     Editor.prototype._handleDocumentChange = function (event, doc, changeList) {
-        var change;
-        
         // we're currently syncing to the Document, so don't echo back FROM the Document
         if (this._duringSync) {
             return;
@@ -565,6 +583,8 @@ define(function (require, exports, module) {
             this._duringSync = true;
             this._applyChanges(changeList);
             this._duringSync = false;
+
+            this._checkMaxWidth();
         }
         // Else, Master editor:
         // we're the ground truth; nothing to do since Document change is just echoing our
@@ -942,6 +962,51 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Returns the right edge of the given line.
+     * @param {number} num The line number to measure.
+     * @param {number} length The length of that line; if unspecified, we'll get it from the editor.
+     */
+    Editor.prototype._getLineRightEdge = function (num, length) {
+        var lineLen = (length !== undefined ? length : this.getLineText(num).length);
+        return this._codeMirror.charCoords({line: num, ch: lineLen}).x - $(this.getRootElement()).offset().left;
+    };
+    
+    /**
+     * Recalculates the desired width of the editor based on the widest visible line.
+     */
+    Editor.prototype._recomputeMaxWidth = function () {
+        if (!this._visibleRange || this._visibleRange.startLine === null || this._visibleRange.endLine === null) {
+            return;
+        }
+
+        var i, lineLength, maxLineNum = -1, maxLength = -1;
+        for (i = this._visibleRange.startLine; i <= this._visibleRange.endLine; i++) {
+            lineLength = this.getLineText(i).length;
+            if (lineLength > maxLength) {
+                maxLength = lineLength;
+                maxLineNum = i;
+            }
+        }
+        this._maxWidthInfo = { num: maxLineNum, width: this._getLineRightEdge(maxLineNum, maxLength) };
+    };
+    
+    /**
+     * Returns the desired width of the editor based on the longest visible line. Note that this is only available
+     * if the editor is viewing a specific range.
+     * @return {number} The width in pixels of the longest visible line, or null if the editor is viewing
+     * the whole document.
+     */
+    Editor.prototype.getDesiredWidth = function () {
+        if (!this._visibleRange) {
+            return null;
+        }
+        if (!this._maxWidthInfo) {
+            this._recomputeMaxWidth();
+        }
+        return this._maxWidthInfo ? this._maxWidthInfo.width : 0;
+    };
+
+    /**
      * The Document we're bound to
      * @type {!Document}
      */
@@ -975,7 +1040,12 @@ define(function (require, exports, module) {
      */
     Editor.prototype._visibleRange = null;
     
-    
+    /**
+     * @private
+     * @type {{num: number, width: number}}
+     */
+    Editor.prototype._maxWidthInfo = null;
+        
     // Global settings that affect all Editor instances (both currently open Editors as well as those created
     // in the future)
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -507,7 +507,7 @@ define(function (require, exports, module) {
         if (this._visibleRange) {
             oldWidth = this._maxWidthInfo ? this._maxWidthInfo.width : -1;
             this._recomputeMaxWidth();
-            if (this._maxWidthInfo.width !== oldWidth) {
+            if (this._maxWidthInfo && this._maxWidthInfo.width !== oldWidth) {
                 $(this).triggerHandler("desiredWidthChange");
             }
         }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -965,11 +965,10 @@ define(function (require, exports, module) {
     /**
      * Returns the right edge of the given line.
      * @param {number} num The line number to measure.
-     * @param {number} length The length of that line; if unspecified, we'll get it from the editor.
      */
-    Editor.prototype._getLineRightEdge = function (num, length) {
-        var lineLen = (length !== undefined ? length : this.getLineText(num).length);
-        return this._codeMirror.charCoords({line: num, ch: lineLen}).x - $(this.getRootElement()).offset().left;
+    Editor.prototype._getLineRightEdge = function (num) {
+        // By passing Number.MAX_VALUE for ch, CodeMirror will get the position immediately after the last character.
+        return this._codeMirror.charCoords({line: num, ch: Number.MAX_VALUE}).x - $(this.getRootElement()).offset().left;
     };
     
     /**
@@ -988,7 +987,7 @@ define(function (require, exports, module) {
                 maxLineNum = i;
             }
         }
-        this._maxWidthInfo = { num: maxLineNum, width: this._getLineRightEdge(maxLineNum, maxLength) };
+        this._maxWidthInfo = { num: maxLineNum, width: this._getLineRightEdge(maxLineNum) };
     };
     
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -119,6 +119,7 @@ define(function (require, exports, module) {
         // Bind event handlers
         this._updateRelatedContainer = this._updateRelatedContainer.bind(this);
         this._ensureCursorVisible = this._ensureCursorVisible.bind(this);
+        this._updateEditorWidth = this._updateEditorWidth.bind(this);
         this._onClick = this._onClick.bind(this);
 
         // Create DOM to hold editors and related list
@@ -228,17 +229,27 @@ define(function (require, exports, module) {
         // Add new editor
         var range = this._getSelectedRange();
         this.createInlineEditorFromText(range.textRange.document, range.textRange.startLine, range.textRange.endLine, this.$editorsDiv.get(0));
+        
+        // Set the container of the editor to be float: left. This is a bit of a hack: it makes it
+        // so that the container's width is the full width of the CodeMirror editor's content, and
+        // therefore CodeMirror never thinks it needs to scroll. We need this because we want to
+        // artificially set the width of the $editorsDiv to fit the longest line in the visible range
+        // (as opposed to the longest line in the editor's content), and we want to do this without
+        // allowing the embedded editor to do its own scrolling. By letting it be its natural width,
+        // we make it so it thinks it never needs to scroll horizontally.
+        $(this.editors[0].getRootElement()).parent().css("float", "left");
+        
         this.editors[0].focus();
 
-        // Changes in size to the inline editor should update the relatedContainer
-        // Note: normally it's not kosher to listen to changes on a specific editor,
-        // but in this case we're specifically concerned with changes in the given
-        // editor, not general document changes.
-        $(this.editors[0]).on("change", this._updateRelatedContainer);
+        // Changes in desired width to the inline editor should resize the editor to fit the
+        // content, and also update the relatedContainer.
+        // Note: We don't need to call _updateRelatedContainer() on general edits to the inline
+        // editor (change events) because all change events currently cause sizeInlineEditorToContents(),
+        // which calls _updateRelatedContainer().
+        $(this.editors[0]).on("desiredWidthChange", this._updateEditorWidth);
         
         // Cursor activity in the inline editor may cause us to horizontally scroll.
         $(this.editors[0]).on("cursorActivity", this._ensureCursorVisible);
-
         
         this.editors[0].refresh();
         // ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a view
@@ -270,6 +281,8 @@ define(function (require, exports, module) {
                     self.$relatedContainer.scrollTop(itemBottom - containerHeight);
                 }
             }
+            
+            self._updateEditorWidth();
         }, 0);
     };
 
@@ -281,8 +294,8 @@ define(function (require, exports, module) {
         
         // remove resize handlers for relatedContainer
         $(this.hostEditor).off("change", this._updateRelatedContainer);
-        $(this.editors[0]).off("change", this._updateRelatedContainer);
         $(this.editors[0]).off("cursorActivity", this._ensureCursorVisible);
+        $(this.editors[0]).off("desiredWidthChange", this._updateEditorWidth);
         $(this).off("offsetTopChanged", this._updateRelatedContainer);
         $(window).off("resize", this._updateRelatedContainer);
         
@@ -325,8 +338,23 @@ define(function (require, exports, module) {
     };
     
     /**
-     *
-     *
+     * Set the inline editor container to the desired width of the currently visible editor.
+     */
+    MultiRangeInlineEditor.prototype._updateEditorWidth = function () {
+        // If the editor's desired width is shorter than the actual width of the overall editor area,
+        // set it to the full editor area width, so that clicks in the dead space are handled by the
+        // editor.
+        this.$editorsDiv.width(Math.max(this.editors[0].getDesiredWidth(),
+                                        this.hostEditor.getScrollerElement().clientWidth - this.$relatedContainer.outerWidth()));
+        this._ensureCursorVisible();
+    };
+    
+    /**
+     * Update the size and position of the rule list.
+     * FUTURE: We should probably call this less often, and break out different kinds of changes that need
+     * different kinds of updates to the rule list. Right now this gets called on every keystroke in the
+     * inline editor (via sizeWidgetToContents()), and a number of the operations in here (like figuring 
+     * out offset() or outerWidth()), as well as resetting style values, are probably nontrivial.
      */
     MultiRangeInlineEditor.prototype._updateRelatedContainer = function () {
         var borderThickness = (this.$htmlContent.outerHeight() - this.$htmlContent.innerHeight()) / 2;
@@ -454,6 +482,14 @@ define(function (require, exports, module) {
 
         // The related ranges container size itself based on htmlContent which is set by setInlineWidgetHeight above.
         this._updateRelatedContainer();
+    };
+    
+    /**
+     * Handles refreshing the inline editor when its host editor is reshown.
+     */
+    MultiRangeInlineEditor.prototype.onParentShown = function () {
+        this.parentClass.onParentShown.call(this);
+        this._updateEditorWidth();
     };
 
     /**

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -449,6 +449,10 @@ a, img {
     }
 }
 
+.inlineEditorHolder {
+    overflow: hidden;
+}
+
 /* CSSInlineEditor rule list */
 .relatedContainer {
     @top-margin: 12px;

--- a/test/spec/MultiRangeInlineEditor-test.js
+++ b/test/spec/MultiRangeInlineEditor-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, xit: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false, HTMLElement: false */
+/*global define: false, describe: false, it: false, xit: false, expect: false, beforeEach: false, afterEach: false, waits: false, waitsFor: false, runs: false, $: false, HTMLElement: false */
 
 define(function (require, exports, module) {
     'use strict';
@@ -233,33 +233,40 @@ define(function (require, exports, module) {
         });
 
         it("should close and return to the host editor", function () {
-            var inlineDoc = SpecRunnerUtils.createMockDocument("div{}\n.foo{}\n");
+            runs(function () {
+                var inlineDoc = SpecRunnerUtils.createMockDocument("div{}\n.foo{}\n");
+                
+                var mockRanges = [
+                    {
+                        document: inlineDoc,
+                        name: "div",
+                        lineStart: 0,
+                        lineEnd: 0
+                    }
+                ];
+                
+                inlineEditor = new MultiRangeInlineEditor(mockRanges);
+                inlineEditor.load(hostEditor);
+            });
             
-            var mockRanges = [
-                {
-                    document: inlineDoc,
-                    name: "div",
-                    lineStart: 0,
-                    lineEnd: 0
-                }
-            ];
+            // Wait for asynchronous side-effects of load() to finish
+            waits(100);
             
-            inlineEditor = new MultiRangeInlineEditor(mockRanges);
-            inlineEditor.load(hostEditor);
-            
-            // add widget directly, bypass _openInlineWidget
-            hostEditor.addInlineWidget({line: 0, ch: 0}, inlineEditor);
-            
-            // verify it was added
-            expect(hostEditor.hasFocus()).toBe(false);
-            expect(hostEditor.getInlineWidgets().length).toBe(1);
-            
-            // close the inline editor directly, should call EditorManager and removeInlineWidget
-            inlineEditor.close();
-            
-            // verify no editors
-            expect(hostEditor.getInlineWidgets().length).toBe(0);
-            expect(hostEditor.hasFocus()).toBe(true);
+            runs(function () {
+                // add widget directly, bypass _openInlineWidget
+                hostEditor.addInlineWidget({line: 0, ch: 0}, inlineEditor);
+                
+                // verify it was added
+                expect(hostEditor.hasFocus()).toBe(false);
+                expect(hostEditor.getInlineWidgets().length).toBe(1);
+                
+                // close the inline editor directly, should call EditorManager and removeInlineWidget
+                inlineEditor.close();
+                
+                // verify no editors
+                expect(hostEditor.getInlineWidgets().length).toBe(0);
+                expect(hostEditor.hasFocus()).toBe(true);
+            });
         });
         
     });


### PR DESCRIPTION
@gruehle 

For issue #600.

We limit the horizontal scrolling by figuring out the longest line visible in the editor, then forcibly resizing the container to that editor's width (plus padding for the rule list). Note that we still have the issue mentioned in #623 (number 2), where the horizontal scroll area is always bigger by the width of the rule list. But at least it will ignore the non-visible lines in the document.

This implementation is pretty simple: on every change to the inline editor's content, it iterates over the text of the visible lines in the inline editor to figure out the longest one, and calculates its width. In theory, we could make this faster by only doing this work if the user either makes a line wider than the widest line, or makes the widest line shorter. But that would involve some messy tracking based on the individual changes we receive on each change in the inline editor (basically duplicating similar logic inside CodeMirror).

Since the number of lines in the inline editor should be relatively small, I'm assuming this isn't too bad. But it does mean we're doing this work on each character typed. I'm wondering whether we should try to optimize this now, or wait until we see the results of the typing performance instrumentation to see whether this changes that materially. Let me know what you think.

Some other notes:
- I noticed while working on this that we seem to be doing more work than we need to on change messages in the inline editor--specifically, we seem to call `_updateRelatedContainer()` more than we need to, which might be expensive. I removed one source of redundancy here, but we should probably check to make sure there isn't more. (For example, we could split `_updateRelatedContainer()` into different pieces that update the vertical size and the horizontal size separately based on different cases.)
- I also noticed a bug in one of the unit tests that didn't account for the fact that some stuff in MultiRangeInlineEditor.load() happens on a setTimeout(). I added a waits() to get around this.
