### PR TITLE
Fixes to recent projects dropdown

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -120,7 +120,14 @@ define(function (require, exports, module) {
             if (root !== currentProject) {
                 var $link = renderPath(root)
                     .click(function () {
-                        ProjectManager.openProject(root);
+                        ProjectManager.openProject(root)
+                            .fail(function () {
+                                // Remove the project from the list.
+                                var index = recentProjects.indexOf(root);
+                                if (index !== -1) {
+                                    recentProjects.splice(index, 1);
+                                }
+                            });
                         closeDropdown();
                     });
                 $("<li></li>")

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
         CommandManager          = brackets.getModule("command/CommandManager"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
         AppInit                 = brackets.getModule("utils/AppInit"),
-        Strings                 = brackets.getModule("strings");
+        Strings                 = brackets.getModule("strings"),
+        SidebarView             = brackets.getModule("project/SidebarView");
     
     var $dropdownToggle;
     var MAX_PROJECTS = 20;
@@ -109,6 +110,7 @@ define(function (require, exports, module) {
         function closeDropdown() {
             $("html").off("click", closeDropdown);
             $("#project-files-container").off("scroll", closeDropdown);
+            $(SidebarView).off("hide", closeDropdown);
             $dropdown.remove();
         }
         
@@ -152,6 +154,10 @@ define(function (require, exports, module) {
         // We should fix this when the popup handling is centralized in PopupManager, as well
         // as making Esc close the dropdown. See issue #1381.
         $("#project-files-container").on("scroll", closeDropdown);
+        
+        // Hide the menu if the sidebar is hidden.
+        // TODO: Is there some more general way we could handle this for dropdowns?
+        $(SidebarView).on("hide", closeDropdown);
     }
     
     // Initialize extension

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
         }
         
         var folderSpan = $("<span></span>").addClass("recent-folder").text(folder),
-            restSpan = $("<span></span>").addClass("recent-folder-path").text(" in " + rest);
+            restSpan = $("<span></span>").addClass("recent-folder-path").text(" - " + rest);
         return $("<a></a>").addClass("recent-folder-link").append(folderSpan).append(restSpan);
     }
     

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -694,16 +694,14 @@ define(function (require, exports, module) {
                         StringUtils.format(
                             Strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR,
                             StringUtils.htmlEscape(rootPath),
-                            error.code,
-                            function () {
-                                result.reject();
-                            }
+                            error.code
                         )
                     ).done(function () {
                         // The project folder stored in preference doesn't exist, so load the default 
                         // project directory.
                         // TODO (issue #267): When Brackets supports having no project directory
                         // defined this code will need to change
+                        result.reject();
                         return _loadProject(_getDefaultProjectPath());
                     });
                 }

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -25,6 +25,12 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $, document, window, brackets  */
 
+/**
+ * The view that controls the showing and hiding of the sidebar. Dispatches the following events:
+ *    hide -- when the sidebar is hidden
+ *    show -- when the sidebar is shown
+ */
+
 define(function (require, exports, module) {
     "use strict";
     
@@ -112,8 +118,10 @@ define(function (require, exports, module) {
     function toggleSidebar(width) {
         if (isSidebarClosed) {
             $sidebar.show();
+            $(exports).triggerHandler("show");
         } else {
             $sidebar.hide();
+            $(exports).triggerHandler("hide");
         }
         
         isSidebarClosed = !isSidebarClosed;


### PR DESCRIPTION
- When the user selects a folder that no longer exists, remove it from the dropdown. (#1485) Note that there was a bug in ProjectManager where it wouldn't actually reject the promise in `openProject()` if the folder doesn't exist. It looks like the rejection was put in the wrong place (it didn't make sense where it was), so I moved it.
- Replace "in" with "-" in the dropdown (where we indicate the parent of the given folder) so we don't have to localize it.
- Hide the dropdown when the sidebar is hidden. To fix this, I added events to SidebarView that are triggered when the sidebar shows or hides.
