### PR TITLE
Fix autoconnect

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -104,7 +104,6 @@ define(function LiveDevelopment(require, exports, module) {
     // store the names (matching property names in the 'agent' object) of agents that we've loaded
     var _loadedAgentNames = [];
 
-    var _htmlDocumentPath; // the path of the html file open for live development
     var _liveDocument; // the document open for live editing.
     var _relatedDocuments; // CSS and JS documents that are used by the live HTML document
 
@@ -472,10 +471,9 @@ define(function LiveDevelopment(require, exports, module) {
                 _openDocument(doc, editor);
             } else {
                 /* FUTURE: support live connections for docments other than html */
-                if (doc.extension && doc.extension.indexOf("htm") === 0 && doc.file.fullPath !== _htmlDocumentPath) {
+                if (exports.config.experimental || (doc.extension && doc.extension.indexOf('htm') === 0)) {
                     close();
                     window.setTimeout(open);
-                    _htmlDocumentPath = doc.file.fullPath;
                 }
             }
         }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -478,8 +478,6 @@ define(function LiveDevelopment(require, exports, module) {
                     _htmlDocumentPath = doc.file.fullPath;
                 }
             }
-        } else if (exports.config.autoconnect) {
-            window.setTimeout(open);
         }
     }
 

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -181,6 +181,11 @@ define(function main(require, exports, module) {
             AppInit.appReady(function () {
                 if (DocumentManager.getCurrentDocument()) {
                     _handleGoLiveCommand();
+                } else {
+                    $(DocumentManager).on("currentDocumentChange", _handleGoLiveCommand);
+                    window.setTimeout(function () {
+                        $(DocumentManager).off("currentDocumentChange", _handleGoLiveCommand);
+                    }, 200);
                 }
             });
         }


### PR DESCRIPTION
The autoconnect behavior was broken after merging live-development into master. This pull request will fix that to the correct behavior:

If autoconnect is enabled in the LiveDevelopment configuration (LiveDevelopment/main.js), Brackets will automatically attempt to connect to Chrome if there has been an active connection when Brackets was shut down the last time (or reloaded).
