### PR TITLE
Support opening multiple files at a time

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -282,7 +282,7 @@ define(function (require, exports, module) {
             
             // Switch editor to next document (or blank it out)
             if (nextFile) {
-                CommandManager.execute(Commands.FILE_OPEN, { fullPath: nextFile.fullPath });
+                CommandManager.execute(Commands.FILE_OPEN, { files: [nextFile.fullPath] });
             } else {
                 _clearCurrentDocument();
             }
@@ -748,7 +748,7 @@ define(function (require, exports, module) {
             }
 
             if (activeFile) {
-                CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile.fullPath });
+                CommandManager.execute(Commands.FILE_OPEN, { files: [activeFile.fullPath] });
             }
         });
     }

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
             EditorManager.focusEditor();
             result = (new $.Deferred()).resolve().promise();
         } else {
-            result = CommandManager.execute(Commands.FILE_OPEN, {fullPath: fullPath});
+            result = CommandManager.execute(Commands.FILE_OPEN, { files: [fullPath] });
         }
         
         // clear after notification is done
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
      * @return {!$.Promise}
      */
     function addToWorkingSetAndSelect(fullPath) {
-        CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath});
+        CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { files: [fullPath] });
 
         // This properly handles sending the right nofications in cases where the document
         // is already the curruent one. In that case we will want to notify with

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -218,8 +218,8 @@ define(function (require, exports, module) {
                                 .appendTo($resultTable);
                             
                             $row.click(function () {
-                                CommandManager.execute(Commands.FILE_OPEN, {fullPath: item.fullPath})
-                                    .done(function (doc) {
+                                CommandManager.execute(Commands.FILE_OPEN, { files: [item.fullPath] })
+                                    .done(function (docs) {
                                         // Opened document is now the current main editor
                                         EditorManager.getCurrentFullEditor().setSelection(match.start, match.end);
                                     });

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
 
             // Nagivate to file and line number
             if (fullPath) {
-                CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath})
+                CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { files: [fullPath] })
                     .done(function () {
                         if (!isNaN(gotoLine)) {
                             EditorManager.getCurrentFullEditor().setCursorPos(cursor);
@@ -257,7 +257,7 @@ define(function (require, exports, module) {
             var fullPath = $(selectedItem).attr("data-fullpath");
             if (fullPath) {
                 fullPath = decodeURIComponent(fullPath);
-                CommandManager.execute(Commands.FILE_OPEN, {fullPath: fullPath, focusEditor: false});
+                CommandManager.execute(Commands.FILE_OPEN, { files: [fullPath], focusEditor: false });
             }
         }
         */
@@ -312,7 +312,7 @@ define(function (require, exports, module) {
 
                 // restore previously viewed doc if user navigated away from it
                 if (origDocPath) {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: origDocPath})
+                    CommandManager.execute(Commands.FILE_OPEN, { files: [origDocPath] })
                         .done(function () {
                             if (origSelection) {
                                 EditorManager.getCurrentFullEditor().setSelection(origSelection.start, origSelection.end);

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
                 var didOpen = false, didClose = false, gotError = false;
 
                 runs(function () {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"})
+                    CommandManager.execute(Commands.FILE_OPEN, { files: [testPath + "/test.js"] })
                         .done(function () { didOpen = true; })
                         .fail(function () { gotError = true; });
                 });
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
                 var didOpen = false, gotError = false;
 
                 runs(function () {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"})
+                    CommandManager.execute(Commands.FILE_OPEN, { files: [testPath + "/test.js"] })
                         .done(function () { didOpen = true; })
                         .fail(function () { gotError = true; });
                 });
@@ -129,7 +129,7 @@ define(function (require, exports, module) {
                     filePath    = testPath + "/test.js";
 
                 runs(function () {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: filePath})
+                    CommandManager.execute(Commands.FILE_OPEN, { files: [filePath] })
                         .done(function () { didOpen = true; })
                         .fail(function () { gotError = true; });
                 });
@@ -173,7 +173,7 @@ define(function (require, exports, module) {
                 var didOpen = false, gotError = false;
 
                 runs(function () {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"})
+                    CommandManager.execute(Commands.FILE_OPEN, { files: [testPath + "/test.js"] })
                         .done(function () { didOpen = true; })
                         .fail(function () { gotError = true; });
                 });


### PR DESCRIPTION
I changed the code the `FILE_OPEN` command so that the user can select multiple files to open at once, instead of having to open the files one at a time with a dialog prompting for each one. This had to change other parts of the code that used the `FILE_OPEN` command. I think I got all of the locations, but please review it :smiley:.

This probably needs pull request [#121](https://github.com/adobe/brackets-app/pull/121) on the brackets-app project that I created for supporting multiple file selection on the Windows app.
