### PR TITLE
Restore Shift-Tab to outdent behavior

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -314,24 +314,25 @@ define(function (require, exports, module) {
         
         // Editor supplies some standard keyboard behavior extensions of its own
         var codeMirrorKeyMap = {
-            "Tab" : _handleTabKey,
+            "Tab": _handleTabKey,
+            "Shift-Tab": "indentLess",
 
-            "Left" : function (instance) {
+            "Left": function (instance) {
                 if (!_handleSoftTabNavigation(instance, -1, "moveH")) {
                     CodeMirror.commands.goCharLeft(instance);
                 }
             },
-            "Right" : function (instance) {
+            "Right": function (instance) {
                 if (!_handleSoftTabNavigation(instance, 1, "moveH")) {
                     CodeMirror.commands.goCharRight(instance);
                 }
             },
-            "Backspace" : function (instance) {
+            "Backspace": function (instance) {
                 if (!_handleSoftTabNavigation(instance, -1, "deleteH")) {
                     CodeMirror.commands.delCharLeft(instance);
                 }
             },
-            "Delete" : function (instance) {
+            "Delete": function (instance) {
                 if (!_handleSoftTabNavigation(instance, 1, "deleteH")) {
                     CodeMirror.commands.delCharRight(instance);
                 }


### PR DESCRIPTION
In the latest CodeMirror merge, we picked up a change that defaults Shift-Tab to fix up indentation rather than outdenting. This restores it to the behavior we had before the merge.

The only real diff is the line about "Shift-Tab"--the other diffs are just cleanups for whitespace inconsistencies I noticed around that area.

Fixes #1035.
