### PR TITLE
Maintain focus in editor when clicking working set. Fixes #1081

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -167,8 +167,9 @@ define(function (require, exports, module) {
         _updateFileStatusIcon($newItem, isOpenAndDirty(file), false);
         _updateListItemSelection($newItem, curDoc);
 
-        $newItem.mousedown(function () {
+        $newItem.mousedown(function (e) {
             FileViewController.openAndSelectDocument(file.fullPath, FileViewController.WORKING_SET_VIEW);
+            e.preventDefault();
         });
 
         $newItem.hover(


### PR DESCRIPTION
now that the working set view handles mousedown instead of click in order to capture left and right clicks, it's necessary to call preventDefault() so the focus is not removed from the editor.

Fixes #1081
