### PR TITLE
Add unit tests for filtering out token types in JavaScript Quick Edit.

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";
     exports.NAVIGATE_GOTO_DEFINITION    = "navigate.gotoDefinition";
     exports.NAVIGATE_GOTO_LINE          = "navigate.gotoLine";
-    exports.TOGGLE_QUICK_EDIT           = "navigate.togleQuickEdit";
+    exports.TOGGLE_QUICK_EDIT           = "navigate.toggleQuickEdit";
     exports.QUICK_EDIT_NEXT_MATCH       = "navigate.nextMatch";
     exports.QUICK_EDIT_PREV_MATCH       = "navigate.previousMatch";
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";
     exports.NAVIGATE_GOTO_DEFINITION    = "navigate.gotoDefinition";
     exports.NAVIGATE_GOTO_LINE          = "navigate.gotoLine";
-    exports.SHOW_INLINE_EDITOR          = "navigate.showInlineEditor";
+    exports.TOGGLE_QUICK_EDIT           = "navigate.togleQuickEdit";
     exports.QUICK_EDIT_NEXT_MATCH       = "navigate.nextMatch";
     exports.QUICK_EDIT_PREV_MATCH       = "navigate.previousMatch";
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -802,7 +802,7 @@ define(function (require, exports, module) {
 
         menu.addMenuItem(Commands.NAVIGATE_GOTO_DEFINITION, "Ctrl-T");
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.SHOW_INLINE_EDITOR,       "Ctrl-E");
+        menu.addMenuItem(Commands.TOGGLE_QUICK_EDIT,        "Ctrl-E");
         menu.addMenuItem(Commands.QUICK_EDIT_PREV_MATCH,    {key: "Alt-Up", displayKey: "Alt-\u2191"});
         menu.addMenuItem(Commands.QUICK_EDIT_NEXT_MATCH,    {key: "Alt-Down", displayKey: "Alt-\u2193"});
 
@@ -832,7 +832,7 @@ define(function (require, exports, module) {
         var project_cmenu = registerContextMenu(ContextMenuIds.PROJECT_MENU);
 
         var editor_cmenu = registerContextMenu(ContextMenuIds.EDITOR_MENU);
-        editor_cmenu.addMenuItem(Commands.SHOW_INLINE_EDITOR);
+        editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);
         editor_cmenu.addMenuItem(Commands.EDIT_SELECT_ALL);
 
         /**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -517,11 +517,17 @@ define(function (require, exports, module) {
                 PerfUtils.markStart(PerfUtils.INLINE_EDITOR_CLOSE);
                 inlineWidget.close();
                 PerfUtils.addMeasurement(PerfUtils.INLINE_EDITOR_CLOSE);
+        
+                // return a resolved promise to CommandManager
+                return new $.Deferred().resolve().promise();
             } else {
                 // main editor has focus, so create an inline editor
-                _openInlineWidget(_currentEditor);
+                return _openInlineWidget(_currentEditor);
             }
         }
+        
+        // Can not open an inline editor without a host editor
+        return new $.Deferred().reject().promise();
     }
 
     CommandManager.register(Strings.CMD_SHOW_INLINE_EDITOR,     Commands.SHOW_INLINE_EDITOR, _showInlineEditor);

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -166,6 +166,7 @@ define(function (require, exports, module) {
     PerfUtils.createPerfMeasurement("JAVASCRIPT_FIND_FUNCTION", "JavaScript Find Function");
     
     // for unit tests only
-    exports._createInlineEditor = _createInlineEditor;
-    exports._findInProject      = _findInProject;
+    exports.javaScriptFunctionProvider  = javaScriptFunctionProvider;
+    exports._createInlineEditor         = _createInlineEditor;
+    exports._findInProject              = _findInProject;
 });

--- a/src/extensions/default/JavaScriptQuickEdit/unittest-files/tokens.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittest-files/tokens.js
@@ -1,0 +1,9 @@
+function foo () {
+}
+
+var regExp = /{{0}}foo()/;
+/*
+{{1}}foo()
+*/
+// {{2}}foo()
+var str1 = "{{3}}foo()", str2 = '{{4}}foo()';

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -111,10 +111,10 @@ define(function (require, exports, module) {
         if (openOffset !== undefined) {
             runs(function () {
                 // open inline editor at specified offset index
-                waitsForDone(SpecRunnerUtils.openInlineEditorAtOffset(
+                waitsForDone(SpecRunnerUtils.toggleQuickEditAtOffset(
                     EditorManager.getCurrentFullEditor(),
                     spec.infos[openFile].offsets[openOffset]
-                ), "openInlineEditorAtOffset");
+                ), "toggleQuickEditAtOffset");
             });
         }
     };

--- a/src/strings.js
+++ b/src/strings.js
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
     exports.CMD_QUICK_OPEN                      = "Quick Open";
     exports.CMD_GOTO_LINE                       = "Go to Line";
     exports.CMD_GOTO_DEFINITION                 = "Go to Definition";
-    exports.CMD_SHOW_INLINE_EDITOR              = "Quick Edit";
+    exports.CMD_TOGGLE_QUICK_EDIT               = "Quick Edit";
     exports.CMD_QUICK_EDIT_PREV_MATCH           = "Previous Match";
     exports.CMD_QUICK_EDIT_NEXT_MATCH           = "Next Match";
     exports.CMD_NEXT_DOC                        = "Next Document";

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
                 });
                 runs(function () {
                     // Open inline editor onto test.css's ".testClass" rule
-                    promise = SpecRunnerUtils.openInlineEditorAtOffset(EditorManager.getCurrentFullEditor(), {line: 8, ch: 4});
+                    promise = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), {line: 8, ch: 4});
                     waitsForDone(promise, "Open inline editor");
                 });
                 runs(function () {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -134,13 +134,13 @@ define(function (require, exports, module) {
                 var editor = EditorManager.getCurrentFullEditor();
                 
                 // open inline editor at specified offset index
-                var inlineEditorResult = SpecRunnerUtils.openInlineEditorAtOffset(
+                var inlineEditorResult = SpecRunnerUtils.toggleQuickEditAtOffset(
                     editor,
                     spec.infos[openFile].offsets[openOffset]
                 );
                 
-                inlineEditorResult.done(function () {
-                    inlineOpened = true;
+                inlineEditorResult.done(function (isOpened) {
+                    inlineOpened = isOpened;
                 }).fail(function () {
                     inlineOpened = false;
                 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -436,10 +436,10 @@ define(function (require, exports, module) {
      * @return {$.Promise} a promise that will be resolved when an inline 
      *  editor is created or rejected when no inline editors are available.
      */
-    function openInlineEditorAtOffset(editor, offset) {
+    function toggleQuickEditAtOffset(editor, offset) {
         editor.setCursorPos(offset.line, offset.ch);
         
-        return testWindow.executeCommand(Commands.SHOW_INLINE_EDITOR);
+        return testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
     }
     
     /**
@@ -474,7 +474,7 @@ define(function (require, exports, module) {
     exports.clickDialogButton           = clickDialogButton;
     exports.loadProjectInTestWindow     = loadProjectInTestWindow;
     exports.openProjectFiles            = openProjectFiles;
-    exports.openInlineEditorAtOffset    = openInlineEditorAtOffset;
+    exports.toggleQuickEditAtOffset     = toggleQuickEditAtOffset;
     exports.saveFilesWithOffsets        = saveFilesWithOffsets;
     exports.saveFilesWithoutOffsets     = saveFilesWithoutOffsets;
     exports.saveFileWithoutOffsets      = saveFileWithoutOffsets;

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -439,8 +439,7 @@ define(function (require, exports, module) {
     function openInlineEditorAtOffset(editor, offset) {
         editor.setCursorPos(offset.line, offset.ch);
         
-        // TODO (jasonsj): refactor CMD+E as a Command instead of a CodeMirror key binding?
-        return testWindow.brackets.test.EditorManager._openInlineWidget(editor);
+        return testWindow.executeCommand(Commands.SHOW_INLINE_EDITOR);
     }
     
     /**


### PR DESCRIPTION
Unit tests for fixed issue #1073. Also includes opportunistic refactoring to use `waitForDone`.
