### PR TITLE
Add CommandManager.getAll() API & minor doc cleanups

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
     /**
      * Restore original commands after test and release copy
      */
-    function _testRestore(commands) {
+    function _testRestore() {
         _commands = _commandsOriginal;
         _commandsOriginal = {};
     }
@@ -206,6 +206,14 @@ define(function (require, exports, module) {
      */
     function get(id) {
         return _commands[id];
+    }
+    
+    /**
+     * Returns the ids of all registered commands
+     * @return {Array.<string>}
+     */
+    function getAll() {
+        return Object.keys(_commands);
     }
 
     /**
@@ -227,6 +235,7 @@ define(function (require, exports, module) {
     exports.register        = register;
     exports.execute         = execute;
     exports.get             = get;
+    exports.getAll          = getAll;
     exports._testReset      = _testReset;
     exports._testRestore    = _testRestore;
 });

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -34,12 +34,14 @@ define(function (require, exports, module) {
     var CommandManager = require("command/CommandManager");
 
     /**
-     * @type {Object.<string, {{commandID: string, key: string, displayKey: string}}}
+     * Maps normalized shortcut descriptor to key binding info.
+     * @type {!Object.<string, {commandID: string, key: string, displayKey: string}>}
      */
     var _keyMap = {};
 
     /**
-     * @type {Object.<string, Array.<{{key: string, displayKey: string}}>}
+     * Maps commandID to the list of shortcuts that are bound to it.
+     * @type {!Object.<string, Array.<{key: string, displayKey: string}>>}
      */
     var _commandMap = {};
 
@@ -341,7 +343,7 @@ define(function (require, exports, module) {
 
     /**
      * Returns a copy of the keymap
-     * @returns {!{commandID:string, displayKey:string}}
+     * @returns {!Object.<string, {commandID: string, key: string, displayKey: string}>}
      */
     function getKeymap() {
         return $.extend({}, _keyMap);


### PR DESCRIPTION
- Add handy CommandManager.getAll() API -- useful for building things like my "search commands" extension, or a key binding management UI
- Remove unused arg to CommandManager._testRestore()
- Clean up some type documentation in KeyBindingManager
