### PR TITLE
Duplicate line/selection command

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -202,6 +202,7 @@ define(function (require, exports, module) {
                     {"Shift-F3": Commands.EDIT_FIND_PREVIOUS, "platform": "win"},
                     {"Ctrl-Alt-F": Commands.EDIT_REPLACE, "platform": "mac"},
                     {"Ctrl-H": Commands.EDIT_REPLACE, "platform": "win"},
+                    {"Ctrl-D": Commands.EDIT_DUPLICATE},
                     {"Ctrl-/": Commands.EDIT_LINE_COMMENT},
 
                     // VIEW

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -58,6 +58,7 @@ define(function (require, exports, module) {
     exports.EDIT_REPLACE        = "edit.replace";
     exports.EDIT_INDENT         = "edit.indent";
     exports.EDIT_UNINDENT       = "edit.unindent";
+    exports.EDIT_DUPLICATE      = "edit.duplicate";
     exports.EDIT_LINE_COMMENT   = "edit.lineComment";
 
     // VIEW

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -104,7 +104,6 @@ define(function (require, exports, module) {
         });
         
     }
-    
 
     /**
      * Invokes a language-specific line-comment/uncomment handler
@@ -126,6 +125,35 @@ define(function (require, exports, module) {
     }
     
     
+    /**
+     * Duplicates the selected text, or current line if no selection. The cursor/selection is left
+     * on the second copy.
+     */
+    function duplicateText(editor) {
+        editor = editor || EditorManager.getFocusedEditor();
+        if (!editor) {
+            return;
+        }
+        
+        var sel = editor.getSelection();
+        
+        var hasSelection = (sel.start.line !== sel.end.line) || (sel.start.ch !== sel.end.ch);
+        
+        if (!hasSelection) {
+            sel.start.ch = 0;
+            sel.end = {line: sel.start.line + 1, ch: 0};
+        }
+        
+        // Make the edit
+        // TODO (#803): should go through Document, not Editor._codeMirror
+        var cm = editor._codeMirror;
+        
+        var selectedText = cm.getRange(sel.start, sel.end);
+        cm.replaceRange(selectedText, sel.start);
+    }
+    
+    
     // Register commands
     CommandManager.register(Commands.EDIT_LINE_COMMENT, lineComment);
+    CommandManager.register(Commands.EDIT_DUPLICATE, duplicateText);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -125,6 +125,7 @@
                             <li><hr class="divider"></li>
                             <li><a href="#" id="menu-edit-replace">Replace</a></li>
                             <li><hr class="divider"></li>
+                            <li><a href="#" id="menu-edit-duplicate">Duplicate</a></li>
                             <li><a href="#" id="menu-edit-line-comment">Comment/Uncomment Lines</a></li>
                         </ul>
                     </li>

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -352,6 +352,138 @@ define(function (require, exports, module) {
             });
             
         });
+        
+        
+        describe("Duplicate", function () {
+            it("should duplicate whole line if no selection", function () {
+                // place cursor in middle of line 1
+                myEditor.setCursorPos(1, 10);
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(1, 0, "    function bar() {");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectCursorAt({line: 2, ch: 10});
+            });
             
+            it("should duplicate first line", function () {
+                // place cursor at start of line 0
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(0, 0, "function foo() {");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectCursorAt({line: 1, ch: 0});
+            });
+            
+            it("should duplicate empty line", function () {
+                // place cursor on line 6
+                myEditor.setCursorPos(6, 0);
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(6, 0, "");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectCursorAt({line: 7, ch: 0});
+            });
+            
+            it("should duplicate selection within a line", function () {
+                // select "bar" on line 1
+                myEditor.setSelection({line: 1, ch: 13}, {line: 1, ch: 16});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines[1] = "    function barbar() {";
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 1, ch: 16}, end: {line: 1, ch: 19}});
+            });
+            
+            it("should duplicate when entire line selected, excluding newline", function () {
+                // select all of line 1, EXcluding trailing \n
+                myEditor.setSelection({line: 1, ch: 0}, {line: 1, ch: 20});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines[1] = "    function bar() {    function bar() {";
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 1, ch: 20}, end: {line: 1, ch: 40}});
+            });
+            it("should duplicate when entire line selected, including newline", function () {
+                // select all of line 1, INcluding trailing \n
+                myEditor.setSelection({line: 1, ch: 0}, {line: 2, ch: 0});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(1, 0, "    function bar() {");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 2, ch: 0}, end: {line: 3, ch: 0}});
+            });
+            
+            it("should duplicate when multiple lines selected", function () {
+                // select lines 1-3
+                myEditor.setSelection({line: 1, ch: 0}, {line: 4, ch: 0});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(1, 0, "    function bar() {",
+                                   "        ",
+                                   "        a();");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 4, ch: 0}, end: {line: 7, ch: 0}});
+            });
+            
+            it("should duplicate selection crossing line boundary", function () {
+                // select from middle of line 1 to middle of line 3
+                myEditor.setSelection({line: 1, ch: 13}, {line: 3, ch: 11});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var lines = defaultContent.split("\n");
+                lines.splice(1, 3, "    function bar() {",
+                                   "        ",
+                                   "        a()bar() {",
+                                   "        ",
+                                   "        a();");
+                var expectedText = lines.join("\n");
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 3, ch: 11}, end: {line: 5, ch: 11}});
+            });
+            
+            it("should duplicate after select all", function () {
+                myEditor.setSelection({line: 0, ch: 0}, {line: 7, ch: 1});
+                
+                CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                
+                var expectedText = defaultContent + defaultContent;
+                
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 7, ch: 1}, end: {line: 14, ch: 1}});
+            });
+        });
+        
+        
     });
 });


### PR DESCRIPTION
This adds a new Edit > Duplicate command that duplicates the selected text, or if no selection, the current line.  Many other text editors have such a command.

I bound it to my favorite shortcut, Ctrl/Cmd+D, but there's little consistency among other apps.  Sublime uses Ctrl/Cmd+Shift+D, TextMate uses Ctrl+Shift+D (not Cmd), Coda uses Cmd+Alt+Up/Down (only for full-line duplicate), IntelliJ uses Ctrl/Cmd+D.

Unit tests are included here.
