### PR TITLE
Change shortcut & clean up docs for Save All command

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -830,8 +830,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_CLOSE,               "Ctrl-W");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_SAVE,                "Ctrl-S");
-        menu.addMenuItem(Commands.FILE_SAVE_ALL,            [{key: "Ctrl-Shift-S",      platform: "win"},
-                                                             {key: "Cmd-Alt-S",         platform: "mac"}]);
+        menu.addMenuItem(Commands.FILE_SAVE_ALL,            "Ctrl-Alt-S");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW,   "Ctrl-Alt-P");
         menu.addMenuDivider();

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -443,13 +443,14 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Saves all the unsaved files.
-     * @param None
-     * @return {$.Promise} a promise that is resolved after the save completes
+     * Saves all unsaved documents.
+     * @return {$.Promise} a promise that is resolved once ALL the saves have been completed; or rejected
+     *      after all operations completed if any ONE of them failed.
      */
     function handleFileSaveAll() {
         return saveAll();
     }
+    
     /**
      * Reverts the Document to the current contents of its file on disk. Discards any unsaved changes
      * in the Document.


### PR DESCRIPTION
This is a follow-up to original pull request #1208, which has already been merged. See comments there for original discussion of these changes (including background / debate around the keyboard shortcut change).
