### PR TITLE
JSLint and comment cleanup for FileViewController

### DIFF
--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -30,6 +30,13 @@
  * ProjectManager can show file selection. In general the WorkingSetView takes higher
  * priority until the user selects a file in the ProjectManager.
  *
+ * Events dispatched:
+ * - documentSelectionFocusChange - indicates a document change has caused the focus to 
+ *   change between the working set and file tree.
+ *
+ * - fileViewFocusChange - indicates the selection focus has changed between the working
+ *   set and the project tree, but the document selection has NOT changed
+ *
  * Current file selection rules in views:
  * - select a file in WorkingSetView > select in WorkingSetView
  * - add a file to the WorkingSetView > select in WorkingSetView

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
         promise.done(function (doc) {
             // FILE_ADD_TO_WORKING_SET command sets the current document. Update the 
             // selection focus and trigger documentSelectionFocusChange event
-            _fileSelectionFocus = selectIn ? selectIn : WORKING_SET_VIEW;
+            _fileSelectionFocus = selectIn || WORKING_SET_VIEW;
             _selectCurrentDocument();
             
             result.resolve(doc);

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -29,11 +29,6 @@
  * WorkingSetView generates the UI for the list of the files user is editing based on the model provided by EditorManager.
  * The UI allows the user to see what files are open/dirty and allows them to close files and specify the current editor.
  *
- * Events dispatched:
- *  documentSelectionFocusChange - indicates a document change has caused the focus to change between the working
- *      set and file tree.
- *  fileViewFocusChange - indicates the selection focus has changed between the working set and the project tree, but the
- *      document selection has NOT changed
  */
 define(function (require, exports, module) {
     "use strict";
@@ -358,7 +353,7 @@ define(function (require, exports, module) {
             _handleDirtyFlagChanged(doc);
         });
     
-        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange )
+        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange);
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);


### PR DESCRIPTION
fix JSLint errors and move event comments to correct location in FileViewController.

fix #1295
fix #1296
