### PR TITLE
Fontsize

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -214,6 +214,8 @@ define(function (require, exports, module) {
 
                     // VIEW
                     {"Ctrl-Shift-H": Commands.VIEW_HIDE_SIDEBAR},
+                    {"Ctrl-=": Commands.VIEW_INCREASE_FONT_SIZE},
+                    {"Ctrl--": Commands.VIEW_DECREASE_FONT_SIZE},
                     
                     // Navigate
                     {"Ctrl-Shift-O": Commands.NAVIGATE_QUICK_OPEN},

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -62,7 +62,9 @@ define(function (require, exports, module) {
     exports.EDIT_LINE_COMMENT   = "edit.lineComment";
 
     // VIEW
-    exports.VIEW_HIDE_SIDEBAR   = "view.hideSidebar";
+    exports.VIEW_HIDE_SIDEBAR       = "view.hideSidebar";
+    exports.VIEW_INCREASE_FONT_SIZE = "view.increaseFontSize";
+    exports.VIEW_DECREASE_FONT_SIZE = "view.decreaseFontSize";
     
     // Navigate
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -35,17 +35,12 @@ define(function (require, exports, module) {
      * @param {boolean} hasAlt Is Alt key enabled
      * @param {boolean} hasShift Is Shift key enabled
      * @param {string} key The key that's pressed
-     * @param {string} origDescriptor The optional original descriptor
      * @return {string} The normalized key descriptor
      */
-    function _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key, origDescriptor) {
+    function _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key) {
         if (!key) {
-            if (origDescriptor && origDescriptor.search(/^.+--$/) !== -1) { // Check if the binding is for "-"
-                key = "-";
-            } else {
-                console.log("KeyMap _buildKeyDescriptor() - No key provided!");
-                return "";
-            }
+            console.log("KeyMap _buildKeyDescriptor() - No key provided!");
+            return "";
         }
         
         var keyDescriptor = [];
@@ -115,8 +110,13 @@ define(function (require, exports, module) {
                 key = ele;
             }
         });
+
+        // Check to see if the binding is for "-".
+        if (key === "" && origDescriptor.search(/^.+--$/) !== -1) {
+            key = "-";
+        }
         
-        return _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key, origDescriptor);
+        return _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key);
     }
     
     /**

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp:true */
 /*global define, brackets */
 
 define(function (require, exports, module) {
@@ -35,12 +35,18 @@ define(function (require, exports, module) {
      * @param {boolean} hasAlt Is Alt key enabled
      * @param {boolean} hasShift Is Shift key enabled
      * @param {string} key The key that's pressed
+     * @param {string} origDescriptor The optional original descriptor
      * @return {string} The normalized key descriptor
      */
-    function _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key) {
+    function _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key, origDescriptor) {
         if (!key) {
-            console.log("KeyMap _buildKeyDescriptor() - No key provided!");
-            return "";
+            
+            if (origDescriptor && origDescriptor.search(/^.+--$/) !== -1) { // Check if the binding is for "-"
+                key = "-";
+            } else {
+                console.log("KeyMap _buildKeyDescriptor() - No key provided!");
+                return "";
+            }
         }
         
         var keyDescriptor = [];
@@ -111,7 +117,7 @@ define(function (require, exports, module) {
             }
         });
         
-        return _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key);
+        return _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key, origDescriptor);
     }
     
     /**

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -40,7 +40,6 @@ define(function (require, exports, module) {
      */
     function _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key, origDescriptor) {
         if (!key) {
-            
             if (origDescriptor && origDescriptor.search(/^.+--$/) !== -1) { // Check if the binding is for "-"
                 key = "-";
             } else {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -917,6 +917,20 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Re-renders the editor, and all children inline editors.
+     */
+    Editor.prototype.refreshAll = function () {
+        this.refresh();
+        this.getInlineWidgets().forEach(function (multilineEditor, i, arr) {
+            multilineEditor.sizeInlineWidgetToContents(true);
+            multilineEditor._updateRelatedContainer();
+            multilineEditor.editors.forEach(function (editor, j, arr) {
+                editor.refresh();
+            });
+        });
+    };
+    
+    /**
      * Shows or hides the editor within its parent. Does not force its ancestors to
      * become visible.
      * @param {boolean} show true to show the editor, false to hide it

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -20,6 +20,15 @@
 
 /* Brackets / CodeMirror Code Formatting */
 
+/*
+ * TODO This can be removed next time we update CodeMirror2.
+ * Marijn made this change to codemirror.css, but I need it now
+ * in order to make font resizing work.
+ */
+.CodeMirror pre {
+    line-height: inherit;
+}
+
 .CodeMirror-scroll {
     background-color: @background-color-3;
 }

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -102,11 +102,9 @@
  */
 .code-font() {
     color: @content-color;
-    pre {
-        // line-height must be specified in px not em because the code font and line number font sizes are different.
-        // Sizing via em will cause the code and line numbers to misalign
-        line-height: 15px;
-    }
+    // line-height must be specified in px not em because the code font and line number font sizes are different.
+    // Sizing via em will cause the code and line numbers to misalign
+    line-height: 15px;
 }
 
 .code-font-win() {

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -77,9 +77,17 @@ define(function (require, exports, module) {
                           " !important;line-height:" + lhStr + " !important;}";
         $("head").append(style);
 
-        var editor = EditorManager.getFocusedEditor();
-        var codeMirror = editor._codeMirror;
-        codeMirror.refresh();
+        var fullEditor = EditorManager.getCurrentFullEditor();
+        fullEditor._codeMirror.refresh();
+        
+        var inlineEditors = fullEditor.getInlineWidgets();
+        inlineEditors.forEach(function (multilineEditor, i, arr) {
+            multilineEditor.sizeInlineWidgetToContents(true);
+            multilineEditor._updateRelatedContainer();
+            multilineEditor.editors.forEach(function (editor, j, arr) {
+                editor._codeMirror.refresh();
+            });
+        });
     }
 
     function _handleIncreaseFontSize() {


### PR DESCRIPTION
Added the ability to increase and decrease the font size of the editor using Ctrl -/+. The change should be persistent across all editors, but not persistent across sessions.

Note that the change to brackets_codemirror_override.less is only temporary and can be removed once we either update CodeMirror2, or once we merge codemirror.css separately.
