### PR TITLE
Issue866

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
                 result.reject(event.target.error);
             };
 
-            reader.readAsText(file, Encodings._IANAToNodeEncoding(Encodings.UTF8));
+            reader.readAsText(file, Encodings.UTF8);
         });
 
         return result.promise();

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -35,6 +35,8 @@ define(function (require, exports, module) {
         Dialogs             = require("widgets/Dialogs"),
         Strings             = require("strings");
     
+    var Encodings           = NativeFileSystem.Encodings;
+    
     /**
      * Asynchronously reads a file as UTF-8 encoded text.
      * @return {$.Promise} a jQuery promise that will be resolved with the 
@@ -63,7 +65,7 @@ define(function (require, exports, module) {
                 result.reject(event.target.error);
             };
 
-            reader.readAsText(file, "utf8");
+            reader.readAsText(file, Encodings._IANAToNodeEncoding(Encodings.UTF8));
         });
 
         return result.promise();

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -33,9 +33,9 @@ define(function (require, exports, module) {
     
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         Dialogs             = require("widgets/Dialogs"),
-        Strings             = require("strings");
-    
-    var Encodings           = NativeFileSystem.Encodings;
+        Strings             = require("strings"),
+        Encodings           = NativeFileSystem.Encodings;
+
     
     /**
      * Asynchronously reads a file as UTF-8 encoded text.

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -144,6 +144,12 @@ define(function (require, exports, module) {
     NativeFileSystem.Encodings.UTF8 = "UTF-8";
     NativeFileSystem.Encodings.UTF16 = "UTF-16";
     
+    /** class: _FSEncodings
+     *
+     * Internal static class that contains constants for file
+     * encoding types to be used by internal file system
+     * implimentation.
+     */
 	NativeFileSystem._FSEncodings = {};
     NativeFileSystem._FSEncodings.UTF8 = "utf8";
     NativeFileSystem._FSEncodings.UTF16 = "utf16";

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -149,8 +149,8 @@ define(function (require, exports, module) {
      * Internal static class that contains constants for file
      * encoding types to be used by internal file system
      * implimentation.
-     */
-	NativeFileSystem._FSEncodings = {};
+    */
+    NativeFileSystem._FSEncodings = {};
     NativeFileSystem._FSEncodings.UTF8 = "utf8";
     NativeFileSystem._FSEncodings.UTF16 = "utf16";
     
@@ -751,10 +751,10 @@ define(function (require, exports, module) {
         var self = this;
 
         if (!encoding) {
-            encoding = _FSEncodings.UTF8;
+            encoding = Encodings.UTF8;
         }
         
-        encoding  = Encodings._IANAToFS(encoding);
+        var internalEncoding  = Encodings._IANAToFS(encoding);
 
         if (this.readyState === this.LOADING) {
             throw new InvalidateStateError();
@@ -766,7 +766,7 @@ define(function (require, exports, module) {
             this.onloadstart(); // TODO (issue #241): progressevent
         }
 
-        brackets.fs.readFile(blob._fullPath, encoding, function (err, data) {
+        brackets.fs.readFile(blob._fullPath, internalEncoding, function (err, data) {
 
             // TODO (issue #241): the event objects passed to these event handlers is fake and incomplete right now
             var fakeEvent = {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -134,7 +134,31 @@ define(function (require, exports, module) {
             return new NativeFileSystem.FileError(error);
         }
     };
-
+    
+    /** class: Encodings
+     *
+     * Static class that contains constants for file
+     * encoding types.
+     */
+    NativeFileSystem.Encodings = {};
+    NativeFileSystem.Encodings.UTF8 = "UTF-8";
+    
+    //NativeFileSystem.NodeEncodingsMap = {};
+    //NativeFileSystem.NodeEncodingsMap[NativeFileSystem.Encodings.UTF8] = "utf8";
+    
+    var Encodings = NativeFileSystem.Encodings;
+    
+    //todo: current encoding strings are case sensitive. Double check if they
+    //are supposed to be
+    Encodings._IANAToNodeEncoding = function (encoding) {
+        switch (encoding) {
+        case (NativeFileSystem.Encodings.UTF8):
+            return "utf8";
+        default:
+            return undefined;
+        }
+    };
+    
     /** class: Entry
      *
      * @param {string} name
@@ -272,7 +296,7 @@ define(function (require, exports, module) {
 
             var self = this;
 
-            brackets.fs.writeFile(fileEntry.fullPath, data, "utf8", function (err) {
+            brackets.fs.writeFile(fileEntry.fullPath, data, Encodings._IANAToNodeEncoding(Encodings.UTF8), function (err) {
 
                 if ((err !== brackets.fs.NO_ERROR) && self.onerror) {
                     var fileError = NativeFileSystem._nativeToFileError(err);
@@ -317,7 +341,7 @@ define(function (require, exports, module) {
 
         // initialize file length
         var result = new $.Deferred();
-        brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
+        brackets.fs.readFile(fileEntry.fullPath, Encodings._IANAToNodeEncoding(Encodings.UTF8), function (err, contents) {
             // Ignore "file not found" errors. It's okay if the file doesn't exist yet.
             if (err !== brackets.fs.ERR_NOT_FOUND) {
                 fileWriter._err = err;
@@ -546,7 +570,7 @@ define(function (require, exports, module) {
 
                 // create the file
                 if (options.create) {
-                    brackets.fs.writeFile(fileFullPath, "", "utf8", function (err) {
+                    brackets.fs.writeFile(fileFullPath, "", Encodings._IANAToNodeEncoding(Encodings.UTF8), function (err) {
                         if (err) {
                             createFileError(err);
                         } else {
@@ -708,8 +732,10 @@ define(function (require, exports, module) {
     NativeFileSystem.FileReader.prototype.readAsText = function (blob, encoding) {
         var self = this;
 
+        encoding  = Encodings._IANAToNodeEncoding(encoding);
+        
         if (!encoding) {
-            encoding = "utf8";
+            encoding = Encodings._IANAToNodeEncoding(Encodings.UTF8);
         }
 
         if (this.readyState === this.LOADING) {

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -35,6 +35,10 @@ define(function (require, exports, module) {
         DocumentManager,     // loaded from brackets.test
         SpecRunnerUtils     = require("./SpecRunnerUtils.js");
     
+    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem;
+    var _FSEncodings        = NativeFileSystem._FSEncodings;
+    
+    
     describe("DocumentCommandHandlers", function () {
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
@@ -148,7 +152,7 @@ define(function (require, exports, module) {
                 // confirm file contents
                 var actualContent = null, error = -1;
                 runs(function () {
-                    brackets.fs.readFile(filePath, "utf8", function (err, contents) {
+                    brackets.fs.readFile(filePath, _FSEncodings.UTF8, function (err, contents) {
                         error = err;
                         actualContent = contents;
                     });
@@ -162,7 +166,7 @@ define(function (require, exports, module) {
 
                 // reset file contents
                 runs(function () {
-                    brackets.fs.writeFile(filePath, TEST_JS_CONTENT, "utf8");
+                    brackets.fs.writeFile(filePath, TEST_JS_CONTENT, _FSEncodings.UTF8);
                 });
             });
         });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -33,10 +33,9 @@ define(function (require, exports, module) {
         Commands,            // loaded from brackets.test
         DocumentCommandHandlers, // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
-    
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem;
-    var _FSEncodings        = NativeFileSystem._FSEncodings;
+        SpecRunnerUtils     = require("./SpecRunnerUtils.js"),
+        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+        _FSEncodings        = NativeFileSystem._FSEncodings;
     
     
     describe("DocumentCommandHandlers", function () {

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to use an unsppported encoding", function () {
-                brackets.fs.readFile(baseDir + "file_one.txt", "utf16", function (err, contents) {
+                brackets.fs.readFile(baseDir + "file_one.txt", _FSEncodings.UTF16, function (err, contents) {
                     error = err;
                     content = contents;
                     complete = true;

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+    var _FSEncodings        = require("file/NativeFileSystem").NativeFileSystem._FSEncodings;
     
     // These are tests for the low-level file io routines in brackets-app. Make sure
     // you have the latest brackets-app before running.
@@ -239,7 +240,7 @@ define(function (require, exports, module) {
             });
         
             it("should read a text file", function () {
-                brackets.fs.readFile(baseDir + "file_one.txt", "utf8", function (err, contents) {
+                brackets.fs.readFile(baseDir + "file_one.txt", _FSEncodings.UTF8, function (err, contents) {
                     error = err;
                     content = contents;
                     complete = true;
@@ -254,7 +255,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to read a non-existent file", function () {
-                brackets.fs.readFile("/This/file/doesnt/exist.txt", "utf8", function (err, contents) {
+                brackets.fs.readFile("/This/file/doesnt/exist.txt", _FSEncodings.UTF8, function (err, contents) {
                     error = err;
                     content = contents;
                     complete = true;
@@ -296,7 +297,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to read a directory", function () {
-                brackets.fs.readFile(baseDir, "utf8", function (err, contents) {
+                brackets.fs.readFile(baseDir, _FSEncodings.UTF8, function (err, contents) {
                     error = err;
                     content = contents;
                     complete = true;
@@ -318,7 +319,7 @@ define(function (require, exports, module) {
             });
         
             it("should write the entire contents of a file", function () {
-                brackets.fs.writeFile(baseDir + "write_test.txt", contents, "utf8", function (err) {
+                brackets.fs.writeFile(baseDir + "write_test.txt", contents, _FSEncodings.UTF8, function (err) {
                     error = err;
                     complete = true;
                 });
@@ -332,7 +333,7 @@ define(function (require, exports, module) {
                 // Read contents to verify
                 runs(function () {
                     complete = false;
-                    brackets.fs.readFile(baseDir + "write_test.txt", "utf8", function (err, data) {
+                    brackets.fs.readFile(baseDir + "write_test.txt", _FSEncodings.UTF8, function (err, data) {
                         error = err;
                         content = data;
                         complete = true;
@@ -349,7 +350,7 @@ define(function (require, exports, module) {
         
             it("should return an error if the file can't be written (Mac only)", function () {
                 if (brackets.platform === "mac") {
-                    brackets.fs.writeFile(baseDir + "cant_write_here/write_test.txt", contents, "utf8", function (err) {
+                    brackets.fs.writeFile(baseDir + "cant_write_here/write_test.txt", contents, _FSEncodings.UTF8, function (err) {
                         error = err;
                         complete = true;
                     });
@@ -377,7 +378,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an error if trying to write a directory", function () {
-                brackets.fs.writeFile(baseDir, contents, "utf8", function (err) {
+                brackets.fs.writeFile(baseDir, contents, _FSEncodings.UTF8, function (err) {
                     error = err;
                     complete = true;
                 });
@@ -401,7 +402,7 @@ define(function (require, exports, module) {
             it("should remove a file", function () {
                 var filename = baseDir + "remove_me.txt";
             
-                brackets.fs.writeFile(filename, contents, "utf8", function (err) {
+                brackets.fs.writeFile(filename, contents, _FSEncodings.UTF8, function (err) {
                     error = err;
                     complete = true;
                 });
@@ -416,7 +417,7 @@ define(function (require, exports, module) {
                 // Read contents to verify
                 runs(function () {
                     complete = false;
-                    brackets.fs.readFile(filename, "utf8", function (err, data) {
+                    brackets.fs.readFile(filename, _FSEncodings.UTF8, function (err, data) {
                         error = err;
                         content = data;
                         complete = true;

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -31,6 +31,8 @@ define(function (require, exports, module) {
     // Load dependent modules
     var NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
         SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+    
+    var Encodings               = NativeFileSystem.Encodings;
 
     describe("NativeFileSystem", function () {
         
@@ -268,7 +270,7 @@ define(function (require, exports, module) {
                     reader.onerror = function (event) {
                         gotError = true;
                     };
-                    reader.readAsText(file, "utf8");
+                    reader.readAsText(file, Encodings.UTF8);
                 });
 
                 waitsFor(function () { return gotFile && readFile; }, 1000);
@@ -293,7 +295,7 @@ define(function (require, exports, module) {
                     reader.onerror = function (event) {
                         errorCode = event.target.error.code;
                     };
-                    reader.readAsText(file, "utf8");
+                    reader.readAsText(file, Encodings.UTF8);
                 });
 
                 waitsFor(function () { return gotFile && errorCode; }, 1000);
@@ -330,7 +332,7 @@ define(function (require, exports, module) {
                     reader.onabort = function (event) {
                         gotAbort = true;
                     };
-                    reader.readAsText(file, "utf8");
+                    reader.readAsText(file, Encodings.UTF8);
                 });
 
                 waitsFor(function () { return gotLoad && gotLoadEnd && gotProgress; }, 1000);
@@ -358,7 +360,7 @@ define(function (require, exports, module) {
                     reader.onerror = function (event) {
                         gotError = true;
                     };
-                    reader.readAsText(file, "utf8");
+                    reader.readAsText(file, Encodings.UTF8);
                 });
 
                 waitsFor(function () { return gotError; }, 1000);

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -258,31 +258,38 @@ define(function (require, exports, module) {
         });
 
         describe("Reading a file", function () {
-            it("should read a file from disk", function () {
-                var gotFile = false, readFile = false, gotError = false, content;
-                var fileEntry = new NativeFileSystem.FileEntry(this.path + "/file1");
-                fileEntry.file(function (file) {
-                    gotFile = true;
-                    var reader = new NativeFileSystem.FileReader();
-                    reader.onload = function (event) {
-                        readFile = true;
-                        content = event.target.result;
-                    };
-                    reader.onerror = function (event) {
-                        gotError = true;
-                    };
-                    reader.readAsText(file, Encodings.UTF8);
-                });
-
-                waitsFor(function () { return gotFile && readFile; }, 1000);
-
-                runs(function () {
-                    expect(gotFile).toBe(true);
-                    expect(readFile).toBe(true);
-                    expect(gotError).toBe(false);
-                    expect(content).toBe(this.file1content);
-                });
-            });
+            
+            var readFile = function (encoding) {
+                return function () {
+                    var gotFile = false, readFile = false, gotError = false, content;
+                    var fileEntry = new NativeFileSystem.FileEntry(this.path + "/file1");
+                    fileEntry.file(function (file) {
+                        gotFile = true;
+                        var reader = new NativeFileSystem.FileReader();
+                        reader.onload = function (event) {
+                            readFile = true;
+                            content = event.target.result;
+                        };
+                        reader.onerror = function (event) {
+                            gotError = true;
+                        };
+                        reader.readAsText(file, encoding);
+                    });
+    
+                    waitsFor(function () { return gotFile && readFile; }, 1000);
+    
+                    runs(function () {
+                        expect(gotFile).toBe(true);
+                        expect(readFile).toBe(true);
+                        expect(gotError).toBe(false);
+                        expect(content).toBe(this.file1content);
+                    });
+                };
+            };
+            
+            it("should read a file from disk", readFile(Encodings.UTF8));
+            it("should read a file from disk with lower case encoding", readFile(Encodings.UTF8.toLowerCase()));
+            it("should read a file from disk with upper case encoding", readFile(Encodings.UTF8.toUpperCase()));
 
             it("should return an error if the file is not found", function () {
                 var gotFile = false, readFile = false, errorCode;
@@ -307,7 +314,7 @@ define(function (require, exports, module) {
                     expect(errorCode).toBe(FileError.NOT_FOUND_ERR);
                 });
             });
-
+            
             it("should fire appropriate events when the file is done loading", function () {
                 var gotFile = false, gotLoad = false, gotLoadStart = false, gotLoadEnd = false,
                     gotProgress = false, gotError = false, gotAbort = false;

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         SpecRunnerUtils         = require("./SpecRunnerUtils.js");
     
     var Encodings               = NativeFileSystem.Encodings;
+    var _FSEncodings            = NativeFileSystem._FSEncodings;
 
     describe("NativeFileSystem", function () {
         
@@ -446,7 +447,7 @@ define(function (require, exports, module) {
 
                 // read the new file
                 runs(function () {
-                    brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
+                    brackets.fs.readFile(fileEntry.fullPath, _FSEncodings.UTF8, function (err, contents) {
                         actualContents = contents;
                     });
                 });
@@ -595,7 +596,7 @@ define(function (require, exports, module) {
                 var actualContents = null;
 
                 runs(function () {
-                    brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
+                    brackets.fs.readFile(fileEntry.fullPath, _FSEncodings.UTF8, function (err, contents) {
                         actualContents = contents;
                     });
                 });
@@ -609,7 +610,7 @@ define(function (require, exports, module) {
 
                     // reset file1 content
                     // reset file1 content
-                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8", function () {
+                    brackets.fs.writeFile(this.path + "/file1", this.file1content, _FSEncodings.UTF8, function () {
                         rewriteComplete = true;
                     });
                 });
@@ -652,7 +653,7 @@ define(function (require, exports, module) {
                 var actualContents = null;
 
                 runs(function () {
-                    brackets.fs.readFile(fileEntry.fullPath, "utf8", function (err, contents) {
+                    brackets.fs.readFile(fileEntry.fullPath, _FSEncodings.UTF8, function (err, contents) {
                         actualContents = contents;
                     });
                 });
@@ -665,7 +666,7 @@ define(function (require, exports, module) {
                     expect(actualContents).toEqual("");
 
                     // reset file1 content
-                    brackets.fs.writeFile(this.path + "/file1", this.file1content, "utf8", function () {
+                    brackets.fs.writeFile(this.path + "/file1", this.file1content, _FSEncodings.UTF8, function () {
                         rewriteComplete = true;
                     });
                 });


### PR DESCRIPTION
All public FileSystem APIs now use IANA names (specified by w3c File System draft specification).

Created two new objects with constants:

NativeFileSystem.Encodings : contains IANA file encoding names, for use with the public file api.
NativeFileSystem_FSEncodings : contains encoding names used for internal, low level file system access (currently compatible with Node.js File API).

Updated all test cases to use Encoding constants.

Added two new test cases to test that public APIs take encoding names regardless of case.

Addressed Issue #866
