### PR TITLE
Fix for #1015 (Brackets won't load properly in a folder with parenthesis)

### DIFF
--- a/src/styles/brackets_shared.less
+++ b/src/styles/brackets_shared.less
@@ -34,7 +34,8 @@
 /* CSS imports */
 
 // CodeMirror
-@import url(../thirdparty/CodeMirror2/lib/codemirror.css);
+// Must wrap in quotes to avoid issue #1015 (true for all relative URLs to non-LESS files)
+@import url("../thirdparty/CodeMirror2/lib/codemirror.css");
 
 /* LESS imports */
 


### PR DESCRIPTION
Fix for #1015 (Brackets won't load properly in a folder with parenthesis)

Work around LESS bug (https://github.com/cloudhead/less.js/issues/831) by putting quotes around all relative URLs in our LESS files (except for URLs importing other LESS files, which are not subject to the bug since they're not preserved in the final output).

This just fixes the one URL in our current code that's subject to the bug.  If we're ok with a bigger diff and really want to cement the best practice, we could also add quotes to all our remaining URLs too (those that import LESS files), so that there are no bad examples in the code for people to follow...
