### PR TITLE
Offset to line number optimization

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -58,6 +58,7 @@ define(function LiveDevelopment(require, exports, module) {
     var NativeApp = require("utils/NativeApp");
     var Dialogs = require("widgets/Dialogs");
     var Strings = require("strings");
+    var StringUtils = require("utils/StringUtils");
 
     // Inspector
     var Inspector = require("LiveDevelopment/Inspector/Inspector");

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -354,7 +354,7 @@ define(function LiveDevelopment(require, exports, module) {
                             if (err === FileError.NOT_FOUND_ERR) {
                                 message = Strings.ERROR_CANT_FIND_CHROME;
                             } else {
-                                message = Strings.format(Strings.ERROR_LAUNCHING_BROWSER, err);
+                                message = StringUtils.format(Strings.ERROR_LAUNCHING_BROWSER, err);
                             }
                             
                             Dialogs.showModalDialog(

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -324,7 +324,7 @@ define(function (require, exports, module) {
         return Dialogs.showModalDialog(
             Dialogs.DIALOG_ID_ERROR,
             Strings.ERROR_SAVING_FILE_TITLE,
-            Strings.format(
+            StringUtils.format(
                 Strings.ERROR_SAVING_FILE,
                 StringUtils.htmlEscape(path),
                 FileUtils.getFileErrorString(code)
@@ -506,7 +506,7 @@ define(function (require, exports, module) {
             Dialogs.showModalDialog(
                 Dialogs.DIALOG_ID_SAVE_CLOSE,
                 Strings.SAVE_CLOSE_TITLE,
-                Strings.format(Strings.SAVE_CLOSE_MESSAGE, StringUtils.htmlEscape(filename))
+                StringUtils.format(Strings.SAVE_CLOSE_MESSAGE, StringUtils.htmlEscape(filename))
             ).done(function (id) {
                 if (id === Dialogs.DIALOG_BTN_CANCEL) {
                     result.reject();

--- a/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
@@ -117,8 +117,8 @@ define(function (require, exports, module) {
                                 matchingFunctions.push({
                                     document: doc,
                                     name: funcEntry.functionName,
-                                    lineStart: StringUtils.offsetToLineNumForLoops(lines, funcEntry.offset),
-                                    lineEnd: StringUtils.offsetToLineNumForLoops(lines, endOffset)
+                                    lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offset),
+                                    lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
                                 });
                             }
                         });
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
      * @return {Array.<{offset:number, functionName:string}>}
      *      Array of objects containing the start offset for each matched function name.
      */
-     function _findAllMatchingFunctionsInText(text, functionName) {
+    function _findAllMatchingFunctionsInText(text, functionName) {
         var allFunctions = _findAllFunctionsInText(text);
         var result = [];
         var lines = text.split("\n");
@@ -281,8 +281,8 @@ define(function (require, exports, module) {
                 var endOffset = _getFunctionEndOffset(text, funcEntry.offset);
                 result.push({
                     name: funcEntry.functionName,
-                    lineStart: StringUtils.offsetToLineNumForLoops(lines, funcEntry.offset),
-                    lineEnd: StringUtils.offsetToLineNumForLoops(lines, endOffset)
+                    lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offset),
+                    lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
                 });
             }
         });

--- a/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
+++ b/src/extensions/disabled/JavaScriptInlineEditor/JSUtils.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
     // Load brackets modules
     var Async               = brackets.getModule("utils/Async"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
+        StringUtils         = brackets.getModule("utils/StringUtils"),
         NativeFileSystem    = brackets.getModule("file/NativeFileSystem").NativeFileSystem;
     
     // Return an Array with names and offsets for all functions in the specified text
@@ -94,9 +95,6 @@ define(function (require, exports, module) {
         return length;
     }
     
-    function _offsetToLineNum(text, offset) {
-        return text.substr(0, offset).split("\n").length - 1;
-    }
     
     // Search function list for a specific function. If found, extract info about the function
     // (line start, line end, etc.) and return.
@@ -111,6 +109,7 @@ define(function (require, exports, module) {
                 DocumentManager.getDocumentForPath(fileInfo.fullPath)
                     .done(function (doc) {
                         var text = doc.getText();
+                        var lines = StringUtils.getLines(text);
                         
                         functions.forEach(function (funcEntry) {
                             if (funcEntry.functionName === functionName) {
@@ -118,8 +117,8 @@ define(function (require, exports, module) {
                                 matchingFunctions.push({
                                     document: doc,
                                     name: funcEntry.functionName,
-                                    lineStart: _offsetToLineNum(text, funcEntry.offset),
-                                    lineEnd: _offsetToLineNum(text, endOffset)
+                                    lineStart: StringUtils.offsetToLineNumForLoops(lines, funcEntry.offset),
+                                    lineEnd: StringUtils.offsetToLineNumForLoops(lines, endOffset)
                                 });
                             }
                         });
@@ -272,21 +271,22 @@ define(function (require, exports, module) {
      * @return {Array.<{offset:number, functionName:string}>}
      *      Array of objects containing the start offset for each matched function name.
      */
-    function _findAllMatchingFunctionsInText(text, functionName) {
+     function _findAllMatchingFunctionsInText(text, functionName) {
         var allFunctions = _findAllFunctionsInText(text);
         var result = [];
-        
+        var lines = text.split("\n");
+         
         allFunctions.forEach(function (funcEntry) {
-            if (funcEntry.functionName === functionName) {
+            if (funcEntry.functionName === functionName || functionName === "*") {
                 var endOffset = _getFunctionEndOffset(text, funcEntry.offset);
                 result.push({
                     name: funcEntry.functionName,
-                    lineStart: _offsetToLineNum(text, funcEntry.offset),
-                    lineEnd: _offsetToLineNum(text, endOffset)
+                    lineStart: StringUtils.offsetToLineNumForLoops(lines, funcEntry.offset),
+                    lineEnd: StringUtils.offsetToLineNumForLoops(lines, endOffset)
                 });
             }
         });
-        
+         
         return result;
     }
 

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
         } else if (code === FileError.NO_MODIFICATION_ALLOWED_ERR) {
             result = Strings.NO_MODIFICATION_ALLOWED_ERR_FILE;
         } else {
-            result = Strings.format(Strings.GENERIC_ERROR, code);
+            result = StringUtils.format(Strings.GENERIC_ERROR, code);
         }
 
         return result;
@@ -176,7 +176,7 @@ define(function (require, exports, module) {
         return Dialogs.showModalDialog(
             Dialogs.DIALOG_ID_ERROR,
             Strings.ERROR_OPENING_FILE_TITLE,
-            Strings.format(
+            StringUtils.format(
                 Strings.ERROR_OPENING_FILE,
                 StringUtils.htmlEscape(path),
                 getFileErrorString(code)

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -212,7 +212,7 @@ define(function (require, exports, module) {
         return Dialogs.showModalDialog(
             Dialogs.DIALOG_ID_ERROR,
             Strings.ERROR_RELOADING_FILE_TITLE,
-            Strings.format(
+            StringUtils.format(
                 Strings.ERROR_RELOADING_FILE,
                 StringUtils.htmlEscape(doc.file.fullPath),
                 FileUtils.getFileErrorString(error.code)
@@ -261,7 +261,7 @@ define(function (require, exports, module) {
             if (i < editConflicts.length) {
                 toClose = false;
                 dialogId = Dialogs.DIALOG_ID_EXT_CHANGED;
-                message = Strings.format(
+                message = StringUtils.format(
                     Strings.EXT_MODIFIED_MESSAGE,
                     StringUtils.htmlEscape(ProjectManager.makeProjectRelativeIfPossible(doc.file.fullPath))
                 );
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
             } else {
                 toClose = true;
                 dialogId = Dialogs.DIALOG_ID_EXT_DELETED;
-                message = Strings.format(
+                message = StringUtils.format(
                     Strings.EXT_DELETED_MESSAGE,
                     StringUtils.htmlEscape(ProjectManager.makeProjectRelativeIfPossible(doc.file.fullPath))
                 );

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -540,7 +540,7 @@ define(function (require, exports, module) {
                 Dialogs.showModalDialog(
                     Dialogs.DIALOG_ID_ERROR,
                     Strings.ERROR_LOADING_PROJECT,
-                    Strings.format(Strings.READ_DIRECTORY_ENTRIES_ERROR,
+                    StringUtils.format(Strings.READ_DIRECTORY_ENTRIES_ERROR,
                         StringUtils.htmlEscape(dirEntry.fullPath),
                         error.code)
                 );
@@ -637,7 +637,7 @@ define(function (require, exports, module) {
                     Dialogs.showModalDialog(
                         Dialogs.DIALOG_ID_ERROR,
                         Strings.ERROR_LOADING_PROJECT,
-                        Strings.format(
+                        StringUtils.format(
                             Strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR,
                             StringUtils.htmlEscape(rootPath),
                             error.code,
@@ -685,7 +685,7 @@ define(function (require, exports, module) {
                         Dialogs.showModalDialog(
                             Dialogs.DIALOG_ID_ERROR,
                             Strings.ERROR_LOADING_PROJECT,
-                            Strings.format(Strings.OPEN_DIALOG_ERROR, error.code)
+                            StringUtils.format(Strings.OPEN_DIALOG_ERROR, error.code)
                         );
                     }
                     );
@@ -812,15 +812,15 @@ define(function (require, exports, module) {
                             Dialogs.showModalDialog(
                                 Dialogs.DIALOG_ID_ERROR,
                                 Strings.INVALID_FILENAME_TITLE,
-                                Strings.format(Strings.FILE_ALREADY_EXISTS,
+                                StringUtils.format(Strings.FILE_ALREADY_EXISTS,
                                     StringUtils.htmlEscape(data.rslt.name))
                             );
                         } else {
                             var errString = error.code === FileError.NO_MODIFICATION_ALLOWED_ERR ?
                                              Strings.NO_MODIFICATION_ALLOWED_ERR :
-                                             Strings.format(String.GENERIC_ERROR, error.code);
+                                             StringUtils.format(String.GENERIC_ERROR, error.code);
 
-                            var errMsg = Strings.format(Strings.ERROR_CREATING_FILE,
+                            var errMsg = StringUtils.format(Strings.ERROR_CREATING_FILE,
                                             StringUtils.htmlEscape(data.rslt.name),
                                             errString);
                           

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
         var match;
         var lines = StringUtils.getLines(contents);
         while ((match = queryExpr.exec(contents)) !== null) {
-            var lineNum = StringUtils.offsetToLineNumForLoops(lines,match.index);
+            var lineNum = StringUtils.offsetToLineNumForLoops(lines, match.index);
             var line = lines[lineNum];
             var ch = match.index - contents.lastIndexOf("\n", match.index) - 1;  // 0-based index
             var matchLength = match[0].length;

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -36,7 +36,6 @@
  *  - Search files in working set that are *not* in the project
  *  - Handle matches that span mulitple lines
  *  - Refactor UI from functionality to enable unit testing
- *  - Cache result of getLine()
  */
 
 
@@ -47,6 +46,7 @@ define(function (require, exports, module) {
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
+        StringUtils         = require("utils/StringUtils"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
         FileIndexManager    = require("project/FileIndexManager");
@@ -138,19 +138,12 @@ define(function (require, exports, module) {
         var matchStart;
         var matches = [];
         
-        function getLineNum(offset) {
-            return contents.substr(0, offset).split("\n").length - 1; // 0 based linenum
-        }
-        
-        function getLine(lineNum) {
-            // Future: cache result 
-            return contents.split("\n")[lineNum];
-        }
         
         var match;
+        var lines = StringUtils.getLines(contents);
         while ((match = queryExpr.exec(contents)) !== null) {
-            var lineNum = getLineNum(match.index);
-            var line = getLine(lineNum);
+            var lineNum = StringUtils.offsetToLineNumForLoops(lines,match.index);
+            var line = lines[lineNum];
             var ch = match.index - contents.lastIndexOf("\n", match.index) - 1;  // 0-based index
             var matchLength = match[0].length;
             

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
         var match;
         var lines = StringUtils.getLines(contents);
         while ((match = queryExpr.exec(contents)) !== null) {
-            var lineNum = StringUtils.offsetToLineNumForLoops(lines, match.index);
+            var lineNum = StringUtils.offsetToLineNum(lines, match.index);
             var line = lines[lineNum];
             var ch = match.index - contents.lastIndexOf("\n", match.index) - 1;  // 0-based index
             var matchLength = match[0].length;

--- a/src/strings.js
+++ b/src/strings.js
@@ -27,28 +27,6 @@
 define(function (require, exports, module) {
     
     'use strict';
-    
-    /**
-     * Format a string by replacing placeholder symbols with passed in arguments.
-     *
-     * Example: var formatted = Strings.format("Hello {0}", "World");
-     *
-     * @param {string} str The base string
-     * @param {...} Arguments to be substituted into the string
-     *
-     * @return {string} Formatted string
-     */
-    function format(str) {
-        // arguments[0] is the base string, so we need to adjust index values here
-        var args = [].slice.call(arguments, 1);
-        return str.replace(/\{(\d+)\}/g, function (match, num) {
-            return typeof args[num] !== 'undefined' ? args[num] : match;
-        });
-    }
-
-    
-    // Define public API
-    exports.format                            = format;
         
     // General file io error strings
     exports.GENERIC_ERROR                     = "(error {0})";

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
+/*global define, $ */
 
 /**
  *	Utilities functions related to string manipulation
@@ -72,43 +72,38 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Returns a line number corresponding to an offset in some text. This version
-     * is optimized for repeatidly calling the function on the same text in a loop.
-     * Use getLines() to divide the text into lines onces, then repeatidly call
+     * Returns a line number corresponding to an offset in some text. The text can
+     * be specified as a single string or as an array of strings that correspond to
+     * the lines of the string.
+     *
+     * Specify the text in lines when repeatedly calling the function on the same
+     * text in a loop. Use getLines() to divide the text into lines, then repeatedly call
      * this function to compute a line number from the offset.
      *
-     * @param {Array.<string>} lines - an array of strings corresponding to the
-     *      lines of text in a string.
+     * @param {string | Array.<string>} textOrLines - string or array of lines from which
+     *      to compute the line number from the offset
      * @param {number} offset
      * @return {number} line number
      */
-    function offsetToLineNumForLoops(lines, offset) {
-        var line, total = 0;
-        for (line = 0; line < lines.length; line++) {
-            if (total <= offset) {
-                // add 1 per line since /n were removed by splitting, but they needed to 
-                // contribute to the total offset count
-                total += lines[line].length + 1;
-            } else {
-                return line - 1;
+    function offsetToLineNum(textOrLines, offset) {
+        if ($.isArray(textOrLines)) {
+            var lines = textOrLines,
+                total = 0,
+                line;
+            for (line = 0; line < lines.length; line++) {
+                if (total <= offset) {
+                    // add 1 per line since /n were removed by splitting, but they needed to 
+                    // contribute to the total offset count
+                    total += lines[line].length + 1;
+                } else {
+                    return line - 1;
+                }
             }
+
+            return undefined;
+        } else {
+            return textOrLines.substr(0, offset).split("\n").length - 1;
         }
-
-        return undefined;
-    }
-
-    /**
-     * Returns the line number corresponding to an offset in text
-     *
-     * Note: When repeatidly computing line numbers for offsets in the same text
-     * use offsetToLineNumForLoops() instead which is performance optimized for loops
-     *
-     * @param {string} text
-     * @param {number} offset
-     * @return {number} line number
-     */
-    function offsetToLineNum(text, offset) {
-        return text.substr(0, offset).split("\n").length - 1;
     }
 
     // Define public API
@@ -117,5 +112,4 @@ define(function (require, exports, module) {
     exports.regexEscape     = regexEscape;
     exports.getLines        = getLines;
     exports.offsetToLineNum = offsetToLineNum;
-    exports.offsetToLineNumForLoops = offsetToLineNumForLoops;
 });

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -87,8 +87,10 @@ define(function (require, exports, module) {
         for (line = 0; line < lines.length; line++) {
             if (total < offset) {
                 total += lines[line].length + 1;
+                console.log( lines[line] + "\b" + total );
             } else {
-                return line - 1;
+                return line -1;
+                console.log( "returned " + line );
             }
         }
 
@@ -105,7 +107,7 @@ define(function (require, exports, module) {
      * @param {number} offset
      * @return {number} line number
      */
-    function _offsetToLineNum(text, offset) {
+    function offsetToLineNum(text, offset) {
         return text.substr(0, offset).split("\n").length - 1;
     }
 
@@ -113,4 +115,6 @@ define(function (require, exports, module) {
     exports.format          = format;
     exports.htmlEscape      = htmlEscape;
     exports.regexEscape     = regexEscape;
+    exports.offsetToLineNum = offsetToLineNum;
+    exports.offsetToLineNumForLoops = offsetToLineNumForLoops;
 });

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -85,12 +85,12 @@ define(function (require, exports, module) {
     function offsetToLineNumForLoops(lines, offset) {
         var line, total = 0;
         for (line = 0; line < lines.length; line++) {
-            if (total < offset) {
-                total += lines[line].length + 1;
-                console.log( lines[line] + "\b" + total );
+            if (total <= offset) {
+                // add 1 per line since /n were removed by splitting, but they needed to 
+                // contribute to the total offset count
+                total += lines[line].length + 1; 
             } else {
                 return line -1;
-                console.log( "returned " + line );
             }
         }
 
@@ -115,6 +115,7 @@ define(function (require, exports, module) {
     exports.format          = format;
     exports.htmlEscape      = htmlEscape;
     exports.regexEscape     = regexEscape;
+    exports.getLines        = getLines;
     exports.offsetToLineNum = offsetToLineNum;
     exports.offsetToLineNumForLoops = offsetToLineNumForLoops;
 });

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -25,7 +25,7 @@
 /*global define, $ */
 
 /**
- *	Utilities functions related to string manipulation
+ *  Utilities functions related to string manipulation
  *
  */
 define(function (require, exports, module) {
@@ -91,16 +91,23 @@ define(function (require, exports, module) {
                 total = 0,
                 line;
             for (line = 0; line < lines.length; line++) {
-                if (total <= offset) {
+                if (total < offset) {
                     // add 1 per line since /n were removed by splitting, but they needed to 
                     // contribute to the total offset count
                     total += lines[line].length + 1;
+                } else if (total === offset) {
+                    return line;
                 } else {
                     return line - 1;
                 }
             }
 
-            return undefined;
+            // if offset is NOT over the total then offset is in the last line
+            if (offset <= total) {
+                return line - 1;
+            } else {
+                return undefined;
+            }
         } else {
             return textOrLines.substr(0, offset).split("\n").length - 1;
         }

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -88,9 +88,9 @@ define(function (require, exports, module) {
             if (total <= offset) {
                 // add 1 per line since /n were removed by splitting, but they needed to 
                 // contribute to the total offset count
-                total += lines[line].length + 1; 
+                total += lines[line].length + 1;
             } else {
-                return line -1;
+                return line - 1;
             }
         }
 

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -31,6 +31,24 @@
 define(function (require, exports, module) {
     'use strict';
 
+    /**
+     * Format a string by replacing placeholder symbols with passed in arguments.
+     *
+     * Example: var formatted = StringUtils.format("Hello {0}", "World");
+     *
+     * @param {string} str The base string
+     * @param {...} Arguments to be substituted into the string
+     *
+     * @return {string} Formatted string
+     */
+    function format(str) {
+        // arguments[0] is the base string, so we need to adjust index values here
+        var args = [].slice.call(arguments, 1);
+        return str.replace(/\{(\d+)\}/g, function (match, num) {
+            return typeof args[num] !== 'undefined' ? args[num] : match;
+        });
+    }
+
     function htmlEscape(str) {
         return String(str)
             .replace(/&/g, '&amp;')
@@ -44,6 +62,55 @@ define(function (require, exports, module) {
         return str.replace(/([.?*+\^$\[\]\\(){}|\-])/g, "\\$1");
     }
 
-    exports.htmlEscape = htmlEscape;
-    exports.regexEscape = regexEscape;
+    /**
+     * Splits the text by new line characters and returns an array of lines
+     * @param {string} text
+     * @return {Array.<string>} lines
+     */
+    function getLines(text) {
+        return text.split("\n");
+    }
+
+    /**
+     * Returns a line number corresponding to an offset in some text. This version
+     * is optimized for repeatidly calling the function on the same text in a loop.
+     * Use getLines() to divide the text into lines onces, then repeatidly call
+     * this function to compute a line number from the offset.
+     *
+     * @param {Array.<string>} lines - an array of strings corresponding to the
+     *      lines of text in a string.
+     * @param {number} offset
+     * @return {number} line number
+     */
+    function offsetToLineNumForLoops(lines, offset) {
+        var line, total = 0;
+        for (line = 0; line < lines.length; line++) {
+            if (total < offset) {
+                total += lines[line].length + 1;
+            } else {
+                return line - 1;
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Returns the line number corresponding to an offset in text
+     *
+     * Note: When repeatidly computing line numbers for offsets in the same text
+     * use offsetToLineNumForLoops() instead which is performance optimized for loops
+     *
+     * @param {string} text
+     * @param {number} offset
+     * @return {number} line number
+     */
+    function _offsetToLineNum(text, offset) {
+        return text.substr(0, offset).split("\n").length - 1;
+    }
+
+    // Define public API
+    exports.format          = format;
+    exports.htmlEscape      = htmlEscape;
+    exports.regexEscape     = regexEscape;
 });


### PR DESCRIPTION
A lot of places in our code convert an offset into a string into a line number. Many places in our code do this in a loop and split the text into lines every iteration which is inefficient. This change centralizes this logic in StringUtils and provides an optimized version for loops that caches the lines.

Added functions:
StringUtils.offsetToLineNumForLoops()
StringUtils.offsetToLineNumFor()

I am curious to see if the JS quick edit perf tests show a difference with this change.

I also moved format() from Strings.js to StringUtils.js as a cleanup task
