### PR TITLE
handle same command in multiple menus

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -298,6 +298,12 @@ define(function (require, exports, module) {
         return (this.id + "-" + commandId);
     };
 
+    /**
+     * Determine MenuItem in this Menu, that has the specified command
+     *
+     * @param {Command} command - the command to search for.
+     * @return {?HTMLLIElement} menu item list element
+     */
     Menu.prototype._getMenuItemForCommand = function (command) {
         if (!command) {
             return null;
@@ -314,6 +320,7 @@ define(function (require, exports, module) {
      *
      * @param {?string} relativeID - id of command (future: sub-menu).
      * @param {?string} position - only needed when relativeID is a MenuSection
+     * @return {?HTMLLIElement} menu item list element
      */
     Menu.prototype._getRelativeMenuItem = function (relativeID, position) {
         var $relativeElement,
@@ -363,11 +370,11 @@ define(function (require, exports, module) {
                     // Lookup Command for this Command id
                     // Find MenuItem that has this command
                     $relativeElement = this._getMenuItemForCommand(command);
-                    if (!$relativeElement) {
-                        console.log("_getRelativeMenuItem(): MenuItem with Command id " + relativeID +
-                                    " not found in Menu " + this.id);
-                        return null;
-                    }
+                }
+                if (!$relativeElement) {
+                    console.log("_getRelativeMenuItem(): MenuItem with Command id " + relativeID +
+                                " not found in Menu " + this.id);
+                    return null;
                 }
             }
             

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -294,21 +294,15 @@ define(function (require, exports, module) {
         this.id = id;
     }
 
+    Menu.prototype._getMenuItemId = function (commandId) {
+        return (this.id + "-" + commandId);
+    };
+
     Menu.prototype._getMenuItemForCommand = function (command) {
-        var foundMenuItem, key, menuItem;
-        for (key in menuItemMap) {
-            if (menuItemMap.hasOwnProperty(key)) {
-                menuItem = menuItemMap[key];
-                if (menuItem.getCommand() === command) {
-                    // There can be multiple menu items with this command, so verify it's the same menu
-                    var parentMenu = menuItem.getParentMenu();
-                    if (parentMenu && (parentMenu.id === this.id)) {
-                        foundMenuItem = menuItem;
-                        break;
-                    }
-                }
-            }
+        if (!command) {
+            return null;
         }
+        var foundMenuItem = menuItemMap[this._getMenuItemId(command.getID())];
         if (!foundMenuItem) {
             return null;
         }
@@ -441,7 +435,7 @@ define(function (require, exports, module) {
         }
 
         // Internal id is the a composite of the parent menu id and the command id.
-        id = this.id + "-" + commandID;
+        id = this._getMenuItemId(commandID);
         
         if (menuItemMap[id]) {
             console.log("MenuItem added with same id of existing MenuItem: " + id);


### PR DESCRIPTION
This is for issue #1293. The main fix is to get the correct MenuItem associated with the Command id for the target Menu.

The designed behavior is to add MenuItem to end of target menu if the correct position cannot be determined (so that it just doesn't disappear into the ether). But, we were not logging any info to the console in some cases, so I added some messages. There should now be a console message for any case where the correct MenuItem position cannot be determined.

I also added an 8th test case to the description of bug.

I wrote an extension to test all of these cases. The main.js file can be found here:
https://gist.github.com/3299639
