### PR TITLE
Issue 1065. Use module.exports for single-class modules

### DIFF
--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     
     var Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
-        Editor                  = require("editor/Editor").Editor,
+        Editor                  = require("editor/Editor"),
         Strings                 = require("strings"),
         JSLintUtils             = require("language/JSLintUtils"),
         PerfUtils               = require("utils/PerfUtils"),

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     var CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         KeyBindingManager   = require("command/KeyBindingManager"),
-        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+        NativeFileSystem    = require("file/NativeFileSystem"),
         ProjectManager      = require("project/ProjectManager"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -67,7 +67,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         ProjectManager      = require("project/ProjectManager"),
         EditorManager       = require("editor/EditorManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -175,5 +175,5 @@ define(function (require, exports, module) {
     
     
     // Define public API
-    exports.TextRange = TextRange;
+    module.exports = TextRange;
 });

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     var CSSUtils                = require("language/CSSUtils"),
         EditorManager           = require("editor/EditorManager"),
         HTMLUtils               = require("language/HTMLUtils"),
-        MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor").MultiRangeInlineEditor;
+        MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor");
 
     /**
      * Given a position in an HTML editor, returns the relevant selector for the attribute/tag

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
         CommandManager  = require("command/CommandManager"),
         PerfUtils       = require("utils/PerfUtils"),
         Strings          = require("strings"),
-        TextRange       = require("document/TextRange").TextRange,
+        TextRange       = require("document/TextRange"),
         ViewUtils       = require("utils/ViewUtils");
     
 
@@ -1067,5 +1067,5 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SELECT_ALL,     Commands.EDIT_SELECT_ALL, _handleSelectAll);
 
     // Define public API
-    exports.Editor = Editor;
+    module.exports = Editor;
 });

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -46,8 +46,8 @@ define(function (require, exports, module) {
         CommandManager      = require("command/CommandManager"),
         DocumentManager     = require("document/DocumentManager"),
         PerfUtils           = require("utils/PerfUtils"),
-        Editor              = require("editor/Editor").Editor,
-        InlineTextEditor    = require("editor/InlineTextEditor").InlineTextEditor,
+        Editor              = require("editor/Editor"),
+        InlineTextEditor    = require("editor/InlineTextEditor"),
         EditorUtils         = require("editor/EditorUtils"),
         ViewUtils           = require("utils/ViewUtils"),
         Strings             = require("strings");

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
         EditorManager       = require("editor/EditorManager"),
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
-        InlineWidget        = require("editor/InlineWidget").InlineWidget;
+        InlineWidget        = require("editor/InlineWidget");
 
     /**
      * Returns editor holder width (not CodeMirror's width).
@@ -289,6 +289,6 @@ define(function (require, exports, module) {
     // consolidate all dirty document updates
     $(DocumentManager).on("dirtyFlagChange", _dirtyFlagChangeHandler);
 
-    exports.InlineTextEditor = InlineTextEditor;
+    module.exports = InlineTextEditor;
 
 });

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -96,6 +96,6 @@ define(function (require, exports, module) {
         // do nothing - base implementation
     };
 
-    exports.InlineWidget = InlineWidget;
+    module.exports = InlineWidget;
 
 });

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -40,8 +40,8 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var TextRange           = require("document/TextRange").TextRange,
-        InlineTextEditor    = require("editor/InlineTextEditor").InlineTextEditor,
+    var TextRange           = require("document/TextRange"),
+        InlineTextEditor    = require("editor/InlineTextEditor"),
         EditorManager       = require("editor/EditorManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
@@ -516,5 +516,5 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_QUICK_EDIT_PREV_MATCH,      Commands.QUICK_EDIT_PREV_MATCH, _previousRange);
     CommandManager.register(Strings.CMD_QUICK_EDIT_NEXT_MATCH,      Commands.QUICK_EDIT_NEXT_MATCH, _nextRange);
 
-    exports.MultiRangeInlineEditor = MultiRangeInlineEditor;
+    module.exports = MultiRangeInlineEditor;
 });

--- a/src/extensions/default/JavaScriptQuickEdit/JSUtils.js
+++ b/src/extensions/default/JavaScriptQuickEdit/JSUtils.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     var Async                   = brackets.getModule("utils/Async"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
         ChangedDocumentTracker  = brackets.getModule("document/ChangedDocumentTracker"),
-        NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem,
+        NativeFileSystem        = brackets.getModule("file/NativeFileSystem"),
         PerfUtils               = brackets.getModule("utils/PerfUtils"),
         StringUtils             = brackets.getModule("utils/StringUtils");
 

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     'use strict';
     
     // Brackets modules
-    var MultiRangeInlineEditor  = brackets.getModule("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
+    var MultiRangeInlineEditor  = brackets.getModule("editor/MultiRangeInlineEditor"),
         FileIndexManager        = brackets.getModule("project/FileIndexManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
         PerfUtils               = brackets.getModule("utils/PerfUtils");

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         PerfUtils,              // loaded from brackets.test
         
         FileUtils           = brackets.getModule("file/FileUtils"),
-        NativeFileSystem    = brackets.getModule("file/NativeFileSystem").NativeFileSystem,
+        NativeFileSystem    = brackets.getModule("file/NativeFileSystem"),
         SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils"),
         PerformanceReporter = brackets.getModule("perf/PerformanceReporter");
 

--- a/src/extensions/disabled/InlineImageViewer/InlineImageViewer.js
+++ b/src/extensions/disabled/InlineImageViewer/InlineImageViewer.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load Brackets modules
-    var InlineWidget        = brackets.getModule("editor/InlineWidget").InlineWidget;
+    var InlineWidget        = brackets.getModule("editor/InlineWidget");
     
     function InlineImageViewer(fileName, fullPath) {
         this.fileName = fileName;

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -31,7 +31,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         PerfUtils           = require("utils/PerfUtils"),
         Dialogs             = require("widgets/Dialogs"),
         Strings             = require("strings"),

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -872,5 +872,5 @@ define(function (require, exports, module) {
     };
 
     // Define public API
-    exports.NativeFileSystem    = NativeFileSystem;
+    module.exports = NativeFileSystem;
 });

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
         EditorManager       = require("editor/EditorManager"),
         HTMLUtils           = require("language/HTMLUtils"),
         FileIndexManager    = require("project/FileIndexManager"),
-        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem;
+        NativeFileSystem    = require("file/NativeFileSystem");
 
     /**
      * Extracts all CSS selectors from the given text

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -172,5 +172,5 @@ define(function (require, exports, module) {
         _commit();
     };
     
-    exports.PreferenceStorage = PreferenceStorage;
+    module.exports = PreferenceStorage;
 });

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -32,7 +32,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var PreferenceStorage = require("preferences/PreferenceStorage").PreferenceStorage;
+    var PreferenceStorage = require("preferences/PreferenceStorage");
     
     var PREFERENCES_KEY = "com.adobe.brackets.preferences";
 

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -39,7 +39,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         PerfUtils           = require("utils/PerfUtils"),
         ProjectManager      = require("project/ProjectManager"),
         Dialogs             = require("widgets/Dialogs"),

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");
 
     // Load dependent modules
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         DocumentManager     = require("document/DocumentManager"),
         CommandManager      = require("command/CommandManager"),

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         Commands              = require("command/Commands"),
         EditorManager         = require("editor/EditorManager"),
         FileViewController    = require("project/FileViewController"),
-        NativeFileSystem      = require("file/NativeFileSystem").NativeFileSystem,
+        NativeFileSystem      = require("file/NativeFileSystem"),
         ViewUtils             = require("utils/ViewUtils");
     
     

--- a/src/utils/BuildInfoUtils.js
+++ b/src/utils/BuildInfoUtils.js
@@ -31,7 +31,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         FileUtils           = require("file/FileUtils");
     
     

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -32,7 +32,7 @@
 define(function (require, exports, module) {
     'use strict';
 
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         FileUtils           = require("file/FileUtils"),
         Async               = require("utils/Async"),
         contexts            = {};

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
     
     // Utility dependency
     var SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
-        PerformanceReporter = require("perf/PerformanceReporter").PerformanceReporter,
+        PerformanceReporter = require("perf/PerformanceReporter"),
         ExtensionLoader     = require("utils/ExtensionLoader"),
         FileUtils           = require("file/FileUtils"),
         Menus               = require("command/Menus");
@@ -164,7 +164,7 @@ define(function (require, exports, module) {
             
             // add performance reporting
             if (isPerfSuite) {
-                jasmineEnv.addReporter(new PerformanceReporter());
+                jasmineEnv.addReporter(PerformanceReporter.createPerformanceReporter());
             }
             
             localStorage.setItem("SpecRunner.suite", suite);

--- a/test/perf/PerformanceReporter.js
+++ b/test/perf/PerformanceReporter.js
@@ -171,7 +171,11 @@ define(function (require, exports, module) {
         delete records[spec];
     };
     
-    exports.PerformanceReporter = PerformanceReporter;
-    exports.logTestWindow = logTestWindow;
-    exports.clearTestWindow = clearTestWindow;
+    function createPerformanceReporter() {
+        return new PerformanceReporter();
+    }
+    
+    exports.createPerformanceReporter   = createPerformanceReporter;
+    exports.logTestWindow               = logTestWindow;
+    exports.clearTestWindow             = clearTestWindow;
 });

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -27,11 +27,11 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem        = require("file/NativeFileSystem"),
         Async                   = require("utils/Async"),
         FileUtils               = require("file/FileUtils"),
         CSSUtils                = require("language/CSSUtils"),
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
     
     var testPath                = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
         simpleCssFileEntry      = new NativeFileSystem.FileEntry(testPath + "/simple.css"),

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -30,8 +30,8 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var HTMLUtils       = require("language/HTMLUtils"),
-        SpecRunnerUtils = require("./SpecRunnerUtils.js"),
-        Editor          = require("editor/Editor").Editor;
+        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
+        Editor          = require("editor/Editor");
     
     //Use a clean version of the editor each time
     var myDocument;

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Commands,            // loaded from brackets.test
         EditorManager,       // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     
     describe("Document", function () {

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -33,8 +33,8 @@ define(function (require, exports, module) {
         Commands,            // loaded from brackets.test
         DocumentCommandHandlers, // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js"),
-        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
+        NativeFileSystem    = require("file/NativeFileSystem"),
         FileUtils           = require("file/FileUtils");
     
     

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -28,8 +28,8 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var Editor          = require("editor/Editor").Editor,
-        SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+    var Editor          = require("editor/Editor"),
+        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         EditorUtils     = require("editor/EditorUtils");
 
     describe("Editor", function () {

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -27,11 +27,11 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var Editor                = require("editor/Editor").Editor,
+    var Editor                = require("editor/Editor"),
         EditorCommandHandlers = require("editor/EditorCommandHandlers"),
         Commands              = require("command/Commands"),
         CommandManager        = require("command/CommandManager"),
-        SpecRunnerUtils       = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils       = require("spec/SpecRunnerUtils"),
         EditorUtils           = require("editor/EditorUtils");
 
     describe("EditorCommandHandlers", function () {

--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     // Load dependent modules
     var FileIndexManager,
         ProjectManager,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     describe("FileIndexManager", function () {
 

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -35,9 +35,9 @@ define(function (require, exports, module) {
         DocumentManager,    // loaded from brackets.test
         FileViewController, // loaded from brackets.test
         Dialogs          = require("widgets/Dialogs"),
-        NativeFileSystem = require("file/NativeFileSystem").NativeFileSystem,
+        NativeFileSystem = require("file/NativeFileSystem"),
         FileUtils        = require("file/FileUtils"),
-        SpecRunnerUtils  = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils  = require("spec/SpecRunnerUtils");
 
     describe("InlineEditorProviders", function () {
 

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -27,7 +27,7 @@
 define(function (require, exports, module) {
     'use strict';
 
-    var SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+    var SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         NativeApp,      //The following are all loaded from the test window
         LiveDevelopment,
         Inspector,

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -29,8 +29,8 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var SpecRunnerUtils     = require("./SpecRunnerUtils.js");
-    var _FSEncodings        = require("file/NativeFileSystem").NativeFileSystem._FSEncodings;
+    var SpecRunnerUtils     = require("spec/SpecRunnerUtils");
+    var _FSEncodings        = require("file/NativeFileSystem")._FSEncodings;
     
     // These are tests for the low-level file io routines in brackets-app. Make sure
     // you have the latest brackets-app before running.

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Commands,
         KeyBindingManager,
         Menus,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         StringsUtils        = require("utils/StringUtils"),
         Strings             = require("strings");
 

--- a/test/spec/MultiRangeInlineEditor-test.js
+++ b/test/spec/MultiRangeInlineEditor-test.js
@@ -28,12 +28,12 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
-        InlineTextEditor        = require("editor/InlineTextEditor").InlineTextEditor,
-        InlineWidget            = require("editor/InlineWidget").InlineWidget,
-        Editor                  = require("editor/Editor").Editor,
+    var MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor"),
+        InlineTextEditor        = require("editor/InlineTextEditor"),
+        InlineWidget            = require("editor/InlineWidget"),
+        Editor                  = require("editor/Editor"),
         EditorManager           = require("editor/EditorManager"),
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
 
     describe("MultiRangeInlineEditor", function () {
         

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -29,8 +29,8 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+    var NativeFileSystem        = require("file/NativeFileSystem"),
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
     
     var Encodings               = NativeFileSystem.Encodings;
     var _FSEncodings            = NativeFileSystem._FSEncodings;

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -28,8 +28,8 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var PreferencesManager      = require("preferences/PreferencesManager"),
-        PreferenceStorage       = require("preferences/PreferenceStorage").PreferenceStorage,
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        PreferenceStorage       = require("preferences/PreferenceStorage"),
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
 
     var CLIENT_ID = "PreferencesManager-test";
         

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var ProjectManager,     // Load from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
     describe("ProjectManager", function () {
 

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -27,7 +27,7 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var NativeFileSystem    = require("file/NativeFileSystem"),
         Commands            = require("command/Commands"),
         FileUtils           = require("file/FileUtils"),
         Async               = require("utils/Async"),

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Commands,
         DocumentManager,
         FileViewController,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
     describe("WorkingSetView", function () {
     


### PR DESCRIPTION
Fix for #1065. 

Also cleaned up some require statements e.g. `require("./SpecUtils.js)"` and refactored PerformanceReporter to remove `PerformanceReporter` class from `exports`.

Unit tests and smoke tests pass.
