### PR TITLE
Enable JS inline edit (& comment/uncomment) in HTML script blocks

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -90,11 +90,7 @@ define(function (require, exports, module) {
      */
     function htmlToCSSProvider(hostEditor, pos) {
         // Only provide a CSS editor when cursor is in HTML content
-        if (hostEditor._codeMirror.getOption("mode") !== "htmlmixed") {
-            return null;
-        }
-        var htmlmixedState = hostEditor._codeMirror.getTokenAt(pos).state;
-        if (htmlmixedState.mode !== "html") {
+        if (hostEditor.getModeForSelection() !== "html") {
             return null;
         }
         

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -965,8 +965,12 @@ define(function (require, exports, module) {
     /**
      * Gets the syntax-highlighting mode for the current selection or cursor position. (The mode may
      * vary within one file due to embedded languages, e.g. JS embedded in an HTML script block).
-     * Returns null if the mode is not consistent across the whole selection.
-     * @return {?string}
+     *
+     * Returns null if the mode at the start of the selection differs from the mode at the end -
+     * an *approximation* of whether the mode is consistent across the whole range (a pattern like
+     * A-B-A would return A as the mode, not null).
+     *
+     * @return {?string} Name of syntax-highlighting mode; see {@link EditorUtils#getModeFromFileExtension()}.
      */
     Editor.prototype.getModeForSelection = function () {
         var sel = this.getSelection();
@@ -977,8 +981,7 @@ define(function (require, exports, module) {
         if (startState.mode) {
             var startMode = startState.mode;
             
-            // If mixed mode, check that mode is the same across the whole selection
-            // (this is actually just an approximation, looking at start & end)
+            // If mixed mode, check that mode is the same at start & end of selection
             if (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch) {
                 var endState = this._codeMirror.getTokenAt(sel.end).state;
                 var endMode = endState.mode;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -963,6 +963,38 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Gets the syntax-highlighting mode for the current selection or cursor position. (The mode may
+     * vary within one file due to embedded languages, e.g. JS embedded in an HTML script block).
+     * Returns null if the mode is not consistent across the whole selection.
+     * @return {?string}
+     */
+    Editor.prototype.getModeForSelection = function () {
+        var sel = this.getSelection();
+        
+        // Check for mixed mode info (meaning mode varies depending on position)
+        // TODO (#921): this only works for certain mixed modes; some do not expose this info
+        var startState = this._codeMirror.getTokenAt(sel.start).state;
+        if (startState.mode) {
+            var startMode = startState.mode;
+            
+            // If mixed mode, check that mode is the same across the whole selection
+            // (this is actually just an approximation, looking at start & end)
+            if (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch) {
+                var endState = this._codeMirror.getTokenAt(sel.end).state;
+                var endMode = endState.mode;
+                if (startMode !== endMode) {
+                    return null;
+                }
+            }
+            return startMode;
+            
+        } else {
+            // Mode does not vary: just use the editor-wide mode
+            return this._codeMirror.getOption("mode");
+        }
+    };
+    
+    /**
      * The Document we're bound to
      * @type {!Document}
      */

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -115,8 +115,7 @@ define(function (require, exports, module) {
             return;
         }
         
-        // TODO: use mode *at cursor location*, so we can support mixed-mode e.g. JS in script blocks
-        var mode = editor._codeMirror.getOption("mode");
+        var mode = editor.getModeForSelection();
         
         // Currently we only support languages with "//" commenting
         if (mode === "javascript" || mode === "less") {

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -44,10 +44,15 @@ define(function (require, exports, module) {
     }
     InlineWidget.prototype.htmlContent = null;
     InlineWidget.prototype.$htmlContent = null;
-    InlineWidget.prototype.height = 0;
     InlineWidget.prototype.id = null;
     InlineWidget.prototype.hostEditor = null;
 
+    /**
+     * Initial height of inline widget in pixels. Can be changed later via hostEditor.setInlineWidgetHeight()
+     * @type {number}
+     */
+    InlineWidget.prototype.height = 0;
+    
     /**
      * Called any time inline is closed, whether manually or automatically
      */
@@ -56,7 +61,8 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Some tasks have to wait until we've been parented into the outer editor
+     * Called once content is parented in the host editor's DOM. Useful for performing tasks like setting
+     * focus or measuring content, which require htmlContent to be in the DOM tree.
      */
     InlineWidget.prototype.onAdded = function () {
         // do nothing - base implementation

--- a/src/extensions/disabled/JavaScriptInlineEditor/main.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/main.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
      */
     function javaScriptFunctionProvider(hostEditor, pos) {
         // Only provide a JavaScript editor when cursor is in JavaScript content
-        if (hostEditor._codeMirror.getOption("mode") !== "javascript") {
+        if (hostEditor.getModeForSelection() !== "javascript") {
             return null;
         }
         

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -176,9 +176,11 @@ define(function (require, exports, module) {
     function _extractTagName(ctx) {
         if (ctx.token.state.tagName) {
             return ctx.token.state.tagName; //XML mode
-        } else {
+        } else if (ctx.token.state.htmlState) {
             return ctx.token.state.htmlState.tagName; //HTML mode
         }
+        // Some mixed modes that offer HTML as a nested mode don't actually expose the HTML state
+        return null;
     }
     
     /**

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -33,31 +33,36 @@ define(function (require, exports, module) {
         EditorUtils     = require("editor/EditorUtils");
 
     describe("Editor", function () {
-        var content = 'Brackets is going to be awesome!\n';
-
+        var defaultContent = 'Brackets is going to be awesome!\n';
         var myDocument, myEditor;
-        beforeEach(function () {
+        
+        function createTestEditor(content, mode) {
             // create dummy Document for the Editor
             myDocument = SpecRunnerUtils.createMockDocument(content);
             
             // create Editor instance (containing a CodeMirror instance)
             $("body").append("<div id='editor'/>");
-            myEditor = new Editor(myDocument, true, "", $("#editor").get(0), {});
-        });
+            myEditor = new Editor(myDocument, true, mode, $("#editor").get(0), {});
+        }
 
         afterEach(function () {
-            myEditor.destroy();
-            myEditor = null;
-            $("#editor").remove();
-            myDocument = null;
+            if (myEditor) {
+                myEditor.destroy();
+                myEditor = null;
+                $("#editor").remove();
+                myDocument = null;
+            }
         });
         
 
         describe("Editor wrapper", function () {
-
+            beforeEach(function () {
+                createTestEditor(defaultContent, "");
+            });
+            
             it("should initialize with content", function () {
                 // verify editor content
-                expect(myEditor._getText()).toEqual(content);
+                expect(myEditor._getText()).toEqual(defaultContent);
             });
             
             // FUTURE: this should really be in a Document unit test, but there's no "official"
@@ -95,7 +100,7 @@ define(function (require, exports, module) {
                 expect(mode).toEqual("css");
             });
             
-            it("should accecpt just a file name too", function () {
+            it("should accept just a file name too", function () {
                 // verify editor content
                 var mode = EditorUtils.getModeFromFileExtension("path.js");
                 expect(mode).toEqual("javascript");
@@ -109,6 +114,9 @@ define(function (require, exports, module) {
         });
         
         describe("Focus", function () {
+            beforeEach(function () {
+                createTestEditor(defaultContent, "");
+            });
             
             it("should not have focus until explicitly set", function () {
                 expect(myEditor.hasFocus()).toBe(false);
@@ -118,6 +126,66 @@ define(function (require, exports, module) {
                 myEditor.focus();
                 expect(myEditor.hasFocus()).toBe(true);
             });
+        });
+        
+        describe("getModeForSelection()", function () {
+            var jsContent = "var foo;";
+            var htmlContent = "<html><head>\n" +
+                              "  <script>\n" +
+                              "    var bar;\n" +
+                              "  </script>\n" +
+                              "</head><body>\n" +
+                              "  <p>Hello</p>\n" +
+                              "</body></html>";
+            
+            it("should get mode in homogenous file", function () {
+                createTestEditor(jsContent, "javascript");
+                
+                // Mode at point
+                myEditor.setCursorPos(0, 0);    // first char in text
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                myEditor.setCursorPos(0, 8);    // last char in text
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                
+                myEditor.setCursorPos(0, 3);    // middle of text
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                
+                // Mode for range
+                myEditor.setSelection({line: 0, ch: 4}, {line: 0, ch: 7});
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                myEditor.setSelection({line: 0, ch: 0}, {line: 0, ch: 8});  // select all
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+            });
+            
+            it("should get mode in htmlmixed file", function () {
+                createTestEditor(htmlContent, "htmlmixed");
+                
+                // Mode at point
+                myEditor.setCursorPos(0, 0);    // first char in text
+                expect(myEditor.getModeForSelection()).toBe("html");
+                myEditor.setCursorPos(6, 14);    // last char in text
+                expect(myEditor.getModeForSelection()).toBe("html");
+                
+                myEditor.setCursorPos(5, 7);    // middle of text - html
+                expect(myEditor.getModeForSelection()).toBe("html");
+                myEditor.setCursorPos(2, 7);    // middle of text - js
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                
+                // Mode for range - homogenous mode
+                myEditor.setSelection({line: 5, ch: 2}, {line: 5, ch: 14});
+                expect(myEditor.getModeForSelection()).toBe("html");
+                myEditor.setSelection({line: 5, ch: 0}, {line: 6, ch: 0});  // whole line
+                expect(myEditor.getModeForSelection()).toBe("html");
+                myEditor.setSelection({line: 2, ch: 4}, {line: 2, ch: 12});
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                myEditor.setSelection({line: 2, ch: 0}, {line: 3, ch: 0});  // whole line
+                expect(myEditor.getModeForSelection()).toBe("javascript");
+                
+                // Mode for range - mix of modes
+                myEditor.setSelection({line: 2, ch: 4}, {line: 3, ch: 7});
+                expect(myEditor.getModeForSelection()).toBeNull();
+            });
+            
         });
     });
 });

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -184,6 +184,12 @@ define(function (require, exports, module) {
                 // Mode for range - mix of modes
                 myEditor.setSelection({line: 2, ch: 4}, {line: 3, ch: 7});
                 expect(myEditor.getModeForSelection()).toBeNull();
+                
+                // Mode for range - mix of modes where start & endpoints are same mode
+                // Known limitation of getModeForSelection() that it does not spot where the mode
+                // differs in mid-selection
+                myEditor.setSelection({line: 0, ch: 0}, {line: 6, ch: 14});  // select all
+                expect(myEditor.getModeForSelection()).toBe("html");
             });
             
         });


### PR DESCRIPTION
Add Editor.getModeForSelection() API for getting the mode at a specific location in the document (in some formats like HTML, mode may vary depending on position due to nested languages). Useful utility for many text-edit commands. Only supports "htmlmixed" and "php" mixed modes currently (see TODO in code, linked to #921).

Improves several parts of Brackets:
- CSSInlineEditor: simplifies code
- EditorCommandHandlers: comment/uncomment now supports JS in HTML script blocks (in both HTML & PHP files)
- JavaScriptInlineEditor: now supports JS in HTML script blocks (in both HTML & PHP files)

Also includes two small docs cleanups in InlineWidget.
