### PR TITLE
wait for styles to load

### DIFF
--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
                 }, "loadStyleSheet() increments array timeout", 1000);
 
                 // after styleSheets array is incremented, wait for cssRules object to be defined.
-                // note that this works for Chrome, bu not sure about other browsers.
+                // note that this works for Chrome, but not sure about other browsers.
                 // someday there may be an event to listen for...
                 runs(function () {
                     lastStyleSheetIndex = doc.styleSheets.length - 1;


### PR DESCRIPTION
This is an attempt to fix issue #1136. I added 2 more conditions to wait on.
1. Based on http://www.phpied.com/when-is-a-stylesheet-really-loaded/ item #4, test waits until the document.styleSheets array length has been incremented.
2. Based http://aaronheckmann.blogspot.com/2010/01/writing-jquery-plugin-manager-part-1.html, test then waits until the .cssRules object has been defined.

@gruehle does this fix the cases that you are seeing?
