### PR TITLE
Adding comment to prevent issue #735

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -103,6 +103,8 @@
 .code-font() {
     color: @content-color;
     pre {
+        // line-height must be specified in px not em because the code font and line number font sizes are different.
+        // Sizing via em will cause the code and line numbers to misalign
         line-height: 15px;
     }
 }


### PR DESCRIPTION
Issue #735 (line number stop short) occurred for Adam because he edited the code font size and line-height for presentation purposes. Line height was changed from px to em. Since the code font and line number font sizes are different in codemirror, line-height must be absolute rather than relative to the font in order for the line numbers and code lines to line up.

This fix just adds a comment about keeping line-height specified in px to help out anyone who may manually edit the font size and line-height size

fixes issue #735
