### PR TITLE
Don't set focus when popups close, fixes #1278

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -651,7 +651,7 @@ define(function (require, exports, module) {
         _insertInList($menubar, $newMenu, position, $relativeElement);
         
         // Install ESC key handling
-        PopUpManager.addPopUp($popUp, menu.close, false);
+        PopUpManager.addPopUp($popUp, closeAll, false);
 
         // todo error handling
 

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -119,7 +119,14 @@ define(function (require, exports, module) {
                     keyEvent.stopImmediatePropagation();
                     
                     _removePopUp($popUp, true);
-                    EditorManager.focusEditor();
+
+                    // TODO: right now Menus and Context Menus do not take focus away from
+                    // the editor. We need to have a focus manager to correctly manage focus
+                    // between editors and other UI elements.
+                    // For now we don't set focus here and assume individual popups
+                    // adjust focus if necessary
+                    // See story in Trello card #404
+                    //EditorManager.focusEditor();
                 }
                 
                 break;


### PR DESCRIPTION
right now Menus and Context Menus do not take focus away from
between editors and other UI elements.
For now we don't set focus here and assume individual popups
adjust focus if necessary.

For popup manager to adjust focus we need a focus manager that remembers the last focused editor when focus moves to a non editor.
See story in Trello [card #404](https://trello.com/card/5-167-focus-management-problems-0/4f90a6d98f77505d7940ce88/404)

fixes #1278
