### PR TITLE
Fix #852 by applying a cursor:col-resize style to the required elements

### DIFF
--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $  */
+/*global define, $, document  */
 
 define(function (require, exports, module) {
     'use strict';
@@ -126,6 +126,8 @@ define(function (require, exports, module) {
         });
         $sidebarResizer.on("mousedown.sidebar", function (e) {
             var startX = e.clientX;
+            // make sure the cursor displays as col-resize across the entire page
+            $("body,a,.CodeMirror-lines").addClass("resizing");
             
             // check to see if we're currently in hidden mode
             if (isSidebarClosed) {
@@ -169,6 +171,8 @@ define(function (require, exports, module) {
                 
             $mainView.one("mouseup.sidebar", function (e) {
                 $mainView.off("mousemove.sidebar");
+                // reset the cursors back to their normal state
+                $("body,a,.CodeMirror-lines").removeClass("resizing");
                 startingSidebarPosition = $sidebar.width();
             });
                 

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
                 // unbind the mouse event. 
                 if ((startX > 10) && (newWidth < 10)) {
                     toggleSidebar(startingSidebarPosition);
-                    //$("body").toggleClass("resizing");
+                    $(document.body).toggleClass("resizing");
                     doResize = false;
                 } else if (startX < 10) {
                     // reset startX if we're going from a snapped closed position to open
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
                 
                 if (newWidth === 0) {
                     $mainView.off("mousemove.sidebar");
-                    //$("body").toggleClass("resizing");
+                    $(document.body).toggleClass("resizing");
                 }
                     
                 e.preventDefault();
@@ -185,7 +185,7 @@ define(function (require, exports, module) {
                 
             $mainView.one("mouseup.sidebar", function (e) {
                 $mainView.off("mousemove.sidebar");
-                //$("body").toggleClass("resizing");
+                $(document.body).toggleClass("resizing");
                 startingSidebarPosition = $sidebar.width();
             });
                 

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, document  */
+/*global define, $  */
 
 define(function (require, exports, module) {
     'use strict';
@@ -108,20 +108,6 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Remove event listeners and clean up the sidebar
-     * Decided this belonged in a separate function in case there are other
-     * things that need to be cleaned up. But it might be better to move
-     * the element references (mainView, resizingDiv) up in the scope chain.
-     * @param {mainView} the mainView object
-     * @param {resizingDiv} the resizingDiv object
-     */
-    function _cleanupSidebar($mainView, $resizingDiv) {
-        $mainView.off("mousemove.sidebar");
-        $resizingDiv.remove();
-    }
-    
-    /**
-     * @private
      * Install sidebar resize handling.
      */
     function _initSidebarResizer() {
@@ -141,7 +127,7 @@ define(function (require, exports, module) {
         });
         $sidebarResizer.on("mousedown.sidebar", function (e) {
             var startX = e.clientX;
-            $(document.body).toggleClass("resizing");
+            $("body").toggleClass("resizing");
             // check to see if we're currently in hidden mode
             if (isSidebarClosed) {
                 toggleSidebar(1);
@@ -157,7 +143,7 @@ define(function (require, exports, module) {
                 if ((startX > 10) && (newWidth < 10)) {
                     toggleSidebar(startingSidebarPosition);
                     $mainView.off("mousemove.sidebar");
-                    $(document.body).toggleClass("resizing");
+                    $("body").toggleClass("resizing");
                     doResize = false;
                 } else if (startX < 10) {
                     // reset startX if we're going from a snapped closed position to open
@@ -178,7 +164,7 @@ define(function (require, exports, module) {
                 
                 if (newWidth === 0) {
                     $mainView.off("mousemove.sidebar");
-                    $(document.body).toggleClass("resizing");
+                    $("body").toggleClass("resizing");
                 }
                     
                 e.preventDefault();
@@ -186,7 +172,7 @@ define(function (require, exports, module) {
                 
             $mainView.one("mouseup.sidebar", function (e) {
                 $mainView.off("mousemove.sidebar");
-                $(document.body).toggleClass("resizing");
+                $("body").toggleClass("resizing");
                 startingSidebarPosition = $sidebar.width();
             });
                 

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $  */
+/*global define, $, document  */
 
 define(function (require, exports, module) {
     'use strict';
@@ -128,6 +128,7 @@ define(function (require, exports, module) {
      */
     function _initSidebarResizer() {
         var $mainView               = $(".main-view"),
+            $body                   = $(document.body),
             prefs                   = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs),
             sidebarWidth            = prefs.getValue("sidebarWidth"),
             startingSidebarPosition = sidebarWidth;
@@ -150,7 +151,7 @@ define(function (require, exports, module) {
         });
         $sidebarResizer.on("mousedown.sidebar", function (e) {
             var startX = e.clientX;
-            $("body").toggleClass("resizing");
+            $body.toggleClass("resizing");
             // check to see if we're currently in hidden mode
             if (isSidebarClosed) {
                 toggleSidebar(1);
@@ -166,7 +167,7 @@ define(function (require, exports, module) {
                 if ((startX > 10) && (newWidth < 10)) {
                     toggleSidebar(startingSidebarPosition);
                     $mainView.off("mousemove.sidebar");
-                    $("body").toggleClass("resizing");
+                    $body.toggleClass("resizing");
                     doResize = false;
                 } else if (startX < 10) {
                     // reset startX if we're going from a snapped closed position to open
@@ -195,7 +196,7 @@ define(function (require, exports, module) {
                 
             $mainView.one("mouseup.sidebar", function (e) {
                 $mainView.off("mousemove.sidebar");
-                $("body").toggleClass("resizing");
+                $body.toggleClass("resizing");
                 startingSidebarPosition = $sidebar.width();
             });
             

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -156,6 +156,7 @@ define(function (require, exports, module) {
                 // unbind the mouse event. 
                 if ((startX > 10) && (newWidth < 10)) {
                     toggleSidebar(startingSidebarPosition);
+                    $mainView.off("mousemove.sidebar");
                     $(document.body).toggleClass("resizing");
                     doResize = false;
                 } else if (startX < 10) {

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -108,12 +108,27 @@ define(function (require, exports, module) {
     
     /**
      * @private
+     * Remove event listeners and clean up the sidebar
+     * Decided this belonged in a separate function in case there are other
+     * things that need to be cleaned up. But it might be better to move
+     * the element references (mainView, resizingDiv) up in the scope chain.
+     * @param {mainView} the mainView object
+     * @param {resizingDiv} the resizingDiv object
+     */
+    function _cleanupSidebar($mainView, $resizingDiv) {
+        $mainView.off("mousemove.sidebar");
+        $resizingDiv.remove();
+    }
+    
+    /**
+     * @private
      * Install sidebar resize handling.
      */
     function _initSidebarResizer() {
         var $mainView               = $(".main-view"),
             sidebarWidth            = $sidebar.width(),
-            startingSidebarPosition = sidebarWidth;
+            startingSidebarPosition = sidebarWidth,
+            $resizingDiv            = null;
         
         $sidebarResizer.css("left", sidebarWidth - 1);
         $sidebarResizer.on("dblclick", function () {
@@ -126,9 +141,7 @@ define(function (require, exports, module) {
         });
         $sidebarResizer.on("mousedown.sidebar", function (e) {
             var startX = e.clientX;
-            // make sure the cursor displays as col-resize across the entire page
-            $("body,a,.CodeMirror-lines").addClass("resizing");
-            
+            $(document.body).toggleClass("resizing");
             // check to see if we're currently in hidden mode
             if (isSidebarClosed) {
                 toggleSidebar(1);
@@ -143,7 +156,7 @@ define(function (require, exports, module) {
                 // unbind the mouse event. 
                 if ((startX > 10) && (newWidth < 10)) {
                     toggleSidebar(startingSidebarPosition);
-                    $mainView.off("mousemove.sidebar");
+                    //$("body").toggleClass("resizing");
                     doResize = false;
                 } else if (startX < 10) {
                     // reset startX if we're going from a snapped closed position to open
@@ -164,6 +177,7 @@ define(function (require, exports, module) {
                 
                 if (newWidth === 0) {
                     $mainView.off("mousemove.sidebar");
+                    //$("body").toggleClass("resizing");
                 }
                     
                 e.preventDefault();
@@ -171,8 +185,7 @@ define(function (require, exports, module) {
                 
             $mainView.one("mouseup.sidebar", function (e) {
                 $mainView.off("mousemove.sidebar");
-                // reset the cursors back to their normal state
-                $("body,a,.CodeMirror-lines").removeClass("resizing");
+                //$("body").toggleClass("resizing");
                 startingSidebarPosition = $sidebar.width();
             });
                 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -64,12 +64,12 @@ body {
     
     /* This appears to be necessary in Firefox when body is set to display: box. */
     width: 100%;
-    
-    &.resizing {
-    /* class for temporary full-screen div to show resize cursor */
-        cursor: col-resize;
+    &.resizing #sidebar #projects a, &.resizing .main-view, &.resizing .CodeMirror-lines, 
+    &.resizing .toolbar .nav a  {
+        cursor: col-resize;   
     }
 }
+
 
 a, img {
     -webkit-user-drag: none;
@@ -204,7 +204,7 @@ a, img {
     z-index: @z-index-brackets-sidebar-resizer;
     opacity: 0;
     cursor: col-resize;
-}
+} 
 
 /*
 .resizing {
@@ -268,10 +268,7 @@ a, img {
                 padding-right: @triangle-size * 2;
                 cursor: default;
             }
-            .resizing a {
-                /* class for temporary full-screen div to show resize cursor */
-                cursor: col-resize;
-            }            
+            
             .extension a {
                 color: #8e9a9d;
             }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -201,6 +201,11 @@ a, img {
     cursor: col-resize;
 }
 
+.resizing {
+    /* setting the cursor to col-resize for everything while we drag */
+    cursor: col-resize !important;
+}
+
 #file-section {
     .vbox;
     .box-flex(1);

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -64,6 +64,11 @@ body {
     
     /* This appears to be necessary in Firefox when body is set to display: box. */
     width: 100%;
+    
+    &.resizing {
+    /* class for temporary full-screen div to show resize cursor */
+        cursor: col-resize;
+    }
 }
 
 a, img {
@@ -201,10 +206,18 @@ a, img {
     cursor: col-resize;
 }
 
+/*
 .resizing {
-    /* setting the cursor to col-resize for everything while we drag */
-    cursor: col-resize !important;
+    cursor: col-resize;
+    width: 100%;
+    height: 100%;
+    z-index: @z-index-brackets-resizer-div;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
+*/
 
 #file-section {
     .vbox;
@@ -255,6 +268,10 @@ a, img {
                 padding-right: @triangle-size * 2;
                 cursor: default;
             }
+            .resizing a {
+                /* class for temporary full-screen div to show resize cursor */
+                cursor: col-resize;
+            }            
             .extension a {
                 color: #8e9a9d;
             }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -206,19 +206,6 @@ a, img {
     cursor: col-resize;
 } 
 
-/*
-.resizing {
-    cursor: col-resize;
-    width: 100%;
-    height: 100%;
-    z-index: @z-index-brackets-resizer-div;
-    opacity: 0;
-    position: absolute;
-    top: 0;
-    left: 0;
-}
-*/
-
 #file-section {
     .vbox;
     .box-flex(1);

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -64,8 +64,7 @@ body {
     
     /* This appears to be necessary in Firefox when body is set to display: box. */
     width: 100%;
-    &.resizing #sidebar #projects a, &.resizing .main-view, &.resizing .CodeMirror-lines, 
-    &.resizing .toolbar .nav a  {
+    &.resizing a, &.resizing #projects a, &.resizing .main-view, &.resizing .CodeMirror-lines {
         cursor: col-resize;   
     }
 }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -78,10 +78,6 @@
     
     .CodeMirror-lines {
         padding: @code-padding;
-        .resizing {
-            /* class for temporary full-screen div to show resize cursor */
-            cursor: col-resize;
-        }
     }
     .CodeMirror-gutter {
         background-color: @background-color-3;

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -69,6 +69,10 @@
     
     .CodeMirror-lines {
         padding: @code-padding;
+        .resizing {
+            /* class for temporary full-screen div to show resize cursor */
+            cursor: col-resize;
+        }
     }
     .CodeMirror-gutter {
         background-color: @background-color-3;

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -49,3 +49,4 @@
 @z-index-brackets-max: @z-index-brackets-toolbar;
 
 @z-index-brackets-sidebar-resizer: @z-index-brackets-ui + 2;
+@z-index-brackets-resizer-div: @z-index-brackets-sidebar-resizer + 1;


### PR DESCRIPTION
I tried a few different ways of doing this including $("*").addClass("resize") but this one was the most inexpensive by far. I hate having to hard-code .CodeMirror-files and a but I couldn't find another way to override the cursor attributes on those. !important didn't work. 
