### PR TITLE
Live development refactoring

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -34,12 +34,12 @@ define(function CSSAgent(require, exports, module) {
     "use strict";
 
     require("thirdparty/path-utils/path-utils.min");
-    
+
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
 
     var _load; // {$.Deferred} load promise
     var _urlToStyle; // {url -> loaded} style definition
-    
+
     /** 
      * Create a canonicalized version of the given URL, stripping off query strings and hashes.
      * @param {string} url the URL to canonicalize
@@ -50,7 +50,7 @@ define(function CSSAgent(require, exports, module) {
     }
 
     // WebInspector Event: Page.loadEventFired
-    function _onLoadEventFired(res) {
+    function _onLoadEventFired(event, res) {
         // res = {timestamp}
         _urlToStyle = {};
         Inspector.CSS.getAllStyleSheets(function onGetAllStyleSheets(res) {
@@ -69,7 +69,7 @@ define(function CSSAgent(require, exports, module) {
     function styleForURL(url) {
         return _urlToStyle[_canonicalize(url)];
     }
-    
+
     /** Get a list of all loaded stylesheet files by URL */
     function getStylesheetURLs() {
         var urls = [], url;
@@ -89,7 +89,7 @@ define(function CSSAgent(require, exports, module) {
         console.assert(style, "Style Sheet for document not loaded: " + doc.url);
         Inspector.CSS.setStyleSheetText(style.styleSheetId, doc.getText());
     }
-    
+
     /** Empties a CSS style sheet given a document that has been deleted
      * @param {Document} document
      */
@@ -102,13 +102,13 @@ define(function CSSAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        Inspector.on("Page.loadEventFired", _onLoadEventFired);
+        $(Inspector.Page).on("loadEventFired.CSSAgent", _onLoadEventFired);
         return _load.promise();
     }
 
     /** Clean up */
     function unload() {
-        Inspector.off("Page.loadEventFired", _onLoadEventFired);
+        $(Inspector.Page).off(".CSSAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
+/*global define, $ */
 
 /**
  * ConsoleAgent forwards all console message from the remote console to the
@@ -53,14 +53,14 @@ define(function ConsoleAgent(require, exports, module) {
     }
 
     // WebInspector Event: Console.messageAdded
-    function _onMessageAdded(res) {
+    function _onMessageAdded(event, res) {
         // res = {message}
         _lastMessage = res.message;
         _log(_lastMessage);
     }
 
     // WebInspector Event: Console.messageRepeatCountUpdated
-    function _onMessageRepeatCountUpdated(res) {
+    function _onMessageRepeatCountUpdated(event, res) {
         // res = {count}
         if (_lastMessage) {
             _log(_lastMessage);
@@ -68,23 +68,22 @@ define(function ConsoleAgent(require, exports, module) {
     }
 
     // WebInspector Event: Console.messagesCleared
-    function _onMessagesCleared(res) {
+    function _onMessagesCleared(event, res) {
         // res = {}
     }
 
     /** Initialize the agent */
     function load() {
         Inspector.Console.enable();
-        Inspector.on("Console.messageAdded", _onMessageAdded);
-        Inspector.on("Console.messageRepeatCountUpdated", _onMessageRepeatCountUpdated);
-        Inspector.on("Console.messagesCleared", _onMessagesCleared);
+        $(Inspector.Console)
+            .on("messageAdded.ConsoleAgent", _onMessageAdded)
+            .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
+            .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
     }
 
     /** Clean up */
     function unload() {
-        Inspector.off("Console.messageAdded", _onMessageAdded);
-        Inspector.off("Console.messageRepeatCountUpdated", _onMessageRepeatCountUpdated);
-        Inspector.off("Console.messagesCleared", _onMessagesCleared);
+        $(Inspector.Console).off(".ConsoleAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/EditAgent.js
+++ b/src/LiveDevelopment/Agents/EditAgent.js
@@ -75,7 +75,7 @@ define(function EditAgent(require, exports, module) {
     }
 
     // Remote Event: Go to the given source node
-    function _onRemoteEdit(res) {
+    function _onRemoteEdit(event, res) {
         // res = {nodeId, name, value}
         var node = DOMAgent.nodeWithId(res.nodeId);
         node = node.children[0];
@@ -90,7 +90,7 @@ define(function EditAgent(require, exports, module) {
             var from = codeMirror.posFromIndex(node.location + change.from);
             var to = codeMirror.posFromIndex(node.location + change.to);
             editor.document.replaceRange(change.text, from, to);
-            
+
             var newPos = codeMirror.posFromIndex(node.location + change.from + change.text.length);
             editor.setCursorPos(newPos.line, newPos.ch);
         }
@@ -98,12 +98,12 @@ define(function EditAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        Inspector.on("RemoteAgent.edit", _onRemoteEdit);
+        $(RemoteAgent).on("edit.EditAgent", _onRemoteEdit);
     }
 
     /** Initialize the agent */
     function unload() {
-        Inspector.off("RemoteAgent.edit", _onRemoteEdit);
+        $(RemoteAgent).off(".EditAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -112,7 +112,7 @@ define(function GotoAgent(require, exports, module) {
     }
 
     /** Gather options where to go to from the given source node */
-    function _onRemoteShowGoto(res) {
+    function _onRemoteShowGoto(event, res) {
         // res = {nodeId, name, value}
         var node = DOMAgent.nodeWithId(res.nodeId);
 
@@ -177,7 +177,7 @@ define(function GotoAgent(require, exports, module) {
     }
 
     /** Go to the given source node */
-    function _onRemoteGoto(res) {
+    function _onRemoteGoto(event, res) {
         // res = {nodeId, name, value}
         var location, url = res.value;
         var matches = /^(.*):([^:]+)$/.exec(url);
@@ -195,14 +195,14 @@ define(function GotoAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        Inspector.on("RemoteAgent.showgoto", _onRemoteShowGoto);
-        Inspector.on("RemoteAgent.goto", _onRemoteGoto);
+        $(RemoteAgent)
+            .on("showgoto.GotoAgent", _onRemoteShowGoto)
+            .on("goto.GotoAgent", _onRemoteGoto);
     }
 
     /** Initialize the agent */
     function unload() {
-        Inspector.off("RemoteAgent.showgoto", _onRemoteShowGoto);
-        Inspector.off("RemoteAgent.goto", _onRemoteGoto);
+        $(RemoteAgent).off(".GotoAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -28,6 +28,8 @@
 /**
  * HighlightAgent dispatches events for highlight requests from in-browser
  * highlight requests, and allows highlighting nodes and rules in the browser.
+ *
+ * Trigger "highlight" when a node should be highlighted
  */
 define(function HighlightAgent(require, exports, module) {
     "use strict";
@@ -39,12 +41,12 @@ define(function HighlightAgent(require, exports, module) {
     var _highlight; // active highlight
 
     // Remote Event: Highlight
-    function _onRemoteHighlight(res) {
+    function _onRemoteHighlight(event, res) {
         var node;
         if (res.value === "1") {
             node = DOMAgent.nodeWithId(res.nodeId);
         }
-        Inspector.trigger("HighlightAgent.highlight", node);
+        $(exports).triggerHandler("highlight", node);
     }
 
     /** Hide in-browser highlighting */
@@ -103,12 +105,12 @@ define(function HighlightAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _highlight = {};
-        Inspector.on("RemoteAgent.highlight", _onRemoteHighlight);
+        $(RemoteAgent).on("highlight.HighlightAgent", _onRemoteHighlight);
     }
 
     /** Clean up */
     function unload() {
-        Inspector.off("RemoteAgent.highlight", _onRemoteHighlight);
+        $(RemoteAgent).off(".HighlightAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
+/*global define, $ */
 
 /**
  * HighlightAgent dispatches events for highlight requests from in-browser

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -55,7 +55,7 @@ define(function NetworkAgent(require, exports, module) {
     }
 
     // WebInspector Event: Network.requestWillBeSent
-    function _onRequestWillBeSent(res) {
+    function _onRequestWillBeSent(event, res) {
         // res = {requestId, frameId, loaderId, documentURL, request, timestamp, initiator, stackTrace, redirectResponse}
         var url = _urlWithoutQueryString(res.request.url);
         _urlRequested[url] = true;
@@ -65,12 +65,12 @@ define(function NetworkAgent(require, exports, module) {
     function load() {
         _urlRequested = {};
         Inspector.Network.enable();
-        Inspector.on("Network.requestWillBeSent", _onRequestWillBeSent);
+        $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
     }
 
     /** Unload the agent */
     function unload() {
-        Inspector.off("Network.requestWillBeSent", _onRequestWillBeSent);
+        $(Inspector.Network).off(".NetworkAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -314,7 +314,7 @@ function RemoteFunctions() {
     }
 
     // install event listeners
-    
+
     /* FUTURE
     window.document.addEventListener("keyup", _onKeyUp);
     window.document.addEventListener("mousemove", _onMouse);
@@ -323,7 +323,7 @@ function RemoteFunctions() {
     window.document.addEventListener("mouseup", _preventEventWhenMeta, true);
     window.document.addEventListener("click", _onClick, true);
     */
-    
+
     return {
         "showGoto": showGoto,
         "hideHighlight": hideHighlight,

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -66,13 +66,13 @@ define(function ScriptAgent(require, exports, module) {
     }
 
     // DOMAgent Event: Document root loaded
-    function _onGetDocument(res) {
+    function _onGetDocument(event, res) {
         Inspector.DOMDebugger.setDOMBreakpoint(res.root.nodeId, "subtree-modified");
         _load.resolve();
     }
 
     // WebInspector Event: DOM.childNodeInserted
-    function _onChildNodeInserted(res) {
+    function _onChildNodeInserted(event, res) {
         // res = {parentNodeId, previousNodeId, node}
         if (_insertTrace) {
             var node = DOMAgent.nodeWithId(res.node.nodeId);
@@ -83,19 +83,19 @@ define(function ScriptAgent(require, exports, module) {
 
     // TODO: Strip off query/hash strings from URL (see CSSAgent._canonicalize())
     // WebInspector Event: Debugger.scriptParsed
-    function _onScriptParsed(res) {
+    function _onScriptParsed(event, res) {
         // res = {scriptId, url, startLine, startColumn, endLine, endColumn, isContentScript, sourceMapURL}
         _idToScript[res.scriptId] = res;
         _urlToScript[res.url] = res;
     }
 
     // WebInspector Event: Debugger.scriptFailedToParse
-    function _onScriptFailedToParse(res) {
+    function _onScriptFailedToParse(event, res) {
         // res = {url, scriptSource, startLine, errorLine, errorMessage}
     }
 
     // WebInspector Event: Debugger.paused
-    function _onPaused(res) {
+    function _onPaused(event, res) {
         // res = {callFrames, reason, data}
         switch (res.reason) {
 
@@ -124,21 +124,20 @@ define(function ScriptAgent(require, exports, module) {
         _load = new $.Deferred();
         Inspector.Debugger.enable();
         Inspector.Debugger.setPauseOnExceptions("uncaught");
-        Inspector.on("DOMAgent.getDocument", _onGetDocument);
-        Inspector.on("Debugger.scriptParsed", _onScriptParsed);
-        Inspector.on("Debugger.scriptFailedToParse", _onScriptFailedToParse);
-        Inspector.on("Debugger.paused", _onPaused);
-        Inspector.on("DOM.childNodeInserted", _onChildNodeInserted);
+        $(DOMAgent).on("getDocument.ScriptAgent", _onGetDocument);
+        $(Inspector.Debugger)
+            .on("scriptParsed.ScriptAgent", _onScriptParsed)
+            .on("scriptFailedToParse.ScriptAgent", _onScriptFailedToParse)
+            .on("paused.ScriptAgent", _onPaused);
+        $(Inspector.DOM).on("childNodeInserted.ScriptAgent", _onChildNodeInserted);
         return _load;
     }
 
     /** Clean up */
     function unload() {
-        Inspector.off("DOMAgent.getDocument", _onGetDocument);
-        Inspector.off("Debugger.scriptParsed", _onScriptParsed);
-        Inspector.off("Debugger.scriptFailedToParse", _onScriptFailedToParse);
-        Inspector.off("Debugger.paused", _onPaused);
-        Inspector.off("DOM.childNodeInserted", _onChildNodeInserted);
+        $(DOMAgent).off(".ScriptAgent");
+        $(Inspector.Debugger).off(".ScriptAgent");
+        $(Inspector.DOM).off(".ScriptAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -58,7 +58,7 @@ define(function CSSDocumentModule(require, exports, module) {
      */
     var CSSDocument = function CSSDocument(doc, editor, inspector) {
         this.doc = doc;
-        
+
         // FUTURE: Highlighting is currently disabled, since this code doesn't yet know
         // how to deal with different editors pointing at the same document.
 /*
@@ -66,9 +66,9 @@ define(function CSSDocumentModule(require, exports, module) {
         this._highlight = [];
         this.onHighlight = this.onHighlight.bind(this);
         this.onCursorActivity = this.onCursorActivity.bind(this);
-        Inspector.on("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).on("highlight", this.onHighlight);
 */
-        
+
         // Add a ref to the doc since we're listening for change events
         this.doc.addRef();
         this.onChange = this.onChange.bind(this);
@@ -89,7 +89,7 @@ define(function CSSDocumentModule(require, exports, module) {
             // res = {styleSheet}
             this.rules = res.styleSheet.rules;
         }.bind(this));
-        
+
         // If the CSS document is dirty, push the changes into the browser now
         if (doc.isDirty) {
             CSSAgent.reloadCSSForDocument(this.doc);
@@ -99,7 +99,7 @@ define(function CSSDocumentModule(require, exports, module) {
     /** Get the browser version of the StyleSheet object */
     CSSDocument.prototype.getStyleSheetFromBrowser = function getStyleSheetFromBrowser() {
         var deferred = new $.Deferred();
-        
+
         // WebInspector Command: CSS.getStyleSheet
         Inspector.CSS.getStyleSheet(this.styleSheet.styleSheetId, function callback(res) {
             // res = {styleSheet}
@@ -109,20 +109,20 @@ define(function CSSDocumentModule(require, exports, module) {
                 deferred.reject();
             }
         });
-        
+
         return deferred.promise();
     };
-    
+
     /** Get the browser version of the source */
     CSSDocument.prototype.getSourceFromBrowser = function getSourceFromBrowser() {
         var deferred = new $.Deferred();
-        
+
         this.getStyleSheetFromBrowser().done(function onDone(styleSheet) {
             deferred.resolve(styleSheet.text);
         }).fail(function onFail() {
             deferred.reject();
         });
-        
+
         return deferred.promise();
     };
 
@@ -132,7 +132,7 @@ define(function CSSDocumentModule(require, exports, module) {
         $(this.doc).off("deleted", this.onDeleted);
         this.doc.releaseRef();
 /*
-        Inspector.off("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).off("highlight", this.onHighlight);
         $(this.editor).off("cursorActivity", this.onCursorActivity);
         this.onHighlight();
 */
@@ -176,7 +176,7 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.onDeleted = function onDeleted(event, editor, change) {
         // clear the CSS
         CSSAgent.clearCSSForDocument(this.doc);
-        
+
         // shut down, since our Document is now dead
         this.close();
         $(this).triggerHandler("deleted", [this]);

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -58,7 +58,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         this.onHighlight = this.onHighlight.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onCursorActivity = this.onCursorActivity.bind(this);
-        Inspector.on("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).on("highlight", this.onHighlight);
         $(this.editor).on("change", this.onChange);
         $(this.editor).on("cursorActivity", this.onCursorActivity);
         this.onCursorActivity();
@@ -66,7 +66,7 @@ define(function HTMLDocumentModule(require, exports, module) {
 
     /** Close the document */
     HTMLDocument.prototype.close = function close() {
-        Inspector.off("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).off("highlight", this.onHighlight);
         $(this.editor).off("change", this.onChange);
         $(this.editor).off("cursorActivity", this.onCursorActivity);
         this.onHighlight();

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -60,7 +60,7 @@ define(function JSDocumentModule(require, exports, module) {
         this.onHighlight = this.onHighlight.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onCursorActivity = this.onCursorActivity.bind(this);
-        Inspector.on("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).on("highlight", this.onHighlight);
         $(this.editor).on("change", this.onChange);
         $(this.editor).on("cursorActivity", this.onCursorActivity);
         this.onCursorActivity();
@@ -68,7 +68,7 @@ define(function JSDocumentModule(require, exports, module) {
 
     /** Close the document */
     JSDocument.prototype.close = function close() {
-        Inspector.off("HighlightAgent.highlight", this.onHighlight);
+        $(HighlightAgent).off("highlight", this.onHighlight);
         $(this.editor).off("change", this.onChange);
         $(this.editor).off("cursorActivity", this.onCursorActivity);
         this.onHighlight();

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -83,31 +83,13 @@
 define(function Inspector(require, exports, module) {
     "use strict";
 
+    // jQuery exports object for events
+    var $exports = $(exports);
+
     var _messageId = 1; // id used for remote method calls, auto-incrementing
     var _messageCallbacks = {}; // {id -> function} for remote method calls
-    var _handlers = {}; // {name -> function} for attached event handlers
     var _socket; // remote debugger WebSocket
     var _connectDeferred; // The deferred connect
-
-    /** Trigger an event handler
-     * @param {function} event handler
-     * @param {Array} arguments array
-     */
-    function _triggerHandler(handler, args) {
-        handler.apply(undefined, args);
-    }
-
-    /** Trigger an event and all attached event handlers
-     * All passed arguments after the name are passed on as parameters.
-     * @param {string} event name
-     */
-    function trigger(name, res) {
-        var i, handlers = _handlers[name];
-        var args = Array.prototype.slice.call(arguments, 1);
-        for (i in handlers) {
-            window.setTimeout(_triggerHandler.bind(undefined, handlers[i], args));
-        }
-    }
 
     /** Check a parameter value against the given signature
      * This only checks for optional parameters, not types
@@ -138,7 +120,7 @@ define(function Inspector(require, exports, module) {
             // off auto re-opening when a new HTML file is selected.
             return;
         }
-        
+
         console.assert(_socket, "You must connect to the WebSocket before sending messages.");
         var id, callback, args, i, params = {};
 
@@ -164,17 +146,17 @@ define(function Inspector(require, exports, module) {
     /** WebSocket did close */
     function _onDisconnect() {
         _socket = undefined;
-        trigger("disconnect");
+        $exports.triggerHandler("disconnect");
     }
 
     /** WebSocket reported an error */
     function _onError(error) {
-        trigger("error", error);
+        $exports.triggerHandler("error", [error]);
     }
 
     /** WebSocket did open */
     function _onConnect() {
-        trigger("connect");
+        $exports.triggerHandler("connect");
     }
 
     /** Received message from the WebSocket
@@ -186,15 +168,18 @@ define(function Inspector(require, exports, module) {
      */
     function _onMessage(message) {
         var response = JSON.parse(message.data);
-        trigger("message", response);
+        $exports.triggerHandler("message", [response]);
         if (response.error) {
-            trigger("error", response.error);
+            $exports.triggerHandler("error", [response.error]);
         } else if (response.result) {
             if (_messageCallbacks[response.id]) {
                 _messageCallbacks[response.id](response.result);
             }
         } else {
-            trigger(response.method, response.params);
+            var domainAndMethod = response.method.split(".");
+            var domain = domainAndMethod[0];
+            var method = domainAndMethod[1];
+            $(exports[domain]).triggerHandler(method, response.params);
         }
     }
 
@@ -231,10 +216,7 @@ define(function Inspector(require, exports, module) {
      * @param {function} handler function
      */
     function on(name, handler) {
-        if (!_handlers[name]) {
-            _handlers[name] = [];
-        }
-        _handlers[name].push(handler);
+        $exports.on(name, handler);
     }
 
     /** Remove the given or all event handler(s) for the given event or remove all event handlers
@@ -242,18 +224,7 @@ define(function Inspector(require, exports, module) {
      * @param {function} optional handler function
      */
     function off(name, handler) {
-        if (!name) {
-            _handlers = {};
-        } else if (!handler) {
-            delete _handlers[name];
-        } else {
-            var i, handlers = _handlers[name];
-            for (i in handlers) {
-                if (handlers[i] === handler) {
-                    handlers.splice(i, 1);
-                }
-            }
-        }
+        $exports.off(name, handler);
     }
 
     /** Disconnect from the remote debugger WebSocket */
@@ -344,7 +315,6 @@ define(function Inspector(require, exports, module) {
     }
 
     // Export public functions
-    exports.trigger = trigger;
     exports.getAvailableSockets = getAvailableSockets;
     exports.on = on;
     exports.off = off;

--- a/src/LiveDevelopment/Inspector/Inspector.json
+++ b/src/LiveDevelopment/Inspector/Inspector.json
@@ -28,20 +28,6 @@
                     { "name": "object", "$ref": "Runtime.RemoteObject" },
                     { "name": "hints", "type": "object" }
                 ]
-            },
-            {
-                "name": "didCreateWorker",
-                "parameters": [
-                    { "name": "id", "type": "integer" },
-                    { "name": "url", "type": "string" },
-                    { "name": "isShared", "type": "boolean" }
-                ]
-            },
-            {
-                "name": "didDestroyWorker",
-                "parameters": [
-                    { "name": "id", "type": "integer" }
-                ]
             }
         ]
     },
@@ -87,6 +73,15 @@
                     { "name": "nodeCount", "type": "array", "items": { "$ref": "NodeCount" }},
                     { "name": "listenerCount", "type": "array", "items": { "$ref": "ListenerCount" }}
                 ]
+            },
+            {
+                "id": "MemoryBlock",
+                "type": "object",
+                "properties": [
+                    { "name": "size", "type": "number", "optional": true, "description": "Size of the block in bytes if available" },
+                    { "name": "name", "type": "string", "description": "Unique name used to identify the component that allocated this block" },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "MemoryBlock" }}
+                ]
             }
         ],
         "commands": [
@@ -95,6 +90,12 @@
                 "returns": [
                     { "name": "domGroups", "type": "array", "items": { "$ref": "DOMGroup" }},
                     { "name": "strings", "$ref": "StringStatistics" }
+                ]
+            },
+            {
+                "name": "getProcessMemoryDistribution",
+                "returns": [
+                    { "name": "distribution", "$ref": "MemoryBlock", "description": "An object describing all memory allocated by the process"}
                 ]
             }
         ]
@@ -177,7 +178,7 @@
                     { "name": "value", "type": "string", "description": "Cookie value." },
                     { "name": "domain", "type": "string", "description": "Cookie domain." },
                     { "name": "path", "type": "string", "description": "Cookie path." },
-                    { "name": "expires", "type": "integer", "description": "Cookie expires." },
+                    { "name": "expires", "type": "number", "description": "Cookie expires." },
                     { "name": "size", "type": "integer", "description": "Cookie size." },
                     { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
                     { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
@@ -310,11 +311,21 @@
                 "hidden": true
             },
             {
-                "name": "setScreenSizeOverride",
-                "description": "Overrides the values of window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and \"device-width\"/\"device-height\"-related CSS media query results",
+                "name": "canOverrideDeviceMetrics",
+                "description": "Checks whether <code>setDeviceMetricsOverride</code> can be invoked.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "If true, <code>setDeviceMetricsOverride</code> can safely be invoked on the agent." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setDeviceMetricsOverride",
+                "description": "Overrides the values of device screen dimensions (window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and \"device-width\"/\"device-height\"-related CSS media query results) and the font scale factor.",
                 "parameters": [
                     { "name": "width", "type": "integer", "description": "Overriding width value in pixels (minimum 0, maximum 10000000). 0 disables the override." },
-                    { "name": "height", "type": "integer", "description": "Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override." }
+                    { "name": "height", "type": "integer", "description": "Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override." },
+                    { "name": "fontScaleFactor", "type": "number", "description": "Overriding font scale factor value (must be positive). 1 disables the override." },
+                    { "name": "fitWindow", "type": "boolean", "description": "Whether a view that exceeds the available browser window area should be scaled down to fit." }
                 ],
                 "hidden": true
             },
@@ -324,6 +335,74 @@
                 "parameters": [
                     { "name": "result", "type": "boolean", "description": "True for showing paint rectangles" }
                 ],
+                "hidden": true
+            },
+            {
+                "name": "getScriptExecutionStatus",
+                "description": "Determines if scripts can be executed in the page.",
+                "returns": [
+                    { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+                ]
+            },
+            {
+                "name": "setScriptExecutionDisabled",
+                "description": "Switches script execution in the page.",
+                "parameters": [
+                    { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+                ]
+            },
+            {
+                "name": "setGeolocationOverride",
+                "description": "Overrides the Geolocation Position or Error.",
+                "parameters": [
+                    { "name": "latitude", "type": "number", "optional": true, "description": "Mock longitude"},
+                    { "name": "longitude", "type": "number", "optional": true, "description": "Mock latitude"},
+                    { "name": "accuracy", "type": "number", "optional": true, "description": "Mock accuracy"}
+                ],
+                "hidden": true
+            },
+            {
+                "name": "clearGeolocationOverride",
+                "description": "Clears the overriden Geolocation Position and Error.",
+                "hidden": true
+            },
+            {
+                "name": "canOverrideGeolocation",
+                "description": "Checks if Geolocation can be overridden.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser can ovrride Geolocation." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setDeviceOrientationOverride",
+                "description": "Overrides the Device Orientation.",
+                "parameters": [
+                    { "name": "alpha", "type": "number", "description": "Mock alpha"},
+                    { "name": "beta", "type": "number", "description": "Mock beta"},
+                    { "name": "gamma", "type": "number", "description": "Mock gamma"}
+                ],
+                "hidden": true
+            },
+            {
+                "name": "clearDeviceOrientationOverride",
+                "description": "Clears the overridden Device Orientation.",
+                "hidden": true
+            },
+            {
+                "name": "canOverrideDeviceOrientation",
+                "description": "Check the backend if Web Inspector can override the device orientation.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "If true, <code>setDeviceOrientationOverride</code> can safely be invoked on the agent." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setTouchEmulationEnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+                ],
+                "description": "Toggles mouse event-based touch event emulation.",
                 "hidden": true
             }
         ],
@@ -377,7 +456,30 @@
                     { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
                     { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
                     { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
-                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." }
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                    { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containsing abbreviated property values.", "hidden": true }
+                ]
+            },
+            {
+                "id": "ObjectPreview",
+                "type": "object",
+                "hidden": true,
+                "description": "Object containing abbreviated remote object value.",
+                "properties": [
+                    { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                    { "name": "overflow", "type": "boolean", "description": "True iff some of the properties of the original did not fit." },
+                    { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." }
+                ]
+            },
+            {
+                "id": "PropertyPreview",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+	                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+	                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+	                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
                 ]
             },
             {
@@ -403,7 +505,26 @@
                     { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
                     { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
                 ]
+            },
+            {
+                "id": "ExecutionContextId",
+                "type": "integer",
+                "description": "Id of an execution context.",
+                "hidden": true
+            },
+            {
+                "id": "ExecutionContextDescription",
+                "type": "object",
+                "description": "Description of an isolated world.",
+                "properties": [
+                    { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                    { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context." },
+                    { "name": "name", "type": "string", "description": "Human readable name describing given context." },
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the owning frame." }
+                ],
+                "hidden": true
             }
+
         ],
         "commands": [
             {
@@ -412,8 +533,8 @@
                     { "name": "expression", "type": "string", "description": "Expression to evaluate." },
                     { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
                     { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation.", "hidden": true },
-                    { "name": "doNotPauseOnExceptions", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions. Overrides setPauseOnException state.", "hidden": true },
-                    { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Specifies in which frame to perform evaluation.", "hidden": true },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page.", "hidden": true },
                     { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
                 ],
                 "returns": [
@@ -428,6 +549,7 @@
                     { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
                     { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
                     { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
                     { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." }
                 ],
                 "returns": [
@@ -465,6 +587,24 @@
                 "name": "run",
                 "hidden": true,
                 "description": "Tells inspected instance(worker or page) that it can run in case it was started paused."
+            },
+            {
+                "name": "setReportExecutionContextCreation",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Reporting enabled state." }
+                ],
+                "hidden": true,
+                "description": "Enables reporting about creation of isolated contexts by means of <code>isolatedContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing isolated context."
+            }
+
+        ],
+        "events": [
+            {
+                "name": "isolatedContextCreated",
+                "parameters": [
+                    { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created isolated contex." }
+                ],
+                "description": "Issued when new isolated context is created."
             }
         ]
     },
@@ -540,7 +680,7 @@
                 "name": "addInspectedHeapObject",
                 "parameters": [
                     { "name": "heapObjectId", "type": "integer" }
-		]
+                ]
             }
         ],
         "events": [
@@ -666,6 +806,17 @@
                 ]
             },
             {
+                "id": "WebSocketFrame",
+                "type": "object",
+                "description": "WebSocket frame data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                    { "name": "mask", "type": "boolean", "description": "WebSocke frame mask." },
+                    { "name": "payloadData", "type": "string", "description": "WebSocke frame payload data." }
+                ]
+            },
+            {
                 "id": "CachedResource",
                 "type": "object",
                 "description": "Information about the cached resource.",
@@ -764,7 +915,6 @@
                     { "name": "request", "$ref": "Request", "description": "Request data." },
                     { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
                     { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
-                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "JavaScript stack trace upon issuing this request." },
                     { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." }
                 ]
             },
@@ -865,6 +1015,36 @@
                     { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
                 ],
                 "hidden": true
+            },
+            {
+                "name": "webSocketFrameReceived",
+                "description": "Fired when WebSocket frame is received.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketFrameError",
+                "description": "Fired when WebSocket frame error occurs.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketFrameSent",
+                "description": "Fired when WebSocket frame is sent.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ],
+                "hidden": true
             }
         ]
     },
@@ -873,12 +1053,18 @@
         "hidden": true,
         "types": [
             {
+                "id": "DatabaseId",
+                "type": "string",
+                "description": "Unique identifier of Database object.",
+                "hidden": true
+            },
+            {
                 "id": "Database",
                 "type": "object",
                 "description": "Database object.",
                 "hidden": true,
                 "properties": [
-                    { "name": "id", "type": "string", "description": "Database ID." },
+                    { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
                     { "name": "domain", "type": "string", "description": "Database domain." },
                     { "name": "name", "type": "string", "description": "Database name." },
                     { "name": "version", "type": "string", "description": "Database version." }
@@ -902,7 +1088,7 @@
             {
                 "name": "getDatabaseTableNames",
                 "parameters": [
-                    { "name": "databaseId", "type": "integer" }
+                    { "name": "databaseId", "$ref": "DatabaseId" }
                 ],
                 "returns": [
                     { "name": "tableNames", "type": "array", "items": { "type": "string" } }
@@ -911,7 +1097,7 @@
             {
                 "name": "executeSQL",
                 "parameters": [
-                    { "name": "databaseId", "type": "integer" },
+                    { "name": "databaseId", "$ref": "DatabaseId" },
                     { "name": "query", "type": "string" }
                 ],
                 "returns": [
@@ -973,7 +1159,8 @@
                 "description": "Object store.",
                 "properties": [
                     { "name": "name", "type": "string", "description": "Object store name." },
-                    { "name": "keyPath", "type": "string", "description": "Object store key path." },
+                    { "name": "keyPath", "$ref": "KeyPath", "description": "Object store key path." },
+                    { "name": "autoIncrement", "type": "boolean", "description": "If true, object store has auto increment flag set." },
                     { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
                 ]
             },
@@ -983,7 +1170,7 @@
                 "description": "Object store index.",
                 "properties": [
                     { "name": "name", "type": "string", "description": "Index name." },
-                    { "name": "keyPath", "type": "string", "description": "Index key path." },
+                    { "name": "keyPath", "$ref": "KeyPath", "description": "Index key path." },
                     { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
                     { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
                 ]
@@ -1014,11 +1201,21 @@
             {
                 "id": "DataEntry",
                 "type": "object",
-                "description": "Key.",
+                "description": "Data entry.",
                 "properties": [
                     { "name": "key", "$ref": "Key", "description": "Key." },
                     { "name": "primaryKey", "$ref": "Key", "description": "Primary key." },
                     { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Value." }
+                ]
+            },
+            {
+                "id": "KeyPath",
+                "type": "object",
+                "description": "Key path.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["null", "string", "array"], "description": "Key path type." },
+                    { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                    { "name": "array", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Array value." }
                 ]
             }
         ],
@@ -1101,15 +1298,28 @@
         "hidden": true,
         "types": [
             {
+                "id": "StorageId",
+                "type": "string",
+                "description": "Unique identifier of DOM storage entry.",
+                "hidden": true
+            },
+            {
                 "id": "Entry",
                 "type": "object",
                 "description": "DOM Storage entry.",
                 "hidden": true,
                 "properties": [
-                    { "name": "host", "type": "string", "description": "Domain name." },
+                    { "name": "origin", "type": "string", "description": "Document origin." },
                     { "name": "isLocalStorage", "type": "boolean", "description": "True for local storage." },
-                    { "name": "id", "type": "number", "description": "Entry id for further reference." }
+                    { "name": "id", "$ref": "StorageId", "description": "Entry id for further reference." }
                 ]
+            },
+            {
+                "id": "Item",
+                "type": "array",
+                "description": "DOM Storage item.",
+                "hidden": true,
+                "items": { "type": "string" }
             }
         ],
         "commands": [
@@ -1124,16 +1334,16 @@
             {
                 "name": "getDOMStorageEntries",
                 "parameters": [
-                    { "name": "storageId", "type": "integer" }
+                    { "name": "storageId", "$ref": "StorageId" }
                 ],
                 "returns": [
-                    { "name": "entries", "type": "array", "items": { "$ref": "Entry"} }
+                    { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
                 ]
             },
             {
                 "name": "setDOMStorageItem",
                 "parameters": [
-                    { "name": "storageId", "type": "integer" },
+                    { "name": "storageId", "$ref": "StorageId" },
                     { "name": "key", "type": "string" },
                     { "name": "value", "type": "string" }
                 ],
@@ -1144,7 +1354,7 @@
             {
                 "name": "removeDOMStorageItem",
                 "parameters": [
-                    { "name": "storageId", "type": "integer" },
+                    { "name": "storageId", "$ref": "StorageId" },
                     { "name": "key", "type": "string" }
                 ],
                 "returns": [
@@ -1160,9 +1370,9 @@
                 ]
             },
             {
-                "name": "updateDOMStorage",
+                "name": "domStorageUpdated",
                 "parameters": [
-                    { "name": "storageId", "type": "integer" }
+                    { "name": "storageId",  "$ref": "StorageId" }
                 ]
             }
         ]
@@ -1257,6 +1467,35 @@
     {
         "domain": "FileSystem",
         "hidden": true,
+        "types": [
+            {
+                "id": "RequestId",
+                "type": "integer",
+                "description": "Request Identifier to glue a request and its completion event."
+            },
+            {
+                "id": "Entry",
+                "type": "object",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "filesystem: URL for the entry." },
+                    { "name": "name", "type": "string", "description": "The name of the file or directory." },
+                    { "name": "isDirectory", "type": "boolean", "description": "True if the entry is a directory." },
+                    { "name": "mimeType", "type": "string", "optional": true, "description": "MIME type of the entry, available for a file only." },
+                    { "name": "resourceType", "$ref": "Page.ResourceType", "optional": true, "description": "ResourceType of the entry, available for a file only." },
+                    { "name": "isTextFile", "type": "boolean", "optional": true, "description": "True if the entry is a text file." }
+                ],
+                "description": "Represents a browser side file or directory."
+            },
+            {
+                "id": "Metadata",
+                "type": "object",
+                "properties": [
+                    { "name": "modificationTime", "type": "number", "description": "Modification time." },
+                    { "name": "size", "type": "number", "description": "File size. This field is always zero for directories." }
+                ],
+                "description": "Represents metadata of a file or entry."
+            }
+        ],
         "commands": [
             {
                 "name": "enable",
@@ -1264,10 +1503,92 @@
             },
             {
                 "name": "disable",
-                "description": "Disables events from backend.."
+                "description": "Disables events from backend."
+            },
+            {
+                "name": "requestFileSystemRoot",
+                "parameters": [
+                    { "name": "origin", "type": "string", "description": "Security origin of requesting FileSystem. One of frames in current page needs to have this security origin." },
+                    { "name": "type", "type": "string", "enum": ["temporary", "persistent"], "description": "FileSystem type of requesting FileSystem." }
+                ],
+                "returns": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier. Corresponding fileSystemRootReceived event should have same requestId with this." }
+                ],
+                "description": "Returns root directory of the FileSystem as fileSystemRootReceived event, if exists."
+            },
+            {
+                "name": "requestDirectoryContent",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the directory that the frontend is requesting to read from." }
+                ],
+                "returns": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier. Corresponding directoryContentReceived event should have same requestId with this." }
+                ],
+                "description": "Returns content of the directory as directoryContentReceived event."
+            },
+            {
+                "name": "requestMetadata",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the entry that the frontend is requesting to get metadata from." }
+                ],
+                "returns": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier. Corresponding metadataReceived event should have same requestId with this." }
+                ],
+                "description": "Returns metadata of the entry as metadataReceived event."
+            },
+            {
+                "name": "requestFileContent",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the file that the frontend is requesting to read from." },
+                    { "name": "readAsText", "type": "boolean", "description": "True if the content should be read as text, otherwise the result will be returned as base64 encoded text." },
+                    { "name": "start", "type": "integer", "optional": true, "description": "Specifies the start of range to read." },
+                    { "name": "end", "type": "integer", "optional": true, "description": "Specifies the end of range to read exclusively." },
+                    { "name": "charset", "type": "string", "optional": true, "description": "Overrides charset of the content when content is served as text." }
+                ],
+                "returns": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier. Corresponding fileContentReceived event should have same requestId with this." }
+                ],
+                "description": "Returns content of the file as fileContentReceived event. Result should be sliced into [start, end)."
             }
         ],
         "events": [
+            {
+                "name": "fileSystemRootReceived",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request Identifier that was returned by corresponding requestFileSystemRoot command." },
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "root", "$ref": "FileSystem.Entry", "optional": true, "description": "Contains root of the requested FileSystem if the command completed successfully." }
+                ],
+                "description": "Completion event of requestFileSystemRoot command."
+            },
+            {
+                "name": "directoryContentReceived",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request Identifier that was returned by corresponding requestDirectoryContent command." },
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "entries", "type": "array", "items": { "$ref": "FileSystem.Entry" }, "optional": true, "description": "Contains all entries on directory if the command completed successfully." }
+                ],
+                "description": "Completion event of requestDirectoryContent command."
+            },
+            {
+                "name": "metadataReceived",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request Identifier that was returned in response to the corresponding requestMetadata command." },
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "metadata", "$ref": "FileSystem.Metadata", "optional": true, "description": "Contains metadata of the entry if the command completed successfully." }
+                ],
+                "description": "Completion event of requestMetadata command."
+            },
+            {
+                "name": "fileContentReceived",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request Identifier that was returned in response to the corresponding requestFileContent command." },
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "content", "type": "string", "optional": true, "description": "Content of the file." },
+                    { "name": "charset", "type": "string", "optional": true, "description": "Charset of the content if it is served as text." }
+                ],
+                "description": "Completion event of requestFileContent command."
+            }
         ]
     },
     {
@@ -1590,14 +1911,6 @@
                 "description": "Moves node into the new container, places it before the given anchor."
             },
             {
-                "name": "setTouchEmulationEnabled",
-                "parameters": [
-                    { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
-                ],
-                "description": "Toggles mouse event-based touch event emulation.",
-                "hidden": true
-            },
-            {
                 "name": "undo",
                 "description": "Undoes the last performed action.",
                 "hidden": true
@@ -1723,6 +2036,12 @@
                 "description": "This object identifies a CSS style in a unique way."
             },
             {
+                "id": "StyleSheetOrigin",
+                "type": "string",
+                "enum": ["user", "user-agent", "inspector", "regular"],
+                "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+            },
+            {
                 "id": "CSSRuleId",
                 "type": "object",
                 "properties": [
@@ -1763,7 +2082,9 @@
                 "type": "object",
                 "properties": [
                     { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Owner frame identifier."},
                     { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
                     { "name": "title", "type": "string", "description": "Stylesheet title."},
                     { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
                 ],
@@ -1787,7 +2108,7 @@
                     { "name": "selectorText", "type": "string", "description": "Rule selector."},
                     { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
                     { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
-                    { "name": "origin", "type": "string", "enum": ["user", "user-agent", "inspector", "regular"], "description": "The parent stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding new rules created with <code>addRule()</code>), \"regular\" for regular stylesheets."},
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
                     { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
                     { "name": "selectorRange", "$ref": "SourceRange", "optional": true, "description": "The rule selector range in the underlying resource (if available)." },
                     { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
@@ -1808,13 +2129,21 @@
                 "type": "object"
             },
             {
+                "id": "CSSPropertyInfo",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." }
+                ]
+            },
+            {
                 "id": "CSSComputedStyleProperty",
                 "type": "object",
                 "properties": [
                     { "name": "name", "type": "string", "description": "Computed style property name." },
                     { "name": "value", "type": "string", "description": "Computed style property value." }
                 ]
-            },            
+            },
             {
                 "id": "CSSStyle",
                 "type": "object",
@@ -1840,7 +2169,6 @@
                     { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
                     { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
                     { "name": "status", "type": "string", "enum": ["active", "inactive", "disabled", "style"], "optional": true, "description": "The property status: \"active\" (implied if absent) if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" if the property is reported by the browser rather than by the CSS source parser." },
-                    { "name": "shorthandName", "type": "string", "optional": true, "description": "The related shorthand property name (absent if this property is not a longhand)." },
                     { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
                 ],
                 "description": "CSS style effective visual dimensions and source offsets."
@@ -1876,6 +2204,29 @@
                     { "name": "totalTime", "type": "number", "description": "Total processing time for all selectors in the profile (in milliseconds.)" },
                     { "name": "data", "type": "array", "items": { "$ref": "SelectorProfileEntry" }, "description": "CSS selector profile entries." }
                 ]
+            },
+            {
+                "id": "Region",
+                "type": "object",
+                "properties": [
+                    { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+                ],
+                "description": "This object represents a region that flows from a Named Flow.",
+                "hidden": true
+            },
+            {
+                "id": "NamedFlow",
+                "type": "object",
+                "properties": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                    { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                    { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+                ],
+                "description": "This object represents a Named Flow.",
+                "hidden": true
             }
         ],
         "commands": [
@@ -1891,7 +2242,6 @@
                 "name": "getMatchedStylesForNode",
                 "parameters": [
                     { "name": "nodeId", "$ref": "DOM.NodeId" },
-                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "optional": true, "description": "Element pseudo classes to force when computing applicable style rules." },
                     { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
                     { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
                 ],
@@ -1916,8 +2266,7 @@
             {
                 "name": "getComputedStyleForNode",
                 "parameters": [
-                    { "name": "nodeId", "$ref": "DOM.NodeId" },
-                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "optional": true, "description": "Element pseudo classes to force when computing applicable style rules." }
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
                 ],
                 "returns": [
                     { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
@@ -2009,9 +2358,17 @@
             {
                 "name": "getSupportedCSSProperties",
                 "returns": [
-                    { "name": "cssProperties", "type": "array", "items": { "type": "string" }, "description": "Supported property names." }
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
                 ],
                 "description": "Returns all supported CSS property names."
+            },
+            {
+                "name": "forcePseudoState",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+                ],
+                "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
             },
             {
                 "name": "startSelectorProfiler"
@@ -2021,6 +2378,29 @@
                 "returns": [
                     { "name": "profile", "$ref": "SelectorProfile" }
                 ]
+            },
+            {
+                "name": "getNamedFlowCollection",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+                ],
+                "returns": [
+                    { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+                ],
+                "description": "Returns the Named Flows from the document.",
+                "hidden": true
+            },
+            {
+                "name": "getFlowByName",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "name", "type": "string", "description": "Named Flow identifier." }
+                ],
+                "returns": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "A Named Flow." }
+                ],
+                "description": "Returns the Named Flow identified by the given name",
+                "hidden": true
             }
         ],
         "events": [
@@ -2034,6 +2414,24 @@
                     { "name": "styleSheetId", "$ref": "StyleSheetId" }
                 ],
                 "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+            },
+            {
+                "name": "namedFlowCreated",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "namedFlow", "type": "string", "description": "Identifier of the new Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is created.",
+                "hidden": true
+            },
+            {
+                "name": "namedFlowRemoved",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "namedFlow", "type": "string", "description": "Identifier of the removed Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is removed: has no associated content nodes and regions.",
+                "hidden": true
             }
         ]
     },
@@ -2071,6 +2469,14 @@
                 ],
                 "hidden": true,
                 "description": "Starts calculating various DOM statistics and sending them as part of timeline events."
+            },
+            {
+                "name": "supportsFrameInstrumentation",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if timeline supports frame instrumentation." }
+                ],
+                "hidden": true,
+                "description": "Tells whether timeline agent supports frame instrumentation."
             }
         ],
         "events": [
@@ -2120,7 +2526,8 @@
                     { "name": "location", "$ref": "Location", "description": "Location of the function." },
                     { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
                     { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
-                    { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." }
+                    { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                    { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
                 ],
                 "description": "Information about the function."
             },
@@ -2156,12 +2563,12 @@
                 "description": "Tells whether enabling debugger causes scripts recompilation."
             },
             {
-                "name": "supportsNativeBreakpoints",
+                "name": "supportsSeparateScriptCompilationAndExecution",
                 "returns": [
-                    { "name": "result", "type": "boolean", "description": "True if debugger supports native breakpoints." }
+                    { "name": "result", "type": "boolean", "description": "True if debugger supports separate script compilation and execution." }
                 ],
                 "hidden": true,
-                "description": "Tells whether debugger supports native breakpoints."
+                "description": "Tells whether debugger supports separate script compilation and execution."
             },
             {
                 "name": "enable",
@@ -2189,7 +2596,7 @@
                 ],
                 "returns": [
                     { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
-                    { "name": "locations", "optional": true, "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+                    { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
                 ],
                 "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
             },
@@ -2273,6 +2680,18 @@
                 "description": "Edits JavaScript source live."
             },
             {
+                "name": "restartFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame"}, "description": "New stack trace." },
+                    { "name": "result", "type": "object", "description": "VM-specific description.", "hidden": true }
+                ],
+                "hidden": true,
+                "description": "Restarts particular call frame from the beginning."
+            },
+            {
                 "name": "getScriptSource",
                 "parameters": [
                     { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
@@ -2307,6 +2726,7 @@
                     { "name": "expression", "type": "string", "description": "Expression to evaluate." },
                     { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
                     { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false.", "hidden": true },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
                     { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
                 ],
                 "returns": [
@@ -2314,6 +2734,42 @@
                     { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
                 ],
                 "description": "Evaluates expression on a given call frame."
+            },
+            {
+                "name": "compileScript",
+                "hidden": true,
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to compile." },
+                    { "name": "sourceURL", "type": "string", "description": "Source url to be set for the script." }
+                ],
+                "returns": [
+                    { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Id of the script." },
+                    { "name": "syntaxErrorMessage", "type": "string", "optional": true, "description": "Syntax error message if compilation failed." }
+                ],
+                "description": "Compiles expression."
+            },
+            {
+                "name": "runScript",
+                "hidden": true,
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to run." },
+                    { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform script run. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether script run should stop on exceptions and mute console. Overrides setPauseOnException state." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Run result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the script run." }
+                ],
+                "description": "Runs script with given id in a given context."
+            },
+            {
+                "name": "setOverlayMessage",
+                "parameters": [
+                    { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+                ],
+                "hidden": true,
+                "description": "Sets overlay message."
             }
         ],
         "events": [
@@ -2448,14 +2904,29 @@
         "hidden": true,
         "types": [
             {
-                "id": "Profile",
-                "type": "object",
-                "description": "Profile."
-            },
-            {
                 "id": "ProfileHeader",
                 "type": "object",
-                "description": "Profile header."
+                "description": "Profile header.",
+                "properties": [
+                    { "name": "typeId", "type": "string", "enum": ["CPU", "CSS", "HEAP"], "description": "Profile type name." },
+                    { "name": "title", "type": "string", "description": "Profile title." },
+                    { "name": "uid", "type": "integer", "description": "Unique identifier of the profile." },
+                    { "name": "maxJSObjectId", "type": "integer", "optional": true, "description": "Last seen JS object Id." }
+                ]
+            },
+            {
+                "id": "Profile",
+                "type": "object",
+                "description": "Profile.",
+                "properties": [
+                    { "name": "head", "type": "object", "optional": true },
+                    { "name": "bottomUpHead", "type": "object", "optional": true }
+                ]
+            },
+            {
+                "id": "HeapSnapshotObjectId",
+                "type": "string",
+                "description": "Heap snashot object id."
             }
         ],
         "commands": [
@@ -2524,11 +2995,20 @@
             {
                 "name": "getObjectByHeapObjectId",
                 "parameters": [
-                    { "name": "objectId", "type": "integer" },
+                    { "name": "objectId", "$ref": "HeapSnapshotObjectId" },
                     { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
                 ],
                 "returns": [
                     { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Evaluation result." }
+                ]
+            },
+            {
+                "name": "getHeapObjectId",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Identifier of the object to get heap object id for." }
+                ],
+                "returns": [
+                    { "name": "heapSnapshotObjectId", "$ref": "HeapSnapshotObjectId", "description": "Id of the heap snapshot object corresponding to the passed remote object id." }
                 ]
             }
         ],
@@ -2576,10 +3056,10 @@
         "types": [],
         "commands": [
             {
-                "name": "setWorkerInspectionEnabled",
-                "parameters": [
-                    { "name": "value", "type": "boolean" }
-                ]
+                "name": "enable"
+            },
+            {
+                "name": "disable"
             },
             {
                 "name": "sendMessageToWorker",
@@ -2633,5 +3113,21 @@
                 "name": "disconnectedFromWorker"
             }
         ]
+    },
+    {
+        "domain": "WebGL",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables WebGL inspection."
+            },
+            {
+                "name": "disable",
+                "description": "Disables WebGL inspection."
+            }
+        ],
+        "events": []
     }]
 }

--- a/src/LiveDevelopment/Inspector/inspector.html
+++ b/src/LiveDevelopment/Inspector/inspector.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html>
 <head>
 <title>Inspector 1.0 Documentation</title>
@@ -25,10 +24,10 @@ _domain = domainAndName[0];
 $(_domain).show();
 speed = 0;
 } else {
-speed = 'fast';
+speed = "fast";
 }
-$('html, body').animate({
-scrollTop: symbol.offset().top - 70 + 'px'
+$("html, body").animate({
+scrollTop: symbol.offset().top - 70 + "px"
 }, speed);
 if (domainAndName.length > 1) symbol.effect("highlight", { color: "#ffc"}, 1000);
 });
@@ -55,557 +54,624 @@ footer p {text-align: center; margin: 0;}
 <li class="dropdown" id="domain-menu">
 <a class="dropdown-toggle" data-toggle="dropdown">Domains<b class="caret"></b></a>
 <ul class="dropdown-menu">
-<li><a href="#ApplicationCache">ApplicationCache</a></li>
-<li><a href="#CSS">CSS</a></li>
-<li><a href="#Console">Console</a></li>
-<li><a href="#DOM">DOM</a></li>
-<li><a href="#DOMDebugger">DOMDebugger</a></li>
-<li><a href="#DOMStorage">DOMStorage</a></li>
-<li><a href="#Database">Database</a></li>
-<li><a href="#Debugger">Debugger</a></li>
-<li><a href="#FileSystem">FileSystem</a></li>
-<li><a href="#IndexedDB">IndexedDB</a></li>
-<li><a href="#Inspector">Inspector</a></li>
-<li><a href="#Memory">Memory</a></li>
-<li><a href="#Network">Network</a></li>
-<li><a href="#Page">Page</a></li>
-<li><a href="#Profiler">Profiler</a></li>
-<li><a href="#Runtime">Runtime</a></li>
-<li><a href="#Timeline">Timeline</a></li>
-<li><a href="#Worker">Worker</a></li>
+<li><a href='#ApplicationCache'>ApplicationCache</a></li>
+<li><a href='#CSS'>CSS</a></li>
+<li><a href='#Console'>Console</a></li>
+<li><a href='#DOM'>DOM</a></li>
+<li><a href='#DOMDebugger'>DOMDebugger</a></li>
+<li><a href='#DOMStorage'>DOMStorage</a></li>
+<li><a href='#Database'>Database</a></li>
+<li><a href='#Debugger'>Debugger</a></li>
+<li><a href='#FileSystem'>FileSystem</a></li>
+<li><a href='#IndexedDB'>IndexedDB</a></li>
+<li><a href='#Inspector'>Inspector</a></li>
+<li><a href='#Memory'>Memory</a></li>
+<li><a href='#Network'>Network</a></li>
+<li><a href='#Page'>Page</a></li>
+<li><a href='#Profiler'>Profiler</a></li>
+<li><a href='#Runtime'>Runtime</a></li>
+<li><a href='#Timeline'>Timeline</a></li>
+<li><a href='#WebGL'>WebGL</a></li>
+<li><a href='#Worker'>Worker</a></li>
 </ul>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="container">
-<section id="toc" class="domain">
+<div class='container'>
+<section id='toc' class='domain'>
 <h1>Table of Contents</h1>
 <h3><a href="#ApplicationCache">ApplicationCache</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#ApplicationCache.ApplicationCacheResource">ApplicationCache.ApplicationCacheResource</a>: Detailed application cache resource information.</li>
-<li><a href="#ApplicationCache.ApplicationCache">ApplicationCache.ApplicationCache</a>: Detailed application cache information.</li>
-<li><a href="#ApplicationCache.FrameWithManifest">ApplicationCache.FrameWithManifest</a>: Frame identifier - manifest URL pair.</li>
+<li><a href='#ApplicationCache.ApplicationCacheResource'>ApplicationCache.ApplicationCacheResource</a>: Detailed application cache resource information.</li>
+<li><a href='#ApplicationCache.ApplicationCache'>ApplicationCache.ApplicationCache</a>: Detailed application cache information.</li>
+<li><a href='#ApplicationCache.FrameWithManifest'>ApplicationCache.FrameWithManifest</a>: Frame identifier - manifest URL pair.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#ApplicationCache.getFramesWithManifests">ApplicationCache.getFramesWithManifests</a>: Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</li>
-<li><a href="#ApplicationCache.enable">ApplicationCache.enable</a>: Enables application cache domain notifications.</li>
-<li><a href="#ApplicationCache.getManifestForFrame">ApplicationCache.getManifestForFrame</a>: Returns manifest URL for document in the given frame.</li>
-<li><a href="#ApplicationCache.getApplicationCacheForFrame">ApplicationCache.getApplicationCacheForFrame</a>: Returns relevant application cache data for the document in given frame.</li>
+<li><a href='#ApplicationCache.getFramesWithManifests'>ApplicationCache.getFramesWithManifests</a>: Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</li>
+<li><a href='#ApplicationCache.enable'>ApplicationCache.enable</a>: Enables application cache domain notifications.</li>
+<li><a href='#ApplicationCache.getManifestForFrame'>ApplicationCache.getManifestForFrame</a>: Returns manifest URL for document in the given frame.</li>
+<li><a href='#ApplicationCache.getApplicationCacheForFrame'>ApplicationCache.getApplicationCacheForFrame</a>: Returns relevant application cache data for the document in given frame.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#ApplicationCache.applicationCacheStatusUpdated">ApplicationCache.applicationCacheStatusUpdated</a></li>
-<li><a href="#ApplicationCache.networkStateUpdated">ApplicationCache.networkStateUpdated</a></li>
+<li><a href='#ApplicationCache.applicationCacheStatusUpdated'>ApplicationCache.applicationCacheStatusUpdated</a></li>
+<li><a href='#ApplicationCache.networkStateUpdated'>ApplicationCache.networkStateUpdated</a></li>
 </ul>
 <h3><a href="#CSS">CSS</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></li>
-<li><a href="#CSS.CSSStyleId">CSS.CSSStyleId</a>: This object identifies a CSS style in a unique way.</li>
-<li><a href="#CSS.CSSRuleId">CSS.CSSRuleId</a>: This object identifies a CSS rule in a unique way.</li>
-<li><a href="#CSS.PseudoIdRules">CSS.PseudoIdRules</a>: CSS rule collection for a single pseudo style.</li>
-<li><a href="#CSS.InheritedStyleEntry">CSS.InheritedStyleEntry</a>: CSS rule collection for a single pseudo style.</li>
-<li><a href="#CSS.CSSStyleAttribute">CSS.CSSStyleAttribute</a>: CSS style information for a DOM style attribute.</li>
-<li><a href="#CSS.CSSStyleSheetHeader">CSS.CSSStyleSheetHeader</a>: CSS stylesheet metainformation.</li>
-<li><a href="#CSS.CSSStyleSheetBody">CSS.CSSStyleSheetBody</a>: CSS stylesheet contents.</li>
-<li><a href="#CSS.CSSRule">CSS.CSSRule</a>: CSS rule representation.</li>
-<li><a href="#CSS.SourceRange">CSS.SourceRange</a>: Text range within a resource.</li>
-<li><a href="#CSS.ShorthandEntry">CSS.ShorthandEntry</a></li>
-<li><a href="#CSS.CSSComputedStyleProperty">CSS.CSSComputedStyleProperty</a></li>
-<li><a href="#CSS.CSSStyle">CSS.CSSStyle</a>: CSS style representation.</li>
-<li><a href="#CSS.CSSProperty">CSS.CSSProperty</a>: CSS style effective visual dimensions and source offsets.</li>
-<li><a href="#CSS.CSSMedia">CSS.CSSMedia</a>: CSS media query descriptor.</li>
-<li><a href="#CSS.SelectorProfileEntry">CSS.SelectorProfileEntry</a>: CSS selector profile entry.</li>
-<li><a href="#CSS.SelectorProfile">CSS.SelectorProfile</a></li>
+<li><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></li>
+<li><a href='#CSS.CSSStyleId'>CSS.CSSStyleId</a>: This object identifies a CSS style in a unique way.</li>
+<li><a href='#CSS.StyleSheetOrigin'>CSS.StyleSheetOrigin</a>: Stylesheet type: "user" for user stylesheets, "user-agent" for user-agent stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via inspector" rules), "regular" for regular stylesheets.</li>
+<li><a href='#CSS.CSSRuleId'>CSS.CSSRuleId</a>: This object identifies a CSS rule in a unique way.</li>
+<li><a href='#CSS.PseudoIdRules'>CSS.PseudoIdRules</a>: CSS rule collection for a single pseudo style.</li>
+<li><a href='#CSS.InheritedStyleEntry'>CSS.InheritedStyleEntry</a>: CSS rule collection for a single pseudo style.</li>
+<li><a href='#CSS.CSSStyleAttribute'>CSS.CSSStyleAttribute</a>: CSS style information for a DOM style attribute.</li>
+<li><a href='#CSS.CSSStyleSheetHeader'>CSS.CSSStyleSheetHeader</a>: CSS stylesheet metainformation.</li>
+<li><a href='#CSS.CSSStyleSheetBody'>CSS.CSSStyleSheetBody</a>: CSS stylesheet contents.</li>
+<li><a href='#CSS.CSSRule'>CSS.CSSRule</a>: CSS rule representation.</li>
+<li><a href='#CSS.SourceRange'>CSS.SourceRange</a>: Text range within a resource.</li>
+<li><a href='#CSS.ShorthandEntry'>CSS.ShorthandEntry</a></li>
+<li><a href='#CSS.CSSPropertyInfo'>CSS.CSSPropertyInfo</a></li>
+<li><a href='#CSS.CSSComputedStyleProperty'>CSS.CSSComputedStyleProperty</a></li>
+<li><a href='#CSS.CSSStyle'>CSS.CSSStyle</a>: CSS style representation.</li>
+<li><a href='#CSS.CSSProperty'>CSS.CSSProperty</a>: CSS style effective visual dimensions and source offsets.</li>
+<li><a href='#CSS.CSSMedia'>CSS.CSSMedia</a>: CSS media query descriptor.</li>
+<li><a href='#CSS.SelectorProfileEntry'>CSS.SelectorProfileEntry</a>: CSS selector profile entry.</li>
+<li><a href='#CSS.SelectorProfile'>CSS.SelectorProfile</a></li>
+<li><a href='#CSS.Region'>CSS.Region</a>: This object represents a region that flows from a Named Flow.</li>
+<li><a href='#CSS.NamedFlow'>CSS.NamedFlow</a>: This object represents a Named Flow.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#CSS.enable">CSS.enable</a>: Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received.</li>
-<li><a href="#CSS.disable">CSS.disable</a>: Disables the CSS agent for the given page.</li>
-<li><a href="#CSS.getMatchedStylesForNode">CSS.getMatchedStylesForNode</a>: Returns requested styles for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getInlineStylesForNode">CSS.getInlineStylesForNode</a>: Returns the styles defined inline (explicitly in the "style" attribute and implicitly, using DOM attributes) for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getComputedStyleForNode">CSS.getComputedStyleForNode</a>: Returns the computed style for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getAllStyleSheets">CSS.getAllStyleSheets</a>: Returns metainfo entries for all known stylesheets.</li>
-<li><a href="#CSS.getStyleSheet">CSS.getStyleSheet</a>: Returns stylesheet data for the specified styleSheetId.</li>
-<li><a href="#CSS.getStyleSheetText">CSS.getStyleSheetText</a>: Returns the current textual content and the URL for a stylesheet.</li>
-<li><a href="#CSS.setStyleSheetText">CSS.setStyleSheetText</a>: Sets the new stylesheet text, thereby invalidating all existing CSSStyleId's and CSSRuleId's contained by this stylesheet.</li>
-<li><a href="#CSS.setPropertyText">CSS.setPropertyText</a>: Sets the new text for a property in the respective style, at offset propertyIndex. If overwrite is true, a property at the given offset is overwritten, otherwise inserted. text entirely replaces the property name: value.</li>
-<li><a href="#CSS.toggleProperty">CSS.toggleProperty</a>: Toggles the property in the respective style, at offset propertyIndex. The disable parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If disable == false, the property gets put back into its original place in the style declaration.</li>
-<li><a href="#CSS.setRuleSelector">CSS.setRuleSelector</a>: Modifies the rule selector.</li>
-<li><a href="#CSS.addRule">CSS.addRule</a>: Creates a new empty rule with the given selector in a special "inspector" stylesheet in the owner document of the context node.</li>
-<li><a href="#CSS.getSupportedCSSProperties">CSS.getSupportedCSSProperties</a>: Returns all supported CSS property names.</li>
-<li><a href="#CSS.startSelectorProfiler">CSS.startSelectorProfiler</a></li>
-<li><a href="#CSS.stopSelectorProfiler">CSS.stopSelectorProfiler</a></li>
+<li><a href='#CSS.enable'>CSS.enable</a>: Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received.</li>
+<li><a href='#CSS.disable'>CSS.disable</a>: Disables the CSS agent for the given page.</li>
+<li><a href='#CSS.getMatchedStylesForNode'>CSS.getMatchedStylesForNode</a>: Returns requested styles for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getInlineStylesForNode'>CSS.getInlineStylesForNode</a>: Returns the styles defined inline (explicitly in the "style" attribute and implicitly, using DOM attributes) for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getComputedStyleForNode'>CSS.getComputedStyleForNode</a>: Returns the computed style for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getAllStyleSheets'>CSS.getAllStyleSheets</a>: Returns metainfo entries for all known stylesheets.</li>
+<li><a href='#CSS.getStyleSheet'>CSS.getStyleSheet</a>: Returns stylesheet data for the specified styleSheetId.</li>
+<li><a href='#CSS.getStyleSheetText'>CSS.getStyleSheetText</a>: Returns the current textual content and the URL for a stylesheet.</li>
+<li><a href='#CSS.setStyleSheetText'>CSS.setStyleSheetText</a>: Sets the new stylesheet text, thereby invalidating all existing CSSStyleId's and CSSRuleId's contained by this stylesheet.</li>
+<li><a href='#CSS.setPropertyText'>CSS.setPropertyText</a>: Sets the new text for a property in the respective style, at offset propertyIndex. If overwrite is true, a property at the given offset is overwritten, otherwise inserted. text entirely replaces the property name: value.</li>
+<li><a href='#CSS.toggleProperty'>CSS.toggleProperty</a>: Toggles the property in the respective style, at offset propertyIndex. The disable parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If disable == false, the property gets put back into its original place in the style declaration.</li>
+<li><a href='#CSS.setRuleSelector'>CSS.setRuleSelector</a>: Modifies the rule selector.</li>
+<li><a href='#CSS.addRule'>CSS.addRule</a>: Creates a new empty rule with the given selector in a special "inspector" stylesheet in the owner document of the context node.</li>
+<li><a href='#CSS.getSupportedCSSProperties'>CSS.getSupportedCSSProperties</a>: Returns all supported CSS property names.</li>
+<li><a href='#CSS.forcePseudoState'>CSS.forcePseudoState</a>: Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser.</li>
+<li><a href='#CSS.startSelectorProfiler'>CSS.startSelectorProfiler</a></li>
+<li><a href='#CSS.stopSelectorProfiler'>CSS.stopSelectorProfiler</a></li>
+<li><a href='#CSS.getNamedFlowCollection'>CSS.getNamedFlowCollection</a>: Returns the Named Flows from the document.</li>
+<li><a href='#CSS.getFlowByName'>CSS.getFlowByName</a>: Returns the Named Flow identified by the given name</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#CSS.mediaQueryResultChanged">CSS.mediaQueryResultChanged</a>: Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features.</li>
-<li><a href="#CSS.styleSheetChanged">CSS.styleSheetChanged</a>: Fired whenever a stylesheet is changed as a result of the client operation.</li>
+<li><a href='#CSS.mediaQueryResultChanged'>CSS.mediaQueryResultChanged</a>: Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features.</li>
+<li><a href='#CSS.styleSheetChanged'>CSS.styleSheetChanged</a>: Fired whenever a stylesheet is changed as a result of the client operation.</li>
+<li><a href='#CSS.namedFlowCreated'>CSS.namedFlowCreated</a>: Fires when a Named Flow is created.</li>
+<li><a href='#CSS.namedFlowRemoved'>CSS.namedFlowRemoved</a>: Fires when a Named Flow is removed: has no associated content nodes and regions.</li>
 </ul>
 <h3><a href="#Console">Console</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Console.ConsoleMessage">Console.ConsoleMessage</a>: Console message.</li>
-<li><a href="#Console.CallFrame">Console.CallFrame</a>: Stack entry for console errors and assertions.</li>
-<li><a href="#Console.StackTrace">Console.StackTrace</a>: Call frames for assertions or error messages.</li>
+<li><a href='#Console.ConsoleMessage'>Console.ConsoleMessage</a>: Console message.</li>
+<li><a href='#Console.CallFrame'>Console.CallFrame</a>: Stack entry for console errors and assertions.</li>
+<li><a href='#Console.StackTrace'>Console.StackTrace</a>: Call frames for assertions or error messages.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Console.enable">Console.enable</a>: Enables console domain, sends the messages collected so far to the client by means of the messageAdded notification.</li>
-<li><a href="#Console.disable">Console.disable</a>: Disables console domain, prevents further console messages from being reported to the client.</li>
-<li><a href="#Console.clearMessages">Console.clearMessages</a>: Clears console messages collected in the browser.</li>
-<li><a href="#Console.setMonitoringXHREnabled">Console.setMonitoringXHREnabled</a>: Toggles monitoring of XMLHttpRequest. If true, console will receive messages upon each XHR issued.</li>
-<li><a href="#Console.addInspectedNode">Console.addInspectedNode</a>: Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).</li>
-<li><a href="#Console.addInspectedHeapObject">Console.addInspectedHeapObject</a></li>
+<li><a href='#Console.enable'>Console.enable</a>: Enables console domain, sends the messages collected so far to the client by means of the messageAdded notification.</li>
+<li><a href='#Console.disable'>Console.disable</a>: Disables console domain, prevents further console messages from being reported to the client.</li>
+<li><a href='#Console.clearMessages'>Console.clearMessages</a>: Clears console messages collected in the browser.</li>
+<li><a href='#Console.setMonitoringXHREnabled'>Console.setMonitoringXHREnabled</a>: Toggles monitoring of XMLHttpRequest. If true, console will receive messages upon each XHR issued.</li>
+<li><a href='#Console.addInspectedNode'>Console.addInspectedNode</a>: Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).</li>
+<li><a href='#Console.addInspectedHeapObject'>Console.addInspectedHeapObject</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Console.messageAdded">Console.messageAdded</a>: Issued when new console message is added.</li>
-<li><a href="#Console.messageRepeatCountUpdated">Console.messageRepeatCountUpdated</a>: Issued when subsequent message(s) are equal to the previous one(s).</li>
-<li><a href="#Console.messagesCleared">Console.messagesCleared</a>: Issued when console is cleared. This happens either upon clearMessages command or after page navigation.</li>
+<li><a href='#Console.messageAdded'>Console.messageAdded</a>: Issued when new console message is added.</li>
+<li><a href='#Console.messageRepeatCountUpdated'>Console.messageRepeatCountUpdated</a>: Issued when subsequent message(s) are equal to the previous one(s).</li>
+<li><a href='#Console.messagesCleared'>Console.messagesCleared</a>: Issued when console is cleared. This happens either upon clearMessages command or after page navigation.</li>
 </ul>
 <h3><a href="#DOM">DOM</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOM.NodeId">DOM.NodeId</a>: Unique DOM node identifier.</li>
-<li><a href="#DOM.Node">DOM.Node</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
-<li><a href="#DOM.EventListener">DOM.EventListener</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
-<li><a href="#DOM.RGBA">DOM.RGBA</a>: A structure holding an RGBA color.</li>
-<li><a href="#DOM.HighlightConfig">DOM.HighlightConfig</a>: Configuration data for the highlighting of page elements.</li>
+<li><a href='#DOM.NodeId'>DOM.NodeId</a>: Unique DOM node identifier.</li>
+<li><a href='#DOM.Node'>DOM.Node</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
+<li><a href='#DOM.EventListener'>DOM.EventListener</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
+<li><a href='#DOM.RGBA'>DOM.RGBA</a>: A structure holding an RGBA color.</li>
+<li><a href='#DOM.HighlightConfig'>DOM.HighlightConfig</a>: Configuration data for the highlighting of page elements.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOM.getDocument">DOM.getDocument</a>: Returns the root DOM node to the caller.</li>
-<li><a href="#DOM.requestChildNodes">DOM.requestChildNodes</a>: Requests that children of the node with given id are returned to the caller in form of setChildNodes events.</li>
-<li><a href="#DOM.querySelector">DOM.querySelector</a>: Executes querySelector on a given node.</li>
-<li><a href="#DOM.querySelectorAll">DOM.querySelectorAll</a>: Executes querySelectorAll on a given node.</li>
-<li><a href="#DOM.setNodeName">DOM.setNodeName</a>: Sets node name for a node with given id.</li>
-<li><a href="#DOM.setNodeValue">DOM.setNodeValue</a>: Sets node value for a node with given id.</li>
-<li><a href="#DOM.removeNode">DOM.removeNode</a>: Removes node with given id.</li>
-<li><a href="#DOM.setAttributeValue">DOM.setAttributeValue</a>: Sets attribute for an element with given id.</li>
-<li><a href="#DOM.setAttributesAsText">DOM.setAttributesAsText</a>: Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.</li>
-<li><a href="#DOM.removeAttribute">DOM.removeAttribute</a>: Removes attribute with given name from an element with given id.</li>
-<li><a href="#DOM.getEventListenersForNode">DOM.getEventListenersForNode</a>: Returns event listeners relevant to the node.</li>
-<li><a href="#DOM.getOuterHTML">DOM.getOuterHTML</a>: Returns node's HTML markup.</li>
-<li><a href="#DOM.setOuterHTML">DOM.setOuterHTML</a>: Sets node HTML markup, returns new node id.</li>
-<li><a href="#DOM.performSearch">DOM.performSearch</a>: Searches for a given string in the DOM tree. Use getSearchResults to access search results or cancelSearch to end this search session.</li>
-<li><a href="#DOM.getSearchResults">DOM.getSearchResults</a>: Returns search results from given fromIndex to given toIndex from the sarch with the given identifier.</li>
-<li><a href="#DOM.discardSearchResults">DOM.discardSearchResults</a>: Discards search results from the session with the given id. getSearchResults should no longer be called for that search.</li>
-<li><a href="#DOM.requestNode">DOM.requestNode</a>: Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of setChildNodes notifications.</li>
-<li><a href="#DOM.setInspectModeEnabled">DOM.setInspectModeEnabled</a>: Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection.</li>
-<li><a href="#DOM.highlightRect">DOM.highlightRect</a>: Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.</li>
-<li><a href="#DOM.highlightNode">DOM.highlightNode</a>: Highlights DOM node with given id.</li>
-<li><a href="#DOM.hideHighlight">DOM.hideHighlight</a>: Hides DOM node highlight.</li>
-<li><a href="#DOM.highlightFrame">DOM.highlightFrame</a>: Highlights owner element of the frame with given id.</li>
-<li><a href="#DOM.pushNodeByPathToFrontend">DOM.pushNodeByPathToFrontend</a>: Requests that the node is sent to the caller given its path. // FIXME, use XPath</li>
-<li><a href="#DOM.resolveNode">DOM.resolveNode</a>: Resolves JavaScript node object for given node id.</li>
-<li><a href="#DOM.getAttributes">DOM.getAttributes</a>: Returns attributes for the specified node.</li>
-<li><a href="#DOM.moveTo">DOM.moveTo</a>: Moves node into the new container, places it before the given anchor.</li>
-<li><a href="#DOM.setTouchEmulationEnabled">DOM.setTouchEmulationEnabled</a>: Toggles mouse event-based touch event emulation.</li>
-<li><a href="#DOM.undo">DOM.undo</a>: Undoes the last performed action.</li>
-<li><a href="#DOM.redo">DOM.redo</a>: Re-does the last undone action.</li>
-<li><a href="#DOM.markUndoableState">DOM.markUndoableState</a>: Marks last undoable state.</li>
+<li><a href='#DOM.getDocument'>DOM.getDocument</a>: Returns the root DOM node to the caller.</li>
+<li><a href='#DOM.requestChildNodes'>DOM.requestChildNodes</a>: Requests that children of the node with given id are returned to the caller in form of setChildNodes events.</li>
+<li><a href='#DOM.querySelector'>DOM.querySelector</a>: Executes querySelector on a given node.</li>
+<li><a href='#DOM.querySelectorAll'>DOM.querySelectorAll</a>: Executes querySelectorAll on a given node.</li>
+<li><a href='#DOM.setNodeName'>DOM.setNodeName</a>: Sets node name for a node with given id.</li>
+<li><a href='#DOM.setNodeValue'>DOM.setNodeValue</a>: Sets node value for a node with given id.</li>
+<li><a href='#DOM.removeNode'>DOM.removeNode</a>: Removes node with given id.</li>
+<li><a href='#DOM.setAttributeValue'>DOM.setAttributeValue</a>: Sets attribute for an element with given id.</li>
+<li><a href='#DOM.setAttributesAsText'>DOM.setAttributesAsText</a>: Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.</li>
+<li><a href='#DOM.removeAttribute'>DOM.removeAttribute</a>: Removes attribute with given name from an element with given id.</li>
+<li><a href='#DOM.getEventListenersForNode'>DOM.getEventListenersForNode</a>: Returns event listeners relevant to the node.</li>
+<li><a href='#DOM.getOuterHTML'>DOM.getOuterHTML</a>: Returns node's HTML markup.</li>
+<li><a href='#DOM.setOuterHTML'>DOM.setOuterHTML</a>: Sets node HTML markup, returns new node id.</li>
+<li><a href='#DOM.performSearch'>DOM.performSearch</a>: Searches for a given string in the DOM tree. Use getSearchResults to access search results or cancelSearch to end this search session.</li>
+<li><a href='#DOM.getSearchResults'>DOM.getSearchResults</a>: Returns search results from given fromIndex to given toIndex from the sarch with the given identifier.</li>
+<li><a href='#DOM.discardSearchResults'>DOM.discardSearchResults</a>: Discards search results from the session with the given id. getSearchResults should no longer be called for that search.</li>
+<li><a href='#DOM.requestNode'>DOM.requestNode</a>: Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of setChildNodes notifications.</li>
+<li><a href='#DOM.setInspectModeEnabled'>DOM.setInspectModeEnabled</a>: Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection.</li>
+<li><a href='#DOM.highlightRect'>DOM.highlightRect</a>: Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.</li>
+<li><a href='#DOM.highlightNode'>DOM.highlightNode</a>: Highlights DOM node with given id.</li>
+<li><a href='#DOM.hideHighlight'>DOM.hideHighlight</a>: Hides DOM node highlight.</li>
+<li><a href='#DOM.highlightFrame'>DOM.highlightFrame</a>: Highlights owner element of the frame with given id.</li>
+<li><a href='#DOM.pushNodeByPathToFrontend'>DOM.pushNodeByPathToFrontend</a>: Requests that the node is sent to the caller given its path. // FIXME, use XPath</li>
+<li><a href='#DOM.resolveNode'>DOM.resolveNode</a>: Resolves JavaScript node object for given node id.</li>
+<li><a href='#DOM.getAttributes'>DOM.getAttributes</a>: Returns attributes for the specified node.</li>
+<li><a href='#DOM.moveTo'>DOM.moveTo</a>: Moves node into the new container, places it before the given anchor.</li>
+<li><a href='#DOM.undo'>DOM.undo</a>: Undoes the last performed action.</li>
+<li><a href='#DOM.redo'>DOM.redo</a>: Re-does the last undone action.</li>
+<li><a href='#DOM.markUndoableState'>DOM.markUndoableState</a>: Marks last undoable state.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#DOM.documentUpdated">DOM.documentUpdated</a>: Fired when Document has been totally updated. Node ids are no longer valid.</li>
-<li><a href="#DOM.setChildNodes">DOM.setChildNodes</a>: Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids.</li>
-<li><a href="#DOM.attributeModified">DOM.attributeModified</a>: Fired when Element's attribute is modified.</li>
-<li><a href="#DOM.attributeRemoved">DOM.attributeRemoved</a>: Fired when Element's attribute is removed.</li>
-<li><a href="#DOM.inlineStyleInvalidated">DOM.inlineStyleInvalidated</a>: Fired when Element's inline style is modified via a CSS property modification.</li>
-<li><a href="#DOM.characterDataModified">DOM.characterDataModified</a>: Mirrors DOMCharacterDataModified event.</li>
-<li><a href="#DOM.childNodeCountUpdated">DOM.childNodeCountUpdated</a>: Fired when Container's child node count has changed.</li>
-<li><a href="#DOM.childNodeInserted">DOM.childNodeInserted</a>: Mirrors DOMNodeInserted event.</li>
-<li><a href="#DOM.childNodeRemoved">DOM.childNodeRemoved</a>: Mirrors DOMNodeRemoved event.</li>
-<li><a href="#DOM.shadowRootPushed">DOM.shadowRootPushed</a>: Called when shadow root is pushed into the element.</li>
-<li><a href="#DOM.shadowRootPopped">DOM.shadowRootPopped</a>: Called when shadow root is popped from the element.</li>
+<li><a href='#DOM.documentUpdated'>DOM.documentUpdated</a>: Fired when Document has been totally updated. Node ids are no longer valid.</li>
+<li><a href='#DOM.setChildNodes'>DOM.setChildNodes</a>: Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids.</li>
+<li><a href='#DOM.attributeModified'>DOM.attributeModified</a>: Fired when Element's attribute is modified.</li>
+<li><a href='#DOM.attributeRemoved'>DOM.attributeRemoved</a>: Fired when Element's attribute is removed.</li>
+<li><a href='#DOM.inlineStyleInvalidated'>DOM.inlineStyleInvalidated</a>: Fired when Element's inline style is modified via a CSS property modification.</li>
+<li><a href='#DOM.characterDataModified'>DOM.characterDataModified</a>: Mirrors DOMCharacterDataModified event.</li>
+<li><a href='#DOM.childNodeCountUpdated'>DOM.childNodeCountUpdated</a>: Fired when Container's child node count has changed.</li>
+<li><a href='#DOM.childNodeInserted'>DOM.childNodeInserted</a>: Mirrors DOMNodeInserted event.</li>
+<li><a href='#DOM.childNodeRemoved'>DOM.childNodeRemoved</a>: Mirrors DOMNodeRemoved event.</li>
+<li><a href='#DOM.shadowRootPushed'>DOM.shadowRootPushed</a>: Called when shadow root is pushed into the element.</li>
+<li><a href='#DOM.shadowRootPopped'>DOM.shadowRootPopped</a>: Called when shadow root is popped from the element.</li>
 </ul>
 <h3><a href="#DOMDebugger">DOMDebugger</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOMDebugger.DOMBreakpointType">DOMDebugger.DOMBreakpointType</a>: DOM breakpoint type.</li>
+<li><a href='#DOMDebugger.DOMBreakpointType'>DOMDebugger.DOMBreakpointType</a>: DOM breakpoint type.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOMDebugger.setDOMBreakpoint">DOMDebugger.setDOMBreakpoint</a>: Sets breakpoint on particular operation with DOM.</li>
-<li><a href="#DOMDebugger.removeDOMBreakpoint">DOMDebugger.removeDOMBreakpoint</a>: Removes DOM breakpoint that was set using setDOMBreakpoint.</li>
-<li><a href="#DOMDebugger.setEventListenerBreakpoint">DOMDebugger.setEventListenerBreakpoint</a>: Sets breakpoint on particular DOM event.</li>
-<li><a href="#DOMDebugger.removeEventListenerBreakpoint">DOMDebugger.removeEventListenerBreakpoint</a>: Removes breakpoint on particular DOM event.</li>
-<li><a href="#DOMDebugger.setInstrumentationBreakpoint">DOMDebugger.setInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
-<li><a href="#DOMDebugger.removeInstrumentationBreakpoint">DOMDebugger.removeInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
-<li><a href="#DOMDebugger.setXHRBreakpoint">DOMDebugger.setXHRBreakpoint</a>: Sets breakpoint on XMLHttpRequest.</li>
-<li><a href="#DOMDebugger.removeXHRBreakpoint">DOMDebugger.removeXHRBreakpoint</a>: Removes breakpoint from XMLHttpRequest.</li>
+<li><a href='#DOMDebugger.setDOMBreakpoint'>DOMDebugger.setDOMBreakpoint</a>: Sets breakpoint on particular operation with DOM.</li>
+<li><a href='#DOMDebugger.removeDOMBreakpoint'>DOMDebugger.removeDOMBreakpoint</a>: Removes DOM breakpoint that was set using setDOMBreakpoint.</li>
+<li><a href='#DOMDebugger.setEventListenerBreakpoint'>DOMDebugger.setEventListenerBreakpoint</a>: Sets breakpoint on particular DOM event.</li>
+<li><a href='#DOMDebugger.removeEventListenerBreakpoint'>DOMDebugger.removeEventListenerBreakpoint</a>: Removes breakpoint on particular DOM event.</li>
+<li><a href='#DOMDebugger.setInstrumentationBreakpoint'>DOMDebugger.setInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
+<li><a href='#DOMDebugger.removeInstrumentationBreakpoint'>DOMDebugger.removeInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
+<li><a href='#DOMDebugger.setXHRBreakpoint'>DOMDebugger.setXHRBreakpoint</a>: Sets breakpoint on XMLHttpRequest.</li>
+<li><a href='#DOMDebugger.removeXHRBreakpoint'>DOMDebugger.removeXHRBreakpoint</a>: Removes breakpoint from XMLHttpRequest.</li>
 </ul>
 <h3><a href="#DOMStorage">DOMStorage</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOMStorage.Entry">DOMStorage.Entry</a>: DOM Storage entry.</li>
+<li><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a>: Unique identifier of DOM storage entry.</li>
+<li><a href='#DOMStorage.Entry'>DOMStorage.Entry</a>: DOM Storage entry.</li>
+<li><a href='#DOMStorage.Item'>DOMStorage.Item</a>: DOM Storage item.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOMStorage.enable">DOMStorage.enable</a>: Enables storage tracking, storage events will now be delivered to the client.</li>
-<li><a href="#DOMStorage.disable">DOMStorage.disable</a>: Disables storage tracking, prevents storage events from being sent to the client.</li>
-<li><a href="#DOMStorage.getDOMStorageEntries">DOMStorage.getDOMStorageEntries</a></li>
-<li><a href="#DOMStorage.setDOMStorageItem">DOMStorage.setDOMStorageItem</a></li>
-<li><a href="#DOMStorage.removeDOMStorageItem">DOMStorage.removeDOMStorageItem</a></li>
+<li><a href='#DOMStorage.enable'>DOMStorage.enable</a>: Enables storage tracking, storage events will now be delivered to the client.</li>
+<li><a href='#DOMStorage.disable'>DOMStorage.disable</a>: Disables storage tracking, prevents storage events from being sent to the client.</li>
+<li><a href='#DOMStorage.getDOMStorageEntries'>DOMStorage.getDOMStorageEntries</a></li>
+<li><a href='#DOMStorage.setDOMStorageItem'>DOMStorage.setDOMStorageItem</a></li>
+<li><a href='#DOMStorage.removeDOMStorageItem'>DOMStorage.removeDOMStorageItem</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#DOMStorage.addDOMStorage">DOMStorage.addDOMStorage</a></li>
-<li><a href="#DOMStorage.updateDOMStorage">DOMStorage.updateDOMStorage</a></li>
+<li><a href='#DOMStorage.addDOMStorage'>DOMStorage.addDOMStorage</a></li>
+<li><a href='#DOMStorage.domStorageUpdated'>DOMStorage.domStorageUpdated</a></li>
 </ul>
 <h3><a href="#Database">Database</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Database.Database">Database.Database</a>: Database object.</li>
-<li><a href="#Database.Error">Database.Error</a>: Database error.</li>
+<li><a href='#Database.DatabaseId'>Database.DatabaseId</a>: Unique identifier of Database object.</li>
+<li><a href='#Database.Database'>Database.Database</a>: Database object.</li>
+<li><a href='#Database.Error'>Database.Error</a>: Database error.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Database.enable">Database.enable</a>: Enables database tracking, database events will now be delivered to the client.</li>
-<li><a href="#Database.disable">Database.disable</a>: Disables database tracking, prevents database events from being sent to the client.</li>
-<li><a href="#Database.getDatabaseTableNames">Database.getDatabaseTableNames</a></li>
-<li><a href="#Database.executeSQL">Database.executeSQL</a></li>
+<li><a href='#Database.enable'>Database.enable</a>: Enables database tracking, database events will now be delivered to the client.</li>
+<li><a href='#Database.disable'>Database.disable</a>: Disables database tracking, prevents database events from being sent to the client.</li>
+<li><a href='#Database.getDatabaseTableNames'>Database.getDatabaseTableNames</a></li>
+<li><a href='#Database.executeSQL'>Database.executeSQL</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Database.addDatabase">Database.addDatabase</a></li>
-<li><a href="#Database.sqlTransactionSucceeded">Database.sqlTransactionSucceeded</a></li>
-<li><a href="#Database.sqlTransactionFailed">Database.sqlTransactionFailed</a></li>
+<li><a href='#Database.addDatabase'>Database.addDatabase</a></li>
+<li><a href='#Database.sqlTransactionSucceeded'>Database.sqlTransactionSucceeded</a></li>
+<li><a href='#Database.sqlTransactionFailed'>Database.sqlTransactionFailed</a></li>
 </ul>
 <h3><a href="#Debugger">Debugger</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a>: Breakpoint identifier.</li>
-<li><a href="#Debugger.ScriptId">Debugger.ScriptId</a>: Unique script identifier.</li>
-<li><a href="#Debugger.CallFrameId">Debugger.CallFrameId</a>: Call frame identifier.</li>
-<li><a href="#Debugger.Location">Debugger.Location</a>: Location in the source code.</li>
-<li><a href="#Debugger.FunctionDetails">Debugger.FunctionDetails</a>: Information about the function.</li>
-<li><a href="#Debugger.CallFrame">Debugger.CallFrame</a>: JavaScript call frame. Array of call frames form the call stack.</li>
-<li><a href="#Debugger.Scope">Debugger.Scope</a>: Scope description.</li>
+<li><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a>: Breakpoint identifier.</li>
+<li><a href='#Debugger.ScriptId'>Debugger.ScriptId</a>: Unique script identifier.</li>
+<li><a href='#Debugger.CallFrameId'>Debugger.CallFrameId</a>: Call frame identifier.</li>
+<li><a href='#Debugger.Location'>Debugger.Location</a>: Location in the source code.</li>
+<li><a href='#Debugger.FunctionDetails'>Debugger.FunctionDetails</a>: Information about the function.</li>
+<li><a href='#Debugger.CallFrame'>Debugger.CallFrame</a>: JavaScript call frame. Array of call frames form the call stack.</li>
+<li><a href='#Debugger.Scope'>Debugger.Scope</a>: Scope description.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Debugger.causesRecompilation">Debugger.causesRecompilation</a>: Tells whether enabling debugger causes scripts recompilation.</li>
-<li><a href="#Debugger.supportsNativeBreakpoints">Debugger.supportsNativeBreakpoints</a>: Tells whether debugger supports native breakpoints.</li>
-<li><a href="#Debugger.enable">Debugger.enable</a>: Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.</li>
-<li><a href="#Debugger.disable">Debugger.disable</a>: Disables debugger for given page.</li>
-<li><a href="#Debugger.setBreakpointsActive">Debugger.setBreakpointsActive</a>: Activates / deactivates all breakpoints on the page.</li>
-<li><a href="#Debugger.setBreakpointByUrl">Debugger.setBreakpointByUrl</a>: Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in locations property. Further matching script parsing will result in subsequent breakpointResolved events issued. This logical breakpoint will survive page reloads.</li>
-<li><a href="#Debugger.setBreakpoint">Debugger.setBreakpoint</a>: Sets JavaScript breakpoint at a given location.</li>
-<li><a href="#Debugger.removeBreakpoint">Debugger.removeBreakpoint</a>: Removes JavaScript breakpoint.</li>
-<li><a href="#Debugger.continueToLocation">Debugger.continueToLocation</a>: Continues execution until specific location is reached.</li>
-<li><a href="#Debugger.stepOver">Debugger.stepOver</a>: Steps over the statement.</li>
-<li><a href="#Debugger.stepInto">Debugger.stepInto</a>: Steps into the function call.</li>
-<li><a href="#Debugger.stepOut">Debugger.stepOut</a>: Steps out of the function call.</li>
-<li><a href="#Debugger.pause">Debugger.pause</a>: Stops on the next JavaScript statement.</li>
-<li><a href="#Debugger.resume">Debugger.resume</a>: Resumes JavaScript execution.</li>
-<li><a href="#Debugger.searchInContent">Debugger.searchInContent</a>: Searches for given string in script content.</li>
-<li><a href="#Debugger.canSetScriptSource">Debugger.canSetScriptSource</a>: Tells whether setScriptSource is supported.</li>
-<li><a href="#Debugger.setScriptSource">Debugger.setScriptSource</a>: Edits JavaScript source live.</li>
-<li><a href="#Debugger.getScriptSource">Debugger.getScriptSource</a>: Returns source for the script with given id.</li>
-<li><a href="#Debugger.getFunctionDetails">Debugger.getFunctionDetails</a>: Returns detailed informtation on given function.</li>
-<li><a href="#Debugger.setPauseOnExceptions">Debugger.setPauseOnExceptions</a>: Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is none.</li>
-<li><a href="#Debugger.evaluateOnCallFrame">Debugger.evaluateOnCallFrame</a>: Evaluates expression on a given call frame.</li>
+<li><a href='#Debugger.causesRecompilation'>Debugger.causesRecompilation</a>: Tells whether enabling debugger causes scripts recompilation.</li>
+<li><a href='#Debugger.supportsSeparateScriptCompilationAndExecution'>Debugger.supportsSeparateScriptCompilationAndExecution</a>: Tells whether debugger supports separate script compilation and execution.</li>
+<li><a href='#Debugger.enable'>Debugger.enable</a>: Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.</li>
+<li><a href='#Debugger.disable'>Debugger.disable</a>: Disables debugger for given page.</li>
+<li><a href='#Debugger.setBreakpointsActive'>Debugger.setBreakpointsActive</a>: Activates / deactivates all breakpoints on the page.</li>
+<li><a href='#Debugger.setBreakpointByUrl'>Debugger.setBreakpointByUrl</a>: Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in locations property. Further matching script parsing will result in subsequent breakpointResolved events issued. This logical breakpoint will survive page reloads.</li>
+<li><a href='#Debugger.setBreakpoint'>Debugger.setBreakpoint</a>: Sets JavaScript breakpoint at a given location.</li>
+<li><a href='#Debugger.removeBreakpoint'>Debugger.removeBreakpoint</a>: Removes JavaScript breakpoint.</li>
+<li><a href='#Debugger.continueToLocation'>Debugger.continueToLocation</a>: Continues execution until specific location is reached.</li>
+<li><a href='#Debugger.stepOver'>Debugger.stepOver</a>: Steps over the statement.</li>
+<li><a href='#Debugger.stepInto'>Debugger.stepInto</a>: Steps into the function call.</li>
+<li><a href='#Debugger.stepOut'>Debugger.stepOut</a>: Steps out of the function call.</li>
+<li><a href='#Debugger.pause'>Debugger.pause</a>: Stops on the next JavaScript statement.</li>
+<li><a href='#Debugger.resume'>Debugger.resume</a>: Resumes JavaScript execution.</li>
+<li><a href='#Debugger.searchInContent'>Debugger.searchInContent</a>: Searches for given string in script content.</li>
+<li><a href='#Debugger.canSetScriptSource'>Debugger.canSetScriptSource</a>: Tells whether setScriptSource is supported.</li>
+<li><a href='#Debugger.setScriptSource'>Debugger.setScriptSource</a>: Edits JavaScript source live.</li>
+<li><a href='#Debugger.restartFrame'>Debugger.restartFrame</a>: Restarts particular call frame from the beginning.</li>
+<li><a href='#Debugger.getScriptSource'>Debugger.getScriptSource</a>: Returns source for the script with given id.</li>
+<li><a href='#Debugger.getFunctionDetails'>Debugger.getFunctionDetails</a>: Returns detailed informtation on given function.</li>
+<li><a href='#Debugger.setPauseOnExceptions'>Debugger.setPauseOnExceptions</a>: Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is none.</li>
+<li><a href='#Debugger.evaluateOnCallFrame'>Debugger.evaluateOnCallFrame</a>: Evaluates expression on a given call frame.</li>
+<li><a href='#Debugger.compileScript'>Debugger.compileScript</a>: Compiles expression.</li>
+<li><a href='#Debugger.runScript'>Debugger.runScript</a>: Runs script with given id in a given context.</li>
+<li><a href='#Debugger.setOverlayMessage'>Debugger.setOverlayMessage</a>: Sets overlay message.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Debugger.globalObjectCleared">Debugger.globalObjectCleared</a>: Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload.</li>
-<li><a href="#Debugger.scriptParsed">Debugger.scriptParsed</a>: Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.</li>
-<li><a href="#Debugger.scriptFailedToParse">Debugger.scriptFailedToParse</a>: Fired when virtual machine fails to parse the script.</li>
-<li><a href="#Debugger.breakpointResolved">Debugger.breakpointResolved</a>: Fired when breakpoint is resolved to an actual script and location.</li>
-<li><a href="#Debugger.paused">Debugger.paused</a>: Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.</li>
-<li><a href="#Debugger.resumed">Debugger.resumed</a>: Fired when the virtual machine resumed execution.</li>
+<li><a href='#Debugger.globalObjectCleared'>Debugger.globalObjectCleared</a>: Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload.</li>
+<li><a href='#Debugger.scriptParsed'>Debugger.scriptParsed</a>: Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.</li>
+<li><a href='#Debugger.scriptFailedToParse'>Debugger.scriptFailedToParse</a>: Fired when virtual machine fails to parse the script.</li>
+<li><a href='#Debugger.breakpointResolved'>Debugger.breakpointResolved</a>: Fired when breakpoint is resolved to an actual script and location.</li>
+<li><a href='#Debugger.paused'>Debugger.paused</a>: Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.</li>
+<li><a href='#Debugger.resumed'>Debugger.resumed</a>: Fired when the virtual machine resumed execution.</li>
 </ul>
 <h3><a href="#FileSystem">FileSystem</a></h3>
-<span class="label label-success">Command</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#FileSystem.enable">FileSystem.enable</a>: Enables events from backend.</li>
-<li><a href="#FileSystem.disable">FileSystem.disable</a>: Disables events from backend..</li>
+<li><a href='#FileSystem.RequestId'>FileSystem.RequestId</a>: Request Identifier to glue a request and its completion event.</li>
+<li><a href='#FileSystem.Entry'>FileSystem.Entry</a>: Represents a browser side file or directory.</li>
+<li><a href='#FileSystem.Metadata'>FileSystem.Metadata</a>: Represents metadata of a file or entry.</li>
+</ul>
+<span class='label label-success'>Command</span>
+<ul>
+<li><a href='#FileSystem.enable'>FileSystem.enable</a>: Enables events from backend.</li>
+<li><a href='#FileSystem.disable'>FileSystem.disable</a>: Disables events from backend.</li>
+<li><a href='#FileSystem.requestFileSystemRoot'>FileSystem.requestFileSystemRoot</a>: Returns root directory of the FileSystem as fileSystemRootReceived event, if exists.</li>
+<li><a href='#FileSystem.requestDirectoryContent'>FileSystem.requestDirectoryContent</a>: Returns content of the directory as directoryContentReceived event.</li>
+<li><a href='#FileSystem.requestMetadata'>FileSystem.requestMetadata</a>: Returns metadata of the entry as metadataReceived event.</li>
+<li><a href='#FileSystem.requestFileContent'>FileSystem.requestFileContent</a>: Returns content of the file as fileContentReceived event. Result should be sliced into [start, end).</li>
+</ul>
+<span class='label label-info'>Event</span>
+<ul>
+<li><a href='#FileSystem.fileSystemRootReceived'>FileSystem.fileSystemRootReceived</a>: Completion event of requestFileSystemRoot command.</li>
+<li><a href='#FileSystem.directoryContentReceived'>FileSystem.directoryContentReceived</a>: Completion event of requestDirectoryContent command.</li>
+<li><a href='#FileSystem.metadataReceived'>FileSystem.metadataReceived</a>: Completion event of requestMetadata command.</li>
+<li><a href='#FileSystem.fileContentReceived'>FileSystem.fileContentReceived</a>: Completion event of requestFileContent command.</li>
 </ul>
 <h3><a href="#IndexedDB">IndexedDB</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#IndexedDB.SecurityOriginWithDatabaseNames">IndexedDB.SecurityOriginWithDatabaseNames</a>: Security origin with database names.</li>
-<li><a href="#IndexedDB.DatabaseWithObjectStores">IndexedDB.DatabaseWithObjectStores</a>: Database with an array of object stores.</li>
-<li><a href="#IndexedDB.ObjectStore">IndexedDB.ObjectStore</a>: Object store.</li>
-<li><a href="#IndexedDB.ObjectStoreIndex">IndexedDB.ObjectStoreIndex</a>: Object store index.</li>
-<li><a href="#IndexedDB.Key">IndexedDB.Key</a>: Key.</li>
-<li><a href="#IndexedDB.KeyRange">IndexedDB.KeyRange</a>: Key range.</li>
-<li><a href="#IndexedDB.DataEntry">IndexedDB.DataEntry</a>: Key.</li>
+<li><a href='#IndexedDB.SecurityOriginWithDatabaseNames'>IndexedDB.SecurityOriginWithDatabaseNames</a>: Security origin with database names.</li>
+<li><a href='#IndexedDB.DatabaseWithObjectStores'>IndexedDB.DatabaseWithObjectStores</a>: Database with an array of object stores.</li>
+<li><a href='#IndexedDB.ObjectStore'>IndexedDB.ObjectStore</a>: Object store.</li>
+<li><a href='#IndexedDB.ObjectStoreIndex'>IndexedDB.ObjectStoreIndex</a>: Object store index.</li>
+<li><a href='#IndexedDB.Key'>IndexedDB.Key</a>: Key.</li>
+<li><a href='#IndexedDB.KeyRange'>IndexedDB.KeyRange</a>: Key range.</li>
+<li><a href='#IndexedDB.DataEntry'>IndexedDB.DataEntry</a>: Data entry.</li>
+<li><a href='#IndexedDB.KeyPath'>IndexedDB.KeyPath</a>: Key path.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#IndexedDB.enable">IndexedDB.enable</a>: Enables events from backend.</li>
-<li><a href="#IndexedDB.disable">IndexedDB.disable</a>: Disables events from backend.</li>
-<li><a href="#IndexedDB.requestDatabaseNamesForFrame">IndexedDB.requestDatabaseNamesForFrame</a>: Requests database names for given frame's security origin.</li>
-<li><a href="#IndexedDB.requestDatabase">IndexedDB.requestDatabase</a>: Requests database with given name in given frame.</li>
-<li><a href="#IndexedDB.requestData">IndexedDB.requestData</a>: Requests data from object store or index.</li>
+<li><a href='#IndexedDB.enable'>IndexedDB.enable</a>: Enables events from backend.</li>
+<li><a href='#IndexedDB.disable'>IndexedDB.disable</a>: Disables events from backend.</li>
+<li><a href='#IndexedDB.requestDatabaseNamesForFrame'>IndexedDB.requestDatabaseNamesForFrame</a>: Requests database names for given frame's security origin.</li>
+<li><a href='#IndexedDB.requestDatabase'>IndexedDB.requestDatabase</a>: Requests database with given name in given frame.</li>
+<li><a href='#IndexedDB.requestData'>IndexedDB.requestData</a>: Requests data from object store or index.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#IndexedDB.databaseNamesLoaded">IndexedDB.databaseNamesLoaded</a></li>
-<li><a href="#IndexedDB.databaseLoaded">IndexedDB.databaseLoaded</a></li>
-<li><a href="#IndexedDB.objectStoreDataLoaded">IndexedDB.objectStoreDataLoaded</a></li>
-<li><a href="#IndexedDB.indexDataLoaded">IndexedDB.indexDataLoaded</a></li>
+<li><a href='#IndexedDB.databaseNamesLoaded'>IndexedDB.databaseNamesLoaded</a></li>
+<li><a href='#IndexedDB.databaseLoaded'>IndexedDB.databaseLoaded</a></li>
+<li><a href='#IndexedDB.objectStoreDataLoaded'>IndexedDB.objectStoreDataLoaded</a></li>
+<li><a href='#IndexedDB.indexDataLoaded'>IndexedDB.indexDataLoaded</a></li>
 </ul>
 <h3><a href="#Inspector">Inspector</a></h3>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Inspector.enable">Inspector.enable</a>: Enables inspector domain notifications.</li>
-<li><a href="#Inspector.disable">Inspector.disable</a>: Disables inspector domain notifications.</li>
+<li><a href='#Inspector.enable'>Inspector.enable</a>: Enables inspector domain notifications.</li>
+<li><a href='#Inspector.disable'>Inspector.disable</a>: Disables inspector domain notifications.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Inspector.evaluateForTestInFrontend">Inspector.evaluateForTestInFrontend</a></li>
-<li><a href="#Inspector.inspect">Inspector.inspect</a></li>
-<li><a href="#Inspector.didCreateWorker">Inspector.didCreateWorker</a></li>
-<li><a href="#Inspector.didDestroyWorker">Inspector.didDestroyWorker</a></li>
+<li><a href='#Inspector.evaluateForTestInFrontend'>Inspector.evaluateForTestInFrontend</a></li>
+<li><a href='#Inspector.inspect'>Inspector.inspect</a></li>
 </ul>
 <h3><a href="#Memory">Memory</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Memory.NodeCount">Memory.NodeCount</a>: Number of nodes with given name.</li>
-<li><a href="#Memory.ListenerCount">Memory.ListenerCount</a>: Number of JS event listeners by event type.</li>
-<li><a href="#Memory.StringStatistics">Memory.StringStatistics</a>: Character data statistics for the page.</li>
-<li><a href="#Memory.DOMGroup">Memory.DOMGroup</a></li>
+<li><a href='#Memory.NodeCount'>Memory.NodeCount</a>: Number of nodes with given name.</li>
+<li><a href='#Memory.ListenerCount'>Memory.ListenerCount</a>: Number of JS event listeners by event type.</li>
+<li><a href='#Memory.StringStatistics'>Memory.StringStatistics</a>: Character data statistics for the page.</li>
+<li><a href='#Memory.DOMGroup'>Memory.DOMGroup</a></li>
+<li><a href='#Memory.MemoryBlock'>Memory.MemoryBlock</a></li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Memory.getDOMNodeCount">Memory.getDOMNodeCount</a></li>
+<li><a href='#Memory.getDOMNodeCount'>Memory.getDOMNodeCount</a></li>
+<li><a href='#Memory.getProcessMemoryDistribution'>Memory.getProcessMemoryDistribution</a></li>
 </ul>
 <h3><a href="#Network">Network</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Network.LoaderId">Network.LoaderId</a>: Unique loader identifier.</li>
-<li><a href="#Network.FrameId">Network.FrameId</a>: Unique frame identifier.</li>
-<li><a href="#Network.RequestId">Network.RequestId</a>: Unique request identifier.</li>
-<li><a href="#Network.Timestamp">Network.Timestamp</a>: Number of seconds since epoch.</li>
-<li><a href="#Network.Headers">Network.Headers</a>: Request / response headers as keys / values of JSON object.</li>
-<li><a href="#Network.ResourceTiming">Network.ResourceTiming</a>: Timing information for the request.</li>
-<li><a href="#Network.Request">Network.Request</a>: HTTP request data.</li>
-<li><a href="#Network.Response">Network.Response</a>: HTTP response data.</li>
-<li><a href="#Network.WebSocketRequest">Network.WebSocketRequest</a>: WebSocket request data.</li>
-<li><a href="#Network.WebSocketResponse">Network.WebSocketResponse</a>: WebSocket response data.</li>
-<li><a href="#Network.CachedResource">Network.CachedResource</a>: Information about the cached resource.</li>
-<li><a href="#Network.Initiator">Network.Initiator</a>: Information about the request initiator.</li>
+<li><a href='#Network.LoaderId'>Network.LoaderId</a>: Unique loader identifier.</li>
+<li><a href='#Network.FrameId'>Network.FrameId</a>: Unique frame identifier.</li>
+<li><a href='#Network.RequestId'>Network.RequestId</a>: Unique request identifier.</li>
+<li><a href='#Network.Timestamp'>Network.Timestamp</a>: Number of seconds since epoch.</li>
+<li><a href='#Network.Headers'>Network.Headers</a>: Request / response headers as keys / values of JSON object.</li>
+<li><a href='#Network.ResourceTiming'>Network.ResourceTiming</a>: Timing information for the request.</li>
+<li><a href='#Network.Request'>Network.Request</a>: HTTP request data.</li>
+<li><a href='#Network.Response'>Network.Response</a>: HTTP response data.</li>
+<li><a href='#Network.WebSocketRequest'>Network.WebSocketRequest</a>: WebSocket request data.</li>
+<li><a href='#Network.WebSocketResponse'>Network.WebSocketResponse</a>: WebSocket response data.</li>
+<li><a href='#Network.WebSocketFrame'>Network.WebSocketFrame</a>: WebSocket frame data.</li>
+<li><a href='#Network.CachedResource'>Network.CachedResource</a>: Information about the cached resource.</li>
+<li><a href='#Network.Initiator'>Network.Initiator</a>: Information about the request initiator.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Network.enable">Network.enable</a>: Enables network tracking, network events will now be delivered to the client.</li>
-<li><a href="#Network.disable">Network.disable</a>: Disables network tracking, prevents network events from being sent to the client.</li>
-<li><a href="#Network.setUserAgentOverride">Network.setUserAgentOverride</a>: Allows overriding user agent with the given string.</li>
-<li><a href="#Network.setExtraHTTPHeaders">Network.setExtraHTTPHeaders</a>: Specifies whether to always send extra HTTP headers with the requests from this page.</li>
-<li><a href="#Network.getResponseBody">Network.getResponseBody</a>: Returns content served for the given request.</li>
-<li><a href="#Network.canClearBrowserCache">Network.canClearBrowserCache</a>: Tells whether clearing browser cache is supported.</li>
-<li><a href="#Network.clearBrowserCache">Network.clearBrowserCache</a>: Clears browser cache.</li>
-<li><a href="#Network.canClearBrowserCookies">Network.canClearBrowserCookies</a>: Tells whether clearing browser cookies is supported.</li>
-<li><a href="#Network.clearBrowserCookies">Network.clearBrowserCookies</a>: Clears browser cookies.</li>
-<li><a href="#Network.setCacheDisabled">Network.setCacheDisabled</a>: Toggles ignoring cache for each request. If true, cache will not be used.</li>
+<li><a href='#Network.enable'>Network.enable</a>: Enables network tracking, network events will now be delivered to the client.</li>
+<li><a href='#Network.disable'>Network.disable</a>: Disables network tracking, prevents network events from being sent to the client.</li>
+<li><a href='#Network.setUserAgentOverride'>Network.setUserAgentOverride</a>: Allows overriding user agent with the given string.</li>
+<li><a href='#Network.setExtraHTTPHeaders'>Network.setExtraHTTPHeaders</a>: Specifies whether to always send extra HTTP headers with the requests from this page.</li>
+<li><a href='#Network.getResponseBody'>Network.getResponseBody</a>: Returns content served for the given request.</li>
+<li><a href='#Network.canClearBrowserCache'>Network.canClearBrowserCache</a>: Tells whether clearing browser cache is supported.</li>
+<li><a href='#Network.clearBrowserCache'>Network.clearBrowserCache</a>: Clears browser cache.</li>
+<li><a href='#Network.canClearBrowserCookies'>Network.canClearBrowserCookies</a>: Tells whether clearing browser cookies is supported.</li>
+<li><a href='#Network.clearBrowserCookies'>Network.clearBrowserCookies</a>: Clears browser cookies.</li>
+<li><a href='#Network.setCacheDisabled'>Network.setCacheDisabled</a>: Toggles ignoring cache for each request. If true, cache will not be used.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Network.requestWillBeSent">Network.requestWillBeSent</a>: Fired when page is about to send HTTP request.</li>
-<li><a href="#Network.requestServedFromCache">Network.requestServedFromCache</a>: Fired if request ended up loading from cache.</li>
-<li><a href="#Network.responseReceived">Network.responseReceived</a>: Fired when HTTP response is available.</li>
-<li><a href="#Network.dataReceived">Network.dataReceived</a>: Fired when data chunk was received over the network.</li>
-<li><a href="#Network.loadingFinished">Network.loadingFinished</a>: Fired when HTTP request has finished loading.</li>
-<li><a href="#Network.loadingFailed">Network.loadingFailed</a>: Fired when HTTP request has failed to load.</li>
-<li><a href="#Network.requestServedFromMemoryCache">Network.requestServedFromMemoryCache</a>: Fired when HTTP request has been served from memory cache.</li>
-<li><a href="#Network.webSocketWillSendHandshakeRequest">Network.webSocketWillSendHandshakeRequest</a>: Fired when WebSocket is about to initiate handshake.</li>
-<li><a href="#Network.webSocketHandshakeResponseReceived">Network.webSocketHandshakeResponseReceived</a>: Fired when WebSocket handshake response becomes available.</li>
-<li><a href="#Network.webSocketCreated">Network.webSocketCreated</a>: Fired upon WebSocket creation.</li>
-<li><a href="#Network.webSocketClosed">Network.webSocketClosed</a>: Fired when WebSocket is closed.</li>
+<li><a href='#Network.requestWillBeSent'>Network.requestWillBeSent</a>: Fired when page is about to send HTTP request.</li>
+<li><a href='#Network.requestServedFromCache'>Network.requestServedFromCache</a>: Fired if request ended up loading from cache.</li>
+<li><a href='#Network.responseReceived'>Network.responseReceived</a>: Fired when HTTP response is available.</li>
+<li><a href='#Network.dataReceived'>Network.dataReceived</a>: Fired when data chunk was received over the network.</li>
+<li><a href='#Network.loadingFinished'>Network.loadingFinished</a>: Fired when HTTP request has finished loading.</li>
+<li><a href='#Network.loadingFailed'>Network.loadingFailed</a>: Fired when HTTP request has failed to load.</li>
+<li><a href='#Network.requestServedFromMemoryCache'>Network.requestServedFromMemoryCache</a>: Fired when HTTP request has been served from memory cache.</li>
+<li><a href='#Network.webSocketWillSendHandshakeRequest'>Network.webSocketWillSendHandshakeRequest</a>: Fired when WebSocket is about to initiate handshake.</li>
+<li><a href='#Network.webSocketHandshakeResponseReceived'>Network.webSocketHandshakeResponseReceived</a>: Fired when WebSocket handshake response becomes available.</li>
+<li><a href='#Network.webSocketCreated'>Network.webSocketCreated</a>: Fired upon WebSocket creation.</li>
+<li><a href='#Network.webSocketClosed'>Network.webSocketClosed</a>: Fired when WebSocket is closed.</li>
+<li><a href='#Network.webSocketFrameReceived'>Network.webSocketFrameReceived</a>: Fired when WebSocket frame is received.</li>
+<li><a href='#Network.webSocketFrameError'>Network.webSocketFrameError</a>: Fired when WebSocket frame error occurs.</li>
+<li><a href='#Network.webSocketFrameSent'>Network.webSocketFrameSent</a>: Fired when WebSocket frame is sent.</li>
 </ul>
 <h3><a href="#Page">Page</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Page.ResourceType">Page.ResourceType</a>: Resource type as it was perceived by the rendering engine.</li>
-<li><a href="#Page.Frame">Page.Frame</a>: Information about the Frame on the page.</li>
-<li><a href="#Page.FrameResourceTree">Page.FrameResourceTree</a>: Information about the Frame hierarchy along with their cached resources.</li>
-<li><a href="#Page.SearchMatch">Page.SearchMatch</a>: Search match for resource.</li>
-<li><a href="#Page.SearchResult">Page.SearchResult</a>: Search result for resource.</li>
-<li><a href="#Page.Cookie">Page.Cookie</a>: Cookie object</li>
-<li><a href="#Page.ScriptIdentifier">Page.ScriptIdentifier</a>: Unique script identifier.</li>
+<li><a href='#Page.ResourceType'>Page.ResourceType</a>: Resource type as it was perceived by the rendering engine.</li>
+<li><a href='#Page.Frame'>Page.Frame</a>: Information about the Frame on the page.</li>
+<li><a href='#Page.FrameResourceTree'>Page.FrameResourceTree</a>: Information about the Frame hierarchy along with their cached resources.</li>
+<li><a href='#Page.SearchMatch'>Page.SearchMatch</a>: Search match for resource.</li>
+<li><a href='#Page.SearchResult'>Page.SearchResult</a>: Search result for resource.</li>
+<li><a href='#Page.Cookie'>Page.Cookie</a>: Cookie object</li>
+<li><a href='#Page.ScriptIdentifier'>Page.ScriptIdentifier</a>: Unique script identifier.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Page.enable">Page.enable</a>: Enables page domain notifications.</li>
-<li><a href="#Page.disable">Page.disable</a>: Disables page domain notifications.</li>
-<li><a href="#Page.addScriptToEvaluateOnLoad">Page.addScriptToEvaluateOnLoad</a></li>
-<li><a href="#Page.removeScriptToEvaluateOnLoad">Page.removeScriptToEvaluateOnLoad</a></li>
-<li><a href="#Page.reload">Page.reload</a>: Reloads given page optionally ignoring the cache.</li>
-<li><a href="#Page.navigate">Page.navigate</a>: Navigates current page to the given URL.</li>
-<li><a href="#Page.getCookies">Page.getCookies</a>: Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the cookie field or string cookie representation using cookieString.</li>
-<li><a href="#Page.deleteCookie">Page.deleteCookie</a>: Deletes browser cookie with given name for the given domain.</li>
-<li><a href="#Page.getResourceTree">Page.getResourceTree</a>: Returns present frame / resource tree structure.</li>
-<li><a href="#Page.getResourceContent">Page.getResourceContent</a>: Returns content of the given resource.</li>
-<li><a href="#Page.searchInResource">Page.searchInResource</a>: Searches for given string in resource content.</li>
-<li><a href="#Page.searchInResources">Page.searchInResources</a>: Searches for given string in frame / resource tree structure.</li>
-<li><a href="#Page.setDocumentContent">Page.setDocumentContent</a>: Sets given markup as the document's HTML.</li>
-<li><a href="#Page.setScreenSizeOverride">Page.setScreenSizeOverride</a>: Overrides the values of window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results</li>
-<li><a href="#Page.setShowPaintRects">Page.setShowPaintRects</a>: Requests that backend shows paint rectangles</li>
+<li><a href='#Page.enable'>Page.enable</a>: Enables page domain notifications.</li>
+<li><a href='#Page.disable'>Page.disable</a>: Disables page domain notifications.</li>
+<li><a href='#Page.addScriptToEvaluateOnLoad'>Page.addScriptToEvaluateOnLoad</a></li>
+<li><a href='#Page.removeScriptToEvaluateOnLoad'>Page.removeScriptToEvaluateOnLoad</a></li>
+<li><a href='#Page.reload'>Page.reload</a>: Reloads given page optionally ignoring the cache.</li>
+<li><a href='#Page.navigate'>Page.navigate</a>: Navigates current page to the given URL.</li>
+<li><a href='#Page.getCookies'>Page.getCookies</a>: Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the cookie field or string cookie representation using cookieString.</li>
+<li><a href='#Page.deleteCookie'>Page.deleteCookie</a>: Deletes browser cookie with given name for the given domain.</li>
+<li><a href='#Page.getResourceTree'>Page.getResourceTree</a>: Returns present frame / resource tree structure.</li>
+<li><a href='#Page.getResourceContent'>Page.getResourceContent</a>: Returns content of the given resource.</li>
+<li><a href='#Page.searchInResource'>Page.searchInResource</a>: Searches for given string in resource content.</li>
+<li><a href='#Page.searchInResources'>Page.searchInResources</a>: Searches for given string in frame / resource tree structure.</li>
+<li><a href='#Page.setDocumentContent'>Page.setDocumentContent</a>: Sets given markup as the document's HTML.</li>
+<li><a href='#Page.canOverrideDeviceMetrics'>Page.canOverrideDeviceMetrics</a>: Checks whether setDeviceMetricsOverride can be invoked.</li>
+<li><a href='#Page.setDeviceMetricsOverride'>Page.setDeviceMetricsOverride</a>: Overrides the values of device screen dimensions (window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results) and the font scale factor.</li>
+<li><a href='#Page.setShowPaintRects'>Page.setShowPaintRects</a>: Requests that backend shows paint rectangles</li>
+<li><a href='#Page.getScriptExecutionStatus'>Page.getScriptExecutionStatus</a>: Determines if scripts can be executed in the page.</li>
+<li><a href='#Page.setScriptExecutionDisabled'>Page.setScriptExecutionDisabled</a>: Switches script execution in the page.</li>
+<li><a href='#Page.setGeolocationOverride'>Page.setGeolocationOverride</a>: Overrides the Geolocation Position or Error.</li>
+<li><a href='#Page.clearGeolocationOverride'>Page.clearGeolocationOverride</a>: Clears the overriden Geolocation Position and Error.</li>
+<li><a href='#Page.canOverrideGeolocation'>Page.canOverrideGeolocation</a>: Checks if Geolocation can be overridden.</li>
+<li><a href='#Page.setDeviceOrientationOverride'>Page.setDeviceOrientationOverride</a>: Overrides the Device Orientation.</li>
+<li><a href='#Page.clearDeviceOrientationOverride'>Page.clearDeviceOrientationOverride</a>: Clears the overridden Device Orientation.</li>
+<li><a href='#Page.canOverrideDeviceOrientation'>Page.canOverrideDeviceOrientation</a>: Check the backend if Web Inspector can override the device orientation.</li>
+<li><a href='#Page.setTouchEmulationEnabled'>Page.setTouchEmulationEnabled</a>: Toggles mouse event-based touch event emulation.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Page.domContentEventFired">Page.domContentEventFired</a></li>
-<li><a href="#Page.loadEventFired">Page.loadEventFired</a></li>
-<li><a href="#Page.frameNavigated">Page.frameNavigated</a>: Fired once navigation of the frame has completed. Frame is now associated with the new loader.</li>
-<li><a href="#Page.frameDetached">Page.frameDetached</a>: Fired when frame has been detached from its parent.</li>
+<li><a href='#Page.domContentEventFired'>Page.domContentEventFired</a></li>
+<li><a href='#Page.loadEventFired'>Page.loadEventFired</a></li>
+<li><a href='#Page.frameNavigated'>Page.frameNavigated</a>: Fired once navigation of the frame has completed. Frame is now associated with the new loader.</li>
+<li><a href='#Page.frameDetached'>Page.frameDetached</a>: Fired when frame has been detached from its parent.</li>
 </ul>
 <h3><a href="#Profiler">Profiler</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Profiler.Profile">Profiler.Profile</a>: Profile.</li>
-<li><a href="#Profiler.ProfileHeader">Profiler.ProfileHeader</a>: Profile header.</li>
+<li><a href='#Profiler.ProfileHeader'>Profiler.ProfileHeader</a>: Profile header.</li>
+<li><a href='#Profiler.Profile'>Profiler.Profile</a>: Profile.</li>
+<li><a href='#Profiler.HeapSnapshotObjectId'>Profiler.HeapSnapshotObjectId</a>: Heap snashot object id.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Profiler.causesRecompilation">Profiler.causesRecompilation</a></li>
-<li><a href="#Profiler.isSampling">Profiler.isSampling</a></li>
-<li><a href="#Profiler.hasHeapProfiler">Profiler.hasHeapProfiler</a></li>
-<li><a href="#Profiler.enable">Profiler.enable</a></li>
-<li><a href="#Profiler.disable">Profiler.disable</a></li>
-<li><a href="#Profiler.start">Profiler.start</a></li>
-<li><a href="#Profiler.stop">Profiler.stop</a></li>
-<li><a href="#Profiler.getProfileHeaders">Profiler.getProfileHeaders</a></li>
-<li><a href="#Profiler.getProfile">Profiler.getProfile</a></li>
-<li><a href="#Profiler.removeProfile">Profiler.removeProfile</a></li>
-<li><a href="#Profiler.clearProfiles">Profiler.clearProfiles</a></li>
-<li><a href="#Profiler.takeHeapSnapshot">Profiler.takeHeapSnapshot</a></li>
-<li><a href="#Profiler.collectGarbage">Profiler.collectGarbage</a></li>
-<li><a href="#Profiler.getObjectByHeapObjectId">Profiler.getObjectByHeapObjectId</a></li>
+<li><a href='#Profiler.causesRecompilation'>Profiler.causesRecompilation</a></li>
+<li><a href='#Profiler.isSampling'>Profiler.isSampling</a></li>
+<li><a href='#Profiler.hasHeapProfiler'>Profiler.hasHeapProfiler</a></li>
+<li><a href='#Profiler.enable'>Profiler.enable</a></li>
+<li><a href='#Profiler.disable'>Profiler.disable</a></li>
+<li><a href='#Profiler.start'>Profiler.start</a></li>
+<li><a href='#Profiler.stop'>Profiler.stop</a></li>
+<li><a href='#Profiler.getProfileHeaders'>Profiler.getProfileHeaders</a></li>
+<li><a href='#Profiler.getProfile'>Profiler.getProfile</a></li>
+<li><a href='#Profiler.removeProfile'>Profiler.removeProfile</a></li>
+<li><a href='#Profiler.clearProfiles'>Profiler.clearProfiles</a></li>
+<li><a href='#Profiler.takeHeapSnapshot'>Profiler.takeHeapSnapshot</a></li>
+<li><a href='#Profiler.collectGarbage'>Profiler.collectGarbage</a></li>
+<li><a href='#Profiler.getObjectByHeapObjectId'>Profiler.getObjectByHeapObjectId</a></li>
+<li><a href='#Profiler.getHeapObjectId'>Profiler.getHeapObjectId</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Profiler.addProfileHeader">Profiler.addProfileHeader</a></li>
-<li><a href="#Profiler.addHeapSnapshotChunk">Profiler.addHeapSnapshotChunk</a></li>
-<li><a href="#Profiler.finishHeapSnapshot">Profiler.finishHeapSnapshot</a></li>
-<li><a href="#Profiler.setRecordingProfile">Profiler.setRecordingProfile</a></li>
-<li><a href="#Profiler.resetProfiles">Profiler.resetProfiles</a></li>
-<li><a href="#Profiler.reportHeapSnapshotProgress">Profiler.reportHeapSnapshotProgress</a></li>
+<li><a href='#Profiler.addProfileHeader'>Profiler.addProfileHeader</a></li>
+<li><a href='#Profiler.addHeapSnapshotChunk'>Profiler.addHeapSnapshotChunk</a></li>
+<li><a href='#Profiler.finishHeapSnapshot'>Profiler.finishHeapSnapshot</a></li>
+<li><a href='#Profiler.setRecordingProfile'>Profiler.setRecordingProfile</a></li>
+<li><a href='#Profiler.resetProfiles'>Profiler.resetProfiles</a></li>
+<li><a href='#Profiler.reportHeapSnapshotProgress'>Profiler.reportHeapSnapshotProgress</a></li>
 </ul>
 <h3><a href="#Runtime">Runtime</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a>: Unique object identifier.</li>
-<li><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a>: Mirror object referencing original JavaScript object.</li>
-<li><a href="#Runtime.PropertyDescriptor">Runtime.PropertyDescriptor</a>: Object property descriptor.</li>
-<li><a href="#Runtime.CallArgument">Runtime.CallArgument</a>: Represents function call argument. Either remote object id objectId or primitive value or neither of (for undefined) them should be specified.</li>
+<li><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a>: Unique object identifier.</li>
+<li><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a>: Mirror object referencing original JavaScript object.</li>
+<li><a href='#Runtime.ObjectPreview'>Runtime.ObjectPreview</a>: Object containing abbreviated remote object value.</li>
+<li><a href='#Runtime.PropertyPreview'>Runtime.PropertyPreview</a></li>
+<li><a href='#Runtime.PropertyDescriptor'>Runtime.PropertyDescriptor</a>: Object property descriptor.</li>
+<li><a href='#Runtime.CallArgument'>Runtime.CallArgument</a>: Represents function call argument. Either remote object id objectId or primitive value or neither of (for undefined) them should be specified.</li>
+<li><a href='#Runtime.ExecutionContextId'>Runtime.ExecutionContextId</a>: Id of an execution context.</li>
+<li><a href='#Runtime.ExecutionContextDescription'>Runtime.ExecutionContextDescription</a>: Description of an isolated world.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Runtime.evaluate">Runtime.evaluate</a>: Evaluates expression on global object.</li>
-<li><a href="#Runtime.callFunctionOn">Runtime.callFunctionOn</a>: Calls function with given declaration on the given object. Object group of the result is inherited from the target object.</li>
-<li><a href="#Runtime.getProperties">Runtime.getProperties</a>: Returns properties of a given object. Object group of the result is inherited from the target object.</li>
-<li><a href="#Runtime.releaseObject">Runtime.releaseObject</a>: Releases remote object with given id.</li>
-<li><a href="#Runtime.releaseObjectGroup">Runtime.releaseObjectGroup</a>: Releases all remote objects that belong to a given group.</li>
-<li><a href="#Runtime.run">Runtime.run</a>: Tells inspected instance(worker or page) that it can run in case it was started paused.</li>
+<li><a href='#Runtime.evaluate'>Runtime.evaluate</a>: Evaluates expression on global object.</li>
+<li><a href='#Runtime.callFunctionOn'>Runtime.callFunctionOn</a>: Calls function with given declaration on the given object. Object group of the result is inherited from the target object.</li>
+<li><a href='#Runtime.getProperties'>Runtime.getProperties</a>: Returns properties of a given object. Object group of the result is inherited from the target object.</li>
+<li><a href='#Runtime.releaseObject'>Runtime.releaseObject</a>: Releases remote object with given id.</li>
+<li><a href='#Runtime.releaseObjectGroup'>Runtime.releaseObjectGroup</a>: Releases all remote objects that belong to a given group.</li>
+<li><a href='#Runtime.run'>Runtime.run</a>: Tells inspected instance(worker or page) that it can run in case it was started paused.</li>
+<li><a href='#Runtime.setReportExecutionContextCreation'>Runtime.setReportExecutionContextCreation</a>: Enables reporting about creation of isolated contexts by means of isolatedContextCreated event. When the reporting gets enabled the event will be sent immediately for each existing isolated context.</li>
+</ul>
+<span class='label label-info'>Event</span>
+<ul>
+<li><a href='#Runtime.isolatedContextCreated'>Runtime.isolatedContextCreated</a>: Issued when new isolated context is created.</li>
 </ul>
 <h3><a href="#Timeline">Timeline</a></h3>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Timeline.TimelineEvent">Timeline.TimelineEvent</a>: Timeline record contains information about the recorded activity.</li>
+<li><a href='#Timeline.TimelineEvent'>Timeline.TimelineEvent</a>: Timeline record contains information about the recorded activity.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Timeline.start">Timeline.start</a>: Starts capturing instrumentation events.</li>
-<li><a href="#Timeline.stop">Timeline.stop</a>: Stops capturing instrumentation events.</li>
-<li><a href="#Timeline.setIncludeMemoryDetails">Timeline.setIncludeMemoryDetails</a>: Starts calculating various DOM statistics and sending them as part of timeline events.</li>
+<li><a href='#Timeline.start'>Timeline.start</a>: Starts capturing instrumentation events.</li>
+<li><a href='#Timeline.stop'>Timeline.stop</a>: Stops capturing instrumentation events.</li>
+<li><a href='#Timeline.setIncludeMemoryDetails'>Timeline.setIncludeMemoryDetails</a>: Starts calculating various DOM statistics and sending them as part of timeline events.</li>
+<li><a href='#Timeline.supportsFrameInstrumentation'>Timeline.supportsFrameInstrumentation</a>: Tells whether timeline agent supports frame instrumentation.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Timeline.eventRecorded">Timeline.eventRecorded</a>: Fired for every instrumentation event while timeline is started.</li>
+<li><a href='#Timeline.eventRecorded'>Timeline.eventRecorded</a>: Fired for every instrumentation event while timeline is started.</li>
+</ul>
+<h3><a href="#WebGL">WebGL</a></h3>
+<span class='label label-success'>Command</span>
+<ul>
+<li><a href='#WebGL.enable'>WebGL.enable</a>: Enables WebGL inspection.</li>
+<li><a href='#WebGL.disable'>WebGL.disable</a>: Disables WebGL inspection.</li>
 </ul>
 <h3><a href="#Worker">Worker</a></h3>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Worker.setWorkerInspectionEnabled">Worker.setWorkerInspectionEnabled</a></li>
-<li><a href="#Worker.sendMessageToWorker">Worker.sendMessageToWorker</a></li>
-<li><a href="#Worker.connectToWorker">Worker.connectToWorker</a></li>
-<li><a href="#Worker.disconnectFromWorker">Worker.disconnectFromWorker</a></li>
-<li><a href="#Worker.setAutoconnectToWorkers">Worker.setAutoconnectToWorkers</a></li>
+<li><a href='#Worker.enable'>Worker.enable</a></li>
+<li><a href='#Worker.disable'>Worker.disable</a></li>
+<li><a href='#Worker.sendMessageToWorker'>Worker.sendMessageToWorker</a></li>
+<li><a href='#Worker.connectToWorker'>Worker.connectToWorker</a></li>
+<li><a href='#Worker.disconnectFromWorker'>Worker.disconnectFromWorker</a></li>
+<li><a href='#Worker.setAutoconnectToWorkers'>Worker.setAutoconnectToWorkers</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Worker.workerCreated">Worker.workerCreated</a></li>
-<li><a href="#Worker.workerTerminated">Worker.workerTerminated</a></li>
-<li><a href="#Worker.dispatchMessageFromWorker">Worker.dispatchMessageFromWorker</a></li>
-<li><a href="#Worker.disconnectedFromWorker">Worker.disconnectedFromWorker</a></li>
+<li><a href='#Worker.workerCreated'>Worker.workerCreated</a></li>
+<li><a href='#Worker.workerTerminated'>Worker.workerTerminated</a></li>
+<li><a href='#Worker.dispatchMessageFromWorker'>Worker.dispatchMessageFromWorker</a></li>
+<li><a href='#Worker.disconnectedFromWorker'>Worker.disconnectedFromWorker</a></li>
 </ul>
 </section>
-<section id="ApplicationCache" class="domain">
+<section id='ApplicationCache' class='domain'>
 <h1>ApplicationCache</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#ApplicationCache.ApplicationCacheResource">ApplicationCache.ApplicationCacheResource</a>: Detailed application cache resource information.</li>
-<li><a href="#ApplicationCache.ApplicationCache">ApplicationCache.ApplicationCache</a>: Detailed application cache information.</li>
-<li><a href="#ApplicationCache.FrameWithManifest">ApplicationCache.FrameWithManifest</a>: Frame identifier - manifest URL pair.</li>
+<li><a href='#ApplicationCache.ApplicationCacheResource'>ApplicationCache.ApplicationCacheResource</a>: Detailed application cache resource information.</li>
+<li><a href='#ApplicationCache.ApplicationCache'>ApplicationCache.ApplicationCache</a>: Detailed application cache information.</li>
+<li><a href='#ApplicationCache.FrameWithManifest'>ApplicationCache.FrameWithManifest</a>: Frame identifier - manifest URL pair.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#ApplicationCache.getFramesWithManifests">ApplicationCache.getFramesWithManifests</a>: Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</li>
-<li><a href="#ApplicationCache.enable">ApplicationCache.enable</a>: Enables application cache domain notifications.</li>
-<li><a href="#ApplicationCache.getManifestForFrame">ApplicationCache.getManifestForFrame</a>: Returns manifest URL for document in the given frame.</li>
-<li><a href="#ApplicationCache.getApplicationCacheForFrame">ApplicationCache.getApplicationCacheForFrame</a>: Returns relevant application cache data for the document in given frame.</li>
+<li><a href='#ApplicationCache.getFramesWithManifests'>ApplicationCache.getFramesWithManifests</a>: Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</li>
+<li><a href='#ApplicationCache.enable'>ApplicationCache.enable</a>: Enables application cache domain notifications.</li>
+<li><a href='#ApplicationCache.getManifestForFrame'>ApplicationCache.getManifestForFrame</a>: Returns manifest URL for document in the given frame.</li>
+<li><a href='#ApplicationCache.getApplicationCacheForFrame'>ApplicationCache.getApplicationCacheForFrame</a>: Returns relevant application cache data for the document in given frame.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#ApplicationCache.applicationCacheStatusUpdated">ApplicationCache.applicationCacheStatusUpdated</a></li>
-<li><a href="#ApplicationCache.networkStateUpdated">ApplicationCache.networkStateUpdated</a></li>
+<li><a href='#ApplicationCache.applicationCacheStatusUpdated'>ApplicationCache.applicationCacheStatusUpdated</a></li>
+<li><a href='#ApplicationCache.networkStateUpdated'>ApplicationCache.networkStateUpdated</a></li>
 </ul>
-<div id="ApplicationCache_ApplicationCacheResource" class="type">
-<h3>ApplicationCache.ApplicationCacheResource <span class="label">Type</span></h3>
+<div id='ApplicationCache_ApplicationCacheResource' class='type'>
+<h3>ApplicationCache.ApplicationCacheResource <span class='label'>Type</span></h3>
 <p>Detailed application cache resource information.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Resource url.</span></dd>
+<dd>String <span class='text'>Resource url.</span></dd>
 <dt>size</dt>
-<dd>Integer <span class="text">Resource size.</span></dd>
+<dd>Integer <span class='text'>Resource size.</span></dd>
 <dt>type</dt>
-<dd>String <span class="text">Resource type.</span></dd>
+<dd>String <span class='text'>Resource type.</span></dd>
 </dl>
 </div>
-<div id="ApplicationCache_ApplicationCache" class="type">
-<h3>ApplicationCache.ApplicationCache <span class="label">Type</span></h3>
+<div id='ApplicationCache_ApplicationCache' class='type'>
+<h3>ApplicationCache.ApplicationCache <span class='label'>Type</span></h3>
 <p>Detailed application cache information.</p>
 <dl>
 <dt>manifestURL</dt>
-<dd>String <span class="text">Manifest URL.</span></dd>
+<dd>String <span class='text'>Manifest URL.</span></dd>
 <dt>size</dt>
-<dd>Number <span class="text">Application cache size.</span></dd>
+<dd>Number <span class='text'>Application cache size.</span></dd>
 <dt>creationTime</dt>
-<dd>Number <span class="text">Application cache creation time.</span></dd>
+<dd>Number <span class='text'>Application cache creation time.</span></dd>
 <dt>updateTime</dt>
-<dd>Number <span class="text">Application cache update time.</span></dd>
+<dd>Number <span class='text'>Application cache update time.</span></dd>
 <dt>resources</dt>
-<dd>[<a href="#ApplicationCache.ApplicationCacheResource">ApplicationCache.ApplicationCacheResource</a>] <span class="text">Application cache resources.</span></dd>
+<dd>[<a href='#ApplicationCache.ApplicationCacheResource'>ApplicationCache.ApplicationCacheResource</a>] <span class='text'>Application cache resources.</span></dd>
 </dl>
 </div>
-<div id="ApplicationCache_FrameWithManifest" class="type">
-<h3>ApplicationCache.FrameWithManifest <span class="label">Type</span></h3>
+<div id='ApplicationCache_FrameWithManifest' class='type'>
+<h3>ApplicationCache.FrameWithManifest <span class='label'>Type</span></h3>
 <p>Frame identifier - manifest URL pair.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame identifier.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame identifier.</span></dd>
 <dt>manifestURL</dt>
-<dd>String <span class="text">Manifest URL.</span></dd>
+<dd>String <span class='text'>Manifest URL.</span></dd>
 <dt>status</dt>
-<dd>Integer <span class="text">Application cache status.</span></dd>
+<dd>Integer <span class='text'>Application cache status.</span></dd>
 </dl>
 </div>
-<div id="ApplicationCache_getFramesWithManifests" class="command">
-<h3>ApplicationCache.getFramesWithManifests <span class="label label-success">Command</span></h3>
+<div id='ApplicationCache_getFramesWithManifests' class='command'>
+<h3>ApplicationCache.getFramesWithManifests <span class='label label-success'>Command</span></h3>
 <p>Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>frameIds</dt>
-<dd>[<a href="#ApplicationCache.FrameWithManifest">ApplicationCache.FrameWithManifest</a>] <span class="text">Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</span></dd>
+<dd>[<a href='#ApplicationCache.FrameWithManifest'>ApplicationCache.FrameWithManifest</a>] <span class='text'>Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -615,8 +681,8 @@ ApplicationCache.getFramesWithManifests(function callback(res) {
 });
 </pre>
 </div>
-<div id="ApplicationCache_enable" class="command">
-<h3>ApplicationCache.enable <span class="label label-success">Command</span></h3>
+<div id='ApplicationCache_enable' class='command'>
+<h3>ApplicationCache.enable <span class='label label-success'>Command</span></h3>
 <p>Enables application cache domain notifications.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -624,17 +690,17 @@ ApplicationCache.getFramesWithManifests(function callback(res) {
 ApplicationCache.enable();
 </pre>
 </div>
-<div id="ApplicationCache_getManifestForFrame" class="command">
-<h3>ApplicationCache.getManifestForFrame <span class="label label-success">Command</span></h3>
+<div id='ApplicationCache_getManifestForFrame' class='command'>
+<h3>ApplicationCache.getManifestForFrame <span class='label label-success'>Command</span></h3>
 <p>Returns manifest URL for document in the given frame.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Identifier of the frame containing document whose manifest is retrieved.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Identifier of the frame containing document whose manifest is retrieved.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>manifestURL</dt>
-<dd>String <span class="text">Manifest URL for document in the given frame.</span></dd>
+<dd>String <span class='text'>Manifest URL for document in the given frame.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -644,17 +710,17 @@ ApplicationCache.getManifestForFrame(frameId, function callback(res) {
 });
 </pre>
 </div>
-<div id="ApplicationCache_getApplicationCacheForFrame" class="command">
-<h3>ApplicationCache.getApplicationCacheForFrame <span class="label label-success">Command</span></h3>
+<div id='ApplicationCache_getApplicationCacheForFrame' class='command'>
+<h3>ApplicationCache.getApplicationCacheForFrame <span class='label label-success'>Command</span></h3>
 <p>Returns relevant application cache data for the document in given frame.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Identifier of the frame containing document whose application cache is retrieved.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Identifier of the frame containing document whose application cache is retrieved.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>applicationCache</dt>
-<dd><a href="#ApplicationCache.ApplicationCache">ApplicationCache.ApplicationCache</a> <span class="text">Relevant application cache data for the document in given frame.</span></dd>
+<dd><a href='#ApplicationCache.ApplicationCache'>ApplicationCache.ApplicationCache</a> <span class='text'>Relevant application cache data for the document in given frame.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -664,15 +730,15 @@ ApplicationCache.getApplicationCacheForFrame(frameId, function callback(res) {
 });
 </pre>
 </div>
-<div id="ApplicationCache_applicationCacheStatusUpdated" class="command">
-<h3>ApplicationCache.applicationCacheStatusUpdated <span class="label label-info">Event</span></h3>
+<div id='ApplicationCache_applicationCacheStatusUpdated' class='command'>
+<h3>ApplicationCache.applicationCacheStatusUpdated <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Identifier of the frame containing document whose application cache updated status.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Identifier of the frame containing document whose application cache updated status.</span></dd>
 <dt>manifestURL</dt>
-<dd>String <span class="text">Manifest URL.</span></dd>
+<dd>String <span class='text'>Manifest URL.</span></dd>
 <dt>status</dt>
-<dd>Integer <span class="text">Updated application cache status.</span></dd>
+<dd>Integer <span class='text'>Updated application cache status.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -682,8 +748,8 @@ function onApplicationCacheStatusUpdated(res) {
 }
 </pre>
 </div>
-<div id="ApplicationCache_networkStateUpdated" class="command">
-<h3>ApplicationCache.networkStateUpdated <span class="label label-info">Event</span></h3>
+<div id='ApplicationCache_networkStateUpdated' class='command'>
+<h3>ApplicationCache.networkStateUpdated <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>isNowOnline</dt>
 <dd>Boolean</dd>
@@ -697,266 +763,319 @@ function onNetworkStateUpdated(res) {
 </pre>
 </div>
 </section>
-<section id="CSS" class="domain">
+<section id='CSS' class='domain'>
 <h1>CSS</h1>
 <p>This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></li>
-<li><a href="#CSS.CSSStyleId">CSS.CSSStyleId</a>: This object identifies a CSS style in a unique way.</li>
-<li><a href="#CSS.CSSRuleId">CSS.CSSRuleId</a>: This object identifies a CSS rule in a unique way.</li>
-<li><a href="#CSS.PseudoIdRules">CSS.PseudoIdRules</a>: CSS rule collection for a single pseudo style.</li>
-<li><a href="#CSS.InheritedStyleEntry">CSS.InheritedStyleEntry</a>: CSS rule collection for a single pseudo style.</li>
-<li><a href="#CSS.CSSStyleAttribute">CSS.CSSStyleAttribute</a>: CSS style information for a DOM style attribute.</li>
-<li><a href="#CSS.CSSStyleSheetHeader">CSS.CSSStyleSheetHeader</a>: CSS stylesheet metainformation.</li>
-<li><a href="#CSS.CSSStyleSheetBody">CSS.CSSStyleSheetBody</a>: CSS stylesheet contents.</li>
-<li><a href="#CSS.CSSRule">CSS.CSSRule</a>: CSS rule representation.</li>
-<li><a href="#CSS.SourceRange">CSS.SourceRange</a>: Text range within a resource.</li>
-<li><a href="#CSS.ShorthandEntry">CSS.ShorthandEntry</a></li>
-<li><a href="#CSS.CSSComputedStyleProperty">CSS.CSSComputedStyleProperty</a></li>
-<li><a href="#CSS.CSSStyle">CSS.CSSStyle</a>: CSS style representation.</li>
-<li><a href="#CSS.CSSProperty">CSS.CSSProperty</a>: CSS style effective visual dimensions and source offsets.</li>
-<li><a href="#CSS.CSSMedia">CSS.CSSMedia</a>: CSS media query descriptor.</li>
-<li><a href="#CSS.SelectorProfileEntry">CSS.SelectorProfileEntry</a>: CSS selector profile entry.</li>
-<li><a href="#CSS.SelectorProfile">CSS.SelectorProfile</a></li>
+<li><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></li>
+<li><a href='#CSS.CSSStyleId'>CSS.CSSStyleId</a>: This object identifies a CSS style in a unique way.</li>
+<li><a href='#CSS.StyleSheetOrigin'>CSS.StyleSheetOrigin</a>: Stylesheet type: "user" for user stylesheets, "user-agent" for user-agent stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via inspector" rules), "regular" for regular stylesheets.</li>
+<li><a href='#CSS.CSSRuleId'>CSS.CSSRuleId</a>: This object identifies a CSS rule in a unique way.</li>
+<li><a href='#CSS.PseudoIdRules'>CSS.PseudoIdRules</a>: CSS rule collection for a single pseudo style.</li>
+<li><a href='#CSS.InheritedStyleEntry'>CSS.InheritedStyleEntry</a>: CSS rule collection for a single pseudo style.</li>
+<li><a href='#CSS.CSSStyleAttribute'>CSS.CSSStyleAttribute</a>: CSS style information for a DOM style attribute.</li>
+<li><a href='#CSS.CSSStyleSheetHeader'>CSS.CSSStyleSheetHeader</a>: CSS stylesheet metainformation.</li>
+<li><a href='#CSS.CSSStyleSheetBody'>CSS.CSSStyleSheetBody</a>: CSS stylesheet contents.</li>
+<li><a href='#CSS.CSSRule'>CSS.CSSRule</a>: CSS rule representation.</li>
+<li><a href='#CSS.SourceRange'>CSS.SourceRange</a>: Text range within a resource.</li>
+<li><a href='#CSS.ShorthandEntry'>CSS.ShorthandEntry</a></li>
+<li><a href='#CSS.CSSPropertyInfo'>CSS.CSSPropertyInfo</a></li>
+<li><a href='#CSS.CSSComputedStyleProperty'>CSS.CSSComputedStyleProperty</a></li>
+<li><a href='#CSS.CSSStyle'>CSS.CSSStyle</a>: CSS style representation.</li>
+<li><a href='#CSS.CSSProperty'>CSS.CSSProperty</a>: CSS style effective visual dimensions and source offsets.</li>
+<li><a href='#CSS.CSSMedia'>CSS.CSSMedia</a>: CSS media query descriptor.</li>
+<li><a href='#CSS.SelectorProfileEntry'>CSS.SelectorProfileEntry</a>: CSS selector profile entry.</li>
+<li><a href='#CSS.SelectorProfile'>CSS.SelectorProfile</a></li>
+<li><a href='#CSS.Region'>CSS.Region</a>: This object represents a region that flows from a Named Flow.</li>
+<li><a href='#CSS.NamedFlow'>CSS.NamedFlow</a>: This object represents a Named Flow.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#CSS.enable">CSS.enable</a>: Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received.</li>
-<li><a href="#CSS.disable">CSS.disable</a>: Disables the CSS agent for the given page.</li>
-<li><a href="#CSS.getMatchedStylesForNode">CSS.getMatchedStylesForNode</a>: Returns requested styles for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getInlineStylesForNode">CSS.getInlineStylesForNode</a>: Returns the styles defined inline (explicitly in the "style" attribute and implicitly, using DOM attributes) for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getComputedStyleForNode">CSS.getComputedStyleForNode</a>: Returns the computed style for a DOM node identified by nodeId.</li>
-<li><a href="#CSS.getAllStyleSheets">CSS.getAllStyleSheets</a>: Returns metainfo entries for all known stylesheets.</li>
-<li><a href="#CSS.getStyleSheet">CSS.getStyleSheet</a>: Returns stylesheet data for the specified styleSheetId.</li>
-<li><a href="#CSS.getStyleSheetText">CSS.getStyleSheetText</a>: Returns the current textual content and the URL for a stylesheet.</li>
-<li><a href="#CSS.setStyleSheetText">CSS.setStyleSheetText</a>: Sets the new stylesheet text, thereby invalidating all existing CSSStyleId's and CSSRuleId's contained by this stylesheet.</li>
-<li><a href="#CSS.setPropertyText">CSS.setPropertyText</a>: Sets the new text for a property in the respective style, at offset propertyIndex. If overwrite is true, a property at the given offset is overwritten, otherwise inserted. text entirely replaces the property name: value.</li>
-<li><a href="#CSS.toggleProperty">CSS.toggleProperty</a>: Toggles the property in the respective style, at offset propertyIndex. The disable parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If disable == false, the property gets put back into its original place in the style declaration.</li>
-<li><a href="#CSS.setRuleSelector">CSS.setRuleSelector</a>: Modifies the rule selector.</li>
-<li><a href="#CSS.addRule">CSS.addRule</a>: Creates a new empty rule with the given selector in a special "inspector" stylesheet in the owner document of the context node.</li>
-<li><a href="#CSS.getSupportedCSSProperties">CSS.getSupportedCSSProperties</a>: Returns all supported CSS property names.</li>
-<li><a href="#CSS.startSelectorProfiler">CSS.startSelectorProfiler</a></li>
-<li><a href="#CSS.stopSelectorProfiler">CSS.stopSelectorProfiler</a></li>
+<li><a href='#CSS.enable'>CSS.enable</a>: Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received.</li>
+<li><a href='#CSS.disable'>CSS.disable</a>: Disables the CSS agent for the given page.</li>
+<li><a href='#CSS.getMatchedStylesForNode'>CSS.getMatchedStylesForNode</a>: Returns requested styles for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getInlineStylesForNode'>CSS.getInlineStylesForNode</a>: Returns the styles defined inline (explicitly in the "style" attribute and implicitly, using DOM attributes) for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getComputedStyleForNode'>CSS.getComputedStyleForNode</a>: Returns the computed style for a DOM node identified by nodeId.</li>
+<li><a href='#CSS.getAllStyleSheets'>CSS.getAllStyleSheets</a>: Returns metainfo entries for all known stylesheets.</li>
+<li><a href='#CSS.getStyleSheet'>CSS.getStyleSheet</a>: Returns stylesheet data for the specified styleSheetId.</li>
+<li><a href='#CSS.getStyleSheetText'>CSS.getStyleSheetText</a>: Returns the current textual content and the URL for a stylesheet.</li>
+<li><a href='#CSS.setStyleSheetText'>CSS.setStyleSheetText</a>: Sets the new stylesheet text, thereby invalidating all existing CSSStyleId's and CSSRuleId's contained by this stylesheet.</li>
+<li><a href='#CSS.setPropertyText'>CSS.setPropertyText</a>: Sets the new text for a property in the respective style, at offset propertyIndex. If overwrite is true, a property at the given offset is overwritten, otherwise inserted. text entirely replaces the property name: value.</li>
+<li><a href='#CSS.toggleProperty'>CSS.toggleProperty</a>: Toggles the property in the respective style, at offset propertyIndex. The disable parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If disable == false, the property gets put back into its original place in the style declaration.</li>
+<li><a href='#CSS.setRuleSelector'>CSS.setRuleSelector</a>: Modifies the rule selector.</li>
+<li><a href='#CSS.addRule'>CSS.addRule</a>: Creates a new empty rule with the given selector in a special "inspector" stylesheet in the owner document of the context node.</li>
+<li><a href='#CSS.getSupportedCSSProperties'>CSS.getSupportedCSSProperties</a>: Returns all supported CSS property names.</li>
+<li><a href='#CSS.forcePseudoState'>CSS.forcePseudoState</a>: Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser.</li>
+<li><a href='#CSS.startSelectorProfiler'>CSS.startSelectorProfiler</a></li>
+<li><a href='#CSS.stopSelectorProfiler'>CSS.stopSelectorProfiler</a></li>
+<li><a href='#CSS.getNamedFlowCollection'>CSS.getNamedFlowCollection</a>: Returns the Named Flows from the document.</li>
+<li><a href='#CSS.getFlowByName'>CSS.getFlowByName</a>: Returns the Named Flow identified by the given name</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#CSS.mediaQueryResultChanged">CSS.mediaQueryResultChanged</a>: Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features.</li>
-<li><a href="#CSS.styleSheetChanged">CSS.styleSheetChanged</a>: Fired whenever a stylesheet is changed as a result of the client operation.</li>
+<li><a href='#CSS.mediaQueryResultChanged'>CSS.mediaQueryResultChanged</a>: Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features.</li>
+<li><a href='#CSS.styleSheetChanged'>CSS.styleSheetChanged</a>: Fired whenever a stylesheet is changed as a result of the client operation.</li>
+<li><a href='#CSS.namedFlowCreated'>CSS.namedFlowCreated</a>: Fires when a Named Flow is created.</li>
+<li><a href='#CSS.namedFlowRemoved'>CSS.namedFlowRemoved</a>: Fires when a Named Flow is removed: has no associated content nodes and regions.</li>
 </ul>
-<div id="CSS_StyleSheetId" class="type">
-<h3>CSS.StyleSheetId <span class="label">Type</span></h3>
+<div id='CSS_StyleSheetId' class='type'>
+<h3>CSS.StyleSheetId <span class='label'>Type</span></h3>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="CSS_CSSStyleId" class="type">
-<h3>CSS.CSSStyleId <span class="label">Type</span></h3>
+<div id='CSS_CSSStyleId' class='type'>
+<h3>CSS.CSSStyleId <span class='label'>Type</span></h3>
 <p>This object identifies a CSS style in a unique way.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a> <span class="text">Enclosing stylesheet identifier.</span></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a> <span class='text'>Enclosing stylesheet identifier.</span></dd>
 <dt>ordinal</dt>
-<dd>Integer <span class="text">The style ordinal within the stylesheet.</span></dd>
+<dd>Integer <span class='text'>The style ordinal within the stylesheet.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSRuleId" class="type">
-<h3>CSS.CSSRuleId <span class="label">Type</span></h3>
+<div id='CSS_StyleSheetOrigin' class='type'>
+<h3>CSS.StyleSheetOrigin <span class='label'>Type</span></h3>
+<p>Stylesheet type: "user" for user stylesheets, "user-agent" for user-agent stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding the "via inspector" rules), "regular" for regular stylesheets.</p>
+<dl>
+<dd>( user | user-agent | inspector | regular )</dd>
+</dl>
+</div>
+<div id='CSS_CSSRuleId' class='type'>
+<h3>CSS.CSSRuleId <span class='label'>Type</span></h3>
 <p>This object identifies a CSS rule in a unique way.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a> <span class="text">Enclosing stylesheet identifier.</span></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a> <span class='text'>Enclosing stylesheet identifier.</span></dd>
 <dt>ordinal</dt>
-<dd>Integer <span class="text">The rule ordinal within the stylesheet.</span></dd>
+<dd>Integer <span class='text'>The rule ordinal within the stylesheet.</span></dd>
 </dl>
 </div>
-<div id="CSS_PseudoIdRules" class="type">
-<h3>CSS.PseudoIdRules <span class="label">Type</span></h3>
+<div id='CSS_PseudoIdRules' class='type'>
+<h3>CSS.PseudoIdRules <span class='label'>Type</span></h3>
 <p>CSS rule collection for a single pseudo style.</p>
 <dl>
 <dt>pseudoId</dt>
-<dd>Integer <span class="text">Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>).</span></dd>
+<dd>Integer <span class='text'>Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>).</span></dd>
 <dt>rules</dt>
-<dd>[<a href="#CSS.CSSRule">CSS.CSSRule</a>] <span class="text">CSS rules applicable to the pseudo style.</span></dd>
+<dd>[<a href='#CSS.CSSRule'>CSS.CSSRule</a>] <span class='text'>CSS rules applicable to the pseudo style.</span></dd>
 </dl>
 </div>
-<div id="CSS_InheritedStyleEntry" class="type">
-<h3>CSS.InheritedStyleEntry <span class="label">Type</span></h3>
+<div id='CSS_InheritedStyleEntry' class='type'>
+<h3>CSS.InheritedStyleEntry <span class='label'>Type</span></h3>
 <p>CSS rule collection for a single pseudo style.</p>
 <dl>
 <dt>inlineStyle (optional)</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">The ancestor node's inline style, if any, in the style inheritance chain.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>The ancestor node's inline style, if any, in the style inheritance chain.</span></dd>
 <dt>matchedCSSRules</dt>
-<dd>[<a href="#CSS.CSSRule">CSS.CSSRule</a>] <span class="text">CSS rules matching the ancestor node in the style inheritance chain.</span></dd>
+<dd>[<a href='#CSS.CSSRule'>CSS.CSSRule</a>] <span class='text'>CSS rules matching the ancestor node in the style inheritance chain.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSStyleAttribute" class="type">
-<h3>CSS.CSSStyleAttribute <span class="label">Type</span></h3>
+<div id='CSS_CSSStyleAttribute' class='type'>
+<h3>CSS.CSSStyleAttribute <span class='label'>Type</span></h3>
 <p>CSS style information for a DOM style attribute.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">DOM attribute name (e.g. "width").</span></dd>
+<dd>String <span class='text'>DOM attribute name (e.g. "width").</span></dd>
 <dt>style</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">CSS style generated by the respective DOM attribute.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>CSS style generated by the respective DOM attribute.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSStyleSheetHeader" class="type">
-<h3>CSS.CSSStyleSheetHeader <span class="label">Type</span></h3>
+<div id='CSS_CSSStyleSheetHeader' class='type'>
+<h3>CSS.CSSStyleSheetHeader <span class='label'>Type</span></h3>
 <p>CSS stylesheet metainformation.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a> <span class="text">The stylesheet identifier.</span></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a> <span class='text'>The stylesheet identifier.</span></dd>
+<dt>frameId</dt>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Owner frame identifier.</span></dd>
 <dt>sourceURL</dt>
-<dd>String <span class="text">Stylesheet resource URL.</span></dd>
+<dd>String <span class='text'>Stylesheet resource URL.</span></dd>
+<dt>origin</dt>
+<dd><a href='#CSS.StyleSheetOrigin'>CSS.StyleSheetOrigin</a> <span class='text'>Stylesheet origin.</span></dd>
 <dt>title</dt>
-<dd>String <span class="text">Stylesheet title.</span></dd>
+<dd>String <span class='text'>Stylesheet title.</span></dd>
 <dt>disabled</dt>
-<dd>Boolean <span class="text">Denotes whether the stylesheet is disabled.</span></dd>
+<dd>Boolean <span class='text'>Denotes whether the stylesheet is disabled.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSStyleSheetBody" class="type">
-<h3>CSS.CSSStyleSheetBody <span class="label">Type</span></h3>
+<div id='CSS_CSSStyleSheetBody' class='type'>
+<h3>CSS.CSSStyleSheetBody <span class='label'>Type</span></h3>
 <p>CSS stylesheet contents.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a> <span class="text">The stylesheet identifier.</span></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a> <span class='text'>The stylesheet identifier.</span></dd>
 <dt>rules</dt>
-<dd>[<a href="#CSS.CSSRule">CSS.CSSRule</a>] <span class="text">Stylesheet resource URL.</span></dd>
+<dd>[<a href='#CSS.CSSRule'>CSS.CSSRule</a>] <span class='text'>Stylesheet resource URL.</span></dd>
 <dt>text (optional)</dt>
-<dd>String <span class="text">Stylesheet resource contents (if available).</span></dd>
+<dd>String <span class='text'>Stylesheet resource contents (if available).</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSRule" class="type">
-<h3>CSS.CSSRule <span class="label">Type</span></h3>
+<div id='CSS_CSSRule' class='type'>
+<h3>CSS.CSSRule <span class='label'>Type</span></h3>
 <p>CSS rule representation.</p>
 <dl>
 <dt>ruleId (optional)</dt>
-<dd><a href="#CSS.CSSRuleId">CSS.CSSRuleId</a> <span class="text">The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules).</span></dd>
+<dd><a href='#CSS.CSSRuleId'>CSS.CSSRuleId</a> <span class='text'>The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules).</span></dd>
 <dt>selectorText</dt>
-<dd>String <span class="text">Rule selector.</span></dd>
+<dd>String <span class='text'>Rule selector.</span></dd>
 <dt>sourceURL (optional)</dt>
-<dd>String <span class="text">Parent stylesheet resource URL (for regular rules).</span></dd>
+<dd>String <span class='text'>Parent stylesheet resource URL (for regular rules).</span></dd>
 <dt>sourceLine</dt>
-<dd>Integer <span class="text">Line ordinal of the rule selector start character in the resource.</span></dd>
+<dd>Integer <span class='text'>Line ordinal of the rule selector start character in the resource.</span></dd>
 <dt>origin</dt>
-<dd>( user | user-agent | inspector | regular ) <span class="text">The parent stylesheet type: "user" for user stylesheets, "user-agent" for user-agent stylesheets, "inspector" for stylesheets created by the inspector (i.e. those holding new rules created with <code>addRule()</code>), "regular" for regular stylesheets.</span></dd>
+<dd><a href='#CSS.StyleSheetOrigin'>CSS.StyleSheetOrigin</a> <span class='text'>Parent stylesheet's origin.</span></dd>
 <dt>style</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">Associated style declaration.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>Associated style declaration.</span></dd>
 <dt>selectorRange (optional)</dt>
-<dd><a href="#CSS.SourceRange">CSS.SourceRange</a> <span class="text">The rule selector range in the underlying resource (if available).</span></dd>
+<dd><a href='#CSS.SourceRange'>CSS.SourceRange</a> <span class='text'>The rule selector range in the underlying resource (if available).</span></dd>
 <dt>media (optional)</dt>
-<dd>[<a href="#CSS.CSSMedia">CSS.CSSMedia</a>] <span class="text">Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards.</span></dd>
+<dd>[<a href='#CSS.CSSMedia'>CSS.CSSMedia</a>] <span class='text'>Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards.</span></dd>
 </dl>
 </div>
-<div id="CSS_SourceRange" class="type">
-<h3>CSS.SourceRange <span class="label">Type</span></h3>
+<div id='CSS_SourceRange' class='type'>
+<h3>CSS.SourceRange <span class='label'>Type</span></h3>
 <p>Text range within a resource.</p>
 <dl>
 <dt>start</dt>
-<dd>Integer <span class="text">Start of range (inclusive).</span></dd>
+<dd>Integer <span class='text'>Start of range (inclusive).</span></dd>
 <dt>end</dt>
-<dd>Integer <span class="text">End of range (exclusive).</span></dd>
+<dd>Integer <span class='text'>End of range (exclusive).</span></dd>
 </dl>
 </div>
-<div id="CSS_ShorthandEntry" class="type">
-<h3>CSS.ShorthandEntry <span class="label">Type</span></h3>
+<div id='CSS_ShorthandEntry' class='type'>
+<h3>CSS.ShorthandEntry <span class='label'>Type</span></h3>
 </div>
-<div id="CSS_CSSComputedStyleProperty" class="type">
-<h3>CSS.CSSComputedStyleProperty <span class="label">Type</span></h3>
+<div id='CSS_CSSPropertyInfo' class='type'>
+<h3>CSS.CSSPropertyInfo <span class='label'>Type</span></h3>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Computed style property name.</span></dd>
-<dt>value</dt>
-<dd>String <span class="text">Computed style property value.</span></dd>
+<dd>String <span class='text'>Property name.</span></dd>
+<dt>longhands (optional)</dt>
+<dd>[String] <span class='text'>Longhand property names.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSStyle" class="type">
-<h3>CSS.CSSStyle <span class="label">Type</span></h3>
+<div id='CSS_CSSComputedStyleProperty' class='type'>
+<h3>CSS.CSSComputedStyleProperty <span class='label'>Type</span></h3>
+<dl>
+<dt>name</dt>
+<dd>String <span class='text'>Computed style property name.</span></dd>
+<dt>value</dt>
+<dd>String <span class='text'>Computed style property value.</span></dd>
+</dl>
+</div>
+<div id='CSS_CSSStyle' class='type'>
+<h3>CSS.CSSStyle <span class='label'>Type</span></h3>
 <p>CSS style representation.</p>
 <dl>
 <dt>styleId (optional)</dt>
-<dd><a href="#CSS.CSSStyleId">CSS.CSSStyleId</a> <span class="text">The CSS style identifier (absent for attribute styles).</span></dd>
+<dd><a href='#CSS.CSSStyleId'>CSS.CSSStyleId</a> <span class='text'>The CSS style identifier (absent for attribute styles).</span></dd>
 <dt>cssProperties</dt>
-<dd>[<a href="#CSS.CSSProperty">CSS.CSSProperty</a>] <span class="text">CSS properties in the style.</span></dd>
+<dd>[<a href='#CSS.CSSProperty'>CSS.CSSProperty</a>] <span class='text'>CSS properties in the style.</span></dd>
 <dt>shorthandEntries</dt>
-<dd>[<a href="#CSS.ShorthandEntry">CSS.ShorthandEntry</a>] <span class="text">Computed values for all shorthands found in the style.</span></dd>
+<dd>[<a href='#CSS.ShorthandEntry'>CSS.ShorthandEntry</a>] <span class='text'>Computed values for all shorthands found in the style.</span></dd>
 <dt>cssText (optional)</dt>
-<dd>String <span class="text">Style declaration text (if available).</span></dd>
+<dd>String <span class='text'>Style declaration text (if available).</span></dd>
 <dt>range (optional)</dt>
-<dd><a href="#CSS.SourceRange">CSS.SourceRange</a> <span class="text">Style declaration range in the enclosing stylesheet (if available).</span></dd>
+<dd><a href='#CSS.SourceRange'>CSS.SourceRange</a> <span class='text'>Style declaration range in the enclosing stylesheet (if available).</span></dd>
 <dt>width (optional)</dt>
-<dd>String <span class="text">The effective "width" property value from this style.</span></dd>
+<dd>String <span class='text'>The effective "width" property value from this style.</span></dd>
 <dt>height (optional)</dt>
-<dd>String <span class="text">The effective "height" property value from this style.</span></dd>
+<dd>String <span class='text'>The effective "height" property value from this style.</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSProperty" class="type">
-<h3>CSS.CSSProperty <span class="label">Type</span></h3>
+<div id='CSS_CSSProperty' class='type'>
+<h3>CSS.CSSProperty <span class='label'>Type</span></h3>
 <p>CSS style effective visual dimensions and source offsets.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">The property name.</span></dd>
+<dd>String <span class='text'>The property name.</span></dd>
 <dt>value</dt>
-<dd>String <span class="text">The property value.</span></dd>
+<dd>String <span class='text'>The property value.</span></dd>
 <dt>priority (optional)</dt>
-<dd>String <span class="text">The property priority (implies "" if absent).</span></dd>
+<dd>String <span class='text'>The property priority (implies "" if absent).</span></dd>
 <dt>implicit (optional)</dt>
-<dd>Boolean <span class="text">Whether the property is implicit (implies <code>false</code> if absent).</span></dd>
+<dd>Boolean <span class='text'>Whether the property is implicit (implies <code>false</code> if absent).</span></dd>
 <dt>text (optional)</dt>
-<dd>String <span class="text">The full property text as specified in the style.</span></dd>
+<dd>String <span class='text'>The full property text as specified in the style.</span></dd>
 <dt>parsedOk (optional)</dt>
-<dd>Boolean <span class="text">Whether the property is understood by the browser (implies <code>true</code> if absent).</span></dd>
+<dd>Boolean <span class='text'>Whether the property is understood by the browser (implies <code>true</code> if absent).</span></dd>
 <dt>status (optional)</dt>
-<dd>( active | inactive | disabled | style ) <span class="text">The property status: "active" (implied if absent) if the property is effective in the style, "inactive" if the property is overridden by a same-named property in this style later on, "disabled" if the property is disabled by the user, "style" if the property is reported by the browser rather than by the CSS source parser.</span></dd>
-<dt>shorthandName (optional)</dt>
-<dd>String <span class="text">The related shorthand property name (absent if this property is not a longhand).</span></dd>
+<dd>( active | inactive | disabled | style ) <span class='text'>The property status: "active" (implied if absent) if the property is effective in the style, "inactive" if the property is overridden by a same-named property in this style later on, "disabled" if the property is disabled by the user, "style" if the property is reported by the browser rather than by the CSS source parser.</span></dd>
 <dt>range (optional)</dt>
-<dd><a href="#CSS.SourceRange">CSS.SourceRange</a> <span class="text">The entire property range in the enclosing style declaration (if available).</span></dd>
+<dd><a href='#CSS.SourceRange'>CSS.SourceRange</a> <span class='text'>The entire property range in the enclosing style declaration (if available).</span></dd>
 </dl>
 </div>
-<div id="CSS_CSSMedia" class="type">
-<h3>CSS.CSSMedia <span class="label">Type</span></h3>
+<div id='CSS_CSSMedia' class='type'>
+<h3>CSS.CSSMedia <span class='label'>Type</span></h3>
 <p>CSS media query descriptor.</p>
 <dl>
 <dt>text</dt>
-<dd>String <span class="text">Media query text.</span></dd>
+<dd>String <span class='text'>Media query text.</span></dd>
 <dt>source</dt>
-<dd>( mediaRule | importRule | linkedSheet | inlineSheet ) <span class="text">Source of the media query: "mediaRule" if specified by a @media rule, "importRule" if specified by an @import rule, "linkedSheet" if specified by a "media" attribute in a linked stylesheet's LINK tag, "inlineSheet" if specified by a "media" attribute in an inline stylesheet's STYLE tag.</span></dd>
+<dd>( mediaRule | importRule | linkedSheet | inlineSheet ) <span class='text'>Source of the media query: "mediaRule" if specified by a @media rule, "importRule" if specified by an @import rule, "linkedSheet" if specified by a "media" attribute in a linked stylesheet's LINK tag, "inlineSheet" if specified by a "media" attribute in an inline stylesheet's STYLE tag.</span></dd>
 <dt>sourceURL (optional)</dt>
-<dd>String <span class="text">URL of the document containing the media query description.</span></dd>
+<dd>String <span class='text'>URL of the document containing the media query description.</span></dd>
 <dt>sourceLine (optional)</dt>
-<dd>Integer <span class="text">Line in the document containing the media query (not defined for the "stylesheet" source).</span></dd>
+<dd>Integer <span class='text'>Line in the document containing the media query (not defined for the "stylesheet" source).</span></dd>
 </dl>
 </div>
-<div id="CSS_SelectorProfileEntry" class="type">
-<h3>CSS.SelectorProfileEntry <span class="label">Type</span></h3>
+<div id='CSS_SelectorProfileEntry' class='type'>
+<h3>CSS.SelectorProfileEntry <span class='label'>Type</span></h3>
 <p>CSS selector profile entry.</p>
 <dl>
 <dt>selector</dt>
-<dd>String <span class="text">CSS selector of the corresponding rule.</span></dd>
+<dd>String <span class='text'>CSS selector of the corresponding rule.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">URL of the resource containing the corresponding rule.</span></dd>
+<dd>String <span class='text'>URL of the resource containing the corresponding rule.</span></dd>
 <dt>lineNumber</dt>
-<dd>Integer <span class="text">Selector line number in the resource for the corresponding rule.</span></dd>
+<dd>Integer <span class='text'>Selector line number in the resource for the corresponding rule.</span></dd>
 <dt>time</dt>
-<dd>Number <span class="text">Total time this rule handling contributed to the browser running time during profiling (in milliseconds.)</span></dd>
+<dd>Number <span class='text'>Total time this rule handling contributed to the browser running time during profiling (in milliseconds.)</span></dd>
 <dt>hitCount</dt>
-<dd>Integer <span class="text">Number of times this rule was considered a candidate for matching against DOM elements.</span></dd>
+<dd>Integer <span class='text'>Number of times this rule was considered a candidate for matching against DOM elements.</span></dd>
 <dt>matchCount</dt>
-<dd>Integer <span class="text">Number of times this rule actually matched a DOM element.</span></dd>
+<dd>Integer <span class='text'>Number of times this rule actually matched a DOM element.</span></dd>
 </dl>
 </div>
-<div id="CSS_SelectorProfile" class="type">
-<h3>CSS.SelectorProfile <span class="label">Type</span></h3>
+<div id='CSS_SelectorProfile' class='type'>
+<h3>CSS.SelectorProfile <span class='label'>Type</span></h3>
 <dl>
 <dt>totalTime</dt>
-<dd>Number <span class="text">Total processing time for all selectors in the profile (in milliseconds.)</span></dd>
+<dd>Number <span class='text'>Total processing time for all selectors in the profile (in milliseconds.)</span></dd>
 <dt>data</dt>
-<dd>[<a href="#CSS.SelectorProfileEntry">CSS.SelectorProfileEntry</a>] <span class="text">CSS selector profile entries.</span></dd>
+<dd>[<a href='#CSS.SelectorProfileEntry'>CSS.SelectorProfileEntry</a>] <span class='text'>CSS selector profile entries.</span></dd>
 </dl>
 </div>
-<div id="CSS_enable" class="command">
-<h3>CSS.enable <span class="label label-success">Command</span></h3>
+<div id='CSS_Region' class='type'>
+<h3>CSS.Region <span class='label'>Type</span></h3>
+<p>This object represents a region that flows from a Named Flow.</p>
+<dl>
+<dt>regionOverset</dt>
+<dd>( overset | fit | empty ) <span class='text'>The "overset" attribute of a Named Flow.</span></dd>
+<dt>nodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The corresponding DOM node id.</span></dd>
+</dl>
+</div>
+<div id='CSS_NamedFlow' class='type'>
+<h3>CSS.NamedFlow <span class='label'>Type</span></h3>
+<p>This object represents a Named Flow.</p>
+<dl>
+<dt>documentNodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The document node id.</span></dd>
+<dt>name</dt>
+<dd>String <span class='text'>Named Flow identifier.</span></dd>
+<dt>overset</dt>
+<dd>Boolean <span class='text'>The "overset" attribute of a Named Flow.</span></dd>
+<dt>content</dt>
+<dd>[<a href='#DOM.NodeId'>DOM.NodeId</a>] <span class='text'>An array of nodes that flow into the Named Flow.</span></dd>
+<dt>regions</dt>
+<dd>[<a href='#CSS.Region'>CSS.Region</a>] <span class='text'>An array of regions associated with the Named Flow.</span></dd>
+</dl>
+</div>
+<div id='CSS_enable' class='command'>
+<h3>CSS.enable <span class='label label-success'>Command</span></h3>
 <p>Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -964,8 +1083,8 @@ function onNetworkStateUpdated(res) {
 CSS.enable();
 </pre>
 </div>
-<div id="CSS_disable" class="command">
-<h3>CSS.disable <span class="label label-success">Command</span></h3>
+<div id='CSS_disable' class='command'>
+<h3>CSS.disable <span class='label label-success'>Command</span></h3>
 <p>Disables the CSS agent for the given page.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -973,49 +1092,47 @@ CSS.enable();
 CSS.disable();
 </pre>
 </div>
-<div id="CSS_getMatchedStylesForNode" class="command">
-<h3>CSS.getMatchedStylesForNode <span class="label label-success">Command</span></h3>
+<div id='CSS_getMatchedStylesForNode' class='command'>
+<h3>CSS.getMatchedStylesForNode <span class='label label-success'>Command</span></h3>
 <p>Returns requested styles for a DOM node identified by <code>nodeId</code>.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a></dd>
-<dt>forcedPseudoClasses (optional)</dt>
-<dd>[( active | focus | hover | visited )] <span class="text">Element pseudo classes to force when computing applicable style rules.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a></dd>
 <dt>includePseudo (optional)</dt>
-<dd>Boolean <span class="text">Whether to include pseudo styles (default: true).</span></dd>
+<dd>Boolean <span class='text'>Whether to include pseudo styles (default: true).</span></dd>
 <dt>includeInherited (optional)</dt>
-<dd>Boolean <span class="text">Whether to include inherited styles (default: true).</span></dd>
+<dd>Boolean <span class='text'>Whether to include inherited styles (default: true).</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>matchedCSSRules (optional)</dt>
-<dd>[<a href="#CSS.CSSRule">CSS.CSSRule</a>] <span class="text">CSS rules matching this node, from all applicable stylesheets.</span></dd>
+<dd>[<a href='#CSS.CSSRule'>CSS.CSSRule</a>] <span class='text'>CSS rules matching this node, from all applicable stylesheets.</span></dd>
 <dt>pseudoElements (optional)</dt>
-<dd>[<a href="#CSS.PseudoIdRules">CSS.PseudoIdRules</a>] <span class="text">Pseudo style rules for this node.</span></dd>
+<dd>[<a href='#CSS.PseudoIdRules'>CSS.PseudoIdRules</a>] <span class='text'>Pseudo style rules for this node.</span></dd>
 <dt>inherited (optional)</dt>
-<dd>[<a href="#CSS.InheritedStyleEntry">CSS.InheritedStyleEntry</a>] <span class="text">A chain of inherited styles (from the immediate node parent up to the DOM tree root).</span></dd>
+<dd>[<a href='#CSS.InheritedStyleEntry'>CSS.InheritedStyleEntry</a>] <span class='text'>A chain of inherited styles (from the immediate node parent up to the DOM tree root).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: CSS.getMatchedStylesForNode
-CSS.getMatchedStylesForNode(nodeId, forcedPseudoClasses, includePseudo, includeInherited, function callback(res) {
+CSS.getMatchedStylesForNode(nodeId, includePseudo, includeInherited, function callback(res) {
 	// res = {matchedCSSRules, pseudoElements, inherited}
 });
 </pre>
 </div>
-<div id="CSS_getInlineStylesForNode" class="command">
-<h3>CSS.getInlineStylesForNode <span class="label label-success">Command</span></h3>
+<div id='CSS_getInlineStylesForNode' class='command'>
+<h3>CSS.getInlineStylesForNode <span class='label label-success'>Command</span></h3>
 <p>Returns the styles defined inline (explicitly in the "style" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>inlineStyle (optional)</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">Inline style for the specified DOM node.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>Inline style for the specified DOM node.</span></dd>
 <dt>attributesStyle (optional)</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">Attribute-defined element style (e.g. resulting from "width=20 height=100%").</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>Attribute-defined element style (e.g. resulting from "width=20 height=100%").</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1025,35 +1142,33 @@ CSS.getInlineStylesForNode(nodeId, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_getComputedStyleForNode" class="command">
-<h3>CSS.getComputedStyleForNode <span class="label label-success">Command</span></h3>
+<div id='CSS_getComputedStyleForNode' class='command'>
+<h3>CSS.getComputedStyleForNode <span class='label label-success'>Command</span></h3>
 <p>Returns the computed style for a DOM node identified by <code>nodeId</code>.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a></dd>
-<dt>forcedPseudoClasses (optional)</dt>
-<dd>[( active | focus | hover | visited )] <span class="text">Element pseudo classes to force when computing applicable style rules.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>computedStyle</dt>
-<dd>[<a href="#CSS.CSSComputedStyleProperty">CSS.CSSComputedStyleProperty</a>] <span class="text">Computed style for the specified DOM node.</span></dd>
+<dd>[<a href='#CSS.CSSComputedStyleProperty'>CSS.CSSComputedStyleProperty</a>] <span class='text'>Computed style for the specified DOM node.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: CSS.getComputedStyleForNode
-CSS.getComputedStyleForNode(nodeId, forcedPseudoClasses, function callback(res) {
+CSS.getComputedStyleForNode(nodeId, function callback(res) {
 	// res = {computedStyle}
 });
 </pre>
 </div>
-<div id="CSS_getAllStyleSheets" class="command">
-<h3>CSS.getAllStyleSheets <span class="label label-success">Command</span></h3>
+<div id='CSS_getAllStyleSheets' class='command'>
+<h3>CSS.getAllStyleSheets <span class='label label-success'>Command</span></h3>
 <p>Returns metainfo entries for all known stylesheets.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>headers</dt>
-<dd>[<a href="#CSS.CSSStyleSheetHeader">CSS.CSSStyleSheetHeader</a>] <span class="text">Descriptor entries for all available stylesheets.</span></dd>
+<dd>[<a href='#CSS.CSSStyleSheetHeader'>CSS.CSSStyleSheetHeader</a>] <span class='text'>Descriptor entries for all available stylesheets.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1063,17 +1178,17 @@ CSS.getAllStyleSheets(function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_getStyleSheet" class="command">
-<h3>CSS.getStyleSheet <span class="label label-success">Command</span></h3>
+<div id='CSS_getStyleSheet' class='command'>
+<h3>CSS.getStyleSheet <span class='label label-success'>Command</span></h3>
 <p>Returns stylesheet data for the specified <code>styleSheetId</code>.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>styleSheet</dt>
-<dd><a href="#CSS.CSSStyleSheetBody">CSS.CSSStyleSheetBody</a> <span class="text">Stylesheet contents for the specified <code>styleSheetId</code>.</span></dd>
+<dd><a href='#CSS.CSSStyleSheetBody'>CSS.CSSStyleSheetBody</a> <span class='text'>Stylesheet contents for the specified <code>styleSheetId</code>.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1083,17 +1198,17 @@ CSS.getStyleSheet(styleSheetId, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_getStyleSheetText" class="command">
-<h3>CSS.getStyleSheetText <span class="label label-success">Command</span></h3>
+<div id='CSS_getStyleSheetText' class='command'>
+<h3>CSS.getStyleSheetText <span class='label label-success'>Command</span></h3>
 <p>Returns the current textual content and the URL for a stylesheet.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>text</dt>
-<dd>String <span class="text">The stylesheet text.</span></dd>
+<dd>String <span class='text'>The stylesheet text.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1103,12 +1218,12 @@ CSS.getStyleSheetText(styleSheetId, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_setStyleSheetText" class="command">
-<h3>CSS.setStyleSheetText <span class="label label-success">Command</span></h3>
+<div id='CSS_setStyleSheetText' class='command'>
+<h3>CSS.setStyleSheetText <span class='label label-success'>Command</span></h3>
 <p>Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></dd>
 <dt>text</dt>
 <dd>String</dd>
 </dl>
@@ -1118,12 +1233,12 @@ CSS.getStyleSheetText(styleSheetId, function callback(res) {
 CSS.setStyleSheetText(styleSheetId, text);
 </pre>
 </div>
-<div id="CSS_setPropertyText" class="command">
-<h3>CSS.setPropertyText <span class="label label-success">Command</span></h3>
+<div id='CSS_setPropertyText' class='command'>
+<h3>CSS.setPropertyText <span class='label label-success'>Command</span></h3>
 <p>Sets the new <code>text</code> for a property in the respective style, at offset <code>propertyIndex</code>. If <code>overwrite</code> is <code>true</code>, a property at the given offset is overwritten, otherwise inserted. <code>text</code> entirely replaces the property <code>name: value</code>.</p>
 <dl>
 <dt>styleId</dt>
-<dd><a href="#CSS.CSSStyleId">CSS.CSSStyleId</a></dd>
+<dd><a href='#CSS.CSSStyleId'>CSS.CSSStyleId</a></dd>
 <dt>propertyIndex</dt>
 <dd>Integer</dd>
 <dt>text</dt>
@@ -1134,7 +1249,7 @@ CSS.setStyleSheetText(styleSheetId, text);
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>style</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">The resulting style after the property text modification.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>The resulting style after the property text modification.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1144,12 +1259,12 @@ CSS.setPropertyText(styleId, propertyIndex, text, overwrite, function callback(r
 });
 </pre>
 </div>
-<div id="CSS_toggleProperty" class="command">
-<h3>CSS.toggleProperty <span class="label label-success">Command</span></h3>
+<div id='CSS_toggleProperty' class='command'>
+<h3>CSS.toggleProperty <span class='label label-success'>Command</span></h3>
 <p>Toggles the property in the respective style, at offset <code>propertyIndex</code>. The <code>disable</code> parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If <code>disable == false</code>, the property gets put back into its original place in the style declaration.</p>
 <dl>
 <dt>styleId</dt>
-<dd><a href="#CSS.CSSStyleId">CSS.CSSStyleId</a></dd>
+<dd><a href='#CSS.CSSStyleId'>CSS.CSSStyleId</a></dd>
 <dt>propertyIndex</dt>
 <dd>Integer</dd>
 <dt>disable</dt>
@@ -1158,7 +1273,7 @@ CSS.setPropertyText(styleId, propertyIndex, text, overwrite, function callback(r
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>style</dt>
-<dd><a href="#CSS.CSSStyle">CSS.CSSStyle</a> <span class="text">The resulting style after the property toggling.</span></dd>
+<dd><a href='#CSS.CSSStyle'>CSS.CSSStyle</a> <span class='text'>The resulting style after the property toggling.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1168,19 +1283,19 @@ CSS.toggleProperty(styleId, propertyIndex, disable, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_setRuleSelector" class="command">
-<h3>CSS.setRuleSelector <span class="label label-success">Command</span></h3>
+<div id='CSS_setRuleSelector' class='command'>
+<h3>CSS.setRuleSelector <span class='label label-success'>Command</span></h3>
 <p>Modifies the rule selector.</p>
 <dl>
 <dt>ruleId</dt>
-<dd><a href="#CSS.CSSRuleId">CSS.CSSRuleId</a></dd>
+<dd><a href='#CSS.CSSRuleId'>CSS.CSSRuleId</a></dd>
 <dt>selector</dt>
 <dd>String</dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>rule</dt>
-<dd><a href="#CSS.CSSRule">CSS.CSSRule</a> <span class="text">The resulting rule after the selector modification.</span></dd>
+<dd><a href='#CSS.CSSRule'>CSS.CSSRule</a> <span class='text'>The resulting rule after the selector modification.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1190,19 +1305,19 @@ CSS.setRuleSelector(ruleId, selector, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_addRule" class="command">
-<h3>CSS.addRule <span class="label label-success">Command</span></h3>
+<div id='CSS_addRule' class='command'>
+<h3>CSS.addRule <span class='label label-success'>Command</span></h3>
 <p>Creates a new empty rule with the given <code>selector</code> in a special "inspector" stylesheet in the owner document of the context node.</p>
 <dl>
 <dt>contextNodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a></dd>
 <dt>selector</dt>
 <dd>String</dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>rule</dt>
-<dd><a href="#CSS.CSSRule">CSS.CSSRule</a> <span class="text">The newly created rule.</span></dd>
+<dd><a href='#CSS.CSSRule'>CSS.CSSRule</a> <span class='text'>The newly created rule.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1212,13 +1327,13 @@ CSS.addRule(contextNodeId, selector, function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_getSupportedCSSProperties" class="command">
-<h3>CSS.getSupportedCSSProperties <span class="label label-success">Command</span></h3>
+<div id='CSS_getSupportedCSSProperties' class='command'>
+<h3>CSS.getSupportedCSSProperties <span class='label label-success'>Command</span></h3>
 <p>Returns all supported CSS property names.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>cssProperties</dt>
-<dd>[String] <span class="text">Supported property names.</span></dd>
+<dd>[<a href='#CSS.CSSPropertyInfo'>CSS.CSSPropertyInfo</a>] <span class='text'>Supported property metainfo.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1228,20 +1343,35 @@ CSS.getSupportedCSSProperties(function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_startSelectorProfiler" class="command">
-<h3>CSS.startSelectorProfiler <span class="label label-success">Command</span></h3>
+<div id='CSS_forcePseudoState' class='command'>
+<h3>CSS.forcePseudoState <span class='label label-success'>Command</span></h3>
+<p>Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser.</p>
+<dl>
+<dt>nodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The element id for which to force the pseudo state.</span></dd>
+<dt>forcedPseudoClasses</dt>
+<dd>[( active | focus | hover | visited )] <span class='text'>Element pseudo classes to force when computing the element's style.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: CSS.forcePseudoState
+CSS.forcePseudoState(nodeId, forcedPseudoClasses);
+</pre>
+</div>
+<div id='CSS_startSelectorProfiler' class='command'>
+<h3>CSS.startSelectorProfiler <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: CSS.startSelectorProfiler
 CSS.startSelectorProfiler();
 </pre>
 </div>
-<div id="CSS_stopSelectorProfiler" class="command">
-<h3>CSS.stopSelectorProfiler <span class="label label-success">Command</span></h3>
+<div id='CSS_stopSelectorProfiler' class='command'>
+<h3>CSS.stopSelectorProfiler <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>profile</dt>
-<dd><a href="#CSS.SelectorProfile">CSS.SelectorProfile</a></dd>
+<dd><a href='#CSS.SelectorProfile'>CSS.SelectorProfile</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1251,8 +1381,50 @@ CSS.stopSelectorProfiler(function callback(res) {
 });
 </pre>
 </div>
-<div id="CSS_mediaQueryResultChanged" class="command">
-<h3>CSS.mediaQueryResultChanged <span class="label label-info">Event</span></h3>
+<div id='CSS_getNamedFlowCollection' class='command'>
+<h3>CSS.getNamedFlowCollection <span class='label label-success'>Command</span></h3>
+<p>Returns the Named Flows from the document.</p>
+<dl>
+<dt>documentNodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The document node id for which to get the Named Flow Collection.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>namedFlows</dt>
+<dd>[<a href='#CSS.NamedFlow'>CSS.NamedFlow</a>] <span class='text'>An array containing the Named Flows in the document.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: CSS.getNamedFlowCollection
+CSS.getNamedFlowCollection(documentNodeId, function callback(res) {
+	// res = {namedFlows}
+});
+</pre>
+</div>
+<div id='CSS_getFlowByName' class='command'>
+<h3>CSS.getFlowByName <span class='label label-success'>Command</span></h3>
+<p>Returns the Named Flow identified by the given name</p>
+<dl>
+<dt>documentNodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The document node id.</span></dd>
+<dt>name</dt>
+<dd>String <span class='text'>Named Flow identifier.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>namedFlow</dt>
+<dd><a href='#CSS.NamedFlow'>CSS.NamedFlow</a> <span class='text'>A Named Flow.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: CSS.getFlowByName
+CSS.getFlowByName(documentNodeId, name, function callback(res) {
+	// res = {namedFlow}
+});
+</pre>
+</div>
+<div id='CSS_mediaQueryResultChanged' class='command'>
+<h3>CSS.mediaQueryResultChanged <span class='label label-info'>Event</span></h3>
 <p>Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1262,12 +1434,12 @@ function onMediaQueryResultChanged(res) {
 }
 </pre>
 </div>
-<div id="CSS_styleSheetChanged" class="command">
-<h3>CSS.styleSheetChanged <span class="label label-info">Event</span></h3>
+<div id='CSS_styleSheetChanged' class='command'>
+<h3>CSS.styleSheetChanged <span class='label label-info'>Event</span></h3>
 <p>Fired whenever a stylesheet is changed as a result of the client operation.</p>
 <dl>
 <dt>styleSheetId</dt>
-<dd><a href="#CSS.StyleSheetId">CSS.StyleSheetId</a></dd>
+<dd><a href='#CSS.StyleSheetId'>CSS.StyleSheetId</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1277,80 +1449,114 @@ function onStyleSheetChanged(res) {
 }
 </pre>
 </div>
+<div id='CSS_namedFlowCreated' class='command'>
+<h3>CSS.namedFlowCreated <span class='label label-info'>Event</span></h3>
+<p>Fires when a Named Flow is created.</p>
+<dl>
+<dt>documentNodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The document node id.</span></dd>
+<dt>namedFlow</dt>
+<dd>String <span class='text'>Identifier of the new Named Flow.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: CSS.namedFlowCreated
+function onNamedFlowCreated(res) {
+	// res = {documentNodeId, namedFlow}
+}
+</pre>
+</div>
+<div id='CSS_namedFlowRemoved' class='command'>
+<h3>CSS.namedFlowRemoved <span class='label label-info'>Event</span></h3>
+<p>Fires when a Named Flow is removed: has no associated content nodes and regions.</p>
+<dl>
+<dt>documentNodeId</dt>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>The document node id.</span></dd>
+<dt>namedFlow</dt>
+<dd>String <span class='text'>Identifier of the removed Named Flow.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: CSS.namedFlowRemoved
+function onNamedFlowRemoved(res) {
+	// res = {documentNodeId, namedFlow}
+}
+</pre>
+</div>
 </section>
-<section id="Console" class="domain">
+<section id='Console' class='domain'>
 <h1>Console</h1>
 <p>Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Console.ConsoleMessage">Console.ConsoleMessage</a>: Console message.</li>
-<li><a href="#Console.CallFrame">Console.CallFrame</a>: Stack entry for console errors and assertions.</li>
-<li><a href="#Console.StackTrace">Console.StackTrace</a>: Call frames for assertions or error messages.</li>
+<li><a href='#Console.ConsoleMessage'>Console.ConsoleMessage</a>: Console message.</li>
+<li><a href='#Console.CallFrame'>Console.CallFrame</a>: Stack entry for console errors and assertions.</li>
+<li><a href='#Console.StackTrace'>Console.StackTrace</a>: Call frames for assertions or error messages.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Console.enable">Console.enable</a>: Enables console domain, sends the messages collected so far to the client by means of the messageAdded notification.</li>
-<li><a href="#Console.disable">Console.disable</a>: Disables console domain, prevents further console messages from being reported to the client.</li>
-<li><a href="#Console.clearMessages">Console.clearMessages</a>: Clears console messages collected in the browser.</li>
-<li><a href="#Console.setMonitoringXHREnabled">Console.setMonitoringXHREnabled</a>: Toggles monitoring of XMLHttpRequest. If true, console will receive messages upon each XHR issued.</li>
-<li><a href="#Console.addInspectedNode">Console.addInspectedNode</a>: Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).</li>
-<li><a href="#Console.addInspectedHeapObject">Console.addInspectedHeapObject</a></li>
+<li><a href='#Console.enable'>Console.enable</a>: Enables console domain, sends the messages collected so far to the client by means of the messageAdded notification.</li>
+<li><a href='#Console.disable'>Console.disable</a>: Disables console domain, prevents further console messages from being reported to the client.</li>
+<li><a href='#Console.clearMessages'>Console.clearMessages</a>: Clears console messages collected in the browser.</li>
+<li><a href='#Console.setMonitoringXHREnabled'>Console.setMonitoringXHREnabled</a>: Toggles monitoring of XMLHttpRequest. If true, console will receive messages upon each XHR issued.</li>
+<li><a href='#Console.addInspectedNode'>Console.addInspectedNode</a>: Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).</li>
+<li><a href='#Console.addInspectedHeapObject'>Console.addInspectedHeapObject</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Console.messageAdded">Console.messageAdded</a>: Issued when new console message is added.</li>
-<li><a href="#Console.messageRepeatCountUpdated">Console.messageRepeatCountUpdated</a>: Issued when subsequent message(s) are equal to the previous one(s).</li>
-<li><a href="#Console.messagesCleared">Console.messagesCleared</a>: Issued when console is cleared. This happens either upon clearMessages command or after page navigation.</li>
+<li><a href='#Console.messageAdded'>Console.messageAdded</a>: Issued when new console message is added.</li>
+<li><a href='#Console.messageRepeatCountUpdated'>Console.messageRepeatCountUpdated</a>: Issued when subsequent message(s) are equal to the previous one(s).</li>
+<li><a href='#Console.messagesCleared'>Console.messagesCleared</a>: Issued when console is cleared. This happens either upon clearMessages command or after page navigation.</li>
 </ul>
-<div id="Console_ConsoleMessage" class="type">
-<h3>Console.ConsoleMessage <span class="label">Type</span></h3>
+<div id='Console_ConsoleMessage' class='type'>
+<h3>Console.ConsoleMessage <span class='label'>Type</span></h3>
 <p>Console message.</p>
 <dl>
 <dt>source</dt>
-<dd>( html | wml | xml | javascript | network | console-api | other ) <span class="text">Message source.</span></dd>
+<dd>( html | wml | xml | javascript | network | console-api | other ) <span class='text'>Message source.</span></dd>
 <dt>level</dt>
-<dd>( tip | log | warning | error | debug ) <span class="text">Message severity.</span></dd>
+<dd>( tip | log | warning | error | debug ) <span class='text'>Message severity.</span></dd>
 <dt>text</dt>
-<dd>String <span class="text">Message text.</span></dd>
+<dd>String <span class='text'>Message text.</span></dd>
 <dt>type (optional)</dt>
-<dd>( log | dir | dirxml | trace | startGroup | startGroupCollapsed | endGroup | assert ) <span class="text">Console message type.</span></dd>
+<dd>( log | dir | dirxml | trace | startGroup | startGroupCollapsed | endGroup | assert ) <span class='text'>Console message type.</span></dd>
 <dt>url (optional)</dt>
-<dd>String <span class="text">URL of the message origin.</span></dd>
+<dd>String <span class='text'>URL of the message origin.</span></dd>
 <dt>line (optional)</dt>
-<dd>Integer <span class="text">Line number in the resource that generated this message.</span></dd>
+<dd>Integer <span class='text'>Line number in the resource that generated this message.</span></dd>
 <dt>repeatCount (optional)</dt>
-<dd>Integer <span class="text">Repeat count for repeated messages.</span></dd>
+<dd>Integer <span class='text'>Repeat count for repeated messages.</span></dd>
 <dt>parameters (optional)</dt>
-<dd>[<a href="#Runtime.RemoteObject">Runtime.RemoteObject</a>] <span class="text">Message parameters in case of the formatted message.</span></dd>
+<dd>[<a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a>] <span class='text'>Message parameters in case of the formatted message.</span></dd>
 <dt>stackTrace (optional)</dt>
-<dd><a href="#Console.StackTrace">Console.StackTrace</a> <span class="text">JavaScript stack trace for assertions and error messages.</span></dd>
+<dd><a href='#Console.StackTrace'>Console.StackTrace</a> <span class='text'>JavaScript stack trace for assertions and error messages.</span></dd>
 <dt>networkRequestId (optional)</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Identifier of the network request associated with this message.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Identifier of the network request associated with this message.</span></dd>
 </dl>
 </div>
-<div id="Console_CallFrame" class="type">
-<h3>Console.CallFrame <span class="label">Type</span></h3>
+<div id='Console_CallFrame' class='type'>
+<h3>Console.CallFrame <span class='label'>Type</span></h3>
 <p>Stack entry for console errors and assertions.</p>
 <dl>
 <dt>functionName</dt>
-<dd>String <span class="text">JavaScript function name.</span></dd>
+<dd>String <span class='text'>JavaScript function name.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">JavaScript script name or url.</span></dd>
+<dd>String <span class='text'>JavaScript script name or url.</span></dd>
 <dt>lineNumber</dt>
-<dd>Integer <span class="text">JavaScript script line number.</span></dd>
+<dd>Integer <span class='text'>JavaScript script line number.</span></dd>
 <dt>columnNumber</dt>
-<dd>Integer <span class="text">JavaScript script column number.</span></dd>
+<dd>Integer <span class='text'>JavaScript script column number.</span></dd>
 </dl>
 </div>
-<div id="Console_StackTrace" class="type">
-<h3>Console.StackTrace <span class="label">Type</span></h3>
+<div id='Console_StackTrace' class='type'>
+<h3>Console.StackTrace <span class='label'>Type</span></h3>
 <p>Call frames for assertions or error messages.</p>
 <dl>
-<dd>[<a href="#Console.CallFrame">Console.CallFrame</a>]</dd>
+<dd>[<a href='#Console.CallFrame'>Console.CallFrame</a>]</dd>
 </dl>
 </div>
-<div id="Console_enable" class="command">
-<h3>Console.enable <span class="label label-success">Command</span></h3>
+<div id='Console_enable' class='command'>
+<h3>Console.enable <span class='label label-success'>Command</span></h3>
 <p>Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1358,8 +1564,8 @@ function onStyleSheetChanged(res) {
 Console.enable();
 </pre>
 </div>
-<div id="Console_disable" class="command">
-<h3>Console.disable <span class="label label-success">Command</span></h3>
+<div id='Console_disable' class='command'>
+<h3>Console.disable <span class='label label-success'>Command</span></h3>
 <p>Disables console domain, prevents further console messages from being reported to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1367,8 +1573,8 @@ Console.enable();
 Console.disable();
 </pre>
 </div>
-<div id="Console_clearMessages" class="command">
-<h3>Console.clearMessages <span class="label label-success">Command</span></h3>
+<div id='Console_clearMessages' class='command'>
+<h3>Console.clearMessages <span class='label label-success'>Command</span></h3>
 <p>Clears console messages collected in the browser.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1376,12 +1582,12 @@ Console.disable();
 Console.clearMessages();
 </pre>
 </div>
-<div id="Console_setMonitoringXHREnabled" class="command">
-<h3>Console.setMonitoringXHREnabled <span class="label label-success">Command</span></h3>
+<div id='Console_setMonitoringXHREnabled' class='command'>
+<h3>Console.setMonitoringXHREnabled <span class='label label-success'>Command</span></h3>
 <p>Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued.</p>
 <dl>
 <dt>enabled</dt>
-<dd>Boolean <span class="text">Monitoring enabled state.</span></dd>
+<dd>Boolean <span class='text'>Monitoring enabled state.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1389,12 +1595,12 @@ Console.clearMessages();
 Console.setMonitoringXHREnabled(enabled);
 </pre>
 </div>
-<div id="Console_addInspectedNode" class="command">
-<h3>Console.addInspectedNode <span class="label label-success">Command</span></h3>
+<div id='Console_addInspectedNode' class='command'>
+<h3>Console.addInspectedNode <span class='label label-success'>Command</span></h3>
 <p>Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">DOM node id to be accessible by means of $x command line API.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>DOM node id to be accessible by means of $x command line API.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1402,8 +1608,8 @@ Console.setMonitoringXHREnabled(enabled);
 Console.addInspectedNode(nodeId);
 </pre>
 </div>
-<div id="Console_addInspectedHeapObject" class="command">
-<h3>Console.addInspectedHeapObject <span class="label label-success">Command</span></h3>
+<div id='Console_addInspectedHeapObject' class='command'>
+<h3>Console.addInspectedHeapObject <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>heapObjectId</dt>
 <dd>Integer</dd>
@@ -1414,12 +1620,12 @@ Console.addInspectedNode(nodeId);
 Console.addInspectedHeapObject(heapObjectId);
 </pre>
 </div>
-<div id="Console_messageAdded" class="command">
-<h3>Console.messageAdded <span class="label label-info">Event</span></h3>
+<div id='Console_messageAdded' class='command'>
+<h3>Console.messageAdded <span class='label label-info'>Event</span></h3>
 <p>Issued when new console message is added.</p>
 <dl>
 <dt>message</dt>
-<dd><a href="#Console.ConsoleMessage">Console.ConsoleMessage</a> <span class="text">Console message that has been added.</span></dd>
+<dd><a href='#Console.ConsoleMessage'>Console.ConsoleMessage</a> <span class='text'>Console message that has been added.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1429,12 +1635,12 @@ function onMessageAdded(res) {
 }
 </pre>
 </div>
-<div id="Console_messageRepeatCountUpdated" class="command">
-<h3>Console.messageRepeatCountUpdated <span class="label label-info">Event</span></h3>
+<div id='Console_messageRepeatCountUpdated' class='command'>
+<h3>Console.messageRepeatCountUpdated <span class='label label-info'>Event</span></h3>
 <p>Issued when subsequent message(s) are equal to the previous one(s).</p>
 <dl>
 <dt>count</dt>
-<dd>Integer <span class="text">New repeat count value.</span></dd>
+<dd>Integer <span class='text'>New repeat count value.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1444,8 +1650,8 @@ function onMessageRepeatCountUpdated(res) {
 }
 </pre>
 </div>
-<div id="Console_messagesCleared" class="command">
-<h3>Console.messagesCleared <span class="label label-info">Event</span></h3>
+<div id='Console_messagesCleared' class='command'>
+<h3>Console.messagesCleared <span class='label label-info'>Event</span></h3>
 <p>Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1456,166 +1662,165 @@ function onMessagesCleared(res) {
 </pre>
 </div>
 </section>
-<section id="DOM" class="domain">
+<section id='DOM' class='domain'>
 <h1>DOM</h1>
 <p>This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOM.NodeId">DOM.NodeId</a>: Unique DOM node identifier.</li>
-<li><a href="#DOM.Node">DOM.Node</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
-<li><a href="#DOM.EventListener">DOM.EventListener</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
-<li><a href="#DOM.RGBA">DOM.RGBA</a>: A structure holding an RGBA color.</li>
-<li><a href="#DOM.HighlightConfig">DOM.HighlightConfig</a>: Configuration data for the highlighting of page elements.</li>
+<li><a href='#DOM.NodeId'>DOM.NodeId</a>: Unique DOM node identifier.</li>
+<li><a href='#DOM.Node'>DOM.Node</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
+<li><a href='#DOM.EventListener'>DOM.EventListener</a>: DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</li>
+<li><a href='#DOM.RGBA'>DOM.RGBA</a>: A structure holding an RGBA color.</li>
+<li><a href='#DOM.HighlightConfig'>DOM.HighlightConfig</a>: Configuration data for the highlighting of page elements.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOM.getDocument">DOM.getDocument</a>: Returns the root DOM node to the caller.</li>
-<li><a href="#DOM.requestChildNodes">DOM.requestChildNodes</a>: Requests that children of the node with given id are returned to the caller in form of setChildNodes events.</li>
-<li><a href="#DOM.querySelector">DOM.querySelector</a>: Executes querySelector on a given node.</li>
-<li><a href="#DOM.querySelectorAll">DOM.querySelectorAll</a>: Executes querySelectorAll on a given node.</li>
-<li><a href="#DOM.setNodeName">DOM.setNodeName</a>: Sets node name for a node with given id.</li>
-<li><a href="#DOM.setNodeValue">DOM.setNodeValue</a>: Sets node value for a node with given id.</li>
-<li><a href="#DOM.removeNode">DOM.removeNode</a>: Removes node with given id.</li>
-<li><a href="#DOM.setAttributeValue">DOM.setAttributeValue</a>: Sets attribute for an element with given id.</li>
-<li><a href="#DOM.setAttributesAsText">DOM.setAttributesAsText</a>: Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.</li>
-<li><a href="#DOM.removeAttribute">DOM.removeAttribute</a>: Removes attribute with given name from an element with given id.</li>
-<li><a href="#DOM.getEventListenersForNode">DOM.getEventListenersForNode</a>: Returns event listeners relevant to the node.</li>
-<li><a href="#DOM.getOuterHTML">DOM.getOuterHTML</a>: Returns node's HTML markup.</li>
-<li><a href="#DOM.setOuterHTML">DOM.setOuterHTML</a>: Sets node HTML markup, returns new node id.</li>
-<li><a href="#DOM.performSearch">DOM.performSearch</a>: Searches for a given string in the DOM tree. Use getSearchResults to access search results or cancelSearch to end this search session.</li>
-<li><a href="#DOM.getSearchResults">DOM.getSearchResults</a>: Returns search results from given fromIndex to given toIndex from the sarch with the given identifier.</li>
-<li><a href="#DOM.discardSearchResults">DOM.discardSearchResults</a>: Discards search results from the session with the given id. getSearchResults should no longer be called for that search.</li>
-<li><a href="#DOM.requestNode">DOM.requestNode</a>: Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of setChildNodes notifications.</li>
-<li><a href="#DOM.setInspectModeEnabled">DOM.setInspectModeEnabled</a>: Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection.</li>
-<li><a href="#DOM.highlightRect">DOM.highlightRect</a>: Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.</li>
-<li><a href="#DOM.highlightNode">DOM.highlightNode</a>: Highlights DOM node with given id.</li>
-<li><a href="#DOM.hideHighlight">DOM.hideHighlight</a>: Hides DOM node highlight.</li>
-<li><a href="#DOM.highlightFrame">DOM.highlightFrame</a>: Highlights owner element of the frame with given id.</li>
-<li><a href="#DOM.pushNodeByPathToFrontend">DOM.pushNodeByPathToFrontend</a>: Requests that the node is sent to the caller given its path. // FIXME, use XPath</li>
-<li><a href="#DOM.resolveNode">DOM.resolveNode</a>: Resolves JavaScript node object for given node id.</li>
-<li><a href="#DOM.getAttributes">DOM.getAttributes</a>: Returns attributes for the specified node.</li>
-<li><a href="#DOM.moveTo">DOM.moveTo</a>: Moves node into the new container, places it before the given anchor.</li>
-<li><a href="#DOM.setTouchEmulationEnabled">DOM.setTouchEmulationEnabled</a>: Toggles mouse event-based touch event emulation.</li>
-<li><a href="#DOM.undo">DOM.undo</a>: Undoes the last performed action.</li>
-<li><a href="#DOM.redo">DOM.redo</a>: Re-does the last undone action.</li>
-<li><a href="#DOM.markUndoableState">DOM.markUndoableState</a>: Marks last undoable state.</li>
+<li><a href='#DOM.getDocument'>DOM.getDocument</a>: Returns the root DOM node to the caller.</li>
+<li><a href='#DOM.requestChildNodes'>DOM.requestChildNodes</a>: Requests that children of the node with given id are returned to the caller in form of setChildNodes events.</li>
+<li><a href='#DOM.querySelector'>DOM.querySelector</a>: Executes querySelector on a given node.</li>
+<li><a href='#DOM.querySelectorAll'>DOM.querySelectorAll</a>: Executes querySelectorAll on a given node.</li>
+<li><a href='#DOM.setNodeName'>DOM.setNodeName</a>: Sets node name for a node with given id.</li>
+<li><a href='#DOM.setNodeValue'>DOM.setNodeValue</a>: Sets node value for a node with given id.</li>
+<li><a href='#DOM.removeNode'>DOM.removeNode</a>: Removes node with given id.</li>
+<li><a href='#DOM.setAttributeValue'>DOM.setAttributeValue</a>: Sets attribute for an element with given id.</li>
+<li><a href='#DOM.setAttributesAsText'>DOM.setAttributesAsText</a>: Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.</li>
+<li><a href='#DOM.removeAttribute'>DOM.removeAttribute</a>: Removes attribute with given name from an element with given id.</li>
+<li><a href='#DOM.getEventListenersForNode'>DOM.getEventListenersForNode</a>: Returns event listeners relevant to the node.</li>
+<li><a href='#DOM.getOuterHTML'>DOM.getOuterHTML</a>: Returns node's HTML markup.</li>
+<li><a href='#DOM.setOuterHTML'>DOM.setOuterHTML</a>: Sets node HTML markup, returns new node id.</li>
+<li><a href='#DOM.performSearch'>DOM.performSearch</a>: Searches for a given string in the DOM tree. Use getSearchResults to access search results or cancelSearch to end this search session.</li>
+<li><a href='#DOM.getSearchResults'>DOM.getSearchResults</a>: Returns search results from given fromIndex to given toIndex from the sarch with the given identifier.</li>
+<li><a href='#DOM.discardSearchResults'>DOM.discardSearchResults</a>: Discards search results from the session with the given id. getSearchResults should no longer be called for that search.</li>
+<li><a href='#DOM.requestNode'>DOM.requestNode</a>: Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of setChildNodes notifications.</li>
+<li><a href='#DOM.setInspectModeEnabled'>DOM.setInspectModeEnabled</a>: Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection.</li>
+<li><a href='#DOM.highlightRect'>DOM.highlightRect</a>: Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.</li>
+<li><a href='#DOM.highlightNode'>DOM.highlightNode</a>: Highlights DOM node with given id.</li>
+<li><a href='#DOM.hideHighlight'>DOM.hideHighlight</a>: Hides DOM node highlight.</li>
+<li><a href='#DOM.highlightFrame'>DOM.highlightFrame</a>: Highlights owner element of the frame with given id.</li>
+<li><a href='#DOM.pushNodeByPathToFrontend'>DOM.pushNodeByPathToFrontend</a>: Requests that the node is sent to the caller given its path. // FIXME, use XPath</li>
+<li><a href='#DOM.resolveNode'>DOM.resolveNode</a>: Resolves JavaScript node object for given node id.</li>
+<li><a href='#DOM.getAttributes'>DOM.getAttributes</a>: Returns attributes for the specified node.</li>
+<li><a href='#DOM.moveTo'>DOM.moveTo</a>: Moves node into the new container, places it before the given anchor.</li>
+<li><a href='#DOM.undo'>DOM.undo</a>: Undoes the last performed action.</li>
+<li><a href='#DOM.redo'>DOM.redo</a>: Re-does the last undone action.</li>
+<li><a href='#DOM.markUndoableState'>DOM.markUndoableState</a>: Marks last undoable state.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#DOM.documentUpdated">DOM.documentUpdated</a>: Fired when Document has been totally updated. Node ids are no longer valid.</li>
-<li><a href="#DOM.setChildNodes">DOM.setChildNodes</a>: Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids.</li>
-<li><a href="#DOM.attributeModified">DOM.attributeModified</a>: Fired when Element's attribute is modified.</li>
-<li><a href="#DOM.attributeRemoved">DOM.attributeRemoved</a>: Fired when Element's attribute is removed.</li>
-<li><a href="#DOM.inlineStyleInvalidated">DOM.inlineStyleInvalidated</a>: Fired when Element's inline style is modified via a CSS property modification.</li>
-<li><a href="#DOM.characterDataModified">DOM.characterDataModified</a>: Mirrors DOMCharacterDataModified event.</li>
-<li><a href="#DOM.childNodeCountUpdated">DOM.childNodeCountUpdated</a>: Fired when Container's child node count has changed.</li>
-<li><a href="#DOM.childNodeInserted">DOM.childNodeInserted</a>: Mirrors DOMNodeInserted event.</li>
-<li><a href="#DOM.childNodeRemoved">DOM.childNodeRemoved</a>: Mirrors DOMNodeRemoved event.</li>
-<li><a href="#DOM.shadowRootPushed">DOM.shadowRootPushed</a>: Called when shadow root is pushed into the element.</li>
-<li><a href="#DOM.shadowRootPopped">DOM.shadowRootPopped</a>: Called when shadow root is popped from the element.</li>
+<li><a href='#DOM.documentUpdated'>DOM.documentUpdated</a>: Fired when Document has been totally updated. Node ids are no longer valid.</li>
+<li><a href='#DOM.setChildNodes'>DOM.setChildNodes</a>: Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids.</li>
+<li><a href='#DOM.attributeModified'>DOM.attributeModified</a>: Fired when Element's attribute is modified.</li>
+<li><a href='#DOM.attributeRemoved'>DOM.attributeRemoved</a>: Fired when Element's attribute is removed.</li>
+<li><a href='#DOM.inlineStyleInvalidated'>DOM.inlineStyleInvalidated</a>: Fired when Element's inline style is modified via a CSS property modification.</li>
+<li><a href='#DOM.characterDataModified'>DOM.characterDataModified</a>: Mirrors DOMCharacterDataModified event.</li>
+<li><a href='#DOM.childNodeCountUpdated'>DOM.childNodeCountUpdated</a>: Fired when Container's child node count has changed.</li>
+<li><a href='#DOM.childNodeInserted'>DOM.childNodeInserted</a>: Mirrors DOMNodeInserted event.</li>
+<li><a href='#DOM.childNodeRemoved'>DOM.childNodeRemoved</a>: Mirrors DOMNodeRemoved event.</li>
+<li><a href='#DOM.shadowRootPushed'>DOM.shadowRootPushed</a>: Called when shadow root is pushed into the element.</li>
+<li><a href='#DOM.shadowRootPopped'>DOM.shadowRootPopped</a>: Called when shadow root is popped from the element.</li>
 </ul>
-<div id="DOM_NodeId" class="type">
-<h3>DOM.NodeId <span class="label">Type</span></h3>
+<div id='DOM_NodeId' class='type'>
+<h3>DOM.NodeId <span class='label'>Type</span></h3>
 <p>Unique DOM node identifier.</p>
 <dl>
 <dd>Integer</dd>
 </dl>
 </div>
-<div id="DOM_Node" class="type">
-<h3>DOM.Node <span class="label">Type</span></h3>
+<div id='DOM_Node' class='type'>
+<h3>DOM.Node <span class='label'>Type</span></h3>
 <p>DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client.</span></dd>
 <dt>nodeType</dt>
-<dd>Integer <span class="text"><code>Node</code>'s nodeType.</span></dd>
+<dd>Integer <span class='text'><code>Node</code>'s nodeType.</span></dd>
 <dt>nodeName</dt>
-<dd>String <span class="text"><code>Node</code>'s nodeName.</span></dd>
+<dd>String <span class='text'><code>Node</code>'s nodeName.</span></dd>
 <dt>localName</dt>
-<dd>String <span class="text"><code>Node</code>'s localName.</span></dd>
+<dd>String <span class='text'><code>Node</code>'s localName.</span></dd>
 <dt>nodeValue</dt>
-<dd>String <span class="text"><code>Node</code>'s nodeValue.</span></dd>
+<dd>String <span class='text'><code>Node</code>'s nodeValue.</span></dd>
 <dt>childNodeCount (optional)</dt>
-<dd>Integer <span class="text">Child count for <code>Container</code> nodes.</span></dd>
+<dd>Integer <span class='text'>Child count for <code>Container</code> nodes.</span></dd>
 <dt>children (optional)</dt>
-<dd>[<a href="#DOM.Node">DOM.Node</a>] <span class="text">Child nodes of this node when requested with children.</span></dd>
+<dd>[<a href='#DOM.Node'>DOM.Node</a>] <span class='text'>Child nodes of this node when requested with children.</span></dd>
 <dt>attributes (optional)</dt>
-<dd>[String] <span class="text">Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>.</span></dd>
+<dd>[String] <span class='text'>Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>.</span></dd>
 <dt>documentURL (optional)</dt>
-<dd>String <span class="text">Document URL that <code>Document</code> or <code>FrameOwner</code> node points to.</span></dd>
+<dd>String <span class='text'>Document URL that <code>Document</code> or <code>FrameOwner</code> node points to.</span></dd>
 <dt>publicId (optional)</dt>
-<dd>String <span class="text"><code>DocumentType</code>'s publicId.</span></dd>
+<dd>String <span class='text'><code>DocumentType</code>'s publicId.</span></dd>
 <dt>systemId (optional)</dt>
-<dd>String <span class="text"><code>DocumentType</code>'s systemId.</span></dd>
+<dd>String <span class='text'><code>DocumentType</code>'s systemId.</span></dd>
 <dt>internalSubset (optional)</dt>
-<dd>String <span class="text"><code>DocumentType</code>'s internalSubset.</span></dd>
+<dd>String <span class='text'><code>DocumentType</code>'s internalSubset.</span></dd>
 <dt>xmlVersion (optional)</dt>
-<dd>String <span class="text"><code>Document</code>'s XML version in case of XML documents.</span></dd>
+<dd>String <span class='text'><code>Document</code>'s XML version in case of XML documents.</span></dd>
 <dt>name (optional)</dt>
-<dd>String <span class="text"><code>Attr</code>'s name.</span></dd>
+<dd>String <span class='text'><code>Attr</code>'s name.</span></dd>
 <dt>value (optional)</dt>
-<dd>String <span class="text"><code>Attr</code>'s value.</span></dd>
+<dd>String <span class='text'><code>Attr</code>'s value.</span></dd>
 <dt>contentDocument (optional)</dt>
-<dd><a href="#DOM.Node">DOM.Node</a> <span class="text">Content document for frame owner elements.</span></dd>
+<dd><a href='#DOM.Node'>DOM.Node</a> <span class='text'>Content document for frame owner elements.</span></dd>
 <dt>shadowRoots (optional)</dt>
-<dd>[<a href="#DOM.Node">DOM.Node</a>] <span class="text">Shadow root list for given element host.</span></dd>
+<dd>[<a href='#DOM.Node'>DOM.Node</a>] <span class='text'>Shadow root list for given element host.</span></dd>
 </dl>
 </div>
-<div id="DOM_EventListener" class="type">
-<h3>DOM.EventListener <span class="label">Type</span></h3>
+<div id='DOM_EventListener' class='type'>
+<h3>DOM.EventListener <span class='label'>Type</span></h3>
 <p>DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type.</p>
 <dl>
 <dt>type</dt>
-<dd>String <span class="text"><code>EventListener</code>'s type.</span></dd>
+<dd>String <span class='text'><code>EventListener</code>'s type.</span></dd>
 <dt>useCapture</dt>
-<dd>Boolean <span class="text"><code>EventListener</code>'s useCapture.</span></dd>
+<dd>Boolean <span class='text'><code>EventListener</code>'s useCapture.</span></dd>
 <dt>isAttribute</dt>
-<dd>Boolean <span class="text"><code>EventListener</code>'s isAttribute.</span></dd>
+<dd>Boolean <span class='text'><code>EventListener</code>'s isAttribute.</span></dd>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Target <code>DOMNode</code> id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Target <code>DOMNode</code> id.</span></dd>
 <dt>handlerBody</dt>
-<dd>String <span class="text">Event handler function body.</span></dd>
+<dd>String <span class='text'>Event handler function body.</span></dd>
 <dt>location (optional)</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Handler code location.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Handler code location.</span></dd>
 </dl>
 </div>
-<div id="DOM_RGBA" class="type">
-<h3>DOM.RGBA <span class="label">Type</span></h3>
+<div id='DOM_RGBA' class='type'>
+<h3>DOM.RGBA <span class='label'>Type</span></h3>
 <p>A structure holding an RGBA color.</p>
 <dl>
 <dt>r</dt>
-<dd>Integer <span class="text">The red component, in the [0-255] range.</span></dd>
+<dd>Integer <span class='text'>The red component, in the [0-255] range.</span></dd>
 <dt>g</dt>
-<dd>Integer <span class="text">The green component, in the [0-255] range.</span></dd>
+<dd>Integer <span class='text'>The green component, in the [0-255] range.</span></dd>
 <dt>b</dt>
-<dd>Integer <span class="text">The blue component, in the [0-255] range.</span></dd>
+<dd>Integer <span class='text'>The blue component, in the [0-255] range.</span></dd>
 <dt>a (optional)</dt>
-<dd>Number <span class="text">The alpha component, in the [0-1] range (default: 1).</span></dd>
+<dd>Number <span class='text'>The alpha component, in the [0-1] range (default: 1).</span></dd>
 </dl>
 </div>
-<div id="DOM_HighlightConfig" class="type">
-<h3>DOM.HighlightConfig <span class="label">Type</span></h3>
+<div id='DOM_HighlightConfig' class='type'>
+<h3>DOM.HighlightConfig <span class='label'>Type</span></h3>
 <p>Configuration data for the highlighting of page elements.</p>
 <dl>
 <dt>showInfo (optional)</dt>
-<dd>Boolean <span class="text">Whether the node info tooltip should be shown (default: false).</span></dd>
+<dd>Boolean <span class='text'>Whether the node info tooltip should be shown (default: false).</span></dd>
 <dt>contentColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The content box highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The content box highlight fill color (default: transparent).</span></dd>
 <dt>paddingColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The padding highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The padding highlight fill color (default: transparent).</span></dd>
 <dt>borderColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The border highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The border highlight fill color (default: transparent).</span></dd>
 <dt>marginColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The margin highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The margin highlight fill color (default: transparent).</span></dd>
 </dl>
 </div>
-<div id="DOM_getDocument" class="command">
-<h3>DOM.getDocument <span class="label label-success">Command</span></h3>
+<div id='DOM_getDocument' class='command'>
+<h3>DOM.getDocument <span class='label label-success'>Command</span></h3>
 <p>Returns the root DOM node to the caller.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>root</dt>
-<dd><a href="#DOM.Node">DOM.Node</a> <span class="text">Resulting node.</span></dd>
+<dd><a href='#DOM.Node'>DOM.Node</a> <span class='text'>Resulting node.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1625,12 +1830,12 @@ DOM.getDocument(function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_requestChildNodes" class="command">
-<h3>DOM.requestChildNodes <span class="label label-success">Command</span></h3>
+<div id='DOM_requestChildNodes' class='command'>
+<h3>DOM.requestChildNodes <span class='label label-success'>Command</span></h3>
 <p>Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to get children for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to get children for.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1638,19 +1843,19 @@ DOM.getDocument(function callback(res) {
 DOM.requestChildNodes(nodeId);
 </pre>
 </div>
-<div id="DOM_querySelector" class="command">
-<h3>DOM.querySelector <span class="label label-success">Command</span></h3>
+<div id='DOM_querySelector' class='command'>
+<h3>DOM.querySelector <span class='label label-success'>Command</span></h3>
 <p>Executes <code>querySelector</code> on a given node.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to query upon.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to query upon.</span></dd>
 <dt>selector</dt>
-<dd>String <span class="text">Selector string.</span></dd>
+<dd>String <span class='text'>Selector string.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Query selector result.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Query selector result.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1660,19 +1865,19 @@ DOM.querySelector(nodeId, selector, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_querySelectorAll" class="command">
-<h3>DOM.querySelectorAll <span class="label label-success">Command</span></h3>
+<div id='DOM_querySelectorAll' class='command'>
+<h3>DOM.querySelectorAll <span class='label label-success'>Command</span></h3>
 <p>Executes <code>querySelectorAll</code> on a given node.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to query upon.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to query upon.</span></dd>
 <dt>selector</dt>
-<dd>String <span class="text">Selector string.</span></dd>
+<dd>String <span class='text'>Selector string.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeIds</dt>
-<dd>[<a href="#DOM.NodeId">DOM.NodeId</a>] <span class="text">Query selector result.</span></dd>
+<dd>[<a href='#DOM.NodeId'>DOM.NodeId</a>] <span class='text'>Query selector result.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1682,19 +1887,19 @@ DOM.querySelectorAll(nodeId, selector, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_setNodeName" class="command">
-<h3>DOM.setNodeName <span class="label label-success">Command</span></h3>
+<div id='DOM_setNodeName' class='command'>
+<h3>DOM.setNodeName <span class='label label-success'>Command</span></h3>
 <p>Sets node name for a node with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to set name for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to set name for.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">New node's name.</span></dd>
+<dd>String <span class='text'>New node's name.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">New node's id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>New node's id.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1704,14 +1909,14 @@ DOM.setNodeName(nodeId, name, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_setNodeValue" class="command">
-<h3>DOM.setNodeValue <span class="label label-success">Command</span></h3>
+<div id='DOM_setNodeValue' class='command'>
+<h3>DOM.setNodeValue <span class='label label-success'>Command</span></h3>
 <p>Sets node value for a node with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to set value for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to set value for.</span></dd>
 <dt>value</dt>
-<dd>String <span class="text">New node's value.</span></dd>
+<dd>String <span class='text'>New node's value.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1719,12 +1924,12 @@ DOM.setNodeName(nodeId, name, function callback(res) {
 DOM.setNodeValue(nodeId, value);
 </pre>
 </div>
-<div id="DOM_removeNode" class="command">
-<h3>DOM.removeNode <span class="label label-success">Command</span></h3>
+<div id='DOM_removeNode' class='command'>
+<h3>DOM.removeNode <span class='label label-success'>Command</span></h3>
 <p>Removes node with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to remove.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to remove.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1732,16 +1937,16 @@ DOM.setNodeValue(nodeId, value);
 DOM.removeNode(nodeId);
 </pre>
 </div>
-<div id="DOM_setAttributeValue" class="command">
-<h3>DOM.setAttributeValue <span class="label label-success">Command</span></h3>
+<div id='DOM_setAttributeValue' class='command'>
+<h3>DOM.setAttributeValue <span class='label label-success'>Command</span></h3>
 <p>Sets attribute for an element with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the element to set attribute for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the element to set attribute for.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">Attribute name.</span></dd>
+<dd>String <span class='text'>Attribute name.</span></dd>
 <dt>value</dt>
-<dd>String <span class="text">Attribute value.</span></dd>
+<dd>String <span class='text'>Attribute value.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1749,16 +1954,16 @@ DOM.removeNode(nodeId);
 DOM.setAttributeValue(nodeId, name, value);
 </pre>
 </div>
-<div id="DOM_setAttributesAsText" class="command">
-<h3>DOM.setAttributesAsText <span class="label label-success">Command</span></h3>
+<div id='DOM_setAttributesAsText' class='command'>
+<h3>DOM.setAttributesAsText <span class='label label-success'>Command</span></h3>
 <p>Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the element to set attributes for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the element to set attributes for.</span></dd>
 <dt>text</dt>
-<dd>String <span class="text">Text with a number of attributes. Will parse this text using HTML parser.</span></dd>
+<dd>String <span class='text'>Text with a number of attributes. Will parse this text using HTML parser.</span></dd>
 <dt>name (optional)</dt>
-<dd>String <span class="text">Attribute name to replace with new attributes derived from text in case text parsed successfully.</span></dd>
+<dd>String <span class='text'>Attribute name to replace with new attributes derived from text in case text parsed successfully.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1766,14 +1971,14 @@ DOM.setAttributeValue(nodeId, name, value);
 DOM.setAttributesAsText(nodeId, text, name);
 </pre>
 </div>
-<div id="DOM_removeAttribute" class="command">
-<h3>DOM.removeAttribute <span class="label label-success">Command</span></h3>
+<div id='DOM_removeAttribute' class='command'>
+<h3>DOM.removeAttribute <span class='label label-success'>Command</span></h3>
 <p>Removes attribute with given name from an element with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the element to remove attribute from.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the element to remove attribute from.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">Name of the attribute to remove.</span></dd>
+<dd>String <span class='text'>Name of the attribute to remove.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1781,17 +1986,17 @@ DOM.setAttributesAsText(nodeId, text, name);
 DOM.removeAttribute(nodeId, name);
 </pre>
 </div>
-<div id="DOM_getEventListenersForNode" class="command">
-<h3>DOM.getEventListenersForNode <span class="label label-success">Command</span></h3>
+<div id='DOM_getEventListenersForNode' class='command'>
+<h3>DOM.getEventListenersForNode <span class='label label-success'>Command</span></h3>
 <p>Returns event listeners relevant to the node.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to get listeners for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to get listeners for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>listeners</dt>
-<dd>[<a href="#DOM.EventListener">DOM.EventListener</a>] <span class="text">Array of relevant listeners.</span></dd>
+<dd>[<a href='#DOM.EventListener'>DOM.EventListener</a>] <span class='text'>Array of relevant listeners.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1801,17 +2006,17 @@ DOM.getEventListenersForNode(nodeId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_getOuterHTML" class="command">
-<h3>DOM.getOuterHTML <span class="label label-success">Command</span></h3>
+<div id='DOM_getOuterHTML' class='command'>
+<h3>DOM.getOuterHTML <span class='label label-success'>Command</span></h3>
 <p>Returns node's HTML markup.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to get markup for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to get markup for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>outerHTML</dt>
-<dd>String <span class="text">Outer HTML markup.</span></dd>
+<dd>String <span class='text'>Outer HTML markup.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1821,14 +2026,14 @@ DOM.getOuterHTML(nodeId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_setOuterHTML" class="command">
-<h3>DOM.setOuterHTML <span class="label label-success">Command</span></h3>
+<div id='DOM_setOuterHTML' class='command'>
+<h3>DOM.setOuterHTML <span class='label label-success'>Command</span></h3>
 <p>Sets node HTML markup, returns new node id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to set markup for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to set markup for.</span></dd>
 <dt>outerHTML</dt>
-<dd>String <span class="text">Outer HTML markup to set.</span></dd>
+<dd>String <span class='text'>Outer HTML markup to set.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1836,19 +2041,19 @@ DOM.getOuterHTML(nodeId, function callback(res) {
 DOM.setOuterHTML(nodeId, outerHTML);
 </pre>
 </div>
-<div id="DOM_performSearch" class="command">
-<h3>DOM.performSearch <span class="label label-success">Command</span></h3>
+<div id='DOM_performSearch' class='command'>
+<h3>DOM.performSearch <span class='label label-success'>Command</span></h3>
 <p>Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session.</p>
 <dl>
 <dt>query</dt>
-<dd>String <span class="text">Plain text or query selector or XPath search query.</span></dd>
+<dd>String <span class='text'>Plain text or query selector or XPath search query.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>searchId</dt>
-<dd>String <span class="text">Unique search session identifier.</span></dd>
+<dd>String <span class='text'>Unique search session identifier.</span></dd>
 <dt>resultCount</dt>
-<dd>Integer <span class="text">Number of search results.</span></dd>
+<dd>Integer <span class='text'>Number of search results.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1858,21 +2063,21 @@ DOM.performSearch(query, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_getSearchResults" class="command">
-<h3>DOM.getSearchResults <span class="label label-success">Command</span></h3>
+<div id='DOM_getSearchResults' class='command'>
+<h3>DOM.getSearchResults <span class='label label-success'>Command</span></h3>
 <p>Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier.</p>
 <dl>
 <dt>searchId</dt>
-<dd>String <span class="text">Unique search session identifier.</span></dd>
+<dd>String <span class='text'>Unique search session identifier.</span></dd>
 <dt>fromIndex</dt>
-<dd>Integer <span class="text">Start index of the search result to be returned.</span></dd>
+<dd>Integer <span class='text'>Start index of the search result to be returned.</span></dd>
 <dt>toIndex</dt>
-<dd>Integer <span class="text">End index of the search result to be returned.</span></dd>
+<dd>Integer <span class='text'>End index of the search result to be returned.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeIds</dt>
-<dd>[<a href="#DOM.NodeId">DOM.NodeId</a>] <span class="text">Ids of the search result nodes.</span></dd>
+<dd>[<a href='#DOM.NodeId'>DOM.NodeId</a>] <span class='text'>Ids of the search result nodes.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1882,12 +2087,12 @@ DOM.getSearchResults(searchId, fromIndex, toIndex, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_discardSearchResults" class="command">
-<h3>DOM.discardSearchResults <span class="label label-success">Command</span></h3>
+<div id='DOM_discardSearchResults' class='command'>
+<h3>DOM.discardSearchResults <span class='label label-success'>Command</span></h3>
 <p>Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search.</p>
 <dl>
 <dt>searchId</dt>
-<dd>String <span class="text">Unique search session identifier.</span></dd>
+<dd>String <span class='text'>Unique search session identifier.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1895,17 +2100,17 @@ DOM.getSearchResults(searchId, fromIndex, toIndex, function callback(res) {
 DOM.discardSearchResults(searchId);
 </pre>
 </div>
-<div id="DOM_requestNode" class="command">
-<h3>DOM.requestNode <span class="label label-success">Command</span></h3>
+<div id='DOM_requestNode' class='command'>
+<h3>DOM.requestNode <span class='label label-success'>Command</span></h3>
 <p>Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications.</p>
 <dl>
 <dt>objectId</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">JavaScript object id to convert into node.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>JavaScript object id to convert into node.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Node id for given object.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Node id for given object.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1915,14 +2120,14 @@ DOM.requestNode(objectId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_setInspectModeEnabled" class="command">
-<h3>DOM.setInspectModeEnabled <span class="label label-success">Command</span></h3>
+<div id='DOM_setInspectModeEnabled' class='command'>
+<h3>DOM.setInspectModeEnabled <span class='label label-success'>Command</span></h3>
 <p>Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection.</p>
 <dl>
 <dt>enabled</dt>
-<dd>Boolean <span class="text">True to enable inspection mode, false to disable it.</span></dd>
+<dd>Boolean <span class='text'>True to enable inspection mode, false to disable it.</span></dd>
 <dt>highlightConfig (optional)</dt>
-<dd><a href="#DOM.HighlightConfig">DOM.HighlightConfig</a> <span class="text">A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>.</span></dd>
+<dd><a href='#DOM.HighlightConfig'>DOM.HighlightConfig</a> <span class='text'>A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1930,22 +2135,22 @@ DOM.requestNode(objectId, function callback(res) {
 DOM.setInspectModeEnabled(enabled, highlightConfig);
 </pre>
 </div>
-<div id="DOM_highlightRect" class="command">
-<h3>DOM.highlightRect <span class="label label-success">Command</span></h3>
+<div id='DOM_highlightRect' class='command'>
+<h3>DOM.highlightRect <span class='label label-success'>Command</span></h3>
 <p>Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport.</p>
 <dl>
 <dt>x</dt>
-<dd>Integer <span class="text">X coordinate</span></dd>
+<dd>Integer <span class='text'>X coordinate</span></dd>
 <dt>y</dt>
-<dd>Integer <span class="text">Y coordinate</span></dd>
+<dd>Integer <span class='text'>Y coordinate</span></dd>
 <dt>width</dt>
-<dd>Integer <span class="text">Rectangle width</span></dd>
+<dd>Integer <span class='text'>Rectangle width</span></dd>
 <dt>height</dt>
-<dd>Integer <span class="text">Rectangle height</span></dd>
+<dd>Integer <span class='text'>Rectangle height</span></dd>
 <dt>color (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The highlight fill color (default: transparent).</span></dd>
 <dt>outlineColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The highlight outline color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The highlight outline color (default: transparent).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1953,14 +2158,14 @@ DOM.setInspectModeEnabled(enabled, highlightConfig);
 DOM.highlightRect(x, y, width, height, color, outlineColor);
 </pre>
 </div>
-<div id="DOM_highlightNode" class="command">
-<h3>DOM.highlightNode <span class="label label-success">Command</span></h3>
+<div id='DOM_highlightNode' class='command'>
+<h3>DOM.highlightNode <span class='label label-success'>Command</span></h3>
 <p>Highlights DOM node with given id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Identifier of the node to highlight.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Identifier of the node to highlight.</span></dd>
 <dt>highlightConfig</dt>
-<dd><a href="#DOM.HighlightConfig">DOM.HighlightConfig</a> <span class="text">A descriptor for the highlight appearance.</span></dd>
+<dd><a href='#DOM.HighlightConfig'>DOM.HighlightConfig</a> <span class='text'>A descriptor for the highlight appearance.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1968,8 +2173,8 @@ DOM.highlightRect(x, y, width, height, color, outlineColor);
 DOM.highlightNode(nodeId, highlightConfig);
 </pre>
 </div>
-<div id="DOM_hideHighlight" class="command">
-<h3>DOM.hideHighlight <span class="label label-success">Command</span></h3>
+<div id='DOM_hideHighlight' class='command'>
+<h3>DOM.hideHighlight <span class='label label-success'>Command</span></h3>
 <p>Hides DOM node highlight.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -1977,16 +2182,16 @@ DOM.highlightNode(nodeId, highlightConfig);
 DOM.hideHighlight();
 </pre>
 </div>
-<div id="DOM_highlightFrame" class="command">
-<h3>DOM.highlightFrame <span class="label label-success">Command</span></h3>
+<div id='DOM_highlightFrame' class='command'>
+<h3>DOM.highlightFrame <span class='label label-success'>Command</span></h3>
 <p>Highlights owner element of the frame with given id.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Identifier of the frame to highlight.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Identifier of the frame to highlight.</span></dd>
 <dt>contentColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The content box highlight fill color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The content box highlight fill color (default: transparent).</span></dd>
 <dt>contentOutlineColor (optional)</dt>
-<dd><a href="#DOM.RGBA">DOM.RGBA</a> <span class="text">The content box highlight outline color (default: transparent).</span></dd>
+<dd><a href='#DOM.RGBA'>DOM.RGBA</a> <span class='text'>The content box highlight outline color (default: transparent).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -1994,17 +2199,17 @@ DOM.hideHighlight();
 DOM.highlightFrame(frameId, contentColor, contentOutlineColor);
 </pre>
 </div>
-<div id="DOM_pushNodeByPathToFrontend" class="command">
-<h3>DOM.pushNodeByPathToFrontend <span class="label label-success">Command</span></h3>
+<div id='DOM_pushNodeByPathToFrontend' class='command'>
+<h3>DOM.pushNodeByPathToFrontend <span class='label label-success'>Command</span></h3>
 <p>Requests that the node is sent to the caller given its path. // FIXME, use XPath</p>
 <dl>
 <dt>path</dt>
-<dd>String <span class="text">Path to node in the proprietary format.</span></dd>
+<dd>String <span class='text'>Path to node in the proprietary format.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node for given path.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node for given path.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2014,19 +2219,19 @@ DOM.pushNodeByPathToFrontend(path, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_resolveNode" class="command">
-<h3>DOM.resolveNode <span class="label label-success">Command</span></h3>
+<div id='DOM_resolveNode' class='command'>
+<h3>DOM.resolveNode <span class='label label-success'>Command</span></h3>
 <p>Resolves JavaScript node object for given node id.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to resolve.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to resolve.</span></dd>
 <dt>objectGroup (optional)</dt>
-<dd>String <span class="text">Symbolic group name that can be used to release multiple objects.</span></dd>
+<dd>String <span class='text'>Symbolic group name that can be used to release multiple objects.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>object</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">JavaScript object wrapper for given node.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>JavaScript object wrapper for given node.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2036,17 +2241,17 @@ DOM.resolveNode(nodeId, objectGroup, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_getAttributes" class="command">
-<h3>DOM.getAttributes <span class="label label-success">Command</span></h3>
+<div id='DOM_getAttributes' class='command'>
+<h3>DOM.getAttributes <span class='label label-success'>Command</span></h3>
 <p>Returns attributes for the specified node.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to retrieve attibutes for.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to retrieve attibutes for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>attributes</dt>
-<dd>[String] <span class="text">An interleaved array of node attribute names and values.</span></dd>
+<dd>[String] <span class='text'>An interleaved array of node attribute names and values.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2056,21 +2261,21 @@ DOM.getAttributes(nodeId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_moveTo" class="command">
-<h3>DOM.moveTo <span class="label label-success">Command</span></h3>
+<div id='DOM_moveTo' class='command'>
+<h3>DOM.moveTo <span class='label label-success'>Command</span></h3>
 <p>Moves node into the new container, places it before the given anchor.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node to drop.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node to drop.</span></dd>
 <dt>targetNodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the element to drop into.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the element to drop into.</span></dd>
 <dt>insertBeforeNodeId (optional)</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Drop node before given one.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Drop node before given one.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">New id of the moved node.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>New id of the moved node.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2080,21 +2285,8 @@ DOM.moveTo(nodeId, targetNodeId, insertBeforeNodeId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOM_setTouchEmulationEnabled" class="command">
-<h3>DOM.setTouchEmulationEnabled <span class="label label-success">Command</span></h3>
-<p>Toggles mouse event-based touch event emulation.</p>
-<dl>
-<dt>enabled</dt>
-<dd>Boolean <span class="text">Whether the touch event emulation should be enabled.</span></dd>
-</dl>
-<h4>Code Example:</h4>
-<pre>
-// WebInspector Command: DOM.setTouchEmulationEnabled
-DOM.setTouchEmulationEnabled(enabled);
-</pre>
-</div>
-<div id="DOM_undo" class="command">
-<h3>DOM.undo <span class="label label-success">Command</span></h3>
+<div id='DOM_undo' class='command'>
+<h3>DOM.undo <span class='label label-success'>Command</span></h3>
 <p>Undoes the last performed action.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2102,8 +2294,8 @@ DOM.setTouchEmulationEnabled(enabled);
 DOM.undo();
 </pre>
 </div>
-<div id="DOM_redo" class="command">
-<h3>DOM.redo <span class="label label-success">Command</span></h3>
+<div id='DOM_redo' class='command'>
+<h3>DOM.redo <span class='label label-success'>Command</span></h3>
 <p>Re-does the last undone action.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2111,8 +2303,8 @@ DOM.undo();
 DOM.redo();
 </pre>
 </div>
-<div id="DOM_markUndoableState" class="command">
-<h3>DOM.markUndoableState <span class="label label-success">Command</span></h3>
+<div id='DOM_markUndoableState' class='command'>
+<h3>DOM.markUndoableState <span class='label label-success'>Command</span></h3>
 <p>Marks last undoable state.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2120,8 +2312,8 @@ DOM.redo();
 DOM.markUndoableState();
 </pre>
 </div>
-<div id="DOM_documentUpdated" class="command">
-<h3>DOM.documentUpdated <span class="label label-info">Event</span></h3>
+<div id='DOM_documentUpdated' class='command'>
+<h3>DOM.documentUpdated <span class='label label-info'>Event</span></h3>
 <p>Fired when <code>Document</code> has been totally updated. Node ids are no longer valid.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2131,14 +2323,14 @@ function onDocumentUpdated(res) {
 }
 </pre>
 </div>
-<div id="DOM_setChildNodes" class="command">
-<h3>DOM.setChildNodes <span class="label label-info">Event</span></h3>
+<div id='DOM_setChildNodes' class='command'>
+<h3>DOM.setChildNodes <span class='label label-info'>Event</span></h3>
 <p>Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids.</p>
 <dl>
 <dt>parentId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Parent node id to populate with children.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Parent node id to populate with children.</span></dd>
 <dt>nodes</dt>
-<dd>[<a href="#DOM.Node">DOM.Node</a>] <span class="text">Child nodes array.</span></dd>
+<dd>[<a href='#DOM.Node'>DOM.Node</a>] <span class='text'>Child nodes array.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2148,16 +2340,16 @@ function onSetChildNodes(res) {
 }
 </pre>
 </div>
-<div id="DOM_attributeModified" class="command">
-<h3>DOM.attributeModified <span class="label label-info">Event</span></h3>
+<div id='DOM_attributeModified' class='command'>
+<h3>DOM.attributeModified <span class='label label-info'>Event</span></h3>
 <p>Fired when <code>Element</code>'s attribute is modified.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has changed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has changed.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">Attribute name.</span></dd>
+<dd>String <span class='text'>Attribute name.</span></dd>
 <dt>value</dt>
-<dd>String <span class="text">Attribute value.</span></dd>
+<dd>String <span class='text'>Attribute value.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2167,14 +2359,14 @@ function onAttributeModified(res) {
 }
 </pre>
 </div>
-<div id="DOM_attributeRemoved" class="command">
-<h3>DOM.attributeRemoved <span class="label label-info">Event</span></h3>
+<div id='DOM_attributeRemoved' class='command'>
+<h3>DOM.attributeRemoved <span class='label label-info'>Event</span></h3>
 <p>Fired when <code>Element</code>'s attribute is removed.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has changed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has changed.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">A ttribute name.</span></dd>
+<dd>String <span class='text'>A ttribute name.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2184,12 +2376,12 @@ function onAttributeRemoved(res) {
 }
 </pre>
 </div>
-<div id="DOM_inlineStyleInvalidated" class="command">
-<h3>DOM.inlineStyleInvalidated <span class="label label-info">Event</span></h3>
+<div id='DOM_inlineStyleInvalidated' class='command'>
+<h3>DOM.inlineStyleInvalidated <span class='label label-info'>Event</span></h3>
 <p>Fired when <code>Element</code>'s inline style is modified via a CSS property modification.</p>
 <dl>
 <dt>nodeIds</dt>
-<dd>[<a href="#DOM.NodeId">DOM.NodeId</a>] <span class="text">Ids of the nodes for which the inline styles have been invalidated.</span></dd>
+<dd>[<a href='#DOM.NodeId'>DOM.NodeId</a>] <span class='text'>Ids of the nodes for which the inline styles have been invalidated.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2199,14 +2391,14 @@ function onInlineStyleInvalidated(res) {
 }
 </pre>
 </div>
-<div id="DOM_characterDataModified" class="command">
-<h3>DOM.characterDataModified <span class="label label-info">Event</span></h3>
+<div id='DOM_characterDataModified' class='command'>
+<h3>DOM.characterDataModified <span class='label label-info'>Event</span></h3>
 <p>Mirrors <code>DOMCharacterDataModified</code> event.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has changed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has changed.</span></dd>
 <dt>characterData</dt>
-<dd>String <span class="text">New text value.</span></dd>
+<dd>String <span class='text'>New text value.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2216,14 +2408,14 @@ function onCharacterDataModified(res) {
 }
 </pre>
 </div>
-<div id="DOM_childNodeCountUpdated" class="command">
-<h3>DOM.childNodeCountUpdated <span class="label label-info">Event</span></h3>
+<div id='DOM_childNodeCountUpdated' class='command'>
+<h3>DOM.childNodeCountUpdated <span class='label label-info'>Event</span></h3>
 <p>Fired when <code>Container</code>'s child node count has changed.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has changed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has changed.</span></dd>
 <dt>childNodeCount</dt>
-<dd>Integer <span class="text">New node count.</span></dd>
+<dd>Integer <span class='text'>New node count.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2233,16 +2425,16 @@ function onChildNodeCountUpdated(res) {
 }
 </pre>
 </div>
-<div id="DOM_childNodeInserted" class="command">
-<h3>DOM.childNodeInserted <span class="label label-info">Event</span></h3>
+<div id='DOM_childNodeInserted' class='command'>
+<h3>DOM.childNodeInserted <span class='label label-info'>Event</span></h3>
 <p>Mirrors <code>DOMNodeInserted</code> event.</p>
 <dl>
 <dt>parentNodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has changed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has changed.</span></dd>
 <dt>previousNodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">If of the previous siblint.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>If of the previous siblint.</span></dd>
 <dt>node</dt>
-<dd><a href="#DOM.Node">DOM.Node</a> <span class="text">Inserted node data.</span></dd>
+<dd><a href='#DOM.Node'>DOM.Node</a> <span class='text'>Inserted node data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2252,14 +2444,14 @@ function onChildNodeInserted(res) {
 }
 </pre>
 </div>
-<div id="DOM_childNodeRemoved" class="command">
-<h3>DOM.childNodeRemoved <span class="label label-info">Event</span></h3>
+<div id='DOM_childNodeRemoved' class='command'>
+<h3>DOM.childNodeRemoved <span class='label label-info'>Event</span></h3>
 <p>Mirrors <code>DOMNodeRemoved</code> event.</p>
 <dl>
 <dt>parentNodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Parent id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Parent id.</span></dd>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Id of the node that has been removed.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Id of the node that has been removed.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2269,14 +2461,14 @@ function onChildNodeRemoved(res) {
 }
 </pre>
 </div>
-<div id="DOM_shadowRootPushed" class="command">
-<h3>DOM.shadowRootPushed <span class="label label-info">Event</span></h3>
+<div id='DOM_shadowRootPushed' class='command'>
+<h3>DOM.shadowRootPushed <span class='label label-info'>Event</span></h3>
 <p>Called when shadow root is pushed into the element.</p>
 <dl>
 <dt>hostId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Host element id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Host element id.</span></dd>
 <dt>root</dt>
-<dd><a href="#DOM.Node">DOM.Node</a> <span class="text">Shadow root.</span></dd>
+<dd><a href='#DOM.Node'>DOM.Node</a> <span class='text'>Shadow root.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2286,14 +2478,14 @@ function onShadowRootPushed(res) {
 }
 </pre>
 </div>
-<div id="DOM_shadowRootPopped" class="command">
-<h3>DOM.shadowRootPopped <span class="label label-info">Event</span></h3>
+<div id='DOM_shadowRootPopped' class='command'>
+<h3>DOM.shadowRootPopped <span class='label label-info'>Event</span></h3>
 <p>Called when shadow root is popped from the element.</p>
 <dl>
 <dt>hostId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Host element id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Host element id.</span></dd>
 <dt>rootId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Shadow root id.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Shadow root id.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2304,39 +2496,39 @@ function onShadowRootPopped(res) {
 </pre>
 </div>
 </section>
-<section id="DOMDebugger" class="domain">
+<section id='DOMDebugger' class='domain'>
 <h1>DOMDebugger</h1>
 <p>DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOMDebugger.DOMBreakpointType">DOMDebugger.DOMBreakpointType</a>: DOM breakpoint type.</li>
+<li><a href='#DOMDebugger.DOMBreakpointType'>DOMDebugger.DOMBreakpointType</a>: DOM breakpoint type.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOMDebugger.setDOMBreakpoint">DOMDebugger.setDOMBreakpoint</a>: Sets breakpoint on particular operation with DOM.</li>
-<li><a href="#DOMDebugger.removeDOMBreakpoint">DOMDebugger.removeDOMBreakpoint</a>: Removes DOM breakpoint that was set using setDOMBreakpoint.</li>
-<li><a href="#DOMDebugger.setEventListenerBreakpoint">DOMDebugger.setEventListenerBreakpoint</a>: Sets breakpoint on particular DOM event.</li>
-<li><a href="#DOMDebugger.removeEventListenerBreakpoint">DOMDebugger.removeEventListenerBreakpoint</a>: Removes breakpoint on particular DOM event.</li>
-<li><a href="#DOMDebugger.setInstrumentationBreakpoint">DOMDebugger.setInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
-<li><a href="#DOMDebugger.removeInstrumentationBreakpoint">DOMDebugger.removeInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
-<li><a href="#DOMDebugger.setXHRBreakpoint">DOMDebugger.setXHRBreakpoint</a>: Sets breakpoint on XMLHttpRequest.</li>
-<li><a href="#DOMDebugger.removeXHRBreakpoint">DOMDebugger.removeXHRBreakpoint</a>: Removes breakpoint from XMLHttpRequest.</li>
+<li><a href='#DOMDebugger.setDOMBreakpoint'>DOMDebugger.setDOMBreakpoint</a>: Sets breakpoint on particular operation with DOM.</li>
+<li><a href='#DOMDebugger.removeDOMBreakpoint'>DOMDebugger.removeDOMBreakpoint</a>: Removes DOM breakpoint that was set using setDOMBreakpoint.</li>
+<li><a href='#DOMDebugger.setEventListenerBreakpoint'>DOMDebugger.setEventListenerBreakpoint</a>: Sets breakpoint on particular DOM event.</li>
+<li><a href='#DOMDebugger.removeEventListenerBreakpoint'>DOMDebugger.removeEventListenerBreakpoint</a>: Removes breakpoint on particular DOM event.</li>
+<li><a href='#DOMDebugger.setInstrumentationBreakpoint'>DOMDebugger.setInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
+<li><a href='#DOMDebugger.removeInstrumentationBreakpoint'>DOMDebugger.removeInstrumentationBreakpoint</a>: Sets breakpoint on particular native event.</li>
+<li><a href='#DOMDebugger.setXHRBreakpoint'>DOMDebugger.setXHRBreakpoint</a>: Sets breakpoint on XMLHttpRequest.</li>
+<li><a href='#DOMDebugger.removeXHRBreakpoint'>DOMDebugger.removeXHRBreakpoint</a>: Removes breakpoint from XMLHttpRequest.</li>
 </ul>
-<div id="DOMDebugger_DOMBreakpointType" class="type">
-<h3>DOMDebugger.DOMBreakpointType <span class="label">Type</span></h3>
+<div id='DOMDebugger_DOMBreakpointType' class='type'>
+<h3>DOMDebugger.DOMBreakpointType <span class='label'>Type</span></h3>
 <p>DOM breakpoint type.</p>
 <dl>
 <dd>( subtree-modified | attribute-modified | node-removed )</dd>
 </dl>
 </div>
-<div id="DOMDebugger_setDOMBreakpoint" class="command">
-<h3>DOMDebugger.setDOMBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_setDOMBreakpoint' class='command'>
+<h3>DOMDebugger.setDOMBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets breakpoint on particular operation with DOM.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Identifier of the node to set breakpoint on.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Identifier of the node to set breakpoint on.</span></dd>
 <dt>type</dt>
-<dd><a href="#DOMDebugger.DOMBreakpointType">DOMDebugger.DOMBreakpointType</a> <span class="text">Type of the operation to stop upon.</span></dd>
+<dd><a href='#DOMDebugger.DOMBreakpointType'>DOMDebugger.DOMBreakpointType</a> <span class='text'>Type of the operation to stop upon.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2344,14 +2536,14 @@ function onShadowRootPopped(res) {
 DOMDebugger.setDOMBreakpoint(nodeId, type);
 </pre>
 </div>
-<div id="DOMDebugger_removeDOMBreakpoint" class="command">
-<h3>DOMDebugger.removeDOMBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_removeDOMBreakpoint' class='command'>
+<h3>DOMDebugger.removeDOMBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>.</p>
 <dl>
 <dt>nodeId</dt>
-<dd><a href="#DOM.NodeId">DOM.NodeId</a> <span class="text">Identifier of the node to remove breakpoint from.</span></dd>
+<dd><a href='#DOM.NodeId'>DOM.NodeId</a> <span class='text'>Identifier of the node to remove breakpoint from.</span></dd>
 <dt>type</dt>
-<dd><a href="#DOMDebugger.DOMBreakpointType">DOMDebugger.DOMBreakpointType</a> <span class="text">Type of the breakpoint to remove.</span></dd>
+<dd><a href='#DOMDebugger.DOMBreakpointType'>DOMDebugger.DOMBreakpointType</a> <span class='text'>Type of the breakpoint to remove.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2359,12 +2551,12 @@ DOMDebugger.setDOMBreakpoint(nodeId, type);
 DOMDebugger.removeDOMBreakpoint(nodeId, type);
 </pre>
 </div>
-<div id="DOMDebugger_setEventListenerBreakpoint" class="command">
-<h3>DOMDebugger.setEventListenerBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_setEventListenerBreakpoint' class='command'>
+<h3>DOMDebugger.setEventListenerBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets breakpoint on particular DOM event.</p>
 <dl>
 <dt>eventName</dt>
-<dd>String <span class="text">DOM Event name to stop on (any DOM event will do).</span></dd>
+<dd>String <span class='text'>DOM Event name to stop on (any DOM event will do).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2372,12 +2564,12 @@ DOMDebugger.removeDOMBreakpoint(nodeId, type);
 DOMDebugger.setEventListenerBreakpoint(eventName);
 </pre>
 </div>
-<div id="DOMDebugger_removeEventListenerBreakpoint" class="command">
-<h3>DOMDebugger.removeEventListenerBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_removeEventListenerBreakpoint' class='command'>
+<h3>DOMDebugger.removeEventListenerBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Removes breakpoint on particular DOM event.</p>
 <dl>
 <dt>eventName</dt>
-<dd>String <span class="text">Event name.</span></dd>
+<dd>String <span class='text'>Event name.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2385,12 +2577,12 @@ DOMDebugger.setEventListenerBreakpoint(eventName);
 DOMDebugger.removeEventListenerBreakpoint(eventName);
 </pre>
 </div>
-<div id="DOMDebugger_setInstrumentationBreakpoint" class="command">
-<h3>DOMDebugger.setInstrumentationBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_setInstrumentationBreakpoint' class='command'>
+<h3>DOMDebugger.setInstrumentationBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets breakpoint on particular native event.</p>
 <dl>
 <dt>eventName</dt>
-<dd>String <span class="text">Instrumentation name to stop on.</span></dd>
+<dd>String <span class='text'>Instrumentation name to stop on.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2398,12 +2590,12 @@ DOMDebugger.removeEventListenerBreakpoint(eventName);
 DOMDebugger.setInstrumentationBreakpoint(eventName);
 </pre>
 </div>
-<div id="DOMDebugger_removeInstrumentationBreakpoint" class="command">
-<h3>DOMDebugger.removeInstrumentationBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_removeInstrumentationBreakpoint' class='command'>
+<h3>DOMDebugger.removeInstrumentationBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets breakpoint on particular native event.</p>
 <dl>
 <dt>eventName</dt>
-<dd>String <span class="text">Instrumentation name to stop on.</span></dd>
+<dd>String <span class='text'>Instrumentation name to stop on.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2411,12 +2603,12 @@ DOMDebugger.setInstrumentationBreakpoint(eventName);
 DOMDebugger.removeInstrumentationBreakpoint(eventName);
 </pre>
 </div>
-<div id="DOMDebugger_setXHRBreakpoint" class="command">
-<h3>DOMDebugger.setXHRBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_setXHRBreakpoint' class='command'>
+<h3>DOMDebugger.setXHRBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets breakpoint on XMLHttpRequest.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Resource URL substring. All XHRs having this substring in the URL will get stopped upon.</span></dd>
+<dd>String <span class='text'>Resource URL substring. All XHRs having this substring in the URL will get stopped upon.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2424,12 +2616,12 @@ DOMDebugger.removeInstrumentationBreakpoint(eventName);
 DOMDebugger.setXHRBreakpoint(url);
 </pre>
 </div>
-<div id="DOMDebugger_removeXHRBreakpoint" class="command">
-<h3>DOMDebugger.removeXHRBreakpoint <span class="label label-success">Command</span></h3>
+<div id='DOMDebugger_removeXHRBreakpoint' class='command'>
+<h3>DOMDebugger.removeXHRBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Removes breakpoint from XMLHttpRequest.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Resource URL substring.</span></dd>
+<dd>String <span class='text'>Resource URL substring.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2438,40 +2630,56 @@ DOMDebugger.removeXHRBreakpoint(url);
 </pre>
 </div>
 </section>
-<section id="DOMStorage" class="domain">
+<section id='DOMStorage' class='domain'>
 <h1>DOMStorage</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#DOMStorage.Entry">DOMStorage.Entry</a>: DOM Storage entry.</li>
+<li><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a>: Unique identifier of DOM storage entry.</li>
+<li><a href='#DOMStorage.Entry'>DOMStorage.Entry</a>: DOM Storage entry.</li>
+<li><a href='#DOMStorage.Item'>DOMStorage.Item</a>: DOM Storage item.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#DOMStorage.enable">DOMStorage.enable</a>: Enables storage tracking, storage events will now be delivered to the client.</li>
-<li><a href="#DOMStorage.disable">DOMStorage.disable</a>: Disables storage tracking, prevents storage events from being sent to the client.</li>
-<li><a href="#DOMStorage.getDOMStorageEntries">DOMStorage.getDOMStorageEntries</a></li>
-<li><a href="#DOMStorage.setDOMStorageItem">DOMStorage.setDOMStorageItem</a></li>
-<li><a href="#DOMStorage.removeDOMStorageItem">DOMStorage.removeDOMStorageItem</a></li>
+<li><a href='#DOMStorage.enable'>DOMStorage.enable</a>: Enables storage tracking, storage events will now be delivered to the client.</li>
+<li><a href='#DOMStorage.disable'>DOMStorage.disable</a>: Disables storage tracking, prevents storage events from being sent to the client.</li>
+<li><a href='#DOMStorage.getDOMStorageEntries'>DOMStorage.getDOMStorageEntries</a></li>
+<li><a href='#DOMStorage.setDOMStorageItem'>DOMStorage.setDOMStorageItem</a></li>
+<li><a href='#DOMStorage.removeDOMStorageItem'>DOMStorage.removeDOMStorageItem</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#DOMStorage.addDOMStorage">DOMStorage.addDOMStorage</a></li>
-<li><a href="#DOMStorage.updateDOMStorage">DOMStorage.updateDOMStorage</a></li>
+<li><a href='#DOMStorage.addDOMStorage'>DOMStorage.addDOMStorage</a></li>
+<li><a href='#DOMStorage.domStorageUpdated'>DOMStorage.domStorageUpdated</a></li>
 </ul>
-<div id="DOMStorage_Entry" class="type">
-<h3>DOMStorage.Entry <span class="label">Type</span></h3>
-<p>DOM Storage entry.</p>
+<div id='DOMStorage_StorageId' class='type'>
+<h3>DOMStorage.StorageId <span class='label'>Type</span></h3>
+<p>Unique identifier of DOM storage entry.</p>
 <dl>
-<dt>host</dt>
-<dd>String <span class="text">Domain name.</span></dd>
-<dt>isLocalStorage</dt>
-<dd>Boolean <span class="text">True for local storage.</span></dd>
-<dt>id</dt>
-<dd>Number <span class="text">Entry id for further reference.</span></dd>
+<dd>String</dd>
 </dl>
 </div>
-<div id="DOMStorage_enable" class="command">
-<h3>DOMStorage.enable <span class="label label-success">Command</span></h3>
+<div id='DOMStorage_Entry' class='type'>
+<h3>DOMStorage.Entry <span class='label'>Type</span></h3>
+<p>DOM Storage entry.</p>
+<dl>
+<dt>origin</dt>
+<dd>String <span class='text'>Document origin.</span></dd>
+<dt>isLocalStorage</dt>
+<dd>Boolean <span class='text'>True for local storage.</span></dd>
+<dt>id</dt>
+<dd><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a> <span class='text'>Entry id for further reference.</span></dd>
+</dl>
+</div>
+<div id='DOMStorage_Item' class='type'>
+<h3>DOMStorage.Item <span class='label'>Type</span></h3>
+<p>DOM Storage item.</p>
+<dl>
+<dd>[String]</dd>
+</dl>
+</div>
+<div id='DOMStorage_enable' class='command'>
+<h3>DOMStorage.enable <span class='label label-success'>Command</span></h3>
 <p>Enables storage tracking, storage events will now be delivered to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2479,8 +2687,8 @@ DOMDebugger.removeXHRBreakpoint(url);
 DOMStorage.enable();
 </pre>
 </div>
-<div id="DOMStorage_disable" class="command">
-<h3>DOMStorage.disable <span class="label label-success">Command</span></h3>
+<div id='DOMStorage_disable' class='command'>
+<h3>DOMStorage.disable <span class='label label-success'>Command</span></h3>
 <p>Disables storage tracking, prevents storage events from being sent to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2488,16 +2696,16 @@ DOMStorage.enable();
 DOMStorage.disable();
 </pre>
 </div>
-<div id="DOMStorage_getDOMStorageEntries" class="command">
-<h3>DOMStorage.getDOMStorageEntries <span class="label label-success">Command</span></h3>
+<div id='DOMStorage_getDOMStorageEntries' class='command'>
+<h3>DOMStorage.getDOMStorageEntries <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>storageId</dt>
-<dd>Integer</dd>
+<dd><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>entries</dt>
-<dd>[<a href="#DOMStorage.Entry">DOMStorage.Entry</a>]</dd>
+<dd>[<a href='#DOMStorage.Item'>DOMStorage.Item</a>]</dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2507,11 +2715,11 @@ DOMStorage.getDOMStorageEntries(storageId, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOMStorage_setDOMStorageItem" class="command">
-<h3>DOMStorage.setDOMStorageItem <span class="label label-success">Command</span></h3>
+<div id='DOMStorage_setDOMStorageItem' class='command'>
+<h3>DOMStorage.setDOMStorageItem <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>storageId</dt>
-<dd>Integer</dd>
+<dd><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a></dd>
 <dt>key</dt>
 <dd>String</dd>
 <dt>value</dt>
@@ -2530,11 +2738,11 @@ DOMStorage.setDOMStorageItem(storageId, key, value, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOMStorage_removeDOMStorageItem" class="command">
-<h3>DOMStorage.removeDOMStorageItem <span class="label label-success">Command</span></h3>
+<div id='DOMStorage_removeDOMStorageItem' class='command'>
+<h3>DOMStorage.removeDOMStorageItem <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>storageId</dt>
-<dd>Integer</dd>
+<dd><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a></dd>
 <dt>key</dt>
 <dd>String</dd>
 </dl>
@@ -2551,11 +2759,11 @@ DOMStorage.removeDOMStorageItem(storageId, key, function callback(res) {
 });
 </pre>
 </div>
-<div id="DOMStorage_addDOMStorage" class="command">
-<h3>DOMStorage.addDOMStorage <span class="label label-info">Event</span></h3>
+<div id='DOMStorage_addDOMStorage' class='command'>
+<h3>DOMStorage.addDOMStorage <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>storage</dt>
-<dd><a href="#DOMStorage.Entry">DOMStorage.Entry</a></dd>
+<dd><a href='#DOMStorage.Entry'>DOMStorage.Entry</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2565,62 +2773,70 @@ function onAddDOMStorage(res) {
 }
 </pre>
 </div>
-<div id="DOMStorage_updateDOMStorage" class="command">
-<h3>DOMStorage.updateDOMStorage <span class="label label-info">Event</span></h3>
+<div id='DOMStorage_domStorageUpdated' class='command'>
+<h3>DOMStorage.domStorageUpdated <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>storageId</dt>
-<dd>Integer</dd>
+<dd><a href='#DOMStorage.StorageId'>DOMStorage.StorageId</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
-// WebInspector Event: DOMStorage.updateDOMStorage
-function onUpdateDOMStorage(res) {
+// WebInspector Event: DOMStorage.domStorageUpdated
+function onDomStorageUpdated(res) {
 	// res = {storageId}
 }
 </pre>
 </div>
 </section>
-<section id="Database" class="domain">
+<section id='Database' class='domain'>
 <h1>Database</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Database.Database">Database.Database</a>: Database object.</li>
-<li><a href="#Database.Error">Database.Error</a>: Database error.</li>
+<li><a href='#Database.DatabaseId'>Database.DatabaseId</a>: Unique identifier of Database object.</li>
+<li><a href='#Database.Database'>Database.Database</a>: Database object.</li>
+<li><a href='#Database.Error'>Database.Error</a>: Database error.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Database.enable">Database.enable</a>: Enables database tracking, database events will now be delivered to the client.</li>
-<li><a href="#Database.disable">Database.disable</a>: Disables database tracking, prevents database events from being sent to the client.</li>
-<li><a href="#Database.getDatabaseTableNames">Database.getDatabaseTableNames</a></li>
-<li><a href="#Database.executeSQL">Database.executeSQL</a></li>
+<li><a href='#Database.enable'>Database.enable</a>: Enables database tracking, database events will now be delivered to the client.</li>
+<li><a href='#Database.disable'>Database.disable</a>: Disables database tracking, prevents database events from being sent to the client.</li>
+<li><a href='#Database.getDatabaseTableNames'>Database.getDatabaseTableNames</a></li>
+<li><a href='#Database.executeSQL'>Database.executeSQL</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Database.addDatabase">Database.addDatabase</a></li>
-<li><a href="#Database.sqlTransactionSucceeded">Database.sqlTransactionSucceeded</a></li>
-<li><a href="#Database.sqlTransactionFailed">Database.sqlTransactionFailed</a></li>
+<li><a href='#Database.addDatabase'>Database.addDatabase</a></li>
+<li><a href='#Database.sqlTransactionSucceeded'>Database.sqlTransactionSucceeded</a></li>
+<li><a href='#Database.sqlTransactionFailed'>Database.sqlTransactionFailed</a></li>
 </ul>
-<div id="Database_Database" class="type">
-<h3>Database.Database <span class="label">Type</span></h3>
+<div id='Database_DatabaseId' class='type'>
+<h3>Database.DatabaseId <span class='label'>Type</span></h3>
+<p>Unique identifier of Database object.</p>
+<dl>
+<dd>String</dd>
+</dl>
+</div>
+<div id='Database_Database' class='type'>
+<h3>Database.Database <span class='label'>Type</span></h3>
 <p>Database object.</p>
 <dl>
 <dt>id</dt>
-<dd>String <span class="text">Database ID.</span></dd>
+<dd><a href='#Database.DatabaseId'>Database.DatabaseId</a> <span class='text'>Database ID.</span></dd>
 <dt>domain</dt>
-<dd>String <span class="text">Database domain.</span></dd>
+<dd>String <span class='text'>Database domain.</span></dd>
 <dt>name</dt>
-<dd>String <span class="text">Database name.</span></dd>
+<dd>String <span class='text'>Database name.</span></dd>
 <dt>version</dt>
-<dd>String <span class="text">Database version.</span></dd>
+<dd>String <span class='text'>Database version.</span></dd>
 </dl>
 </div>
-<div id="Database_Error" class="type">
-<h3>Database.Error <span class="label">Type</span></h3>
+<div id='Database_Error' class='type'>
+<h3>Database.Error <span class='label'>Type</span></h3>
 <p>Database error.</p>
 </div>
-<div id="Database_enable" class="command">
-<h3>Database.enable <span class="label label-success">Command</span></h3>
+<div id='Database_enable' class='command'>
+<h3>Database.enable <span class='label label-success'>Command</span></h3>
 <p>Enables database tracking, database events will now be delivered to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2628,8 +2844,8 @@ function onUpdateDOMStorage(res) {
 Database.enable();
 </pre>
 </div>
-<div id="Database_disable" class="command">
-<h3>Database.disable <span class="label label-success">Command</span></h3>
+<div id='Database_disable' class='command'>
+<h3>Database.disable <span class='label label-success'>Command</span></h3>
 <p>Disables database tracking, prevents database events from being sent to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2637,11 +2853,11 @@ Database.enable();
 Database.disable();
 </pre>
 </div>
-<div id="Database_getDatabaseTableNames" class="command">
-<h3>Database.getDatabaseTableNames <span class="label label-success">Command</span></h3>
+<div id='Database_getDatabaseTableNames' class='command'>
+<h3>Database.getDatabaseTableNames <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>databaseId</dt>
-<dd>Integer</dd>
+<dd><a href='#Database.DatabaseId'>Database.DatabaseId</a></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
@@ -2656,11 +2872,11 @@ Database.getDatabaseTableNames(databaseId, function callback(res) {
 });
 </pre>
 </div>
-<div id="Database_executeSQL" class="command">
-<h3>Database.executeSQL <span class="label label-success">Command</span></h3>
+<div id='Database_executeSQL' class='command'>
+<h3>Database.executeSQL <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>databaseId</dt>
-<dd>Integer</dd>
+<dd><a href='#Database.DatabaseId'>Database.DatabaseId</a></dd>
 <dt>query</dt>
 <dd>String</dd>
 </dl>
@@ -2679,11 +2895,11 @@ Database.executeSQL(databaseId, query, function callback(res) {
 });
 </pre>
 </div>
-<div id="Database_addDatabase" class="command">
-<h3>Database.addDatabase <span class="label label-info">Event</span></h3>
+<div id='Database_addDatabase' class='command'>
+<h3>Database.addDatabase <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>database</dt>
-<dd><a href="#Database.Database">Database.Database</a></dd>
+<dd><a href='#Database.Database'>Database.Database</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2693,8 +2909,8 @@ function onAddDatabase(res) {
 }
 </pre>
 </div>
-<div id="Database_sqlTransactionSucceeded" class="command">
-<h3>Database.sqlTransactionSucceeded <span class="label label-info">Event</span></h3>
+<div id='Database_sqlTransactionSucceeded' class='command'>
+<h3>Database.sqlTransactionSucceeded <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>transactionId</dt>
 <dd>Integer</dd>
@@ -2711,13 +2927,13 @@ function onSqlTransactionSucceeded(res) {
 }
 </pre>
 </div>
-<div id="Database_sqlTransactionFailed" class="command">
-<h3>Database.sqlTransactionFailed <span class="label label-info">Event</span></h3>
+<div id='Database_sqlTransactionFailed' class='command'>
+<h3>Database.sqlTransactionFailed <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>transactionId</dt>
 <dd>Integer</dd>
 <dt>sqlError</dt>
-<dd><a href="#Database.Error">Database.Error</a></dd>
+<dd><a href='#Database.Error'>Database.Error</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2728,132 +2944,138 @@ function onSqlTransactionFailed(res) {
 </pre>
 </div>
 </section>
-<section id="Debugger" class="domain">
+<section id='Debugger' class='domain'>
 <h1>Debugger</h1>
 <p>Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a>: Breakpoint identifier.</li>
-<li><a href="#Debugger.ScriptId">Debugger.ScriptId</a>: Unique script identifier.</li>
-<li><a href="#Debugger.CallFrameId">Debugger.CallFrameId</a>: Call frame identifier.</li>
-<li><a href="#Debugger.Location">Debugger.Location</a>: Location in the source code.</li>
-<li><a href="#Debugger.FunctionDetails">Debugger.FunctionDetails</a>: Information about the function.</li>
-<li><a href="#Debugger.CallFrame">Debugger.CallFrame</a>: JavaScript call frame. Array of call frames form the call stack.</li>
-<li><a href="#Debugger.Scope">Debugger.Scope</a>: Scope description.</li>
+<li><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a>: Breakpoint identifier.</li>
+<li><a href='#Debugger.ScriptId'>Debugger.ScriptId</a>: Unique script identifier.</li>
+<li><a href='#Debugger.CallFrameId'>Debugger.CallFrameId</a>: Call frame identifier.</li>
+<li><a href='#Debugger.Location'>Debugger.Location</a>: Location in the source code.</li>
+<li><a href='#Debugger.FunctionDetails'>Debugger.FunctionDetails</a>: Information about the function.</li>
+<li><a href='#Debugger.CallFrame'>Debugger.CallFrame</a>: JavaScript call frame. Array of call frames form the call stack.</li>
+<li><a href='#Debugger.Scope'>Debugger.Scope</a>: Scope description.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Debugger.causesRecompilation">Debugger.causesRecompilation</a>: Tells whether enabling debugger causes scripts recompilation.</li>
-<li><a href="#Debugger.supportsNativeBreakpoints">Debugger.supportsNativeBreakpoints</a>: Tells whether debugger supports native breakpoints.</li>
-<li><a href="#Debugger.enable">Debugger.enable</a>: Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.</li>
-<li><a href="#Debugger.disable">Debugger.disable</a>: Disables debugger for given page.</li>
-<li><a href="#Debugger.setBreakpointsActive">Debugger.setBreakpointsActive</a>: Activates / deactivates all breakpoints on the page.</li>
-<li><a href="#Debugger.setBreakpointByUrl">Debugger.setBreakpointByUrl</a>: Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in locations property. Further matching script parsing will result in subsequent breakpointResolved events issued. This logical breakpoint will survive page reloads.</li>
-<li><a href="#Debugger.setBreakpoint">Debugger.setBreakpoint</a>: Sets JavaScript breakpoint at a given location.</li>
-<li><a href="#Debugger.removeBreakpoint">Debugger.removeBreakpoint</a>: Removes JavaScript breakpoint.</li>
-<li><a href="#Debugger.continueToLocation">Debugger.continueToLocation</a>: Continues execution until specific location is reached.</li>
-<li><a href="#Debugger.stepOver">Debugger.stepOver</a>: Steps over the statement.</li>
-<li><a href="#Debugger.stepInto">Debugger.stepInto</a>: Steps into the function call.</li>
-<li><a href="#Debugger.stepOut">Debugger.stepOut</a>: Steps out of the function call.</li>
-<li><a href="#Debugger.pause">Debugger.pause</a>: Stops on the next JavaScript statement.</li>
-<li><a href="#Debugger.resume">Debugger.resume</a>: Resumes JavaScript execution.</li>
-<li><a href="#Debugger.searchInContent">Debugger.searchInContent</a>: Searches for given string in script content.</li>
-<li><a href="#Debugger.canSetScriptSource">Debugger.canSetScriptSource</a>: Tells whether setScriptSource is supported.</li>
-<li><a href="#Debugger.setScriptSource">Debugger.setScriptSource</a>: Edits JavaScript source live.</li>
-<li><a href="#Debugger.getScriptSource">Debugger.getScriptSource</a>: Returns source for the script with given id.</li>
-<li><a href="#Debugger.getFunctionDetails">Debugger.getFunctionDetails</a>: Returns detailed informtation on given function.</li>
-<li><a href="#Debugger.setPauseOnExceptions">Debugger.setPauseOnExceptions</a>: Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is none.</li>
-<li><a href="#Debugger.evaluateOnCallFrame">Debugger.evaluateOnCallFrame</a>: Evaluates expression on a given call frame.</li>
+<li><a href='#Debugger.causesRecompilation'>Debugger.causesRecompilation</a>: Tells whether enabling debugger causes scripts recompilation.</li>
+<li><a href='#Debugger.supportsSeparateScriptCompilationAndExecution'>Debugger.supportsSeparateScriptCompilationAndExecution</a>: Tells whether debugger supports separate script compilation and execution.</li>
+<li><a href='#Debugger.enable'>Debugger.enable</a>: Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.</li>
+<li><a href='#Debugger.disable'>Debugger.disable</a>: Disables debugger for given page.</li>
+<li><a href='#Debugger.setBreakpointsActive'>Debugger.setBreakpointsActive</a>: Activates / deactivates all breakpoints on the page.</li>
+<li><a href='#Debugger.setBreakpointByUrl'>Debugger.setBreakpointByUrl</a>: Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in locations property. Further matching script parsing will result in subsequent breakpointResolved events issued. This logical breakpoint will survive page reloads.</li>
+<li><a href='#Debugger.setBreakpoint'>Debugger.setBreakpoint</a>: Sets JavaScript breakpoint at a given location.</li>
+<li><a href='#Debugger.removeBreakpoint'>Debugger.removeBreakpoint</a>: Removes JavaScript breakpoint.</li>
+<li><a href='#Debugger.continueToLocation'>Debugger.continueToLocation</a>: Continues execution until specific location is reached.</li>
+<li><a href='#Debugger.stepOver'>Debugger.stepOver</a>: Steps over the statement.</li>
+<li><a href='#Debugger.stepInto'>Debugger.stepInto</a>: Steps into the function call.</li>
+<li><a href='#Debugger.stepOut'>Debugger.stepOut</a>: Steps out of the function call.</li>
+<li><a href='#Debugger.pause'>Debugger.pause</a>: Stops on the next JavaScript statement.</li>
+<li><a href='#Debugger.resume'>Debugger.resume</a>: Resumes JavaScript execution.</li>
+<li><a href='#Debugger.searchInContent'>Debugger.searchInContent</a>: Searches for given string in script content.</li>
+<li><a href='#Debugger.canSetScriptSource'>Debugger.canSetScriptSource</a>: Tells whether setScriptSource is supported.</li>
+<li><a href='#Debugger.setScriptSource'>Debugger.setScriptSource</a>: Edits JavaScript source live.</li>
+<li><a href='#Debugger.restartFrame'>Debugger.restartFrame</a>: Restarts particular call frame from the beginning.</li>
+<li><a href='#Debugger.getScriptSource'>Debugger.getScriptSource</a>: Returns source for the script with given id.</li>
+<li><a href='#Debugger.getFunctionDetails'>Debugger.getFunctionDetails</a>: Returns detailed informtation on given function.</li>
+<li><a href='#Debugger.setPauseOnExceptions'>Debugger.setPauseOnExceptions</a>: Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is none.</li>
+<li><a href='#Debugger.evaluateOnCallFrame'>Debugger.evaluateOnCallFrame</a>: Evaluates expression on a given call frame.</li>
+<li><a href='#Debugger.compileScript'>Debugger.compileScript</a>: Compiles expression.</li>
+<li><a href='#Debugger.runScript'>Debugger.runScript</a>: Runs script with given id in a given context.</li>
+<li><a href='#Debugger.setOverlayMessage'>Debugger.setOverlayMessage</a>: Sets overlay message.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Debugger.globalObjectCleared">Debugger.globalObjectCleared</a>: Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload.</li>
-<li><a href="#Debugger.scriptParsed">Debugger.scriptParsed</a>: Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.</li>
-<li><a href="#Debugger.scriptFailedToParse">Debugger.scriptFailedToParse</a>: Fired when virtual machine fails to parse the script.</li>
-<li><a href="#Debugger.breakpointResolved">Debugger.breakpointResolved</a>: Fired when breakpoint is resolved to an actual script and location.</li>
-<li><a href="#Debugger.paused">Debugger.paused</a>: Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.</li>
-<li><a href="#Debugger.resumed">Debugger.resumed</a>: Fired when the virtual machine resumed execution.</li>
+<li><a href='#Debugger.globalObjectCleared'>Debugger.globalObjectCleared</a>: Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload.</li>
+<li><a href='#Debugger.scriptParsed'>Debugger.scriptParsed</a>: Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.</li>
+<li><a href='#Debugger.scriptFailedToParse'>Debugger.scriptFailedToParse</a>: Fired when virtual machine fails to parse the script.</li>
+<li><a href='#Debugger.breakpointResolved'>Debugger.breakpointResolved</a>: Fired when breakpoint is resolved to an actual script and location.</li>
+<li><a href='#Debugger.paused'>Debugger.paused</a>: Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.</li>
+<li><a href='#Debugger.resumed'>Debugger.resumed</a>: Fired when the virtual machine resumed execution.</li>
 </ul>
-<div id="Debugger_BreakpointId" class="type">
-<h3>Debugger.BreakpointId <span class="label">Type</span></h3>
+<div id='Debugger_BreakpointId' class='type'>
+<h3>Debugger.BreakpointId <span class='label'>Type</span></h3>
 <p>Breakpoint identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Debugger_ScriptId" class="type">
-<h3>Debugger.ScriptId <span class="label">Type</span></h3>
+<div id='Debugger_ScriptId' class='type'>
+<h3>Debugger.ScriptId <span class='label'>Type</span></h3>
 <p>Unique script identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Debugger_CallFrameId" class="type">
-<h3>Debugger.CallFrameId <span class="label">Type</span></h3>
+<div id='Debugger_CallFrameId' class='type'>
+<h3>Debugger.CallFrameId <span class='label'>Type</span></h3>
 <p>Call frame identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Debugger_Location" class="type">
-<h3>Debugger.Location <span class="label">Type</span></h3>
+<div id='Debugger_Location' class='type'>
+<h3>Debugger.Location <span class='label'>Type</span></h3>
 <p>Location in the source code.</p>
 <dl>
 <dt>scriptId</dt>
-<dd><a href="#Debugger.ScriptId">Debugger.ScriptId</a> <span class="text">Script identifier as reported in the <code>Debugger.scriptParsed</code>.</span></dd>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Script identifier as reported in the <code>Debugger.scriptParsed</code>.</span></dd>
 <dt>lineNumber</dt>
-<dd>Integer <span class="text">Line number in the script.</span></dd>
+<dd>Integer <span class='text'>Line number in the script.</span></dd>
 <dt>columnNumber (optional)</dt>
-<dd>Integer <span class="text">Column number in the script.</span></dd>
+<dd>Integer <span class='text'>Column number in the script.</span></dd>
 </dl>
 </div>
-<div id="Debugger_FunctionDetails" class="type">
-<h3>Debugger.FunctionDetails <span class="label">Type</span></h3>
+<div id='Debugger_FunctionDetails' class='type'>
+<h3>Debugger.FunctionDetails <span class='label'>Type</span></h3>
 <p>Information about the function.</p>
 <dl>
 <dt>location</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Location of the function.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Location of the function.</span></dd>
 <dt>name (optional)</dt>
-<dd>String <span class="text">Name of the function. Not present for anonymous functions.</span></dd>
+<dd>String <span class='text'>Name of the function. Not present for anonymous functions.</span></dd>
 <dt>displayName (optional)</dt>
-<dd>String <span class="text">Display name of the function(specified in 'displayName' property on the function object).</span></dd>
+<dd>String <span class='text'>Display name of the function(specified in 'displayName' property on the function object).</span></dd>
 <dt>inferredName (optional)</dt>
-<dd>String <span class="text">Name of the function inferred from its initial assignment.</span></dd>
+<dd>String <span class='text'>Name of the function inferred from its initial assignment.</span></dd>
+<dt>scopeChain (optional)</dt>
+<dd>[<a href='#Debugger.Scope'>Debugger.Scope</a>] <span class='text'>Scope chain for this closure.</span></dd>
 </dl>
 </div>
-<div id="Debugger_CallFrame" class="type">
-<h3>Debugger.CallFrame <span class="label">Type</span></h3>
+<div id='Debugger_CallFrame' class='type'>
+<h3>Debugger.CallFrame <span class='label'>Type</span></h3>
 <p>JavaScript call frame. Array of call frames form the call stack.</p>
 <dl>
 <dt>callFrameId</dt>
-<dd><a href="#Debugger.CallFrameId">Debugger.CallFrameId</a> <span class="text">Call frame identifier. This identifier is only valid while the virtual machine is paused.</span></dd>
+<dd><a href='#Debugger.CallFrameId'>Debugger.CallFrameId</a> <span class='text'>Call frame identifier. This identifier is only valid while the virtual machine is paused.</span></dd>
 <dt>functionName</dt>
-<dd>String <span class="text">Name of the JavaScript function called on this call frame.</span></dd>
+<dd>String <span class='text'>Name of the JavaScript function called on this call frame.</span></dd>
 <dt>location</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Location in the source code.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Location in the source code.</span></dd>
 <dt>scopeChain</dt>
-<dd>[<a href="#Debugger.Scope">Debugger.Scope</a>] <span class="text">Scope chain for this call frame.</span></dd>
+<dd>[<a href='#Debugger.Scope'>Debugger.Scope</a>] <span class='text'>Scope chain for this call frame.</span></dd>
 <dt>this</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text"><code>this</code> object for this call frame.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'><code>this</code> object for this call frame.</span></dd>
 </dl>
 </div>
-<div id="Debugger_Scope" class="type">
-<h3>Debugger.Scope <span class="label">Type</span></h3>
+<div id='Debugger_Scope' class='type'>
+<h3>Debugger.Scope <span class='label'>Type</span></h3>
 <p>Scope description.</p>
 <dl>
 <dt>type</dt>
-<dd>( global | local | with | closure | catch ) <span class="text">Scope type.</span></dd>
+<dd>( global | local | with | closure | catch ) <span class='text'>Scope type.</span></dd>
 <dt>object</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.</span></dd>
 </dl>
 </div>
-<div id="Debugger_causesRecompilation" class="command">
-<h3>Debugger.causesRecompilation <span class="label label-success">Command</span></h3>
+<div id='Debugger_causesRecompilation' class='command'>
+<h3>Debugger.causesRecompilation <span class='label label-success'>Command</span></h3>
 <p>Tells whether enabling debugger causes scripts recompilation.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True if enabling debugger causes scripts recompilation.</span></dd>
+<dd>Boolean <span class='text'>True if enabling debugger causes scripts recompilation.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2863,24 +3085,24 @@ Debugger.causesRecompilation(function callback(res) {
 });
 </pre>
 </div>
-<div id="Debugger_supportsNativeBreakpoints" class="command">
-<h3>Debugger.supportsNativeBreakpoints <span class="label label-success">Command</span></h3>
-<p>Tells whether debugger supports native breakpoints.</p>
+<div id='Debugger_supportsSeparateScriptCompilationAndExecution' class='command'>
+<h3>Debugger.supportsSeparateScriptCompilationAndExecution <span class='label label-success'>Command</span></h3>
+<p>Tells whether debugger supports separate script compilation and execution.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True if debugger supports native breakpoints.</span></dd>
+<dd>Boolean <span class='text'>True if debugger supports separate script compilation and execution.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
-// WebInspector Command: Debugger.supportsNativeBreakpoints
-Debugger.supportsNativeBreakpoints(function callback(res) {
+// WebInspector Command: Debugger.supportsSeparateScriptCompilationAndExecution
+Debugger.supportsSeparateScriptCompilationAndExecution(function callback(res) {
 	// res = {result}
 });
 </pre>
 </div>
-<div id="Debugger_enable" class="command">
-<h3>Debugger.enable <span class="label label-success">Command</span></h3>
+<div id='Debugger_enable' class='command'>
+<h3>Debugger.enable <span class='label label-success'>Command</span></h3>
 <p>Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2888,8 +3110,8 @@ Debugger.supportsNativeBreakpoints(function callback(res) {
 Debugger.enable();
 </pre>
 </div>
-<div id="Debugger_disable" class="command">
-<h3>Debugger.disable <span class="label label-success">Command</span></h3>
+<div id='Debugger_disable' class='command'>
+<h3>Debugger.disable <span class='label label-success'>Command</span></h3>
 <p>Disables debugger for given page.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2897,12 +3119,12 @@ Debugger.enable();
 Debugger.disable();
 </pre>
 </div>
-<div id="Debugger_setBreakpointsActive" class="command">
-<h3>Debugger.setBreakpointsActive <span class="label label-success">Command</span></h3>
+<div id='Debugger_setBreakpointsActive' class='command'>
+<h3>Debugger.setBreakpointsActive <span class='label label-success'>Command</span></h3>
 <p>Activates / deactivates all breakpoints on the page.</p>
 <dl>
 <dt>active</dt>
-<dd>Boolean <span class="text">New value for breakpoints active state.</span></dd>
+<dd>Boolean <span class='text'>New value for breakpoints active state.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2910,27 +3132,27 @@ Debugger.disable();
 Debugger.setBreakpointsActive(active);
 </pre>
 </div>
-<div id="Debugger_setBreakpointByUrl" class="command">
-<h3>Debugger.setBreakpointByUrl <span class="label label-success">Command</span></h3>
+<div id='Debugger_setBreakpointByUrl' class='command'>
+<h3>Debugger.setBreakpointByUrl <span class='label label-success'>Command</span></h3>
 <p>Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads.</p>
 <dl>
 <dt>lineNumber</dt>
-<dd>Integer <span class="text">Line number to set breakpoint at.</span></dd>
+<dd>Integer <span class='text'>Line number to set breakpoint at.</span></dd>
 <dt>url (optional)</dt>
-<dd>String <span class="text">URL of the resources to set breakpoint on.</span></dd>
+<dd>String <span class='text'>URL of the resources to set breakpoint on.</span></dd>
 <dt>urlRegex (optional)</dt>
-<dd>String <span class="text">Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.</span></dd>
+<dd>String <span class='text'>Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.</span></dd>
 <dt>columnNumber (optional)</dt>
-<dd>Integer <span class="text">Offset in the line to set breakpoint at.</span></dd>
+<dd>Integer <span class='text'>Offset in the line to set breakpoint at.</span></dd>
 <dt>condition (optional)</dt>
-<dd>String <span class="text">Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.</span></dd>
+<dd>String <span class='text'>Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>breakpointId</dt>
-<dd><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a> <span class="text">Id of the created breakpoint for further reference.</span></dd>
-<dt>locations (optional)</dt>
-<dd>[<a href="#Debugger.Location">Debugger.Location</a>] <span class="text">List of the locations this breakpoint resolved into upon addition.</span></dd>
+<dd><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a> <span class='text'>Id of the created breakpoint for further reference.</span></dd>
+<dt>locations</dt>
+<dd>[<a href='#Debugger.Location'>Debugger.Location</a>] <span class='text'>List of the locations this breakpoint resolved into upon addition.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2940,21 +3162,21 @@ Debugger.setBreakpointByUrl(lineNumber, url, urlRegex, columnNumber, condition, 
 });
 </pre>
 </div>
-<div id="Debugger_setBreakpoint" class="command">
-<h3>Debugger.setBreakpoint <span class="label label-success">Command</span></h3>
+<div id='Debugger_setBreakpoint' class='command'>
+<h3>Debugger.setBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Sets JavaScript breakpoint at a given location.</p>
 <dl>
 <dt>location</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Location to set breakpoint in.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Location to set breakpoint in.</span></dd>
 <dt>condition (optional)</dt>
-<dd>String <span class="text">Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.</span></dd>
+<dd>String <span class='text'>Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>breakpointId</dt>
-<dd><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a> <span class="text">Id of the created breakpoint for further reference.</span></dd>
+<dd><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a> <span class='text'>Id of the created breakpoint for further reference.</span></dd>
 <dt>actualLocation</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Location this breakpoint resolved into.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Location this breakpoint resolved into.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2964,12 +3186,12 @@ Debugger.setBreakpoint(location, condition, function callback(res) {
 });
 </pre>
 </div>
-<div id="Debugger_removeBreakpoint" class="command">
-<h3>Debugger.removeBreakpoint <span class="label label-success">Command</span></h3>
+<div id='Debugger_removeBreakpoint' class='command'>
+<h3>Debugger.removeBreakpoint <span class='label label-success'>Command</span></h3>
 <p>Removes JavaScript breakpoint.</p>
 <dl>
 <dt>breakpointId</dt>
-<dd><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a></dd>
+<dd><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2977,12 +3199,12 @@ Debugger.setBreakpoint(location, condition, function callback(res) {
 Debugger.removeBreakpoint(breakpointId);
 </pre>
 </div>
-<div id="Debugger_continueToLocation" class="command">
-<h3>Debugger.continueToLocation <span class="label label-success">Command</span></h3>
+<div id='Debugger_continueToLocation' class='command'>
+<h3>Debugger.continueToLocation <span class='label label-success'>Command</span></h3>
 <p>Continues execution until specific location is reached.</p>
 <dl>
 <dt>location</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Location to continue to.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Location to continue to.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -2990,8 +3212,8 @@ Debugger.removeBreakpoint(breakpointId);
 Debugger.continueToLocation(location);
 </pre>
 </div>
-<div id="Debugger_stepOver" class="command">
-<h3>Debugger.stepOver <span class="label label-success">Command</span></h3>
+<div id='Debugger_stepOver' class='command'>
+<h3>Debugger.stepOver <span class='label label-success'>Command</span></h3>
 <p>Steps over the statement.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -2999,8 +3221,8 @@ Debugger.continueToLocation(location);
 Debugger.stepOver();
 </pre>
 </div>
-<div id="Debugger_stepInto" class="command">
-<h3>Debugger.stepInto <span class="label label-success">Command</span></h3>
+<div id='Debugger_stepInto' class='command'>
+<h3>Debugger.stepInto <span class='label label-success'>Command</span></h3>
 <p>Steps into the function call.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3008,8 +3230,8 @@ Debugger.stepOver();
 Debugger.stepInto();
 </pre>
 </div>
-<div id="Debugger_stepOut" class="command">
-<h3>Debugger.stepOut <span class="label label-success">Command</span></h3>
+<div id='Debugger_stepOut' class='command'>
+<h3>Debugger.stepOut <span class='label label-success'>Command</span></h3>
 <p>Steps out of the function call.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3017,8 +3239,8 @@ Debugger.stepInto();
 Debugger.stepOut();
 </pre>
 </div>
-<div id="Debugger_pause" class="command">
-<h3>Debugger.pause <span class="label label-success">Command</span></h3>
+<div id='Debugger_pause' class='command'>
+<h3>Debugger.pause <span class='label label-success'>Command</span></h3>
 <p>Stops on the next JavaScript statement.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3026,8 +3248,8 @@ Debugger.stepOut();
 Debugger.pause();
 </pre>
 </div>
-<div id="Debugger_resume" class="command">
-<h3>Debugger.resume <span class="label label-success">Command</span></h3>
+<div id='Debugger_resume' class='command'>
+<h3>Debugger.resume <span class='label label-success'>Command</span></h3>
 <p>Resumes JavaScript execution.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3035,23 +3257,23 @@ Debugger.pause();
 Debugger.resume();
 </pre>
 </div>
-<div id="Debugger_searchInContent" class="command">
-<h3>Debugger.searchInContent <span class="label label-success">Command</span></h3>
+<div id='Debugger_searchInContent' class='command'>
+<h3>Debugger.searchInContent <span class='label label-success'>Command</span></h3>
 <p>Searches for given string in script content.</p>
 <dl>
 <dt>scriptId</dt>
-<dd><a href="#Debugger.ScriptId">Debugger.ScriptId</a> <span class="text">Id of the script to search in.</span></dd>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Id of the script to search in.</span></dd>
 <dt>query</dt>
-<dd>String <span class="text">String to search for.</span></dd>
+<dd>String <span class='text'>String to search for.</span></dd>
 <dt>caseSensitive (optional)</dt>
-<dd>Boolean <span class="text">If true, search is case sensitive.</span></dd>
+<dd>Boolean <span class='text'>If true, search is case sensitive.</span></dd>
 <dt>isRegex (optional)</dt>
-<dd>Boolean <span class="text">If true, treats string parameter as regex.</span></dd>
+<dd>Boolean <span class='text'>If true, treats string parameter as regex.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>[<a href="#Page.SearchMatch">Page.SearchMatch</a>] <span class="text">List of search matches.</span></dd>
+<dd>[<a href='#Page.SearchMatch'>Page.SearchMatch</a>] <span class='text'>List of search matches.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3061,13 +3283,13 @@ Debugger.searchInContent(scriptId, query, caseSensitive, isRegex, function callb
 });
 </pre>
 </div>
-<div id="Debugger_canSetScriptSource" class="command">
-<h3>Debugger.canSetScriptSource <span class="label label-success">Command</span></h3>
+<div id='Debugger_canSetScriptSource' class='command'>
+<h3>Debugger.canSetScriptSource <span class='label label-success'>Command</span></h3>
 <p>Tells whether <code>setScriptSource</code> is supported.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True if <code>setScriptSource</code> is supported.</span></dd>
+<dd>Boolean <span class='text'>True if <code>setScriptSource</code> is supported.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3077,23 +3299,23 @@ Debugger.canSetScriptSource(function callback(res) {
 });
 </pre>
 </div>
-<div id="Debugger_setScriptSource" class="command">
-<h3>Debugger.setScriptSource <span class="label label-success">Command</span></h3>
+<div id='Debugger_setScriptSource' class='command'>
+<h3>Debugger.setScriptSource <span class='label label-success'>Command</span></h3>
 <p>Edits JavaScript source live.</p>
 <dl>
 <dt>scriptId</dt>
-<dd><a href="#Debugger.ScriptId">Debugger.ScriptId</a> <span class="text">Id of the script to edit.</span></dd>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Id of the script to edit.</span></dd>
 <dt>scriptSource</dt>
-<dd>String <span class="text">New content of the script.</span></dd>
+<dd>String <span class='text'>New content of the script.</span></dd>
 <dt>preview (optional)</dt>
-<dd>Boolean <span class="text"> If true the change will not actually be applied. Preview mode may be used to get result description without actually modifying the code.</span></dd>
+<dd>Boolean <span class='text'> If true the change will not actually be applied. Preview mode may be used to get result description without actually modifying the code.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>callFrames (optional)</dt>
-<dd>[<a href="#Debugger.CallFrame">Debugger.CallFrame</a>] <span class="text">New stack trace in case editing has happened while VM was stopped.</span></dd>
+<dd>[<a href='#Debugger.CallFrame'>Debugger.CallFrame</a>] <span class='text'>New stack trace in case editing has happened while VM was stopped.</span></dd>
 <dt>result (optional)</dt>
-<dd>Object <span class="text">VM-specific description of the changes applied.</span></dd>
+<dd>Object <span class='text'>VM-specific description of the changes applied.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3103,17 +3325,39 @@ Debugger.setScriptSource(scriptId, scriptSource, preview, function callback(res)
 });
 </pre>
 </div>
-<div id="Debugger_getScriptSource" class="command">
-<h3>Debugger.getScriptSource <span class="label label-success">Command</span></h3>
+<div id='Debugger_restartFrame' class='command'>
+<h3>Debugger.restartFrame <span class='label label-success'>Command</span></h3>
+<p>Restarts particular call frame from the beginning.</p>
+<dl>
+<dt>callFrameId</dt>
+<dd><a href='#Debugger.CallFrameId'>Debugger.CallFrameId</a> <span class='text'>Call frame identifier to evaluate on.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>callFrames</dt>
+<dd>[<a href='#Debugger.CallFrame'>Debugger.CallFrame</a>] <span class='text'>New stack trace.</span></dd>
+<dt>result</dt>
+<dd>Object <span class='text'>VM-specific description.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Debugger.restartFrame
+Debugger.restartFrame(callFrameId, function callback(res) {
+	// res = {callFrames, result}
+});
+</pre>
+</div>
+<div id='Debugger_getScriptSource' class='command'>
+<h3>Debugger.getScriptSource <span class='label label-success'>Command</span></h3>
 <p>Returns source for the script with given id.</p>
 <dl>
 <dt>scriptId</dt>
-<dd><a href="#Debugger.ScriptId">Debugger.ScriptId</a> <span class="text">Id of the script to get source for.</span></dd>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Id of the script to get source for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>scriptSource</dt>
-<dd>String <span class="text">Script source.</span></dd>
+<dd>String <span class='text'>Script source.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3123,17 +3367,17 @@ Debugger.getScriptSource(scriptId, function callback(res) {
 });
 </pre>
 </div>
-<div id="Debugger_getFunctionDetails" class="command">
-<h3>Debugger.getFunctionDetails <span class="label label-success">Command</span></h3>
+<div id='Debugger_getFunctionDetails' class='command'>
+<h3>Debugger.getFunctionDetails <span class='label label-success'>Command</span></h3>
 <p>Returns detailed informtation on given function.</p>
 <dl>
 <dt>functionId</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Id of the function to get location for.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Id of the function to get location for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>details</dt>
-<dd><a href="#Debugger.FunctionDetails">Debugger.FunctionDetails</a> <span class="text">Information about the function.</span></dd>
+<dd><a href='#Debugger.FunctionDetails'>Debugger.FunctionDetails</a> <span class='text'>Information about the function.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3143,12 +3387,12 @@ Debugger.getFunctionDetails(functionId, function callback(res) {
 });
 </pre>
 </div>
-<div id="Debugger_setPauseOnExceptions" class="command">
-<h3>Debugger.setPauseOnExceptions <span class="label label-success">Command</span></h3>
+<div id='Debugger_setPauseOnExceptions' class='command'>
+<h3>Debugger.setPauseOnExceptions <span class='label label-success'>Command</span></h3>
 <p>Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>.</p>
 <dl>
 <dt>state</dt>
-<dd>( none | uncaught | all ) <span class="text">Pause on exceptions mode.</span></dd>
+<dd>( none | uncaught | all ) <span class='text'>Pause on exceptions mode.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3156,38 +3400,105 @@ Debugger.getFunctionDetails(functionId, function callback(res) {
 Debugger.setPauseOnExceptions(state);
 </pre>
 </div>
-<div id="Debugger_evaluateOnCallFrame" class="command">
-<h3>Debugger.evaluateOnCallFrame <span class="label label-success">Command</span></h3>
+<div id='Debugger_evaluateOnCallFrame' class='command'>
+<h3>Debugger.evaluateOnCallFrame <span class='label label-success'>Command</span></h3>
 <p>Evaluates expression on a given call frame.</p>
 <dl>
 <dt>callFrameId</dt>
-<dd><a href="#Debugger.CallFrameId">Debugger.CallFrameId</a> <span class="text">Call frame identifier to evaluate on.</span></dd>
+<dd><a href='#Debugger.CallFrameId'>Debugger.CallFrameId</a> <span class='text'>Call frame identifier to evaluate on.</span></dd>
 <dt>expression</dt>
-<dd>String <span class="text">Expression to evaluate.</span></dd>
+<dd>String <span class='text'>Expression to evaluate.</span></dd>
 <dt>objectGroup (optional)</dt>
-<dd>String <span class="text">String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).</span></dd>
+<dd>String <span class='text'>String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).</span></dd>
 <dt>includeCommandLineAPI (optional)</dt>
-<dd>Boolean <span class="text">Specifies whether command line API should be available to the evaluated expression, defaults to false.</span></dd>
+<dd>Boolean <span class='text'>Specifies whether command line API should be available to the evaluated expression, defaults to false.</span></dd>
+<dt>doNotPauseOnExceptionsAndMuteConsole (optional)</dt>
+<dd>Boolean <span class='text'>Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.</span></dd>
 <dt>returnByValue (optional)</dt>
-<dd>Boolean <span class="text">Whether the result is expected to be a JSON object that should be sent by value.</span></dd>
+<dd>Boolean <span class='text'>Whether the result is expected to be a JSON object that should be sent by value.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Object wrapper for the evaluation result.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Object wrapper for the evaluation result.</span></dd>
 <dt>wasThrown (optional)</dt>
-<dd>Boolean <span class="text">True if the result was thrown during the evaluation.</span></dd>
+<dd>Boolean <span class='text'>True if the result was thrown during the evaluation.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Debugger.evaluateOnCallFrame
-Debugger.evaluateOnCallFrame(callFrameId, expression, objectGroup, includeCommandLineAPI, returnByValue, function callback(res) {
+Debugger.evaluateOnCallFrame(callFrameId, expression, objectGroup, includeCommandLineAPI, doNotPauseOnExceptionsAndMuteConsole, returnByValue, function callback(res) {
 	// res = {result, wasThrown}
 });
 </pre>
 </div>
-<div id="Debugger_globalObjectCleared" class="command">
-<h3>Debugger.globalObjectCleared <span class="label label-info">Event</span></h3>
+<div id='Debugger_compileScript' class='command'>
+<h3>Debugger.compileScript <span class='label label-success'>Command</span></h3>
+<p>Compiles expression.</p>
+<dl>
+<dt>expression</dt>
+<dd>String <span class='text'>Expression to compile.</span></dd>
+<dt>sourceURL</dt>
+<dd>String <span class='text'>Source url to be set for the script.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>scriptId (optional)</dt>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Id of the script.</span></dd>
+<dt>syntaxErrorMessage (optional)</dt>
+<dd>String <span class='text'>Syntax error message if compilation failed.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Debugger.compileScript
+Debugger.compileScript(expression, sourceURL, function callback(res) {
+	// res = {scriptId, syntaxErrorMessage}
+});
+</pre>
+</div>
+<div id='Debugger_runScript' class='command'>
+<h3>Debugger.runScript <span class='label label-success'>Command</span></h3>
+<p>Runs script with given id in a given context.</p>
+<dl>
+<dt>scriptId</dt>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Id of the script to run.</span></dd>
+<dt>contextId (optional)</dt>
+<dd><a href='#Runtime.ExecutionContextId'>Runtime.ExecutionContextId</a> <span class='text'>Specifies in which isolated context to perform script run. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page.</span></dd>
+<dt>objectGroup (optional)</dt>
+<dd>String <span class='text'>Symbolic group name that can be used to release multiple objects.</span></dd>
+<dt>doNotPauseOnExceptionsAndMuteConsole (optional)</dt>
+<dd>Boolean <span class='text'>Specifies whether script run should stop on exceptions and mute console. Overrides setPauseOnException state.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>result</dt>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Run result.</span></dd>
+<dt>wasThrown (optional)</dt>
+<dd>Boolean <span class='text'>True if the result was thrown during the script run.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Debugger.runScript
+Debugger.runScript(scriptId, contextId, objectGroup, doNotPauseOnExceptionsAndMuteConsole, function callback(res) {
+	// res = {result, wasThrown}
+});
+</pre>
+</div>
+<div id='Debugger_setOverlayMessage' class='command'>
+<h3>Debugger.setOverlayMessage <span class='label label-success'>Command</span></h3>
+<p>Sets overlay message.</p>
+<dl>
+<dt>message (optional)</dt>
+<dd>String <span class='text'>Overlay message to display when paused in debugger.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Debugger.setOverlayMessage
+Debugger.setOverlayMessage(message);
+</pre>
+</div>
+<div id='Debugger_globalObjectCleared' class='command'>
+<h3>Debugger.globalObjectCleared <span class='label label-info'>Event</span></h3>
 <p>Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3197,26 +3508,26 @@ function onGlobalObjectCleared(res) {
 }
 </pre>
 </div>
-<div id="Debugger_scriptParsed" class="command">
-<h3>Debugger.scriptParsed <span class="label label-info">Event</span></h3>
+<div id='Debugger_scriptParsed' class='command'>
+<h3>Debugger.scriptParsed <span class='label label-info'>Event</span></h3>
 <p>Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.</p>
 <dl>
 <dt>scriptId</dt>
-<dd><a href="#Debugger.ScriptId">Debugger.ScriptId</a> <span class="text">Identifier of the script parsed.</span></dd>
+<dd><a href='#Debugger.ScriptId'>Debugger.ScriptId</a> <span class='text'>Identifier of the script parsed.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">URL or name of the script parsed (if any).</span></dd>
+<dd>String <span class='text'>URL or name of the script parsed (if any).</span></dd>
 <dt>startLine</dt>
-<dd>Integer <span class="text">Line offset of the script within the resource with given URL (for script tags).</span></dd>
+<dd>Integer <span class='text'>Line offset of the script within the resource with given URL (for script tags).</span></dd>
 <dt>startColumn</dt>
-<dd>Integer <span class="text">Column offset of the script within the resource with given URL.</span></dd>
+<dd>Integer <span class='text'>Column offset of the script within the resource with given URL.</span></dd>
 <dt>endLine</dt>
-<dd>Integer <span class="text">Last line of the script.</span></dd>
+<dd>Integer <span class='text'>Last line of the script.</span></dd>
 <dt>endColumn</dt>
-<dd>Integer <span class="text">Length of the last line of the script.</span></dd>
+<dd>Integer <span class='text'>Length of the last line of the script.</span></dd>
 <dt>isContentScript (optional)</dt>
-<dd>Boolean <span class="text">Determines whether this script is a user extension script.</span></dd>
+<dd>Boolean <span class='text'>Determines whether this script is a user extension script.</span></dd>
 <dt>sourceMapURL (optional)</dt>
-<dd>String <span class="text">URL of source map associated with script (if any).</span></dd>
+<dd>String <span class='text'>URL of source map associated with script (if any).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3226,20 +3537,20 @@ function onScriptParsed(res) {
 }
 </pre>
 </div>
-<div id="Debugger_scriptFailedToParse" class="command">
-<h3>Debugger.scriptFailedToParse <span class="label label-info">Event</span></h3>
+<div id='Debugger_scriptFailedToParse' class='command'>
+<h3>Debugger.scriptFailedToParse <span class='label label-info'>Event</span></h3>
 <p>Fired when virtual machine fails to parse the script.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">URL of the script that failed to parse.</span></dd>
+<dd>String <span class='text'>URL of the script that failed to parse.</span></dd>
 <dt>scriptSource</dt>
-<dd>String <span class="text">Source text of the script that failed to parse.</span></dd>
+<dd>String <span class='text'>Source text of the script that failed to parse.</span></dd>
 <dt>startLine</dt>
-<dd>Integer <span class="text">Line offset of the script within the resource.</span></dd>
+<dd>Integer <span class='text'>Line offset of the script within the resource.</span></dd>
 <dt>errorLine</dt>
-<dd>Integer <span class="text">Line with error.</span></dd>
+<dd>Integer <span class='text'>Line with error.</span></dd>
 <dt>errorMessage</dt>
-<dd>String <span class="text">Parse error message.</span></dd>
+<dd>String <span class='text'>Parse error message.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3249,14 +3560,14 @@ function onScriptFailedToParse(res) {
 }
 </pre>
 </div>
-<div id="Debugger_breakpointResolved" class="command">
-<h3>Debugger.breakpointResolved <span class="label label-info">Event</span></h3>
+<div id='Debugger_breakpointResolved' class='command'>
+<h3>Debugger.breakpointResolved <span class='label label-info'>Event</span></h3>
 <p>Fired when breakpoint is resolved to an actual script and location.</p>
 <dl>
 <dt>breakpointId</dt>
-<dd><a href="#Debugger.BreakpointId">Debugger.BreakpointId</a> <span class="text">Breakpoint unique identifier.</span></dd>
+<dd><a href='#Debugger.BreakpointId'>Debugger.BreakpointId</a> <span class='text'>Breakpoint unique identifier.</span></dd>
 <dt>location</dt>
-<dd><a href="#Debugger.Location">Debugger.Location</a> <span class="text">Actual breakpoint location.</span></dd>
+<dd><a href='#Debugger.Location'>Debugger.Location</a> <span class='text'>Actual breakpoint location.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3266,16 +3577,16 @@ function onBreakpointResolved(res) {
 }
 </pre>
 </div>
-<div id="Debugger_paused" class="command">
-<h3>Debugger.paused <span class="label label-info">Event</span></h3>
+<div id='Debugger_paused' class='command'>
+<h3>Debugger.paused <span class='label label-info'>Event</span></h3>
 <p>Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.</p>
 <dl>
 <dt>callFrames</dt>
-<dd>[<a href="#Debugger.CallFrame">Debugger.CallFrame</a>] <span class="text">Call stack the virtual machine stopped on.</span></dd>
+<dd>[<a href='#Debugger.CallFrame'>Debugger.CallFrame</a>] <span class='text'>Call stack the virtual machine stopped on.</span></dd>
 <dt>reason</dt>
-<dd>( XHR | DOM | EventListener | exception | other ) <span class="text">Pause reason.</span></dd>
+<dd>( XHR | DOM | EventListener | exception | other ) <span class='text'>Pause reason.</span></dd>
 <dt>data (optional)</dt>
-<dd>Object <span class="text">Object containing break-specific auxiliary properties.</span></dd>
+<dd>Object <span class='text'>Object containing break-specific auxiliary properties.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3285,8 +3596,8 @@ function onPaused(res) {
 }
 </pre>
 </div>
-<div id="Debugger_resumed" class="command">
-<h3>Debugger.resumed <span class="label label-info">Event</span></h3>
+<div id='Debugger_resumed' class='command'>
+<h3>Debugger.resumed <span class='label label-info'>Event</span></h3>
 <p>Fired when the virtual machine resumed execution.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3297,16 +3608,68 @@ function onResumed(res) {
 </pre>
 </div>
 </section>
-<section id="FileSystem" class="domain">
+<section id='FileSystem' class='domain'>
 <h1>FileSystem</h1>
 <p></p>
-<span class="label label-success">Command</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#FileSystem.enable">FileSystem.enable</a>: Enables events from backend.</li>
-<li><a href="#FileSystem.disable">FileSystem.disable</a>: Disables events from backend..</li>
+<li><a href='#FileSystem.RequestId'>FileSystem.RequestId</a>: Request Identifier to glue a request and its completion event.</li>
+<li><a href='#FileSystem.Entry'>FileSystem.Entry</a>: Represents a browser side file or directory.</li>
+<li><a href='#FileSystem.Metadata'>FileSystem.Metadata</a>: Represents metadata of a file or entry.</li>
 </ul>
-<div id="FileSystem_enable" class="command">
-<h3>FileSystem.enable <span class="label label-success">Command</span></h3>
+<span class='label label-success'>Command</span>
+<ul>
+<li><a href='#FileSystem.enable'>FileSystem.enable</a>: Enables events from backend.</li>
+<li><a href='#FileSystem.disable'>FileSystem.disable</a>: Disables events from backend.</li>
+<li><a href='#FileSystem.requestFileSystemRoot'>FileSystem.requestFileSystemRoot</a>: Returns root directory of the FileSystem as fileSystemRootReceived event, if exists.</li>
+<li><a href='#FileSystem.requestDirectoryContent'>FileSystem.requestDirectoryContent</a>: Returns content of the directory as directoryContentReceived event.</li>
+<li><a href='#FileSystem.requestMetadata'>FileSystem.requestMetadata</a>: Returns metadata of the entry as metadataReceived event.</li>
+<li><a href='#FileSystem.requestFileContent'>FileSystem.requestFileContent</a>: Returns content of the file as fileContentReceived event. Result should be sliced into [start, end).</li>
+</ul>
+<span class='label label-info'>Event</span>
+<ul>
+<li><a href='#FileSystem.fileSystemRootReceived'>FileSystem.fileSystemRootReceived</a>: Completion event of requestFileSystemRoot command.</li>
+<li><a href='#FileSystem.directoryContentReceived'>FileSystem.directoryContentReceived</a>: Completion event of requestDirectoryContent command.</li>
+<li><a href='#FileSystem.metadataReceived'>FileSystem.metadataReceived</a>: Completion event of requestMetadata command.</li>
+<li><a href='#FileSystem.fileContentReceived'>FileSystem.fileContentReceived</a>: Completion event of requestFileContent command.</li>
+</ul>
+<div id='FileSystem_RequestId' class='type'>
+<h3>FileSystem.RequestId <span class='label'>Type</span></h3>
+<p>Request Identifier to glue a request and its completion event.</p>
+<dl>
+<dd>Integer</dd>
+</dl>
+</div>
+<div id='FileSystem_Entry' class='type'>
+<h3>FileSystem.Entry <span class='label'>Type</span></h3>
+<p>Represents a browser side file or directory.</p>
+<dl>
+<dt>url</dt>
+<dd>String <span class='text'>filesystem: URL for the entry.</span></dd>
+<dt>name</dt>
+<dd>String <span class='text'>The name of the file or directory.</span></dd>
+<dt>isDirectory</dt>
+<dd>Boolean <span class='text'>True if the entry is a directory.</span></dd>
+<dt>mimeType (optional)</dt>
+<dd>String <span class='text'>MIME type of the entry, available for a file only.</span></dd>
+<dt>resourceType (optional)</dt>
+<dd><a href='#Page.ResourceType'>Page.ResourceType</a> <span class='text'>ResourceType of the entry, available for a file only.</span></dd>
+<dt>isTextFile (optional)</dt>
+<dd>Boolean <span class='text'>True if the entry is a text file.</span></dd>
+</dl>
+</div>
+<div id='FileSystem_Metadata' class='type'>
+<h3>FileSystem.Metadata <span class='label'>Type</span></h3>
+<p>Represents metadata of a file or entry.</p>
+<dl>
+<dt>modificationTime</dt>
+<dd>Number <span class='text'>Modification time.</span></dd>
+<dt>size</dt>
+<dd>Number <span class='text'>File size. This field is always zero for directories.</span></dd>
+</dl>
+</div>
+<div id='FileSystem_enable' class='command'>
+<h3>FileSystem.enable <span class='label label-success'>Command</span></h3>
 <p>Enables events from backend.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3314,136 +3677,319 @@ function onResumed(res) {
 FileSystem.enable();
 </pre>
 </div>
-<div id="FileSystem_disable" class="command">
-<h3>FileSystem.disable <span class="label label-success">Command</span></h3>
-<p>Disables events from backend..</p>
+<div id='FileSystem_disable' class='command'>
+<h3>FileSystem.disable <span class='label label-success'>Command</span></h3>
+<p>Disables events from backend.</p>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: FileSystem.disable
 FileSystem.disable();
 </pre>
 </div>
+<div id='FileSystem_requestFileSystemRoot' class='command'>
+<h3>FileSystem.requestFileSystemRoot <span class='label label-success'>Command</span></h3>
+<p>Returns root directory of the FileSystem as fileSystemRootReceived event, if exists.</p>
+<dl>
+<dt>origin</dt>
+<dd>String <span class='text'>Security origin of requesting FileSystem. One of frames in current page needs to have this security origin.</span></dd>
+<dt>type</dt>
+<dd>( temporary | persistent ) <span class='text'>FileSystem type of requesting FileSystem.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#FileSystem.RequestId'>FileSystem.RequestId</a> <span class='text'>Request identifier. Corresponding fileSystemRootReceived event should have same requestId with this.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: FileSystem.requestFileSystemRoot
+FileSystem.requestFileSystemRoot(origin, type, function callback(res) {
+	// res = {requestId}
+});
+</pre>
+</div>
+<div id='FileSystem_requestDirectoryContent' class='command'>
+<h3>FileSystem.requestDirectoryContent <span class='label label-success'>Command</span></h3>
+<p>Returns content of the directory as directoryContentReceived event.</p>
+<dl>
+<dt>url</dt>
+<dd>String <span class='text'>URL of the directory that the frontend is requesting to read from.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#FileSystem.RequestId'>FileSystem.RequestId</a> <span class='text'>Request identifier. Corresponding directoryContentReceived event should have same requestId with this.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: FileSystem.requestDirectoryContent
+FileSystem.requestDirectoryContent(url, function callback(res) {
+	// res = {requestId}
+});
+</pre>
+</div>
+<div id='FileSystem_requestMetadata' class='command'>
+<h3>FileSystem.requestMetadata <span class='label label-success'>Command</span></h3>
+<p>Returns metadata of the entry as metadataReceived event.</p>
+<dl>
+<dt>url</dt>
+<dd>String <span class='text'>URL of the entry that the frontend is requesting to get metadata from.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#FileSystem.RequestId'>FileSystem.RequestId</a> <span class='text'>Request identifier. Corresponding metadataReceived event should have same requestId with this.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: FileSystem.requestMetadata
+FileSystem.requestMetadata(url, function callback(res) {
+	// res = {requestId}
+});
+</pre>
+</div>
+<div id='FileSystem_requestFileContent' class='command'>
+<h3>FileSystem.requestFileContent <span class='label label-success'>Command</span></h3>
+<p>Returns content of the file as fileContentReceived event. Result should be sliced into [start, end).</p>
+<dl>
+<dt>url</dt>
+<dd>String <span class='text'>URL of the file that the frontend is requesting to read from.</span></dd>
+<dt>readAsText</dt>
+<dd>Boolean <span class='text'>True if the content should be read as text, otherwise the result will be returned as base64 encoded text.</span></dd>
+<dt>start (optional)</dt>
+<dd>Integer <span class='text'>Specifies the start of range to read.</span></dd>
+<dt>end (optional)</dt>
+<dd>Integer <span class='text'>Specifies the end of range to read exclusively.</span></dd>
+<dt>charset (optional)</dt>
+<dd>String <span class='text'>Overrides charset of the content when content is served as text.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#FileSystem.RequestId'>FileSystem.RequestId</a> <span class='text'>Request identifier. Corresponding fileContentReceived event should have same requestId with this.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: FileSystem.requestFileContent
+FileSystem.requestFileContent(url, readAsText, start, end, charset, function callback(res) {
+	// res = {requestId}
+});
+</pre>
+</div>
+<div id='FileSystem_fileSystemRootReceived' class='command'>
+<h3>FileSystem.fileSystemRootReceived <span class='label label-info'>Event</span></h3>
+<p>Completion event of requestFileSystemRoot command.</p>
+<dl>
+<dt>requestId</dt>
+<dd>Integer <span class='text'>Request Identifier that was returned by corresponding requestFileSystemRoot command.</span></dd>
+<dt>errorCode</dt>
+<dd>Integer <span class='text'>0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value.</span></dd>
+<dt>root (optional)</dt>
+<dd><a href='#FileSystem.Entry'>FileSystem.Entry</a> <span class='text'>Contains root of the requested FileSystem if the command completed successfully.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: FileSystem.fileSystemRootReceived
+function onFileSystemRootReceived(res) {
+	// res = {requestId, errorCode, root}
+}
+</pre>
+</div>
+<div id='FileSystem_directoryContentReceived' class='command'>
+<h3>FileSystem.directoryContentReceived <span class='label label-info'>Event</span></h3>
+<p>Completion event of requestDirectoryContent command.</p>
+<dl>
+<dt>requestId</dt>
+<dd>Integer <span class='text'>Request Identifier that was returned by corresponding requestDirectoryContent command.</span></dd>
+<dt>errorCode</dt>
+<dd>Integer <span class='text'>0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value.</span></dd>
+<dt>entries (optional)</dt>
+<dd>[<a href='#FileSystem.Entry'>FileSystem.Entry</a>] <span class='text'>Contains all entries on directory if the command completed successfully.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: FileSystem.directoryContentReceived
+function onDirectoryContentReceived(res) {
+	// res = {requestId, errorCode, entries}
+}
+</pre>
+</div>
+<div id='FileSystem_metadataReceived' class='command'>
+<h3>FileSystem.metadataReceived <span class='label label-info'>Event</span></h3>
+<p>Completion event of requestMetadata command.</p>
+<dl>
+<dt>requestId</dt>
+<dd>Integer <span class='text'>Request Identifier that was returned in response to the corresponding requestMetadata command.</span></dd>
+<dt>errorCode</dt>
+<dd>Integer <span class='text'>0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value.</span></dd>
+<dt>metadata (optional)</dt>
+<dd><a href='#FileSystem.Metadata'>FileSystem.Metadata</a> <span class='text'>Contains metadata of the entry if the command completed successfully.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: FileSystem.metadataReceived
+function onMetadataReceived(res) {
+	// res = {requestId, errorCode, metadata}
+}
+</pre>
+</div>
+<div id='FileSystem_fileContentReceived' class='command'>
+<h3>FileSystem.fileContentReceived <span class='label label-info'>Event</span></h3>
+<p>Completion event of requestFileContent command.</p>
+<dl>
+<dt>requestId</dt>
+<dd>Integer <span class='text'>Request Identifier that was returned in response to the corresponding requestFileContent command.</span></dd>
+<dt>errorCode</dt>
+<dd>Integer <span class='text'>0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value.</span></dd>
+<dt>content (optional)</dt>
+<dd>String <span class='text'>Content of the file.</span></dd>
+<dt>charset (optional)</dt>
+<dd>String <span class='text'>Charset of the content if it is served as text.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: FileSystem.fileContentReceived
+function onFileContentReceived(res) {
+	// res = {requestId, errorCode, content, charset}
+}
+</pre>
+</div>
 </section>
-<section id="IndexedDB" class="domain">
+<section id='IndexedDB' class='domain'>
 <h1>IndexedDB</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#IndexedDB.SecurityOriginWithDatabaseNames">IndexedDB.SecurityOriginWithDatabaseNames</a>: Security origin with database names.</li>
-<li><a href="#IndexedDB.DatabaseWithObjectStores">IndexedDB.DatabaseWithObjectStores</a>: Database with an array of object stores.</li>
-<li><a href="#IndexedDB.ObjectStore">IndexedDB.ObjectStore</a>: Object store.</li>
-<li><a href="#IndexedDB.ObjectStoreIndex">IndexedDB.ObjectStoreIndex</a>: Object store index.</li>
-<li><a href="#IndexedDB.Key">IndexedDB.Key</a>: Key.</li>
-<li><a href="#IndexedDB.KeyRange">IndexedDB.KeyRange</a>: Key range.</li>
-<li><a href="#IndexedDB.DataEntry">IndexedDB.DataEntry</a>: Key.</li>
+<li><a href='#IndexedDB.SecurityOriginWithDatabaseNames'>IndexedDB.SecurityOriginWithDatabaseNames</a>: Security origin with database names.</li>
+<li><a href='#IndexedDB.DatabaseWithObjectStores'>IndexedDB.DatabaseWithObjectStores</a>: Database with an array of object stores.</li>
+<li><a href='#IndexedDB.ObjectStore'>IndexedDB.ObjectStore</a>: Object store.</li>
+<li><a href='#IndexedDB.ObjectStoreIndex'>IndexedDB.ObjectStoreIndex</a>: Object store index.</li>
+<li><a href='#IndexedDB.Key'>IndexedDB.Key</a>: Key.</li>
+<li><a href='#IndexedDB.KeyRange'>IndexedDB.KeyRange</a>: Key range.</li>
+<li><a href='#IndexedDB.DataEntry'>IndexedDB.DataEntry</a>: Data entry.</li>
+<li><a href='#IndexedDB.KeyPath'>IndexedDB.KeyPath</a>: Key path.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#IndexedDB.enable">IndexedDB.enable</a>: Enables events from backend.</li>
-<li><a href="#IndexedDB.disable">IndexedDB.disable</a>: Disables events from backend.</li>
-<li><a href="#IndexedDB.requestDatabaseNamesForFrame">IndexedDB.requestDatabaseNamesForFrame</a>: Requests database names for given frame's security origin.</li>
-<li><a href="#IndexedDB.requestDatabase">IndexedDB.requestDatabase</a>: Requests database with given name in given frame.</li>
-<li><a href="#IndexedDB.requestData">IndexedDB.requestData</a>: Requests data from object store or index.</li>
+<li><a href='#IndexedDB.enable'>IndexedDB.enable</a>: Enables events from backend.</li>
+<li><a href='#IndexedDB.disable'>IndexedDB.disable</a>: Disables events from backend.</li>
+<li><a href='#IndexedDB.requestDatabaseNamesForFrame'>IndexedDB.requestDatabaseNamesForFrame</a>: Requests database names for given frame's security origin.</li>
+<li><a href='#IndexedDB.requestDatabase'>IndexedDB.requestDatabase</a>: Requests database with given name in given frame.</li>
+<li><a href='#IndexedDB.requestData'>IndexedDB.requestData</a>: Requests data from object store or index.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#IndexedDB.databaseNamesLoaded">IndexedDB.databaseNamesLoaded</a></li>
-<li><a href="#IndexedDB.databaseLoaded">IndexedDB.databaseLoaded</a></li>
-<li><a href="#IndexedDB.objectStoreDataLoaded">IndexedDB.objectStoreDataLoaded</a></li>
-<li><a href="#IndexedDB.indexDataLoaded">IndexedDB.indexDataLoaded</a></li>
+<li><a href='#IndexedDB.databaseNamesLoaded'>IndexedDB.databaseNamesLoaded</a></li>
+<li><a href='#IndexedDB.databaseLoaded'>IndexedDB.databaseLoaded</a></li>
+<li><a href='#IndexedDB.objectStoreDataLoaded'>IndexedDB.objectStoreDataLoaded</a></li>
+<li><a href='#IndexedDB.indexDataLoaded'>IndexedDB.indexDataLoaded</a></li>
 </ul>
-<div id="IndexedDB_SecurityOriginWithDatabaseNames" class="type">
-<h3>IndexedDB.SecurityOriginWithDatabaseNames <span class="label">Type</span></h3>
+<div id='IndexedDB_SecurityOriginWithDatabaseNames' class='type'>
+<h3>IndexedDB.SecurityOriginWithDatabaseNames <span class='label'>Type</span></h3>
 <p>Security origin with database names.</p>
 <dl>
 <dt>securityOrigin</dt>
-<dd>String <span class="text">Security origin.</span></dd>
+<dd>String <span class='text'>Security origin.</span></dd>
 <dt>databaseNames</dt>
-<dd>[String] <span class="text">Database names for this origin.</span></dd>
+<dd>[String] <span class='text'>Database names for this origin.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_DatabaseWithObjectStores" class="type">
-<h3>IndexedDB.DatabaseWithObjectStores <span class="label">Type</span></h3>
+<div id='IndexedDB_DatabaseWithObjectStores' class='type'>
+<h3>IndexedDB.DatabaseWithObjectStores <span class='label'>Type</span></h3>
 <p>Database with an array of object stores.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Database name.</span></dd>
+<dd>String <span class='text'>Database name.</span></dd>
 <dt>version</dt>
-<dd>String <span class="text">Database version.</span></dd>
+<dd>String <span class='text'>Database version.</span></dd>
 <dt>objectStores</dt>
-<dd>[<a href="#IndexedDB.ObjectStore">IndexedDB.ObjectStore</a>] <span class="text">Object stores in this database.</span></dd>
+<dd>[<a href='#IndexedDB.ObjectStore'>IndexedDB.ObjectStore</a>] <span class='text'>Object stores in this database.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_ObjectStore" class="type">
-<h3>IndexedDB.ObjectStore <span class="label">Type</span></h3>
+<div id='IndexedDB_ObjectStore' class='type'>
+<h3>IndexedDB.ObjectStore <span class='label'>Type</span></h3>
 <p>Object store.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Object store name.</span></dd>
+<dd>String <span class='text'>Object store name.</span></dd>
 <dt>keyPath</dt>
-<dd>String <span class="text">Object store key path.</span></dd>
+<dd><a href='#IndexedDB.KeyPath'>IndexedDB.KeyPath</a> <span class='text'>Object store key path.</span></dd>
+<dt>autoIncrement</dt>
+<dd>Boolean <span class='text'>If true, object store has auto increment flag set.</span></dd>
 <dt>indexes</dt>
-<dd>[<a href="#IndexedDB.ObjectStoreIndex">IndexedDB.ObjectStoreIndex</a>] <span class="text">Indexes in this object store.</span></dd>
+<dd>[<a href='#IndexedDB.ObjectStoreIndex'>IndexedDB.ObjectStoreIndex</a>] <span class='text'>Indexes in this object store.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_ObjectStoreIndex" class="type">
-<h3>IndexedDB.ObjectStoreIndex <span class="label">Type</span></h3>
+<div id='IndexedDB_ObjectStoreIndex' class='type'>
+<h3>IndexedDB.ObjectStoreIndex <span class='label'>Type</span></h3>
 <p>Object store index.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Index name.</span></dd>
+<dd>String <span class='text'>Index name.</span></dd>
 <dt>keyPath</dt>
-<dd>String <span class="text">Index key path.</span></dd>
+<dd><a href='#IndexedDB.KeyPath'>IndexedDB.KeyPath</a> <span class='text'>Index key path.</span></dd>
 <dt>unique</dt>
-<dd>Boolean <span class="text">If true, index is unique.</span></dd>
+<dd>Boolean <span class='text'>If true, index is unique.</span></dd>
 <dt>multiEntry</dt>
-<dd>Boolean <span class="text">If true, index allows multiple entries for a key.</span></dd>
+<dd>Boolean <span class='text'>If true, index allows multiple entries for a key.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_Key" class="type">
-<h3>IndexedDB.Key <span class="label">Type</span></h3>
+<div id='IndexedDB_Key' class='type'>
+<h3>IndexedDB.Key <span class='label'>Type</span></h3>
 <p>Key.</p>
 <dl>
 <dt>type</dt>
-<dd>( number | string | date | array ) <span class="text">Key type.</span></dd>
+<dd>( number | string | date | array ) <span class='text'>Key type.</span></dd>
 <dt>number (optional)</dt>
-<dd>Number <span class="text">Number value.</span></dd>
+<dd>Number <span class='text'>Number value.</span></dd>
 <dt>string (optional)</dt>
-<dd>String <span class="text">String value.</span></dd>
+<dd>String <span class='text'>String value.</span></dd>
 <dt>date (optional)</dt>
-<dd>Number <span class="text">Date value.</span></dd>
+<dd>Number <span class='text'>Date value.</span></dd>
 <dt>array (optional)</dt>
-<dd>[<a href="#IndexedDB.Key">IndexedDB.Key</a>] <span class="text">Array value.</span></dd>
+<dd>[<a href='#IndexedDB.Key'>IndexedDB.Key</a>] <span class='text'>Array value.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_KeyRange" class="type">
-<h3>IndexedDB.KeyRange <span class="label">Type</span></h3>
+<div id='IndexedDB_KeyRange' class='type'>
+<h3>IndexedDB.KeyRange <span class='label'>Type</span></h3>
 <p>Key range.</p>
 <dl>
 <dt>lower (optional)</dt>
-<dd><a href="#IndexedDB.Key">IndexedDB.Key</a> <span class="text">Lower bound.</span></dd>
+<dd><a href='#IndexedDB.Key'>IndexedDB.Key</a> <span class='text'>Lower bound.</span></dd>
 <dt>upper (optional)</dt>
-<dd><a href="#IndexedDB.Key">IndexedDB.Key</a> <span class="text">Upper bound.</span></dd>
+<dd><a href='#IndexedDB.Key'>IndexedDB.Key</a> <span class='text'>Upper bound.</span></dd>
 <dt>lowerOpen</dt>
-<dd>Boolean <span class="text">If true lower bound is open.</span></dd>
+<dd>Boolean <span class='text'>If true lower bound is open.</span></dd>
 <dt>upperOpen</dt>
-<dd>Boolean <span class="text">If true upper bound is open.</span></dd>
+<dd>Boolean <span class='text'>If true upper bound is open.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_DataEntry" class="type">
-<h3>IndexedDB.DataEntry <span class="label">Type</span></h3>
-<p>Key.</p>
+<div id='IndexedDB_DataEntry' class='type'>
+<h3>IndexedDB.DataEntry <span class='label'>Type</span></h3>
+<p>Data entry.</p>
 <dl>
 <dt>key</dt>
-<dd><a href="#IndexedDB.Key">IndexedDB.Key</a> <span class="text">Key.</span></dd>
+<dd><a href='#IndexedDB.Key'>IndexedDB.Key</a> <span class='text'>Key.</span></dd>
 <dt>primaryKey</dt>
-<dd><a href="#IndexedDB.Key">IndexedDB.Key</a> <span class="text">Primary key.</span></dd>
+<dd><a href='#IndexedDB.Key'>IndexedDB.Key</a> <span class='text'>Primary key.</span></dd>
 <dt>value</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Value.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Value.</span></dd>
 </dl>
 </div>
-<div id="IndexedDB_enable" class="command">
-<h3>IndexedDB.enable <span class="label label-success">Command</span></h3>
+<div id='IndexedDB_KeyPath' class='type'>
+<h3>IndexedDB.KeyPath <span class='label'>Type</span></h3>
+<p>Key path.</p>
+<dl>
+<dt>type</dt>
+<dd>( null | string | array ) <span class='text'>Key path type.</span></dd>
+<dt>string (optional)</dt>
+<dd>String <span class='text'>String value.</span></dd>
+<dt>array (optional)</dt>
+<dd>[String] <span class='text'>Array value.</span></dd>
+</dl>
+</div>
+<div id='IndexedDB_enable' class='command'>
+<h3>IndexedDB.enable <span class='label label-success'>Command</span></h3>
 <p>Enables events from backend.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3451,8 +3997,8 @@ FileSystem.disable();
 IndexedDB.enable();
 </pre>
 </div>
-<div id="IndexedDB_disable" class="command">
-<h3>IndexedDB.disable <span class="label label-success">Command</span></h3>
+<div id='IndexedDB_disable' class='command'>
+<h3>IndexedDB.disable <span class='label label-success'>Command</span></h3>
 <p>Disables events from backend.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3460,14 +4006,14 @@ IndexedDB.enable();
 IndexedDB.disable();
 </pre>
 </div>
-<div id="IndexedDB_requestDatabaseNamesForFrame" class="command">
-<h3>IndexedDB.requestDatabaseNamesForFrame <span class="label label-success">Command</span></h3>
+<div id='IndexedDB_requestDatabaseNamesForFrame' class='command'>
+<h3>IndexedDB.requestDatabaseNamesForFrame <span class='label label-success'>Command</span></h3>
 <p>Requests database names for given frame's security origin.</p>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3475,16 +4021,16 @@ IndexedDB.disable();
 IndexedDB.requestDatabaseNamesForFrame(requestId, frameId);
 </pre>
 </div>
-<div id="IndexedDB_requestDatabase" class="command">
-<h3>IndexedDB.requestDatabase <span class="label label-success">Command</span></h3>
+<div id='IndexedDB_requestDatabase' class='command'>
+<h3>IndexedDB.requestDatabase <span class='label label-success'>Command</span></h3>
 <p>Requests database with given name in given frame.</p>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id.</span></dd>
 <dt>databaseName</dt>
-<dd>String <span class="text">Database name.</span></dd>
+<dd>String <span class='text'>Database name.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3492,26 +4038,26 @@ IndexedDB.requestDatabaseNamesForFrame(requestId, frameId);
 IndexedDB.requestDatabase(requestId, frameId, databaseName);
 </pre>
 </div>
-<div id="IndexedDB_requestData" class="command">
-<h3>IndexedDB.requestData <span class="label label-success">Command</span></h3>
+<div id='IndexedDB_requestData' class='command'>
+<h3>IndexedDB.requestData <span class='label label-success'>Command</span></h3>
 <p>Requests data from object store or index.</p>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id.</span></dd>
 <dt>databaseName</dt>
-<dd>String <span class="text">Database name.</span></dd>
+<dd>String <span class='text'>Database name.</span></dd>
 <dt>objectStoreName</dt>
-<dd>String <span class="text">Object store name.</span></dd>
+<dd>String <span class='text'>Object store name.</span></dd>
 <dt>indexName</dt>
-<dd>String <span class="text">Index name, empty string for object store data requests.</span></dd>
+<dd>String <span class='text'>Index name, empty string for object store data requests.</span></dd>
 <dt>skipCount</dt>
-<dd>Integer <span class="text">Number of records to skip.</span></dd>
+<dd>Integer <span class='text'>Number of records to skip.</span></dd>
 <dt>pageSize</dt>
-<dd>Integer <span class="text">Number of records to fetch.</span></dd>
+<dd>Integer <span class='text'>Number of records to fetch.</span></dd>
 <dt>keyRange (optional)</dt>
-<dd><a href="#IndexedDB.KeyRange">IndexedDB.KeyRange</a> <span class="text">Key range.</span></dd>
+<dd><a href='#IndexedDB.KeyRange'>IndexedDB.KeyRange</a> <span class='text'>Key range.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3519,13 +4065,13 @@ IndexedDB.requestDatabase(requestId, frameId, databaseName);
 IndexedDB.requestData(requestId, frameId, databaseName, objectStoreName, indexName, skipCount, pageSize, keyRange);
 </pre>
 </div>
-<div id="IndexedDB_databaseNamesLoaded" class="command">
-<h3>IndexedDB.databaseNamesLoaded <span class="label label-info">Event</span></h3>
+<div id='IndexedDB_databaseNamesLoaded' class='command'>
+<h3>IndexedDB.databaseNamesLoaded <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>requestId</dt>
-<dd>Number <span class="text">Request id.</span></dd>
+<dd>Number <span class='text'>Request id.</span></dd>
 <dt>securityOriginWithDatabaseNames</dt>
-<dd><a href="#IndexedDB.SecurityOriginWithDatabaseNames">IndexedDB.SecurityOriginWithDatabaseNames</a> <span class="text">Frame with database names.</span></dd>
+<dd><a href='#IndexedDB.SecurityOriginWithDatabaseNames'>IndexedDB.SecurityOriginWithDatabaseNames</a> <span class='text'>Frame with database names.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3535,13 +4081,13 @@ function onDatabaseNamesLoaded(res) {
 }
 </pre>
 </div>
-<div id="IndexedDB_databaseLoaded" class="command">
-<h3>IndexedDB.databaseLoaded <span class="label label-info">Event</span></h3>
+<div id='IndexedDB_databaseLoaded' class='command'>
+<h3>IndexedDB.databaseLoaded <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>databaseWithObjectStores</dt>
-<dd><a href="#IndexedDB.DatabaseWithObjectStores">IndexedDB.DatabaseWithObjectStores</a> <span class="text">Database with an array of object stores.</span></dd>
+<dd><a href='#IndexedDB.DatabaseWithObjectStores'>IndexedDB.DatabaseWithObjectStores</a> <span class='text'>Database with an array of object stores.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3551,15 +4097,15 @@ function onDatabaseLoaded(res) {
 }
 </pre>
 </div>
-<div id="IndexedDB_objectStoreDataLoaded" class="command">
-<h3>IndexedDB.objectStoreDataLoaded <span class="label label-info">Event</span></h3>
+<div id='IndexedDB_objectStoreDataLoaded' class='command'>
+<h3>IndexedDB.objectStoreDataLoaded <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>objectStoreDataEntries</dt>
-<dd>[<a href="#IndexedDB.DataEntry">IndexedDB.DataEntry</a>] <span class="text">Array of object store data entries.</span></dd>
+<dd>[<a href='#IndexedDB.DataEntry'>IndexedDB.DataEntry</a>] <span class='text'>Array of object store data entries.</span></dd>
 <dt>hasMore</dt>
-<dd>Boolean <span class="text">If true, there are more entries to fetch in the given range.</span></dd>
+<dd>Boolean <span class='text'>If true, there are more entries to fetch in the given range.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3569,15 +4115,15 @@ function onObjectStoreDataLoaded(res) {
 }
 </pre>
 </div>
-<div id="IndexedDB_indexDataLoaded" class="command">
-<h3>IndexedDB.indexDataLoaded <span class="label label-info">Event</span></h3>
+<div id='IndexedDB_indexDataLoaded' class='command'>
+<h3>IndexedDB.indexDataLoaded <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>requestId</dt>
-<dd>Integer <span class="text">Request id.</span></dd>
+<dd>Integer <span class='text'>Request id.</span></dd>
 <dt>indexDataEntries</dt>
-<dd>[<a href="#IndexedDB.DataEntry">IndexedDB.DataEntry</a>] <span class="text">Array of index data entries.</span></dd>
+<dd>[<a href='#IndexedDB.DataEntry'>IndexedDB.DataEntry</a>] <span class='text'>Array of index data entries.</span></dd>
 <dt>hasMore</dt>
-<dd>Boolean <span class="text">If true, there are more entries to fetch in the given range.</span></dd>
+<dd>Boolean <span class='text'>If true, there are more entries to fetch in the given range.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3588,23 +4134,21 @@ function onIndexDataLoaded(res) {
 </pre>
 </div>
 </section>
-<section id="Inspector" class="domain">
+<section id='Inspector' class='domain'>
 <h1>Inspector</h1>
 <p></p>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Inspector.enable">Inspector.enable</a>: Enables inspector domain notifications.</li>
-<li><a href="#Inspector.disable">Inspector.disable</a>: Disables inspector domain notifications.</li>
+<li><a href='#Inspector.enable'>Inspector.enable</a>: Enables inspector domain notifications.</li>
+<li><a href='#Inspector.disable'>Inspector.disable</a>: Disables inspector domain notifications.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Inspector.evaluateForTestInFrontend">Inspector.evaluateForTestInFrontend</a></li>
-<li><a href="#Inspector.inspect">Inspector.inspect</a></li>
-<li><a href="#Inspector.didCreateWorker">Inspector.didCreateWorker</a></li>
-<li><a href="#Inspector.didDestroyWorker">Inspector.didDestroyWorker</a></li>
+<li><a href='#Inspector.evaluateForTestInFrontend'>Inspector.evaluateForTestInFrontend</a></li>
+<li><a href='#Inspector.inspect'>Inspector.inspect</a></li>
 </ul>
-<div id="Inspector_enable" class="command">
-<h3>Inspector.enable <span class="label label-success">Command</span></h3>
+<div id='Inspector_enable' class='command'>
+<h3>Inspector.enable <span class='label label-success'>Command</span></h3>
 <p>Enables inspector domain notifications.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3612,8 +4156,8 @@ function onIndexDataLoaded(res) {
 Inspector.enable();
 </pre>
 </div>
-<div id="Inspector_disable" class="command">
-<h3>Inspector.disable <span class="label label-success">Command</span></h3>
+<div id='Inspector_disable' class='command'>
+<h3>Inspector.disable <span class='label label-success'>Command</span></h3>
 <p>Disables inspector domain notifications.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3621,8 +4165,8 @@ Inspector.enable();
 Inspector.disable();
 </pre>
 </div>
-<div id="Inspector_evaluateForTestInFrontend" class="command">
-<h3>Inspector.evaluateForTestInFrontend <span class="label label-info">Event</span></h3>
+<div id='Inspector_evaluateForTestInFrontend' class='command'>
+<h3>Inspector.evaluateForTestInFrontend <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>testCallId</dt>
 <dd>Integer</dd>
@@ -3637,11 +4181,11 @@ function onEvaluateForTestInFrontend(res) {
 }
 </pre>
 </div>
-<div id="Inspector_inspect" class="command">
-<h3>Inspector.inspect <span class="label label-info">Event</span></h3>
+<div id='Inspector_inspect' class='command'>
+<h3>Inspector.inspect <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>object</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a></dd>
 <dt>hints</dt>
 <dd>Object</dd>
 </dl>
@@ -3653,55 +4197,25 @@ function onInspect(res) {
 }
 </pre>
 </div>
-<div id="Inspector_didCreateWorker" class="command">
-<h3>Inspector.didCreateWorker <span class="label label-info">Event</span></h3>
-<dl>
-<dt>id</dt>
-<dd>Integer</dd>
-<dt>url</dt>
-<dd>String</dd>
-<dt>isShared</dt>
-<dd>Boolean</dd>
-</dl>
-<h4>Code Example:</h4>
-<pre>
-// WebInspector Event: Inspector.didCreateWorker
-function onDidCreateWorker(res) {
-	// res = {id, url, isShared}
-}
-</pre>
-</div>
-<div id="Inspector_didDestroyWorker" class="command">
-<h3>Inspector.didDestroyWorker <span class="label label-info">Event</span></h3>
-<dl>
-<dt>id</dt>
-<dd>Integer</dd>
-</dl>
-<h4>Code Example:</h4>
-<pre>
-// WebInspector Event: Inspector.didDestroyWorker
-function onDidDestroyWorker(res) {
-	// res = {id}
-}
-</pre>
-</div>
 </section>
-<section id="Memory" class="domain">
+<section id='Memory' class='domain'>
 <h1>Memory</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Memory.NodeCount">Memory.NodeCount</a>: Number of nodes with given name.</li>
-<li><a href="#Memory.ListenerCount">Memory.ListenerCount</a>: Number of JS event listeners by event type.</li>
-<li><a href="#Memory.StringStatistics">Memory.StringStatistics</a>: Character data statistics for the page.</li>
-<li><a href="#Memory.DOMGroup">Memory.DOMGroup</a></li>
+<li><a href='#Memory.NodeCount'>Memory.NodeCount</a>: Number of nodes with given name.</li>
+<li><a href='#Memory.ListenerCount'>Memory.ListenerCount</a>: Number of JS event listeners by event type.</li>
+<li><a href='#Memory.StringStatistics'>Memory.StringStatistics</a>: Character data statistics for the page.</li>
+<li><a href='#Memory.DOMGroup'>Memory.DOMGroup</a></li>
+<li><a href='#Memory.MemoryBlock'>Memory.MemoryBlock</a></li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Memory.getDOMNodeCount">Memory.getDOMNodeCount</a></li>
+<li><a href='#Memory.getDOMNodeCount'>Memory.getDOMNodeCount</a></li>
+<li><a href='#Memory.getProcessMemoryDistribution'>Memory.getProcessMemoryDistribution</a></li>
 </ul>
-<div id="Memory_NodeCount" class="type">
-<h3>Memory.NodeCount <span class="label">Type</span></h3>
+<div id='Memory_NodeCount' class='type'>
+<h3>Memory.NodeCount <span class='label'>Type</span></h3>
 <p>Number of nodes with given name.</p>
 <dl>
 <dt>nodeName</dt>
@@ -3710,8 +4224,8 @@ function onDidDestroyWorker(res) {
 <dd>Integer</dd>
 </dl>
 </div>
-<div id="Memory_ListenerCount" class="type">
-<h3>Memory.ListenerCount <span class="label">Type</span></h3>
+<div id='Memory_ListenerCount' class='type'>
+<h3>Memory.ListenerCount <span class='label'>Type</span></h3>
 <p>Number of JS event listeners by event type.</p>
 <dl>
 <dt>type</dt>
@@ -3720,8 +4234,8 @@ function onDidDestroyWorker(res) {
 <dd>Integer</dd>
 </dl>
 </div>
-<div id="Memory_StringStatistics" class="type">
-<h3>Memory.StringStatistics <span class="label">Type</span></h3>
+<div id='Memory_StringStatistics' class='type'>
+<h3>Memory.StringStatistics <span class='label'>Type</span></h3>
 <p>Character data statistics for the page.</p>
 <dl>
 <dt>dom</dt>
@@ -3732,8 +4246,8 @@ function onDidDestroyWorker(res) {
 <dd>Integer</dd>
 </dl>
 </div>
-<div id="Memory_DOMGroup" class="type">
-<h3>Memory.DOMGroup <span class="label">Type</span></h3>
+<div id='Memory_DOMGroup' class='type'>
+<h3>Memory.DOMGroup <span class='label'>Type</span></h3>
 <dl>
 <dt>size</dt>
 <dd>Integer</dd>
@@ -3742,19 +4256,30 @@ function onDidDestroyWorker(res) {
 <dt>documentURI (optional)</dt>
 <dd>String</dd>
 <dt>nodeCount</dt>
-<dd>[<a href="#Memory.NodeCount">Memory.NodeCount</a>]</dd>
+<dd>[<a href='#Memory.NodeCount'>Memory.NodeCount</a>]</dd>
 <dt>listenerCount</dt>
-<dd>[<a href="#Memory.ListenerCount">Memory.ListenerCount</a>]</dd>
+<dd>[<a href='#Memory.ListenerCount'>Memory.ListenerCount</a>]</dd>
 </dl>
 </div>
-<div id="Memory_getDOMNodeCount" class="command">
-<h3>Memory.getDOMNodeCount <span class="label label-success">Command</span></h3>
+<div id='Memory_MemoryBlock' class='type'>
+<h3>Memory.MemoryBlock <span class='label'>Type</span></h3>
+<dl>
+<dt>size (optional)</dt>
+<dd>Number <span class='text'>Size of the block in bytes if available</span></dd>
+<dt>name</dt>
+<dd>String <span class='text'>Unique name used to identify the component that allocated this block</span></dd>
+<dt>children (optional)</dt>
+<dd>[<a href='#Memory.MemoryBlock'>Memory.MemoryBlock</a>]</dd>
+</dl>
+</div>
+<div id='Memory_getDOMNodeCount' class='command'>
+<h3>Memory.getDOMNodeCount <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>domGroups</dt>
-<dd>[<a href="#Memory.DOMGroup">Memory.DOMGroup</a>]</dd>
+<dd>[<a href='#Memory.DOMGroup'>Memory.DOMGroup</a>]</dd>
 <dt>strings</dt>
-<dd><a href="#Memory.StringStatistics">Memory.StringStatistics</a></dd>
+<dd><a href='#Memory.StringStatistics'>Memory.StringStatistics</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3764,212 +4289,243 @@ Memory.getDOMNodeCount(function callback(res) {
 });
 </pre>
 </div>
+<div id='Memory_getProcessMemoryDistribution' class='command'>
+<h3>Memory.getProcessMemoryDistribution <span class='label label-success'>Command</span></h3>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>distribution</dt>
+<dd><a href='#Memory.MemoryBlock'>Memory.MemoryBlock</a> <span class='text'>An object describing all memory allocated by the process</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Memory.getProcessMemoryDistribution
+Memory.getProcessMemoryDistribution(function callback(res) {
+	// res = {distribution}
+});
+</pre>
+</div>
 </section>
-<section id="Network" class="domain">
+<section id='Network' class='domain'>
 <h1>Network</h1>
 <p>Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Network.LoaderId">Network.LoaderId</a>: Unique loader identifier.</li>
-<li><a href="#Network.FrameId">Network.FrameId</a>: Unique frame identifier.</li>
-<li><a href="#Network.RequestId">Network.RequestId</a>: Unique request identifier.</li>
-<li><a href="#Network.Timestamp">Network.Timestamp</a>: Number of seconds since epoch.</li>
-<li><a href="#Network.Headers">Network.Headers</a>: Request / response headers as keys / values of JSON object.</li>
-<li><a href="#Network.ResourceTiming">Network.ResourceTiming</a>: Timing information for the request.</li>
-<li><a href="#Network.Request">Network.Request</a>: HTTP request data.</li>
-<li><a href="#Network.Response">Network.Response</a>: HTTP response data.</li>
-<li><a href="#Network.WebSocketRequest">Network.WebSocketRequest</a>: WebSocket request data.</li>
-<li><a href="#Network.WebSocketResponse">Network.WebSocketResponse</a>: WebSocket response data.</li>
-<li><a href="#Network.CachedResource">Network.CachedResource</a>: Information about the cached resource.</li>
-<li><a href="#Network.Initiator">Network.Initiator</a>: Information about the request initiator.</li>
+<li><a href='#Network.LoaderId'>Network.LoaderId</a>: Unique loader identifier.</li>
+<li><a href='#Network.FrameId'>Network.FrameId</a>: Unique frame identifier.</li>
+<li><a href='#Network.RequestId'>Network.RequestId</a>: Unique request identifier.</li>
+<li><a href='#Network.Timestamp'>Network.Timestamp</a>: Number of seconds since epoch.</li>
+<li><a href='#Network.Headers'>Network.Headers</a>: Request / response headers as keys / values of JSON object.</li>
+<li><a href='#Network.ResourceTiming'>Network.ResourceTiming</a>: Timing information for the request.</li>
+<li><a href='#Network.Request'>Network.Request</a>: HTTP request data.</li>
+<li><a href='#Network.Response'>Network.Response</a>: HTTP response data.</li>
+<li><a href='#Network.WebSocketRequest'>Network.WebSocketRequest</a>: WebSocket request data.</li>
+<li><a href='#Network.WebSocketResponse'>Network.WebSocketResponse</a>: WebSocket response data.</li>
+<li><a href='#Network.WebSocketFrame'>Network.WebSocketFrame</a>: WebSocket frame data.</li>
+<li><a href='#Network.CachedResource'>Network.CachedResource</a>: Information about the cached resource.</li>
+<li><a href='#Network.Initiator'>Network.Initiator</a>: Information about the request initiator.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Network.enable">Network.enable</a>: Enables network tracking, network events will now be delivered to the client.</li>
-<li><a href="#Network.disable">Network.disable</a>: Disables network tracking, prevents network events from being sent to the client.</li>
-<li><a href="#Network.setUserAgentOverride">Network.setUserAgentOverride</a>: Allows overriding user agent with the given string.</li>
-<li><a href="#Network.setExtraHTTPHeaders">Network.setExtraHTTPHeaders</a>: Specifies whether to always send extra HTTP headers with the requests from this page.</li>
-<li><a href="#Network.getResponseBody">Network.getResponseBody</a>: Returns content served for the given request.</li>
-<li><a href="#Network.canClearBrowserCache">Network.canClearBrowserCache</a>: Tells whether clearing browser cache is supported.</li>
-<li><a href="#Network.clearBrowserCache">Network.clearBrowserCache</a>: Clears browser cache.</li>
-<li><a href="#Network.canClearBrowserCookies">Network.canClearBrowserCookies</a>: Tells whether clearing browser cookies is supported.</li>
-<li><a href="#Network.clearBrowserCookies">Network.clearBrowserCookies</a>: Clears browser cookies.</li>
-<li><a href="#Network.setCacheDisabled">Network.setCacheDisabled</a>: Toggles ignoring cache for each request. If true, cache will not be used.</li>
+<li><a href='#Network.enable'>Network.enable</a>: Enables network tracking, network events will now be delivered to the client.</li>
+<li><a href='#Network.disable'>Network.disable</a>: Disables network tracking, prevents network events from being sent to the client.</li>
+<li><a href='#Network.setUserAgentOverride'>Network.setUserAgentOverride</a>: Allows overriding user agent with the given string.</li>
+<li><a href='#Network.setExtraHTTPHeaders'>Network.setExtraHTTPHeaders</a>: Specifies whether to always send extra HTTP headers with the requests from this page.</li>
+<li><a href='#Network.getResponseBody'>Network.getResponseBody</a>: Returns content served for the given request.</li>
+<li><a href='#Network.canClearBrowserCache'>Network.canClearBrowserCache</a>: Tells whether clearing browser cache is supported.</li>
+<li><a href='#Network.clearBrowserCache'>Network.clearBrowserCache</a>: Clears browser cache.</li>
+<li><a href='#Network.canClearBrowserCookies'>Network.canClearBrowserCookies</a>: Tells whether clearing browser cookies is supported.</li>
+<li><a href='#Network.clearBrowserCookies'>Network.clearBrowserCookies</a>: Clears browser cookies.</li>
+<li><a href='#Network.setCacheDisabled'>Network.setCacheDisabled</a>: Toggles ignoring cache for each request. If true, cache will not be used.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Network.requestWillBeSent">Network.requestWillBeSent</a>: Fired when page is about to send HTTP request.</li>
-<li><a href="#Network.requestServedFromCache">Network.requestServedFromCache</a>: Fired if request ended up loading from cache.</li>
-<li><a href="#Network.responseReceived">Network.responseReceived</a>: Fired when HTTP response is available.</li>
-<li><a href="#Network.dataReceived">Network.dataReceived</a>: Fired when data chunk was received over the network.</li>
-<li><a href="#Network.loadingFinished">Network.loadingFinished</a>: Fired when HTTP request has finished loading.</li>
-<li><a href="#Network.loadingFailed">Network.loadingFailed</a>: Fired when HTTP request has failed to load.</li>
-<li><a href="#Network.requestServedFromMemoryCache">Network.requestServedFromMemoryCache</a>: Fired when HTTP request has been served from memory cache.</li>
-<li><a href="#Network.webSocketWillSendHandshakeRequest">Network.webSocketWillSendHandshakeRequest</a>: Fired when WebSocket is about to initiate handshake.</li>
-<li><a href="#Network.webSocketHandshakeResponseReceived">Network.webSocketHandshakeResponseReceived</a>: Fired when WebSocket handshake response becomes available.</li>
-<li><a href="#Network.webSocketCreated">Network.webSocketCreated</a>: Fired upon WebSocket creation.</li>
-<li><a href="#Network.webSocketClosed">Network.webSocketClosed</a>: Fired when WebSocket is closed.</li>
+<li><a href='#Network.requestWillBeSent'>Network.requestWillBeSent</a>: Fired when page is about to send HTTP request.</li>
+<li><a href='#Network.requestServedFromCache'>Network.requestServedFromCache</a>: Fired if request ended up loading from cache.</li>
+<li><a href='#Network.responseReceived'>Network.responseReceived</a>: Fired when HTTP response is available.</li>
+<li><a href='#Network.dataReceived'>Network.dataReceived</a>: Fired when data chunk was received over the network.</li>
+<li><a href='#Network.loadingFinished'>Network.loadingFinished</a>: Fired when HTTP request has finished loading.</li>
+<li><a href='#Network.loadingFailed'>Network.loadingFailed</a>: Fired when HTTP request has failed to load.</li>
+<li><a href='#Network.requestServedFromMemoryCache'>Network.requestServedFromMemoryCache</a>: Fired when HTTP request has been served from memory cache.</li>
+<li><a href='#Network.webSocketWillSendHandshakeRequest'>Network.webSocketWillSendHandshakeRequest</a>: Fired when WebSocket is about to initiate handshake.</li>
+<li><a href='#Network.webSocketHandshakeResponseReceived'>Network.webSocketHandshakeResponseReceived</a>: Fired when WebSocket handshake response becomes available.</li>
+<li><a href='#Network.webSocketCreated'>Network.webSocketCreated</a>: Fired upon WebSocket creation.</li>
+<li><a href='#Network.webSocketClosed'>Network.webSocketClosed</a>: Fired when WebSocket is closed.</li>
+<li><a href='#Network.webSocketFrameReceived'>Network.webSocketFrameReceived</a>: Fired when WebSocket frame is received.</li>
+<li><a href='#Network.webSocketFrameError'>Network.webSocketFrameError</a>: Fired when WebSocket frame error occurs.</li>
+<li><a href='#Network.webSocketFrameSent'>Network.webSocketFrameSent</a>: Fired when WebSocket frame is sent.</li>
 </ul>
-<div id="Network_LoaderId" class="type">
-<h3>Network.LoaderId <span class="label">Type</span></h3>
+<div id='Network_LoaderId' class='type'>
+<h3>Network.LoaderId <span class='label'>Type</span></h3>
 <p>Unique loader identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Network_FrameId" class="type">
-<h3>Network.FrameId <span class="label">Type</span></h3>
+<div id='Network_FrameId' class='type'>
+<h3>Network.FrameId <span class='label'>Type</span></h3>
 <p>Unique frame identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Network_RequestId" class="type">
-<h3>Network.RequestId <span class="label">Type</span></h3>
+<div id='Network_RequestId' class='type'>
+<h3>Network.RequestId <span class='label'>Type</span></h3>
 <p>Unique request identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Network_Timestamp" class="type">
-<h3>Network.Timestamp <span class="label">Type</span></h3>
+<div id='Network_Timestamp' class='type'>
+<h3>Network.Timestamp <span class='label'>Type</span></h3>
 <p>Number of seconds since epoch.</p>
 <dl>
 <dd>Number</dd>
 </dl>
 </div>
-<div id="Network_Headers" class="type">
-<h3>Network.Headers <span class="label">Type</span></h3>
+<div id='Network_Headers' class='type'>
+<h3>Network.Headers <span class='label'>Type</span></h3>
 <p>Request / response headers as keys / values of JSON object.</p>
 </div>
-<div id="Network_ResourceTiming" class="type">
-<h3>Network.ResourceTiming <span class="label">Type</span></h3>
+<div id='Network_ResourceTiming' class='type'>
+<h3>Network.ResourceTiming <span class='label'>Type</span></h3>
 <p>Timing information for the request.</p>
 <dl>
 <dt>requestTime</dt>
-<dd>Number <span class="text">Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime.</span></dd>
+<dd>Number <span class='text'>Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime.</span></dd>
 <dt>proxyStart</dt>
-<dd>Number <span class="text">Started resolving proxy.</span></dd>
+<dd>Number <span class='text'>Started resolving proxy.</span></dd>
 <dt>proxyEnd</dt>
-<dd>Number <span class="text">Finished resolving proxy.</span></dd>
+<dd>Number <span class='text'>Finished resolving proxy.</span></dd>
 <dt>dnsStart</dt>
-<dd>Number <span class="text">Started DNS address resolve.</span></dd>
+<dd>Number <span class='text'>Started DNS address resolve.</span></dd>
 <dt>dnsEnd</dt>
-<dd>Number <span class="text">Finished DNS address resolve.</span></dd>
+<dd>Number <span class='text'>Finished DNS address resolve.</span></dd>
 <dt>connectStart</dt>
-<dd>Number <span class="text">Started connecting to the remote host.</span></dd>
+<dd>Number <span class='text'>Started connecting to the remote host.</span></dd>
 <dt>connectEnd</dt>
-<dd>Number <span class="text">Connected to the remote host.</span></dd>
+<dd>Number <span class='text'>Connected to the remote host.</span></dd>
 <dt>sslStart</dt>
-<dd>Number <span class="text">Started SSL handshake.</span></dd>
+<dd>Number <span class='text'>Started SSL handshake.</span></dd>
 <dt>sslEnd</dt>
-<dd>Number <span class="text">Finished SSL handshake.</span></dd>
+<dd>Number <span class='text'>Finished SSL handshake.</span></dd>
 <dt>sendStart</dt>
-<dd>Number <span class="text">Started sending request.</span></dd>
+<dd>Number <span class='text'>Started sending request.</span></dd>
 <dt>sendEnd</dt>
-<dd>Number <span class="text">Finished sending request.</span></dd>
+<dd>Number <span class='text'>Finished sending request.</span></dd>
 <dt>receiveHeadersEnd</dt>
-<dd>Number <span class="text">Finished receiving response headers.</span></dd>
+<dd>Number <span class='text'>Finished receiving response headers.</span></dd>
 </dl>
 </div>
-<div id="Network_Request" class="type">
-<h3>Network.Request <span class="label">Type</span></h3>
+<div id='Network_Request' class='type'>
+<h3>Network.Request <span class='label'>Type</span></h3>
 <p>HTTP request data.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Request URL.</span></dd>
+<dd>String <span class='text'>Request URL.</span></dd>
 <dt>method</dt>
-<dd>String <span class="text">HTTP request method.</span></dd>
+<dd>String <span class='text'>HTTP request method.</span></dd>
 <dt>headers</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">HTTP request headers.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>HTTP request headers.</span></dd>
 <dt>postData (optional)</dt>
-<dd>String <span class="text">HTTP POST request data.</span></dd>
+<dd>String <span class='text'>HTTP POST request data.</span></dd>
 </dl>
 </div>
-<div id="Network_Response" class="type">
-<h3>Network.Response <span class="label">Type</span></h3>
+<div id='Network_Response' class='type'>
+<h3>Network.Response <span class='label'>Type</span></h3>
 <p>HTTP response data.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Response URL.</span></dd>
+<dd>String <span class='text'>Response URL.</span></dd>
 <dt>status</dt>
-<dd>Number <span class="text">HTTP response status code.</span></dd>
+<dd>Number <span class='text'>HTTP response status code.</span></dd>
 <dt>statusText</dt>
-<dd>String <span class="text">HTTP response status text.</span></dd>
+<dd>String <span class='text'>HTTP response status text.</span></dd>
 <dt>headers</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">HTTP response headers.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>HTTP response headers.</span></dd>
 <dt>headersText (optional)</dt>
-<dd>String <span class="text">HTTP response headers text.</span></dd>
+<dd>String <span class='text'>HTTP response headers text.</span></dd>
 <dt>mimeType</dt>
-<dd>String <span class="text">Resource mimeType as determined by the browser.</span></dd>
+<dd>String <span class='text'>Resource mimeType as determined by the browser.</span></dd>
 <dt>requestHeaders (optional)</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">Refined HTTP request headers that were actually transmitted over the network.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>Refined HTTP request headers that were actually transmitted over the network.</span></dd>
 <dt>requestHeadersText (optional)</dt>
-<dd>String <span class="text">HTTP request headers text.</span></dd>
+<dd>String <span class='text'>HTTP request headers text.</span></dd>
 <dt>connectionReused</dt>
-<dd>Boolean <span class="text">Specifies whether physical connection was actually reused for this request.</span></dd>
+<dd>Boolean <span class='text'>Specifies whether physical connection was actually reused for this request.</span></dd>
 <dt>connectionId</dt>
-<dd>Number <span class="text">Physical connection id that was actually used for this request.</span></dd>
+<dd>Number <span class='text'>Physical connection id that was actually used for this request.</span></dd>
 <dt>fromDiskCache (optional)</dt>
-<dd>Boolean <span class="text">Specifies that the request was served from the disk cache.</span></dd>
+<dd>Boolean <span class='text'>Specifies that the request was served from the disk cache.</span></dd>
 <dt>timing (optional)</dt>
-<dd><a href="#Network.ResourceTiming">Network.ResourceTiming</a> <span class="text">Timing information for the given request.</span></dd>
+<dd><a href='#Network.ResourceTiming'>Network.ResourceTiming</a> <span class='text'>Timing information for the given request.</span></dd>
 </dl>
 </div>
-<div id="Network_WebSocketRequest" class="type">
-<h3>Network.WebSocketRequest <span class="label">Type</span></h3>
+<div id='Network_WebSocketRequest' class='type'>
+<h3>Network.WebSocketRequest <span class='label'>Type</span></h3>
 <p>WebSocket request data.</p>
 <dl>
 <dt>requestKey3</dt>
-<dd>String <span class="text">HTTP response status text.</span></dd>
+<dd>String <span class='text'>HTTP response status text.</span></dd>
 <dt>headers</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">HTTP response headers.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>HTTP response headers.</span></dd>
 </dl>
 </div>
-<div id="Network_WebSocketResponse" class="type">
-<h3>Network.WebSocketResponse <span class="label">Type</span></h3>
+<div id='Network_WebSocketResponse' class='type'>
+<h3>Network.WebSocketResponse <span class='label'>Type</span></h3>
 <p>WebSocket response data.</p>
 <dl>
 <dt>status</dt>
-<dd>Number <span class="text">HTTP response status code.</span></dd>
+<dd>Number <span class='text'>HTTP response status code.</span></dd>
 <dt>statusText</dt>
-<dd>String <span class="text">HTTP response status text.</span></dd>
+<dd>String <span class='text'>HTTP response status text.</span></dd>
 <dt>headers</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">HTTP response headers.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>HTTP response headers.</span></dd>
 <dt>challengeResponse</dt>
-<dd>String <span class="text">Challenge response.</span></dd>
+<dd>String <span class='text'>Challenge response.</span></dd>
 </dl>
 </div>
-<div id="Network_CachedResource" class="type">
-<h3>Network.CachedResource <span class="label">Type</span></h3>
+<div id='Network_WebSocketFrame' class='type'>
+<h3>Network.WebSocketFrame <span class='label'>Type</span></h3>
+<p>WebSocket frame data.</p>
+<dl>
+<dt>opcode</dt>
+<dd>Number <span class='text'>WebSocket frame opcode.</span></dd>
+<dt>mask</dt>
+<dd>Boolean <span class='text'>WebSocke frame mask.</span></dd>
+<dt>payloadData</dt>
+<dd>String <span class='text'>WebSocke frame payload data.</span></dd>
+</dl>
+</div>
+<div id='Network_CachedResource' class='type'>
+<h3>Network.CachedResource <span class='label'>Type</span></h3>
 <p>Information about the cached resource.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Resource URL.</span></dd>
+<dd>String <span class='text'>Resource URL.</span></dd>
 <dt>type</dt>
-<dd><a href="#Page.ResourceType">Page.ResourceType</a> <span class="text">Type of this resource.</span></dd>
+<dd><a href='#Page.ResourceType'>Page.ResourceType</a> <span class='text'>Type of this resource.</span></dd>
 <dt>response (optional)</dt>
-<dd><a href="#Network.Response">Network.Response</a> <span class="text">Cached response data.</span></dd>
+<dd><a href='#Network.Response'>Network.Response</a> <span class='text'>Cached response data.</span></dd>
 <dt>bodySize</dt>
-<dd>Number <span class="text">Cached response body size.</span></dd>
+<dd>Number <span class='text'>Cached response body size.</span></dd>
 </dl>
 </div>
-<div id="Network_Initiator" class="type">
-<h3>Network.Initiator <span class="label">Type</span></h3>
+<div id='Network_Initiator' class='type'>
+<h3>Network.Initiator <span class='label'>Type</span></h3>
 <p>Information about the request initiator.</p>
 <dl>
 <dt>type</dt>
-<dd>( parser | script | other ) <span class="text">Type of this initiator.</span></dd>
+<dd>( parser | script | other ) <span class='text'>Type of this initiator.</span></dd>
 <dt>stackTrace (optional)</dt>
-<dd><a href="#Console.StackTrace">Console.StackTrace</a> <span class="text">Initiator JavaScript stack trace, set for Script only.</span></dd>
+<dd><a href='#Console.StackTrace'>Console.StackTrace</a> <span class='text'>Initiator JavaScript stack trace, set for Script only.</span></dd>
 <dt>url (optional)</dt>
-<dd>String <span class="text">Initiator URL, set for Parser type only.</span></dd>
+<dd>String <span class='text'>Initiator URL, set for Parser type only.</span></dd>
 <dt>lineNumber (optional)</dt>
-<dd>Number <span class="text">Initiator line number, set for Parser type only.</span></dd>
+<dd>Number <span class='text'>Initiator line number, set for Parser type only.</span></dd>
 </dl>
 </div>
-<div id="Network_enable" class="command">
-<h3>Network.enable <span class="label label-success">Command</span></h3>
+<div id='Network_enable' class='command'>
+<h3>Network.enable <span class='label label-success'>Command</span></h3>
 <p>Enables network tracking, network events will now be delivered to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3977,8 +4533,8 @@ Memory.getDOMNodeCount(function callback(res) {
 Network.enable();
 </pre>
 </div>
-<div id="Network_disable" class="command">
-<h3>Network.disable <span class="label label-success">Command</span></h3>
+<div id='Network_disable' class='command'>
+<h3>Network.disable <span class='label label-success'>Command</span></h3>
 <p>Disables network tracking, prevents network events from being sent to the client.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -3986,12 +4542,12 @@ Network.enable();
 Network.disable();
 </pre>
 </div>
-<div id="Network_setUserAgentOverride" class="command">
-<h3>Network.setUserAgentOverride <span class="label label-success">Command</span></h3>
+<div id='Network_setUserAgentOverride' class='command'>
+<h3>Network.setUserAgentOverride <span class='label label-success'>Command</span></h3>
 <p>Allows overriding user agent with the given string.</p>
 <dl>
 <dt>userAgent</dt>
-<dd>String <span class="text">User agent to use.</span></dd>
+<dd>String <span class='text'>User agent to use.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -3999,12 +4555,12 @@ Network.disable();
 Network.setUserAgentOverride(userAgent);
 </pre>
 </div>
-<div id="Network_setExtraHTTPHeaders" class="command">
-<h3>Network.setExtraHTTPHeaders <span class="label label-success">Command</span></h3>
+<div id='Network_setExtraHTTPHeaders' class='command'>
+<h3>Network.setExtraHTTPHeaders <span class='label label-success'>Command</span></h3>
 <p>Specifies whether to always send extra HTTP headers with the requests from this page.</p>
 <dl>
 <dt>headers</dt>
-<dd><a href="#Network.Headers">Network.Headers</a> <span class="text">Map with extra HTTP headers.</span></dd>
+<dd><a href='#Network.Headers'>Network.Headers</a> <span class='text'>Map with extra HTTP headers.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4012,19 +4568,19 @@ Network.setUserAgentOverride(userAgent);
 Network.setExtraHTTPHeaders(headers);
 </pre>
 </div>
-<div id="Network_getResponseBody" class="command">
-<h3>Network.getResponseBody <span class="label label-success">Command</span></h3>
+<div id='Network_getResponseBody' class='command'>
+<h3>Network.getResponseBody <span class='label label-success'>Command</span></h3>
 <p>Returns content served for the given request.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Identifier of the network request to get content for.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Identifier of the network request to get content for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>body</dt>
-<dd>String <span class="text">Response body.</span></dd>
+<dd>String <span class='text'>Response body.</span></dd>
 <dt>base64Encoded</dt>
-<dd>Boolean <span class="text">True, if content was sent as base64.</span></dd>
+<dd>Boolean <span class='text'>True, if content was sent as base64.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4034,13 +4590,13 @@ Network.getResponseBody(requestId, function callback(res) {
 });
 </pre>
 </div>
-<div id="Network_canClearBrowserCache" class="command">
-<h3>Network.canClearBrowserCache <span class="label label-success">Command</span></h3>
+<div id='Network_canClearBrowserCache' class='command'>
+<h3>Network.canClearBrowserCache <span class='label label-success'>Command</span></h3>
 <p>Tells whether clearing browser cache is supported.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True if browser cache can be cleared.</span></dd>
+<dd>Boolean <span class='text'>True if browser cache can be cleared.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4050,8 +4606,8 @@ Network.canClearBrowserCache(function callback(res) {
 });
 </pre>
 </div>
-<div id="Network_clearBrowserCache" class="command">
-<h3>Network.clearBrowserCache <span class="label label-success">Command</span></h3>
+<div id='Network_clearBrowserCache' class='command'>
+<h3>Network.clearBrowserCache <span class='label label-success'>Command</span></h3>
 <p>Clears browser cache.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -4059,13 +4615,13 @@ Network.canClearBrowserCache(function callback(res) {
 Network.clearBrowserCache();
 </pre>
 </div>
-<div id="Network_canClearBrowserCookies" class="command">
-<h3>Network.canClearBrowserCookies <span class="label label-success">Command</span></h3>
+<div id='Network_canClearBrowserCookies' class='command'>
+<h3>Network.canClearBrowserCookies <span class='label label-success'>Command</span></h3>
 <p>Tells whether clearing browser cookies is supported.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True if browser cookies can be cleared.</span></dd>
+<dd>Boolean <span class='text'>True if browser cookies can be cleared.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4075,8 +4631,8 @@ Network.canClearBrowserCookies(function callback(res) {
 });
 </pre>
 </div>
-<div id="Network_clearBrowserCookies" class="command">
-<h3>Network.clearBrowserCookies <span class="label label-success">Command</span></h3>
+<div id='Network_clearBrowserCookies' class='command'>
+<h3>Network.clearBrowserCookies <span class='label label-success'>Command</span></h3>
 <p>Clears browser cookies.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -4084,12 +4640,12 @@ Network.canClearBrowserCookies(function callback(res) {
 Network.clearBrowserCookies();
 </pre>
 </div>
-<div id="Network_setCacheDisabled" class="command">
-<h3>Network.setCacheDisabled <span class="label label-success">Command</span></h3>
+<div id='Network_setCacheDisabled' class='command'>
+<h3>Network.setCacheDisabled <span class='label label-success'>Command</span></h3>
 <p>Toggles ignoring cache for each request. If <code>true</code>, cache will not be used.</p>
 <dl>
 <dt>cacheDisabled</dt>
-<dd>Boolean <span class="text">Cache disabled state.</span></dd>
+<dd>Boolean <span class='text'>Cache disabled state.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4097,43 +4653,41 @@ Network.clearBrowserCookies();
 Network.setCacheDisabled(cacheDisabled);
 </pre>
 </div>
-<div id="Network_requestWillBeSent" class="command">
-<h3>Network.requestWillBeSent <span class="label label-info">Event</span></h3>
+<div id='Network_requestWillBeSent' class='command'>
+<h3>Network.requestWillBeSent <span class='label label-info'>Event</span></h3>
 <p>Fired when page is about to send HTTP request.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame identifier.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame identifier.</span></dd>
 <dt>loaderId</dt>
-<dd><a href="#Network.LoaderId">Network.LoaderId</a> <span class="text">Loader identifier.</span></dd>
+<dd><a href='#Network.LoaderId'>Network.LoaderId</a> <span class='text'>Loader identifier.</span></dd>
 <dt>documentURL</dt>
-<dd>String <span class="text">URL of the document this request is loaded for.</span></dd>
+<dd>String <span class='text'>URL of the document this request is loaded for.</span></dd>
 <dt>request</dt>
-<dd><a href="#Network.Request">Network.Request</a> <span class="text">Request data.</span></dd>
+<dd><a href='#Network.Request'>Network.Request</a> <span class='text'>Request data.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>initiator</dt>
-<dd><a href="#Network.Initiator">Network.Initiator</a> <span class="text">Request initiator.</span></dd>
-<dt>stackTrace (optional)</dt>
-<dd><a href="#Console.StackTrace">Console.StackTrace</a> <span class="text">JavaScript stack trace upon issuing this request.</span></dd>
+<dd><a href='#Network.Initiator'>Network.Initiator</a> <span class='text'>Request initiator.</span></dd>
 <dt>redirectResponse (optional)</dt>
-<dd><a href="#Network.Response">Network.Response</a> <span class="text">Redirect response data.</span></dd>
+<dd><a href='#Network.Response'>Network.Response</a> <span class='text'>Redirect response data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Event: Network.requestWillBeSent
 function onRequestWillBeSent(res) {
-	// res = {requestId, frameId, loaderId, documentURL, request, timestamp, initiator, stackTrace, redirectResponse}
+	// res = {requestId, frameId, loaderId, documentURL, request, timestamp, initiator, redirectResponse}
 }
 </pre>
 </div>
-<div id="Network_requestServedFromCache" class="command">
-<h3>Network.requestServedFromCache <span class="label label-info">Event</span></h3>
+<div id='Network_requestServedFromCache' class='command'>
+<h3>Network.requestServedFromCache <span class='label label-info'>Event</span></h3>
 <p>Fired if request ended up loading from cache.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4143,22 +4697,22 @@ function onRequestServedFromCache(res) {
 }
 </pre>
 </div>
-<div id="Network_responseReceived" class="command">
-<h3>Network.responseReceived <span class="label label-info">Event</span></h3>
+<div id='Network_responseReceived' class='command'>
+<h3>Network.responseReceived <span class='label label-info'>Event</span></h3>
 <p>Fired when HTTP response is available.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame identifier.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame identifier.</span></dd>
 <dt>loaderId</dt>
-<dd><a href="#Network.LoaderId">Network.LoaderId</a> <span class="text">Loader identifier.</span></dd>
+<dd><a href='#Network.LoaderId'>Network.LoaderId</a> <span class='text'>Loader identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>type</dt>
-<dd><a href="#Page.ResourceType">Page.ResourceType</a> <span class="text">Resource type.</span></dd>
+<dd><a href='#Page.ResourceType'>Page.ResourceType</a> <span class='text'>Resource type.</span></dd>
 <dt>response</dt>
-<dd><a href="#Network.Response">Network.Response</a> <span class="text">Response data.</span></dd>
+<dd><a href='#Network.Response'>Network.Response</a> <span class='text'>Response data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4168,18 +4722,18 @@ function onResponseReceived(res) {
 }
 </pre>
 </div>
-<div id="Network_dataReceived" class="command">
-<h3>Network.dataReceived <span class="label label-info">Event</span></h3>
+<div id='Network_dataReceived' class='command'>
+<h3>Network.dataReceived <span class='label label-info'>Event</span></h3>
 <p>Fired when data chunk was received over the network.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>dataLength</dt>
-<dd>Integer <span class="text">Data chunk length.</span></dd>
+<dd>Integer <span class='text'>Data chunk length.</span></dd>
 <dt>encodedDataLength</dt>
-<dd>Integer <span class="text">Actual bytes received (might be less than dataLength for compressed encodings).</span></dd>
+<dd>Integer <span class='text'>Actual bytes received (might be less than dataLength for compressed encodings).</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4189,14 +4743,14 @@ function onDataReceived(res) {
 }
 </pre>
 </div>
-<div id="Network_loadingFinished" class="command">
-<h3>Network.loadingFinished <span class="label label-info">Event</span></h3>
+<div id='Network_loadingFinished' class='command'>
+<h3>Network.loadingFinished <span class='label label-info'>Event</span></h3>
 <p>Fired when HTTP request has finished loading.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4206,18 +4760,18 @@ function onLoadingFinished(res) {
 }
 </pre>
 </div>
-<div id="Network_loadingFailed" class="command">
-<h3>Network.loadingFailed <span class="label label-info">Event</span></h3>
+<div id='Network_loadingFailed' class='command'>
+<h3>Network.loadingFailed <span class='label label-info'>Event</span></h3>
 <p>Fired when HTTP request has failed to load.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>errorText</dt>
-<dd>String <span class="text">User friendly error message.</span></dd>
+<dd>String <span class='text'>User friendly error message.</span></dd>
 <dt>canceled (optional)</dt>
-<dd>Boolean <span class="text">True if loading was canceled.</span></dd>
+<dd>Boolean <span class='text'>True if loading was canceled.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4227,24 +4781,24 @@ function onLoadingFailed(res) {
 }
 </pre>
 </div>
-<div id="Network_requestServedFromMemoryCache" class="command">
-<h3>Network.requestServedFromMemoryCache <span class="label label-info">Event</span></h3>
+<div id='Network_requestServedFromMemoryCache' class='command'>
+<h3>Network.requestServedFromMemoryCache <span class='label label-info'>Event</span></h3>
 <p>Fired when HTTP request has been served from memory cache.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame identifier.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame identifier.</span></dd>
 <dt>loaderId</dt>
-<dd><a href="#Network.LoaderId">Network.LoaderId</a> <span class="text">Loader identifier.</span></dd>
+<dd><a href='#Network.LoaderId'>Network.LoaderId</a> <span class='text'>Loader identifier.</span></dd>
 <dt>documentURL</dt>
-<dd>String <span class="text">URL of the document this request is loaded for.</span></dd>
+<dd>String <span class='text'>URL of the document this request is loaded for.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>initiator</dt>
-<dd><a href="#Network.Initiator">Network.Initiator</a> <span class="text">Request initiator.</span></dd>
+<dd><a href='#Network.Initiator'>Network.Initiator</a> <span class='text'>Request initiator.</span></dd>
 <dt>resource</dt>
-<dd><a href="#Network.CachedResource">Network.CachedResource</a> <span class="text">Cached resource data.</span></dd>
+<dd><a href='#Network.CachedResource'>Network.CachedResource</a> <span class='text'>Cached resource data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4254,16 +4808,16 @@ function onRequestServedFromMemoryCache(res) {
 }
 </pre>
 </div>
-<div id="Network_webSocketWillSendHandshakeRequest" class="command">
-<h3>Network.webSocketWillSendHandshakeRequest <span class="label label-info">Event</span></h3>
+<div id='Network_webSocketWillSendHandshakeRequest' class='command'>
+<h3>Network.webSocketWillSendHandshakeRequest <span class='label label-info'>Event</span></h3>
 <p>Fired when WebSocket is about to initiate handshake.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>request</dt>
-<dd><a href="#Network.WebSocketRequest">Network.WebSocketRequest</a> <span class="text">WebSocket request data.</span></dd>
+<dd><a href='#Network.WebSocketRequest'>Network.WebSocketRequest</a> <span class='text'>WebSocket request data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4273,16 +4827,16 @@ function onWebSocketWillSendHandshakeRequest(res) {
 }
 </pre>
 </div>
-<div id="Network_webSocketHandshakeResponseReceived" class="command">
-<h3>Network.webSocketHandshakeResponseReceived <span class="label label-info">Event</span></h3>
+<div id='Network_webSocketHandshakeResponseReceived' class='command'>
+<h3>Network.webSocketHandshakeResponseReceived <span class='label label-info'>Event</span></h3>
 <p>Fired when WebSocket handshake response becomes available.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 <dt>response</dt>
-<dd><a href="#Network.WebSocketResponse">Network.WebSocketResponse</a> <span class="text">WebSocket response data.</span></dd>
+<dd><a href='#Network.WebSocketResponse'>Network.WebSocketResponse</a> <span class='text'>WebSocket response data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4292,14 +4846,14 @@ function onWebSocketHandshakeResponseReceived(res) {
 }
 </pre>
 </div>
-<div id="Network_webSocketCreated" class="command">
-<h3>Network.webSocketCreated <span class="label label-info">Event</span></h3>
+<div id='Network_webSocketCreated' class='command'>
+<h3>Network.webSocketCreated <span class='label label-info'>Event</span></h3>
 <p>Fired upon WebSocket creation.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">WebSocket request URL.</span></dd>
+<dd>String <span class='text'>WebSocket request URL.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4309,14 +4863,14 @@ function onWebSocketCreated(res) {
 }
 </pre>
 </div>
-<div id="Network_webSocketClosed" class="command">
-<h3>Network.webSocketClosed <span class="label label-info">Event</span></h3>
+<div id='Network_webSocketClosed' class='command'>
+<h3>Network.webSocketClosed <span class='label label-info'>Event</span></h3>
 <p>Fired when WebSocket is closed.</p>
 <dl>
 <dt>requestId</dt>
-<dd><a href="#Network.RequestId">Network.RequestId</a> <span class="text">Request identifier.</span></dd>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
 <dt>timestamp</dt>
-<dd><a href="#Network.Timestamp">Network.Timestamp</a> <span class="text">Timestamp.</span></dd>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4326,139 +4880,206 @@ function onWebSocketClosed(res) {
 }
 </pre>
 </div>
+<div id='Network_webSocketFrameReceived' class='command'>
+<h3>Network.webSocketFrameReceived <span class='label label-info'>Event</span></h3>
+<p>Fired when WebSocket frame is received.</p>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
+<dt>timestamp</dt>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
+<dt>response</dt>
+<dd><a href='#Network.WebSocketFrame'>Network.WebSocketFrame</a> <span class='text'>WebSocket response data.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: Network.webSocketFrameReceived
+function onWebSocketFrameReceived(res) {
+	// res = {requestId, timestamp, response}
+}
+</pre>
+</div>
+<div id='Network_webSocketFrameError' class='command'>
+<h3>Network.webSocketFrameError <span class='label label-info'>Event</span></h3>
+<p>Fired when WebSocket frame error occurs.</p>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
+<dt>timestamp</dt>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
+<dt>errorMessage</dt>
+<dd>String <span class='text'>WebSocket frame error message.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: Network.webSocketFrameError
+function onWebSocketFrameError(res) {
+	// res = {requestId, timestamp, errorMessage}
+}
+</pre>
+</div>
+<div id='Network_webSocketFrameSent' class='command'>
+<h3>Network.webSocketFrameSent <span class='label label-info'>Event</span></h3>
+<p>Fired when WebSocket frame is sent.</p>
+<dl>
+<dt>requestId</dt>
+<dd><a href='#Network.RequestId'>Network.RequestId</a> <span class='text'>Request identifier.</span></dd>
+<dt>timestamp</dt>
+<dd><a href='#Network.Timestamp'>Network.Timestamp</a> <span class='text'>Timestamp.</span></dd>
+<dt>response</dt>
+<dd><a href='#Network.WebSocketFrame'>Network.WebSocketFrame</a> <span class='text'>WebSocket response data.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: Network.webSocketFrameSent
+function onWebSocketFrameSent(res) {
+	// res = {requestId, timestamp, response}
+}
+</pre>
+</div>
 </section>
-<section id="Page" class="domain">
+<section id='Page' class='domain'>
 <h1>Page</h1>
 <p>Actions and events related to the inspected page belong to the page domain.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Page.ResourceType">Page.ResourceType</a>: Resource type as it was perceived by the rendering engine.</li>
-<li><a href="#Page.Frame">Page.Frame</a>: Information about the Frame on the page.</li>
-<li><a href="#Page.FrameResourceTree">Page.FrameResourceTree</a>: Information about the Frame hierarchy along with their cached resources.</li>
-<li><a href="#Page.SearchMatch">Page.SearchMatch</a>: Search match for resource.</li>
-<li><a href="#Page.SearchResult">Page.SearchResult</a>: Search result for resource.</li>
-<li><a href="#Page.Cookie">Page.Cookie</a>: Cookie object</li>
-<li><a href="#Page.ScriptIdentifier">Page.ScriptIdentifier</a>: Unique script identifier.</li>
+<li><a href='#Page.ResourceType'>Page.ResourceType</a>: Resource type as it was perceived by the rendering engine.</li>
+<li><a href='#Page.Frame'>Page.Frame</a>: Information about the Frame on the page.</li>
+<li><a href='#Page.FrameResourceTree'>Page.FrameResourceTree</a>: Information about the Frame hierarchy along with their cached resources.</li>
+<li><a href='#Page.SearchMatch'>Page.SearchMatch</a>: Search match for resource.</li>
+<li><a href='#Page.SearchResult'>Page.SearchResult</a>: Search result for resource.</li>
+<li><a href='#Page.Cookie'>Page.Cookie</a>: Cookie object</li>
+<li><a href='#Page.ScriptIdentifier'>Page.ScriptIdentifier</a>: Unique script identifier.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Page.enable">Page.enable</a>: Enables page domain notifications.</li>
-<li><a href="#Page.disable">Page.disable</a>: Disables page domain notifications.</li>
-<li><a href="#Page.addScriptToEvaluateOnLoad">Page.addScriptToEvaluateOnLoad</a></li>
-<li><a href="#Page.removeScriptToEvaluateOnLoad">Page.removeScriptToEvaluateOnLoad</a></li>
-<li><a href="#Page.reload">Page.reload</a>: Reloads given page optionally ignoring the cache.</li>
-<li><a href="#Page.navigate">Page.navigate</a>: Navigates current page to the given URL.</li>
-<li><a href="#Page.getCookies">Page.getCookies</a>: Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the cookie field or string cookie representation using cookieString.</li>
-<li><a href="#Page.deleteCookie">Page.deleteCookie</a>: Deletes browser cookie with given name for the given domain.</li>
-<li><a href="#Page.getResourceTree">Page.getResourceTree</a>: Returns present frame / resource tree structure.</li>
-<li><a href="#Page.getResourceContent">Page.getResourceContent</a>: Returns content of the given resource.</li>
-<li><a href="#Page.searchInResource">Page.searchInResource</a>: Searches for given string in resource content.</li>
-<li><a href="#Page.searchInResources">Page.searchInResources</a>: Searches for given string in frame / resource tree structure.</li>
-<li><a href="#Page.setDocumentContent">Page.setDocumentContent</a>: Sets given markup as the document's HTML.</li>
-<li><a href="#Page.setScreenSizeOverride">Page.setScreenSizeOverride</a>: Overrides the values of window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results</li>
-<li><a href="#Page.setShowPaintRects">Page.setShowPaintRects</a>: Requests that backend shows paint rectangles</li>
+<li><a href='#Page.enable'>Page.enable</a>: Enables page domain notifications.</li>
+<li><a href='#Page.disable'>Page.disable</a>: Disables page domain notifications.</li>
+<li><a href='#Page.addScriptToEvaluateOnLoad'>Page.addScriptToEvaluateOnLoad</a></li>
+<li><a href='#Page.removeScriptToEvaluateOnLoad'>Page.removeScriptToEvaluateOnLoad</a></li>
+<li><a href='#Page.reload'>Page.reload</a>: Reloads given page optionally ignoring the cache.</li>
+<li><a href='#Page.navigate'>Page.navigate</a>: Navigates current page to the given URL.</li>
+<li><a href='#Page.getCookies'>Page.getCookies</a>: Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the cookie field or string cookie representation using cookieString.</li>
+<li><a href='#Page.deleteCookie'>Page.deleteCookie</a>: Deletes browser cookie with given name for the given domain.</li>
+<li><a href='#Page.getResourceTree'>Page.getResourceTree</a>: Returns present frame / resource tree structure.</li>
+<li><a href='#Page.getResourceContent'>Page.getResourceContent</a>: Returns content of the given resource.</li>
+<li><a href='#Page.searchInResource'>Page.searchInResource</a>: Searches for given string in resource content.</li>
+<li><a href='#Page.searchInResources'>Page.searchInResources</a>: Searches for given string in frame / resource tree structure.</li>
+<li><a href='#Page.setDocumentContent'>Page.setDocumentContent</a>: Sets given markup as the document's HTML.</li>
+<li><a href='#Page.canOverrideDeviceMetrics'>Page.canOverrideDeviceMetrics</a>: Checks whether setDeviceMetricsOverride can be invoked.</li>
+<li><a href='#Page.setDeviceMetricsOverride'>Page.setDeviceMetricsOverride</a>: Overrides the values of device screen dimensions (window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results) and the font scale factor.</li>
+<li><a href='#Page.setShowPaintRects'>Page.setShowPaintRects</a>: Requests that backend shows paint rectangles</li>
+<li><a href='#Page.getScriptExecutionStatus'>Page.getScriptExecutionStatus</a>: Determines if scripts can be executed in the page.</li>
+<li><a href='#Page.setScriptExecutionDisabled'>Page.setScriptExecutionDisabled</a>: Switches script execution in the page.</li>
+<li><a href='#Page.setGeolocationOverride'>Page.setGeolocationOverride</a>: Overrides the Geolocation Position or Error.</li>
+<li><a href='#Page.clearGeolocationOverride'>Page.clearGeolocationOverride</a>: Clears the overriden Geolocation Position and Error.</li>
+<li><a href='#Page.canOverrideGeolocation'>Page.canOverrideGeolocation</a>: Checks if Geolocation can be overridden.</li>
+<li><a href='#Page.setDeviceOrientationOverride'>Page.setDeviceOrientationOverride</a>: Overrides the Device Orientation.</li>
+<li><a href='#Page.clearDeviceOrientationOverride'>Page.clearDeviceOrientationOverride</a>: Clears the overridden Device Orientation.</li>
+<li><a href='#Page.canOverrideDeviceOrientation'>Page.canOverrideDeviceOrientation</a>: Check the backend if Web Inspector can override the device orientation.</li>
+<li><a href='#Page.setTouchEmulationEnabled'>Page.setTouchEmulationEnabled</a>: Toggles mouse event-based touch event emulation.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Page.domContentEventFired">Page.domContentEventFired</a></li>
-<li><a href="#Page.loadEventFired">Page.loadEventFired</a></li>
-<li><a href="#Page.frameNavigated">Page.frameNavigated</a>: Fired once navigation of the frame has completed. Frame is now associated with the new loader.</li>
-<li><a href="#Page.frameDetached">Page.frameDetached</a>: Fired when frame has been detached from its parent.</li>
+<li><a href='#Page.domContentEventFired'>Page.domContentEventFired</a></li>
+<li><a href='#Page.loadEventFired'>Page.loadEventFired</a></li>
+<li><a href='#Page.frameNavigated'>Page.frameNavigated</a>: Fired once navigation of the frame has completed. Frame is now associated with the new loader.</li>
+<li><a href='#Page.frameDetached'>Page.frameDetached</a>: Fired when frame has been detached from its parent.</li>
 </ul>
-<div id="Page_ResourceType" class="type">
-<h3>Page.ResourceType <span class="label">Type</span></h3>
+<div id='Page_ResourceType' class='type'>
+<h3>Page.ResourceType <span class='label'>Type</span></h3>
 <p>Resource type as it was perceived by the rendering engine.</p>
 <dl>
 <dd>( Document | Stylesheet | Image | Font | Script | XHR | WebSocket | Other )</dd>
 </dl>
 </div>
-<div id="Page_Frame" class="type">
-<h3>Page.Frame <span class="label">Type</span></h3>
+<div id='Page_Frame' class='type'>
+<h3>Page.Frame <span class='label'>Type</span></h3>
 <p>Information about the Frame on the page.</p>
 <dl>
 <dt>id</dt>
-<dd>String <span class="text">Frame unique identifier.</span></dd>
+<dd>String <span class='text'>Frame unique identifier.</span></dd>
 <dt>parentId (optional)</dt>
-<dd>String <span class="text">Parent frame identifier.</span></dd>
+<dd>String <span class='text'>Parent frame identifier.</span></dd>
 <dt>loaderId</dt>
-<dd><a href="#Network.LoaderId">Network.LoaderId</a> <span class="text">Identifier of the loader associated with this frame.</span></dd>
+<dd><a href='#Network.LoaderId'>Network.LoaderId</a> <span class='text'>Identifier of the loader associated with this frame.</span></dd>
 <dt>name (optional)</dt>
-<dd>String <span class="text">Frame's name as specified in the tag.</span></dd>
+<dd>String <span class='text'>Frame's name as specified in the tag.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">Frame document's URL.</span></dd>
+<dd>String <span class='text'>Frame document's URL.</span></dd>
 <dt>securityOrigin (optional)</dt>
-<dd>String <span class="text">Frame document's security origin.</span></dd>
+<dd>String <span class='text'>Frame document's security origin.</span></dd>
 <dt>mimeType</dt>
-<dd>String <span class="text">Frame document's mimeType as determined by the browser.</span></dd>
+<dd>String <span class='text'>Frame document's mimeType as determined by the browser.</span></dd>
 </dl>
 </div>
-<div id="Page_FrameResourceTree" class="type">
-<h3>Page.FrameResourceTree <span class="label">Type</span></h3>
+<div id='Page_FrameResourceTree' class='type'>
+<h3>Page.FrameResourceTree <span class='label'>Type</span></h3>
 <p>Information about the Frame hierarchy along with their cached resources.</p>
 <dl>
 <dt>frame</dt>
-<dd><a href="#Page.Frame">Page.Frame</a> <span class="text">Frame information for this tree item.</span></dd>
+<dd><a href='#Page.Frame'>Page.Frame</a> <span class='text'>Frame information for this tree item.</span></dd>
 <dt>childFrames (optional)</dt>
-<dd>[<a href="#Page.FrameResourceTree">Page.FrameResourceTree</a>] <span class="text">Child frames.</span></dd>
+<dd>[<a href='#Page.FrameResourceTree'>Page.FrameResourceTree</a>] <span class='text'>Child frames.</span></dd>
 <dt>resources</dt>
-<dd>[Object] <span class="text">Information about frame resources.</span></dd>
+<dd>[Object] <span class='text'>Information about frame resources.</span></dd>
 </dl>
 </div>
-<div id="Page_SearchMatch" class="type">
-<h3>Page.SearchMatch <span class="label">Type</span></h3>
+<div id='Page_SearchMatch' class='type'>
+<h3>Page.SearchMatch <span class='label'>Type</span></h3>
 <p>Search match for resource.</p>
 <dl>
 <dt>lineNumber</dt>
-<dd>Number <span class="text">Line number in resource content.</span></dd>
+<dd>Number <span class='text'>Line number in resource content.</span></dd>
 <dt>lineContent</dt>
-<dd>String <span class="text">Line with match content.</span></dd>
+<dd>String <span class='text'>Line with match content.</span></dd>
 </dl>
 </div>
-<div id="Page_SearchResult" class="type">
-<h3>Page.SearchResult <span class="label">Type</span></h3>
+<div id='Page_SearchResult' class='type'>
+<h3>Page.SearchResult <span class='label'>Type</span></h3>
 <p>Search result for resource.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">Resource URL.</span></dd>
+<dd>String <span class='text'>Resource URL.</span></dd>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Resource frame id.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Resource frame id.</span></dd>
 <dt>matchesCount</dt>
-<dd>Number <span class="text">Number of matches in the resource content.</span></dd>
+<dd>Number <span class='text'>Number of matches in the resource content.</span></dd>
 </dl>
 </div>
-<div id="Page_Cookie" class="type">
-<h3>Page.Cookie <span class="label">Type</span></h3>
+<div id='Page_Cookie' class='type'>
+<h3>Page.Cookie <span class='label'>Type</span></h3>
 <p>Cookie object</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Cookie name.</span></dd>
+<dd>String <span class='text'>Cookie name.</span></dd>
 <dt>value</dt>
-<dd>String <span class="text">Cookie value.</span></dd>
+<dd>String <span class='text'>Cookie value.</span></dd>
 <dt>domain</dt>
-<dd>String <span class="text">Cookie domain.</span></dd>
+<dd>String <span class='text'>Cookie domain.</span></dd>
 <dt>path</dt>
-<dd>String <span class="text">Cookie path.</span></dd>
+<dd>String <span class='text'>Cookie path.</span></dd>
 <dt>expires</dt>
-<dd>Integer <span class="text">Cookie expires.</span></dd>
+<dd>Number <span class='text'>Cookie expires.</span></dd>
 <dt>size</dt>
-<dd>Integer <span class="text">Cookie size.</span></dd>
+<dd>Integer <span class='text'>Cookie size.</span></dd>
 <dt>httpOnly</dt>
-<dd>Boolean <span class="text">True if cookie is http-only.</span></dd>
+<dd>Boolean <span class='text'>True if cookie is http-only.</span></dd>
 <dt>secure</dt>
-<dd>Boolean <span class="text">True if cookie is secure.</span></dd>
+<dd>Boolean <span class='text'>True if cookie is secure.</span></dd>
 <dt>session</dt>
-<dd>Boolean <span class="text">True in case of session cookie.</span></dd>
+<dd>Boolean <span class='text'>True in case of session cookie.</span></dd>
 </dl>
 </div>
-<div id="Page_ScriptIdentifier" class="type">
-<h3>Page.ScriptIdentifier <span class="label">Type</span></h3>
+<div id='Page_ScriptIdentifier' class='type'>
+<h3>Page.ScriptIdentifier <span class='label'>Type</span></h3>
 <p>Unique script identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Page_enable" class="command">
-<h3>Page.enable <span class="label label-success">Command</span></h3>
+<div id='Page_enable' class='command'>
+<h3>Page.enable <span class='label label-success'>Command</span></h3>
 <p>Enables page domain notifications.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -4466,8 +5087,8 @@ function onWebSocketClosed(res) {
 Page.enable();
 </pre>
 </div>
-<div id="Page_disable" class="command">
-<h3>Page.disable <span class="label label-success">Command</span></h3>
+<div id='Page_disable' class='command'>
+<h3>Page.disable <span class='label label-success'>Command</span></h3>
 <p>Disables page domain notifications.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -4475,8 +5096,8 @@ Page.enable();
 Page.disable();
 </pre>
 </div>
-<div id="Page_addScriptToEvaluateOnLoad" class="command">
-<h3>Page.addScriptToEvaluateOnLoad <span class="label label-success">Command</span></h3>
+<div id='Page_addScriptToEvaluateOnLoad' class='command'>
+<h3>Page.addScriptToEvaluateOnLoad <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>scriptSource</dt>
 <dd>String</dd>
@@ -4484,7 +5105,7 @@ Page.disable();
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>identifier</dt>
-<dd><a href="#Page.ScriptIdentifier">Page.ScriptIdentifier</a> <span class="text">Identifier of the added script.</span></dd>
+<dd><a href='#Page.ScriptIdentifier'>Page.ScriptIdentifier</a> <span class='text'>Identifier of the added script.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4494,11 +5115,11 @@ Page.addScriptToEvaluateOnLoad(scriptSource, function callback(res) {
 });
 </pre>
 </div>
-<div id="Page_removeScriptToEvaluateOnLoad" class="command">
-<h3>Page.removeScriptToEvaluateOnLoad <span class="label label-success">Command</span></h3>
+<div id='Page_removeScriptToEvaluateOnLoad' class='command'>
+<h3>Page.removeScriptToEvaluateOnLoad <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>identifier</dt>
-<dd><a href="#Page.ScriptIdentifier">Page.ScriptIdentifier</a></dd>
+<dd><a href='#Page.ScriptIdentifier'>Page.ScriptIdentifier</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4506,14 +5127,14 @@ Page.addScriptToEvaluateOnLoad(scriptSource, function callback(res) {
 Page.removeScriptToEvaluateOnLoad(identifier);
 </pre>
 </div>
-<div id="Page_reload" class="command">
-<h3>Page.reload <span class="label label-success">Command</span></h3>
+<div id='Page_reload' class='command'>
+<h3>Page.reload <span class='label label-success'>Command</span></h3>
 <p>Reloads given page optionally ignoring the cache.</p>
 <dl>
 <dt>ignoreCache (optional)</dt>
-<dd>Boolean <span class="text">If true, browser cache is ignored (as if the user pressed Shift+refresh).</span></dd>
+<dd>Boolean <span class='text'>If true, browser cache is ignored (as if the user pressed Shift+refresh).</span></dd>
 <dt>scriptToEvaluateOnLoad (optional)</dt>
-<dd>String <span class="text">If set, the script will be injected into all frames of the inspected page after reload.</span></dd>
+<dd>String <span class='text'>If set, the script will be injected into all frames of the inspected page after reload.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4521,12 +5142,12 @@ Page.removeScriptToEvaluateOnLoad(identifier);
 Page.reload(ignoreCache, scriptToEvaluateOnLoad);
 </pre>
 </div>
-<div id="Page_navigate" class="command">
-<h3>Page.navigate <span class="label label-success">Command</span></h3>
+<div id='Page_navigate' class='command'>
+<h3>Page.navigate <span class='label label-success'>Command</span></h3>
 <p>Navigates current page to the given URL.</p>
 <dl>
 <dt>url</dt>
-<dd>String <span class="text">URL to navigate the page to.</span></dd>
+<dd>String <span class='text'>URL to navigate the page to.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4534,15 +5155,15 @@ Page.reload(ignoreCache, scriptToEvaluateOnLoad);
 Page.navigate(url);
 </pre>
 </div>
-<div id="Page_getCookies" class="command">
-<h3>Page.getCookies <span class="label label-success">Command</span></h3>
+<div id='Page_getCookies' class='command'>
+<h3>Page.getCookies <span class='label label-success'>Command</span></h3>
 <p>Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the <code>cookie</code> field or string cookie representation using <code>cookieString</code>.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>cookies</dt>
-<dd>[<a href="#Page.Cookie">Page.Cookie</a>] <span class="text">Array of cookie objects.</span></dd>
+<dd>[<a href='#Page.Cookie'>Page.Cookie</a>] <span class='text'>Array of cookie objects.</span></dd>
 <dt>cookiesString</dt>
-<dd>String <span class="text">document.cookie string representation of the cookies.</span></dd>
+<dd>String <span class='text'>document.cookie string representation of the cookies.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4552,14 +5173,14 @@ Page.getCookies(function callback(res) {
 });
 </pre>
 </div>
-<div id="Page_deleteCookie" class="command">
-<h3>Page.deleteCookie <span class="label label-success">Command</span></h3>
+<div id='Page_deleteCookie' class='command'>
+<h3>Page.deleteCookie <span class='label label-success'>Command</span></h3>
 <p>Deletes browser cookie with given name for the given domain.</p>
 <dl>
 <dt>cookieName</dt>
-<dd>String <span class="text">Name of the cookie to remove.</span></dd>
+<dd>String <span class='text'>Name of the cookie to remove.</span></dd>
 <dt>domain</dt>
-<dd>String <span class="text">Domain of the cookie to remove.</span></dd>
+<dd>String <span class='text'>Domain of the cookie to remove.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4567,13 +5188,13 @@ Page.getCookies(function callback(res) {
 Page.deleteCookie(cookieName, domain);
 </pre>
 </div>
-<div id="Page_getResourceTree" class="command">
-<h3>Page.getResourceTree <span class="label label-success">Command</span></h3>
+<div id='Page_getResourceTree' class='command'>
+<h3>Page.getResourceTree <span class='label label-success'>Command</span></h3>
 <p>Returns present frame / resource tree structure.</p>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>frameTree</dt>
-<dd><a href="#Page.FrameResourceTree">Page.FrameResourceTree</a> <span class="text">Present frame / resource tree structure.</span></dd>
+<dd><a href='#Page.FrameResourceTree'>Page.FrameResourceTree</a> <span class='text'>Present frame / resource tree structure.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4583,21 +5204,21 @@ Page.getResourceTree(function callback(res) {
 });
 </pre>
 </div>
-<div id="Page_getResourceContent" class="command">
-<h3>Page.getResourceContent <span class="label label-success">Command</span></h3>
+<div id='Page_getResourceContent' class='command'>
+<h3>Page.getResourceContent <span class='label label-success'>Command</span></h3>
 <p>Returns content of the given resource.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id to get resource for.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id to get resource for.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">URL of the resource to get content for.</span></dd>
+<dd>String <span class='text'>URL of the resource to get content for.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>content</dt>
-<dd>String <span class="text">Resource content.</span></dd>
+<dd>String <span class='text'>Resource content.</span></dd>
 <dt>base64Encoded</dt>
-<dd>Boolean <span class="text">True, if content was served as base64.</span></dd>
+<dd>Boolean <span class='text'>True, if content was served as base64.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4607,25 +5228,25 @@ Page.getResourceContent(frameId, url, function callback(res) {
 });
 </pre>
 </div>
-<div id="Page_searchInResource" class="command">
-<h3>Page.searchInResource <span class="label label-success">Command</span></h3>
+<div id='Page_searchInResource' class='command'>
+<h3>Page.searchInResource <span class='label label-success'>Command</span></h3>
 <p>Searches for given string in resource content.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id for resource to search in.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id for resource to search in.</span></dd>
 <dt>url</dt>
-<dd>String <span class="text">URL of the resource to search in.</span></dd>
+<dd>String <span class='text'>URL of the resource to search in.</span></dd>
 <dt>query</dt>
-<dd>String <span class="text">String to search for.</span></dd>
+<dd>String <span class='text'>String to search for.</span></dd>
 <dt>caseSensitive (optional)</dt>
-<dd>Boolean <span class="text">If true, search is case sensitive.</span></dd>
+<dd>Boolean <span class='text'>If true, search is case sensitive.</span></dd>
 <dt>isRegex (optional)</dt>
-<dd>Boolean <span class="text">If true, treats string parameter as regex.</span></dd>
+<dd>Boolean <span class='text'>If true, treats string parameter as regex.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>[<a href="#Page.SearchMatch">Page.SearchMatch</a>] <span class="text">List of search matches.</span></dd>
+<dd>[<a href='#Page.SearchMatch'>Page.SearchMatch</a>] <span class='text'>List of search matches.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4635,21 +5256,21 @@ Page.searchInResource(frameId, url, query, caseSensitive, isRegex, function call
 });
 </pre>
 </div>
-<div id="Page_searchInResources" class="command">
-<h3>Page.searchInResources <span class="label label-success">Command</span></h3>
+<div id='Page_searchInResources' class='command'>
+<h3>Page.searchInResources <span class='label label-success'>Command</span></h3>
 <p>Searches for given string in frame / resource tree structure.</p>
 <dl>
 <dt>text</dt>
-<dd>String <span class="text">String to search for.</span></dd>
+<dd>String <span class='text'>String to search for.</span></dd>
 <dt>caseSensitive (optional)</dt>
-<dd>Boolean <span class="text">If true, search is case sensitive.</span></dd>
+<dd>Boolean <span class='text'>If true, search is case sensitive.</span></dd>
 <dt>isRegex (optional)</dt>
-<dd>Boolean <span class="text">If true, treats string parameter as regex.</span></dd>
+<dd>Boolean <span class='text'>If true, treats string parameter as regex.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>[<a href="#Page.SearchResult">Page.SearchResult</a>] <span class="text">List of search results.</span></dd>
+<dd>[<a href='#Page.SearchResult'>Page.SearchResult</a>] <span class='text'>List of search results.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4659,14 +5280,14 @@ Page.searchInResources(text, caseSensitive, isRegex, function callback(res) {
 });
 </pre>
 </div>
-<div id="Page_setDocumentContent" class="command">
-<h3>Page.setDocumentContent <span class="label label-success">Command</span></h3>
+<div id='Page_setDocumentContent' class='command'>
+<h3>Page.setDocumentContent <span class='label label-success'>Command</span></h3>
 <p>Sets given markup as the document's HTML.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Frame id to set HTML for.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Frame id to set HTML for.</span></dd>
 <dt>html</dt>
-<dd>String <span class="text">HTML content to set.</span></dd>
+<dd>String <span class='text'>HTML content to set.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4674,27 +5295,47 @@ Page.searchInResources(text, caseSensitive, isRegex, function callback(res) {
 Page.setDocumentContent(frameId, html);
 </pre>
 </div>
-<div id="Page_setScreenSizeOverride" class="command">
-<h3>Page.setScreenSizeOverride <span class="label label-success">Command</span></h3>
-<p>Overrides the values of window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results</p>
+<div id='Page_canOverrideDeviceMetrics' class='command'>
+<h3>Page.canOverrideDeviceMetrics <span class='label label-success'>Command</span></h3>
+<p>Checks whether <code>setDeviceMetricsOverride</code> can be invoked.</p>
+<h4>Callback Parameters:</h4>
 <dl>
-<dt>width</dt>
-<dd>Integer <span class="text">Overriding width value in pixels (minimum 0, maximum 10000000). 0 disables the override.</span></dd>
-<dt>height</dt>
-<dd>Integer <span class="text">Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override.</span></dd>
+<dt>result</dt>
+<dd>Boolean <span class='text'>If true, <code>setDeviceMetricsOverride</code> can safely be invoked on the agent.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
-// WebInspector Command: Page.setScreenSizeOverride
-Page.setScreenSizeOverride(width, height);
+// WebInspector Command: Page.canOverrideDeviceMetrics
+Page.canOverrideDeviceMetrics(function callback(res) {
+	// res = {result}
+});
 </pre>
 </div>
-<div id="Page_setShowPaintRects" class="command">
-<h3>Page.setShowPaintRects <span class="label label-success">Command</span></h3>
+<div id='Page_setDeviceMetricsOverride' class='command'>
+<h3>Page.setDeviceMetricsOverride <span class='label label-success'>Command</span></h3>
+<p>Overrides the values of device screen dimensions (window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media query results) and the font scale factor.</p>
+<dl>
+<dt>width</dt>
+<dd>Integer <span class='text'>Overriding width value in pixels (minimum 0, maximum 10000000). 0 disables the override.</span></dd>
+<dt>height</dt>
+<dd>Integer <span class='text'>Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override.</span></dd>
+<dt>fontScaleFactor</dt>
+<dd>Number <span class='text'>Overriding font scale factor value (must be positive). 1 disables the override.</span></dd>
+<dt>fitWindow</dt>
+<dd>Boolean <span class='text'>Whether a view that exceeds the available browser window area should be scaled down to fit.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.setDeviceMetricsOverride
+Page.setDeviceMetricsOverride(width, height, fontScaleFactor, fitWindow);
+</pre>
+</div>
+<div id='Page_setShowPaintRects' class='command'>
+<h3>Page.setShowPaintRects <span class='label label-success'>Command</span></h3>
 <p>Requests that backend shows paint rectangles</p>
 <dl>
 <dt>result</dt>
-<dd>Boolean <span class="text">True for showing paint rectangles</span></dd>
+<dd>Boolean <span class='text'>True for showing paint rectangles</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4702,8 +5343,134 @@ Page.setScreenSizeOverride(width, height);
 Page.setShowPaintRects(result);
 </pre>
 </div>
-<div id="Page_domContentEventFired" class="command">
-<h3>Page.domContentEventFired <span class="label label-info">Event</span></h3>
+<div id='Page_getScriptExecutionStatus' class='command'>
+<h3>Page.getScriptExecutionStatus <span class='label label-success'>Command</span></h3>
+<p>Determines if scripts can be executed in the page.</p>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>result</dt>
+<dd>( allowed | disabled | forbidden ) <span class='text'>Script execution status: "allowed" if scripts can be executed, "disabled" if script execution has been disabled through page settings, "forbidden" if script execution for the given page is not possible for other reasons.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.getScriptExecutionStatus
+Page.getScriptExecutionStatus(function callback(res) {
+	// res = {result}
+});
+</pre>
+</div>
+<div id='Page_setScriptExecutionDisabled' class='command'>
+<h3>Page.setScriptExecutionDisabled <span class='label label-success'>Command</span></h3>
+<p>Switches script execution in the page.</p>
+<dl>
+<dt>value</dt>
+<dd>Boolean <span class='text'>Whether script execution should be disabled in the page.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.setScriptExecutionDisabled
+Page.setScriptExecutionDisabled(value);
+</pre>
+</div>
+<div id='Page_setGeolocationOverride' class='command'>
+<h3>Page.setGeolocationOverride <span class='label label-success'>Command</span></h3>
+<p>Overrides the Geolocation Position or Error.</p>
+<dl>
+<dt>latitude (optional)</dt>
+<dd>Number <span class='text'>Mock longitude</span></dd>
+<dt>longitude (optional)</dt>
+<dd>Number <span class='text'>Mock latitude</span></dd>
+<dt>accuracy (optional)</dt>
+<dd>Number <span class='text'>Mock accuracy</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.setGeolocationOverride
+Page.setGeolocationOverride(latitude, longitude, accuracy);
+</pre>
+</div>
+<div id='Page_clearGeolocationOverride' class='command'>
+<h3>Page.clearGeolocationOverride <span class='label label-success'>Command</span></h3>
+<p>Clears the overriden Geolocation Position and Error.</p>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.clearGeolocationOverride
+Page.clearGeolocationOverride();
+</pre>
+</div>
+<div id='Page_canOverrideGeolocation' class='command'>
+<h3>Page.canOverrideGeolocation <span class='label label-success'>Command</span></h3>
+<p>Checks if Geolocation can be overridden.</p>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>result</dt>
+<dd>Boolean <span class='text'>True if browser can ovrride Geolocation.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.canOverrideGeolocation
+Page.canOverrideGeolocation(function callback(res) {
+	// res = {result}
+});
+</pre>
+</div>
+<div id='Page_setDeviceOrientationOverride' class='command'>
+<h3>Page.setDeviceOrientationOverride <span class='label label-success'>Command</span></h3>
+<p>Overrides the Device Orientation.</p>
+<dl>
+<dt>alpha</dt>
+<dd>Number <span class='text'>Mock alpha</span></dd>
+<dt>beta</dt>
+<dd>Number <span class='text'>Mock beta</span></dd>
+<dt>gamma</dt>
+<dd>Number <span class='text'>Mock gamma</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.setDeviceOrientationOverride
+Page.setDeviceOrientationOverride(alpha, beta, gamma);
+</pre>
+</div>
+<div id='Page_clearDeviceOrientationOverride' class='command'>
+<h3>Page.clearDeviceOrientationOverride <span class='label label-success'>Command</span></h3>
+<p>Clears the overridden Device Orientation.</p>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.clearDeviceOrientationOverride
+Page.clearDeviceOrientationOverride();
+</pre>
+</div>
+<div id='Page_canOverrideDeviceOrientation' class='command'>
+<h3>Page.canOverrideDeviceOrientation <span class='label label-success'>Command</span></h3>
+<p>Check the backend if Web Inspector can override the device orientation.</p>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>result</dt>
+<dd>Boolean <span class='text'>If true, <code>setDeviceOrientationOverride</code> can safely be invoked on the agent.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.canOverrideDeviceOrientation
+Page.canOverrideDeviceOrientation(function callback(res) {
+	// res = {result}
+});
+</pre>
+</div>
+<div id='Page_setTouchEmulationEnabled' class='command'>
+<h3>Page.setTouchEmulationEnabled <span class='label label-success'>Command</span></h3>
+<p>Toggles mouse event-based touch event emulation.</p>
+<dl>
+<dt>enabled</dt>
+<dd>Boolean <span class='text'>Whether the touch event emulation should be enabled.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Page.setTouchEmulationEnabled
+Page.setTouchEmulationEnabled(enabled);
+</pre>
+</div>
+<div id='Page_domContentEventFired' class='command'>
+<h3>Page.domContentEventFired <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>timestamp</dt>
 <dd>Number</dd>
@@ -4716,8 +5483,8 @@ function onDomContentEventFired(res) {
 }
 </pre>
 </div>
-<div id="Page_loadEventFired" class="command">
-<h3>Page.loadEventFired <span class="label label-info">Event</span></h3>
+<div id='Page_loadEventFired' class='command'>
+<h3>Page.loadEventFired <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>timestamp</dt>
 <dd>Number</dd>
@@ -4730,12 +5497,12 @@ function onLoadEventFired(res) {
 }
 </pre>
 </div>
-<div id="Page_frameNavigated" class="command">
-<h3>Page.frameNavigated <span class="label label-info">Event</span></h3>
+<div id='Page_frameNavigated' class='command'>
+<h3>Page.frameNavigated <span class='label label-info'>Event</span></h3>
 <p>Fired once navigation of the frame has completed. Frame is now associated with the new loader.</p>
 <dl>
 <dt>frame</dt>
-<dd><a href="#Page.Frame">Page.Frame</a> <span class="text">Frame object.</span></dd>
+<dd><a href='#Page.Frame'>Page.Frame</a> <span class='text'>Frame object.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4745,12 +5512,12 @@ function onFrameNavigated(res) {
 }
 </pre>
 </div>
-<div id="Page_frameDetached" class="command">
-<h3>Page.frameDetached <span class="label label-info">Event</span></h3>
+<div id='Page_frameDetached' class='command'>
+<h3>Page.frameDetached <span class='label label-info'>Event</span></h3>
 <p>Fired when frame has been detached from its parent.</p>
 <dl>
 <dt>frameId</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Id of the frame that has been detached.</span></dd>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Id of the frame that has been detached.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4761,50 +5528,75 @@ function onFrameDetached(res) {
 </pre>
 </div>
 </section>
-<section id="Profiler" class="domain">
+<section id='Profiler' class='domain'>
 <h1>Profiler</h1>
 <p></p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Profiler.Profile">Profiler.Profile</a>: Profile.</li>
-<li><a href="#Profiler.ProfileHeader">Profiler.ProfileHeader</a>: Profile header.</li>
+<li><a href='#Profiler.ProfileHeader'>Profiler.ProfileHeader</a>: Profile header.</li>
+<li><a href='#Profiler.Profile'>Profiler.Profile</a>: Profile.</li>
+<li><a href='#Profiler.HeapSnapshotObjectId'>Profiler.HeapSnapshotObjectId</a>: Heap snashot object id.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Profiler.causesRecompilation">Profiler.causesRecompilation</a></li>
-<li><a href="#Profiler.isSampling">Profiler.isSampling</a></li>
-<li><a href="#Profiler.hasHeapProfiler">Profiler.hasHeapProfiler</a></li>
-<li><a href="#Profiler.enable">Profiler.enable</a></li>
-<li><a href="#Profiler.disable">Profiler.disable</a></li>
-<li><a href="#Profiler.start">Profiler.start</a></li>
-<li><a href="#Profiler.stop">Profiler.stop</a></li>
-<li><a href="#Profiler.getProfileHeaders">Profiler.getProfileHeaders</a></li>
-<li><a href="#Profiler.getProfile">Profiler.getProfile</a></li>
-<li><a href="#Profiler.removeProfile">Profiler.removeProfile</a></li>
-<li><a href="#Profiler.clearProfiles">Profiler.clearProfiles</a></li>
-<li><a href="#Profiler.takeHeapSnapshot">Profiler.takeHeapSnapshot</a></li>
-<li><a href="#Profiler.collectGarbage">Profiler.collectGarbage</a></li>
-<li><a href="#Profiler.getObjectByHeapObjectId">Profiler.getObjectByHeapObjectId</a></li>
+<li><a href='#Profiler.causesRecompilation'>Profiler.causesRecompilation</a></li>
+<li><a href='#Profiler.isSampling'>Profiler.isSampling</a></li>
+<li><a href='#Profiler.hasHeapProfiler'>Profiler.hasHeapProfiler</a></li>
+<li><a href='#Profiler.enable'>Profiler.enable</a></li>
+<li><a href='#Profiler.disable'>Profiler.disable</a></li>
+<li><a href='#Profiler.start'>Profiler.start</a></li>
+<li><a href='#Profiler.stop'>Profiler.stop</a></li>
+<li><a href='#Profiler.getProfileHeaders'>Profiler.getProfileHeaders</a></li>
+<li><a href='#Profiler.getProfile'>Profiler.getProfile</a></li>
+<li><a href='#Profiler.removeProfile'>Profiler.removeProfile</a></li>
+<li><a href='#Profiler.clearProfiles'>Profiler.clearProfiles</a></li>
+<li><a href='#Profiler.takeHeapSnapshot'>Profiler.takeHeapSnapshot</a></li>
+<li><a href='#Profiler.collectGarbage'>Profiler.collectGarbage</a></li>
+<li><a href='#Profiler.getObjectByHeapObjectId'>Profiler.getObjectByHeapObjectId</a></li>
+<li><a href='#Profiler.getHeapObjectId'>Profiler.getHeapObjectId</a></li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Profiler.addProfileHeader">Profiler.addProfileHeader</a></li>
-<li><a href="#Profiler.addHeapSnapshotChunk">Profiler.addHeapSnapshotChunk</a></li>
-<li><a href="#Profiler.finishHeapSnapshot">Profiler.finishHeapSnapshot</a></li>
-<li><a href="#Profiler.setRecordingProfile">Profiler.setRecordingProfile</a></li>
-<li><a href="#Profiler.resetProfiles">Profiler.resetProfiles</a></li>
-<li><a href="#Profiler.reportHeapSnapshotProgress">Profiler.reportHeapSnapshotProgress</a></li>
+<li><a href='#Profiler.addProfileHeader'>Profiler.addProfileHeader</a></li>
+<li><a href='#Profiler.addHeapSnapshotChunk'>Profiler.addHeapSnapshotChunk</a></li>
+<li><a href='#Profiler.finishHeapSnapshot'>Profiler.finishHeapSnapshot</a></li>
+<li><a href='#Profiler.setRecordingProfile'>Profiler.setRecordingProfile</a></li>
+<li><a href='#Profiler.resetProfiles'>Profiler.resetProfiles</a></li>
+<li><a href='#Profiler.reportHeapSnapshotProgress'>Profiler.reportHeapSnapshotProgress</a></li>
 </ul>
-<div id="Profiler_Profile" class="type">
-<h3>Profiler.Profile <span class="label">Type</span></h3>
-<p>Profile.</p>
-</div>
-<div id="Profiler_ProfileHeader" class="type">
-<h3>Profiler.ProfileHeader <span class="label">Type</span></h3>
+<div id='Profiler_ProfileHeader' class='type'>
+<h3>Profiler.ProfileHeader <span class='label'>Type</span></h3>
 <p>Profile header.</p>
+<dl>
+<dt>typeId</dt>
+<dd>( CPU | CSS | HEAP ) <span class='text'>Profile type name.</span></dd>
+<dt>title</dt>
+<dd>String <span class='text'>Profile title.</span></dd>
+<dt>uid</dt>
+<dd>Integer <span class='text'>Unique identifier of the profile.</span></dd>
+<dt>maxJSObjectId (optional)</dt>
+<dd>Integer <span class='text'>Last seen JS object Id.</span></dd>
+</dl>
 </div>
-<div id="Profiler_causesRecompilation" class="command">
-<h3>Profiler.causesRecompilation <span class="label label-success">Command</span></h3>
+<div id='Profiler_Profile' class='type'>
+<h3>Profiler.Profile <span class='label'>Type</span></h3>
+<p>Profile.</p>
+<dl>
+<dt>head (optional)</dt>
+<dd>Object</dd>
+<dt>bottomUpHead (optional)</dt>
+<dd>Object</dd>
+</dl>
+</div>
+<div id='Profiler_HeapSnapshotObjectId' class='type'>
+<h3>Profiler.HeapSnapshotObjectId <span class='label'>Type</span></h3>
+<p>Heap snashot object id.</p>
+<dl>
+<dd>String</dd>
+</dl>
+</div>
+<div id='Profiler_causesRecompilation' class='command'>
+<h3>Profiler.causesRecompilation <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
@@ -4818,8 +5610,8 @@ Profiler.causesRecompilation(function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_isSampling" class="command">
-<h3>Profiler.isSampling <span class="label label-success">Command</span></h3>
+<div id='Profiler_isSampling' class='command'>
+<h3>Profiler.isSampling <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
@@ -4833,8 +5625,8 @@ Profiler.isSampling(function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_hasHeapProfiler" class="command">
-<h3>Profiler.hasHeapProfiler <span class="label label-success">Command</span></h3>
+<div id='Profiler_hasHeapProfiler' class='command'>
+<h3>Profiler.hasHeapProfiler <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
@@ -4848,44 +5640,44 @@ Profiler.hasHeapProfiler(function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_enable" class="command">
-<h3>Profiler.enable <span class="label label-success">Command</span></h3>
+<div id='Profiler_enable' class='command'>
+<h3>Profiler.enable <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.enable
 Profiler.enable();
 </pre>
 </div>
-<div id="Profiler_disable" class="command">
-<h3>Profiler.disable <span class="label label-success">Command</span></h3>
+<div id='Profiler_disable' class='command'>
+<h3>Profiler.disable <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.disable
 Profiler.disable();
 </pre>
 </div>
-<div id="Profiler_start" class="command">
-<h3>Profiler.start <span class="label label-success">Command</span></h3>
+<div id='Profiler_start' class='command'>
+<h3>Profiler.start <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.start
 Profiler.start();
 </pre>
 </div>
-<div id="Profiler_stop" class="command">
-<h3>Profiler.stop <span class="label label-success">Command</span></h3>
+<div id='Profiler_stop' class='command'>
+<h3>Profiler.stop <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.stop
 Profiler.stop();
 </pre>
 </div>
-<div id="Profiler_getProfileHeaders" class="command">
-<h3>Profiler.getProfileHeaders <span class="label label-success">Command</span></h3>
+<div id='Profiler_getProfileHeaders' class='command'>
+<h3>Profiler.getProfileHeaders <span class='label label-success'>Command</span></h3>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>headers</dt>
-<dd>[<a href="#Profiler.ProfileHeader">Profiler.ProfileHeader</a>]</dd>
+<dd>[<a href='#Profiler.ProfileHeader'>Profiler.ProfileHeader</a>]</dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4895,8 +5687,8 @@ Profiler.getProfileHeaders(function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_getProfile" class="command">
-<h3>Profiler.getProfile <span class="label label-success">Command</span></h3>
+<div id='Profiler_getProfile' class='command'>
+<h3>Profiler.getProfile <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>type</dt>
 <dd>String</dd>
@@ -4906,7 +5698,7 @@ Profiler.getProfileHeaders(function callback(res) {
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>profile</dt>
-<dd><a href="#Profiler.Profile">Profiler.Profile</a></dd>
+<dd><a href='#Profiler.Profile'>Profiler.Profile</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4916,8 +5708,8 @@ Profiler.getProfile(type, uid, function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_removeProfile" class="command">
-<h3>Profiler.removeProfile <span class="label label-success">Command</span></h3>
+<div id='Profiler_removeProfile' class='command'>
+<h3>Profiler.removeProfile <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>type</dt>
 <dd>String</dd>
@@ -4930,42 +5722,42 @@ Profiler.getProfile(type, uid, function callback(res) {
 Profiler.removeProfile(type, uid);
 </pre>
 </div>
-<div id="Profiler_clearProfiles" class="command">
-<h3>Profiler.clearProfiles <span class="label label-success">Command</span></h3>
+<div id='Profiler_clearProfiles' class='command'>
+<h3>Profiler.clearProfiles <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.clearProfiles
 Profiler.clearProfiles();
 </pre>
 </div>
-<div id="Profiler_takeHeapSnapshot" class="command">
-<h3>Profiler.takeHeapSnapshot <span class="label label-success">Command</span></h3>
+<div id='Profiler_takeHeapSnapshot' class='command'>
+<h3>Profiler.takeHeapSnapshot <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.takeHeapSnapshot
 Profiler.takeHeapSnapshot();
 </pre>
 </div>
-<div id="Profiler_collectGarbage" class="command">
-<h3>Profiler.collectGarbage <span class="label label-success">Command</span></h3>
+<div id='Profiler_collectGarbage' class='command'>
+<h3>Profiler.collectGarbage <span class='label label-success'>Command</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Profiler.collectGarbage
 Profiler.collectGarbage();
 </pre>
 </div>
-<div id="Profiler_getObjectByHeapObjectId" class="command">
-<h3>Profiler.getObjectByHeapObjectId <span class="label label-success">Command</span></h3>
+<div id='Profiler_getObjectByHeapObjectId' class='command'>
+<h3>Profiler.getObjectByHeapObjectId <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>objectId</dt>
-<dd>Integer</dd>
+<dd><a href='#Profiler.HeapSnapshotObjectId'>Profiler.HeapSnapshotObjectId</a></dd>
 <dt>objectGroup (optional)</dt>
-<dd>String <span class="text">Symbolic group name that can be used to release multiple objects.</span></dd>
+<dd>String <span class='text'>Symbolic group name that can be used to release multiple objects.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Evaluation result.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Evaluation result.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4975,11 +5767,30 @@ Profiler.getObjectByHeapObjectId(objectId, objectGroup, function callback(res) {
 });
 </pre>
 </div>
-<div id="Profiler_addProfileHeader" class="command">
-<h3>Profiler.addProfileHeader <span class="label label-info">Event</span></h3>
+<div id='Profiler_getHeapObjectId' class='command'>
+<h3>Profiler.getHeapObjectId <span class='label label-success'>Command</span></h3>
+<dl>
+<dt>objectId</dt>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Identifier of the object to get heap object id for.</span></dd>
+</dl>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>heapSnapshotObjectId</dt>
+<dd><a href='#Profiler.HeapSnapshotObjectId'>Profiler.HeapSnapshotObjectId</a> <span class='text'>Id of the heap snapshot object corresponding to the passed remote object id.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Profiler.getHeapObjectId
+Profiler.getHeapObjectId(objectId, function callback(res) {
+	// res = {heapSnapshotObjectId}
+});
+</pre>
+</div>
+<div id='Profiler_addProfileHeader' class='command'>
+<h3>Profiler.addProfileHeader <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>header</dt>
-<dd><a href="#Profiler.ProfileHeader">Profiler.ProfileHeader</a></dd>
+<dd><a href='#Profiler.ProfileHeader'>Profiler.ProfileHeader</a></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -4989,8 +5800,8 @@ function onAddProfileHeader(res) {
 }
 </pre>
 </div>
-<div id="Profiler_addHeapSnapshotChunk" class="command">
-<h3>Profiler.addHeapSnapshotChunk <span class="label label-info">Event</span></h3>
+<div id='Profiler_addHeapSnapshotChunk' class='command'>
+<h3>Profiler.addHeapSnapshotChunk <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>uid</dt>
 <dd>Integer</dd>
@@ -5005,8 +5816,8 @@ function onAddHeapSnapshotChunk(res) {
 }
 </pre>
 </div>
-<div id="Profiler_finishHeapSnapshot" class="command">
-<h3>Profiler.finishHeapSnapshot <span class="label label-info">Event</span></h3>
+<div id='Profiler_finishHeapSnapshot' class='command'>
+<h3>Profiler.finishHeapSnapshot <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>uid</dt>
 <dd>Integer</dd>
@@ -5019,8 +5830,8 @@ function onFinishHeapSnapshot(res) {
 }
 </pre>
 </div>
-<div id="Profiler_setRecordingProfile" class="command">
-<h3>Profiler.setRecordingProfile <span class="label label-info">Event</span></h3>
+<div id='Profiler_setRecordingProfile' class='command'>
+<h3>Profiler.setRecordingProfile <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>isProfiling</dt>
 <dd>Boolean</dd>
@@ -5033,8 +5844,8 @@ function onSetRecordingProfile(res) {
 }
 </pre>
 </div>
-<div id="Profiler_resetProfiles" class="command">
-<h3>Profiler.resetProfiles <span class="label label-info">Event</span></h3>
+<div id='Profiler_resetProfiles' class='command'>
+<h3>Profiler.resetProfiles <span class='label label-info'>Event</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Event: Profiler.resetProfiles
@@ -5043,8 +5854,8 @@ function onResetProfiles(res) {
 }
 </pre>
 </div>
-<div id="Profiler_reportHeapSnapshotProgress" class="command">
-<h3>Profiler.reportHeapSnapshotProgress <span class="label label-info">Event</span></h3>
+<div id='Profiler_reportHeapSnapshotProgress' class='command'>
+<h3>Profiler.reportHeapSnapshotProgress <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>done</dt>
 <dd>Integer</dd>
@@ -5060,155 +5871,214 @@ function onReportHeapSnapshotProgress(res) {
 </pre>
 </div>
 </section>
-<section id="Runtime" class="domain">
+<section id='Runtime' class='domain'>
 <h1>Runtime</h1>
 <p>Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a>: Unique object identifier.</li>
-<li><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a>: Mirror object referencing original JavaScript object.</li>
-<li><a href="#Runtime.PropertyDescriptor">Runtime.PropertyDescriptor</a>: Object property descriptor.</li>
-<li><a href="#Runtime.CallArgument">Runtime.CallArgument</a>: Represents function call argument. Either remote object id objectId or primitive value or neither of (for undefined) them should be specified.</li>
+<li><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a>: Unique object identifier.</li>
+<li><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a>: Mirror object referencing original JavaScript object.</li>
+<li><a href='#Runtime.ObjectPreview'>Runtime.ObjectPreview</a>: Object containing abbreviated remote object value.</li>
+<li><a href='#Runtime.PropertyPreview'>Runtime.PropertyPreview</a></li>
+<li><a href='#Runtime.PropertyDescriptor'>Runtime.PropertyDescriptor</a>: Object property descriptor.</li>
+<li><a href='#Runtime.CallArgument'>Runtime.CallArgument</a>: Represents function call argument. Either remote object id objectId or primitive value or neither of (for undefined) them should be specified.</li>
+<li><a href='#Runtime.ExecutionContextId'>Runtime.ExecutionContextId</a>: Id of an execution context.</li>
+<li><a href='#Runtime.ExecutionContextDescription'>Runtime.ExecutionContextDescription</a>: Description of an isolated world.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Runtime.evaluate">Runtime.evaluate</a>: Evaluates expression on global object.</li>
-<li><a href="#Runtime.callFunctionOn">Runtime.callFunctionOn</a>: Calls function with given declaration on the given object. Object group of the result is inherited from the target object.</li>
-<li><a href="#Runtime.getProperties">Runtime.getProperties</a>: Returns properties of a given object. Object group of the result is inherited from the target object.</li>
-<li><a href="#Runtime.releaseObject">Runtime.releaseObject</a>: Releases remote object with given id.</li>
-<li><a href="#Runtime.releaseObjectGroup">Runtime.releaseObjectGroup</a>: Releases all remote objects that belong to a given group.</li>
-<li><a href="#Runtime.run">Runtime.run</a>: Tells inspected instance(worker or page) that it can run in case it was started paused.</li>
+<li><a href='#Runtime.evaluate'>Runtime.evaluate</a>: Evaluates expression on global object.</li>
+<li><a href='#Runtime.callFunctionOn'>Runtime.callFunctionOn</a>: Calls function with given declaration on the given object. Object group of the result is inherited from the target object.</li>
+<li><a href='#Runtime.getProperties'>Runtime.getProperties</a>: Returns properties of a given object. Object group of the result is inherited from the target object.</li>
+<li><a href='#Runtime.releaseObject'>Runtime.releaseObject</a>: Releases remote object with given id.</li>
+<li><a href='#Runtime.releaseObjectGroup'>Runtime.releaseObjectGroup</a>: Releases all remote objects that belong to a given group.</li>
+<li><a href='#Runtime.run'>Runtime.run</a>: Tells inspected instance(worker or page) that it can run in case it was started paused.</li>
+<li><a href='#Runtime.setReportExecutionContextCreation'>Runtime.setReportExecutionContextCreation</a>: Enables reporting about creation of isolated contexts by means of isolatedContextCreated event. When the reporting gets enabled the event will be sent immediately for each existing isolated context.</li>
 </ul>
-<div id="Runtime_RemoteObjectId" class="type">
-<h3>Runtime.RemoteObjectId <span class="label">Type</span></h3>
+<span class='label label-info'>Event</span>
+<ul>
+<li><a href='#Runtime.isolatedContextCreated'>Runtime.isolatedContextCreated</a>: Issued when new isolated context is created.</li>
+</ul>
+<div id='Runtime_RemoteObjectId' class='type'>
+<h3>Runtime.RemoteObjectId <span class='label'>Type</span></h3>
 <p>Unique object identifier.</p>
 <dl>
 <dd>String</dd>
 </dl>
 </div>
-<div id="Runtime_RemoteObject" class="type">
-<h3>Runtime.RemoteObject <span class="label">Type</span></h3>
+<div id='Runtime_RemoteObject' class='type'>
+<h3>Runtime.RemoteObject <span class='label'>Type</span></h3>
 <p>Mirror object referencing original JavaScript object.</p>
 <dl>
 <dt>type</dt>
-<dd>( object | function | undefined | string | number | boolean ) <span class="text">Object type.</span></dd>
+<dd>( object | function | undefined | string | number | boolean ) <span class='text'>Object type.</span></dd>
 <dt>subtype (optional)</dt>
-<dd>( array | null | node | regexp | date ) <span class="text">Object subtype hint. Specified for <code>object</code> type values only.</span></dd>
+<dd>( array | null | node | regexp | date ) <span class='text'>Object subtype hint. Specified for <code>object</code> type values only.</span></dd>
 <dt>className (optional)</dt>
-<dd>String <span class="text">Object class (constructor) name. Specified for <code>object</code> type values only.</span></dd>
+<dd>String <span class='text'>Object class (constructor) name. Specified for <code>object</code> type values only.</span></dd>
 <dt>value (optional)</dt>
-<dd>Any <span class="text">Remote object value (in case of primitive values or JSON values if it was requested).</span></dd>
+<dd>Any <span class='text'>Remote object value (in case of primitive values or JSON values if it was requested).</span></dd>
 <dt>description (optional)</dt>
-<dd>String <span class="text">String representation of the object.</span></dd>
+<dd>String <span class='text'>String representation of the object.</span></dd>
 <dt>objectId (optional)</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Unique object identifier (for non-primitive values).</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Unique object identifier (for non-primitive values).</span></dd>
+<dt>preview (optional)</dt>
+<dd><a href='#Runtime.ObjectPreview'>Runtime.ObjectPreview</a> <span class='text'>Preview containsing abbreviated property values.</span></dd>
 </dl>
 </div>
-<div id="Runtime_PropertyDescriptor" class="type">
-<h3>Runtime.PropertyDescriptor <span class="label">Type</span></h3>
+<div id='Runtime_ObjectPreview' class='type'>
+<h3>Runtime.ObjectPreview <span class='label'>Type</span></h3>
+<p>Object containing abbreviated remote object value.</p>
+<dl>
+<dt>lossless</dt>
+<dd>Boolean <span class='text'>Determines whether preview is lossless (contains all information of the original object).</span></dd>
+<dt>overflow</dt>
+<dd>Boolean <span class='text'>True iff some of the properties of the original did not fit.</span></dd>
+<dt>properties</dt>
+<dd>[<a href='#Runtime.PropertyPreview'>Runtime.PropertyPreview</a>] <span class='text'>List of the properties.</span></dd>
+</dl>
+</div>
+<div id='Runtime_PropertyPreview' class='type'>
+<h3>Runtime.PropertyPreview <span class='label'>Type</span></h3>
+<dl>
+<dt>name</dt>
+<dd>String <span class='text'>Property name.</span></dd>
+<dt>type</dt>
+<dd>( object | function | undefined | string | number | boolean ) <span class='text'>Object type.</span></dd>
+<dt>value (optional)</dt>
+<dd>String <span class='text'>User-friendly property value string.</span></dd>
+<dt>subtype (optional)</dt>
+<dd>( array | null | node | regexp | date ) <span class='text'>Object subtype hint. Specified for <code>object</code> type values only.</span></dd>
+</dl>
+</div>
+<div id='Runtime_PropertyDescriptor' class='type'>
+<h3>Runtime.PropertyDescriptor <span class='label'>Type</span></h3>
 <p>Object property descriptor.</p>
 <dl>
 <dt>name</dt>
-<dd>String <span class="text">Property name.</span></dd>
+<dd>String <span class='text'>Property name.</span></dd>
 <dt>value (optional)</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">The value associated with the property.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>The value associated with the property.</span></dd>
 <dt>writable (optional)</dt>
-<dd>Boolean <span class="text">True if the value associated with the property may be changed (data descriptors only).</span></dd>
+<dd>Boolean <span class='text'>True if the value associated with the property may be changed (data descriptors only).</span></dd>
 <dt>get (optional)</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).</span></dd>
 <dt>set (optional)</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).</span></dd>
 <dt>configurable</dt>
-<dd>Boolean <span class="text">True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.</span></dd>
+<dd>Boolean <span class='text'>True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.</span></dd>
 <dt>enumerable</dt>
-<dd>Boolean <span class="text">True if this property shows up during enumeration of the properties on the corresponding object.</span></dd>
+<dd>Boolean <span class='text'>True if this property shows up during enumeration of the properties on the corresponding object.</span></dd>
 <dt>wasThrown (optional)</dt>
-<dd>Boolean <span class="text">True if the result was thrown during the evaluation.</span></dd>
+<dd>Boolean <span class='text'>True if the result was thrown during the evaluation.</span></dd>
 </dl>
 </div>
-<div id="Runtime_CallArgument" class="type">
-<h3>Runtime.CallArgument <span class="label">Type</span></h3>
+<div id='Runtime_CallArgument' class='type'>
+<h3>Runtime.CallArgument <span class='label'>Type</span></h3>
 <p>Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.</p>
 <dl>
 <dt>value (optional)</dt>
-<dd>Any <span class="text">Primitive value.</span></dd>
+<dd>Any <span class='text'>Primitive value.</span></dd>
 <dt>objectId (optional)</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Remote object handle.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Remote object handle.</span></dd>
 </dl>
 </div>
-<div id="Runtime_evaluate" class="command">
-<h3>Runtime.evaluate <span class="label label-success">Command</span></h3>
+<div id='Runtime_ExecutionContextId' class='type'>
+<h3>Runtime.ExecutionContextId <span class='label'>Type</span></h3>
+<p>Id of an execution context.</p>
+<dl>
+<dd>Integer</dd>
+</dl>
+</div>
+<div id='Runtime_ExecutionContextDescription' class='type'>
+<h3>Runtime.ExecutionContextDescription <span class='label'>Type</span></h3>
+<p>Description of an isolated world.</p>
+<dl>
+<dt>id</dt>
+<dd><a href='#Runtime.ExecutionContextId'>Runtime.ExecutionContextId</a> <span class='text'>Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed.</span></dd>
+<dt>isPageContext</dt>
+<dd>Boolean <span class='text'>True if this is a context where inpspected web page scripts run. False if it is a content script isolated context.</span></dd>
+<dt>name</dt>
+<dd>String <span class='text'>Human readable name describing given context.</span></dd>
+<dt>frameId</dt>
+<dd><a href='#Network.FrameId'>Network.FrameId</a> <span class='text'>Id of the owning frame.</span></dd>
+</dl>
+</div>
+<div id='Runtime_evaluate' class='command'>
+<h3>Runtime.evaluate <span class='label label-success'>Command</span></h3>
 <p>Evaluates expression on global object.</p>
 <dl>
 <dt>expression</dt>
-<dd>String <span class="text">Expression to evaluate.</span></dd>
+<dd>String <span class='text'>Expression to evaluate.</span></dd>
 <dt>objectGroup (optional)</dt>
-<dd>String <span class="text">Symbolic group name that can be used to release multiple objects.</span></dd>
+<dd>String <span class='text'>Symbolic group name that can be used to release multiple objects.</span></dd>
 <dt>includeCommandLineAPI (optional)</dt>
-<dd>Boolean <span class="text">Determines whether Command Line API should be available during the evaluation.</span></dd>
-<dt>doNotPauseOnExceptions (optional)</dt>
-<dd>Boolean <span class="text">Specifies whether evaluation should stop on exceptions. Overrides setPauseOnException state.</span></dd>
-<dt>frameId (optional)</dt>
-<dd><a href="#Network.FrameId">Network.FrameId</a> <span class="text">Specifies in which frame to perform evaluation.</span></dd>
+<dd>Boolean <span class='text'>Determines whether Command Line API should be available during the evaluation.</span></dd>
+<dt>doNotPauseOnExceptionsAndMuteConsole (optional)</dt>
+<dd>Boolean <span class='text'>Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.</span></dd>
+<dt>contextId (optional)</dt>
+<dd><a href='#Runtime.ExecutionContextId'>Runtime.ExecutionContextId</a> <span class='text'>Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page.</span></dd>
 <dt>returnByValue (optional)</dt>
-<dd>Boolean <span class="text">Whether the result is expected to be a JSON object that should be sent by value.</span></dd>
+<dd>Boolean <span class='text'>Whether the result is expected to be a JSON object that should be sent by value.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Evaluation result.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Evaluation result.</span></dd>
 <dt>wasThrown (optional)</dt>
-<dd>Boolean <span class="text">True if the result was thrown during the evaluation.</span></dd>
+<dd>Boolean <span class='text'>True if the result was thrown during the evaluation.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Runtime.evaluate
-Runtime.evaluate(expression, objectGroup, includeCommandLineAPI, doNotPauseOnExceptions, frameId, returnByValue, function callback(res) {
+Runtime.evaluate(expression, objectGroup, includeCommandLineAPI, doNotPauseOnExceptionsAndMuteConsole, contextId, returnByValue, function callback(res) {
 	// res = {result, wasThrown}
 });
 </pre>
 </div>
-<div id="Runtime_callFunctionOn" class="command">
-<h3>Runtime.callFunctionOn <span class="label label-success">Command</span></h3>
+<div id='Runtime_callFunctionOn' class='command'>
+<h3>Runtime.callFunctionOn <span class='label label-success'>Command</span></h3>
 <p>Calls function with given declaration on the given object. Object group of the result is inherited from the target object.</p>
 <dl>
 <dt>objectId</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Identifier of the object to call function on.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Identifier of the object to call function on.</span></dd>
 <dt>functionDeclaration</dt>
-<dd>String <span class="text">Declaration of the function to call.</span></dd>
+<dd>String <span class='text'>Declaration of the function to call.</span></dd>
 <dt>arguments (optional)</dt>
-<dd>[<a href="#Runtime.CallArgument">Runtime.CallArgument</a>] <span class="text">Call arguments. All call arguments must belong to the same JavaScript world as the target object.</span></dd>
+<dd>[<a href='#Runtime.CallArgument'>Runtime.CallArgument</a>] <span class='text'>Call arguments. All call arguments must belong to the same JavaScript world as the target object.</span></dd>
+<dt>doNotPauseOnExceptionsAndMuteConsole (optional)</dt>
+<dd>Boolean <span class='text'>Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state.</span></dd>
 <dt>returnByValue (optional)</dt>
-<dd>Boolean <span class="text">Whether the result is expected to be a JSON object which should be sent by value.</span></dd>
+<dd>Boolean <span class='text'>Whether the result is expected to be a JSON object which should be sent by value.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd><a href="#Runtime.RemoteObject">Runtime.RemoteObject</a> <span class="text">Call result.</span></dd>
+<dd><a href='#Runtime.RemoteObject'>Runtime.RemoteObject</a> <span class='text'>Call result.</span></dd>
 <dt>wasThrown (optional)</dt>
-<dd>Boolean <span class="text">True if the result was thrown during the evaluation.</span></dd>
+<dd>Boolean <span class='text'>True if the result was thrown during the evaluation.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Command: Runtime.callFunctionOn
-Runtime.callFunctionOn(objectId, functionDeclaration, arguments, returnByValue, function callback(res) {
+Runtime.callFunctionOn(objectId, functionDeclaration, arguments, doNotPauseOnExceptionsAndMuteConsole, returnByValue, function callback(res) {
 	// res = {result, wasThrown}
 });
 </pre>
 </div>
-<div id="Runtime_getProperties" class="command">
-<h3>Runtime.getProperties <span class="label label-success">Command</span></h3>
+<div id='Runtime_getProperties' class='command'>
+<h3>Runtime.getProperties <span class='label label-success'>Command</span></h3>
 <p>Returns properties of a given object. Object group of the result is inherited from the target object.</p>
 <dl>
 <dt>objectId</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Identifier of the object to return properties for.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Identifier of the object to return properties for.</span></dd>
 <dt>ownProperties (optional)</dt>
-<dd>Boolean <span class="text">If true, returns properties belonging only to the element itself, not to its prototype chain.</span></dd>
+<dd>Boolean <span class='text'>If true, returns properties belonging only to the element itself, not to its prototype chain.</span></dd>
 </dl>
 <h4>Callback Parameters:</h4>
 <dl>
 <dt>result</dt>
-<dd>[<a href="#Runtime.PropertyDescriptor">Runtime.PropertyDescriptor</a>] <span class="text">Object properties.</span></dd>
+<dd>[<a href='#Runtime.PropertyDescriptor'>Runtime.PropertyDescriptor</a>] <span class='text'>Object properties.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5218,12 +6088,12 @@ Runtime.getProperties(objectId, ownProperties, function callback(res) {
 });
 </pre>
 </div>
-<div id="Runtime_releaseObject" class="command">
-<h3>Runtime.releaseObject <span class="label label-success">Command</span></h3>
+<div id='Runtime_releaseObject' class='command'>
+<h3>Runtime.releaseObject <span class='label label-success'>Command</span></h3>
 <p>Releases remote object with given id.</p>
 <dl>
 <dt>objectId</dt>
-<dd><a href="#Runtime.RemoteObjectId">Runtime.RemoteObjectId</a> <span class="text">Identifier of the object to release.</span></dd>
+<dd><a href='#Runtime.RemoteObjectId'>Runtime.RemoteObjectId</a> <span class='text'>Identifier of the object to release.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5231,12 +6101,12 @@ Runtime.getProperties(objectId, ownProperties, function callback(res) {
 Runtime.releaseObject(objectId);
 </pre>
 </div>
-<div id="Runtime_releaseObjectGroup" class="command">
-<h3>Runtime.releaseObjectGroup <span class="label label-success">Command</span></h3>
+<div id='Runtime_releaseObjectGroup' class='command'>
+<h3>Runtime.releaseObjectGroup <span class='label label-success'>Command</span></h3>
 <p>Releases all remote objects that belong to a given group.</p>
 <dl>
 <dt>objectGroup</dt>
-<dd>String <span class="text">Symbolic object group name.</span></dd>
+<dd>String <span class='text'>Symbolic object group name.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5244,8 +6114,8 @@ Runtime.releaseObject(objectId);
 Runtime.releaseObjectGroup(objectGroup);
 </pre>
 </div>
-<div id="Runtime_run" class="command">
-<h3>Runtime.run <span class="label label-success">Command</span></h3>
+<div id='Runtime_run' class='command'>
+<h3>Runtime.run <span class='label label-success'>Command</span></h3>
 <p>Tells inspected instance(worker or page) that it can run in case it was started paused.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -5253,42 +6123,71 @@ Runtime.releaseObjectGroup(objectGroup);
 Runtime.run();
 </pre>
 </div>
+<div id='Runtime_setReportExecutionContextCreation' class='command'>
+<h3>Runtime.setReportExecutionContextCreation <span class='label label-success'>Command</span></h3>
+<p>Enables reporting about creation of isolated contexts by means of <code>isolatedContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing isolated context.</p>
+<dl>
+<dt>enabled</dt>
+<dd>Boolean <span class='text'>Reporting enabled state.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Runtime.setReportExecutionContextCreation
+Runtime.setReportExecutionContextCreation(enabled);
+</pre>
+</div>
+<div id='Runtime_isolatedContextCreated' class='command'>
+<h3>Runtime.isolatedContextCreated <span class='label label-info'>Event</span></h3>
+<p>Issued when new isolated context is created.</p>
+<dl>
+<dt>context</dt>
+<dd><a href='#Runtime.ExecutionContextDescription'>Runtime.ExecutionContextDescription</a> <span class='text'>A newly created isolated contex.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Event: Runtime.isolatedContextCreated
+function onIsolatedContextCreated(res) {
+	// res = {context}
+}
+</pre>
+</div>
 </section>
-<section id="Timeline" class="domain">
+<section id='Timeline' class='domain'>
 <h1>Timeline</h1>
 <p>Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.</p>
-<span class="label">Type</span>
+<span class='label'>Type</span>
 <ul>
-<li><a href="#Timeline.TimelineEvent">Timeline.TimelineEvent</a>: Timeline record contains information about the recorded activity.</li>
+<li><a href='#Timeline.TimelineEvent'>Timeline.TimelineEvent</a>: Timeline record contains information about the recorded activity.</li>
 </ul>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Timeline.start">Timeline.start</a>: Starts capturing instrumentation events.</li>
-<li><a href="#Timeline.stop">Timeline.stop</a>: Stops capturing instrumentation events.</li>
-<li><a href="#Timeline.setIncludeMemoryDetails">Timeline.setIncludeMemoryDetails</a>: Starts calculating various DOM statistics and sending them as part of timeline events.</li>
+<li><a href='#Timeline.start'>Timeline.start</a>: Starts capturing instrumentation events.</li>
+<li><a href='#Timeline.stop'>Timeline.stop</a>: Stops capturing instrumentation events.</li>
+<li><a href='#Timeline.setIncludeMemoryDetails'>Timeline.setIncludeMemoryDetails</a>: Starts calculating various DOM statistics and sending them as part of timeline events.</li>
+<li><a href='#Timeline.supportsFrameInstrumentation'>Timeline.supportsFrameInstrumentation</a>: Tells whether timeline agent supports frame instrumentation.</li>
 </ul>
-<span class="label label-info">Event</span>
+<span class='label label-info'>Event</span>
 <ul>
-<li><a href="#Timeline.eventRecorded">Timeline.eventRecorded</a>: Fired for every instrumentation event while timeline is started.</li>
+<li><a href='#Timeline.eventRecorded'>Timeline.eventRecorded</a>: Fired for every instrumentation event while timeline is started.</li>
 </ul>
-<div id="Timeline_TimelineEvent" class="type">
-<h3>Timeline.TimelineEvent <span class="label">Type</span></h3>
+<div id='Timeline_TimelineEvent' class='type'>
+<h3>Timeline.TimelineEvent <span class='label'>Type</span></h3>
 <p>Timeline record contains information about the recorded activity.</p>
 <dl>
 <dt>type</dt>
-<dd>String <span class="text">Event type.</span></dd>
+<dd>String <span class='text'>Event type.</span></dd>
 <dt>data</dt>
-<dd>Object <span class="text">Event data.</span></dd>
+<dd>Object <span class='text'>Event data.</span></dd>
 <dt>children (optional)</dt>
-<dd>[<a href="#Timeline.TimelineEvent">Timeline.TimelineEvent</a>] <span class="text">Nested records.</span></dd>
+<dd>[<a href='#Timeline.TimelineEvent'>Timeline.TimelineEvent</a>] <span class='text'>Nested records.</span></dd>
 </dl>
 </div>
-<div id="Timeline_start" class="command">
-<h3>Timeline.start <span class="label label-success">Command</span></h3>
+<div id='Timeline_start' class='command'>
+<h3>Timeline.start <span class='label label-success'>Command</span></h3>
 <p>Starts capturing instrumentation events.</p>
 <dl>
 <dt>maxCallStackDepth (optional)</dt>
-<dd>Integer <span class="text">Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5.</span></dd>
+<dd>Integer <span class='text'>Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5296,8 +6195,8 @@ Runtime.run();
 Timeline.start(maxCallStackDepth);
 </pre>
 </div>
-<div id="Timeline_stop" class="command">
-<h3>Timeline.stop <span class="label label-success">Command</span></h3>
+<div id='Timeline_stop' class='command'>
+<h3>Timeline.stop <span class='label label-success'>Command</span></h3>
 <p>Stops capturing instrumentation events.</p>
 <h4>Code Example:</h4>
 <pre>
@@ -5305,12 +6204,12 @@ Timeline.start(maxCallStackDepth);
 Timeline.stop();
 </pre>
 </div>
-<div id="Timeline_setIncludeMemoryDetails" class="command">
-<h3>Timeline.setIncludeMemoryDetails <span class="label label-success">Command</span></h3>
+<div id='Timeline_setIncludeMemoryDetails' class='command'>
+<h3>Timeline.setIncludeMemoryDetails <span class='label label-success'>Command</span></h3>
 <p>Starts calculating various DOM statistics and sending them as part of timeline events.</p>
 <dl>
 <dt>enabled</dt>
-<dd>Boolean <span class="text">True to start collecting DOM counters.</span></dd>
+<dd>Boolean <span class='text'>True to start collecting DOM counters.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5318,12 +6217,28 @@ Timeline.stop();
 Timeline.setIncludeMemoryDetails(enabled);
 </pre>
 </div>
-<div id="Timeline_eventRecorded" class="command">
-<h3>Timeline.eventRecorded <span class="label label-info">Event</span></h3>
+<div id='Timeline_supportsFrameInstrumentation' class='command'>
+<h3>Timeline.supportsFrameInstrumentation <span class='label label-success'>Command</span></h3>
+<p>Tells whether timeline agent supports frame instrumentation.</p>
+<h4>Callback Parameters:</h4>
+<dl>
+<dt>result</dt>
+<dd>Boolean <span class='text'>True if timeline supports frame instrumentation.</span></dd>
+</dl>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Timeline.supportsFrameInstrumentation
+Timeline.supportsFrameInstrumentation(function callback(res) {
+	// res = {result}
+});
+</pre>
+</div>
+<div id='Timeline_eventRecorded' class='command'>
+<h3>Timeline.eventRecorded <span class='label label-info'>Event</span></h3>
 <p>Fired for every instrumentation event while timeline is started.</p>
 <dl>
 <dt>record</dt>
-<dd><a href="#Timeline.TimelineEvent">Timeline.TimelineEvent</a> <span class="text">Timeline event record data.</span></dd>
+<dd><a href='#Timeline.TimelineEvent'>Timeline.TimelineEvent</a> <span class='text'>Timeline event record data.</span></dd>
 </dl>
 <h4>Code Example:</h4>
 <pre>
@@ -5334,38 +6249,70 @@ function onEventRecorded(res) {
 </pre>
 </div>
 </section>
-<section id="Worker" class="domain">
-<h1>Worker</h1>
+<section id='WebGL' class='domain'>
+<h1>WebGL</h1>
 <p></p>
-<span class="label label-success">Command</span>
+<span class='label label-success'>Command</span>
 <ul>
-<li><a href="#Worker.setWorkerInspectionEnabled">Worker.setWorkerInspectionEnabled</a></li>
-<li><a href="#Worker.sendMessageToWorker">Worker.sendMessageToWorker</a></li>
-<li><a href="#Worker.connectToWorker">Worker.connectToWorker</a></li>
-<li><a href="#Worker.disconnectFromWorker">Worker.disconnectFromWorker</a></li>
-<li><a href="#Worker.setAutoconnectToWorkers">Worker.setAutoconnectToWorkers</a></li>
+<li><a href='#WebGL.enable'>WebGL.enable</a>: Enables WebGL inspection.</li>
+<li><a href='#WebGL.disable'>WebGL.disable</a>: Disables WebGL inspection.</li>
 </ul>
-<span class="label label-info">Event</span>
-<ul>
-<li><a href="#Worker.workerCreated">Worker.workerCreated</a></li>
-<li><a href="#Worker.workerTerminated">Worker.workerTerminated</a></li>
-<li><a href="#Worker.dispatchMessageFromWorker">Worker.dispatchMessageFromWorker</a></li>
-<li><a href="#Worker.disconnectedFromWorker">Worker.disconnectedFromWorker</a></li>
-</ul>
-<div id="Worker_setWorkerInspectionEnabled" class="command">
-<h3>Worker.setWorkerInspectionEnabled <span class="label label-success">Command</span></h3>
-<dl>
-<dt>value</dt>
-<dd>Boolean</dd>
-</dl>
+<div id='WebGL_enable' class='command'>
+<h3>WebGL.enable <span class='label label-success'>Command</span></h3>
+<p>Enables WebGL inspection.</p>
 <h4>Code Example:</h4>
 <pre>
-// WebInspector Command: Worker.setWorkerInspectionEnabled
-Worker.setWorkerInspectionEnabled(value);
+// WebInspector Command: WebGL.enable
+WebGL.enable();
 </pre>
 </div>
-<div id="Worker_sendMessageToWorker" class="command">
-<h3>Worker.sendMessageToWorker <span class="label label-success">Command</span></h3>
+<div id='WebGL_disable' class='command'>
+<h3>WebGL.disable <span class='label label-success'>Command</span></h3>
+<p>Disables WebGL inspection.</p>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: WebGL.disable
+WebGL.disable();
+</pre>
+</div>
+</section>
+<section id='Worker' class='domain'>
+<h1>Worker</h1>
+<p></p>
+<span class='label label-success'>Command</span>
+<ul>
+<li><a href='#Worker.enable'>Worker.enable</a></li>
+<li><a href='#Worker.disable'>Worker.disable</a></li>
+<li><a href='#Worker.sendMessageToWorker'>Worker.sendMessageToWorker</a></li>
+<li><a href='#Worker.connectToWorker'>Worker.connectToWorker</a></li>
+<li><a href='#Worker.disconnectFromWorker'>Worker.disconnectFromWorker</a></li>
+<li><a href='#Worker.setAutoconnectToWorkers'>Worker.setAutoconnectToWorkers</a></li>
+</ul>
+<span class='label label-info'>Event</span>
+<ul>
+<li><a href='#Worker.workerCreated'>Worker.workerCreated</a></li>
+<li><a href='#Worker.workerTerminated'>Worker.workerTerminated</a></li>
+<li><a href='#Worker.dispatchMessageFromWorker'>Worker.dispatchMessageFromWorker</a></li>
+<li><a href='#Worker.disconnectedFromWorker'>Worker.disconnectedFromWorker</a></li>
+</ul>
+<div id='Worker_enable' class='command'>
+<h3>Worker.enable <span class='label label-success'>Command</span></h3>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Worker.enable
+Worker.enable();
+</pre>
+</div>
+<div id='Worker_disable' class='command'>
+<h3>Worker.disable <span class='label label-success'>Command</span></h3>
+<h4>Code Example:</h4>
+<pre>
+// WebInspector Command: Worker.disable
+Worker.disable();
+</pre>
+</div>
+<div id='Worker_sendMessageToWorker' class='command'>
+<h3>Worker.sendMessageToWorker <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5378,8 +6325,8 @@ Worker.setWorkerInspectionEnabled(value);
 Worker.sendMessageToWorker(workerId, message);
 </pre>
 </div>
-<div id="Worker_connectToWorker" class="command">
-<h3>Worker.connectToWorker <span class="label label-success">Command</span></h3>
+<div id='Worker_connectToWorker' class='command'>
+<h3>Worker.connectToWorker <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5390,8 +6337,8 @@ Worker.sendMessageToWorker(workerId, message);
 Worker.connectToWorker(workerId);
 </pre>
 </div>
-<div id="Worker_disconnectFromWorker" class="command">
-<h3>Worker.disconnectFromWorker <span class="label label-success">Command</span></h3>
+<div id='Worker_disconnectFromWorker' class='command'>
+<h3>Worker.disconnectFromWorker <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5402,8 +6349,8 @@ Worker.connectToWorker(workerId);
 Worker.disconnectFromWorker(workerId);
 </pre>
 </div>
-<div id="Worker_setAutoconnectToWorkers" class="command">
-<h3>Worker.setAutoconnectToWorkers <span class="label label-success">Command</span></h3>
+<div id='Worker_setAutoconnectToWorkers' class='command'>
+<h3>Worker.setAutoconnectToWorkers <span class='label label-success'>Command</span></h3>
 <dl>
 <dt>value</dt>
 <dd>Boolean</dd>
@@ -5414,8 +6361,8 @@ Worker.disconnectFromWorker(workerId);
 Worker.setAutoconnectToWorkers(value);
 </pre>
 </div>
-<div id="Worker_workerCreated" class="command">
-<h3>Worker.workerCreated <span class="label label-info">Event</span></h3>
+<div id='Worker_workerCreated' class='command'>
+<h3>Worker.workerCreated <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5432,8 +6379,8 @@ function onWorkerCreated(res) {
 }
 </pre>
 </div>
-<div id="Worker_workerTerminated" class="command">
-<h3>Worker.workerTerminated <span class="label label-info">Event</span></h3>
+<div id='Worker_workerTerminated' class='command'>
+<h3>Worker.workerTerminated <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5446,8 +6393,8 @@ function onWorkerTerminated(res) {
 }
 </pre>
 </div>
-<div id="Worker_dispatchMessageFromWorker" class="command">
-<h3>Worker.dispatchMessageFromWorker <span class="label label-info">Event</span></h3>
+<div id='Worker_dispatchMessageFromWorker' class='command'>
+<h3>Worker.dispatchMessageFromWorker <span class='label label-info'>Event</span></h3>
 <dl>
 <dt>workerId</dt>
 <dd>Integer</dd>
@@ -5462,8 +6409,8 @@ function onDispatchMessageFromWorker(res) {
 }
 </pre>
 </div>
-<div id="Worker_disconnectedFromWorker" class="command">
-<h3>Worker.disconnectedFromWorker <span class="label label-info">Event</span></h3>
+<div id='Worker_disconnectedFromWorker' class='command'>
+<h3>Worker.disconnectedFromWorker <span class='label label-info'>Event</span></h3>
 <h4>Code Example:</h4>
 <pre>
 // WebInspector Event: Worker.disconnectedFromWorker
@@ -5475,8 +6422,8 @@ function onDisconnectedFromWorker(res) {
 </section>
 </div>
 <footer>
-<p>Generated from Inspector.json v1.0 on 2012-03-18 22:23:32-0700</p>
-<p>Implementation by <a href="mailto:jdiehl@adobe.com">Jonathan Diehl</a></p>
+<p>Generated from Inspector.json v1.0 on 2012-08-17 16:44:25+0200</p>
+<p>Implementation by <a href='mailto:jdiehl@adobe.com'>Jonathan Diehl</a></p>
 </footer>
 </body>
 </html>

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -497,7 +497,6 @@ define(function LiveDevelopment(require, exports, module) {
         Inspector.on("connect", _onConnect);
         Inspector.on("disconnect", _onDisconnect);
         Inspector.on("error", _onError);
-        Inspector.on("load", _onLoad);
         $(DocumentManager).on("currentDocumentChange", _onDocumentChange);
     }
 

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -108,7 +108,7 @@ define(function main(require, exports, module) {
 
     /** Toggles LiveDevelopment and synchronizes the state of UI elements that reports LiveDevelopment status */
     function _handleGoLiveCommand() {
-        if (LiveDevelopment.status > 0) {
+        if (LiveDevelopment.status >= LiveDevelopment.STATUS_CONNECTING) {
             LiveDevelopment.close();
             // TODO Ty: when checkmark support lands, remove checkmark
         } else {

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -63,7 +63,7 @@ define(function main(require, exports, module) {
                           Strings.LIVE_DEV_STATUS_TIP_PROGRESS2, Strings.LIVE_DEV_STATUS_TIP_CONNECTED];  // Status indicator tooltip
     var _statusStyle = ["warning", "", "info", "info", "success"];  // Status indicator's CSS class
     var _allStatusStyles = _statusStyle.join(" ");
-    
+
     var _$btnGoLive; // reference to the GoLive button
     var _$btnHighlight; // reference to the HighlightButton
 
@@ -90,7 +90,7 @@ define(function main(require, exports, module) {
         // Clear text/styles from previous status
         $("span", $btn).remove();
         $btn.removeClass(_allStatusStyles);
-        
+
         // Set text/styles for new status
         if (text && text.length > 0) {
             $("<span class=\"label\">")
@@ -100,7 +100,7 @@ define(function main(require, exports, module) {
         } else {
             $btn.addClass(style);
         }
-        
+
         if (tooltip) {
             $btn.attr("title", tooltip);
         }
@@ -129,7 +129,7 @@ define(function main(require, exports, module) {
             // various status codes.
             _setLabel(_$btnGoLive, null, _statusStyle[status + 1], _statusTooltip[status + 1]);
         });
-        
+
         // Initialize tooltip for 'not connected' state
         _setLabel(_$btnGoLive, null, _statusStyle[1], _statusTooltip[1]);
     }


### PR DESCRIPTION
As suggested in #1340:
- Inspector and agents now use jQuery events. I mapped Inspector.on and .off to jQuery's methods to make migrating to the new events easier. Feel free to take these methods out (they are not used).
- LiveDevelopment.open() now returns a promise
- I removed the `load` event handler (it is triggered otherwise)
- Status codes are now constants (the mapping remains the same to support >= STATUS_CONNECTING to check if there is an connection attempt or an active connection in one line)
