### PR TITLE
Live Development -- Provide API for enabling/disabling Agents

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -82,15 +82,18 @@ define(function LiveDevelopment(require, exports, module) {
     };
 
     // Some agents are still experimental, so we don't enable them all by default
-    // However, extensions can enable them by calling enableAgent()
-    var _enabledAgents = {
+    // However, extensions can enable them by calling enableAgent().
+    // This object is used as a set (thus all properties have the value 'true').
+    // Property names should match property names in the 'agents' object.
+    var _enabledAgentNames = {
         "console": true,
         "remote": true,
         "network": true,
         "dom": true,
         "css": true
     };
-    var _loadedAgents = [];
+    // store the names (matching property names in the 'agent' object) of agents that we've loaded
+    var _loadedAgentNames = [];
 
     var _htmlDocumentPath; // the path of the html file open for live development
     var _liveDocument; // the document open for live editing.
@@ -230,21 +233,19 @@ define(function LiveDevelopment(require, exports, module) {
 
     /** Unload the agents */
     function unloadAgents() {
-        _loadedAgents.forEach(function (i) {
-            if (agents.hasOwnProperty(i) && agents[i].unload) {
-                agents[i].unload();
-            }
+        _loadedAgentNames.forEach(function (i) {
+            agents[i].unload();
         });
-        _loadedAgents = [];
+        _loadedAgentNames = [];
     }
 
     /** Load the agents */
     function loadAgents() {
         var i, promises = [];
-        for (i in _enabledAgents) {
-            if (_enabledAgents.hasOwnProperty(i) && agents.hasOwnProperty(i) && agents[i].load) {
+        for (i in _enabledAgentNames) {
+            if (_enabledAgentNames.hasOwnProperty(i) && agents.hasOwnProperty(i) && agents[i].load) {
                 promises.push(agents[i].load());
-                _loadedAgents.push(i);
+                _loadedAgentNames.push(i);
             }
         }
         return promises;
@@ -256,8 +257,8 @@ define(function LiveDevelopment(require, exports, module) {
      *  @param {string} name of agent to enable
      */
     function enableAgent(name) {
-        if (!_enabledAgents.hasOwnProperty(name)) {
-            _enabledAgents[name] = true;
+        if (!_enabledAgentNames.hasOwnProperty(name)) {
+            _enabledAgentNames[name] = true;
         }
     }
 
@@ -267,8 +268,8 @@ define(function LiveDevelopment(require, exports, module) {
      *  @param {string} name of agent to disable
      */
     function disableAgent(name) {
-        if (_enabledAgents.hasOwnProperty(name)) {
-            delete _enabledAgents[name];
+        if (_enabledAgentNames.hasOwnProperty(name)) {
+            delete _enabledAgentNames[name];
         }
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -243,7 +243,7 @@ define(function LiveDevelopment(require, exports, module) {
     function loadAgents() {
         var name, promises = [];
         for (name in _enabledAgentNames) {
-            if (_enabledAgentNames.hasOwnProperty(name) && agents.hasOwnProperty(name) && agents[name].load) {
+            if (_enabledAgentNames.hasOwnProperty(name) && agents[name].load) {
                 promises.push(agents[name].load());
                 _loadedAgentNames.push(name);
             }
@@ -257,7 +257,7 @@ define(function LiveDevelopment(require, exports, module) {
      *  @param {string} name of agent to enable
      */
     function enableAgent(name) {
-        if (!_enabledAgentNames.hasOwnProperty(name)) {
+        if (agents.hasOwnProperty(name) && !_enabledAgentNames.hasOwnProperty(name)) {
             _enabledAgentNames[name] = true;
         }
     }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -241,11 +241,11 @@ define(function LiveDevelopment(require, exports, module) {
 
     /** Load the agents */
     function loadAgents() {
-        var i, promises = [];
-        for (i in _enabledAgentNames) {
-            if (_enabledAgentNames.hasOwnProperty(i) && agents.hasOwnProperty(i) && agents[i].load) {
-                promises.push(agents[i].load());
-                _loadedAgentNames.push(i);
+        var name, promises = [];
+        for (name in _enabledAgentNames) {
+            if (_enabledAgentNames.hasOwnProperty(name) && agents.hasOwnProperty(name) && agents[name].load) {
+                promises.push(agents[name].load());
+                _loadedAgentNames.push(name);
             }
         }
         return promises;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -74,13 +74,11 @@ define(function LiveDevelopment(require, exports, module) {
         "remote": require("LiveDevelopment/Agents/RemoteAgent"),
         "network": require("LiveDevelopment/Agents/NetworkAgent"),
         "dom": require("LiveDevelopment/Agents/DOMAgent"),
-        "css": require("LiveDevelopment/Agents/CSSAgent")
-        /* FUTURE 
+        "css": require("LiveDevelopment/Agents/CSSAgent"),
         "script": require("LiveDevelopment/Agents/ScriptAgent"),
         "highlight": require("LiveDevelopment/Agents/HighlightAgent"),
         "goto": require("LiveDevelopment/Agents/GotoAgent"),
         "edit": require("LiveDevelopment/Agents/EditAgent")
-        */
     };
 
     var _htmlDocumentPath; // the path of the html file open for live development

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -233,8 +233,8 @@ define(function LiveDevelopment(require, exports, module) {
 
     /** Unload the agents */
     function unloadAgents() {
-        _loadedAgentNames.forEach(function (i) {
-            agents[i].unload();
+        _loadedAgentNames.forEach(function (name) {
+            agents[name].unload();
         });
         _loadedAgentNames = [];
     }


### PR DESCRIPTION
Provides an enableAgent/disableAgent API in LiveDevelopment so that extensions can enable more 'experimental' agents.

Satisfies goals of #1301, but doesn't enable experimental agents by default (i.e. their 'load' functions won't get called).
