### PR TITLE
Fix HTMLUtils unit tests by adding a new parameter for the new property in tag info.

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
         var tagName = _extractTagName(ctx);
  
         //We're good. 
-        return createTagInfo(ATTR_VALUE, offset, tagName, attrName, attrVal);
+        return createTagInfo(ATTR_VALUE, offset, tagName, attrName, attrVal, true);
     }
 
     /**

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
                     '<p class="');
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class", "", true));
             });
             
             it("should find an attribute as it's added to a tag", function () {
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
                     [ '</div>', '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "id"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "id", "", true));
             });
             
             it("should find an attribute as the value is typed", function () {
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
                     [ '</div>', '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "id", "one"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "id", "one", true));
             });
             
             it("should not find an attribute as text is added", function () {
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
                     [ '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true));
             });
             
             it("should find the full attribute as an existing value is changed", function () {
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
                     [ '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo bar"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo bar", true));
             });
             
             it("should find the attribute value even when there is space around the =", function () {
@@ -152,7 +152,7 @@ define(function (require, exports, module) {
                     [ '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true));
             });
             
             it("should find the attribute value when the IP is after the =", function () {
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
                     [ '</body>', '</html>']);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class", "foo"));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class", "foo", true));
             });
             
             it("should find the tagname as it's typed", function () {


### PR DESCRIPTION
Also make it consistent by setting the new property to be true regardless of the value is empty or not as long as there is a equal sign.

This fixes issue #1339.
