### PR TITLE
Fix #971 (Find in Files treats \n, \r, etc. as regular expressions)

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
         // Query is a string. Turn it into a case-insensitive regexp
         
         // Escape regex special chars
-        query = query.replace(/(\(|\)|\{|\}|\[|\]|\.|\^|\$|\||\?|\+|\*)/g, "\\$1");
+        query = query.replace(/([(){}\[\].\^$|?+*\\])/g, "\\$1");
         return new RegExp(query, "gi");
     }
     


### PR DESCRIPTION
Fix #971 -- Escape backslash too (and simplify escaping regexp to use char class instead of `|`)
