### PR TITLE
Click on inline header to jump to full editor

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -666,7 +666,7 @@ define(function (require, exports, module) {
     /**
      * Sets the cursor position within the editor. Removes any selection.
      * @param {number} line The 0 based line number.
-     * @param {number} ch   The 0 based character position.
+     * @param {number=} ch  The 0 based character position; treated as 0 if unspecified.
      */
     Editor.prototype.setCursorPos = function (line, ch) {
         this._codeMirror.setCursor(line, ch);

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -32,6 +32,8 @@ define(function (require, exports, module) {
     // Load dependent modules
     var DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
+        CommandManager      = require("command/CommandManager"),
+        Commands            = require("command/Commands"),
         InlineWidget        = require("editor/InlineWidget").InlineWidget;
 
     /**
@@ -202,14 +204,15 @@ define(function (require, exports, module) {
             self.close();
         }
         
-        // create the filename div
+        // root container holding header & editor
         var wrapperDiv = window.document.createElement("div");
         var $wrapperDiv = $(wrapperDiv);
         
-        // dirty indicator followed by filename
-        var $filenameDiv = $(window.document.createElement("div")).addClass("filename");
+        // header containing filename, dirty indicator, line number
+        var $header = $(window.document.createElement("div")).addClass("inline-editor-header");
+        var $filenameDiv = $(window.document.createElement("span")).addClass("filename");
         
-        // save file path data to dirty-indicator
+        // dirty indicator, with file path stored on it
         var $dirtyIndicatorDiv = $(window.document.createElement("div"))
             .addClass("dirty-indicator")
             .width(0); // initialize indicator as hidden
@@ -222,8 +225,18 @@ define(function (require, exports, module) {
             .append($nameWithTooltip)
             .append(" : ")
             .append($lineNumber);
-        $wrapperDiv.append($filenameDiv);
+        $header.append($filenameDiv);
+        $wrapperDiv.append($header);
+        
+        // Clicking filename jumps to full editor view
+        $filenameDiv.click(function () {
+            CommandManager.execute(Commands.FILE_OPEN, { fullPath: doc.file.fullPath })
+                .done(function () {
+                    EditorManager.getCurrentFullEditor().setCursorPos(startLine);
+                });
+        });
 
+        // Create actual Editor instance
         var inlineInfo = EditorManager.createInlineEditorForDocument(doc, range, wrapperDiv, closeThisInline, additionalKeys);
         this.editors.push(inlineInfo.editor);
         container.appendChild(wrapperDiv);

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -205,37 +205,39 @@ define(function (require, exports, module) {
         }
         
         // root container holding header & editor
-        var wrapperDiv = window.document.createElement("div");
-        var $wrapperDiv = $(wrapperDiv);
+        var $wrapperDiv = $("<div/>");
+        var wrapperDiv = $wrapperDiv[0];
         
         // header containing filename, dirty indicator, line number
-        var $header = $(window.document.createElement("div")).addClass("inline-editor-header");
-        var $filenameDiv = $(window.document.createElement("span")).addClass("filename");
+        var $header = $("<div/>").addClass("inline-editor-header");
+        var $filenameInfo = $("<a/>").addClass("filename");
         
         // dirty indicator, with file path stored on it
-        var $dirtyIndicatorDiv = $(window.document.createElement("div"))
+        var $dirtyIndicatorDiv = $("<div/>")
             .addClass("dirty-indicator")
             .width(0); // initialize indicator as hidden
         $dirtyIndicatorDiv.data("fullPath", doc.file.fullPath);
         
-        var $nameWithTooltip = $("<span></span>").text(doc.file.name).attr("title", doc.file.fullPath);
         var $lineNumber = $("<span class='line-number'>" + (startLine + 1) + "</span>");
 
-        $filenameDiv.append($dirtyIndicatorDiv)
-            .append($nameWithTooltip)
-            .append(" : ")
-            .append($lineNumber);
-        $header.append($filenameDiv);
-        $wrapperDiv.append($header);
+        // wrap filename & line number in clickable link with tooltip
+        $filenameInfo.append($dirtyIndicatorDiv)
+            .append(doc.file.name + " : ")
+            .append($lineNumber)
+            .attr("title", doc.file.fullPath);
         
-        // Clicking filename jumps to full editor view
-        $filenameDiv.click(function () {
+        // clicking filename jumps to full editor view
+        $filenameInfo.click(function () {
             CommandManager.execute(Commands.FILE_OPEN, { fullPath: doc.file.fullPath })
                 .done(function () {
                     EditorManager.getCurrentFullEditor().setCursorPos(startLine);
                 });
         });
 
+        $header.append($filenameInfo);
+        $wrapperDiv.append($header);
+        
+        
         // Create actual Editor instance
         var inlineInfo = EditorManager.createInlineEditorForDocument(doc, range, wrapperDiv, closeThisInline, additionalKeys);
         this.editors.push(inlineInfo.editor);

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -312,8 +312,8 @@ define(function (require, exports, module) {
             editorRoot = childEditor.getRootElement(),
             editorPos = $(editorRoot).offset();
         
-        function containsClick(parent) {
-            return parent.find(event.target) > 0 || parent[0] === event.target;
+        function containsClick($parent) {
+            return $parent.find(event.target) > 0 || $parent[0] === event.target;
         }
         
         // Ignore clicks in editor and clicks on filename link

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -311,10 +311,16 @@ define(function (require, exports, module) {
         var childEditor = this.editors[0],
             editorRoot = childEditor.getRootElement(),
             editorPos = $(editorRoot).offset();
-        if ($(editorRoot).find(event.target).length === 0) {
+        
+        function containsClick(parent) {
+            return parent.find(event.target) > 0 || parent[0] === event.target;
+        }
+        
+        // Ignore clicks in editor and clicks on filename link
+        if (!containsClick($(editorRoot)) && !containsClick($(".filename", this.$editorsDiv))) {
             childEditor.focus();
             // Only set the cursor if the click isn't in the range list.
-            if (this.$relatedContainer.find(event.target).length === 0) {
+            if (!containsClick(this.$relatedContainer)) {
                 if (event.pageY < editorPos.top) {
                     childEditor.setCursorPos(0, 0);
                 } else if (event.pageY > editorPos.top + $(editorRoot).height()) {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -418,7 +418,8 @@ ins.jstree-icon {
             font-size: 1.1em;
             color: @inline-color-1;
             
-            // Filename header is clickable
+            // Filename header is clickable (it's an <a> tag, so we get underscore on hover by
+            // default; but the hand cursor is shut off by Bootstrap's reset stylesheet)
             cursor: pointer;
             
             .dirty-indicator {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -410,21 +410,27 @@ ins.jstree-icon {
 .inline-widget {
     background-color:   @inline-background-color-1;
     
-    .filename {
-        font-family: @fontstack-sans-serif;
-        font-size: 1.1em;
-        color: @inline-color-1;
+    .inline-editor-header {
         padding: 10px 10px 0px 10px;
         
-        .dirty-indicator {
-            .bracket-sprite;
-            display: inline-block;
-            background-position: -32px 0;
-            padding-top: 3px;
-        }
-        
-        .line-number {
-            color: @inline-color-2;
+        .filename {
+            font-family: @fontstack-sans-serif;
+            font-size: 1.1em;
+            color: @inline-color-1;
+            
+            // Filename header is clickable
+            cursor: pointer;
+            
+            .dirty-indicator {
+                .bracket-sprite;
+                display: inline-block;
+                background-position: -32px 0;
+                padding-top: 3px;
+            }
+            
+            .line-number {
+                color: @inline-color-2;
+            }
         }
     }
     


### PR DESCRIPTION
Clicking the filename label in an inline editor's header jumps to full editor (at correct line number).  Link "hand" cursor indicates clickability.

Adds a wrapper span to the header layout so cursor / click region stays tight around filename label instead of extending across blank part of header.
