### PR TITLE
Set cache=false when fetching update data.

### DIFF
--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -113,6 +113,7 @@ define(function (require, exports, module) {
         if (fetchData) {
             $.ajax(_versionInfoURL, {
                 dataType: "text",
+                cache: false,
                 complete: function (jqXHR, status) {
                     if (status === "success") {
                         try {


### PR DESCRIPTION
We always want the latest update information to be downloaded.
