### PR TITLE
Refactor global brackets ready and htmlContentLoadComplete events to a new Global module

### DIFF
--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -31,6 +31,8 @@
 define(function GotoAgent(require, exports, module) {
     "use strict";
 
+    require("utils/Global");
+
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
     var DOMAgent = require("LiveDevelopment/Agents/DOMAgent");
     var ScriptAgent = require("LiveDevelopment/Agents/ScriptAgent");

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -53,6 +53,8 @@
 define(function LiveDevelopment(require, exports, module) {
     "use strict";
 
+    require("utils/Global");
+
     // Status Codes
     var STATUS_ERROR          = exports.STATUS_ERROR = -1;
     var STATUS_INACTIVE       = exports.STATUS_INACTIVE = 0;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -46,10 +46,6 @@ require.config({
  *
  * Unlike other modules, this one can be accessed without an explicit require() because it exposes
  * a global object, window.brackets.
- *
- * Events:
- *      htmlContentLoadComplete - sent when the HTML DOM is fully loaded. Modules should not touch
- *      or modify DOM elements before this event is sent.
  */
 define(function (require, exports, module) {
     "use strict";
@@ -91,12 +87,11 @@ define(function (require, exports, module) {
         SidebarView             = require("project/SidebarView"),
         Async                   = require("utils/Async"),
         UpdateNotification      = require("utils/UpdateNotification"),
-        UrlParams               = require("utils/UrlParams").UrlParams;
+        UrlParams               = require("utils/UrlParams").UrlParams,
+        Global                  = require("utils/Global");
 
     // Local variables
-    var bracketsReady           = false,
-        bracketsReadyHandlers   = [],
-        params                  = new UrlParams();
+    var params                  = new UrlParams();
     
     // read URL params
     params.parse();
@@ -109,89 +104,9 @@ define(function (require, exports, module) {
     require("search/FindInFiles");
     require("search/FindReplace");
     require("utils/ExtensionUtils");
-
-    function _callBracketsReadyHandler(handler) {
-        try {
-            handler();
-        } catch (e) {
-            console.log("Exception when calling a 'brackets done loading' handler");
-            console.log(e);
-        }
-    }
-
-    function _onBracketsReady() {
-        var i;
-        bracketsReady = true;
-        for (i = 0; i < bracketsReadyHandlers.length; i++) {
-            _callBracketsReadyHandler(bracketsReadyHandlers[i]);
-        }
-        bracketsReadyHandlers = [];
-    }
-
-    // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
-    // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
-    function _registerBracketsReadyHandler(handler) {
-        if (bracketsReady) {
-            _callBracketsReadyHandler(handler);
-        } else {
-            bracketsReadyHandlers.push(handler);
-        }
-    }
-    
-    // TODO: Issue 949 - the following code should be shared
-    
-    function _initGlobalBrackets() {
-        // Define core brackets namespace if it isn't already defined
-        //
-        // We can't simply do 'brackets = {}' to define it in the global namespace because
-        // we're in "use strict" mode. Most likely, 'window' will always point to the global
-        // object when this code is running. However, in case it isn't (e.g. if we're running 
-        // inside Node for CI testing) we use this trick to get the global object.
-        //
-        // Taken from:
-        //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
-        var Fn = Function, global = (new Fn("return this"))();
-        if (!global.brackets) {
-            global.brackets = {};
-        }
-        
-        // Uncomment the following line to force all low level file i/o routines to complete
-        // asynchronously. This should only be done for testing/debugging.
-        // NOTE: Make sure this line is commented out again before committing!
-        //brackets.forceAsyncCallbacks = true;
-    
-        // Load native shell when brackets is run in a native shell rather than the browser
-        // TODO: (issue #266) load conditionally
-        brackets.shellAPI = require("utils/ShellAPI");
-        
-        brackets.inBrowser = !brackets.hasOwnProperty("fs");
-        
-        brackets.platform = (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") ? "mac" : "win";
-        
-        // Loading extensions requires creating new require.js contexts, which requires access to the global 'require' object
-        // that always gets hidden by the 'require' in the AMD wrapper. We store this in the brackets object here so that 
-        // the ExtensionLoader doesn't have to have access to the global object.
-        brackets.libRequire = global.require;
-
-        // Also store our current require.js context (the one that loads brackets core modules) so that extensions can use it
-        // Note: we change the name to "getModule" because this won't do exactly the same thing as 'require' in AMD-wrapped
-        // modules. The extension will only be able to load modules that have already been loaded once.
-        brackets.getModule = require;
-
-        // Provide a way for anyone (including code not using require) to register a handler for the brackets 'ready' event
-        // This event is like $(document).ready in that it will call the handler immediately if brackets is already done loading
-        //
-        // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
-        // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
-        //
-        // TODO (issue 1034): We *could* use a $.Deferred for this, except deferred objects enter a broken
-        // state if any resolution callback throws an exception. Since third parties (e.g. extensions) may
-        // add callbacks to this, we need to be robust to exceptions
-        brackets.ready = _registerBracketsReadyHandler;
-    }
     
     // TODO: (issue 1029) Add timeout to main extension loading promise, so that we always call this function
-    // Making this fix will fix a warning (search for issue 1029) related to the brackets 'ready' event.
+    // Making this fix will fix a warning (search for issue 1029) related to the global brackets 'ready' event.
     function _initExtensions() {
         // allow unit tests to override which plugin folder(s) to load
         var paths = params.get("extensions") || "default,user";
@@ -341,7 +256,11 @@ define(function (require, exports, module) {
         var initialProjectPath = ProjectManager.getInitialProjectPath();
         ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
-            _initExtensions().always(_onBracketsReady);
+
+            // WARNING: brackets.ready won't fire if ANY extension fails to
+            // load or throws an error during init. To fix this, we need to
+            // make a change to _initExtensions (filed as issue 1029)
+            _initExtensions().always(Global.dispatchEvent(Global.READY));
         });
         
         // Check for updates
@@ -349,15 +268,10 @@ define(function (require, exports, module) {
             UpdateNotification.checkForUpdate();
         }
     }
-            
-    // Main Brackets initialization
-    _initGlobalBrackets();
 
     // Localize MainViewHTML and inject into <BODY> tag
     $('body').html(Mustache.render(MainViewHTML, Strings));
-    // modules that depend on the HTML DOM should listen to
-    // the htmlContentLoadComplete event.
-    $(brackets).trigger("htmlContentLoadComplete");
+    Global.dispatchEvent(Global.HTML_CONTENT_LOAD_COMPLETE);
 
     $(window.document).ready(_onReady);
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,6 +61,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Global                  = require("utils/Global"),
+        LoadEvents              = require("utils/LoadEvents"),
         ProjectManager          = require("project/ProjectManager"),
         DocumentManager         = require("document/DocumentManager"),
         EditorManager           = require("editor/EditorManager"),
@@ -260,7 +261,7 @@ define(function (require, exports, module) {
             // WARNING: brackets.ready won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
-            _initExtensions().always(Global._dispatchEvent(Global.READY));
+            _initExtensions().always(LoadEvents._dispatchEvent(LoadEvents.READY));
         });
         
         // Check for updates
@@ -271,7 +272,7 @@ define(function (require, exports, module) {
 
     // Localize MainViewHTML and inject into <BODY> tag
     $('body').html(Mustache.render(MainViewHTML, Strings));
-    Global._dispatchEvent(Global.HTML_CONTENT_LOAD_COMPLETE);
+    LoadEvents._dispatchEvent(LoadEvents.HTML_CONTENT_LOAD_COMPLETE);
 
     $(window.document).ready(_onReady);
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -258,7 +258,7 @@ define(function (require, exports, module) {
         ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
 
-            // WARNING: brackets.ready won't fire if ANY extension fails to
+            // WARNING: LoadEvents.ready won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
             _initExtensions().always(LoadEvents._dispatchEvent(LoadEvents.READY));

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             doneLoading             : false
         };
 
-        brackets.ready(function () {
+        LoadEvents.ready(function () {
             brackets.test.doneLoading = true;
         });
     }

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -60,7 +60,8 @@ define(function (require, exports, module) {
     require("LiveDevelopment/main");
     
     // Load dependent modules
-    var ProjectManager          = require("project/ProjectManager"),
+    var Global                  = require("utils/Global"),
+        ProjectManager          = require("project/ProjectManager"),
         DocumentManager         = require("document/DocumentManager"),
         EditorManager           = require("editor/EditorManager"),
         CSSInlineEditor         = require("editor/CSSInlineEditor"),
@@ -87,8 +88,7 @@ define(function (require, exports, module) {
         SidebarView             = require("project/SidebarView"),
         Async                   = require("utils/Async"),
         UpdateNotification      = require("utils/UpdateNotification"),
-        UrlParams               = require("utils/UrlParams").UrlParams,
-        Global                  = require("utils/Global");
+        UrlParams               = require("utils/UrlParams").UrlParams;
 
     // Local variables
     var params                  = new UrlParams();
@@ -260,7 +260,7 @@ define(function (require, exports, module) {
             // WARNING: brackets.ready won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
-            _initExtensions().always(Global.dispatchEvent(Global.READY));
+            _initExtensions().always(Global._dispatchEvent(Global.READY));
         });
         
         // Check for updates
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
 
     // Localize MainViewHTML and inject into <BODY> tag
     $('body').html(Mustache.render(MainViewHTML, Strings));
-    Global.dispatchEvent(Global.HTML_CONTENT_LOAD_COMPLETE);
+    Global._dispatchEvent(Global.HTML_CONTENT_LOAD_COMPLETE);
 
     $(window.document).ready(_onReady);
     

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -31,6 +31,8 @@
 define(function (require, exports, module) {
     "use strict";
 
+    require("utils/Global");
+
     var CommandManager = require("command/CommandManager");
 
     /**

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -30,6 +30,8 @@
  */
 define(function (require, exports, module) {
     "use strict";
+
+    require("utils/Global");
     
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         PerfUtils           = require("utils/PerfUtils"),

--- a/src/index.html
+++ b/src/index.html
@@ -58,8 +58,9 @@
 
     <!-- HTML content is dynamically loaded and rendered by brackets.js.
          Any modules that depend on or modify HTML during load should 
-         listen for the "htmlContentLoadComplete" event that is triggered from
-         the brackets global object before touching the dom. -->
+         require the "utils/LoadEvents" modules and install an event handler
+         for "htmlContentLoadComplete" (e.g. LoadEvents.htmlContentLoadComplete(handler))
+         before touching the DOM. -->
    
     <!-- All other scripts are loaded through require. -->
     <script src="thirdparty/require.js" data-main="brackets"></script>

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -38,6 +38,8 @@
  */
 define(function (require, exports, module) {
     "use strict";
+
+    require("utils/Global");
     
     // Load dependent non-module scripts
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -43,7 +43,8 @@ define(function (require, exports, module) {
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");
 
     // Load dependent modules
-    var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
+    var LoadEvents          = require("utils/LoadEvents"),
+        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         PreferencesManager  = require("preferences/PreferencesManager"),
         DocumentManager     = require("document/DocumentManager"),
         CommandManager      = require("command/CommandManager"),
@@ -55,8 +56,7 @@ define(function (require, exports, module) {
         FileViewController  = require("project/FileViewController"),
         PerfUtils           = require("utils/PerfUtils"),
         ViewUtils           = require("utils/ViewUtils"),
-        FileUtils           = require("file/FileUtils"),
-        Global              = require("utils/Global");
+        FileUtils           = require("file/FileUtils");
     
     /**
      * @private
@@ -931,7 +931,7 @@ define(function (require, exports, module) {
 
 
     // Initialize variables and listeners that depend on the HTML DOM
-    brackets.htmlContentLoadComplete(function () {
+    LoadEvents.htmlContentLoadComplete(function () {
         $projectTreeContainer = $("#project-files-container");
 
         $("#open-files-container").on("contentChanged", function () {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -55,7 +55,8 @@ define(function (require, exports, module) {
         FileViewController  = require("project/FileViewController"),
         PerfUtils           = require("utils/PerfUtils"),
         ViewUtils           = require("utils/ViewUtils"),
-        FileUtils           = require("file/FileUtils");
+        FileUtils           = require("file/FileUtils"),
+        Global              = require("utils/Global");
     
     /**
      * @private
@@ -930,7 +931,7 @@ define(function (require, exports, module) {
 
 
     // Initialize variables and listeners that depend on the HTML DOM
-    $(brackets).on("htmlContentLoadComplete", function () {
+    brackets.htmlContentLoadComplete(function () {
         $projectTreeContainer = $("#project-files-container");
 
         $("#open-files-container").on("contentChanged", function () {

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         Commands                = require("command/Commands"),
         Strings                 = require("strings"),
         PreferencesManager      = require("preferences/PreferencesManager"),
-        EditorManager           = require("editor/EditorManager");
+        EditorManager           = require("editor/EditorManager"),
+        Global                  = require("utils/Global");
 
     var isSidebarClosed         = false;
 
@@ -232,7 +233,7 @@ define(function (require, exports, module) {
     }
 
     // Initialize items dependent on HTML DOM
-    $(brackets).on("htmlContentLoadComplete", function () {
+    brackets.htmlContentLoadComplete(function () {
         $sidebar                = $("#sidebar");
         $sidebarMenuText        = $("#menu-view-hide-sidebar span");
         $sidebarResizer         = $("#sidebar-resizer");

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -28,14 +28,15 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var ProjectManager          = require("project/ProjectManager"),
-        WorkingSetView          = require("project/WorkingSetView"),
-        CommandManager          = require("command/CommandManager"),
-        Commands                = require("command/Commands"),
-        Strings                 = require("strings"),
-        PreferencesManager      = require("preferences/PreferencesManager"),
-        EditorManager           = require("editor/EditorManager"),
-        Global                  = require("utils/Global");
+    var LoadEvents          = require("utils/LoadEvents"),
+        ProjectManager      = require("project/ProjectManager"),
+        WorkingSetView      = require("project/WorkingSetView"),
+        CommandManager      = require("command/CommandManager"),
+        Commands            = require("command/Commands"),
+        Strings             = require("strings"),
+        PreferencesManager  = require("preferences/PreferencesManager"),
+        EditorManager       = require("editor/EditorManager"),
+        Global              = require("utils/Global");
 
     var isSidebarClosed         = false;
 
@@ -233,7 +234,7 @@ define(function (require, exports, module) {
     }
 
     // Initialize items dependent on HTML DOM
-    brackets.htmlContentLoadComplete(function () {
+    LoadEvents.htmlContentLoadComplete(function () {
         $sidebar                = $("#sidebar");
         $sidebarMenuText        = $("#menu-view-hide-sidebar span");
         $sidebarResizer         = $("#sidebar-resizer");

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -32,6 +32,8 @@
 define(function (require, exports, module) {
     "use strict";
 
+    require("utils/Global");
+
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils           = require("file/FileUtils"),
         Async               = require("utils/Async"),

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets */
+
+/**
+ * Defines 'ready' on the global brackets object 
+ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    // Fires when the base htmlContent/main-view.html is loaded
+    var HTML_CONTENT_LOAD_COMPLETE  = "htmlContentLoadComplete";
+
+    // Fires when all extensions are loaded
+    var READY                       = "ready";
+
+    var eventStatus                 = { HTML_CONTENT_LOAD_COMPLETE : false, READY : false },
+        handlers                    = {};
+
+    handlers[HTML_CONTENT_LOAD_COMPLETE] = [];
+    handlers[READY] = [];
+
+    function _callEventHandler(handler) {
+        try {
+            // TODO (issue 1034): We *could* use a $.Deferred for this, except deferred objects enter a broken
+            // state if any resolution callback throws an exception. Since third parties (e.g. extensions) may
+            // add callbacks to this, we need to be robust to exceptions
+            handler();
+        } catch (e) {
+            console.log("Exception when calling a 'brackets done loading' handler");
+            console.log(e);
+        }
+    }
+
+    function dispatchEvent(type) {
+        var i,
+            eventTypeHandlers = handlers[type];
+
+        // mark this event type as fired
+        eventStatus[type] = true;
+
+        for (i = 0; i < eventTypeHandlers.length; i++) {
+            _callEventHandler(eventTypeHandlers[i]);
+        }
+
+        // clear all handlers after being called
+        eventTypeHandlers = [];
+    }
+
+    // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
+    // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
+    function _addListener(type, handler) {
+        if (eventStatus[type]) {
+            _callEventHandler(handler);
+        } else {
+            handlers[type].push(handler);
+        }
+    }
+
+    function ready(handler) {
+        _addListener(READY, handler);
+    }
+
+    function htmlContentLoadComplete(handler) {
+        _addListener(HTML_CONTENT_LOAD_COMPLETE, handler);
+    }
+    
+    // Define core brackets namespace if it isn't already defined
+    //
+    // We can't simply do 'brackets = {}' to define it in the global namespace because
+    // we're in "use strict" mode. Most likely, 'window' will always point to the global
+    // object when this code is running. However, in case it isn't (e.g. if we're running 
+    // inside Node for CI testing) we use this trick to get the global object.
+    //
+    // Taken from:
+    //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
+    var Fn = Function, global = (new Fn("return this"))();
+    if (!global.brackets) {
+        global.brackets = {};
+    }
+        
+    // Uncomment the following line to force all low level file i/o routines to complete
+    // asynchronously. This should only be done for testing/debugging.
+    // NOTE: Make sure this line is commented out again before committing!
+    //brackets.forceAsyncCallbacks = true;
+
+    // Load native shell when brackets is run in a native shell rather than the browser
+    // TODO: (issue #266) load conditionally
+    brackets.shellAPI = require("utils/ShellAPI");
+    
+    brackets.inBrowser = !brackets.hasOwnProperty("fs");
+    
+    brackets.platform = (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") ? "mac" : "win";
+    
+    // Loading extensions requires creating new require.js contexts, which
+    // requires access to the global 'require' object that always gets hidden
+    // by the 'require' in the AMD wrapper. We store this in the brackets
+    // object here so that the ExtensionLoader doesn't have to have access to
+    // the global object.
+    brackets.libRequire = global.require;
+
+    // Also store our current require.js context (the one that loads brackets
+    // core modules) so that extensions can use it.
+    // Note: we change the name to "getModule" because this won't do exactly
+    // the same thing as 'require' in AMD-wrapped modules. The extension will
+    // only be able to load modules that have already been loaded once.
+    brackets.getModule = require;
+
+    // Provide a way for anyone (including code not using require) to register
+    // a handler for the brackets 'ready' and 'htmlContentLoadComplete' events
+    // This event is like $(document).ready in that it will call the handler
+    // immediately if brackets is already done loading
+    brackets.ready = ready;
+    brackets.htmlContentLoadComplete = htmlContentLoadComplete;
+
+    exports.global = global;
+    exports.HTML_CONTENT_LOAD_COMPLETE = HTML_CONTENT_LOAD_COMPLETE;
+    exports.READY = READY;
+
+    // internal use only
+    exports.dispatchEvent = dispatchEvent;
+});

--- a/src/utils/LoadEvents.js
+++ b/src/utils/LoadEvents.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+/**
+ * Defines events to assist with module initialization.
+ *
+ * This module dispatches these events:
+ *    - htmlContentLoadComplete - When the main application template is rendered
+ *    - ready - When Brackets completes loading all modules and extensions
+ *
+ * These are *not* jQuery events. Each event has it's own event registration.
+ * Each event is similar to $(document).ready in that it will call the handler
+ * immediately if brackets is already done loading
+ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    // Fires when the base htmlContent/main-view.html is loaded
+    var HTML_CONTENT_LOAD_COMPLETE  = "htmlContentLoadComplete";
+
+    // Fires when all extensions are loaded
+    var READY                       = "ready";
+
+    var eventStatus                 = { HTML_CONTENT_LOAD_COMPLETE : false, READY : false },
+        handlers                    = {};
+
+    handlers[HTML_CONTENT_LOAD_COMPLETE] = [];
+    handlers[READY] = [];
+
+    function _callEventHandler(handler) {
+        try {
+            // TODO (issue 1034): We *could* use a $.Deferred for this, except deferred objects enter a broken
+            // state if any resolution callback throws an exception. Since third parties (e.g. extensions) may
+            // add callbacks to this, we need to be robust to exceptions
+            handler();
+        } catch (e) {
+            console.log("Exception when calling a 'brackets done loading' handler");
+            console.log(e);
+        }
+    }
+
+    function _dispatchEvent(type) {
+        var i,
+            eventTypeHandlers = handlers[type];
+
+        // mark this event type as fired
+        eventStatus[type] = true;
+
+        for (i = 0; i < eventTypeHandlers.length; i++) {
+            _callEventHandler(eventTypeHandlers[i]);
+        }
+
+        // clear all handlers after being called
+        eventTypeHandlers = [];
+    }
+
+    // WARNING: This event won't fire if ANY extension fails to load or throws an error during init.
+    // To fix this, we need to make a change to _initExtensions (filed as issue 1029)
+    function _addListener(type, handler) {
+        if (eventStatus[type]) {
+            _callEventHandler(handler);
+        } else {
+            handlers[type].push(handler);
+        }
+    }
+
+    /**
+     * Adds an event handler for the ready event. Handlers are called after
+     * htmlContentLoadComplete, the initial project is loaded, and all
+     * extensions are loaded.
+     * @param {function} handler
+     */
+    function ready(handler) {
+        _addListener(READY, handler);
+    }
+
+    /**
+     * Adds an event handler for the htmlContentLoadComplete event. Handlers
+      * are called after the main application html template is rendered.
+     * @param {function} handler
+     */
+    function htmlContentLoadComplete(handler) {
+        _addListener(HTML_CONTENT_LOAD_COMPLETE, handler);
+    }
+
+    exports.ready = ready;
+    exports.htmlContentLoadComplete = htmlContentLoadComplete;
+    
+    exports.HTML_CONTENT_LOAD_COMPLETE = HTML_CONTENT_LOAD_COMPLETE;
+    exports.READY = READY;
+
+    // internal use only
+    exports._dispatchEvent = _dispatchEvent;
+});

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -31,6 +31,8 @@
 define(function (require, exports, module) {
     "use strict";
     
+    require("utils/Global");
+
     var KeyBindingManager = require("command/KeyBindingManager");
 
     var DIALOG_BTN_CANCEL = "cancel",

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
     'use strict';
     
     // Utility dependency
-    var SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
+    var Global              = require("utils/Global"),
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         PerformanceReporter = require("perf/PerformanceReporter").PerformanceReporter,
         ExtensionLoader     = require("utils/ExtensionLoader"),
         Async               = require("utils/Async"),
@@ -51,7 +52,6 @@ define(function (require, exports, module) {
     // Jasmine reporter UI
     require("test/BootstrapReporter");
     
-    // TODO: Issue 949 - the following code should be shared
     // Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
     
@@ -110,32 +110,6 @@ define(function (require, exports, module) {
     }
     
     function init() {
-        // TODO: Issue 949 - the following code should be shared
-
-        // Define core brackets namespace if it isn't already defined
-        //
-        // We can't simply do 'brackets = {}' to define it in the global namespace because
-        // we're in "use strict" mode. Most likely, 'window' will always point to the global
-        // object when this code is running. However, in case it isn't (e.g. if we're running 
-        // inside Node for CI testing) we use this trick to get the global object.
-        //
-        // Taken from:
-        //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
-        var Fn = Function, global = (new Fn('return this'))();
-        if (!global.brackets) {
-            global.brackets = {};
-        }
-
-        // Loading extensions requires creating new require.js contexts, which requires access to the global 'require' object
-        // that always gets hidden by the 'require' in the AMD wrapper. We store this in the brackets object here so that 
-        // the ExtensionLoader doesn't have to have access to the global object.
-        brackets.libRequire = global.require;
-
-        // Also store our current require.js context (the one that loads brackets core modules) so that extensions can use it
-        // Note: we change the name to "getModule" because this won't do exactly the same thing as 'require' in AMD-wrapped
-        // modules. The extension will only be able to load modules that have already been loaded once.
-        brackets.getModule = require;
-            
         suite = params.get("suite") || localStorage.getItem("SpecRunner.suite") || "UnitTestSuite";
         
         // Create a top-level filter to show/hide performance and extensions tests

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -28,6 +28,8 @@
 define(function (require, exports, module) {
     'use strict';
     
+    require("utils/Global");
+
     // Load dependent modules
     var CommandManager      = require("command/CommandManager"),
         KeyBindingManager   = require("command/KeyBindingManager");

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -57,6 +57,10 @@ define(function (require, exports, module) {
         
         var platform = brackets.platform;
         
+        beforeEach(function () {
+            brackets.platform = "test";
+        });
+        
         afterEach(function () {
             KeyBindingManager._reset();
             brackets.platform = platform;
@@ -80,9 +84,6 @@ define(function (require, exports, module) {
             });
             
             it("should add single bindings to the keymap", function () {
-                // use a fake platform
-                brackets.platform = "test";
-                
                 var result = KeyBindingManager.addBinding("test.foo", "Ctrl-A");
                 expect(result).toEqual(key("Ctrl-A"));
                 expect(KeyBindingManager.getKeyBindings("test.foo")).toEqual([key("Ctrl-A")]);

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -27,6 +27,8 @@
 
 define(function (require, exports, module) {
     'use strict';
+
+    require("utils/Global");
     
     // Load dependent modules
     var SpecRunnerUtils     = require("spec/SpecRunnerUtils");

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -27,6 +27,8 @@
 
 define(function (require, exports, module) {
     'use strict';
+
+    require("utils/Global");
     
     // Load dependent modules
     var NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
                 function () {
                     // check working set UI list content
                     $listItems = testWindow.$("#open-files-container > ul").children();
-                    return $listItems.length === 2;
+                    return ($listItems.length === 2) && $($listItems[1]).hasClass("selected");
                 },
                 1000
             );


### PR DESCRIPTION
- Adds `utils/Global` module that initializes the global `brackets` namespace
- Fixes #1404 so that listeners for htmlContentLoadComplete will be called even if the event has already fired
- Fixes #949 to factor out common `brackets` init code
