### PR TITLE
Fix for issue #1530

### DIFF
--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -331,11 +331,13 @@ define(function (require, exports, module) {
             })
             .fail(function () {
                 // Error fetching the update data. If this is a forced check, alert the user
-                Dialogs.showModalDialog(
-                    Dialogs.DIALOG_ID_ERROR,
-                    Strings.ERROR_FETCHING_UPDATE_INFO_TITLE,
-                    Strings.ERROR_FETCHING_UPDATE_INFO_MSG
-                );
+                if (force) {
+                    Dialogs.showModalDialog(
+                        Dialogs.DIALOG_ID_ERROR,
+                        Strings.ERROR_FETCHING_UPDATE_INFO_TITLE,
+                        Strings.ERROR_FETCHING_UPDATE_INFO_MSG
+                    );
+                }
                 result.reject();
             });
         


### PR DESCRIPTION
Only show the 'error fetching update info' dialog when doing a forced check for updates. 
