### PR TITLE
Fix code hinting that broke due to localizing index.html

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         ViewUtils       = require("utils/ViewUtils");
 
 
-    var hintList,  /// initialized by htmlContentLoadComplete handler
+    var hintList,  // initialized by htmlContentLoadComplete handler
         shouldShowHintsOnKeyUp = false;
 
 
@@ -425,8 +425,8 @@ define(function (require, exports, module) {
 
     // Initialize variables and listeners that depend on the HTML DOM
     $(brackets).on("htmlContentLoadComplete", function () {
-       // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
-       // and different types of hint list when other types of hinting is added.
+        // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
+        // and different types of hint list when other types of hinting is added.
         hintList = new CodeHintList();
     });
     

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -36,6 +36,11 @@ define(function (require, exports, module) {
         PopUpManager    = require("widgets/PopUpManager"),
         ViewUtils       = require("utils/ViewUtils");
 
+
+    var hintList,  /// initialized by htmlContentLoadComplete handler
+        shouldShowHintsOnKeyUp = false;
+
+
     /**
      * @constructor
      *
@@ -339,10 +344,6 @@ define(function (require, exports, module) {
         return itemsPerPage;
     };
 
-    // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
-    // and different types of hint list when other types of hinting is added.
-    var hintList = new CodeHintList(),
-        shouldShowHintsOnKeyUp = false;
         
      /**
       * Show the code hint list near the current cursor position for the specified editor
@@ -421,6 +422,13 @@ define(function (require, exports, module) {
     function _getCodeHintList() {
         return hintList;
     }
+
+    // Initialize variables and listeners that depend on the HTML DOM
+    $(brackets).on("htmlContentLoadComplete", function () {
+       // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
+       // and different types of hint list when other types of hinting is added.
+        hintList = new CodeHintList();
+    });
     
     // Define public API
     exports.handleKeyEvent          = handleKeyEvent;

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
+/*global define, $, window, brackets */
 
 define(function (require, exports, module) {
     "use strict";
@@ -35,6 +35,11 @@ define(function (require, exports, module) {
         EditorManager   = require("editor/EditorManager"),
         PopUpManager    = require("widgets/PopUpManager"),
         ViewUtils       = require("utils/ViewUtils");
+
+
+    var hintList,  /// initialized by htmlContentLoadComplete handler
+        shouldShowHintsOnKeyUp = false;
+
 
     /**
      * @constructor
@@ -339,10 +344,6 @@ define(function (require, exports, module) {
         return itemsPerPage;
     };
 
-    // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
-    // and different types of hint list when other types of hinting is added.
-    var hintList = new CodeHintList(),
-        shouldShowHintsOnKeyUp = false;
         
      /**
       * Show the code hint list near the current cursor position for the specified editor
@@ -421,6 +422,13 @@ define(function (require, exports, module) {
     function _getCodeHintList() {
         return hintList;
     }
+
+    // Initialize variables and listeners that depend on the HTML DOM
+    $(brackets).on("htmlContentLoadComplete", function () {
+       // HintList is a singleton for now. Todo: Figure out broader strategy for hint list across editors
+       // and different types of hint list when other types of hinting is added.
+        hintList = new CodeHintList();
+    });
     
     // Define public API
     exports.handleKeyEvent          = handleKeyEvent;


### PR DESCRIPTION
CodeHintManager initalized some references to DOM elements in module init. Moved this code to the event handler for "htmlContentLoadComplete"
