### PR TITLE
Removed semi-bold from the selection weight

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -261,7 +261,6 @@ a, img {
             }
             &.selected {
                 a {
-                    font-weight: @font-weight-semibold;
                     color: #fff;
                 }
             }

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -60,7 +60,6 @@
         
         &.jstree-clicked {
             color: #fff;
-            font-weight: @font-weight-semibold;
         }
     }
     .extension a {
@@ -70,7 +69,6 @@
         margin-left: 10px;
         > a {
             color: #fff;
-            font-weight: @font-weight-semibold;
         }
     }
     &.jstree-leaf {


### PR DESCRIPTION
I just removed the semi bold from the selection style.  This will work better in the future plans for the project panel design and fixes issue #875 as well.
