### PR TITLE
Updates to work with merged CodeMirror for sprint 10

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -907,7 +907,7 @@ define(function (require, exports, module) {
     /** Returns true if the editor has focus */
     Editor.prototype.hasFocus = function () {
         // The CodeMirror instance wrapper has a "CodeMirror-focused" class set when focused
-        return $(this.getRootElement()).hasClass("CodeMirror-focused");
+        return $(this.getScrollerElement()).hasClass("CodeMirror-focused");
     };
     
     /**

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -112,14 +112,14 @@
     .CodeMirror pre.CodeMirror-cursor {
         visibility: hidden;
     }
-    .CodeMirror.CodeMirror-focused pre.CodeMirror-cursor {
+    .CodeMirror .CodeMirror-focused pre.CodeMirror-cursor {
         visibility: visible;
     }
     
     .CodeMirror div.CodeMirror-selected {
         background: #d9d9d9;
     }
-    .CodeMirror.CodeMirror-focused div.CodeMirror-selected {
+    .CodeMirror .CodeMirror-focused div.CodeMirror-selected {
         background: #d2dcf8;
     }
     .CodeMirror .CodeMirror-gutter {


### PR DESCRIPTION
@gruehle 

These changes are necessary because as part of the scrolling implementation in CodeMirror, we had to move the ".CodeMirror-focused" class from the wrapper node to the scroller node in order to work around an IE7 bug.
