### PR TITLE
Changes default encoding from 'utf-8' to 'utf8'.

### DIFF
--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -709,7 +709,7 @@ define(function (require, exports, module) {
         var self = this;
 
         if (!encoding) {
-            encoding = "utf-8";
+            encoding = "utf8";
         }
 
         if (this.readyState === this.LOADING) {


### PR DESCRIPTION
This fixes encoding errors when trying to read UTF-8 encoded files, and is consitent with encoding strings used in the rest of brackets.

Fixes Issue #848
