### PR TITLE
Correctly handle focus changes between working set and file tree when activating document from find in filesfixes #1280

### DIFF
--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -114,13 +114,13 @@ define(function (require, exports, module) {
      * in the working set (the open files) or in the file tree, but not both.
      * @param {String} fileSelectionFocus - either PROJECT_MANAGER or WORKING_SET_VIEW
      */
-    function setFileSelectionFocus(fileSelectionFocus) {
+    function setFileViewFocus(fileSelectionFocus) {
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
-            throw new Error("Bad parameter passed to FileViewController.setFileSelectionFocus");
+            throw new Error("Bad parameter passed to FileViewController.setFileViewFocus");
         }
 
         _fileSelectionFocus = fileSelectionFocus;
-        $(exports).triggerHandler("documentSelectionFocusChange");
+        $(exports).triggerHandler("fileViewFocusChange");
     }
 
     /** 
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
     exports.getFileSelectionFocus = getFileSelectionFocus;
     exports.openAndSelectDocument = openAndSelectDocument;
     exports.addToWorkingSetAndSelect = addToWorkingSetAndSelect;
-    exports.setFileSelectionFocus = setFileSelectionFocus;
+    exports.setFileViewFocus = setFileViewFocus;
     exports.WORKING_SET_VIEW = WORKING_SET_VIEW;
     exports.PROJECT_MANAGER = PROJECT_MANAGER;
 });

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -163,18 +163,14 @@ define(function (require, exports, module) {
         }
         return null;
     }
+
+    function _fileViewFocusChange() {
+        _redraw(true);
+    }
     
-    var _documentSelectionFocusChange = function () {
+    function _documentSelectionFocusChange() {
         var curDoc = DocumentManager.getCurrentDocument();
         if (curDoc && _hasFileSelectionFocus()) {
-
-            // Don't update the file tree selection to the current open doc when there is a directory
-            // already selected
-            var selected = getSelectedItem();
-            if (selected && selected.isDirectory) {
-                return;
-            }
-
             $("#project-files-container li").is(function (index) {
                 var entry = $(this).data("entry");
                 if (entry && entry.fullPath === curDoc.file.fullPath && !_projectTree.jstree("is_selected", $(this))) {
@@ -192,7 +188,7 @@ define(function (require, exports, module) {
         }
         
         _redraw(true);
-    };
+    }
 
     /**
      * Returns the root folder of the currently loaded project, or null if no project is open (during
@@ -375,7 +371,7 @@ define(function (require, exports, module) {
                             }
                         });
                     } else {
-                        FileViewController.setFileSelectionFocus(FileViewController.PROJECT_MANAGER);
+                        FileViewController.setFileViewFocus(FileViewController.PROJECT_MANAGER);
                         // show selection marker on folders
                         _redraw(true);
                         
@@ -953,6 +949,7 @@ define(function (require, exports, module) {
 
         // Event Handlers
         $(FileViewController).on("documentSelectionFocusChange", _documentSelectionFocusChange);
+        $(FileViewController).on("fileViewFocusChange", _fileViewFocusChange);
         $("#open-files-container").on("contentChanged", function () {
             _redraw(false); // redraw jstree when working set size changes
         });

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -289,13 +289,6 @@ define(function (require, exports, module) {
 
     /** 
      * @private
-     */
-    function _handleDocumentSelectionChange() {
-        _updateListSelection();
-    }
-
-    /** 
-     * @private
      * @param {FileEntry} file 
      */
     function _handleFileRemoved(file) {
@@ -357,12 +350,7 @@ define(function (require, exports, module) {
             _handleDirtyFlagChanged(doc);
         });
     
-        $(FileViewController).on("documentSelectionFocusChange", function (event, eventTarget) {
-            _handleDocumentSelectionChange();
-            _fireSelectionChanged();
-        });
-
-        $(FileViewController).on("fileViewFocusChange", _updateListSelection);
+        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _updateListSelection );
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -289,6 +289,14 @@ define(function (require, exports, module) {
 
     /** 
      * @private
+     */
+    function _handleDocumentSelectionChange() {
+        _updateListSelection();
+        _fireSelectionChanged();
+    }
+
+    /** 
+     * @private
      * @param {FileEntry} file 
      */
     function _handleFileRemoved(file) {
@@ -350,7 +358,7 @@ define(function (require, exports, module) {
             _handleDirtyFlagChanged(doc);
         });
     
-        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _updateListSelection );
+        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange )
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -28,6 +28,12 @@
 /**
  * WorkingSetView generates the UI for the list of the files user is editing based on the model provided by EditorManager.
  * The UI allows the user to see what files are open/dirty and allows them to close files and specify the current editor.
+ *
+ * Events dispatched:
+ *  documentSelectionFocusChange - indicates a document change has caused the focus to change between the working
+ *      set and file tree.
+ *  fileViewFocusChange - indicates the selection focus has changed between the working set and the project tree, but the
+ *      document selection has NOT changed
  */
 define(function (require, exports, module) {
     "use strict";
@@ -355,6 +361,8 @@ define(function (require, exports, module) {
             _handleDocumentSelectionChange();
             _fireSelectionChanged();
         });
+
+        $(FileViewController).on("fileViewFocusChange", _updateListSelection);
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);


### PR DESCRIPTION
fixes #1280. Send a different type of notification from FileViewController when only the focus has changed so that the working set and file tree redraw without assuming a document change notification
