### PR TITLE
Implement initial code hints unit tests

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -86,7 +86,6 @@ define(function (require, exports, module) {
         
     //Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
-    require("editor/CodeHintManager");
     require("editor/EditorCommandHandlers");
     require("debug/DebugCommandHandlers");
     require("view/ViewCommandHandlers");
@@ -207,6 +206,7 @@ define(function (require, exports, module) {
             FileIndexManager        : FileIndexManager,
             Menus                   : Menus,
             KeyBindingManager       : KeyBindingManager,
+            CodeHintManager         : CodeHintManager,
             CSSUtils                : require("language/CSSUtils"),
             LiveDevelopment         : require("LiveDevelopment/LiveDevelopment"),
             Inspector               : require("LiveDevelopment/Inspector/Inspector"),

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -396,7 +396,15 @@ define(function (require, exports, module) {
             hintList.handleKeyEvent(editor, event);
         }
     }
+
+    /**
+     * Expose CodeHintList for unit testing
+     */
+    function _getCodeHintList() {
+        return hintList;
+    }
     
     // Define public API
-    exports.handleKeyEvent = handleKeyEvent;
+    exports.handleKeyEvent      = handleKeyEvent;
+    exports._getCodeHintList    = _getCodeHintList;
 });

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -26,6 +26,7 @@
 define(function (require, exports, module) {
     'use strict';
     
+    require("spec/CodeHint-test");
     require("spec/CodeHintUtils-test");
     require("spec/CommandManager-test");
     require("spec/CSSUtils-test");

--- a/test/spec/CodeHint-test-files/test1.html
+++ b/test/spec/CodeHint-test-files/test1.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+<
+</body>
+</html>

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, beforeEach, afterEach, it, runs, waits, waitsFor, expect, $, CodeMirror, brackets  */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    // Load dependent modules
+    var HTMLUtils       = require("language/HTMLUtils"),
+        SpecRunnerUtils = require("./SpecRunnerUtils.js"),
+        Editor          = require("editor/Editor").Editor,
+        EditorManager,      // loaded from brackets.test
+        CodeHintManager;
+
+    var testPath = SpecRunnerUtils.getTestPath("/spec/CodeHint-test-files"),
+        testWindow,
+        initCodeHintTest;
+
+
+    /**
+     * Performs setup for a code hint test. Opens a file and set pos.
+     * 
+     * @param {!string} openFile Project relative file path to open in a main editor.
+     * @param {!number} openPos The pos within openFile to place the IP.
+     */
+    var _initCodeHintTest = function (openFile, openPos) {
+        var hostOpened = false,
+            err = false,
+            workingSet = [];
+        
+        SpecRunnerUtils.loadProjectInTestWindow(testPath);
+
+        runs(function () {
+            workingSet.push(openFile);
+            SpecRunnerUtils.openProjectFiles(workingSet).done(function (documents) {
+                hostOpened = true;
+            }).fail(function () {
+                err = true;
+            });
+        });
+        
+        waitsFor(function () { return hostOpened && !err; }, "FILE_OPEN timeout", 1000);
+
+        runs(function () {
+            var editor = EditorManager.getCurrentFullEditor();
+            editor.setCursorPos(openPos.line, openPos.ch);
+        });
+    };
+
+    beforeEach(function () {
+        initCodeHintTest = _initCodeHintTest.bind(this);
+        SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+            testWindow = w;
+            
+            // uncomment this line to debug test window:
+            //testWindow.brackets.app.showDeveloperTools();
+
+            // Load module instances from brackets.test
+            CodeHintManager     = testWindow.brackets.test.CodeHintManager;
+            EditorManager       = testWindow.brackets.test.EditorManager;
+        });
+    });
+
+    afterEach(function () {
+        SpecRunnerUtils.closeTestWindow();
+    });
+
+
+    describe("Code Hint Menus", function () {
+        
+        describe("HTML Tests", function () {
+
+            it("should show code hints menu and insert text at IP", function () {
+
+                var editor,
+                    pos = {line: 3, ch: 1},
+                    lineBefore,
+                    lineAfter;
+
+                // minimal markup with an open '<' before IP
+                // Note: line for pos is 0-based and editor lines numbers are 1-based
+                initCodeHintTest("test1.html", pos);
+
+                // simulate Ctrl+space keystroke to invoke code hints menu
+                runs(function () {
+                    var e = $.Event("keydown");
+                    e.keyCode = 32;      // spacebar key
+                    e.ctrlKey = true;
+
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor).toBeTruthy();
+
+                    // get text before insert operation
+                    lineBefore = editor._codeMirror.getLine(pos.line);
+                    
+                    CodeHintManager.handleKeyEvent(editor, e);
+
+                    var codeHintList = CodeHintManager._getCodeHintList();
+                    expect(codeHintList).toBeTruthy();
+                    expect(codeHintList.isOpen()).toBe(true);
+                });
+
+/***
+                // simulate Enter key to insert code hint into doc
+                runs(function () {
+                    var e = $.Event("keydown");
+                    e.keyCode = 20;      // Enter/return key
+
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor).toBeTruthy();
+
+                    CodeHintManager.handleKeyEvent(editor, e);
+
+                    // don't know what was inserted, but it should be different
+                    var newPos = editor.getCursorPos();
+                    lineAfter = editor._codeMirror.getLine(pos.line);
+                    expect(lineBefore).not.toEqual(lineAfter);
+                });
+***/
+            });
+
+        });
+    });
+});

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
                     expect(editor).toBeTruthy();
 
                     // get text before insert operation
-                    lineBefore = editor._codeMirror.getLine(pos.line);
+                    lineBefore = editor.document.getLine(pos.line);
 
                     CodeHintManager.handleKeyEvent(editor, e);
 
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
 
                     // doesn't matter what was inserted, but line should be different
                     var newPos = editor.getCursorPos();
-                    lineAfter = editor._codeMirror.getLine(pos.line);
+                    lineAfter = editor.document.getLine(pos.line);
                     expect(lineBefore).not.toEqual(lineAfter);
                 });
             });

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
         var hostOpened = false,
             err = false,
             workingSet = [];
-        
+
         SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
         runs(function () {
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
                 err = true;
             });
         });
-        
+
         waitsFor(function () { return hostOpened && !err; }, "FILE_OPEN timeout", 1000);
 
         runs(function () {
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
         initCodeHintTest = _initCodeHintTest.bind(this);
         SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
             testWindow = w;
-            
+
             // uncomment this line to debug test window:
             //testWindow.brackets.app.showDeveloperTools();
 
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
 
 
     describe("Code Hint Menus", function () {
-        
+
         describe("HTML Tests", function () {
 
             it("should show code hints menu and insert text at IP", function () {
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
 
                     // get text before insert operation
                     lineBefore = editor._codeMirror.getLine(pos.line);
-                    
+
                     CodeHintManager.handleKeyEvent(editor, e);
 
                     var codeHintList = CodeHintManager._getCodeHintList();
@@ -122,25 +122,22 @@ define(function (require, exports, module) {
                     expect(codeHintList.isOpen()).toBe(true);
                 });
 
-/***
                 // simulate Enter key to insert code hint into doc
                 runs(function () {
                     var e = $.Event("keydown");
-                    e.keyCode = 20;      // Enter/return key
+                    e.keyCode = 13;      // Enter/return key
 
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
 
                     CodeHintManager.handleKeyEvent(editor, e);
 
-                    // don't know what was inserted, but it should be different
+                    // doesn't matter what was inserted, but line should be different
                     var newPos = editor.getCursorPos();
                     lineAfter = editor._codeMirror.getLine(pos.line);
                     expect(lineBefore).not.toEqual(lineAfter);
                 });
-***/
             });
-
         });
     });
 });


### PR DESCRIPTION
For now, just test that Ctrl+space invokes code hint menu and then Enter key selects first item and inserts it into doc.
