### PR TITLE
working set navigation forward / back commands and hotkeys

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -215,6 +215,11 @@ define(function (require, exports, module) {
                     {"Ctrl-E": Commands.SHOW_INLINE_EDITOR},
                     {"Alt-Up": Commands.QUICK_EDIT_PREV_MATCH},
                     {"Alt-Down": Commands.QUICK_EDIT_NEXT_MATCH},
+                    
+                    //Cmd on mac is bound to toggle the debugger and main window but the control key does work... so Alt for now
+                    {"Alt-`": Commands.NAVIGATE_NEXT_PROJECT_FILE},
+                    {"Alt-Shift-~": Commands.NAVIGATE_PREV_PROJECT_FILE},
+                    
 
                     // DEBUG
                     {"F5": Commands.DEBUG_REFRESH_WINDOW, "platform": "win"},
@@ -231,6 +236,10 @@ define(function (require, exports, module) {
                 function (event) {
                     if (KeyBindingManager.handleKey(KeyMap.translateKeyboardEvent(event))) {
                         event.stopPropagation();
+                        
+                        // without preventDefault some handled keystrokes make it into CodeMirror
+                        // without it the keystroke "Alt-Shift-~" causes a ' character to flow into a document while cycling
+                        event.preventDefault();
                     }
                 },
                 true

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -70,6 +70,9 @@ define(function (require, exports, module) {
     exports.SHOW_INLINE_EDITOR      = "navigate.showInlineEditor";
     exports.QUICK_EDIT_NEXT_MATCH   = "navigate.nextMatch";
     exports.QUICK_EDIT_PREV_MATCH   = "navigate.previousMatch";
+    
+    exports.NAVIGATE_NEXT_PROJECT_FILE     = "navigate.nextProjectFile";
+    exports.NAVIGATE_PREV_PROJECT_FILE     = "navigate.prevProjectFile";
 
     exports.DEBUG_REFRESH_WINDOW = "debug.refreshWindow"; // string must MATCH string in native code (brackets_extensions)
     exports.DEBUG_SHOW_DEVELOPER_TOOLS = "debug.showDeveloperTools";

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -692,55 +692,8 @@ define(function (require, exports, module) {
 
         _prefs.setValue("files", files);
     }
-    
-    
-    /**
-     * @private
-     * Cycle files in the project set.
-     */
-    function _cycleProjectFile(inc) {
-        var i, file, oSelectFile, iNewIndex, workingSet = getWorkingSet();
-        var oDocCurrent = getCurrentDocument();
-        
-        for (i = 0; i < workingSet.length; i++) {
-            file = workingSet[i];
-            if (oDocCurrent.file.fullPath === file.fullPath) {
-                if (inc < 0 && i === 0) {
-                    i = workingSet.length;
-                }
-                iNewIndex = Math.min(Math.max(0, (i + inc) % workingSet.length), workingSet.length - 1);
-                
-                oSelectFile = workingSet[iNewIndex];
-                break;
-            }
-        }
-        
-        if (oSelectFile) {
-            getDocumentForPath(oSelectFile.fullPath).done(function (doc) {
-                setCurrentDocument(doc);
-            });
-        }
-    }
 
-    /**
-     * @private
-     * navigate to the previous project file
-     */
-    function _prevProjectFile() {
-        _cycleProjectFile(-1);
-    }
     
-    /**
-     * @private
-     * navigate to the next project file
-     */
-    function _nextProjectFile() {
-        _cycleProjectFile(1);
-    }
-    
-    
-    
-
     /**
      * @private
      * Initializes the working set.
@@ -799,9 +752,6 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile.fullPath });
             }
         });
-        
-        CommandManager.register(Commands.NAVIGATE_PREV_PROJECT_FILE, _prevProjectFile);
-        CommandManager.register(Commands.NAVIGATE_NEXT_PROJECT_FILE, _nextProjectFile);
         
     }
 

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -542,7 +542,11 @@ define(function (require, exports, module) {
         // On any change, mark the file dirty. In the future, we should make it so that if you
         // undo back to the last saved state, we mark the file clean.
         var wasDirty = this.isDirty;
-        this.isDirty = editor._codeMirror.isDirty();
+        if (editor._codeMirror.isDirty) {
+            this.isDirty = editor._codeMirror.isDirty();
+        } else {
+            this.isDirty = true;
+        }
 
         // If file just became dirty, notify listeners, and add it to working set (if not already there)
         if (wasDirty !== this.isDirty) {

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -693,7 +693,6 @@ define(function (require, exports, module) {
         _prefs.setValue("files", files);
     }
 
-    
     /**
      * @private
      * Initializes the working set.
@@ -752,7 +751,6 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile.fullPath });
             }
         });
-        
     }
 
 

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -566,6 +566,9 @@ define(function (require, exports, module) {
      */
     Document.prototype._markClean = function () {
         this.isDirty = false;
+        if (this._masterEditor) {
+            this._masterEditor._codeMirror.markClean();
+        }
         $(exports).triggerHandler("dirtyFlagChange", this);
     };
     

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -542,10 +542,10 @@ define(function (require, exports, module) {
         // On any change, mark the file dirty. In the future, we should make it so that if you
         // undo back to the last saved state, we mark the file clean.
         var wasDirty = this.isDirty;
-        this.isDirty = true;
+        this.isDirty = editor._codeMirror.isDirty();
 
         // If file just became dirty, notify listeners, and add it to working set (if not already there)
-        if (!wasDirty) {
+        if (wasDirty !== this.isDirty) {
             $(exports).triggerHandler("dirtyFlagChange", [this]);
             addToWorkingSet(this.file);
         }

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -692,6 +692,54 @@ define(function (require, exports, module) {
 
         _prefs.setValue("files", files);
     }
+    
+    
+    /**
+     * @private
+     * Cycle files in the project set.
+     */
+    function _cycleProjectFile(inc) {
+        var i, file, oSelectFile, iNewIndex, workingSet = getWorkingSet();
+        var oDocCurrent = getCurrentDocument();
+        
+        for (i = 0; i < workingSet.length; i++) {
+            file = workingSet[i];
+            if (oDocCurrent.file.fullPath === file.fullPath) {
+                if (inc < 0 && i === 0) {
+                    i = workingSet.length;
+                }
+                iNewIndex = Math.min(Math.max(0, (i + inc) % workingSet.length), workingSet.length - 1);
+                
+                oSelectFile = workingSet[iNewIndex];
+                break;
+            }
+        }
+        
+        if (oSelectFile) {
+            getDocumentForPath(oSelectFile.fullPath).done(function (doc) {
+                setCurrentDocument(doc);
+            });
+        }
+    }
+
+    /**
+     * @private
+     * navigate to the previous project file
+     */
+    function _prevProjectFile() {
+        _cycleProjectFile(-1);
+    }
+    
+    /**
+     * @private
+     * navigate to the next project file
+     */
+    function _nextProjectFile() {
+        _cycleProjectFile(1);
+    }
+    
+    
+    
 
     /**
      * @private
@@ -751,6 +799,10 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile.fullPath });
             }
         });
+        
+        CommandManager.register(Commands.NAVIGATE_PREV_PROJECT_FILE, _prevProjectFile);
+        CommandManager.register(Commands.NAVIGATE_NEXT_PROJECT_FILE, _nextProjectFile);
+        
     }
 
 

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -154,7 +154,40 @@ define(function (require, exports, module) {
         return _fileSelectionFocus;
     }
 
+    
+    /**
+     * @private
+     * Cycle files in the project set.
+     */
+    function _cycleProjectFile(inc) {
+        var i,
+            file,
+            fileSelected,
+            newIndex,
+            workingSet = DocumentManager.getWorkingSet(),
+            docCurrent = DocumentManager.getCurrentDocument();
+        
+        for (i = 0; i < workingSet.length; i++) {
+            file = workingSet[i];
+            if (docCurrent.file.fullPath === file.fullPath) {
+                if (inc < 0 && i === 0) {
+                    i = workingSet.length;
+                }
+                newIndex = Math.min(Math.max(0, (i + inc) % workingSet.length), workingSet.length - 1);
+                
+                fileSelected = workingSet[newIndex];
+                break;
+            }
+        }
+        
+        if (fileSelected) {
+            openAndSelectDocument(fileSelected.fullPath, WORKING_SET_VIEW);
+        }
+    }
 
+    CommandManager.register(Commands.NAVIGATE_PREV_PROJECT_FILE, function () { _cycleProjectFile(-1); });
+    CommandManager.register(Commands.NAVIGATE_NEXT_PROJECT_FILE, function () { _cycleProjectFile(1); });
+    
 
     // Define public API
     exports.getFileSelectionFocus = getFileSelectionFocus;


### PR DESCRIPTION
backlog item #84 : "Working Set Navigation  - As a user I want configurable keyboard shortcuts to move forward and backward between files in the working set."

This pull request doesn't have configurable shortcuts, only the working set navigation piece.  bound to alt-backtick and alt-shift-backtick

In order to get this working I had to change command handling a little so that when commands are handled e.preventDefault().  Without e.preventDefault() alt-shift-backtick caused a backtick to be entered into the editor.
