### PR TITLE
Prevent document changes when clicking close button in working set

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -111,6 +111,12 @@ define(function (require, exports, module) {
             
             $fileStatusIcon = $("<div class='file-status-icon'></div>")
                 .prependTo(listElement)
+                .mousedown(function (e) {
+                    // stopPropagation of mousedown for fileStatusIcon so the parent <LI> item, which
+                    // selects documents on mousedown, doesn't select the document in the case 
+                    // when the click is on fileStatusIcon
+                    e.stopPropagation();
+                })
                 .click(function () {
                     // Clicking the "X" button is equivalent to File > Close; it doesn't merely
                     // remove a file from the working set
@@ -321,7 +327,7 @@ define(function (require, exports, module) {
     function _handleDirtyFlagChanged(doc) {
         var listItem = _findListItemFromFile(doc.file);
         if (listItem) {
-            var canClose = $(listItem).find("can-close").length === 1;
+            var canClose = $(listItem).find(".can-close").length === 1;
             _updateFileStatusIcon(listItem, doc.isDirty, canClose);
         }
 


### PR DESCRIPTION
The dot "." for a class specifier was missing in _handleDirtyFlagChanged(). This caused the close icon to not work when clicking it when the document was loaded in the working set from application launch. When first selecting the document on mousedown, the close button would be set incorrectly so that the click event on the file status icon would never occur.
fix #1315

mouseDown needed to stop propagation when clicking on the close icon to prevent document selection prior to closing document
fix #1253

Also appears to fix #1059
