### PR TITLE
Fix issue #1240 (Inline editor background width)

### DIFF
--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -386,7 +386,7 @@ define(function (require, exports, module) {
         // growing the overall width.
         // This is a bit of a hack since it relies on knowing some detail about the innards of CodeMirror.
         var lineSpace = this.hostEditor._getLineSpaceElement(),
-            minWidth = $(lineSpace).offset().left - this.$htmlContent.offset().left + $(lineSpace).width();
+            minWidth = $(lineSpace).offset().left - this.$htmlContent.offset().left + lineSpace.scrollWidth;
         this.$htmlContent.css("min-width", minWidth + "px");
     };
     


### PR DESCRIPTION
Fix issue #1240 (Inline editor background doesn't extend all the way to right when scrolling)

CodeMirror changed the way it props its width open such that lineSpace's width is no longer explicitly set to the max width of all the lines (lines wider than the viewport simply overflow it). We were checking this width to decide how wide inline editors must be. However, lineSpace's _content_ is still as wide as the max line (due to the pos of the new widthForcer div) so we can use lineSpace's scrollWidth and still get an accurate number.

See the bug for slightly more detail.
