### PR TITLE
Improve console output of LiveDevelopment errors (#1200)

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -250,9 +250,18 @@ define(function LiveDevelopment(require, exports, module) {
 
     /** Triggered by Inspector.error */
     function _onError(error) {
-        console.error(error.message);
-    }
+        var message = error.message;
 
+        // Additional information, like exactly which parameter could not be processed.
+        var data = error.data;
+        if ($.isArray(data)) {
+            message += "\n" + data.join("\n");
+        }
+
+        // Show the message, but include the error object for further information (e.g. error code)
+        console.error(message, error);
+    }
+    
     /** Run when all agents are loaded */
     function _onLoad() {
         var doc = _getCurrentDocument();


### PR DESCRIPTION
Before:
    Some arguments of method 'Debugger.setBreakpointByUrl' can't be processed

After:
    Some arguments of method 'Debugger.setBreakpointByUrl' can't be processed
    Parameter 'lineNumber' has wrong type. It must be 'Number'.
    Parameter 'url' has wrong type. It must be 'String'.
    [expandable error object]
