### PR TITLE
disabled dev tools in brackets-shell

### DIFF
--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -131,17 +131,15 @@ define(function (require, exports, module) {
         window.open(window.location.href);
     }
     
-    
-    // Register all the command handlers
-    CommandManager.register(Strings.CMD_RUN_UNIT_TESTS, Commands.DEBUG_RUN_UNIT_TESTS,      _handleRunUnitTests);
-    CommandManager.register(Strings.CMD_SHOW_PERF_DATA, Commands.DEBUG_SHOW_PERF_DATA,      _handleShowPerfData);
-    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,
-                                                        Commands.DEBUG_NEW_BRACKETS_WINDOW, _handleNewBracketsWindow);
-    
-    CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.TOGGLE_USE_TAB_CHARS,      _handleUseTabChars)
-        .setChecked(Editor.getUseTabChar());
+    /* Register all the command handlers */
     
     // Show Developer Tools (optionally enabled)
-    var cmdShowDevTools = CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
-    cmdShowDevTools.setEnabled(!!brackets.app.showDeveloperTools);
+    CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS,      Commands.DEBUG_SHOW_DEVELOPER_TOOLS,   handleShowDeveloperTools)
+        .setEnabled(!!brackets.app.showDeveloperTools);
+    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW, Commands.DEBUG_NEW_BRACKETS_WINDOW,    _handleNewBracketsWindow);
+    CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,      Commands.DEBUG_RUN_UNIT_TESTS,         _handleRunUnitTests);
+    CommandManager.register(Strings.CMD_SHOW_PERF_DATA,      Commands.DEBUG_SHOW_PERF_DATA,         _handleShowPerfData);
+    
+    CommandManager.register(Strings.CMD_USE_TAB_CHARS,       Commands.TOGGLE_USE_TAB_CHARS,         _handleUseTabChars)
+        .setChecked(Editor.getUseTabChar());
 });

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -133,7 +133,6 @@ define(function (require, exports, module) {
     
     
     // Register all the command handlers
-    CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
     CommandManager.register(Strings.CMD_RUN_UNIT_TESTS, Commands.DEBUG_RUN_UNIT_TESTS,      _handleRunUnitTests);
     CommandManager.register(Strings.CMD_SHOW_PERF_DATA, Commands.DEBUG_SHOW_PERF_DATA,      _handleShowPerfData);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,
@@ -141,4 +140,8 @@ define(function (require, exports, module) {
     
     CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.TOGGLE_USE_TAB_CHARS,      _handleUseTabChars)
         .setChecked(Editor.getUseTabChar());
+    
+    // Show Developer Tools (optionally enabled)
+    var cmdShowDevTools = CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, Commands.DEBUG_SHOW_DEVELOPER_TOOLS, handleShowDeveloperTools);
+    cmdShowDevTools.setEnabled(!!brackets.app.showDeveloperTools);
 });

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -91,9 +91,14 @@ define(function (require, exports, module) {
     }
     
     function _documentReadyHandler() {
-        $("#show-dev-tools").click(function () {
-            brackets.app.showDeveloperTools();
-        });
+        if (brackets.app.showDeveloperTools) {
+            $("#show-dev-tools").click(function () {
+                brackets.app.showDeveloperTools();
+            });
+        } else {
+            $("#show-dev-tools").remove();
+        }
+        
         $("#reload").click(function () {
             window.location.reload(true);
         });


### PR DESCRIPTION
brackets-shell will omit `brackets.app.showDeveloperTools()` in a later pull request.

When in brackets-shell: Disable menu item, remove nav link in SpecRunner.
