### PR TITLE
Rename LoadEvents to AppIinit

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Global                  = require("utils/Global"),
-        LoadEvents              = require("utils/LoadEvents"),
+        Ready                   = require("utils/Ready"),
         ProjectManager          = require("project/ProjectManager"),
         DocumentManager         = require("document/DocumentManager"),
         EditorManager           = require("editor/EditorManager"),
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             doneLoading             : false
         };
 
-        LoadEvents.ready(function () {
+        Ready.ready(function () {
             brackets.test.doneLoading = true;
         });
     }
@@ -258,10 +258,10 @@ define(function (require, exports, module) {
         ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
 
-            // WARNING: LoadEvents.ready won't fire if ANY extension fails to
+            // WARNING: Ready.ready won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
-            _initExtensions().always(LoadEvents._dispatchEvent(LoadEvents.READY));
+            _initExtensions().always(Ready._dispatchReady(Ready.READY));
         });
         
         // Check for updates
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
 
     // Localize MainViewHTML and inject into <BODY> tag
     $('body').html(Mustache.render(MainViewHTML, Strings));
-    LoadEvents._dispatchEvent(LoadEvents.HTML_CONTENT_LOAD_COMPLETE);
+    Ready._dispatchReady(Ready.HTML_READY);
 
     $(window.document).ready(_onReady);
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Global                  = require("utils/Global"),
-        Ready                   = require("utils/Ready"),
+        AppInit                 = require("utils/AppInit"),
         ProjectManager          = require("project/ProjectManager"),
         DocumentManager         = require("document/DocumentManager"),
         EditorManager           = require("editor/EditorManager"),
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             doneLoading             : false
         };
 
-        Ready.ready(function () {
+        AppInit.ready(function () {
             brackets.test.doneLoading = true;
         });
     }
@@ -258,10 +258,10 @@ define(function (require, exports, module) {
         ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
 
-            // WARNING: Ready.ready won't fire if ANY extension fails to
+            // WARNING: AppInit.ready won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
-            _initExtensions().always(Ready._dispatchReady(Ready.READY));
+            _initExtensions().always(AppInit._dispatchReady(AppInit.APP_READY));
         });
         
         // Check for updates
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
 
     // Localize MainViewHTML and inject into <BODY> tag
     $('body').html(Mustache.render(MainViewHTML, Strings));
-    Ready._dispatchReady(Ready.HTML_READY);
+    AppInit._dispatchReady(AppInit.HTML_READY);
 
     $(window.document).ready(_onReady);
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             doneLoading             : false
         };
 
-        AppInit.ready(function () {
+        AppInit.appReady(function () {
             brackets.test.doneLoading = true;
         });
     }
@@ -258,7 +258,7 @@ define(function (require, exports, module) {
         ProjectManager.openProject(initialProjectPath).done(function () {
             _initTest();
 
-            // WARNING: AppInit.ready won't fire if ANY extension fails to
+            // WARNING: AppInit.appReady won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
             _initExtensions().always(AppInit._dispatchReady(AppInit.APP_READY));

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -22,8 +22,8 @@
 
 
 <!--
-    This is the HTML for the body tag of index.html. It is loaded dynamically by the 
-    htmlContentLoad module and localized using a combination of mustache.js and i18n.js.
+    HTML template for the body tag of index.html. It is rendered dynamically in
+    brackets.js with Mustache and localized with the i18n RequireJS plugin.
 
     LOCALIZATION NOTE:
     All display text for this file must use templating so the text can be localized.

--- a/src/index.html
+++ b/src/index.html
@@ -58,10 +58,10 @@
 
     <!-- HTML content is dynamically loaded and rendered by brackets.js.
          Any modules that depend on or modify HTML during load should 
-         require the "utils/LoadEvents" modules and install an event handler
-         for "htmlContentLoadComplete" (e.g. LoadEvents.htmlContentLoadComplete(handler))
-         before touching the DOM. -->
-   
+         require the "utils/Ready" modules and install a callback for
+         "htmlReady" (e.g. Ready.htmlReady(handler)) before touching the DOM.
+    -->
+    
     <!-- All other scripts are loaded through require. -->
     <script src="thirdparty/require.js" data-main="brackets"></script>
 

--- a/src/index.html
+++ b/src/index.html
@@ -59,7 +59,7 @@
     <!-- HTML content is dynamically loaded and rendered by brackets.js.
          Any modules that depend on or modify HTML during load should 
          require the "utils/Ready" modules and install a callback for
-         "htmlReady" (e.g. Ready.htmlReady(handler)) before touching the DOM.
+         "htmlReady" (e.g. AppInit.htmlReady(handler)) before touching the DOM.
     -->
     
     <!-- All other scripts are loaded through require. -->

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");
 
     // Load dependent modules
-    var Ready               = require("utils/Ready"),
+    var AppInit             = require("utils/AppInit"),
         NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         PreferencesManager  = require("preferences/PreferencesManager"),
         DocumentManager     = require("document/DocumentManager"),
@@ -933,7 +933,7 @@ define(function (require, exports, module) {
 
 
     // Initialize variables and listeners that depend on the HTML DOM
-    Ready.htmlReady(function () {
+    AppInit.htmlReady(function () {
         $projectTreeContainer = $("#project-files-container");
 
         $("#open-files-container").on("contentChanged", function () {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     require("thirdparty/jstree_pre1.0_fix_1/jquery.jstree");
 
     // Load dependent modules
-    var LoadEvents          = require("utils/LoadEvents"),
+    var Ready               = require("utils/Ready"),
         NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         PreferencesManager  = require("preferences/PreferencesManager"),
         DocumentManager     = require("document/DocumentManager"),
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Reference to the tree control container div. Initialized by
-     * htmlContentLoadComplete handler
+     * htmlReady handler
      * @type {jQueryObject}
      */
     var $projectTreeContainer;
@@ -933,7 +933,7 @@ define(function (require, exports, module) {
 
 
     // Initialize variables and listeners that depend on the HTML DOM
-    LoadEvents.htmlContentLoadComplete(function () {
+    Ready.htmlReady(function () {
         $projectTreeContainer = $("#project-files-container");
 
         $("#open-files-container").on("contentChanged", function () {

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -28,7 +28,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var Ready               = require("utils/Ready"),
+    var AppInit             = require("utils/AppInit"),
         ProjectManager      = require("project/ProjectManager"),
         WorkingSetView      = require("project/WorkingSetView"),
         CommandManager      = require("command/CommandManager"),
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
     }
 
     // Initialize items dependent on HTML DOM
-    Ready.htmlReady(function () {
+    AppInit.htmlReady(function () {
         $sidebar                = $("#sidebar");
         $sidebarMenuText        = $("#menu-view-hide-sidebar span");
         $sidebarResizer         = $("#sidebar-resizer");

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -28,7 +28,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var LoadEvents          = require("utils/LoadEvents"),
+    var Ready               = require("utils/Ready"),
         ProjectManager      = require("project/ProjectManager"),
         WorkingSetView      = require("project/WorkingSetView"),
         CommandManager      = require("command/CommandManager"),
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
     var PREFERENCES_CLIENT_ID = "com.adobe.brackets.SidebarView",
         defaultPrefs = { sidebarWidth: 200, sidebarClosed: false };
 
-    // These vars are initialized by the htmlContentLoadComplete handler
+    // These vars are initialized by the htmlReady handler
     // below since they refer to DOM elements
     var $sidebar,
         $sidebarMenuText,
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
     }
 
     // Initialize items dependent on HTML DOM
-    LoadEvents.htmlContentLoadComplete(function () {
+    Ready.htmlReady(function () {
         $sidebar                = $("#sidebar");
         $sidebarMenuText        = $("#menu-view-hide-sidebar span");
         $sidebarResizer         = $("#sidebar-resizer");

--- a/src/utils/AppInit.js
+++ b/src/utils/AppInit.js
@@ -30,7 +30,7 @@
  *
  * This module defines 2 methods for client modules to attach callbacks:
  *    - htmlReady - When the main application template is rendered
- *    - ready - When Brackets completes loading all modules and extensions
+ *    - appReady - When Brackets completes loading all modules and extensions
  *
  * These are *not* jQuery events. Each method is similar to $(document).ready
  * in that it will call the handler immediately if brackets is already done
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
      * loaded.
      * @param {function} handler
      */
-    function ready(callback) {
+    function appReady(callback) {
         // WARNING: "ready" won't fire if ANY extension fails to load or
         // throws an error during init. To fix this, we need to make a change
         // to _initExtensions (filed as issue 1029)
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
         _addListener(HTML_READY, callback);
     }
 
-    exports.ready = ready;
+    exports.appReady = appReady;
     exports.htmlReady = htmlReady;
     
     exports.HTML_READY = HTML_READY;

--- a/src/utils/AppInit.js
+++ b/src/utils/AppInit.js
@@ -43,13 +43,13 @@ define(function (require, exports, module) {
     var HTML_READY  = "htmlReady";
 
     // Fires when all extensions are loaded
-    var READY       = "ready";
+    var APP_READY   = "appReady";
 
-    var status      = { HTML_READY : false, READY : false },
+    var status      = { HTML_READY : false, APP_READY : false },
         callbacks   = {};
 
     callbacks[HTML_READY] = [];
-    callbacks[READY] = [];
+    callbacks[APP_READY] = [];
 
     function _callHandler(handler) {
         try {
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
         // WARNING: "ready" won't fire if ANY extension fails to load or
         // throws an error during init. To fix this, we need to make a change
         // to _initExtensions (filed as issue 1029)
-        _addListener(READY, callback);
+        _addListener(APP_READY, callback);
     }
 
     /**
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
     exports.htmlReady = htmlReady;
     
     exports.HTML_READY = HTML_READY;
-    exports.READY = READY;
+    exports.APP_READY = APP_READY;
 
     // internal use only
     exports._dispatchReady = _dispatchReady;

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -29,7 +29,7 @@
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
  * (a) the module requires this module, i.e. require("utils/Global") or
- * (b) the module receives a "ready" event from the utils/LoadEvents module.
+ * (b) the module receives a "ready" event from the utils/Ready module.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -29,7 +29,7 @@
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
  * (a) the module requires this module, i.e. require("utils/Global") or
- * (b) the module receives a "ready" event from the utils/Ready module.
+ * (b) the module receives a "ready" callback from the utils/Ready module.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -29,7 +29,7 @@
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
  * (a) the module requires this module, i.e. require("utils/Global") or
- * (b) the module receives a "ready" callback from the utils/Ready module.
+ * (b) the module receives a "ready" callback from the utils/AppReady module.
  */
 define(function (require, exports, module) {
     "use strict";


### PR DESCRIPTION
Fix for #1404
- Rename LoadEvents to AppInit
- Rename `ready` to `appReady`
- Rename `htmlContentLoadComplete` to `htmlReady`

Wiki pages have been updated as well: https://github.com/adobe/brackets/wiki/Brackets-Development-How-Tos and https://github.com/adobe/brackets/wiki/Release-notes:-Sprint-13
