### PR TITLE
Close html tags

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -313,7 +313,9 @@ define(function (require, exports, module) {
             },
             "Shift-Delete": "cut",
             "Ctrl-Insert": "copy",
-            "Shift-Insert": "paste"
+            "Shift-Insert": "paste",
+            "'>'": function (cm) { cm.closeTag(cm, '>'); },
+            "'/'": function (cm) { cm.closeTag(cm, '/'); }
         };
         
         EditorManager.mergeExtraKeys(self, codeMirrorKeyMap, additionalKeys);

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -108,8 +108,6 @@ define(function (require, exports, module) {
         } else {
             editor.document.replaceRange(completion, start);
         }
-        
-        editor._codeMirror.closeTag(editor._codeMirror, ">");
     };
 
     /**

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -108,6 +108,8 @@ define(function (require, exports, module) {
         } else {
             editor.document.replaceRange(completion, start);
         }
+        
+        editor._codeMirror.closeTag(editor._codeMirror, ">");
     };
 
     /**

--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,7 @@
     <script src="thirdparty/CodeMirror2/lib/util/dialog.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/search.js"></script>
+    <script src="thirdparty/CodeMirror2/lib/util/closetag.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
I implemented autoclosing html tags through codemirror addon.

This pull request assumes the next fix to be implemented:
https://github.com/adobe/CodeMirror2/pull/76
