### PR TITLE
Improve automatic indentation

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -188,18 +188,18 @@ define(function (require, exports, module) {
         var instance = editor._codeMirror;
         if (event.type === "keypress") {
             var keyStr = String.fromCharCode(event.which || event.keyCode);
-            if (/[\]\}\)]/.test(keyStr)) {
-                // If the whole line is whitespace, auto-indent it
-                var lineNum = instance.getCursor().line;
-                var lineStr = instance.getLine(lineNum);
+            if (/[\]\{\}\)]/.test(keyStr)) {
+                // If all text before the cursor is whitespace, auto-indent it
+                var cursor = instance.getCursor();
+                var lineStr = instance.getLine(cursor.line);
                 
-                if (!/\S/.test(lineStr)) {
+                if (lineStr.search(/\S/) >= cursor.ch) {
                     // Need to do the auto-indent on a timeout to ensure
                     // the keypress is handled before auto-indenting.
                     // This is the same timeout value used by the
                     // electricChars feature in CodeMirror.
                     window.setTimeout(function () {
-                        instance.indentLine(lineNum);
+                        instance.indentLine(cursor.line);
                     }, 75);
                 }
             }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -192,8 +192,9 @@ define(function (require, exports, module) {
                 // If all text before the cursor is whitespace, auto-indent it
                 var cursor = instance.getCursor();
                 var lineStr = instance.getLine(cursor.line);
+                var nonWS = lineStr.search(/S/);
                 
-                if (lineStr.search(/\S/) >= cursor.ch) {
+                if (nonWS === -1 || nonWS >= cursor.ch) {
                     // Need to do the auto-indent on a timeout to ensure
                     // the keypress is handled before auto-indenting.
                     // This is the same timeout value used by the

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
                 // If all text before the cursor is whitespace, auto-indent it
                 var cursor = instance.getCursor();
                 var lineStr = instance.getLine(cursor.line);
-                var nonWS = lineStr.search(/S/);
+                var nonWS = lineStr.search(/\S/);
                 
                 if (nonWS === -1 || nonWS >= cursor.ch) {
                     // Need to do the auto-indent on a timeout to ensure


### PR DESCRIPTION
This pull request includes two improvements to automatic indentation:
1. Opening curly brace ('{') triggers auto-indent. Fixes issue #776.
2. Run auto-indent code if the character typed is preceded by whitespace. Previously the entire line needed to be whitespace. 
