### PR TITLE
Enabled the remaining agents

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -74,13 +74,11 @@ define(function LiveDevelopment(require, exports, module) {
         "remote": require("LiveDevelopment/Agents/RemoteAgent"),
         "network": require("LiveDevelopment/Agents/NetworkAgent"),
         "dom": require("LiveDevelopment/Agents/DOMAgent"),
-        "css": require("LiveDevelopment/Agents/CSSAgent")
-        /* FUTURE 
+        "css": require("LiveDevelopment/Agents/CSSAgent"),
         "script": require("LiveDevelopment/Agents/ScriptAgent"),
         "highlight": require("LiveDevelopment/Agents/HighlightAgent"),
         "goto": require("LiveDevelopment/Agents/GotoAgent"),
         "edit": require("LiveDevelopment/Agents/EditAgent")
-        */
     };
 
     var _htmlDocumentPath; // the path of the html file open for live development


### PR DESCRIPTION
Please load the remaining agents for extension usage. Otherwise, there is no way to access this functionality.

Here is what the agents do:
- EditAgent: listen to and execute edit events from the remote agent
- GotoAgent: listen to and execute goto events from the remote agent + provide a goto (open document and show line) API
- HighlightAgent: listen to and forward highlight events from the remote agent to the current live document
- ScriptAgent: track loaded script resources, add DOM manipulation breakpoints and track these

Non of this should be very invasive. If you want to disable all remote functionality (the stuff that happens inside the Chrome life Preview) you should comment out the event listeners from RemoteAgent, instead:

106:        Inspector.on("Page.loadEventFired", _onLoadEventFired);
107:        Inspector.on("DOM.attributeModified", _onAttributeModified);

The first loads the remote functions into the active page and the second listens to dom changes and creates edit events if appropriate.
