### PR TITLE
Fix bug #1384 (Exception when selecting Quick Open result by clicking)

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
+/*global define, $, window, setTimeout */
 
 /*
 * Displays an auto suggest pop-up list of files to allow the user to quickly navigate to a file and lines
@@ -267,7 +267,6 @@ define(function (require, exports, module) {
 
     /**
      * KeyUp is for cases that handle AFTER a character has been committed to $searchField
-     *
      */
     QuickNavigateDialog.prototype._handleKeyUp = function (e) {
         var query = this.$searchField.val();
@@ -351,13 +350,27 @@ define(function (require, exports, module) {
 
         // Ty TODO: disabled for now while file switching is disabled in _handleItemFocus
         //JSLintUtils.setEnabled(true);
+        
+        // Make sure Smart Autocomplete knows its popup is getting closed (in cases where there's no
+        // editor to give focus to below, it won't notice otherwise).
+        this.$searchField.trigger("lostFocus");
 
         EditorManager.focusEditor();
-
-        this.dialog.remove();
+        
+        // Closing the dialog is a little tricky (see #1384): some Smart Autocomplete code may run later (e.g.
+        // (because it's a later handler of the event that just triggered _close()), and that code expects to
+        // find metadata that it stuffed onto the DOM node earlier. But $.remove() strips that metadata.
+        // So, to hide the dialog immediately it's only safe to remove using raw DOM APIs:
+        this.dialog[0].parentNode.removeChild(this.dialog[0]);
+        var self = this;
+        setTimeout(function () {
+            // Now that it's safe, call the real jQuery API to clear the metadata & prevent a memory leak
+            self.dialog.remove();
+        }, 0);
+        
         $(".smart_autocomplete_container").remove();
 
-        $(window.document).off("mousedown", this.handleDocumentClick);
+        $(window.document).off("mousedown", this.handleDocumentMouseDown);
     };
     
     function filterFileList(query) {
@@ -485,10 +498,11 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Close the dialog when the user clicks outside of it. Note, auto smart complete has a "lostFocus" event that is
-     * supposed to capture this event, but it also gets triggered on keyUp which doesn't work for quick find.
+     * Close the dialog when the user clicks outside of it. Smart-autocomplete listens for this and automatically closes its popup,
+     * but we want to close the whole search "dialog." (And we can't just piggyback on the popup closing event, since there are cases
+     * where the popup closes that we want the dialog to remain open (e.g. deleting search term via backspace).
      */
-    QuickNavigateDialog.prototype.handleDocumentClick = function (e) {
+    QuickNavigateDialog.prototype.handleDocumentMouseDown = function (e) {
         if ($(this.dialog).find(e.target).length === 0 && $(".smart_autocomplete_container").find(e.target).length === 0) {
             this._close();
         }
@@ -505,8 +519,8 @@ define(function (require, exports, module) {
         }
         dialogOpen = true;
 
-        this.handleDocumentClick = this.handleDocumentClick.bind(this);
-        $(window.document).on("mousedown", this.handleDocumentClick);
+        this.handleDocumentMouseDown = this.handleDocumentMouseDown.bind(this);
+        $(window.document).on("mousedown", this.handleDocumentMouseDown);
 
 
         // Ty TODO: disabled for now while file switching is disabled in _handleItemFocus


### PR DESCRIPTION
Fix bug #1384 (Exception when selecting Quick Open result by clicking).

Any Smart Autocomplete code that runs after $.remove() will fail because remove() strips off metadata that it expects to find on the text input element. The fix is (a) to forcibly close Smart Autocomplete every time we're closing the search bar, and (b) only fully clean up the search bar after a timeout, to let Smart Autocomplete's event handlers finish running.  ('A' is needed due to the [additional case Randy spotted](https://github.com/adobe/brackets/issues/1384#issuecomment-8108746), where Smart Autocomplete _never_ tries to close if there's no Editor open for it to lose focus to).

Also: rename handleDocumentClick() since it actually handles mouseDown, and clarify its comment.
