### PR TITLE
Issue 1072. Use getDocumentForPath instead of getOpenDocumentForPath.

### DIFF
--- a/src/document/ChangedDocumentTracker.js
+++ b/src/document/ChangedDocumentTracker.js
@@ -53,8 +53,9 @@ define(function (require, exports, module) {
         $(DocumentManager).on("workingSetAdd", function (event, fileEntry) {
             // Only track documents in the current project
             if (ProjectManager.isWithinProject(fileEntry.fullPath)) {
-                var doc = DocumentManager.getOpenDocumentForPath(fileEntry.fullPath);
-                self._addListener(doc);
+                DocumentManager.getDocumentForPath(fileEntry.fullPath).done(function (doc) {
+                    self._addListener(doc);
+                });
             }
         });
         


### PR DESCRIPTION
#1072

`workingSetAdd` does not necessarily mean that (a) the file is in the project or (b) the file is open in an editor. Even though we handle the app-init case, we didn't handle the project switching case where the new project removes and re-adds files in the working set. ChangedDocumentTracker responds to the working set changes before the new project's documents are opened.
