### PR TITLE
fixes issue 1440

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -368,8 +368,10 @@ define(function (require, exports, module) {
                 if (!_movePrevToken(ctx)) {
                     return createTagInfo();
                 }
-            
-                if (ctx.token.className !== "tag") {
+
+                if (ctx.token.className === "comment") {
+                    return createTagInfo();
+                } else if (ctx.token.className !== "tag") {
                     //if wasn't the tag name, assume it was an attr value
                     tagInfo = _getTagInfoStartingFromAttrValue(ctx);
 


### PR DESCRIPTION
Don't scan backwards through comments in getTagInfo() when looking for the tag when current token is at white space.

@RaymondLim can you review

fix issue #1440
