### PR TITLE
Add some common language color syntaxing (php, coffee, ruby, ...)

### DIFF
--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -37,6 +37,16 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror2/mode/css/css");
     require("thirdparty/CodeMirror2/mode/less/less");
     require("thirdparty/CodeMirror2/mode/htmlmixed/htmlmixed");
+    require("thirdparty/CodeMirror2/mode/xml/xml");
+    require("thirdparty/CodeMirror2/mode/clike/clike");
+    require("thirdparty/CodeMirror2/mode/php/php");
+    require("thirdparty/CodeMirror2/mode/coffeescript/coffeescript");
+    require("thirdparty/CodeMirror2/mode/clojure/clojure");
+    require("thirdparty/CodeMirror2/mode/perl/perl");
+    require("thirdparty/CodeMirror2/mode/ruby/ruby");
+    require("thirdparty/CodeMirror2/mode/mysql/mysql");
+    require("thirdparty/CodeMirror2/mode/diff/diff");
+    require("thirdparty/CodeMirror2/mode/markdown/markdown");
 
     /**
      * @private
@@ -72,6 +82,47 @@ define(function (require, exports, module) {
         case "htm":
         case "xhtml":
             return "htmlmixed";
+
+        case "xml":
+            return "xml";
+
+        case "php":
+            return "php";
+
+        case "c":
+        case "cc":
+        case "c++":
+        case "cxx":
+        case "cp":
+        case "cpp":
+        case "h":
+        case "hpp":
+        case "vert":
+        case "frag":
+        case "java":
+            return "clike";
+
+        case "coffee":
+            return "coffeescript";
+
+        case "clj":
+            return "clojure";
+
+        case "pl":
+            return "perl";
+        
+        case "rb":
+            return "ruby";
+
+        case "sql":
+            return "mysql";
+
+        case "diff":
+        case "patch":
+            return "diff";
+
+        case "md":
+            return "markdown";
 
         default:
             console.log("Called EditorUtils.js _getModeFromFileExtensions with an unhandled file extension: " + ext);

--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -87,20 +87,35 @@ define(function (require, exports, module) {
             return "xml";
 
         case "php":
+        case "php3":
+        case "php4":
+        case "php5":
+        case "phtm":
+        case "phtml":
             return "php";
 
-        case "c":
         case "cc":
-        case "c++":
-        case "cxx":
         case "cp":
         case "cpp":
-        case "h":
+        case "c++":
+        case "cxx":
+        case "hh":
         case "hpp":
-        case "vert":
-        case "frag":
+        case "hxx":
+        case "h++":
+        case "ii":
+            return "text/x-c++src";
+
+        case "c":
+        case "h":
+        case "i":
+            return "text/x-csrc";
+
+        case "cs":
+            return "text/x-csharp";
+
         case "java":
-            return "clike";
+            return "text/x-java";
 
         case "coffee":
             return "coffeescript";
@@ -110,7 +125,7 @@ define(function (require, exports, module) {
 
         case "pl":
             return "perl";
-        
+
         case "rb":
             return "ruby";
 

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -62,6 +62,9 @@
     span.cm-quote {color: @accent-quote;}
     span.cm-hr {color: @accent-hr;}
     span.cm-link {color: @accent-link;}
+    span.cm-rangeinfo {color: @accent-rangeinfo;}
+    span.cm-minus {color: @accent-minus;}
+    span.cm-plus {color: @accent-plus;}
     
     span.CodeMirror-matchingbracket {color: @accent-bracket !important; background-color: @background-color-2;}
     span.CodeMirror-nonmatchingbracket {color: @accent-bracket !important;}

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -65,7 +65,7 @@
 @accent-atom: #f18900;
 @accent-number: #738d00;
 @accent-def: #8757ad;
-@accent-variable: #446fbd;
+@accent-variable: #535353;
 @accent-variable-2: #535353;
 @accent-variable-3: #535353;
 @accent-property: #8757ad;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -84,6 +84,9 @@
 @accent-quote: #446fbd;
 @accent-hr: #f18900;
 @accent-link: #8757ad;
+@accent-rangeinfo: #6c71c4;
+@accent-minus: #dc322f;
+@accent-plus: #859900;
 
 /* inline editor colors */
 @inline-background-color-1: #eaeaea;


### PR DESCRIPTION
I work a lot with coffeescript, php, patches and sometimes java files so I added those since they are included in codemirror.
- php
- coffeescript (.coffee)
- clike (java, c++ , c#, ...)
- clojure (clj)
- ruby (rb)
- mysql (sql)
- diff (diff, patch)
- markdown (md)

I've quickly tested with .md, .coffee, .php, .java, ..cpp, clj, .patch (not much colors with a patch coming from a git diff >)

By the way, I've already filled the form at http://brackets.io/brackets-contributor-license-agreement.html
