### PR TITLE
Deselect working set when clicking folder in project panel, fixes #1117

### DIFF
--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -72,8 +72,6 @@ define(function (require, exports, module) {
         $(exports).triggerHandler("documentSelectionFocusChange");
     });
 
-
-
     /** 
       * Update the file selection focus when ever the current document changes
       */
@@ -111,6 +109,11 @@ define(function (require, exports, module) {
         EditorManager.focusEditor();
     }
 
+    /**
+     * Modifies the selection focus in the project side bar. A file can either be selected
+     * in the working set (the open files) or in the file tree, but not both.
+     * @param {String} fileSelectionFocus - either PROJECT_MANAGER or WORKING_SET_VIEW
+     */
     function setFileSelectionFocus(fileSelectionFocus) {
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
             throw new Error("Bad parameter passed to FileViewController.openAndSelectDocument");

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
      */
     function setFileSelectionFocus(fileSelectionFocus) {
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
-            throw new Error("Bad parameter passed to FileViewController.openAndSelectDocument");
+            throw new Error("Bad parameter passed to FileViewController.setFileSelectionFocus");
         }
 
         _fileSelectionFocus = fileSelectionFocus;

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -72,6 +72,8 @@ define(function (require, exports, module) {
         $(exports).triggerHandler("documentSelectionFocusChange");
     });
 
+
+
     /** 
       * Update the file selection focus when ever the current document changes
       */
@@ -107,6 +109,15 @@ define(function (require, exports, module) {
         
         // Ensure the editor has focus even though we didn't open a new file.
         EditorManager.focusEditor();
+    }
+
+    function setFileSelectionFocus(fileSelectionFocus) {
+        if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
+            throw new Error("Bad parameter passed to FileViewController.openAndSelectDocument");
+        }
+
+        _fileSelectionFocus = fileSelectionFocus;
+        $(exports).triggerHandler("documentSelectionFocusChange");
     }
 
     /** 
@@ -190,8 +201,7 @@ define(function (require, exports, module) {
     exports.getFileSelectionFocus = getFileSelectionFocus;
     exports.openAndSelectDocument = openAndSelectDocument;
     exports.addToWorkingSetAndSelect = addToWorkingSetAndSelect;
+    exports.setFileSelectionFocus = setFileSelectionFocus;
     exports.WORKING_SET_VIEW = WORKING_SET_VIEW;
     exports.PROJECT_MANAGER = PROJECT_MANAGER;
-
-
 });

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -354,6 +354,7 @@ define(function (require, exports, module) {
                             }
                         });
                     } else {
+                        FileViewController.setFileSelectionFocus(FileViewController.PROJECT_MANAGER);
                         // show selection marker on folders
                         _redraw(true);
                         

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -153,9 +153,16 @@ define(function (require, exports, module) {
     var _documentSelectionFocusChange = function () {
         var curDoc = DocumentManager.getCurrentDocument();
         if (curDoc && _hasFileSelectionFocus()) {
+
+            // Don't update the file tree selection to the current open doc when there is a directory
+            // already selected
+            var selected = getSelectedItem();
+            if(selected && selected.isDirectory) {
+                return;
+            }
+
             $("#project-files-container li").is(function (index) {
                 var entry = $(this).data("entry");
-                
                 if (entry && entry.fullPath === curDoc.file.fullPath && !_projectTree.jstree("is_selected", $(this))) {
                     //we don't want to trigger another selection change event, so manually deselect
                     //and select without sending out notifications

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -150,6 +150,20 @@ define(function (require, exports, module) {
         }
     }
     
+    /**
+     * Returns the FileEntry or DirectoryEntry corresponding to the selected item, or null
+     * if no item is selected.
+     *
+     * @return {?Entry}
+     */
+    function getSelectedItem() {
+        var selected = _projectTree.jstree("get_selected");
+        if (selected) {
+            return selected.data("entry");
+        }
+        return null;
+    }
+    
     var _documentSelectionFocusChange = function () {
         var curDoc = DocumentManager.getCurrentDocument();
         if (curDoc && _hasFileSelectionFocus()) {
@@ -157,7 +171,7 @@ define(function (require, exports, module) {
             // Don't update the file tree selection to the current open doc when there is a directory
             // already selected
             var selected = getSelectedItem();
-            if(selected && selected.isDirectory) {
+            if (selected && selected.isDirectory) {
                 return;
             }
 
@@ -749,19 +763,6 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
-    /**
-     * Returns the FileEntry or DirectoryEntry corresponding to the selected item, or null
-     * if no item is selected.
-     *
-     * @return {?Entry}
-     */
-    function getSelectedItem() {
-        var selected = _projectTree.jstree("get_selected");
-        if (selected) {
-            return selected.data("entry");
-        }
-        return null;
-    }
 
     /**
      * Create a new item in the project tree.


### PR DESCRIPTION
Made FileViewController.setFileSelectionFocus() public so that project tree could call it to set the focus to the project area when clicking on a folder.

Updated ProjectManager.documentSelectionFocusChange() so that it does not sync the file tree selection with the current document when a folder is already selected

fixes issue #1117
