### PR TITLE
add New command back to project context menu

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -828,6 +828,7 @@ define(function (require, exports, module) {
          * Context Menus
          */
         var project_cmenu = registerContextMenu(ContextMenuIds.PROJECT_MENU);
+        project_cmenu.addMenuItem(Commands.FILE_NEW);
 
         var editor_cmenu = registerContextMenu(ContextMenuIds.EDITOR_MENU);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);


### PR DESCRIPTION
@tvoliter 

I added the New command back in the project context menu now that right-click selection is working.
