### PR TITLE
Open menus by hovering when an adjacent menu is opened

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -139,11 +139,22 @@ define(function (require, exports, module) {
             }
         }
 
-        // Prevent clicks on the top-level menu bar from taking focus
-        // Note, bootstrap handles this already for the menu drop downs 
-        $("#main-toolbar .dropdown").mousedown(function (e) {
-            e.preventDefault();
-        });
+        $("#main-toolbar .dropdown")
+            // Prevent clicks on the top-level menu bar from taking focus
+            // Note, bootstrap handles this already for the menu drop downs 
+            .mousedown(function (e) {
+                e.preventDefault();
+            })
+            // Switch menus when the mouse enters an adjacent menu
+            // Only open the menu if another one has already been opened
+            // by clicking
+            .mouseenter(function (e) {
+                var open = $(this).siblings(".open");
+                if (open.length > 0) {
+                    open.removeClass("open");
+                    $(this).addClass("open");
+                }
+            });
 
 // Other debug menu items
 //            $("#menu-debug-wordwrap").click(function() {


### PR DESCRIPTION
Not sure that this is the right place to do this (maybe should be in bootstrap?), but I modified the menu to automatically switch to an adjacent menu when you mouse over another menu.

Example:
Say you're on the File menu and mouse over the Edit menu. In a normal desktop app, it would switch to the Edit menu. In brackets, you have to click on the Edit menu to open it.

This pull request changes it so that when you mouse over the Edit (or any other) menu with another menu (File menu for example) open, it will close the File menu and switch to the Edit menu.
