### PR TITLE
Fix scope of beforeEach/afterEach

### DIFF
--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -38,57 +38,55 @@ define(function (require, exports, module) {
         testWindow,
         initCodeHintTest;
 
+    describe("Code Hint Menus", function () {
 
-    /**
-     * Performs setup for a code hint test. Opens a file and set pos.
-     * 
-     * @param {!string} openFile Project relative file path to open in a main editor.
-     * @param {!number} openPos The pos within openFile to place the IP.
-     */
-    var _initCodeHintTest = function (openFile, openPos) {
-        var hostOpened = false,
-            err = false,
-            workingSet = [];
-
-        SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
-        runs(function () {
-            workingSet.push(openFile);
-            SpecRunnerUtils.openProjectFiles(workingSet).done(function (documents) {
-                hostOpened = true;
-            }).fail(function () {
-                err = true;
+        /**
+         * Performs setup for a code hint test. Opens a file and set pos.
+         * 
+         * @param {!string} openFile Project relative file path to open in a main editor.
+         * @param {!number} openPos The pos within openFile to place the IP.
+         */
+        var _initCodeHintTest = function (openFile, openPos) {
+            var hostOpened = false,
+                err = false,
+                workingSet = [];
+    
+            SpecRunnerUtils.loadProjectInTestWindow(testPath);
+    
+            runs(function () {
+                workingSet.push(openFile);
+                SpecRunnerUtils.openProjectFiles(workingSet).done(function (documents) {
+                    hostOpened = true;
+                }).fail(function () {
+                    err = true;
+                });
+            });
+    
+            waitsFor(function () { return hostOpened && !err; }, "FILE_OPEN timeout", 1000);
+    
+            runs(function () {
+                var editor = EditorManager.getCurrentFullEditor();
+                editor.setCursorPos(openPos.line, openPos.ch);
+            });
+        };
+    
+        beforeEach(function () {
+            initCodeHintTest = _initCodeHintTest.bind(this);
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
+    
+                // uncomment this line to debug test window:
+                //testWindow.brackets.app.showDeveloperTools();
+    
+                // Load module instances from brackets.test
+                CodeHintManager     = testWindow.brackets.test.CodeHintManager;
+                EditorManager       = testWindow.brackets.test.EditorManager;
             });
         });
-
-        waitsFor(function () { return hostOpened && !err; }, "FILE_OPEN timeout", 1000);
-
-        runs(function () {
-            var editor = EditorManager.getCurrentFullEditor();
-            editor.setCursorPos(openPos.line, openPos.ch);
+    
+        afterEach(function () {
+            SpecRunnerUtils.closeTestWindow();
         });
-    };
-
-    beforeEach(function () {
-        initCodeHintTest = _initCodeHintTest.bind(this);
-        SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-            testWindow = w;
-
-            // uncomment this line to debug test window:
-            //testWindow.brackets.app.showDeveloperTools();
-
-            // Load module instances from brackets.test
-            CodeHintManager     = testWindow.brackets.test.CodeHintManager;
-            EditorManager       = testWindow.brackets.test.EditorManager;
-        });
-    });
-
-    afterEach(function () {
-        SpecRunnerUtils.closeTestWindow();
-    });
-
-
-    describe("Code Hint Menus", function () {
 
         describe("HTML Tests", function () {
 


### PR DESCRIPTION
CodeHint-test added beforeEach/afterEach to the scope of every spec. Moved down into the test suite.
