### PR TITLE
Turn off sample project for unit test windows

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
             // samples folder in case this is the first time we're launching Brackets after upgrading from
             // an old version that might not have set the "afterFirstLaunch" pref.)
             var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID);
-            if (!prefs.getValue("afterFirstLaunch")) {
+            if (!params.get("skipSampleProjectLoad") && !prefs.getValue("afterFirstLaunch")) {
                 prefs.setValue("afterFirstLaunch", "true");
                 if (ProjectManager.isDefaultProjectPath(initialProjectPath)) {
                     var dirEntry = new NativeFileSystem.DirectoryEntry(initialProjectPath);

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -139,6 +139,9 @@ define(function (require, exports, module) {
             // disable update check in test windows
             params.put("skipUpdateCheck", true);
             
+            // disable loading of sample project
+            params.put("skipSampleProjectLoad", true);
+            
             _testWindow = window.open(getBracketsSourceRoot() + "/index.html?" + params.toString(), "_blank", optionsStr);
             
             _testWindow.executeCommand = function executeCommand(cmd, args) {


### PR DESCRIPTION
Many unit tests assume that when they create a new unit test window, the working set is empty. The sample project code violates this assumption, so we just turn it off (similar to the way we turn off the update check for test windows).
