### PR TITLE
fix issue #861 (and more)

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -63,136 +63,316 @@ define(function (require, exports, module) {
     function extractAllSelectors(text) {
         var selectors = [];
         var mode = CodeMirror.getMode({indentUnit: 2}, "css");
-        var state = CodeMirror.startState(mode);
-
-        var lines = CodeMirror.splitLines(text);
-        var lineCount = lines.length;
-        
+        var state, lines, lineCount;
+        var token, style, stream, line;
         var currentSelector = "";
         var ruleStartChar = -1, ruleStartLine = -1;
         var selectorStartChar = -1, selectorStartLine = -1;
-        var token, style, stream, i, j;
-
-        var inDeclList = false, inAtRule = false;
         var selectorGroupStartLine = -1, selectorGroupStartChar = -1;
         var declListStartLine = -1, declListStartChar = -1;
 
-        for (i = 0; i < lineCount; ++i) {
-            if (currentSelector.trim() !== "") {
-                // If we are in a current selector and starting a newline, make sure there is whitespace in the selector
-                currentSelector += " ";
-            }
-            
-            stream = new CodeMirror.StringStream(lines[i]);
-            while (!stream.eol()) {
-                style = mode.token(stream, state);
-                token = stream.current();
-
-                // DEBUG STATEMENT -- printer(token, style, i, stream.start, state.stack);
-
-                if (state.stack.indexOf("{") === -1 && // not in a declaration list
-                        (state.stack.length === 0 || state.stack[state.stack.length - 1] !== "@media") && // not parsing a media query
-                        ((style === null && token !== "{" && token !== "}" && token !== ",") || (style !== null))) { // not at a non-selector token
-
-                    // check for these special cases:
-                    if (inAtRule) {
-                        // once we're in at @rule, consume tokens until next semi-colon
-                        if (token === ";") {
-                            inAtRule = false;
-                        }
-                    } else if (token.match(/@(charset|import|namespace)/i)) {
-                        // This code only handles @rules in this format:
-                        //   @rule ... ;
-                        //
-                        // This code does not handle @rules that use this format:
-                        //    @rule ... { ... }
-                        // such as @media (which is handled elsewhere) @page,
-                        // @keyframes (also -webkit-keyframes, etc.), and @font-face.
-                        inAtRule = true;
-                        ruleStartLine = -1;  // reset so we don't get @rules following comments
-                        selectorStartChar = -1;
-                        selectorGroupStartLine = -1;
-                    } else {
-                        // detect non-crlf whitespace, comments on same line as '}'
-                        if (ruleStartLine < 0 && (token.trim() !== "") &&
-                                !(style === "comment" && stream.start > 0 && lines[i].substr(0, stream.start).indexOf('}') !== -1)) {
-                             
-                            // start of a new selector, or comment above selector
-                            ruleStartChar = stream.start;
-                            ruleStartLine = i;
-                        }
-
-                        if (selectorStartChar < 0 && (token.trim() !== "") && style !== "comment") {
-                             
-                            // start of a new selector, or comment above selector
-                            currentSelector = "";
-                            selectorStartChar = stream.start;
-                            selectorStartLine = i;
-                            if (selectorGroupStartLine < 0) {
-                                // this is the start of a new comma-separated selector group
-                                // (whenever we start parsing a declaration list, we set selectorGroupStartLine to -1)
-                                selectorGroupStartLine = selectorStartLine;
-                                selectorGroupStartChar = selectorStartChar;
-                            }
-                        }
-                        if (selectorStartChar !== -1) {
-                            currentSelector += token;
-                        }
-                    }
-                } else { // we aren't parsing a selector
-                    if (currentSelector.trim() !== "") { // we have a selector, and we parsed something that is not part of a selector, so we just finished parsing a selector
-                        selectors.push({selector: currentSelector.trim(),
-                                        ruleStartLine: ruleStartLine,
-                                        ruleStartChar: ruleStartChar,
-                                        selectorStartLine: selectorStartLine,
-                                        selectorStartChar: selectorStartChar,
-                                        declListEndLine: -1,
-                                        selectorEndLine: i,
-                                        selectorEndChar: stream.start - 1, // stream.start points to the first char of the non-selector token
-                                        selectorGroupStartLine: selectorGroupStartLine,
-                                        selectorGroupStartChar: selectorGroupStartChar
-                                       });
-                    }
-                    currentSelector = "";
-                    selectorStartChar = -1;
-
-                    if (!inDeclList) {
-                        if (state.stack.indexOf("{") > -1) { // just started parsing a declaration list
-                            inDeclList = true;
-                            declListStartLine = i;
-                            declListStartChar = stream.start;
-    
-                            // Since we're now in a declartion list, that means we also finished parsing the whole selector group.
-                            // Therefore, reset selectorGroupStartLine so that next time we parse a selector we know it's a new group
-                            selectorGroupStartLine = -1;
-                            selectorGroupStartChar = -1;
-                            ruleStartLine = -1;
-                            ruleStartChar = -1;
-                        } else if (token === "@media") {
-                            // ignore comments preceding @rules
-                            ruleStartLine = -1;
-                            ruleStartChar = -1;
-                        }
-                    } else if (inDeclList && state.stack.indexOf("{") === -1) {  // just finished parsing a declaration list
-                        inDeclList = false;
-                        // assign this declaration list position to every selector on the stack that doesn't have a declaration list start and end line
-                        for (j = selectors.length - 1; j >= 0; j--) {
-                            if (selectors[j].declListEndLine !== -1) {
-                                break;
-                            } else {
-                                selectors[j].declListStartLine = declListStartLine;
-                                selectors[j].declListStartChar = declListStartChar;
-                                selectors[j].declListEndLine = i;
-                                selectors[j].declListEndChar = stream.pos - 1; // stream.pos actually points to the char after the }
-                            }
-                        }
-                    }
+        // implement _getFirstToken()/_getNextToken() methods to
+        // provide a single stream of tokens
+        
+        function _hasStream() {
+            while (stream.eol()) {
+                line++;
+                if (line >= lineCount) {
+                    return false;
                 }
+                if (currentSelector.match(/\S/)) {
+                    // If we are in a current selector and starting a newline,
+                    // make sure there is whitespace in the selector
+                    currentSelector += " ";
+                }
+                stream = new CodeMirror.StringStream(lines[line]);
+            }
+            return true;
+        }
+        
+        function _getFirstToken() {
+            state = CodeMirror.startState(mode);
+            lines = CodeMirror.splitLines(text);
+            lineCount = lines.length;
+            if (lineCount === 0) {
+                return false;
+            }
+            line = 0;
+            stream = new CodeMirror.StringStream(lines[line]);
+            if (!_hasStream()) {
+                return false;
+            }
+            style = mode.token(stream, state);
+            token = stream.current();
+            return true;
+        }
+        
+        function _getNextToken() {
+            // advance the stream past this token
+            stream.start = stream.pos;
+            if (!_hasStream()) {
+                return false;
+            }
+            style = mode.token(stream, state);
+            token = stream.current();
+            return true;
+        }
+        
+        function _getFirstTokenSkippingWhitespace() {
+            if (!_getFirstToken()) {
+                return false;
+            }
+            while (!token.match(/\S/)) {
+                if (!_getNextToken()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        function _getNextTokenSkippingWhitespace() {
+            if (!_getNextToken()) {
+                return false;
+            }
+            while (!token.match(/\S/)) {
+                if (!_getNextToken()) {
+                    return false;
+                }
+            }
+            return true;
+        }
 
-                // advance the stream past this token
-                stream.start = stream.pos;
+        function _isStartComment() {
+            return (token.match(/^\/\*/));
+        }
+        
+        function _parseComment() {
+            while (!token.match(/\*\/$/)) {
+                if (!_getNextToken()) {
+                    break;
+                }
             }
         }
+
+        function _getNextTokenSkippingComments() {
+            if (!_getNextToken()) {
+                return false;
+            }
+            while (_isStartComment()) {
+                _parseComment();
+                if (!_getNextToken()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        function _parseSelector() {
+            
+            currentSelector = "";
+            selectorStartChar = stream.start;
+            selectorStartLine = line;
+            
+            // Skip everything until the next ',' or '{'
+            while (token !== "," && token !== "{") {
+                currentSelector += token;
+                if (!_getNextTokenSkippingComments()) {
+                    break;
+                }
+            }
+
+            currentSelector = currentSelector.trim();
+            if (currentSelector !== "") {
+                selectors.push({selector: currentSelector,
+                                ruleStartLine: ruleStartLine,
+                                ruleStartChar: ruleStartChar,
+                                selectorStartLine: selectorStartLine,
+                                selectorStartChar: selectorStartChar,
+                                declListEndLine: -1,
+                                selectorEndLine: line,
+                                selectorEndChar: stream.start - 1, // stream.start points to the first char of the non-selector token
+                                selectorGroupStartLine: selectorGroupStartLine,
+                                selectorGroupStartChar: selectorGroupStartChar
+                               });
+                currentSelector = "";
+            }
+            selectorStartChar = -1;
+        }
+        
+        function _parseSelectorList() {
+
+            selectorGroupStartLine = line;
+            selectorGroupStartChar = stream.start;
+
+            _parseSelector();
+            while (token === ",") {
+                if (!_getNextTokenSkippingComments()) {
+                    break;
+                }
+                _parseSelector();
+            }
+        }
+
+        function _parseDeclarationList() {
+
+            var j;
+            declListStartLine = line;
+            declListStartChar = stream.start;
+
+            // Since we're now in a declartion list, that means we also finished
+            // parsing the whole selector group. Therefore, reset selectorGroupStartLine
+            // so that next time we parse a selector we know it's a new group
+            selectorGroupStartLine = -1;
+            selectorGroupStartChar = -1;
+            ruleStartLine = -1;
+            ruleStartChar = -1;
+
+            // Skip everything until the next '}'
+            while (token !== "}") {
+                if (!_getNextTokenSkippingComments()) {
+                    break;
+                }
+            }
+            
+            // assign this declaration list position to every selector on the stack
+            // that doesn't have a declaration list start and end line
+            for (j = selectors.length - 1; j >= 0; j--) {
+                if (selectors[j].declListEndLine !== -1) {
+                    break;
+                } else {
+                    selectors[j].declListStartLine = declListStartLine;
+                    selectors[j].declListStartChar = declListStartChar;
+                    selectors[j].declListEndLine = line;
+                    selectors[j].declListEndChar = stream.pos - 1; // stream.pos actually points to the char after the }
+                }
+            }
+        }
+        
+        function _parseRule() {
+            _parseSelectorList();
+            _parseDeclarationList();
+        }
+        
+        function _isStartAtRule() {
+            return (token.match(/^@/));
+        }
+        
+        function includeCommentInNextRule() {
+            if (ruleStartChar !== -1) {
+                return false;       // already included
+            }
+            if (stream.start > 0 && lines[line].substr(0, stream.start).indexOf('}') !== -1) {
+                return false;       // on same line as '}', so it's for previous rule
+            }
+            return true;
+        }
+        
+        function _parseAtRule() {
+
+            // reset these fields to ignore comments preceding @rules
+            ruleStartLine = -1;
+            ruleStartChar = -1;
+            selectorStartLine = -1;
+            selectorStartChar = -1;
+            selectorGroupStartLine = -1;
+            selectorGroupStartChar = -1;
+            
+            if (token.match(/@media/i)) {
+                // @media rule holds a rule list
+                
+                // Skip everything until the opening '{'
+                while (token !== "{") {
+                    if (!_getNextTokenSkippingComments()) {
+                        break;
+                    }
+                }
+                _getNextToken();    // skip the '{'
+
+                // Parse rules until we see '}'
+                
+                while (token !== "}") {
+
+                    if (_isStartAtRule()) {
+                        // @rule
+                        _parseAtRule();
+        
+                    } else if (_isStartComment()) {
+                        // comment - make this part of style rule
+                        if (includeCommentInNextRule()) {
+                            ruleStartChar = stream.start;
+                            ruleStartLine = line;
+                        }
+                        _parseComment();
+        
+                    } else {
+                        // Otherwise, it's style rule
+                        if (ruleStartChar === -1) {
+                            ruleStartChar = stream.start;
+                            ruleStartLine = line;
+                        }
+                        _parseRule();
+                    }
+                    
+                    if (!_getNextTokenSkippingWhitespace()) {
+                        break;
+                    }
+                }
+                
+            } else if (token.match(/@(charset|import|namespace)/i)) {
+                
+                // This code handles @rules in this format:
+                //   @rule ... ;
+                // Skip everything until the next ';'
+                while (token !== ";") {
+                    if (!_getNextTokenSkippingComments()) {
+                        break;
+                    }
+                }
+                
+            } else {
+                // This code handle @rules that use this format:
+                //    @rule ... { ... }
+                // such as @page, @keyframes (also -webkit-keyframes, etc.), and @font-face.
+                // Skip everything until the next '}'
+                while (token !== "}") {
+                    if (!_getNextTokenSkippingComments()) {
+                        break;
+                    }
+                }
+            }
+        }
+        
+        // Start parsing
+
+        if (!_getFirstTokenSkippingWhitespace()) {
+            return selectors;
+        }
+
+        // Process rule list
+        
+        do {
+            if (_isStartAtRule()) {
+                // @rule
+                _parseAtRule();
+
+            } else if (_isStartComment()) {
+                // comment - make this part of style rule
+                if (includeCommentInNextRule()) {
+                    ruleStartChar = stream.start;
+                    ruleStartLine = line;
+                }
+                _parseComment();
+
+            } else {
+                // Otherwise, it's style rule
+                if (ruleStartChar === -1) {
+                    ruleStartChar = stream.start;
+                    ruleStartLine = line;
+                }
+                _parseRule();
+            }
+
+        } while (_getNextTokenSkippingWhitespace());
 
         return selectors;
     }

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
         var selectorGroupStartLine = -1, selectorGroupStartChar = -1;
         var declListStartLine = -1, declListStartChar = -1;
 
-        // implement _getFirstToken()/_getNextToken() methods to
+        // implement _firstToken()/_nextToken() methods to
         // provide a single stream of tokens
         
         function _hasStream() {
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
             return true;
         }
         
-        function _getFirstToken() {
+        function _firstToken() {
             state = CodeMirror.startState(mode);
             lines = CodeMirror.splitLines(text);
             lineCount = lines.length;
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
             return true;
         }
         
-        function _getNextToken() {
+        function _nextToken() {
             // advance the stream past this token
             stream.start = stream.pos;
             if (!_hasStream()) {
@@ -118,24 +118,24 @@ define(function (require, exports, module) {
             return true;
         }
         
-        function _getFirstTokenSkippingWhitespace() {
-            if (!_getFirstToken()) {
+        function _firstTokenSkippingWhitespace() {
+            if (!_firstToken()) {
                 return false;
             }
             while (!token.match(/\S/)) {
-                if (!_getNextToken()) {
+                if (!_nextToken()) {
                     return false;
                 }
             }
             return true;
         }
         
-        function _getNextTokenSkippingWhitespace() {
-            if (!_getNextToken()) {
+        function _nextTokenSkippingWhitespace() {
+            if (!_nextToken()) {
                 return false;
             }
             while (!token.match(/\S/)) {
-                if (!_getNextToken()) {
+                if (!_nextToken()) {
                     return false;
                 }
             }
@@ -148,19 +148,19 @@ define(function (require, exports, module) {
         
         function _parseComment() {
             while (!token.match(/\*\/$/)) {
-                if (!_getNextToken()) {
+                if (!_nextToken()) {
                     break;
                 }
             }
         }
 
-        function _getNextTokenSkippingComments() {
-            if (!_getNextToken()) {
+        function _nextTokenSkippingComments() {
+            if (!_nextToken()) {
                 return false;
             }
             while (_isStartComment()) {
                 _parseComment();
-                if (!_getNextToken()) {
+                if (!_nextToken()) {
                     return false;
                 }
             }
@@ -173,10 +173,10 @@ define(function (require, exports, module) {
             selectorStartChar = stream.start;
             selectorStartLine = line;
             
-            // Skip everything until the next ',' or '{'
+            // Everything until the next ',' or '{' is part of the current selector
             while (token !== "," && token !== "{") {
                 currentSelector += token;
-                if (!_getNextTokenSkippingComments()) {
+                if (!_nextTokenSkippingComments()) {
                     break;
                 }
             }
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
 
             _parseSelector();
             while (token === ",") {
-                if (!_getNextTokenSkippingComments()) {
+                if (!_nextTokenSkippingComments()) {
                     break;
                 }
                 _parseSelector();
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
             declListStartLine = line;
             declListStartChar = stream.start;
 
-            // Since we're now in a declartion list, that means we also finished
+            // Since we're now in a declaration list, that means we also finished
             // parsing the whole selector group. Therefore, reset selectorGroupStartLine
             // so that next time we parse a selector we know it's a new group
             selectorGroupStartLine = -1;
@@ -229,7 +229,7 @@ define(function (require, exports, module) {
 
             // Skip everything until the next '}'
             while (token !== "}") {
-                if (!_getNextTokenSkippingComments()) {
+                if (!_nextTokenSkippingComments()) {
                     break;
                 }
             }
@@ -282,11 +282,11 @@ define(function (require, exports, module) {
                 
                 // Skip everything until the opening '{'
                 while (token !== "{") {
-                    if (!_getNextTokenSkippingComments()) {
+                    if (!_nextTokenSkippingComments()) {
                         break;
                     }
                 }
-                _getNextToken();    // skip the '{'
+                _nextToken();    // skip the '{'
 
                 // Parse rules until we see '}'
                 
@@ -313,7 +313,7 @@ define(function (require, exports, module) {
                         _parseRule();
                     }
                     
-                    if (!_getNextTokenSkippingWhitespace()) {
+                    if (!_nextTokenSkippingWhitespace()) {
                         break;
                     }
                 }
@@ -324,7 +324,7 @@ define(function (require, exports, module) {
                 //   @rule ... ;
                 // Skip everything until the next ';'
                 while (token !== ";") {
-                    if (!_getNextTokenSkippingComments()) {
+                    if (!_nextTokenSkippingComments()) {
                         break;
                     }
                 }
@@ -335,7 +335,7 @@ define(function (require, exports, module) {
                 // such as @page, @keyframes (also -webkit-keyframes, etc.), and @font-face.
                 // Skip everything until the next '}'
                 while (token !== "}") {
-                    if (!_getNextTokenSkippingComments()) {
+                    if (!_nextTokenSkippingComments()) {
                         break;
                     }
                 }
@@ -344,7 +344,7 @@ define(function (require, exports, module) {
         
         // Start parsing
 
-        if (!_getFirstTokenSkippingWhitespace()) {
+        if (!_firstTokenSkippingWhitespace()) {
             return selectors;
         }
 
@@ -372,7 +372,7 @@ define(function (require, exports, module) {
                 _parseRule();
             }
 
-        } while (_getNextTokenSkippingWhitespace());
+        } while (_nextTokenSkippingWhitespace());
 
         return selectors;
     }

--- a/src/styles/quiet-scrollbars.css
+++ b/src/styles/quiet-scrollbars.css
@@ -36,7 +36,7 @@
 
 .quiet-scrollbars ::-webkit-scrollbar-thumb {
     background-color: rgba(0,0,0,0);
-}​​​
+}
 
 /* This looks like a dupe, but without it the thumb doesn't fade in
  * properly, probably due to flakiness in how these styles are handled

--- a/test/spec/CSSUtils-test-files/offsets.css
+++ b/test/spec/CSSUtils-test-files/offsets.css
@@ -14,7 +14,7 @@ a { color: red; }/*END*/a { color: blue; }/*END*/
  * examples are technically malformed, but parsing is the same
  */
 @charset "UTF-8";
-/* comment after @rule should be included */
+/* comment after @rule should be included, even if it contains @import (Issue #861) */
 a {
 	color: lime;
 }


### PR DESCRIPTION
extractAllSelectors() was a bit cryptic and not scalable, so to fix issue #861, I refactored it. Actually, it's a major rewrite, so ignore the diff. This should make it easier for future maintenance.

Changes include:
- better handling of all @rules
- updated a unit test to catch issue #861
- verified performance is no worse (actually slightly faster)
- converted trim() function calls to RegExp: !string.match(/\S/)

I also discovered some non-visual, non-whitespace unicode chars in quiet-scrollbars.css, so I removed them.
