### PR TITLE
Replace window.onload with $.ready() to fix unit tests.

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -31,7 +31,7 @@ require.config({
         "test": "../test",
         "perf": "../test/perf",
         "spec": "../test/spec",
-        "text" : "thirdparty/text"
+        "text": "thirdparty/text"
     }
 });
 
@@ -71,8 +71,7 @@ define(function (require, exports, module) {
     
     function init() {
         var jasmineEnv = jasmine.getEnv(),
-            runner = jasmineEnv.currentRunner(),
-            currentWindowOnload = window.onload;
+            runner = jasmineEnv.currentRunner();
         
         // TODO: Issue 949 - the following code should be shared
 
@@ -127,11 +126,7 @@ define(function (require, exports, module) {
         
         jasmineEnv.updateInterval = 1000;
         
-        window.onload = function () {
-            if (currentWindowOnload) {
-                currentWindowOnload();
-            }
-            
+        $(window.document).ready(function () {
             $("#show-dev-tools").click(function () {
                 brackets.app.showDeveloperTools();
             });
@@ -173,7 +168,7 @@ define(function (require, exports, module) {
             $("#" + suite).closest("li").toggleClass("active", true);
             
             jasmineEnv.execute();
-        };
+        });
     }
 
     init();


### PR DESCRIPTION
Fixes loading issues in SpecRunner.html
