### PR TITLE
Make function regexp match JS identifier syntax exactly

### DIFF
--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
      * RegExp matches any sequence of characters that is not whitespace.
      * @type {RegExp}
      */
-    var _functionRegExp = /(function\s+([$_A-Za-z][$_A-Za-z0-9]*)\s*(\([^)]*\)))|(([$_A-Za-z][$_A-Za-z0-9]*)\s*[:=]\s*function\s*(\([^)]*\)))/g;
+    var _functionRegExp = /(function\s+([$_A-Za-z\u007F-\uFFFF][$_A-Za-z0-9\u007F-\uFFFF]*)\s*(\([^)]*\)))|(([$_A-Za-z\u007F-\uFFFF][$_A-Za-z0-9\u007F-\uFFFF]*)\s*[:=]\s*function\s*(\([^)]*\)))/g;
     
     /**
      * @private

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
      * RegExp matches any sequence of characters that is not whitespace.
      * @type {RegExp}
      */
-    var _functionRegExp = /(function\b\s+([^\s]+)(\([^)]*\)))|(([^\s\.]+)\s*[:=]\s*function\s*(\([^)]*\)))/g;
+    var _functionRegExp = /(function\s+([$_A-Za-z][$_A-Za-z0-9]*)\s*(\([^)]*\)))|(([$_A-Za-z][$_A-Za-z0-9]*)\s*[:=]\s*function\s*(\([^)]*\)))/g;
     
     /**
      * @private

--- a/test/spec/JSUtils-test-files/invalid.js
+++ b/test/spec/JSUtils-test-files/invalid.js
@@ -1,0 +1,8 @@
+function 0digitIdentifierStart () {
+}
+
+function .punctuationIdentifierStart () {
+}
+
+function punctuation.IdentifierPart () {
+}

--- a/test/spec/JSUtils-test-files/simple.js
+++ b/test/spec/JSUtils-test-files/simple.js
@@ -91,3 +91,4 @@ var anotherObj = {
 var noSpaceAfterFunction2 = function() {
     /* jslint hates this too */
 };
+var anotherCrowdedObj={a:100,b:-1,findMe:function () {}};

--- a/test/spec/JSUtils-test-files/simple.js
+++ b/test/spec/JSUtils-test-files/simple.js
@@ -92,3 +92,11 @@ var noSpaceAfterFunction2 = function() {
     /* jslint hates this too */
 };
 var anotherCrowdedObj={a:100,b:-1,findMe:function () {}};
+
+var highAscÍÍChars = function() {
+    /* jslint hates this too */
+}
+
+function moreHighAscÍÍChars() {
+    /* jslint is really in a bad mood now */
+}

--- a/test/spec/JSUtils-test-files/simple.js
+++ b/test/spec/JSUtils-test-files/simple.js
@@ -100,3 +100,24 @@ var highAscÍÍChars = function() {
 function moreHighAscÍÍChars() {
     /* jslint is really in a bad mood now */
 }
+
+function ÅsciiExtendedIdentifierStart () {
+}
+
+function ʸUnicodeModifierLettervalidIdentifierStart () {
+}
+
+function \u02b8UnicodeEscapedIdentifierStart () {
+}
+
+function unicodeModifierLettervalidIdentifierPartʸ () {
+}
+
+function unicodeEscapedIdentifierPart\u02b8 () {
+}
+
+function\u0009unicodeTabBefore () {
+}
+
+function unicodeTabAfter\u0009() {
+}

--- a/test/spec/JSUtils-test-files/simple.js
+++ b/test/spec/JSUtils-test-files/simple.js
@@ -62,3 +62,32 @@ function3: function () {
 
 // functions with invalid identifiers
 function invalid identifier () {}
+
+// functions with dot before them
+MyClass.prototype.myMethod = function () {
+    /* myMethod */
+};
+
+// whitespace variations (see #1108)
+var crowdedObj = {noSpaceBeforeFunc:function () { /* noSpaceBeforeFunc */ }};
+var anotherObj = {
+    spaceBeforeColon : function (param) { 
+        /* spaceBeforeColon */
+    },
+    
+    noSpaceAfterColon:function (param) {
+        /* noSpaceAfterColon */
+    },
+    
+    // A comment that ends with a period.
+    fakePeriodBeforeFunction: function () {
+        /* fakePeriodBeforeFunction */
+    },
+    
+    noSpaceAfterFunction: function() {
+        /* jslint hates this */
+    }
+};
+var noSpaceAfterFunction2 = function() {
+    /* jslint hates this too */
+};

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -180,6 +180,31 @@ define(function (require, exports, module) {
                     });
                 });
             });
+            
+            it("should return correct start and end line numbers for prototype method declarations", function () {
+                runs(function () {
+                    init(this, simpleJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "myMethod", [ {start: 66, end: 68} ]);
+                });
+            });
+            
+            it("should handle various whitespace variations", function () {
+                runs(function () {
+                    init(this, simpleJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "noSpaceBeforeFunc", [ {start: 71, end: 71} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "spaceBeforeColon", [ {start: 73, end: 75} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterColon", [ {start: 77, end: 79} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "fakePeriodBeforeFunction", [ {start: 82, end: 84} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction", [ {start: 86, end: 88} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction2", [ {start: 90, end: 92} ]);
+                });
+            });
         });
         
         describe("brace ends of functions", function () {

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -206,6 +206,17 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "findMe", [ {start: 93, end: 93} ]);
                 });
             });
+            
+            it("should work with high-ascii characters in function names", function () {
+                runs(function () {
+                    init(this, simpleJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "highAscÍÍChars", [ {start: 95, end: 97} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "moreHighAscÍÍChars", [ {start: 99, end: 101} ]);
+                });
+            });
         });
         
         describe("brace ends of functions", function () {

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, xit: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false, brackets: false */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone */
 
 define(function (require, exports, module) {
     'use strict';
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
     };
 
     var simpleJsFileEntry   = new NativeFileSystem.FileEntry(testPath + "/simple.js");
+    var invalidJsFileEntry  = new NativeFileSystem.FileEntry(testPath + "/invalid.js");
     var jQueryJsFileEntry   = new NativeFileSystem.FileEntry(testPath + "/jquery-1.7.js");
     var braceEndJsFileEntry = new NativeFileSystem.FileEntry(testPath + "/braceEnd.js");
     var eofJsFileEntry      = new NativeFileSystem.FileEntry(testPath + "/eof.js");
@@ -89,6 +90,7 @@ define(function (require, exports, module) {
             });
         });
         
+        // TODO (jason-sanjose): use offset markup in these test files
         describe("line offsets", function () {
             
             // Checks the lines ranges of the results returned by JSUtils. Expects the numbers of
@@ -102,6 +104,11 @@ define(function (require, exports, module) {
                     spec.expect(result[i].lineStart).toEqual(range.start);
                     spec.expect(result[i].lineEnd).toEqual(range.end);
                 });
+            }
+            
+            function expectNoFunction(jsCode, functionName) {
+                var result = JSUtils.findAllMatchingFunctionsInText(jsCode, functionName);
+                expect(result.length).toBe(0);
             }
             
             it("should return correct start and end line numbers for simple functions", function () {
@@ -215,6 +222,44 @@ define(function (require, exports, module) {
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "highAscÍÍChars", [ {start: 95, end: 97} ]);
                     expectFunctionRanges(this, this.fileJsContent, "moreHighAscÍÍChars", [ {start: 99, end: 101} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "ÅsciiExtendedIdentifierStart", [ {start: 103, end: 104} ]);
+                });
+            });
+            
+            it("should work with unicode characters in or around function names", function () {
+                runs(function () {
+                    init(this, simpleJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "ʸUnicodeModifierLettervalidIdentifierStart", [ {start: 106, end: 107} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "unicodeModifierLettervalidIdentifierPartʸ", [ {start: 112, end: 113} ]);
+                });
+            });
+            
+            // TODO (issue #1125): support escaped unicode
+            xit("FAIL should work with unicode characters in or around function names", function () {
+                runs(function () {
+                    init(this, simpleJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "\u02b8UnicodeEscapedIdentifierStart", [ {start: 109, end: 110} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "unicodeEscapedIdentifierPart\u02b8", [ {start: 115, end: 116} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "unicodeTabBefore", [ {start: 118, end: 119} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "unicodeTabAfter", [ {start: 121, end: 122} ]);
+                });
+            });
+            
+            it("should fail with invalid function names", function () {
+                runs(function () {
+                    init(this, invalidJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectNoFunction(this.fileJsContent, "0digitIdentifierStart");
+                    expectNoFunction(this.fileJsContent, ".punctuationIdentifierStart");
+                    expectNoFunction(this.fileJsContent, "punctuation.IdentifierPart");
                 });
             });
         });

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -203,6 +203,7 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "fakePeriodBeforeFunction", [ {start: 82, end: 84} ]);
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction", [ {start: 86, end: 88} ]);
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction2", [ {start: 90, end: 92} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "findMe", [ {start: 93, end: 93} ]);
                 });
             });
         });


### PR DESCRIPTION
Fixes #1108.

In addition to changing the function name regexps to exactly match JS identifier syntax (first char is $, _, or alpha; later chars are $, _, or alphanumeric), I removed a `\b` from the first arm of the regexp that seems unnecessary since it explicitly looks for a `\s` afterwards anyway.

Added unit tests for various whitespace cases, but we might want to add some more as well (including false positives).
