### PR TITLE
* Remove support for HTML entities in MenuItems

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -123,6 +123,11 @@ define(function (require, exports, module) {
     /**
      * Sets the name of the Command and dispatches "nameChange" so that
      * UI that reflects the command name can update.
+     *
+     * Note, a Command name can appear in either HTML or native UI
+     * so HTML tags should not be used. To add a Unicode character,
+     * use \uXXXX instead of an HTML entity.
+     *
      * @param {string} name
      */
     Command.prototype.setName = function (name) {

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -451,7 +451,7 @@ define(function (require, exports, module) {
      * Synchronizes MenuItem name with underlying Command name
      */
     MenuItem.prototype._nameChanged = function () {
-        $(_getHTMLMenuItem(this.id)).find(".menu-name").html(this._command.getName());
+        $(_getHTMLMenuItem(this.id)).find(".menu-name").text(this._command.getName());
     };
     
     /**


### PR DESCRIPTION
- Remove support for HTML entities
- Adds comment to CommandManger.setName regarding HTML entities and Unicode characters

fixes #984
