### PR TITLE
Show hidden ".htaccess" files

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -461,7 +461,7 @@ define(function (require, exports, module) {
     
     /** @param {Entry} entry File or directory to filter */
     function _shouldShowInTree(entry) {
-        if (entry.name[0] === ".") {       // "." prefix is always hidden on Mac
+        if (entry.name[0] === "." && entry.name !== ".htaccess") {       // "." prefix is always hidden on Mac
             return false;
         }
         


### PR DESCRIPTION
Issue #98 addressed hidden files being shown, and as a result, filtered all files, excluding any that began with ".", making it very difficult to edit an .htaccess file.
