### PR TITLE
Issue #408 - cleanup style names

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
                     sidebarSnappedClosed = true;
                     
                     // this keeps the triangle from jumping around
-                    $(".triangleVisible").css("display", "none");
+                    $(".triangle-visible").css("display", "none");
                 }
                 $(".main-view").on("mousemove.sidebar", function (e) {
                     // if we've gone below 10 pixels on a mouse move, and the
@@ -286,7 +286,7 @@ define(function (require, exports, module) {
                         // and register that the sidebar is no longer snapped closed. 
                         if (e.clientX > 10) {
                             sidebarSnappedClosed = false;
-                            $(".triangleVisible").css("display", "block");
+                            $(".triangle-visible").css("display", "block");
                         }
                         
                         $("#sidebar-resizer").css("left", e.clientX);
@@ -296,8 +296,8 @@ define(function (require, exports, module) {
                         $("#project-files-container").trigger("scroll");
                         $("#open-files-container").trigger("scroll");
                         
-                        // the .sidebarSelection needs to be explicitly set
-                        $(".sidebarSelection").width(e.clientX);
+                        // the .sidebar-selection needs to be explicitly set
+                        $(".sidebar-selection").width(e.clientX);
                     }
                     EditorManager.resizeEditor();
                     e.preventDefault();
@@ -316,7 +316,7 @@ define(function (require, exports, module) {
         $("body").addClass("platform-" + brackets.platform);
 
 
-        EditorManager.setEditorHolder($('#editorHolder'));
+        EditorManager.setEditorHolder($('#editor-holder'));
 
         // Let the user know Brackets doesn't run in a web browser yet
         if (brackets.inBrowser) {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -354,7 +354,7 @@ define(function (require, exports, module) {
     function _showEditor(document) {
         // Hide whatever was visible before
         if (!_currentEditor) {
-            $("#notEditor").css("display", "none");
+            $("#not-editor").css("display", "none");
         } else {
             _currentEditor.setVisible(false);
             _destroyEditorIfUnneeded(_currentEditorsDocument);
@@ -379,7 +379,7 @@ define(function (require, exports, module) {
             _currentEditorsDocument = null;
             _currentEditor = null;
             
-            $("#notEditor").css("display", "");
+            $("#not-editor").css("display", "");
         
             $(exports).triggerHandler("focusedEditorChange", _currentEditor);
         }
@@ -390,7 +390,7 @@ define(function (require, exports, module) {
         var doc = DocumentManager.getCurrentDocument(),
             container = _editorHolder.get(0);
         
-        // Remove scrollerShadow from the current editor
+        // Remove scroller-shadow from the current editor
         if (_currentEditor) {
             ViewUtils.removeScrollerShadow(container, _currentEditor);
         }

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
      * @private
      */
     function _editorHolderWidth() {
-        return $("#editorHolder").width();
+        return $("#editor-holder").width();
     }
 
     /**
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
         $dirtyIndicatorDiv.data("fullPath", doc.file.fullPath);
         
         var $nameWithTooltip = $("<span></span>").text(doc.file.name).attr("title", doc.file.fullPath);
-        var $lineNumber = $("<span class='lineNumber'>" + (startLine + 1) + "</span>");
+        var $lineNumber = $("<span class='line-number'>" + (startLine + 1) + "</span>");
 
         $filenameDiv.append($dirtyIndicatorDiv)
             .append($nameWithTooltip)

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     function InlineWidget() {
         // create the outer wrapper div
         this.htmlContent = window.document.createElement("div");
-        this.$htmlContent = $(this.htmlContent).addClass("InlineWidget");
+        this.$htmlContent = $(this.htmlContent).addClass("inline-widget");
         this.$htmlContent.append('<div class="shadow top"/>')
             .append('<div class="shadow bottom"/>');
     }

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
         this.$editorsDiv = $(document.createElement('div')).addClass("inlineEditorHolder");
         
         // Outer container for border-left and scrolling
-        this.$relatedContainer = $(document.createElement("div")).addClass("relatedContainer");
+        this.$relatedContainer = $(document.createElement("div")).addClass("related-container");
         this._relatedContainerInserted = false;
         this._relatedContainerInsertedHandler = this._relatedContainerInsertedHandler.bind(this);
         
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
         // attach to main container
         this.$htmlContent.append(this.$editorsDiv).append(this.$relatedContainer);
         
-        // initialize position based on the main #editorHolder
+        // initialize position based on the main #editor-holder
         setTimeout(this._updateRelatedContainer, 0);
         
         // Changes to the host editor should update the relatedContainer

--- a/src/index.html
+++ b/src/index.html
@@ -192,20 +192,20 @@
                 </div>
             </div>
             
-            <div id="editorHolder">
-                <div id="notEditor">
-                    <div id="notEditorContent">[&nbsp;&nbsp;]</div>
+            <div id="editor-holder">
+                <div id="not-editor">
+                    <div id="not-editor-content">[&nbsp;&nbsp;]</div>
                 </div>
             </div>
             
             <div id="jslint-results">
-                <div class="toolbar simpleToolbarLayout">
+                <div class="toolbar simple-toolbar-layout">
                     <div class="title">JSLint errors</div>
                 </div>
                 <div class="table-container"></div>
             </div>
             <div id="search-results">
-                <div class="toolbar simpleToolbarLayout">
+                <div class="toolbar simple-toolbar-layout">
                     <div class="title">Search Results</div>
                     <div class="title" id="search-result-summary"></div>
                     <a href="#" class="close">&times;</a>

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -362,7 +362,7 @@ define(function (require, exports, module) {
                     }
                 });
 
-            // fire selection changed events for sidebarSelection
+            // fire selection changed events for sidebar-selection
             $projectTreeList = $projectTreeContainer.find("ul");
             ViewUtils.sidebarList($projectTreeContainer, "jstree-clicked", "jstree-leaf");
             $projectTreeContainer.show();

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
         if ($fileStatusIcon) {
             // cast to Boolean needed because toggleClass() distinguishes true/false from truthy/falsy
             $fileStatusIcon.toggleClass("dirty", Boolean(isDirty));
-            $fileStatusIcon.toggleClass("canClose", Boolean(canClose));
+            $fileStatusIcon.toggleClass("can-close", Boolean(canClose));
         }
     }
     
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
     function _handleDirtyFlagChanged(doc) {
         var listItem = _findListItemFromFile(doc.file);
         if (listItem) {
-            var canClose = $(listItem).find("canClose").length === 1;
+            var canClose = $(listItem).find("can-close").length === 1;
             _updateFileStatusIcon(listItem, doc.isDirty, canClose);
         }
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     */
     FindInFilesDialog.prototype._createDialogDiv = function (template) {
         // FUTURE: consider using jQuery for all the DOM manipulation here
-        var wrap = $("#editorHolder")[0];
+        var wrap = $("#editor-holder")[0];
         this.dialog = wrap.insertBefore(window.document.createElement("div"), wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
         this.dialog.innerHTML = '<div>' + template + '</div>';

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
      * Creates a dialog div floating on top of the current code mirror editor
      */
     QuickNavigateDialog.prototype._createDialogDiv = function (template) {
-        var $wrap = $("#editorHolder")[0];
+        var $wrap = $("#editor-holder")[0];
         this.dialog = $wrap.insertBefore(window.document.createElement("div"), $wrap.firstChild);
         this.dialog.className = "CodeMirror-dialog";
         this.dialog.innerHTML = '<div align="right">' + template + '</div>';
@@ -461,7 +461,7 @@ define(function (require, exports, module) {
             }
 
             return "<li data-fullpath='" + encodeURIComponent(item) + "'>" + displayName +
-                "<br><span class='quickOpenPath'>" + rPath + "</span></li>";
+                "<br><span class='quick-open-path'>" + rPath + "</span></li>";
         }
     }
 

--- a/src/styles/bootstrap/mixins.less
+++ b/src/styles/bootstrap/mixins.less
@@ -44,9 +44,9 @@
 }
 
 // Font Stacks
-@fontStackSansSerif: "Helvetica Neue", Helvetica, Arial, sans-serif;
-@fontStackSerif:     "Georgia", Times New Roman, Times, serif;
-@fontStackMonospace: "Monaco", Courier New, monospace;
+@fontstack-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
+@fontstack-serif:      "Georgia", Times New Roman, Times, serif;
+@fontstack-monospace:  "Monaco", Courier New, monospace;
 
 #font {
   .shorthand(@weight: normal, @size: 14px, @lineHeight: 20px) {
@@ -55,19 +55,19 @@
     line-height: @lineHeight;
   }
   .sans-serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: @fontStackSansSerif;
+    font-family: @fontstack-sans-serif;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;
   }
   .serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: @fontStackSerif;
+    font-family: @fontstack-serif;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;
   }
   .monospace(@weight: normal, @size: 12px, @lineHeight: 20px) {
-    font-family: @fontStackMonospace;
+    font-family: @fontstack-monospace;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -90,20 +90,20 @@ a, img {
     z-index: @z-index-brackets-toolbar;
 }
 
-#editorHolder {
+#editor-holder {
     .vbox;
     .box-flex(1);
     position: relative;
     
     /* Placeholder shown when there is no editor open */
-    #notEditor {
+    #not-editor {
         .box-flex(1);
         .vbox;
         .box-pack(center);
         .box-align(center);
         background-color: @background-color-2;
         
-        #notEditorContent {
+        #not-editor-content {
             color: @background-color-1;
             font-size: 350px;
             line-height: normal;
@@ -167,20 +167,20 @@ a, img {
     
     // Default icon is for the 'disconnected' state
     // The 'connecting failed' (.warning) state also maps here
-    .spriteIcon(0,0, 22px,11px, "styles/images/live_development_sprites.svg");
+    .sprite-icon(0,0, 22px,11px, "styles/images/live_development_sprites.svg");
     &:hover {
-        .spriteSwap(0,11px);
+        .sprite-swap(0,11px);
     }
     // 'Connected' state
     &.success {
-        .spriteSwap(0,22px);
+        .sprite-swap(0,22px);
     }
     &.success:hover {
-        .spriteSwap(0,33px);
+        .sprite-swap(0,33px);
     }
     // 'Connection in progress' state
     &.info {
-        .spriteSwap(0,44px);
+        .sprite-swap(0,44px);
     }
 }
 
@@ -269,22 +269,22 @@ a, img {
     }
 }
 
-.sidebarSelection {
+.sidebar-selection {
     background: url("styles/images/active_back.png") no-repeat top right;
     height: 25px;
     position: absolute;
 }
 
-.sidebarSelectionTriangle {
+.sidebar-selection-triangle {
     background: url("styles/images/active_back.png");
     width: 10px;
     height: 25px;
     position: fixed;
 
-    z-index: @z-index-brackets-selection-triangle; /* scrollerShadow appears above this triangle */
+    z-index: @z-index-brackets-selection-triangle; /* scroller-shadow appears above this triangle */
 }
 
-.sidebarSelectionTriangle.triangleVisible:before {
+.sidebar-selection-triangle.triangle-visible:before {
     content: "";
     
     border-top: @triangle-size solid transparent;
@@ -298,7 +298,7 @@ a, img {
     width: 0;
     height: 0;
     
-    .scaleX(0.9, right, top);
+    .scale-x(0.9, right, top);
 }
 
 //Initially start with the open files hidden, they will get show as files are added
@@ -318,11 +318,11 @@ a, img {
     }
 }
 
-#editorHolder .scrollerShadow {
+#editor-holder .scroller-shadow {
     width: 100%;
 }
 
-.scrollerShadow {
+.scroller-shadow {
     background-size: 100% 5px;
     background-repeat: no-repeat;
     height: 5px;
@@ -341,27 +341,27 @@ a, img {
     }
 }
 
-@spriteSize18: 18px;
+@sprite-size-18: 18px;
 
 /** Classes for icons from jsTreeSprites.png 
 */
-.jsTreeSprite {
+.jstree-sprite {
     background-image: url("styles/images/jsTreeSprites.png");
     background-repeat: no-repeat;
     background-color: transparent;
     vertical-align: middle;
-    width: @spriteSize18;
-    height: @spriteSize18;
+    width: @sprite-size-18;
+    height: @sprite-size-18;
 }
 
 .disclosure-arrow-opened {
-    .jsTreeSprite;
+    .jstree-sprite;
     display: inline-block;
-    background-position: -@spriteSize18 0px;
+    background-position: -@sprite-size-18 0px;
 }
 
 .disclosure-arrow-closed {
-    .jsTreeSprite;
+    .jstree-sprite;
     display: inline-block;
     background-position: 0px 0px;
 }
@@ -369,7 +369,7 @@ a, img {
 /** Classes for icons from bracketSprites.png 
 */
 
-.bracketSprite {
+.bracket-sprite {
     background-image: url("styles/images/close_btn.png");
     background-repeat: no-repeat;
     background-color: transparent;
@@ -381,7 +381,7 @@ a, img {
 
 .file-status-icon {
     margin: 3px 0 0 8px;
-    .bracketSprite;
+    .bracket-sprite;
     display: inline-block;
     position: absolute;
     left: 0px;
@@ -391,21 +391,21 @@ a, img {
         background-position: -30px 0;
     }
     
-    &.canClose {
+    &.can-close {
         background-position: 0 0;
     }
   
-    &.canClose:hover {
+    &.can-close:hover {
         background-position: -15px 0;
     }
     
-    &.canClose:active {
+    &.can-close:active {
         background-position: -15px 1px;
     }
 }
 
 /* Styles for inline editors */
-.InlineWidget {
+.inline-widget {
     background-color:   @inline-background-color-1;
     
     .filename {
@@ -415,13 +415,13 @@ a, img {
         padding: 10px 10px 0px 10px;
         
         .dirty-indicator {
-            .bracketSprite;
+            .bracket-sprite;
             display: inline-block;
             background-position: -32px 0;
             padding-top: 3px;
         }
         
-        .lineNumber {
+        .line-number {
             color: @inline-color-2;
         }
     }
@@ -454,7 +454,7 @@ a, img {
 }
 
 /* CSSInlineEditor rule list */
-.relatedContainer {
+.related-container {
     @top-margin: 12px;
     
     /*width: 0;*/
@@ -491,7 +491,7 @@ a, img {
         border-left: @triangle-size solid @inline-background-color-1;
         margin-top: -@triangle-size;
         top: 50%;
-        .scaleX(0.9, left, top);
+        .scale-x(0.9, left, top);
     }
     
     .related {
@@ -567,7 +567,7 @@ a, img {
     padding: 0px 8px 0px 0px;
     margin: 9px 0px 0px 0px;
 
-    .quickOpenPath {
+    .quick-open-path {
         font-size: 11px;
         color: gray;
     }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -409,7 +409,7 @@ a, img {
     background-color:   @inline-background-color-1;
     
     .filename {
-        font-family: @fontStackSansSerif;
+        font-family: @fontstack-sans-serif;
         font-size: 1.1em;
         color: @inline-color-1;
         padding: 10px 10px 0px 10px;
@@ -458,7 +458,7 @@ a, img {
     @top-margin: 12px;
     
     /*width: 0;*/
-    font-family: @fontStackSansSerif;
+    font-family: @fontstack-sans-serif;
     position: fixed;
     width: 250px;
     overflow: hidden;
@@ -531,7 +531,7 @@ a, img {
 }
 
 .CodeMirror-dialog > div {
-  font-family: @fontStackSansSerif;
+  font-family: @fontstack-sans-serif;
   position: absolute;
   top: 0; left: 0; right: 0;
   background: @background-color-2;
@@ -544,7 +544,7 @@ a, img {
 }
 
 .CodeMirror-dialog input {
-  font-family: @fontStackSansSerif;
+  font-family: @fontstack-sans-serif;
   border: 1px solid @content-color-weaker;
   outline: none;
   background: @background-color-3;

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -65,4 +65,4 @@
 
 /* Font Stacks */
 
-@fontStackSansSerif: 'SourceSans', Helvetica, Arial, sans-serif;
+@fontstack-sans-serif: 'SourceSans', Helvetica, Arial, sans-serif;

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -65,15 +65,15 @@
 /* Helpers for spritesheet images */
 /* Sets the background to the given offset in the spritesheet. Typically, the element you set this on requires
    a fixed size so that other parts of the spritesheet don't show. */
-.sprite(@xOffset, @yOffset, @spriteSheet) {
-    background: url(@spriteSheet) -@xOffset -@yOffset no-repeat;
+.sprite(@x-offset, @y-offset, @sprite-sheet) {
+    background: url(@sprite-sheet) -@x-offset -@y-offset no-repeat;
 }
 
 /* Turns the given element into an icon showing the given rectangle in the spritesheet. Can be used on empty elements
    (e.g. a link with no text) or on the :before/:after selector of elements that have content. */
-.sprite-icon(@xOffset, @yOffset, @width, @height, @spriteSheet) {
+.sprite-icon(@x-offset, @y-offset, @width, @height, @sprite-sheet) {
     content: "";
-    .sprite(@xOffset, @yOffset, @spriteSheet);
+    .sprite(@x-offset, @y-offset, @sprite-sheet);
     display: inline-block;
     width: @width;
     height: @height;
@@ -81,8 +81,8 @@
 
 /* Changes an element that's already showing one area of a spritesheet to show a different area of the same size.
    Should be used with an element whose base styling includes .sprite() or .sprite-icon() */
-.sprite-swap(@xOffset, @yOffset) {
-    background-position: -@xOffset -@yOffset;
+.sprite-swap(@x-offset, @y-offset) {
+    background-position: -@x-offset -@y-offset;
 }
 
     

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -71,7 +71,7 @@
 
 /* Turns the given element into an icon showing the given rectangle in the spritesheet. Can be used on empty elements
    (e.g. a link with no text) or on the :before/:after selector of elements that have content. */
-.spriteIcon(@xOffset, @yOffset, @width, @height, @spriteSheet) {
+.sprite-icon(@xOffset, @yOffset, @width, @height, @spriteSheet) {
     content: "";
     .sprite(@xOffset, @yOffset, @spriteSheet);
     display: inline-block;
@@ -80,14 +80,14 @@
 }
 
 /* Changes an element that's already showing one area of a spritesheet to show a different area of the same size.
-   Should be used with an element whose base styling includes .sprite() or .spriteIcon() */
-.spriteSwap(@xOffset, @yOffset) {
+   Should be used with an element whose base styling includes .sprite() or .sprite-icon() */
+.sprite-swap(@xOffset, @yOffset) {
     background-position: -@xOffset -@yOffset;
 }
 
     
 /* Scale x-axis using top-left as the origin  */
-.scaleX (@value: 1.0, @horizontal: 50%, @vertical: 50%) {
+.scale-x (@value: 1.0, @horizontal: 50%, @vertical: 50%) {
     -ms-transform: scaleX(@value);
     -moz-transform: scaleX(@value);
     -webkit-transform: scaleX(@value);

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -61,7 +61,7 @@
 /* Simple toolbar layout (project panel, find in files, etc.)
    We don't set this directly on .toolbar because it'd be a pain to override all the pieces
    if other code (e.g. #main-toolbar) wants to do a different layout */
-.simpleToolbarLayout.toolbar {
+.simple-toolbar-layout.toolbar {
     .hbox;
     .box-align(center);
     .title-wrapper {

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -41,7 +41,7 @@
  * so the text ends up back in the same spot visually
  */
 .jstree-brackets li > a {
-    padding-left: @spriteSize18 + 10000;
+    padding-left: @sprite-size-18 + 10000;
     margin-left: -10000px;
     display: block;
 }

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -57,8 +57,8 @@ define(function (require, exports, module) {
      * Positions shadow background elements to indicate vertical scrolling.
      * @param {!DOMElement} $displayElement the DOMElement that displays the shadow
      * @param {!Object} $scrollElement the object that is scrolled
-     * @param {!DOMElement} $shadowTop div .scrollerShadow.top
-     * @param {!DOMElement} $shadowBottom div .scrollerShadow.bottom
+     * @param {!DOMElement} $shadowTop div .scroller-shadow.top
+     * @param {!DOMElement} $shadowBottom div .scroller-shadow.bottom
      * @param {boolean} isPositionFixed When using absolute position, top remains at 0.
      */
     function _updateScrollerShadow($displayElement, $scrollElement, $shadowTop, $shadowBottom, isPositionFixed) {
@@ -96,10 +96,10 @@ define(function (require, exports, module) {
     }
 
     function getOrCreateShadow($displayElement, position, isPositionFixed) {
-        var $findShadow = $displayElement.find(".scrollerShadow." + position);
+        var $findShadow = $displayElement.find(".scroller-shadow." + position);
 
         if ($findShadow.length === 0) {
-            $findShadow = $(window.document.createElement("div")).addClass("scrollerShadow " + position);
+            $findShadow = $(window.document.createElement("div")).addClass("scroller-shadow " + position);
             $displayElement.append($findShadow);
         }
         
@@ -140,15 +140,15 @@ define(function (require, exports, module) {
             _updateScrollerShadow($displayElement, $scrollElement, $shadowTop, $shadowBottom, isPositionFixed);
         };
         
-        $scrollElement.on("scroll.scrollerShadow", doUpdate);
-        $displayElement.on("contentChanged.scrollerShadow", doUpdate);
+        $scrollElement.on("scroll.scroller-shadow", doUpdate);
+        $displayElement.on("contentChanged.scroller-shadow", doUpdate);
         
         // update immediately
         doUpdate();
     }
     
     /**
-     * Remove scrollerShadow effect.
+     * Remove scroller-shadow effect.
      * @param {!DOMElement} displayElement the DOMElement that displays the shadow
      * @param {?Object} scrollElement the object that is scrolled
      */
@@ -160,13 +160,13 @@ define(function (require, exports, module) {
         var $displayElement = $(displayElement),
             $scrollElement = $(scrollElement);
         
-        // remove scrollerShadow elements from DOM
-        $(displayElement).find(".scrollerShadow.top").remove();
-        $(displayElement).find(".scrollerShadow.bottom").remove();
+        // remove scroller-shadow elements from DOM
+        $(displayElement).find(".scroller-shadow.top").remove();
+        $(displayElement).find(".scroller-shadow.bottom").remove();
         
         // remove event handlers
-        $scrollElement.off("scroll.scrollerShadow");
-        $displayElement.off("contentChanged.scrollerShadow");
+        $scrollElement.off("scroll.scroller-shadow");
+        $displayElement.off("contentChanged.scroller-shadow");
     }
     
     /** 
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
             showTriangle = true;
         
         // build selectionMarker and position absolute within the scroller
-        $selectionMarker = $(window.document.createElement("div")).addClass("sidebarSelection");
+        $selectionMarker = $(window.document.createElement("div")).addClass("sidebar-selection");
         $scrollerElement.prepend($selectionMarker);
         
         // enable scrolling
@@ -199,7 +199,7 @@ define(function (require, exports, module) {
         $scrollerElement.css("position", "relative");
         
         // build selectionTriangle and position fixed to the window
-        $selectionTriangle = $(window.document.createElement("div")).addClass("sidebarSelectionTriangle");
+        $selectionTriangle = $(window.document.createElement("div")).addClass("sidebar-selection-triangle");
         
         $fileSection.append($selectionTriangle);
         
@@ -218,7 +218,7 @@ define(function (require, exports, module) {
             $selectionTriangle.css("top", triangleTop);
             
             $selectionTriangle.css("left", $fileSection.width() - $selectionTriangle.outerWidth());
-            $selectionTriangle.toggleClass("triangleVisible", showTriangle);
+            $selectionTriangle.toggleClass("triangle-visible", showTriangle);
             
             var triangleClipOffsetYBy = Math.floor((selectionMarkerHeight - triangleHeight) / 2),
                 triangleBottom = triangleTop + triangleHeight + triangleClipOffsetYBy;

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
             // but ultimately these should go into ProjectManager.js with a "notify" 
             // event that we can just call from anywhere instead of hard-coding it.
             // waiting on a ProjectManager refactor to add that. 
-            $(".sidebarSelection").width(sidebarWidth);
+            $(".sidebar-selection").width(sidebarWidth);
             $("#project-files-container").trigger("scroll");
             $("#open-files-container").trigger("scroll");
 

--- a/test/spec/MultiRangeInlineEditor-test.js
+++ b/test/spec/MultiRangeInlineEditor-test.js
@@ -43,8 +43,8 @@ define(function (require, exports, module) {
         
         beforeEach(function () {
             // init Editor instance (containing a CodeMirror instance)
-            $("body").append("<div id='editorHolder'/>");
-            $editorHolder = $("#editorHolder");
+            $("body").append("<div id='editor-holder'/>");
+            $editorHolder = $("#editor-holder");
             EditorManager.setEditorHolder(this.$editorHolder);
             
             var doc = SpecRunnerUtils.createMockDocument("hostEditor");

--- a/test/spec/ViewUtils-test.js
+++ b/test/spec/ViewUtils-test.js
@@ -14,7 +14,7 @@ define(function (require, exports, module) {
     describe("ViewUtils", function () {
 
         /*
-         * Note: This suite uses ViewUtils to apply the .scrollerShadow class to the fixture.
+         * Note: This suite uses ViewUtils to apply the .scroller-shadow class to the fixture.
          * However, the brackets.less file is not part of the SpecRunner. Therefore, no background-image
          * is displayed or animated. These tests simply validate that the correct
          * background-position value is written to the scrolling DOMElement.
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
             }
             
             function backgroundY(position) {
-                return parseInt($fixture.find(".scrollerShadow." + position).css("background-position").split(" ")[1], 10);
+                return parseInt($fixture.find(".scroller-shadow." + position).css("background-position").split(" ")[1], 10);
             }
         
             it("should not show the top shadow when no scrolling is available", function () {


### PR DESCRIPTION
This fixes file renaming part of Issue #408.

Style naming convention is to only use lowercase chars and hyphens.

Exceptions are styles defined in external frameworks and overridden in brackets:
1. .Codemirror-\* classes
2. jQuery Smart Autocomplete class: .smart_autocomplete_highlight
