### PR TITLE
Make 'Find in Files' result sections collapsible

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -182,9 +182,10 @@ define(function (require, exports, module) {
             
             // Show result summary in header
             $("#search-result-summary")
-                .text(" - " + numMatches + " match" + (numMatches > 1 ? "es" : "") +
+                .text("- " + numMatches + " match" + (numMatches > 1 ? "es" : "") +
                       " in " + searchResults.length + " file" + (searchResults.length > 1 ? "s" : "") +
-                     (numMatches > 100 ? " (showing the first 100 matches)" : ""));
+                     (numMatches > 100 ? " (showing the first 100 matches)" : ""))
+                .prepend("&nbsp;");  // putting a normal space before the "-" is not enough
             
             var resultsDisplayed = 0;
             
@@ -205,8 +206,13 @@ define(function (require, exports, module) {
                     };
                     
                     // Add row for file name
-                    $("<tr/>")
+                    $("<tr class='file-section' />")
                         .append("<td colspan='3'>File: <b>" + item.fullPath + "</b></td>")
+                        .click(function () {
+                            // Clicking file section header collapses/expands result rows for that file
+                            var $fileHeader = $(this);
+                            $fileHeader.nextUntil(".file-section").toggle();
+                        })
                         .appendTo($resultTable);
                     
                     // Add row for each match in file


### PR DESCRIPTION
This is admittedly pretty bare-bones.  I didn't bother to add a disclosure triangle (the sections all start out expanded, so it didn't feel as important).  And because the table layout is so simple, the column widths will shift around slightly as you hide/show rows (you can see the same effect without this patch simply by running a few searches in a row -- column widths very slightly depending on the content).

Also fixed a minor glitch with text spacing in the 'Find in Files' panel header.
