### PR TITLE
In Live Development, strip off query/hash strings from stylesheet URLs when comparing them

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define, $, PathUtils */
 
 /**
  * CSSAgent keeps track of loaded style sheets and allows reloading them
@@ -33,10 +33,21 @@
 define(function CSSAgent(require, exports, module) {
     "use strict";
 
+    require("thirdparty/path-utils/path-utils.min");
+    
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
 
     var _load; // {$.Deferred} load promise
     var _urlToStyle; // {url -> loaded} style definition
+    
+    /** 
+     * Create a canonicalized version of the given URL, stripping off query strings and hashes.
+     * @param {string} url the URL to canonicalize
+     * @return the canonicalized URL
+     */
+    function _canonicalize(url) {
+        return PathUtils.parseUrl(url).hrefNoSearch;
+    }
 
     // WebInspector Event: Page.loadEventFired
     function _onLoadEventFired(res) {
@@ -46,7 +57,7 @@ define(function CSSAgent(require, exports, module) {
             var i, header;
             for (i in res.headers) {
                 header = res.headers[i];
-                _urlToStyle[header.sourceURL] = header;
+                _urlToStyle[_canonicalize(header.sourceURL)] = header;
             }
             _load.resolve();
         });
@@ -56,7 +67,7 @@ define(function CSSAgent(require, exports, module) {
      * @param {string} url
      */
     function styleForURL(url) {
-        return _urlToStyle[url];
+        return _urlToStyle[_canonicalize(url)];
     }
     
     /** Get a list of all loaded stylesheet files by URL */

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -49,6 +49,7 @@ define(function ScriptAgent(require, exports, module) {
         node.trace = trace;
     }
 
+    // TODO: should the parameter to this be an ID rather than a URL?
     /** Get the script information for a given url
      * @param {string} url
      */
@@ -56,6 +57,7 @@ define(function ScriptAgent(require, exports, module) {
         return _idToScript[url];
     }
 
+    // TODO: Strip off query/hash strings from URL (see CSSAgent._canonicalize())
     /** Get the script information for a given url
      * @param {string} url
      */
@@ -79,6 +81,7 @@ define(function ScriptAgent(require, exports, module) {
         }
     }
 
+    // TODO: Strip off query/hash strings from URL (see CSSAgent._canonicalize())
     // WebInspector Event: Debugger.scriptParsed
     function _onScriptParsed(res) {
         // res = {scriptId, url, startLine, startColumn, endLine, endColumn, isContentScript, sourceMapURL}

--- a/test/spec/LiveDevelopment-test-files/simple1Query.html
+++ b/test/spec/LiveDevelopment-test-files/simple1Query.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Simple Test</title>
+<link rel="stylesheet" href="simpleShared.css">
+<link rel="stylesheet" href="simple1.css?1384938572406">
+</head>
+
+<body>
+<p id="testId" class="testClass">Brackets is awesome!</p>
+</body>
+</html>


### PR DESCRIPTION
Fixes #1373.
