### PR TITLE
Add error message when update info can't be fetched

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -100,6 +100,9 @@ define({
     "NO_UPDATE_TITLE"                   : "You're up to date!",
     "NO_UPDATE_MESSAGE"                 : "You are running the latest version of Brackets.",
 
+    "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Error getting update info",
+    "ERROR_FETCHING_UPDATE_INFO_MSG"    : "There was a problem getting the latest update information from the server. Please make sure you are connected to the internet and try again.",
+    
     // Switch language
     "LANGUAGE_TITLE"                    : "Switch Language",
     "LANGUAGE_MESSAGE"                  : "Please select the desired language from the list below:",

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -330,6 +330,12 @@ define(function (require, exports, module) {
                 result.resolve();
             })
             .fail(function () {
+                // Error fetching the update data. If this is a forced check, alert the user
+                Dialogs.showModalDialog(
+                    Dialogs.DIALOG_ID_ERROR,
+                    Strings.ERROR_FETCHING_UPDATE_INFO_TITLE,
+                    Strings.ERROR_FETCHING_UPDATE_INFO_MSG
+                );
                 result.reject();
             });
         


### PR DESCRIPTION
Fix for #1435

If you manually check for updates (by selecting Debug > Check for Updates or clicking the present icon), show an error dialog if the update information can't be retrieved.

No dialogs are shown if there is an error during the update check at app startup.
