### PR TITLE
Clean up Debug menu (issues #977, #1056)

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -60,12 +60,14 @@ define(function (require, exports, module) {
     exports.EDIT_UNINDENT               = "edit.unindent";
     exports.EDIT_DUPLICATE              = "edit.duplicate";
     exports.EDIT_LINE_COMMENT           = "edit.lineComment";
+    exports.TOGGLE_USE_TAB_CHARS        = "debug.useTabChars";
 
     // VIEW
     exports.VIEW_HIDE_SIDEBAR           = "view.hideSidebar";
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";
     exports.VIEW_DECREASE_FONT_SIZE     = "view.decreaseFontSize";
     exports.VIEW_RESTORE_FONT_SIZE      = "view.restoreFontSize";
+    exports.TOGGLE_JSLINT               = "debug.jslint";
     
     // Navigate
     exports.NAVIGATE_NEXT_DOC           = "navigate.nextDoc";
@@ -78,15 +80,11 @@ define(function (require, exports, module) {
     exports.QUICK_EDIT_PREV_MATCH       = "navigate.previousMatch";
 
     // Debug
-    exports.DEBUG_EXPERIMENTAL          = "debug.experimental";
     exports.DEBUG_REFRESH_WINDOW        = "debug.refreshWindow"; // string must MATCH string in native code (brackets_extensions)
     exports.DEBUG_SHOW_DEVELOPER_TOOLS  = "debug.showDeveloperTools";
     exports.DEBUG_RUN_UNIT_TESTS        = "debug.runUnitTests";
-    exports.DEBUG_JSLINT                = "debug.jslint";
     exports.DEBUG_SHOW_PERF_DATA        = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW   = "debug.newBracketsWindow";
-    exports.DEBUG_CLOSE_ALL_LIVE_BROWSERS = "debug.closeAllLiveBrowsers";
-    exports.DEBUG_USE_TAB_CHARS         = "debug.useTabChars";
 
 	// Command that does nothing. Can be used for place holder menuItems
     

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -354,7 +354,7 @@ define(function (require, exports, module) {
     /**
      * Add one or more key bindings to a particular Command.
      * 
-     * @param {string} commandID
+     * @param {!string} commandID
      * @param {?({key: string, displayKey: string} | Array.<{key: string, displayKey: string, platform: string)}>}  keyBindings - a single key binding
      *      or an array of keybindings. Example: "Shift-Cmd-F". Mac and Win key equivalents are automatically
      *      mapped to each other. Use displayKey property to display a different string (e.g. "CMD+" instead of "CMD=").
@@ -394,8 +394,8 @@ define(function (require, exports, module) {
     /**
      * Remove a key binding from _keymap
      *
-     * @param {string} key - a key-description string that may or may not be normalized.
-     * @param {string} platform - the intended OS of the key.
+     * @param {!string} key - a key-description string that may or may not be normalized.
+     * @param {?string} platform - OS from which to remove the binding (all platforms if unspecified)
      */
     function removeBinding(key, platform) {
         if (!key || ((platform !== null) && (platform !== undefined) && (platform !== brackets.platform))) {

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -781,6 +781,8 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_DUPLICATE,           "Ctrl-D");
         menu.addMenuItem(Commands.EDIT_LINE_COMMENT,        "Ctrl-/");
+        menu.addMenuDivider();
+        menu.addMenuItem(Commands.TOGGLE_USE_TAB_CHARS);
 
         /*
          * View menu
@@ -791,6 +793,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE, [{key: "Ctrl-=", displayKey: "Ctrl-+"}]);
         menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE, [{key: "Ctrl--", displayKey: "Ctrl-\u2212"}]);
         menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE, "Ctrl-0");
+        menu.addMenuDivider();
+        menu.addMenuItem(Commands.TOGGLE_JSLINT);
 
         /*
          * Navigate menu
@@ -810,20 +814,14 @@ define(function (require, exports, module) {
          * Debug menu
          */
         menu = addMenu(Strings.DEBUG_MENU, AppMenuBar.DEBUG_MENU);
-        menu.addMenuItem(Commands.DEBUG_REFRESH_WINDOW, [{key: "F5",     platform: "win"},
-                                                         {key: "Ctrl-R", platform:  "mac"}]);
-
         menu.addMenuItem(Commands.DEBUG_SHOW_DEVELOPER_TOOLS, [{key: "F12",        platform: "win"},
                                                                {key: "Ctrl-Opt-I", platform: "mac"}]);
-        menu.addMenuItem(Commands.DEBUG_RUN_UNIT_TESTS);
-        menu.addMenuItem(Commands.DEBUG_JSLINT);
-        menu.addMenuItem(Commands.DEBUG_SHOW_PERF_DATA);
-		
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.DEBUG_EXPERIMENTAL);
+        menu.addMenuItem(Commands.DEBUG_REFRESH_WINDOW, [{key: "F5",     platform: "win"},
+                                                         {key: "Ctrl-R", platform:  "mac"}]);
         menu.addMenuItem(Commands.DEBUG_NEW_BRACKETS_WINDOW);
-        menu.addMenuItem(Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS);
-        menu.addMenuItem(Commands.DEBUG_USE_TAB_CHARS);
+        menu.addMenuDivider();
+        menu.addMenuItem(Commands.DEBUG_RUN_UNIT_TESTS);
+        menu.addMenuItem(Commands.DEBUG_SHOW_PERF_DATA);
 
 
         /*

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -32,7 +32,6 @@ define(function (require, exports, module) {
         CommandManager          = require("command/CommandManager"),
         Editor                  = require("editor/Editor").Editor,
         Strings                 = require("strings"),
-        JSLintUtils             = require("language/JSLintUtils"),
         PerfUtils               = require("utils/PerfUtils"),
         NativeApp               = require("utils/NativeApp");
     
@@ -40,16 +39,10 @@ define(function (require, exports, module) {
         brackets.app.showDeveloperTools();
     }
     
-    function _handleEnableJSLint() {
-        var enabled = !JSLintUtils.getEnabled();
-        JSLintUtils.setEnabled(enabled);
-        CommandManager.get(Commands.DEBUG_JSLINT).setChecked(enabled);
-    }
-
     function _handleUseTabChars() {
         var useTabs = !Editor.getUseTabChar();
         Editor.setUseTabChar(useTabs);
-        CommandManager.get(Commands.DEBUG_USE_TAB_CHARS).setChecked(useTabs);
+        CommandManager.get(Commands.TOGGLE_USE_TAB_CHARS).setChecked(useTabs);
     }
     
     
@@ -138,24 +131,14 @@ define(function (require, exports, module) {
         window.open(window.location.href);
     }
     
-    function _handleCloseAllLiveBrowsers() {
-        NativeApp.closeAllLiveBrowsers().always(function () {
-            console.log("all live browsers closed");
-        });
-    }
     
     // Register all the command handlers
     CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
-    CommandManager.register(Strings.CMD_JSLINT,         Commands.DEBUG_JSLINT,              _handleEnableJSLint)
-        .setChecked(JSLintUtils.getEnabled());
     CommandManager.register(Strings.CMD_RUN_UNIT_TESTS, Commands.DEBUG_RUN_UNIT_TESTS,      _handleRunUnitTests);
     CommandManager.register(Strings.CMD_SHOW_PERF_DATA, Commands.DEBUG_SHOW_PERF_DATA,      _handleShowPerfData);
-    CommandManager.register(Strings.CMD_EXPERIMENTAL,   Commands.DEBUG_EXPERIMENTAL,        function () {})
-        .setEnabled(false);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,
                                                         Commands.DEBUG_NEW_BRACKETS_WINDOW, _handleNewBracketsWindow);
-    CommandManager.register(Strings.CMD_CLOSE_ALL_LIVE_BROWSERS,
-                                                        Commands.DEBUG_CLOSE_ALL_LIVE_BROWSERS, _handleCloseAllLiveBrowsers);
-    CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.DEBUG_USE_TAB_CHARS,       _handleUseTabChars)
+    
+    CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.TOGGLE_USE_TAB_CHARS,      _handleUseTabChars)
         .setChecked(Editor.getUseTabChar());
 });

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -37,9 +37,12 @@ define(function (require, exports, module) {
     require("thirdparty/jslint/jslint");
     
     // Load dependent modules
-    var DocumentManager         = require("document/DocumentManager"),
+    var Commands                = require("command/Commands"),
+        CommandManager          = require("command/CommandManager"),
+        DocumentManager         = require("document/DocumentManager"),
         PreferencesManager      = require("preferences/PreferencesManager"),
         PerfUtils               = require("utils/PerfUtils"),
+        Strings                 = require("strings"),
         EditorManager           = require("editor/EditorManager");
     
     /**
@@ -172,6 +175,8 @@ define(function (require, exports, module) {
     
     function _setEnabled(enabled) {
         _enabled = enabled;
+        
+        CommandManager.get(Commands.TOGGLE_JSLINT).setChecked(_enabled);
         _updateListeners();
         _prefs.setValue("enabled", _enabled);
     
@@ -188,6 +193,15 @@ define(function (require, exports, module) {
             _setEnabled(enabled);
         }
     }
+    
+    /** Command to toggle enablement */
+    function _handleToggleJSLint() {
+        setEnabled(!getEnabled());
+    }
+    
+    
+    // Register command handlers
+    CommandManager.register(Strings.CMD_JSLINT, Commands.TOGGLE_JSLINT, _handleToggleJSLint);
     
     // Init PreferenceStorage
     _prefs = PreferencesManager.getPreferenceStorage(module.id, { enabled: true });

--- a/src/strings.js
+++ b/src/strings.js
@@ -98,8 +98,7 @@ define(function (require, exports, module) {
 
     /**
      * Command Name Constants
-     *
-    */
+     */
 
     // File menu commands
     exports.FILE_MENU                           = "File";
@@ -145,18 +144,17 @@ define(function (require, exports, module) {
     
     // Debug menu commands
     exports.DEBUG_MENU                          = "Debug";
-    exports.CMD_REFRESH_WINDOW                  = "Reload Window";
-    exports.CMD_CLOSE_WINDOW                    = "Close Window";
+    exports.CMD_REFRESH_WINDOW                  = "Reload Brackets";
     exports.CMD_SHOW_DEV_TOOLS                  = "Show Developer Tools";
     exports.CMD_RUN_UNIT_TESTS                  = "Run Tests";
     exports.CMD_JSLINT                          = "Enable JSLint";
-    exports.CMD_SHOW_PERF_DATA                  = "Show Perf Data";
-    exports.CMD_EXPERIMENTAL                    = "Experimental";
-    exports.CMD_NEW_BRACKETS_WINDOW             = "New Window";
-    exports.CMD_CLOSE_ALL_LIVE_BROWSERS         = "Close Browsers";
+    exports.CMD_SHOW_PERF_DATA                  = "Show Performance Data";
+    exports.CMD_NEW_BRACKETS_WINDOW             = "New Brackets Window";
     exports.CMD_USE_TAB_CHARS                   = "Use Tab Characters";
 
     // Help menu commands
     exports.CMD_ABOUT                           = "About";
 
+    // Special commands invoked by the native shell
+    exports.CMD_CLOSE_WINDOW                    = "Close Window";
 });

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -94,6 +94,7 @@ define(function (require, exports, module) {
     
     /** closeAllLiveBrowsers
      * Closes all the browsers that were tracked on open
+     * TODO: does not seem to work on Windows
      * @return {$.Promise}
      */
     function closeAllLiveBrowsers() {


### PR DESCRIPTION
Clean up Debug menu (issues #977, #1056):
- Move JSLint to View menu; Use Tabs to Edit menu
- Remove "Experimental" heading
- Remove "Close Browsers" command (after discussion w/ Glenn) - underlying NativeApp API not removed since it's still used by unit tests
- Reorder remaining Debug menu items
- Rename "Reload Window"->"Reload Brackets" for clarity
- Rename "New Window"->"New Brackets Window" for clarity
- Move JSLint command impl to JSLintUtils
- (Left Use Tabs impl in DebugCommandHandlers for now until it has a more natural home)

Minor other cleanups:
- Add TODO about NativeApp API not working on Win
- Improve docs in KeyBindingManager
