### PR TITLE
Updated getModeFromFileExtensions to let cfm and cfc files use the html editor

### DIFF
--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -80,6 +80,8 @@ define(function (require, exports, module) {
         case "html":
         case "htm":
         case "xhtml":
+        case "cfm":
+        case "cfc":
             return "htmlmixed";
 
         case "xml":


### PR DESCRIPTION
This will make any ColdFusion developers experience with brackets much much better, currently if you open a cfm or cfc file it is unstyled. I know this project is not aimed supporting server side coding right now but I think this change (two lines of code added) is hopefully a no brainer.
