### PR TITLE
Fix for issue #918

### DIFF
--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -195,8 +195,14 @@ define(function (require, exports, module) {
             return "/";
         case 192:
             return "`";
+        case 219:
+            return "[";
         case 220:
             return "\\";
+        case 221:
+            return "]";
+        case 222:
+            return "'";
         default:
             return key;
         }

--- a/src/command/KeyMap.js
+++ b/src/command/KeyMap.js
@@ -171,6 +171,37 @@ define(function (require, exports, module) {
         return map;
     }
     
+    
+    /**
+     * @private
+     * Looks for keycodes that have os-inconsistent keys and fixes them.
+     * @param {number} The keycode from the keyboard event.
+     * @param {string} The current best guess at what the key is.
+     * @return {string} If the key is OS-inconsistent, the correct key; otherwise, the original key.
+     **/
+    function _mapKeycodeToKey(keycode, key) {
+        switch (keycode) {
+        case 186:
+            return ";";
+        case 187:
+            return "=";
+        case 188:
+            return ",";
+        case 189:
+            return "-";
+        case 190:
+            return ".";
+        case 191:
+            return "/";
+        case 192:
+            return "`";
+        case 220:
+            return "\\";
+        default:
+            return key;
+        }
+    }
+    
     /** class Keymap
      *
      * A keymap specifies how keys are mapped to commands. This currently just holds the map, but in future
@@ -228,7 +259,7 @@ define(function (require, exports, module) {
         
         // Translate some keys to their common names
         if (key === "\t") { key = "Tab"; }
-        if (event.keyCode === 191) { key = "/"; }
+        key = _mapKeycodeToKey(event.keyCode, key);
 
         return _buildKeyDescriptor(hasCtrl, hasAlt, hasShift, key);
     }


### PR DESCRIPTION
This is a fix for issue #918. I added a function to KeyMap that looks for keycodes that result in inconsistent keys across operating systems, and then translates them into their correct keys. In the process, it fixes the bug that prevents Ctrl-+/- from working on Windows.
