### PR TITLE
terminate perfutil timers

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -154,9 +154,13 @@ define(function (require, exports, module) {
                 PerfUtils.addMeasurement(PerfUtils.OPEN_INLINE_EDITOR);
                 result.resolve();
             }).fail(function () {
+                // terminate timer that was started above
+                PerfUtils.finalizeMeasurement(PerfUtils.OPEN_INLINE_EDITOR);
                 result.reject();
             });
         } else {
+            // terminate timer that was started above
+            PerfUtils.finalizeMeasurement(PerfUtils.OPEN_INLINE_EDITOR);
             result.reject();
         }
         

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -211,6 +211,8 @@ define(function (require, exports, module) {
     function updateMeasurement(name) {
         var elapsedTime = brackets.app.getElapsedMilliseconds();
 
+        name = toMeasurementId(name);
+
         if (updatableTests[name]) {
             // update existing measurement
             elapsedTime -= updatableTests[name].startTime;
@@ -246,9 +248,13 @@ define(function (require, exports, module) {
      * @param {string} name  Timer name.
      */
     function finalizeMeasurement(name) {
+
+        name = toMeasurementId(name);
+
         if (activeTests[name]) {
             delete activeTests[name];
         }
+
         if (updatableTests[name]) {
             delete updatableTests[name];
         }


### PR DESCRIPTION
This fixes issue #974

There were 2 problems.
1. The timer started (via PerfUtils.markStart()) in EditorManager._openInlineWidget() was only terminated (via PerfUtils.addMeasurement()) in the case where Deferred completed successfully. PerfUtils timer need to be terminated in all cases.
2. PerfUtils names were converted to objects with name and id fields, but toMeasurementId() was not being called in finalizeMeasurement() and updateMeasurement() functions.
