### PR TITLE
Remove extra brace in dialog template. Fix typo in comment.

### DIFF
--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -169,7 +169,7 @@
             <p class="dialog-message">Message goes here</p>
         </div>
         <div class="modal-footer">
-            <a href="#" class="dialog-button btn left" data-button-id="cancel">{{CANCEL}}}</a>
+            <a href="#" class="dialog-button btn left" data-button-id="cancel">{{CANCEL}}</a>
             <a href="#" class="dialog-button btn primary" data-button-id="ok">{{RELAUNCH_CHROME}}</a>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
 </head>
 <body>
 
-    <!-- HTML content is dynamically loaded and rendered by bracket.js.
+    <!-- HTML content is dynamically loaded and rendered by brackets.js.
          Any modules that depend on or modify HTML during load should 
          listen for the "htmlContentLoadComplete" event that is triggered from
          the brackets global object before touching the dom. -->


### PR DESCRIPTION
Fixed a string bug I noticed in the Live Development Error dialog, and also fixed a comment typo I noticed in index.html.
