### PR TITLE
Add class 'vertical-scroll' to the working set container when the scrollbar is present

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -66,13 +66,12 @@ define(function (require, exports, module) {
      * adds the style 'vertical-scroll' if a vertical scroll bar is present
      */
     function _adjustForScrollbars() {
-        var $container = $("#open-files-container");
-        if ($container[0].scrollHeight > $container[0].clientHeight) {
-            if (!$container.hasClass("vertical-scroll")) {
-                $container.addClass("vertical-scroll");
+        if ($openFilesContainer[0].scrollHeight > $openFilesContainer[0].clientHeight) {
+            if (!$openFilesContainer.hasClass("vertical-scroll")) {
+                $openFilesContainer.addClass("vertical-scroll");
             }
         } else {
-            $container.removeClass("vertical-scroll");
+            $openFilesContainer.removeClass("vertical-scroll");
         }
     }
     

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -63,6 +63,21 @@ define(function (require, exports, module) {
 
     /**
      * @private
+     * adds the style 'vertical-scroll' if a vertical scroll bar is present
+     */
+    function _adjustForScrollbars() {
+        var $container = $("#open-files-container");
+        if ($container[0].scrollHeight > $container[0].clientHeight) {
+            if (!$container.hasClass("vertical-scroll")) {
+                $container.addClass("vertical-scroll");
+            }
+        } else {
+            $container.removeClass("vertical-scroll");
+        }
+    }
+    
+    /**
+     * @private
      * Shows/Hides open files list based on working set content.
      */
     function _redraw() {
@@ -71,7 +86,7 @@ define(function (require, exports, module) {
         } else {
             $openFilesContainer.show();
         }
-        
+        _adjustForScrollbars();
         _fireSelectionChanged();
     }
     


### PR DESCRIPTION
Provides a hook to adjust the layout of a working set item when the
scroll bar pops in, which is useful if you are laying something out to
the right edge of that view.

I ran into the need for this in creating a related files extension.
