### PR TITLE
Don't create an html tag info for an invalid html tag inside a style block or a css file.

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -290,7 +290,7 @@ define(function (require, exports, module) {
             tokenType;
         
         // check if this is inside a style block.
-        if (ctx.token.className === "tag" && editor.getModeForSelection() !== "html") {
+        if (editor.getModeForSelection() !== "html") {
             return createTagInfo();
         }
         

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -289,6 +289,11 @@ define(function (require, exports, module) {
             tagInfo,
             tokenType;
         
+        // check if this is inside a style block.
+        if (ctx.token.className === "tag" && editor.getModeForSelection() !== "html") {
+            return createTagInfo();
+        }
+        
         //check and see where we are in the tag
         if (ctx.token.string.length > 0 && ctx.token.string.trim().length === 0) {
 
@@ -330,11 +335,6 @@ define(function (require, exports, module) {
         }
         
         if (ctx.token.className === "tag") {
-            // check if this is inside a style block.
-            if (editor.getModeForSelection() !== "html") {
-                return createTagInfo();
-            }
-            
             //check to see if this is the closing of a tag (either the start or end)
             if (ctx.token.string === ">" ||
                     (ctx.token.string.charAt(0) === "<" && ctx.token.string.charAt(1) === "/")) {

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -330,6 +330,11 @@ define(function (require, exports, module) {
         }
         
         if (ctx.token.className === "tag") {
+            // check if this is inside a style block.
+            if (editor.getModeForSelection() !== "html") {
+                return createTagInfo();
+            }
+            
             //check to see if this is the closing of a tag (either the start or end)
             if (ctx.token.string === ">" ||
                     (ctx.token.string.charAt(0) === "<" && ctx.token.string.charAt(1) === "/")) {


### PR DESCRIPTION
This fixes issue #1277.
