### PR TITLE
Keyboard Controls for Quick Editors Unit Tests

### DIFF
--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -114,6 +114,8 @@ define(function (require, exports, module) {
                     // get text before insert operation
                     lineBefore = editor.document.getLine(pos.line);
 
+                    // Ultimately want to use SpecRunnerUtils.simulateKeyEvent()
+                    // here, but it does not yet support modifer keys
                     CodeHintManager.handleKeyEvent(editor, e);
 
                     var codeHintList = CodeHintManager._getCodeHintList();
@@ -155,6 +157,8 @@ define(function (require, exports, module) {
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
 
+                    // Ultimately want to use SpecRunnerUtils.simulateKeyEvent()
+                    // here, but it does not yet support modifer keys
                     CodeHintManager.handleKeyEvent(editor, e);
 
                     // verify list is open
@@ -166,9 +170,8 @@ define(function (require, exports, module) {
                 // simulate Esc key to dismiss code hints menu
                 runs(function () {
                     var key = 27,   // Esc key
-                        doc = testWindow.document,
-                        element = doc.getElementsByClassName("codehint-menu open")[0];
-                    SpecRunnerUtils.simulateKeyEvent(key, element);
+                        element = testWindow.$(".dropdown.open")[0];
+                    SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 
                     // verify list is no longer open
                     var codeHintList = CodeHintManager._getCodeHintList();

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -93,7 +93,6 @@ define(function (require, exports, module) {
         describe("HTML Tests", function () {
 
             it("should show code hints menu and insert text at IP", function () {
-
                 var editor,
                     pos = {line: 3, ch: 1},
                     lineBefore,
@@ -136,6 +135,49 @@ define(function (require, exports, module) {
                     var newPos = editor.getCursorPos();
                     lineAfter = editor.document.getLine(pos.line);
                     expect(lineBefore).not.toEqual(lineAfter);
+                });
+            });
+
+            it("should dismiss code hints menu with Esc key", function () {
+                var editor,
+                    pos = {line: 3, ch: 1},
+                    lineBefore,
+                    lineAfter;
+
+                // minimal markup with an open '<' before IP
+                // Note: line for pos is 0-based and editor lines numbers are 1-based
+                initCodeHintTest("test1.html", pos);
+
+                // simulate Ctrl+space keystroke to invoke code hints menu
+                runs(function () {
+                    var e = $.Event("keydown");
+                    e.keyCode = 32;      // spacebar key
+                    e.ctrlKey = true;
+
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor).toBeTruthy();
+
+                    // get text before insert operation
+                    lineBefore = editor.document.getLine(pos.line);
+
+                    CodeHintManager.handleKeyEvent(editor, e);
+
+                    // verify list is open
+                    var codeHintList = CodeHintManager._getCodeHintList();
+                    expect(codeHintList).toBeTruthy();
+                    expect(codeHintList.isOpen()).toBe(true);
+                });
+
+                // simulate Esc key to dismiss code hints menu
+                runs(function () {
+                    var key = 27,   // Esc key
+                        doc = testWindow.document,
+                        element = doc.getElementsByClassName("codehint-menu open")[0];
+                    SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+
+                    // verify list is no longer open
+                    var codeHintList = CodeHintManager._getCodeHintList();
+                    expect(codeHintList.isOpen()).toBe(false);
                 });
             });
         });

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -140,9 +140,7 @@ define(function (require, exports, module) {
 
             it("should dismiss code hints menu with Esc key", function () {
                 var editor,
-                    pos = {line: 3, ch: 1},
-                    lineBefore,
-                    lineAfter;
+                    pos = {line: 3, ch: 1};
 
                 // minimal markup with an open '<' before IP
                 // Note: line for pos is 0-based and editor lines numbers are 1-based
@@ -157,9 +155,6 @@ define(function (require, exports, module) {
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
 
-                    // get text before insert operation
-                    lineBefore = editor.document.getLine(pos.line);
-
                     CodeHintManager.handleKeyEvent(editor, e);
 
                     // verify list is open
@@ -173,7 +168,7 @@ define(function (require, exports, module) {
                     var key = 27,   // Esc key
                         doc = testWindow.document,
                         element = doc.getElementsByClassName("codehint-menu open")[0];
-                    SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+                    SpecRunnerUtils.simulateKeyEvent(key, element);
 
                     // verify list is no longer open
                     var codeHintList = CodeHintManager._getCodeHintList();

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, $, brackets */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, $, brackets */
 
 define(function (require, exports, module) {
     'use strict';
@@ -328,21 +328,16 @@ define(function (require, exports, module) {
             it("should close inline widget on Esc Key", function () {
                 initInlineTest("test1.html", 0);
 
-                var hostEditor, inlineWidget, inlinePos, savedPos;
-
                 runs(function () {
-                    hostEditor =  EditorManager.getCurrentFullEditor();
-                    inlineWidget = hostEditor.getInlineWidgets()[0];
-                    inlinePos = inlineWidget.editors[0].getCursorPos();
-
-                    // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+                    var hostEditor =  EditorManager.getCurrentFullEditor(),
+                        inlineWidget = hostEditor.getInlineWidgets()[0],
+                        inlinePos = inlineWidget.editors[0].getCursorPos();
 
                     // close the editor by simulating Esc key
                     var key = 27,   // Esc key
                         doc = testWindow.document,
                         element = doc.getElementsByClassName("inline-widget")[0];
-                    SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+                    SpecRunnerUtils.simulateKeyEvent(key, element);
 
                     // verify no inline widgets 
                     expect(hostEditor.getInlineWidgets().length).toBe(0);

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -329,17 +329,20 @@ define(function (require, exports, module) {
                 initInlineTest("test1.html", 0);
 
                 runs(function () {
-                    var hostEditor =  EditorManager.getCurrentFullEditor(),
+                    var hostEditor = EditorManager.getCurrentFullEditor(),
                         inlineWidget = hostEditor.getInlineWidgets()[0],
                         inlinePos = inlineWidget.editors[0].getCursorPos();
+
+                    // verify inline widget
+                    expect(hostEditor.getInlineWidgets().length).toBe(1);
 
                     // close the editor by simulating Esc key
                     var key = 27,   // Esc key
                         doc = testWindow.document,
                         element = doc.getElementsByClassName("inline-widget")[0];
-                    SpecRunnerUtils.simulateKeyEvent(key, element);
+                    SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 
-                    // verify no inline widgets 
+                    // verify no inline widgets
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                 });
             });

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -325,6 +325,30 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should close inline widget on Esc Key", function () {
+                initInlineTest("test1.html", 0);
+
+                var hostEditor, inlineWidget, inlinePos, savedPos;
+
+                runs(function () {
+                    hostEditor =  EditorManager.getCurrentFullEditor();
+                    inlineWidget = hostEditor.getInlineWidgets()[0];
+                    inlinePos = inlineWidget.editors[0].getCursorPos();
+
+                    // verify cursor position in inline editor
+                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+
+                    // close the editor by simulating Esc key
+                    var key = 27,   // Esc key
+                        doc = testWindow.document,
+                        element = doc.getElementsByClassName("inline-widget")[0];
+                    SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+
+                    // verify no inline widgets 
+                    expect(hostEditor.getInlineWidgets().length).toBe(0);
+                });
+            });
+
             it("should not open an inline editor when positioned on textContent", function () {
                 initInlineTest("test1.html", 3, false);
                 

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $ */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, $ */
 
 define(function (require, exports, module) {
     'use strict';
@@ -638,9 +638,8 @@ define(function (require, exports, module) {
 
                 // close the context menu by simulating Esc key
                 var key = 27,   // Esc key
-                    doc = testWindow.document,
-                    element = doc.getElementsByClassName("dropdown open")[0];
-                SpecRunnerUtils.simulateKeyEvent(key, element);
+                    element = $menus[0];
+                SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 
                 // verify close event
                 // TODO: issue #1270

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, $ */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $ */
 
 define(function (require, exports, module) {
     'use strict';
@@ -619,7 +619,36 @@ define(function (require, exports, module) {
                 // verify all dropdowns are closed
                 var $menus = testWindow.$(".dropdown.open");
                 expect($menus.length).toBe(0);
+            });
 
+            it("close context menu using Esc key", function () {
+                CommandManager.register("Brackets Test Command Custom", "custom.command", function () {});
+                var cmenu = Menus.registerContextMenu("test-cmenu");
+                var menuItem = cmenu.addMenuItem("custom.command");
+
+                var closeEvent = false;
+                testWindow.$(cmenu).on("contextMenuClose", function () {
+                    closeEvent = true;
+                });
+                cmenu.open({pageX: 0, pageY: 0});
+
+                // verify dropdown is open
+                var $menus = testWindow.$(".dropdown.open");
+                expect($menus.length).toBe(1);
+
+                // close the context menu by simulating Esc key
+                var key = 27,   // Esc key
+                    doc = testWindow.document,
+                    element = doc.getElementsByClassName("dropdown open")[0];
+                SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+
+                // verify close event
+                // TODO: issue #1270
+                //expect(closeEvent).toBeTruthy();
+
+                // verify all dropdowns are closed
+                $menus = testWindow.$(".dropdown.open");
+                expect($menus.length).toBe(0);
             });
         });
     });

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -391,17 +391,17 @@ define(function (require, exports, module) {
                     CommandManager.register("Brackets Test Command Custom 0", "custom.command0", function () {});
                     CommandManager.register("Brackets Test Command Custom 1", "custom.command1", function () {});
                     var menu = Menus.addMenu("Custom", "menu-custom");
-                    var menuItem = menu.addMenuItem("custom.command0");
-                    menuItem = menu.addMenuItem("custom.command1");
+                    menu.addMenuItem("custom.command0");
+                    menu.addMenuItem("custom.command1");
                     
                     // add positioned divider
-                    menuItem = menu.addMenuDivider(Menus.AFTER, "custom.command0");
+                    menu.addMenuDivider(Menus.AFTER, "custom.command0");
                     var $listItems = testWindow.$("#menu-custom > ul").children();
                     expect($listItems.length).toBe(3);
                     expect($($listItems[1]).find("hr.divider").length).toBe(1);
 
                     // add divider to end
-                    menuItem = menu.addMenuDivider();
+                    menu.addMenuDivider();
                     $listItems = testWindow.$("#menu-custom > ul").children();
                     expect($listItems.length).toBe(4);
                     expect($($listItems[3]).find("hr.divider").length).toBe(1);
@@ -418,7 +418,7 @@ define(function (require, exports, module) {
                     expect(cmd).toBeDefined();
 
                     var menu = Menus.addMenu("Custom", "menu-custom");
-                    var menuItem = menu.addMenuItem("custom.command0");
+                    menu.addMenuItem("custom.command0");
                     var menuSelector = "#menu-custom-custom\\.command0";
                     
                     // Verify menu is synced with command
@@ -449,7 +449,7 @@ define(function (require, exports, module) {
                     expect(cmd).toBeDefined();
 
                     var menu = Menus.addMenu("Custom", "menu-custom");
-                    var menuItem = menu.addMenuItem("custom.command0");
+                    menu.addMenuItem("custom.command0");
                     var menuSelector = "#menu-custom-custom\\.command0";
                     
                     // Verify menu is synced with command
@@ -476,7 +476,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     CommandManager.register("Brackets Test Command Custom 0", "custom.command0", function () {});
                     var menu = Menus.addMenu("Custom", "menu-custom");
-                    var menuItem = menu.addMenuItem("custom.command0", "Ctrl-9");
+                    menu.addMenuItem("custom.command0", "Ctrl-9");
                     var menuSelector = "#menu-custom-custom\\.command0";
                     
                     // Verify menu is synced with command
@@ -541,7 +541,7 @@ define(function (require, exports, module) {
                     var openEvent = false;
                     CommandManager.register("Brackets Test Command Custom", "custom.command", function () {});
                     var cmenu = Menus.registerContextMenu("test-cmenu");
-                    var menuItem = cmenu.addMenuItem("custom.command");
+                    cmenu.addMenuItem("custom.command");
 
                     testWindow.$(cmenu).on("beforeContextMenuOpen", function () {
                         openEvent = true;
@@ -579,7 +579,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     CommandManager.register("Brackets Test Command Custom", "custom.command", function () {});
                     var cmenu = Menus.registerContextMenu("test-cmenu");
-                    var menuItem = cmenu.addMenuItem("custom.command");
+                    cmenu.addMenuItem("custom.command");
                     var winWidth = $(testWindow).width();
                     var winHeight = $(testWindow).height();
                     
@@ -604,7 +604,7 @@ define(function (require, exports, module) {
             it("close context menu", function () {
                 CommandManager.register("Brackets Test Command Custom", "custom.command", function () {});
                 var cmenu = Menus.registerContextMenu("test-cmenu");
-                var menuItem = cmenu.addMenuItem("custom.command");
+                cmenu.addMenuItem("custom.command");
 
                 var closeEvent = false;
                 testWindow.$(cmenu).on("contextMenuClose", function () {
@@ -624,7 +624,7 @@ define(function (require, exports, module) {
             it("close context menu using Esc key", function () {
                 CommandManager.register("Brackets Test Command Custom", "custom.command", function () {});
                 var cmenu = Menus.registerContextMenu("test-cmenu");
-                var menuItem = cmenu.addMenuItem("custom.command");
+                cmenu.addMenuItem("custom.command");
 
                 var closeEvent = false;
                 testWindow.$(cmenu).on("contextMenuClose", function () {
@@ -640,7 +640,7 @@ define(function (require, exports, module) {
                 var key = 27,   // Esc key
                     doc = testWindow.document,
                     element = doc.getElementsByClassName("dropdown open")[0];
-                SpecRunnerUtils.simulateKeyEvent(key, doc, element);
+                SpecRunnerUtils.simulateKeyEvent(key, element);
 
                 // verify close event
                 // TODO: issue #1270

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -642,8 +642,7 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 
                 // verify close event
-                // TODO: issue #1270
-                //expect(closeEvent).toBeTruthy();
+                expect(closeEvent).toBeTruthy();
 
                 // verify all dropdowns are closed
                 $menus = testWindow.$(".dropdown.open");

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -476,25 +476,28 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Simulate key event
+     * Simulate key event. Found this code here:
+     * http://stackoverflow.com/questions/10455626/keydown-simulation-in-chrome-fires-normally-but-not-the-correct-key
      *
      * TODO: need parameter(s) for modifier keys
      *
      * @param {number} key - key code
-     * @param {HTMLDocument} doc - containing document
      * @param {HTMLElement} element - element to receive event
      */
-    function simulateKeyEvent(key, doc, element) {
-        var oEvent = doc.createEvent('KeyboardEvent');
+    function simulateKeyEvent(key, element) {
+        var doc = element.ownerDocument,
+            oEvent = doc.createEvent('KeyboardEvent');
 
-        // Chromium Hack
+        // Chromium Hack: need to override the 'which' property.
+        // Note: this code is not designed to work in IE, Safari,
+        // or other browsers. Well, maybe with Firefox. YMMV.
         Object.defineProperty(oEvent, 'keyCode', {
-            get : function() {
+            get: function () {
                 return this.keyCodeVal;
             }
         });
         Object.defineProperty(oEvent, 'which', {
-            get : function() {
+            get: function () {
                 return this.keyCodeVal;
             }
         });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -475,6 +475,44 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
+    /**
+     * Simulate key event
+     *
+     * TODO: need parameter(s) for modifier keys
+     *
+     * @param {number} key - key code
+     * @param {HTMLDocument} doc - containing document
+     * @param {HTMLElement} element - element to receive event
+     */
+    function simulateKeyEvent(key, doc, element) {
+        var oEvent = doc.createEvent('KeyboardEvent');
+
+        // Chromium Hack
+        Object.defineProperty(oEvent, 'keyCode', {
+            get : function() {
+                return this.keyCodeVal;
+            }
+        });
+        Object.defineProperty(oEvent, 'which', {
+            get : function() {
+                return this.keyCodeVal;
+            }
+        });
+
+        if (oEvent.initKeyboardEvent) {
+            oEvent.initKeyboardEvent("keydown", true, true, doc.defaultView, false, false, false, false, key, key);
+        } else {
+            oEvent.initKeyEvent("keydown", true, true, doc.defaultView, false, false, false, false, key, 0);
+        }
+
+        oEvent.keyCodeVal = key;
+        if (oEvent.keyCode !== key) {
+            console.log("keyCode mismatch " + oEvent.keyCode + "(" + oEvent.which + ")");
+        }
+
+        element.dispatchEvent(oEvent);
+    }
+
     function getTestWindow() {
         return testWindow;
     }
@@ -497,4 +535,5 @@ define(function (require, exports, module) {
     exports.saveFileWithoutOffsets      = saveFileWithoutOffsets;
     exports.deleteFile                  = deleteFile;
     exports.getTestWindow               = getTestWindow;
+    exports.simulateKeyEvent            = simulateKeyEvent;
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -481,12 +481,18 @@ define(function (require, exports, module) {
      *
      * TODO: need parameter(s) for modifier keys
      *
-     * @param {number} key - key code
-     * @param {HTMLElement} element - element to receive event
+     * @param {Number} key Key code
+     * @param (String) event Key event to simulate
+     * @param {HTMLElement} element Element to receive event
      */
-    function simulateKeyEvent(key, element) {
+    function simulateKeyEvent(key, event, element) {
         var doc = element.ownerDocument,
             oEvent = doc.createEvent('KeyboardEvent');
+
+        if (event !== "keydown" && event !== "keyup" && event !== "keypress") {
+            console.log("SpecRunnerUtils.simulateKeyEvent() - unsupported keyevent: " + event);
+            return;
+        }
 
         // Chromium Hack: need to override the 'which' property.
         // Note: this code is not designed to work in IE, Safari,
@@ -503,9 +509,9 @@ define(function (require, exports, module) {
         });
 
         if (oEvent.initKeyboardEvent) {
-            oEvent.initKeyboardEvent("keydown", true, true, doc.defaultView, false, false, false, false, key, key);
+            oEvent.initKeyboardEvent(event, true, true, doc.defaultView, false, false, false, false, key, key);
         } else {
-            oEvent.initKeyEvent("keydown", true, true, doc.defaultView, false, false, false, false, key, 0);
+            oEvent.initKeyEvent(event, true, true, doc.defaultView, false, false, false, false, key, 0);
         }
 
         oEvent.keyCodeVal = key;


### PR DESCRIPTION
Added a new function to SpecRunnerUtils for simulating keyboard events. Currently no way to specify modifier keys.

Added test to close an inline editor via Esc key. There are currently no unit tests for multiple inline editors, so there is no test for closing more than 1 via Esc key.

Added test for code hints.

Added test for closing context-menu via Esc Key. Opened issue #1270 for contextMenuClose event. There are no unit tests for closing main menus, so no tests were added for Esc key.
