### PR TITLE
Extract code hint query from tagInfo.tagName instead of extracting it directly from code mirror text.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -178,19 +178,13 @@ define(function (require, exports, module) {
      */
     CodeHintList.prototype.updateQueryFromCurPos = function () {
         var pos = this.editor.getCursorPos(),
-            cursor = this.editor.indexFromPos(pos),
             tagInfo = HTMLUtils.getTagInfo(this.editor, pos);
-
+        
+        this.query = null;
         if (tagInfo.position.tokenType === HTMLUtils.TAG_NAME) {
-            var text = this.editor.document.getText(),
-                start = text.lastIndexOf("<", cursor) + 1;
-            if (start <= cursor) {
-                this.query = text.slice(start, cursor);
-            } else {
-                this.query = null;
+            if (tagInfo.position.offset >= 0) {
+                this.query = tagInfo.tagName.slice(0, tagInfo.position.offset);
             }
-        } else {
-            this.query = null;
         }
     };
 

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -304,7 +304,8 @@ define(function (require, exports, module) {
                 // pos has whitespace before it and non-whitespace after it, so use token after
                 ctx.pos = testPos;
                 ctx.token = testToken;
-                offset = _offsetInToken(ctx) - 1; // Get the new offset from test token and subtract one for testPos adjustment
+                // Get the new offset from test token and subtract one for testPos adjustment
+                offset = _offsetInToken(ctx) - 1;
             } else {
                 // next, see what's before pos
                 if (!_movePrevToken(ctx)) {

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -304,6 +304,7 @@ define(function (require, exports, module) {
                 // pos has whitespace before it and non-whitespace after it, so use token after
                 ctx.pos = testPos;
                 ctx.token = testToken;
+                offset = _offsetInToken(ctx) - 1; // Get the new offset from test token and subtract one for testPos adjustment
             } else {
                 // next, see what's before pos
                 if (!_movePrevToken(ctx)) {


### PR DESCRIPTION
This fixes issue #1260
