### PR TITLE
fix module loading for SpecRunnerUtils

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -146,6 +146,11 @@ define(function (require, exports, module) {
                                 extensions.push(entries[i].name);
                             }
                         }
+
+                        if (extensions.length === 0) {
+                            result.resolve();
+                            return;
+                        }
                         
                         Async.doInParallel(extensions, function (item) {
                             var extConfig = {
@@ -153,10 +158,9 @@ define(function (require, exports, module) {
                                 paths: config.paths
                             };
                             return processExtension(item, extConfig, entryPoint);
-                        }).done(function () {
+                        }).always(function () {
+                            // Always resolve the promise even when the extension entry point is missing
                             result.resolve();
-                        }).fail(function () {
-                            result.reject();
                         });
                     },
                     function (error) {

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -172,8 +172,6 @@ define(function (require, exports, module) {
             localStorage.setItem("SpecRunner.suite", suite);
             
             $(window.document).ready(_documentReadyHandler);
-        }).fail(function () {
-            console.log("Error");
         });
     }
 

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Async                   = require("utils/Async"),
         FileUtils               = require("file/FileUtils"),
         CSSUtils                = require("language/CSSUtils"),
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
     
     var testPath                = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
         simpleCssFileEntry      = new NativeFileSystem.FileEntry(testPath + "/simple.css"),

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -33,38 +33,38 @@ define(function (require, exports, module) {
         SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         Editor          = require("editor/Editor").Editor;
     
-    //Use a clean version of the editor each time
-    var myDocument;
-    var myEditor;
-    beforeEach(function () {
-        // init Editor instance (containing a CodeMirror instance)
-        $("body").append("<div id='editor'/>");
-        myDocument = SpecRunnerUtils.createMockDocument("");
-        myEditor = new Editor(myDocument, true, "", $("#editor").get(0), {});
-    });
-
-    afterEach(function () {
-        myEditor.destroy();
-        myEditor = null;
-        $("#editor").remove();
-        myDocument = null;
-    });
-    
-    function setContentAndUpdatePos(pos, linesBefore, hintLineBefore, hintLineAfter, linesAfter) {
-        pos.line = linesBefore.length;
-        pos.ch = hintLineBefore.length;
-        var finalHintLine = (hintLineAfter ? hintLineBefore + hintLineAfter : hintLineBefore);
-        var finalLines = linesBefore.concat([finalHintLine]);
-        if (linesAfter) {
-            finalLines = finalLines.concat(linesAfter);
-        }
-        
-        var content = finalLines.join("\n");
-        myDocument.setText(content);
-    }
-    
-    
     describe("HTMLUtils", function () {
+    
+        //Use a clean version of the editor each time
+        var myDocument,
+            myEditor;
+
+        beforeEach(function () {
+            // init Editor instance (containing a CodeMirror instance)
+            $("body").append("<div id='editor'/>");
+            myDocument = SpecRunnerUtils.createMockDocument("");
+            myEditor = new Editor(myDocument, true, "", $("#editor").get(0), {});
+        });
+
+        afterEach(function () {
+            myEditor.destroy();
+            myEditor = null;
+            $("#editor").remove();
+            myDocument = null;
+        });
+    
+        function setContentAndUpdatePos(pos, linesBefore, hintLineBefore, hintLineAfter, linesAfter) {
+            pos.line = linesBefore.length;
+            pos.ch = hintLineBefore.length;
+            var finalHintLine = (hintLineAfter ? hintLineBefore + hintLineAfter : hintLineBefore);
+            var finalLines = linesBefore.concat([finalHintLine]);
+            if (linesAfter) {
+                finalLines = finalLines.concat(linesAfter);
+            }
+            
+            var content = finalLines.join("\n");
+            myDocument.setText(content);
+        }
         
         describe("Html Hinting", function () {
             beforeEach(function () {

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var HTMLUtils       = require("language/HTMLUtils"),
-        SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         Editor          = require("editor/Editor").Editor;
     
     //Use a clean version of the editor each time

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Commands,            // loaded from brackets.test
         EditorManager,       // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     
     describe("Document", function () {

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Commands,            // loaded from brackets.test
         DocumentCommandHandlers, // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils           = require("file/FileUtils");
     

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     'use strict';
     
     var Editor          = require("editor/Editor").Editor,
-        SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         EditorUtils     = require("editor/EditorUtils");
 
     describe("Editor", function () {

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         EditorCommandHandlers = require("editor/EditorCommandHandlers"),
         Commands              = require("command/Commands"),
         CommandManager        = require("command/CommandManager"),
-        SpecRunnerUtils       = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils       = require("spec/SpecRunnerUtils"),
         EditorUtils           = require("editor/EditorUtils");
 
     describe("EditorCommandHandlers", function () {

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
     'use strict';
 
     var ExtensionUtils,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
 
     describe("Extension Utils", function () {

--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     // Load dependent modules
     var FileIndexManager,
         ProjectManager,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     describe("FileIndexManager", function () {
 

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         Dialogs          = require("widgets/Dialogs"),
         NativeFileSystem = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils        = require("file/FileUtils"),
-        SpecRunnerUtils  = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils  = require("spec/SpecRunnerUtils");
 
     describe("InlineEditorProviders", function () {
 

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -27,7 +27,7 @@
 define(function (require, exports, module) {
     'use strict';
 
-    var SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+    var SpecRunnerUtils = require("spec/SpecRunnerUtils"),
         NativeApp,      //The following are all loaded from the test window
         LiveDevelopment,
         Inspector,

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+    var SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     var _FSEncodings        = require("file/NativeFileSystem").NativeFileSystem._FSEncodings;
     
     // These are tests for the low-level file io routines in brackets-app. Make sure

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
         Commands,
         KeyBindingManager,
         Menus,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js"),
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         StringsUtils        = require("utils/StringUtils"),
         Strings             = require("strings");
 

--- a/test/spec/MultiRangeInlineEditor-test.js
+++ b/test/spec/MultiRangeInlineEditor-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         InlineWidget            = require("editor/InlineWidget").InlineWidget,
         Editor                  = require("editor/Editor").Editor,
         EditorManager           = require("editor/EditorManager"),
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
 
     describe("MultiRangeInlineEditor", function () {
         

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     // Load dependent modules
     var PreferencesManager      = require("preferences/PreferencesManager"),
         PreferenceStorage       = require("preferences/PreferenceStorage").PreferenceStorage,
-        SpecRunnerUtils         = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
 
     var CLIENT_ID = "PreferencesManager-test";
         

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var ProjectManager,     // Load from brackets.test
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
     describe("ProjectManager", function () {
 

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         Commands,
         DocumentManager,
         FileViewController,
-        SpecRunnerUtils     = require("./SpecRunnerUtils.js");
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
     describe("WorkingSetView", function () {
     


### PR DESCRIPTION
The first testWindow didn't close because multiple instances of the `SpecRunnerUtils` module were loaded. Fixes adobe/brackets-shell#33.
