### PR TITLE
Fix regex expression for recognizing single line functions, fixes issue-924

### DIFF
--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -101,9 +101,12 @@ define(function (require, exports, module) {
             
             // TODO: use a shared JS language intelligence module
             // TODO: this doesn't handle functions with params that spread across lines
-            var regexA = new RegExp(/(function\b)(.+)\b\(.*?\)/gi);  // recognizes the form: function functionName()
-            var regexB = new RegExp(/(\w+)\s*=\s*function\s*(\(.*?\))/gi); // recognizes the form: functionName = function()
-            var regexC = new RegExp(/((\w+)\s*:\s*function\s*\(.*?\))/gi); // recognizes the form: functionName: function()
+            //
+            // Note, the global switch on the regex expressions below is NOT used because this code assumes
+            // one function per line.  exec() is not called repeatedly for each line.
+            var regexA = new RegExp(/(function\b)([^)]+)\b\([^)]*\)/i);  // recognizes the form: function functionName()
+            var regexB = new RegExp(/(\w+)\s*=\s*function\s*(\([^)]*\))/i); // recognizes the form: functionName = function()
+            var regexC = new RegExp(/((\w+)\s*:\s*function\s*\([^)]*\))/i); // recognizes the form: functionName: function()
             var infoA, infoB, infoC, i, line;
             var funcName, chFrom, chTo;
 

--- a/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
@@ -40,9 +40,9 @@ define(function (require, exports, module) {
     // Return an Array with names and offsets for all functions in the specified text
     function _findAllFunctionsInText(text) {
         var result = [];
-        var regexA = new RegExp(/(function\b)(.+)\b\(.*?\)/gi);  // recognizes the form: function functionName()
-        var regexB = new RegExp(/(\w+)\s*=\s*function\s*(\(.*?\))/gi); // recognizes the form: functionName = function()
-        var regexC = new RegExp(/((\w+)\s*:\s*function\s*\(.*?\))/gi); // recognizes the form: functionName: function()
+        var regexA = new RegExp(/(function\b)([^)]+)\b\([^)]*\)/gi);  // recognizes the form: function functionName()
+        var regexB = new RegExp(/(\w+)\s*=\s*function\s*(\([^)]*\))/gi); // recognizes the form: functionName = function()
+        var regexC = new RegExp(/((\w+)\s*:\s*function\s*\([^)]*\))/gi); // recognizes the form: functionName: function()
         var match;
         
         while ((match = regexA.exec(text)) !== null) {


### PR DESCRIPTION
- removed global flag since algorithm doesn't iterate through multiple matches per line
- changed lazy matches to use negative matching instead which is faster since parser doesn't need to back up (great article on this here: http://www.regular-expressions.info/repeat.html)

@gruehle can you review and see if the rexeg expressions for JavaScript quick edit should change too?

fixes issue #924
