### PR TITLE
Fix issue #1221 (Quick Open lists git metafiles)

### DIFF
--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -125,8 +125,8 @@ define(function (require, exports, module) {
     //
     function _addFileToIndexes(entry) {
 
-        // skip invisible files on mac
-        if (brackets.platform === "mac" && entry.name.charAt(0) === ".") {
+        // skip invisible files
+        if (!ProjectManager.shouldShow(entry)) {
             return;
         }
 
@@ -195,8 +195,8 @@ define(function (require, exports, module) {
 
         // inner helper function
         function _scanDirectoryRecurse(dirEntry) {
-            // skip invisible directories on mac
-            if (brackets.platform === "mac" && dirEntry.name.charAt(0) === ".") {
+            // skip invisible directories
+            if (!ProjectManager.shouldShow(dirEntry)) {
                 return;
             }
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -460,7 +460,7 @@ define(function (require, exports, module) {
     }
     
     /** @param {Entry} entry File or directory to filter */
-    function _shouldShowInTree(entry) {
+    function shouldShow(entry) {
         return [".git", ".svn", ".DS_Store", "Thumbs.db"].indexOf(entry.name) === -1;
     }
 
@@ -484,7 +484,7 @@ define(function (require, exports, module) {
         for (entryI = 0; entryI < entries.length; entryI++) {
             entry = entries[entryI];
             
-            if (_shouldShowInTree(entry)) {
+            if (shouldShow(entry)) {
                 var jsonEntry = {
                     data: entry.name,
                     attr: { id: "node" + _projectInitialLoad.id++ },
@@ -892,6 +892,7 @@ define(function (require, exports, module) {
     exports.getProjectRoot  = getProjectRoot;
     exports.isWithinProject = isWithinProject;
     exports.makeProjectRelativeIfPossible = makeProjectRelativeIfPossible;
+    exports.shouldShow      = shouldShow;
     exports.openProject     = openProject;
     exports.loadProject     = loadProject;
     exports.getSelectedItem = getSelectedItem;


### PR DESCRIPTION
Fix issue #1221 (Quick Open lists git metafiles) -- Expose ProjectManager's existing file/folder filtering logic as a public API, and use it in FileIndexManager too for consistency (which provides the file list for Quick Open).
