### PR TITLE
refactor api to allow for programmatically opening a project

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -316,7 +316,8 @@ define(function (require, exports, module) {
         PerfUtils.addMeasurement("Application Startup");
         
         // finish UI initialization before loading extensions
-        ProjectManager.loadProject().done(function () {
+        var initialProjectPath = ProjectManager.getInitialProjectPath();
+        ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
             _initExtensions().always(_onBracketsReady);
         });

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -952,6 +952,10 @@ define(function (require, exports, module) {
             currentDoc  = getCurrentDocument(),
             projectRoot = ProjectManager.getProjectRoot();
 
+        if (!projectRoot) {
+            return;
+        }
+
         workingSet.forEach(function (file, index) {
             // flag the currently active editor
             isActive = currentDoc && (file.fullPath === currentDoc.file.fullPath);

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
 
         runs(function () {
             // begin loading project path
-            var result = testWindow.brackets.test.ProjectManager.loadProject(path);
+            var result = testWindow.brackets.test.ProjectManager.openProject(path);
             result.done(function () {
                 isReady = true;
             });


### PR DESCRIPTION
Project Manager API updates:
- openProject() is now the main public API. Call it with no parameter to get the file open dialog, or pass a path to project to open it directly.
- loadProject() is no longer public
- added getInitialProjectPath() for project to open at startup.

This fixes issue #1090
