### PR TITLE
Filter for valid function expressions

### DIFF
--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -54,7 +54,9 @@ define(function (require, exports, module) {
         }
         
         // Return valid function expressions only (function call or reference)
-        if (!((token.className === "variable-2") || (token.className === "property"))) {
+        if (!((token.className === "variable")
+              || (token.className === "variable-2")
+              || (token.className === "property"))) {
             return null;
         }
         

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -53,6 +53,11 @@ define(function (require, exports, module) {
             token = hostEditor._codeMirror.getTokenAt({line: pos.line, ch: pos.ch + 1});
         }
         
+        // Return valid function expressions only (function call or reference)
+        if (!((token.className === "variable-2") || (token.className === "property"))) {
+            return null;
+        }
+        
         return token.string;
     }
     
@@ -146,7 +151,7 @@ define(function (require, exports, module) {
         // Always use the selection start for determining the function name. The pos
         // parameter is usually the selection end.        
         var functionName = _getFunctionName(hostEditor, hostEditor.getSelection().start);
-        if (functionName === "") {
+        if ((functionName === null) || (functionName === "")) {
             return null;
         }
         

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
         // Always use the selection start for determining the function name. The pos
         // parameter is usually the selection end.        
         var functionName = _getFunctionName(hostEditor, hostEditor.getSelection().start);
-        if ((functionName === null) || (functionName === "")) {
+        if (!functionName) {
             return null;
         }
         

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -586,7 +586,7 @@ define(function (require, exports, module) {
                     SpecRunnerUtils.closeTestWindow();
                 });
                 
-                it("should return the correct offsets if the file has changed", function () {
+                function fileChangedTest(buildCache) {
                     var doc,
                         didOpen = false,
                         gotError = false,
@@ -595,6 +595,9 @@ define(function (require, exports, module) {
                         functions = null;
 
                     runs(function () {
+                        extensionRequire = brackets.getModule('utils/ExtensionLoader').getRequireContextForExtension('JavaScriptQuickEdit');
+                        JSUtilsInExtension = extensionRequire("JSUtils");
+                        
                         FileViewController.openAndSelectDocument(testPath + "/edit.js", FileViewController.PROJECT_MANAGER)
                             .done(function () { didOpen = true; })
                             .fail(function () { gotError = true; });
@@ -603,25 +606,24 @@ define(function (require, exports, module) {
                     waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
                     
                     // Populate JSUtils cache
-                    runs(function () {
-                        extensionRequire = brackets.getModule('utils/ExtensionLoader').getRequireContextForExtension('JavaScriptQuickEdit');
-                        JSUtilsInExtension = extensionRequire("JSUtils");
-                            
-                        FileIndexManager.getFileInfoList("all")
-                            .done(function (fileInfos) {
-                                // Look for "edit2" function
-                                JSUtilsInExtension.findMatchingFunctions("edit2", fileInfos)
-                                    .done(function (result) { functions = result; });
-                            });
-                    });
-                    
-                    waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
-                    
-                    runs(function () {
-                        expect(functions.length).toBe(1);
-                        expect(functions[0].lineStart).toBe(7);
-                        expect(functions[0].lineEnd).toBe(9);
-                    });
+                    if (buildCache) {
+                        runs(function () {
+                            FileIndexManager.getFileInfoList("all")
+                                .done(function (fileInfos) {
+                                    // Look for "edit2" function
+                                    JSUtilsInExtension.findMatchingFunctions("edit2", fileInfos)
+                                        .done(function (result) { functions = result; });
+                                });
+                        });
+                        
+                        waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
+                        
+                        runs(function () {
+                            expect(functions.length).toBe(1);
+                            expect(functions[0].lineStart).toBe(7);
+                            expect(functions[0].lineEnd).toBe(9);
+                        });
+                    }
                     
                     runs(function () {
                         var doc = DocumentManager.getCurrentDocument();
@@ -647,13 +649,27 @@ define(function (require, exports, module) {
                         expect(functions[0].lineStart).toBe(11);
                         expect(functions[0].lineEnd).toBe(13);
                     });
+                }
+                
+                it("should return the correct offsets if the file has changed", function () {
+                    fileChangedTest(false);
                 });
-
-                it("should return a newly created function in an unsaved file", function () {
+                
+                it("should return the correct offsets if the results were cached and the file has changed", function () {
+                    fileChangedTest(true);
+                });
+                
+                function insertFunctionTest(buildCache) {
                     var didOpen = false,
-                        gotError = false;
+                        gotError = false,
+                        extensionRequire,
+                        JSUtilsInExtension,
+                        functions = null;
                     
                     runs(function () {
+                        extensionRequire = brackets.getModule('utils/ExtensionLoader').getRequireContextForExtension('JavaScriptQuickEdit');
+                        JSUtilsInExtension = extensionRequire("JSUtils");
+                        
                         FileViewController.openAndSelectDocument(testPath + "/edit.js", FileViewController.PROJECT_MANAGER)
                             .done(function () { didOpen = true; })
                             .fail(function () { gotError = true; });
@@ -661,9 +677,31 @@ define(function (require, exports, module) {
                     
                     waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
                     
-                    var functions = null;
+                    // Populate JSUtils cache
+                    if (buildCache) {
+                        runs(function () {
+                            // Look for the selector we just created
+                            FileIndexManager.getFileInfoList("all")
+                                .done(function (fileInfos) {
+                                    // Look for "TESTFUNCTION" function
+                                    JSUtilsInExtension.findMatchingFunctions("TESTFUNCTION", fileInfos)
+                                        .done(function (result) {
+                                            functions = result;
+                                        });
+                                });
+                        });
+                        
+                        waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
+                        
+                        runs(function () {
+                            expect(functions.length).toBe(0);
+                        });
+                    }
                     
                     runs(function () {
+                        // reset result functions array
+                        functions = null;
+                        
                         var doc = DocumentManager.getCurrentDocument();
                         // Add a new function to the file
                         doc.setText(doc.getText() + "\n\nfunction TESTFUNCTION() {\n    return true;\n}\n");
@@ -689,6 +727,14 @@ define(function (require, exports, module) {
                         expect(functions[0].lineStart).toBe(33);
                         expect(functions[0].lineEnd).toBe(35);
                     });
+                }
+
+                it("should return a newly created function in an unsaved file", function () {
+                    insertFunctionTest(false);
+                });
+
+                it("should return a newly created function in an unsaved file that already has cached results", function () {
+                    insertFunctionTest(true);
                 });
             });
         }); //describe("JS Parsing")

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -680,7 +680,7 @@ define(function (require, exports, module) {
                     // Populate JSUtils cache
                     if (buildCache) {
                         runs(function () {
-                            // Look for the selector we just created
+                            // Look for the selector we're about to create--we shouldn't find it yet
                             FileIndexManager.getFileInfoList("all")
                                 .done(function (fileInfos) {
                                     // Look for "TESTFUNCTION" function


### PR DESCRIPTION
#1073

JavaScriptQuickEdit fails fast when the current token is not a valid function expression. Does not fix the larger issues of handling Async creation (and failure to create) inline editors.

@njx 
