### PR TITLE
Fix bug in Menus.addMenuItem() when passing a command directly instead of its ID

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -361,13 +361,14 @@ define(function (require, exports, module) {
                 name = command.getName();
             }
         } else {
-            commandID = command.getID;
+            commandID = command.getID();
         }
 
         // Internal id is the a composite of the parent menu id and the command id.
         id = this.id + "-" + commandID;
         
         if (menuItemMap[id]) {
+            debugger;
             throw new Error("MenuItem added with same id of existing MenuItem: " + id);
         }
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -368,7 +368,6 @@ define(function (require, exports, module) {
         id = this.id + "-" + commandID;
         
         if (menuItemMap[id]) {
-            debugger;
             throw new Error("MenuItem added with same id of existing MenuItem: " + id);
         }
 


### PR DESCRIPTION
@tvoliter 

Passing a Command directly to addMenuItem() was no longer working. This fixes that bug. (Found it because one of my local extension experiments relied on this working.)
