### PR TITLE
fix name conflict between test extension and unit tests

### DIFF
--- a/src/extensions/disabled/ContextMenuTest/main.js
+++ b/src/extensions/disabled/ContextMenuTest/main.js
@@ -36,11 +36,11 @@ define(function (require, exports, module) {
 
     // Define the functions that Commands will execute
     function TestCommand1() {
-        var command1 = CommandManager.get("custom.command1");
+        var command1 = CommandManager.get("extensionTest.command1");
         if (!command1) {
             return;
         }
-        var command2 = CommandManager.get("custom.command2");
+        var command2 = CommandManager.get("extensionTest.command2");
         if (!command2) {
             return;
         }
@@ -65,9 +65,9 @@ define(function (require, exports, module) {
     }
     
     // Register the functions as commands
-    var command1 = CommandManager.register("Toggle Checkmark", "custom.command1", TestCommand1);
-    var command2 = CommandManager.register("Enabled when previous is Checked", "custom.command2", TestCommand2);
-    var command3 = CommandManager.register("Enabled when text selected", "custom.command3", TestCommand3);
+    var command1 = CommandManager.register("Toggle Checkmark", "extensionTest.command1", TestCommand1);
+    var command2 = CommandManager.register("Enabled when previous is Checked", "extensionTest.command2", TestCommand2);
+    var command3 = CommandManager.register("Enabled when text selected", "extensionTest.command3", TestCommand3);
 
     // Set the Command initial state
     command1.setChecked(true);
@@ -86,8 +86,8 @@ define(function (require, exports, module) {
     // Add the Commands as MenuItems of the Editor context menu
     if (editor_cmenu) {
         editor_cmenu.addMenuDivider();
-        editor_cmenu.addMenuItem("custom.command1");
-        editor_cmenu.addMenuItem("custom.command2");
-        editor_cmenu.addMenuItem("custom.command3");
+        editor_cmenu.addMenuItem("extensionTest.command1");
+        editor_cmenu.addMenuItem("extensionTest.command2");
+        editor_cmenu.addMenuItem("extensionTest.command3");
     }
 });


### PR DESCRIPTION
The context menu test extension command ids were the same as some of the menu unit test command ids, so installing this extension breaks 2 of the menu unit tests.

@RaymondLim this was probably the problem you mentioned in today's standup.
