### PR TITLE
Disable CodeMirror drag & drop functionality to avoid hitting #1123

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -360,6 +360,7 @@ define(function (require, exports, module) {
             indentWithTabs: _useTabChar,
             lineNumbers: true,
             matchBrackets: true,
+            dragDrop: false,    // work around issue #1123
             extraKeys: codeMirrorKeyMap
         });
         


### PR DESCRIPTION
Disable CodeMirror drag & drop functionality to avoid hitting #1123 (Dragging text in editor breaks dirty flag)

This doesn't fix the underlying bug, but does block the only case where it's possible to repro it in our current UI.  Drag & drop accidentally started working this sprint after the CM merge (it wasn't intended/expected to work yet), so it seems fine to disable it.  See #1123 for more details.
