### PR TITLE
Refactor styles to allow nowrap in dialog box footer

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -314,6 +314,18 @@
 
 /* Dialog-related styles */
 
+.modal {
+    width: auto;
+}
+
+.modal-body, .modal-header {
+    width: 560px;
+}
+
+.modal-footer {
+    white-space: nowrap;
+}
+
 .modal-footer .btn.left {
     float: left;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -319,6 +319,9 @@
 }
 
 .modal-body, .modal-header {
+    /* See styles/bootstrap/patterns.less .modal class.
+       Pushing this value down to .modal-header and .modal-body
+       to allow the overall modal to take the width of the footer */
     width: 560px;
 }
 


### PR DESCRIPTION
Fix for #1477.

Move dialog width style from .modal to .modal-header and .modal-body. Allow .modal-footer to use nowrap so buttons don't wrap
