### PR TITLE
cycle through working set files with hotkey (alt-` and alt-shift-`)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -215,6 +215,11 @@ define(function (require, exports, module) {
                     {"Ctrl-E": Commands.SHOW_INLINE_EDITOR},
                     {"Alt-Up": Commands.QUICK_EDIT_PREV_MATCH},
                     {"Alt-Down": Commands.QUICK_EDIT_NEXT_MATCH},
+                    
+                    //Cmd on mac is bound to toggle the debugger and main window but the control key does work... so Alt for now
+                    {"Alt-`": Commands.NAVIGATE_NEXT_PROJECT_FILE},
+                    {"Alt-Shift-~": Commands.NAVIGATE_PREV_PROJECT_FILE},
+                    
 
                     // DEBUG
                     {"F5": Commands.DEBUG_REFRESH_WINDOW, "platform": "win"},
@@ -231,6 +236,10 @@ define(function (require, exports, module) {
                 function (event) {
                     if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
                         event.stopPropagation();
+                        
+                        // without preventDefault some handled keystrokes make it into CodeMirror
+                        // without it the keystroke "Alt-Shift-~" causes a ' character to flow into a document while cycling
+                        event.preventDefault();
                     }
                 },
                 true

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -70,6 +70,9 @@ define(function (require, exports, module) {
     exports.SHOW_INLINE_EDITOR      = "navigate.showInlineEditor";
     exports.QUICK_EDIT_NEXT_MATCH   = "navigate.nextMatch";
     exports.QUICK_EDIT_PREV_MATCH   = "navigate.previousMatch";
+    
+    exports.NAVIGATE_NEXT_PROJECT_FILE     = "navigate.nextProjectFile";
+    exports.NAVIGATE_PREV_PROJECT_FILE     = "navigate.prevProjectFile";
 
     exports.DEBUG_REFRESH_WINDOW = "debug.refreshWindow"; // string must MATCH string in native code (brackets_extensions)
     exports.DEBUG_SHOW_DEVELOPER_TOOLS = "debug.showDeveloperTools";

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -692,6 +692,54 @@ define(function (require, exports, module) {
 
         _prefs.setValue("files", files);
     }
+    
+    
+    /**
+     * @private
+     * Cycle files in the project set.
+     */
+    function _cycleProjectFile(inc) {
+        var i, file, oSelectFile, iNewIndex, workingSet = getWorkingSet();
+        var oDocCurrent = getCurrentDocument();
+        
+        for (i = 0; i < workingSet.length; i++) {
+            file = workingSet[i];
+            if (oDocCurrent.file.fullPath === file.fullPath) {
+                if (inc < 0 && i === 0) {
+                    i = workingSet.length;
+                }
+                iNewIndex = Math.min(Math.max(0, (i + inc) % workingSet.length), workingSet.length - 1);
+                
+                oSelectFile = workingSet[iNewIndex];
+                break;
+            }
+        }
+        
+        if (oSelectFile) {
+            getDocumentForPath(oSelectFile.fullPath).done(function (doc) {
+                setCurrentDocument(doc);
+            });
+        }
+    }
+
+    /**
+     * @private
+     * navigate to the previous project file
+     */
+    function _prevProjectFile() {
+        _cycleProjectFile(-1);
+    }
+    
+    /**
+     * @private
+     * navigate to the next project file
+     */
+    function _nextProjectFile() {
+        _cycleProjectFile(1);
+    }
+    
+    
+    
 
     /**
      * @private
@@ -751,6 +799,10 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile.fullPath });
             }
         });
+        
+        CommandManager.register(Commands.NAVIGATE_PREV_PROJECT_FILE, _prevProjectFile);
+        CommandManager.register(Commands.NAVIGATE_NEXT_PROJECT_FILE, _nextProjectFile);
+        
     }
 
 


### PR DESCRIPTION
backlog item #84 - without the custom key binding.

if you have a non-working set file open then the command does nothing.

currently bound to alt-`and alt-shift-`  I wanted to bind it to cmd,
but the inspector / brackets-app toggle is consuming that key-combo
