### PR TITLE
Don't block keyPress events for charCode 33 and 34 (! and "). Let CodeMirror handles these.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -176,8 +176,9 @@ define(function (require, exports, module) {
         var keyCode = event.keyCode;
         
         // Up arrow, down arrow and enter key are always handled here
-        if (keyCode === 38 || keyCode === 40 || keyCode === 13 ||
-                keyCode === 33 || keyCode === 34) {
+        if (event.type !== "keypress" &&
+                (keyCode === 38 || keyCode === 40 || keyCode === 13 ||
+                keyCode === 33 || keyCode === 34)) {
 
             if (event.type === "keydown") {
                 if (keyCode === 38) {


### PR DESCRIPTION
This fixes issue #1394.
