### PR TITLE
Alternative fix for issue #1028. 

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -324,7 +324,9 @@ define(function (require, exports, module) {
             ProjectManager.createNewItem(baseDir, suggestedName, false)
                 .pipe(deferred.resolve, deferred.reject, deferred.notify)
                 .always(function () { fileNewInProgress = false; })
-                .done(function (entry) { FileViewController.addToWorkingSetAndSelect(entry.fullPath); });
+                .done(function (entry) {
+                    FileViewController.addToWorkingSetAndSelect(entry.fullPath, FileViewController.PROJECT_MANAGER);
+                });
         };
 
         deferred.done(createWithSuggestedName);

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -153,9 +153,11 @@ define(function (require, exports, module) {
      * Opens the specified document if it's not already open, adds it to the working set,
      * and selects it in the WorkingSetView
      * @param {!fullPath}
+     * @param {?String} selectIn - specify either WORING_SET_VIEW or PROJECT_MANAGER.
+     *      Default is WORING_SET_VIEW.
      * @return {!$.Promise}
      */
-    function addToWorkingSetAndSelect(fullPath) {
+    function addToWorkingSetAndSelect(fullPath, selectIn) {
         var result = new $.Deferred(),
             promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath});
 
@@ -165,7 +167,7 @@ define(function (require, exports, module) {
         promise.done(function (doc) {
             // FILE_ADD_TO_WORKING_SET command sets the current document. Update the 
             // selection focus and trigger documentSelectionFocusChange event
-            _fileSelectionFocus = WORKING_SET_VIEW;
+            _fileSelectionFocus = selectIn ? selectIn : WORKING_SET_VIEW;
             _selectCurrentDocument();
             
             result.resolve(doc);


### PR DESCRIPTION
Add new file in working set, but keep it selected in the project tree since that is where the user created and named the file.

This is an alternate fix for this pull request which adds new files to the working set, but also causes the selected file to jump from the project tree to the working set
https://github.com/adobe/brackets/pull/1249

@redmunds can you review since you looked at the earlier pull request
