### PR TITLE
Support Windows context menu key

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -836,53 +836,53 @@ define(function (require, exports, module) {
         editor_cmenu.addMenuItem(Commands.EDIT_SELECT_ALL);
 
         /**
-         * Displays context menu when right clicking editor.
+         * Context menu for code editors (both full-size and inline)
          * Auto selects the word the user clicks if the click does not occur over
          * an existing selection
-         *
-         * TODO: doesn't word select when changing editors with right click
-         *
          */
-        $("#editor-holder").contextmenu(function (e) {
-            if (e.which === 3) {
-                if ($(e.target).parents(".CodeMirror-gutter").length !== 0) {
-                    return;
+        $("#editor-holder").on("contextmenu", function (e) {
+            if ($(e.target).parents(".CodeMirror-gutter").length !== 0) {
+                return;
+            }
+            
+            // Note: on mousedown before this event, CodeMirror automatically checks mouse pos, and
+            // if not clicking on a selection moves the cursor to click location. When triggered
+            // from keyboard, no pre-processing occurs and the cursor/selection is left as is.
+            
+            var editor = EditorManager.getFocusedEditor();
+            if (editor) {
+                // If there's just an insertion point select the word token at the cursor pos so
+                // it's more clear what the context menu applies to.
+                if (!editor.hasSelection()) {
+                    editor.selectWordAt(editor.getCursorPos());
+                    
+                    // Prevent menu from overlapping text by moving it down a little
+                    e.pageY += 6;
                 }
-
-                var editor = EditorManager.getFocusedEditor();
-                if (editor) {
-                    var clickedSel = false,
-                        pos = editor.coordsChar({x: e.pageX, y: e.pageY});
-                    if (editor.getSelectedText() !== "") {
-                        var sel = editor.getSelection();
-                        clickedSel =  editor.coordsWithinRange(pos, sel.start, sel.end);
-                    }
-
-                    if (!clickedSel) {
-                        editor.selectWordAt(pos);
-                        // Prevent menu from overlapping text by
-                        // moving it down a little
-                        e.pageY += 6;
-                    }
-                    editor_cmenu.open(e);
-                }
+                
+                editor_cmenu.open(e);
             }
         });
 
-
-        $("#projects").contextmenu(function (e) {
-            if (e.which === 3) {
-                project_cmenu.open(e);
-            }
+        /**
+         * Context menu for folder tree & working set list
+         *
+         * TODO (#1069): change selection on right mousedown if not on something already selected
+         */
+        $("#projects").on("contextmenu", function (e) {
+            project_cmenu.open(e);
         });
 
         // Prevent the browser context menu since Brackets creates a custom context menu
         $(window).contextmenu(function (e) {
             e.preventDefault();
         });
-
-        // Prevent clicks on the top-level menu bar from taking focus
-        // Note, bootstrap handles this already for the menu drop downs
+        
+        
+        /*
+         * General menu event processing
+         */
+        // Prevent clicks on top level menus and menu items from taking focus
         $(window.document).on("mousedown", ".dropdown", function (e) {
             e.preventDefault();
         });

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -654,7 +654,8 @@ define(function (require, exports, module) {
     };
 
     /**
-     * @param {line:number, ch:number}
+     * Given a position, returns its index within the text (assuming \n newlines)
+     * @param {!{line:number, ch:number}}
      * @return {number}
      */
     Editor.prototype.indexFromPos = function (coords) {
@@ -662,33 +663,36 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Returns true if coords is between start and end (inclusive)
-     * @param {line:number, ch:number} coords
-     * @param {line:number, ch:number} start
-     * @param {line:number, ch:number} end
+     * Returns true if pos is between start and end (inclusive at both ends)
+     * @param {{line:number, ch:number}} pos
+     * @param {{line:number, ch:number}} start
+     * @param {{line:number, ch:number}} end
      *
      */
-    Editor.prototype.coordsWithinRange = function (coords, start, end) {
+    Editor.prototype.posWithinRange = function (pos, start, end) {
         var startIndex = this.indexFromPos(start),
             endIndex = this.indexFromPos(end),
-            coordIndex = this.indexFromPos(coords);
+            posIndex = this.indexFromPos(pos);
 
-        return coordIndex >= startIndex && coordIndex <= endIndex;
+        return posIndex >= startIndex && posIndex <= endIndex;
     };
-
-    Editor.prototype.coordsChar = function (coords) {
-        return this._codeMirror.coordsChar(coords);
+    
+    /**
+     * @return {boolean} True if there's a text selection; false if there's just an insertion point
+     */
+    Editor.prototype.hasSelection = function () {
+        return this._codeMirror.somethingSelected();
     };
-
+    
     /**
      * Gets the current selection. Start is inclusive, end is exclusive. If there is no selection,
      * returns the current cursor position as both the start and end of the range (i.e. a selection
      * of length zero).
-     * @return !{start:{line:number, ch:number}, end:{line:number, ch:number}}
+     * @return {!{start:{line:number, ch:number}, end:{line:number, ch:number}}}
      */
     Editor.prototype.getSelection = function () {
         var selStart = this._codeMirror.getCursor(true),
-            selEnd = this._codeMirror.getCursor(false);
+            selEnd   = this._codeMirror.getCursor(false);
         return { start: selStart, end: selEnd };
     };
     
@@ -711,8 +715,9 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Selects a the word nearest to the position
-     * @param {line:number, ch:number}
+     * Selects word that the given pos lies within or adjacent to. If pos isn't touching a word
+     * (e.g. within a token like "//"), moves the cursor to pos without selecting a range.
+     * @param {!{line:number, ch:number}}
      */
     Editor.prototype.selectWordAt = function (pos) {
         this._codeMirror.selectWordAt(pos);


### PR DESCRIPTION
In general, anything using mouse coords for purposes other than menu positioning should use mousedown, while the menu itself should be popped up via contextmenu.

In the case of our editor context menu, it turns out that the special processing we were doing with mouse position and selection is already done by CodeMirror too (see onContextMenu()), so in this case we can simply remove that logic instead of creating an additional mousedown handler.

This renders unused several Editor APIs that were recently added to support the above logic. I removed one that seemed less useful, and cleaned up/renamed the other two.

_Caveat:_ when using the context menu key, menu position is not always that nice. This is due to CodeMirror bugs: it doesn't always update the pos of the focused textarea at the right times. However, the pos of the menu when opened via keyboard is often poor in other apps too.
