### PR TITLE
Add "Show Extensions Folder" item to the Debug menu

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -88,6 +88,7 @@ define(function (require, exports, module) {
     exports.DEBUG_RUN_UNIT_TESTS        = "debug.runUnitTests";
     exports.DEBUG_SHOW_PERF_DATA        = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW   = "debug.newBracketsWindow";
+    exports.DEBUG_SHOW_EXT_FOLDER       = "debug.showExtensionsFolder";
     exports.DEBUG_SWITCH_LANGUAGE       = "debug.switchLanguage";
     exports.CHECK_FOR_UPDATE            = "app.checkForUpdate";
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -926,6 +926,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.DEBUG_REFRESH_WINDOW, [{key: "F5",     platform: "win"},
                                                          {key: "Cmd-R", platform:  "mac"}]);
         menu.addMenuItem(Commands.DEBUG_NEW_BRACKETS_WINDOW);
+        menu.addMenuItem(Commands.DEBUG_SHOW_EXT_FOLDER);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.DEBUG_SWITCH_LANGUAGE);
         menu.addMenuDivider();

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -235,6 +235,15 @@ define(function (require, exports, module) {
         });
     }
     
+    function _handleShowExtensionsFolder() {
+        brackets.app.showExtensionsFolder(
+            window.location.href,
+            function (err) {
+                // Ignore errors
+            }
+        );
+    }
+    
     function _handleCheckForUpdates() {
         UpdateNotification.checkForUpdate(true);
     }
@@ -245,6 +254,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS,      Commands.DEBUG_SHOW_DEVELOPER_TOOLS,   handleShowDeveloperTools)
         .setEnabled(!!brackets.app.showDeveloperTools);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW, Commands.DEBUG_NEW_BRACKETS_WINDOW,    _handleNewBracketsWindow);
+    CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.DEBUG_SHOW_EXT_FOLDER,     _handleShowExtensionsFolder);
     CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,      Commands.DEBUG_RUN_UNIT_TESTS,         _handleRunUnitTests);
     CommandManager.register(Strings.CMD_SHOW_PERF_DATA,      Commands.DEBUG_SHOW_PERF_DATA,         _handleShowPerfData);
     CommandManager.register(Strings.CMD_SWITCH_LANGUAGE,     Commands.DEBUG_SWITCH_LANGUAGE,        _handleSwitchLanguage);

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
     
     function _handleShowExtensionsFolder() {
         brackets.app.showExtensionsFolder(
-            window.location.href,
+            FileUtils.convertToNativePath(window.location.href),
             function (err) {
                 // Ignore errors
             }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -171,6 +171,7 @@ define({
     "CMD_JSLINT"                          : "Enable JSLint",
     "CMD_SHOW_PERF_DATA"                  : "Show Performance Data",
     "CMD_NEW_BRACKETS_WINDOW"             : "New Brackets Window",
+    "CMD_SHOW_EXTENSIONS_FOLDER"          : "Show Extensions Folder",
     "CMD_USE_TAB_CHARS"                   : "Use Tab Characters",
     "CMD_SWITCH_LANGUAGE"                 : "Switch Language",
     "CMD_CHECK_FOR_UPDATE"                : "Check for Updates",


### PR DESCRIPTION
This is a convenience menu item that opens the extensions folder in the Finder/Explorer.

This pull request depends on adobe/brackets-shell#72
