### PR TITLE
Improved performance by making the CodeMirror element directly inherit ...

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -262,6 +262,7 @@ define(function (require, exports, module) {
 
 
         EditorManager.setEditorHolder($('#editor-holder'));
+        EditorManager.setPositionedEditorHolder($('#positioned-editor-holder'));
 
         // Let the user know Brackets doesn't run in a web browser yet
         if (brackets.inBrowser) {

--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,9 @@
 
 </head>
 <body>
+    <!-- Actual container of CodeMirror editor. -->
+    <div id="positioned-editor-holder"></div>
+
     <!-- Main UI -->
     <div class="main-view">
         <div id="sidebar-resizer"></div>


### PR DESCRIPTION
... from a root element.

This way it avoids the layout of the flex box, which affects both layout runtime and dirty rectangles sizes.
