### PR TITLE
Fix unit tests for JavaScriptInlineEditor

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -157,6 +157,10 @@ define(function (require, exports, module) {
         //
         // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
         // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
+        //
+        // TODO (issue 1034): We *could* use a $.Deferred for this, except deferred objects enter a broken
+        // state if any resolution callback throws an exception. Since third parties (e.g. extensions) may
+        // add callbacks to this, we need to be robust to exceptions
         brackets.ready = _registerBracketsReadyHandler;
     }
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -72,6 +72,10 @@ define(function (require, exports, module) {
         ExtensionLoader         = require("utils/ExtensionLoader"),
         SidebarView             = require("project/SidebarView"),
         Async                   = require("utils/Async");
+
+    // Local variables
+    var bracketsReady         = false,
+        bracketsReadyHandlers = [];
         
     //Load modules that self-register and just need to get included in the main project
     require("editor/CodeHintManager");
@@ -80,6 +84,34 @@ define(function (require, exports, module) {
     require("view/ViewCommandHandlers");
     require("search/FindInFiles");
 
+    function _callBracketsReadyHandler(handler) {
+        try {
+            handler();
+        } catch (e) {
+            console.log("Exception when calling a 'brackets done loading' handler");
+            console.log(e);
+        }
+    }
+
+    function _onBracketsReady() {
+        var i;
+        bracketsReady = true;
+        for (i = 0; i < bracketsReadyHandlers.length; i++) {
+            _callBracketsReadyHandler(bracketsReadyHandlers[i]);
+        }
+        bracketsReadyHandlers = [];
+    }
+
+    // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
+    // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
+    function _registerBracketsReadyHandler(handler) {
+        if (bracketsReady) {
+            _callBracketsReadyHandler(handler);
+        } else {
+            bracketsReadyHandlers.push(handler);
+        }
+    }
+    
     // TODO: Issue 949 - the following code should be shared
     
     function _initGlobalBrackets() {
@@ -119,10 +151,18 @@ define(function (require, exports, module) {
         // Note: we change the name to "getModule" because this won't do exactly the same thing as 'require' in AMD-wrapped
         // modules. The extension will only be able to load modules that have already been loaded once.
         brackets.getModule = require;
+
+        // Provide a way for anyone (including code not using require) to register a handler for the brackets 'ready' event
+        // This event is like $(document).ready in that it will call the handler immediately if brackets is already done loading
+        //
+        // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
+        // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
+        brackets.ready = _registerBracketsReadyHandler;
     }
     
+    // TODO: (issue 1029) Add timeout to main extension loading promise, so that we always call this function
+    // Making this fix will fix a warning (search for issue 1029) related to the brackets 'ready' event.
     function _initExtensions() {
-        // FUTURE (JRB): As we get more fine-grained performance measurement, move this out of core application startup
         return Async.doInParallel(["default", "user"], function (item) {
             return ExtensionLoader.loadAllExtensionsInNativeDirectory(
                 FileUtils.getNativeBracketsDirectoryPath() + "/extensions/" + item,
@@ -156,8 +196,13 @@ define(function (require, exports, module) {
             CSSUtils                : require("language/CSSUtils"),
             LiveDevelopment         : require("LiveDevelopment/LiveDevelopment"),
             Inspector               : require("LiveDevelopment/Inspector/Inspector"),
-            NativeApp               : require("utils/NativeApp")
+            NativeApp               : require("utils/NativeApp"),
+            doneLoading             : false
         };
+
+        brackets.ready(function () {
+            brackets.test.doneLoading = true;
+        });
     }
     
     function _initDragAndDropListeners() {
@@ -261,7 +306,7 @@ define(function (require, exports, module) {
         // finish UI initialization before loading extensions
         ProjectManager.loadProject().done(function () {
             _initTest();
-            _initExtensions();
+            _initExtensions().always(_onBracketsReady);
         });
     }
             

--- a/src/extensions/disabled/JavaScriptInlineEditor/unittests.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/unittests.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
 
     var extensionPath = FileUtils.getNativeModuleDirectoryPath(module);
     
-    describe("JSQuickEdit", function () {
+    describe("JavaScriptInlineEditor", function () {
 
         var testPath = extensionPath + "/unittest-files",
             testWindow,
@@ -495,7 +495,6 @@ define(function (require, exports, module) {
                     SpecRunnerUtils.closeTestWindow();
                 });
                 
-/***
                 it("should return the correct offsets if the file has changed", function () {
                     var didOpen = false,
                         gotError = false;
@@ -531,8 +530,11 @@ define(function (require, exports, module) {
 
                         FileIndexManager.getFileInfoList("all")
                             .done(function (fileInfos) {
+                                var extensionRequire = brackets.getModule('utils/ExtensionLoader').getRequireContextForExtension('JavaScriptInlineEditor');
+                                var JSUtilsInExtension = extensionRequire("JSUtils");
+
                                 // Look for "edit2" function
-                                JSUtils.findMatchingFunctions("edit2", fileInfos)
+                                JSUtilsInExtension.findMatchingFunctions("edit2", fileInfos)
                                     .done(function (result) { functions = result; });
                             });
                     });
@@ -545,8 +547,7 @@ define(function (require, exports, module) {
                         expect(functions[0].lineEnd).toBe(13);
                     });
                 });
-***/
-/***
+
                 it("should return a newly created function in an unsaved file", function () {
                     var didOpen = false,
                         gotError = false;
@@ -563,24 +564,31 @@ define(function (require, exports, module) {
                     
                     runs(function () {
                         var doc = DocumentManager.getCurrentDocument();
-                        
                         // Add a new function to the file
                         doc.setText(doc.getText() + "\n\nfunction TESTFUNCTION() {\n    return true;\n}\n");
                         
                         // Look for the selector we just created
-                        JSUtils.findMatchingFunctions("TESTFUNCTION", FileIndexManager.getFileInfoList("all"))
-                            .done(function (result) { functions = result; });
+                        FileIndexManager.getFileInfoList("all")
+                            .done(function (fileInfos) {
+                                var extensionRequire = brackets.getModule('utils/ExtensionLoader').getRequireContextForExtension('JavaScriptInlineEditor');
+                                var JSUtilsInExtension = extensionRequire("JSUtils");
+
+                                // Look for "TESTFUNCTION" function
+                                JSUtilsInExtension.findMatchingFunctions("TESTFUNCTION", fileInfos)
+                                    .done(function (result) {
+                                        functions = result;
+                                    });
+                            });
                     });
                     
                     waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
                     
                     runs(function () {
                         expect(functions.length).toBe(1);
-                        expect(functions[0].lineStart).toBe(24);
-                        expect(functions[0].lineEnd).toBe(26);
+                        expect(functions[0].lineStart).toBe(33);
+                        expect(functions[0].lineEnd).toBe(35);
                     });
                 });
-***/
             });
         }); //describe("JS Parsing")
     });

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -34,7 +34,19 @@ define(function (require, exports, module) {
 
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils           = require("file/FileUtils"),
-        Async               = require("utils/Async");
+        Async               = require("utils/Async"),
+        contexts            = {};
+    /**
+     * Returns the require.js require context used to load an extension
+     *
+     * @param {!string} name, used to identify the extension
+     * @return {!Object} A require.js require object used to load the extension, or undefined if 
+     * there is no require object ith that name
+     */
+    function getRequireContextForExtension(name) {
+        return contexts[name];
+    }
+
     
     /**
      * Loads the extension that lives at baseUrl into its own Require.js context
@@ -50,6 +62,7 @@ define(function (require, exports, module) {
                 context: name,
                 baseUrl: baseUrl
             });
+        contexts[name] = extensionRequire;
 
         console.log("[Extension] starting to load " + baseUrl);
         
@@ -173,6 +186,7 @@ define(function (require, exports, module) {
         return _loadAll(directory, baseUrl, "unittests", testExtension);
     }
     
+    exports.getRequireContextForExtension = getRequireContextForExtension;
     exports.loadExtension = loadExtension;
     exports.testExtension = testExtension;
     exports.loadAllExtensionsInNativeDirectory = loadAllExtensionsInNativeDirectory;

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -107,10 +107,10 @@ define(function (require, exports, module) {
 
         // FIXME (issue #249): Need an event or something a little more reliable...
         waitsFor(
-            function () {
-                return testWindow.brackets && testWindow.brackets.test;
+            function isBracketsDoneLoading() {
+                return testWindow.brackets && testWindow.brackets.test && testWindow.brackets.test.doneLoading;
             },
-            5000
+            10000
         );
 
         runs(function () {


### PR DESCRIPTION
@redmunds 

This fixes the two broken unit tests for the JavaScriptInlineEditor. The problem with the unit tests was that they weren't using the JSUtils that had been loaded by the extension. Instead, they were using a different JSUtils loaded in the same require context that loaded SpecRunner (i.e. the wrong window).

This worked for some unit tests because they were just testing "independent" functionality of JSUtils. However, JSUtils reaches in to the DocumentManager in some tests. Thus, these tests were failing because they were getting the wrong DocumentManager inside the JSUtils code (even though the unit test code was accessing the correct DocumentManager).

I added code to the ExtensionLoader that allows us to retrieve require contexts for extensions using the name of the extension. (This is the first commit).

Then, I modified the unit tests to request the JSUtils module from the extension's context. This fixed the unit tests. (This is the second commit).

There were also a few bugs in one of the unit tests. I fixed those too.

We should think about re-architecting how we run unit tests. It might make sense for each test window to import (a modified) SpecRunner and then load a particular test spec and run it. Then, the modified SpecRunner could report the results back to the main test window. This would potentially make it much simpler to write unit tests because they could simply use the global 'brackets' object to get at the modules they needed.
