### PR TITLE
Fix for #955

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -418,7 +418,7 @@ define(function (require, exports, module) {
      * Synchronizes MenuItem name with underlying Command name
      */
     MenuItem.prototype._nameChanged = function () {
-        $(_getHTMLMenuItem(this.id)).find(".menu-name").text(this._command.getName());
+        $(_getHTMLMenuItem(this.id)).find(".menu-name").html(this._command.getName());
     };
     
     /**

--- a/src/strings.js
+++ b/src/strings.js
@@ -126,9 +126,9 @@ define(function (require, exports, module) {
     // File menu commands
     exports.FILE_MENU                           = "File";
     exports.CMD_FILE_NEW                        = "New";
-    exports.CMD_FILE_OPEN                       = "Open";
+    exports.CMD_FILE_OPEN                       = "Open&#8230;";
     exports.CMD_ADD_TO_WORKING_SET              = "Add To Working Set";
-    exports.CMD_OPEN_FOLDER                     = "Open Folder";
+    exports.CMD_OPEN_FOLDER                     = "Open Folder&#8230;";
     exports.CMD_FILE_CLOSE                      = "Close";
     exports.CMD_FILE_CLOSE_ALL                  = "Close All";
     exports.CMD_FILE_SAVE                       = "Save";
@@ -178,6 +178,6 @@ define(function (require, exports, module) {
     exports.CMD_USE_TAB_CHARS                   = "Use Tab Characters";
 
     // Help menu commands
-    exports.CMD_ABOUT                           = "About...";
+    exports.CMD_ABOUT                           = "About";
 
 });


### PR DESCRIPTION
Add ellipsis to Open and Open Folder menu items. Allow HTML entities in strings. Fixes #955.
