### PR TITLE
Select tree node on right-click

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -411,8 +411,13 @@ define(function (require, exports, module) {
                     if (event.which === 3) {
                         var treenode = $(event.target).closest("li");
                         if (treenode) {
+                            var saveSuppressToggleOpen = suppressToggleOpen;
+                            
+                            // don't toggle open folders (just select)
+                            suppressToggleOpen = true;
                             _projectTree.jstree("deselect_all");
                             _projectTree.jstree("select_node", treenode, false);
+                            suppressToggleOpen = saveSuppressToggleOpen;
                         }
                     }
                 }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -403,6 +403,19 @@ define(function (require, exports, module) {
                     
                     _savePreferences();
                 }
+            )
+            .bind(
+                "mousedown.jstree",
+                function (event) {
+                    // select tree node on right-click
+                    if (event.which === 3) {
+                        var treenode = $(event.target).closest("li");
+                        if (treenode) {
+                            _projectTree.jstree("deselect_all");
+                            _projectTree.jstree("select_node", treenode, false);
+                        }
+                    }
+                }
             );
 
         // jstree has a default event handler for dblclick that attempts to clear the


### PR DESCRIPTION
@tvoliter

This fixes issue #1069.

Note that this makes right-click behave exactly the same as left-click, which means that the open/close state of folders is toggled. Is that OK, or should we select without toggling?
