### PR TITLE
fixing issue 811, escape strings used in regex expressions

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define, $, window */
 
 /*
 * Displays an auto suggest pop-up list of files to allow the user to quickly navigate to a file and lines
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
         var ESCKey = 27, EnterKey = 13;
 
         // clear the query on ESC key and restore document and cursor position
-        if (event.keyCode === EnterKey || e.keyCode === ESCKey) {
+        if (e.keyCode === EnterKey || e.keyCode === ESCKey) {
             e.stopPropagation();
             e.preventDefault();
 
@@ -358,7 +358,7 @@ define(function (require, exports, module) {
         this.dialog.parentNode.removeChild(this.dialog);
         $(".smart_autocomplete_container").remove();
 
-        $(document).off("mousedown", this.handleDocumentClick);
+        $(window.document).off("mousedown", this.handleDocumentClick);
     };
     
     function filterFileList(query) {
@@ -427,9 +427,12 @@ define(function (require, exports, module) {
         item = StringUtils.htmlEscape(item);
 
         var displayName;
-        if(query.length > 0 ) {
+        if (query.length > 0) {
             // make the users query bold within the item's text
-            displayName = item.replace(new RegExp(query, "gi"), "<strong>$&</strong>");
+            item = item.replace(
+                new RegExp(StringUtils.regexEscape(query), "gi"),
+                "<strong>$&</strong>"
+            );
         } else {
             displayName = item;
         }
@@ -453,9 +456,12 @@ define(function (require, exports, module) {
             var rPath = StringUtils.htmlEscape(ProjectManager.makeProjectRelativeIfPossible(item));
 
             var displayName;
-            if(query.length > 0 ) {
+            if (query.length > 0) {
                 // make the users query bold within the item's text
-                displayName = filename.replace(new RegExp(query, "gi"), "<strong>$&</strong>");
+                displayName = filename.replace(
+                    new RegExp(StringUtils.regexEscape(query), "gi"),
+                    "<strong>$&</strong>"
+                );
             } else {
                 displayName = filename;
             }
@@ -501,7 +507,7 @@ define(function (require, exports, module) {
         dialogOpen = true;
 
         this.handleDocumentClick = this.handleDocumentClick.bind(this);
-        $(document).on("mousedown", this.handleDocumentClick);
+        $(window.document).on("mousedown", this.handleDocumentClick);
 
 
         // Ty TODO: disabled for now while file switching is disabled in _handleItemFocus

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -37,6 +37,11 @@ define(function (require, exports, module) {
             .replace(/>/g, '&gt;');
     }
 
+    function regexEscape(str) {
+        return (str+'').replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+    }
+
     exports.htmlEscape = htmlEscape;
+    exports.regexEscape = regexEscape;
 
 });


### PR DESCRIPTION
Quick open was crashing when regexp-related chars were searched for. This fix adds proper regex escaping.
- Added new function to StringUtils for escaping regex. This file now has HTML and regex escaping.
- Also did some LintJS cleanup in QuickOpen.js

Fixes issue #811
