### PR TITLE
Replace Brackets with APP_NAME constant

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -103,8 +103,9 @@ define(function (require, exports, module) {
     //Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
     require("editor/EditorCommandHandlers");
-    require("debug/DebugCommandHandlers");
     require("view/ViewCommandHandlers");
+    require("debug/DebugCommandHandlers");
+    require("help/HelpCommandHandlers");
     require("search/FindInFiles");
     require("search/FindReplace");
     require("utils/ExtensionUtils");
@@ -186,23 +187,6 @@ define(function (require, exports, module) {
         // that self-register" above for some). A few commands need an extra kick here though:
         
         DocumentCommandHandlers.init($("#main-toolbar"));
-        
-        // About dialog
-        CommandManager.register(Strings.CMD_ABOUT,  Commands.HELP_ABOUT, function () {
-            // If we've successfully determined a "build number" via .git metadata, add it to dialog
-            var bracketsSHA = BuildInfoUtils.getBracketsSHA(),
-                bracketsAppSHA = BuildInfoUtils.getBracketsAppSHA(),
-                versionLabel = "";
-            if (bracketsSHA) {
-                versionLabel += " (" + bracketsSHA.substr(0, 7) + ")";
-            }
-            if (bracketsAppSHA) {
-                versionLabel += " (shell " + bracketsAppSHA.substr(0, 7) + ")";
-            }
-            $("#about-build-number").text(versionLabel);
-            
-            Dialogs.showModalDialog(Dialogs.DIALOG_ID_ABOUT);
-        });
     }
     
     function _initWindowListeners() {
@@ -289,8 +273,11 @@ define(function (require, exports, module) {
     }
 
     // Localize MainViewHTML and inject into <BODY> tag
-    $('body').html(Mustache.render(MainViewHTML, Strings));
+    $("body").html(Mustache.render(MainViewHTML, Strings));
     AppInit._dispatchReady(AppInit.HTML_READY);
+    
+    // Update title
+    $("title").text(Strings.APP_NAME);
 
     $(window.document).ready(_onReady);
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -224,8 +224,8 @@ define(function (require, exports, module) {
         if (brackets.inBrowser) {
             Dialogs.showModalDialog(
                 Dialogs.DIALOG_ID_ERROR,
-                Strings.ERROR_BRACKETS_IN_BROWSER_TITLE,
-                Strings.ERROR_BRACKETS_IN_BROWSER
+                Strings.ERROR_IN_BROWSER_TITLE,
+                Strings.ERROR_IN_BROWSER
             );
         }
 

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -274,10 +274,12 @@ define(function (require, exports, module) {
 
     // Localize MainViewHTML and inject into <BODY> tag
     $("body").html(Mustache.render(MainViewHTML, Strings));
-    AppInit._dispatchReady(AppInit.HTML_READY);
     
     // Update title
     $("title").text(Strings.APP_NAME);
+
+    // Dispatch htmlReady callbacks
+    AppInit._dispatchReady(AppInit.HTML_READY);
 
     $(window.document).ready(_onReady);
     

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -88,12 +88,12 @@ define(function (require, exports, module) {
     exports.DEBUG_RUN_UNIT_TESTS        = "debug.runUnitTests";
     exports.DEBUG_SHOW_PERF_DATA        = "debug.showPerfData";
     exports.DEBUG_NEW_BRACKETS_WINDOW   = "debug.newBracketsWindow";
-    exports.DEBUG_SHOW_EXT_FOLDER       = "debug.showExtensionsFolder";
     exports.DEBUG_SWITCH_LANGUAGE       = "debug.switchLanguage";
-    exports.CHECK_FOR_UPDATE            = "app.checkForUpdate";
 
-	// Command that does nothing. Can be used for place holder menuItems
-    
+    // Help
+    exports.HELP_SHOW_EXT_FOLDER        = "help.showExtensionsFolder";
+    exports.HELP_CHECK_FOR_UPDATE       = "help.checkForUpdate";
+    exports.HELP_FORUM                  = "help.forum";
     exports.HELP_ABOUT                  = "help.about";
 
     // File shell callbacks

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var Commands                = require("command/Commands"),
+    var Global                  = require("utils/Global"),
+        Commands                = require("command/Commands"),
         KeyBindingManager       = require("command/KeyBindingManager"),
         EditorManager           = require("editor/EditorManager"),
         Strings                 = require("strings"),
@@ -42,11 +43,12 @@ define(function (require, exports, module) {
      * @enum {string}
      */
     var AppMenuBar = {
-        FILE_MENU:     "file-menu",
-        EDIT_MENU:     "edit-menu",
-        VIEW_MENU :    "view-menu",
-        NAVIGATE_MENU: "navigate-menu",
-        DEBUG_MENU:    "debug-menu"
+        FILE_MENU       : "file-menu",
+        EDIT_MENU       : "edit-menu",
+        VIEW_MENU       : "view-menu",
+        NAVIGATE_MENU   : "navigate-menu",
+        DEBUG_MENU      : "debug-menu",
+        HELP_MENU       : "help-menu"
     };
 
     /**
@@ -920,20 +922,34 @@ define(function (require, exports, module) {
         /*
          * Debug menu
          */
-        menu = addMenu(Strings.DEBUG_MENU, AppMenuBar.DEBUG_MENU);
-        menu.addMenuItem(Commands.DEBUG_SHOW_DEVELOPER_TOOLS, [{key: "F12",        platform: "win"},
-                                                               {key: "Cmd-Opt-I", platform: "mac"}]);
-        menu.addMenuItem(Commands.DEBUG_REFRESH_WINDOW, [{key: "F5",     platform: "win"},
-                                                         {key: "Cmd-R", platform:  "mac"}]);
-        menu.addMenuItem(Commands.DEBUG_NEW_BRACKETS_WINDOW);
-        menu.addMenuItem(Commands.DEBUG_SHOW_EXT_FOLDER);
+        if (brackets.config.show_debug_menu) {
+            menu = addMenu(Strings.DEBUG_MENU, AppMenuBar.DEBUG_MENU);
+            menu.addMenuItem(Commands.DEBUG_SHOW_DEVELOPER_TOOLS, [{key: "F12",        platform: "win"},
+                                                                   {key: "Cmd-Opt-I", platform: "mac"}]);
+            menu.addMenuItem(Commands.DEBUG_REFRESH_WINDOW, [{key: "F5",     platform: "win"},
+                                                             {key: "Cmd-R", platform:  "mac"}]);
+            menu.addMenuItem(Commands.DEBUG_NEW_BRACKETS_WINDOW);
+            menu.addMenuDivider();
+            menu.addMenuItem(Commands.DEBUG_SWITCH_LANGUAGE);
+            menu.addMenuDivider();
+            menu.addMenuItem(Commands.DEBUG_RUN_UNIT_TESTS);
+            menu.addMenuItem(Commands.DEBUG_SHOW_PERF_DATA);
+        }
+
+        /*
+         * Help menu
+         */
+        menu = addMenu(Strings.HELP_MENU, AppMenuBar.HELP_MENU);
+        menu.addMenuItem(Commands.HELP_SHOW_EXT_FOLDER);
+        menu.addMenuItem(Commands.HELP_CHECK_FOR_UPDATE);
+
+        if (brackets.config.forum_url) {
+            menu.addMenuDivider();
+            menu.addMenuItem(Commands.HELP_FORUM);
+        }
+
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.DEBUG_SWITCH_LANGUAGE);
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.DEBUG_RUN_UNIT_TESTS);
-        menu.addMenuItem(Commands.DEBUG_SHOW_PERF_DATA);
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.CHECK_FOR_UPDATE);
+        menu.addMenuItem(Commands.HELP_ABOUT);
 
 
         /*

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,6 @@
+{
+    "app_name"          : "Brackets",
+    "show_debug_menu"   : true,
+    "enable_jslint"     : true,
+    "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev"
+}

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,0 @@
-{
-    "app_name"          : "Brackets",
-    "show_debug_menu"   : true,
-    "enable_jslint"     : true,
-    "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev"
-}

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -31,23 +31,15 @@ define(function (require, exports, module) {
     var Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
         Editor                  = require("editor/Editor").Editor,
+        FileUtils               = require("file/FileUtils"),
         Strings                 = require("strings"),
         PerfUtils               = require("utils/PerfUtils"),
         NativeApp               = require("utils/NativeApp"),
-        NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
-        FileUtils               = require("file/FileUtils"),
-        UpdateNotification      = require("utils/UpdateNotification");
+        NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem;
     
     function handleShowDeveloperTools(commandData) {
         brackets.app.showDeveloperTools();
     }
-    
-    function _handleUseTabChars() {
-        var useTabs = !Editor.getUseTabChar();
-        Editor.setUseTabChar(useTabs);
-        CommandManager.get(Commands.TOGGLE_USE_TAB_CHARS).setChecked(useTabs);
-    }
-    
     
     // Implements the 'Run Tests' menu to bring up the Jasmine unit test window
     var _testWindow = null;
@@ -245,19 +237,6 @@ define(function (require, exports, module) {
         });
     }
     
-    function _handleShowExtensionsFolder() {
-        brackets.app.showExtensionsFolder(
-            FileUtils.convertToNativePath(window.location.href),
-            function (err) {
-                // Ignore errors
-            }
-        );
-    }
-    
-    function _handleCheckForUpdates() {
-        UpdateNotification.checkForUpdate(true);
-    }
-    
     function _enableRunTestsMenuItem() {
         // Check for the SpecRunner.html file
         var fileEntry = new NativeFileSystem.FileEntry(
@@ -283,7 +262,6 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS,      Commands.DEBUG_SHOW_DEVELOPER_TOOLS,   handleShowDeveloperTools)
         .setEnabled(!!brackets.app.showDeveloperTools);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW, Commands.DEBUG_NEW_BRACKETS_WINDOW,    _handleNewBracketsWindow);
-    CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.DEBUG_SHOW_EXT_FOLDER,     _handleShowExtensionsFolder);
     
     // Start with the "Run Tests" item disabled. It will be enabled later if the test file can be found.
     CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,      Commands.DEBUG_RUN_UNIT_TESTS,         _handleRunUnitTests)
@@ -291,11 +269,6 @@ define(function (require, exports, module) {
     
     CommandManager.register(Strings.CMD_SHOW_PERF_DATA,      Commands.DEBUG_SHOW_PERF_DATA,         _handleShowPerfData);
     CommandManager.register(Strings.CMD_SWITCH_LANGUAGE,     Commands.DEBUG_SWITCH_LANGUAGE,        _handleSwitchLanguage);
-    
-    CommandManager.register(Strings.CMD_USE_TAB_CHARS,       Commands.TOGGLE_USE_TAB_CHARS,         _handleUseTabChars)
-        .setChecked(Editor.getUseTabChar());
-    
-    CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE,    Commands.CHECK_FOR_UPDATE,             _handleCheckForUpdates);
     
     _enableRunTestsMenuItem();
 });

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -35,7 +35,8 @@ define(function (require, exports, module) {
     var Commands           = require("command/Commands"),
         Strings            = require("strings"),
         CommandManager     = require("command/CommandManager"),
-        EditorManager      = require("editor/EditorManager");
+        EditorManager      = require("editor/EditorManager"),
+        Editor             = require("editor/Editor").Editor;
     
     
     /**
@@ -262,12 +263,23 @@ define(function (require, exports, module) {
         
         editor._codeMirror.execCommand("indentLess");
     }
+    
+    /**
+     * Toggles tabs/spaces preferences
+     */
+    function toggleUseTabChars() {
+        var useTabs = !Editor.getUseTabChar();
+        Editor.setUseTabChar(useTabs);
+        CommandManager.get(Commands.TOGGLE_USE_TAB_CHARS).setChecked(useTabs);
+    }
         
     // Register commands
-    CommandManager.register(Strings.CMD_INDENT,         Commands.EDIT_INDENT,       indentText);
-    CommandManager.register(Strings.CMD_UNINDENT,       Commands.EDIT_UNINDENT,     unidentText);
-    CommandManager.register(Strings.CMD_COMMENT,        Commands.EDIT_LINE_COMMENT, lineComment);
-    CommandManager.register(Strings.CMD_DUPLICATE,      Commands.EDIT_DUPLICATE,    duplicateText);
-    CommandManager.register(Strings.CMD_LINE_UP,        Commands.EDIT_LINE_UP,      moveLineUp);
-    CommandManager.register(Strings.CMD_LINE_DOWN,      Commands.EDIT_LINE_DOWN,    moveLineDown);
+    CommandManager.register(Strings.CMD_INDENT,         Commands.EDIT_INDENT,           indentText);
+    CommandManager.register(Strings.CMD_UNINDENT,       Commands.EDIT_UNINDENT,         unidentText);
+    CommandManager.register(Strings.CMD_COMMENT,        Commands.EDIT_LINE_COMMENT,     lineComment);
+    CommandManager.register(Strings.CMD_DUPLICATE,      Commands.EDIT_DUPLICATE,        duplicateText);
+    CommandManager.register(Strings.CMD_LINE_UP,        Commands.EDIT_LINE_UP,          moveLineUp);
+    CommandManager.register(Strings.CMD_LINE_DOWN,      Commands.EDIT_LINE_DOWN,        moveLineDown);
+    CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.TOGGLE_USE_TAB_CHARS,  toggleUseTabChars)
+        .setChecked(Editor.getUseTabChar());
 });

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets, window */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var Global                  = require("utils/Global"),
+        BuildInfoUtils          = require("utils/BuildInfoUtils"),
+        Commands                = require("command/Commands"),
+        CommandManager          = require("command/CommandManager"),
+        Dialogs                 = require("widgets/Dialogs"),
+        Strings                 = require("strings"),
+        UpdateNotification      = require("utils/UpdateNotification"),
+        FileUtils               = require("file/FileUtils"),
+        NativeApp               = require("utils/NativeApp");
+    
+    function _handleShowExtensionsFolder() {
+        brackets.app.showExtensionsFolder(
+            FileUtils.convertToNativePath(window.location.href),
+            function (err) {
+                // Ignore errors
+            }
+        );
+    }
+    
+    function _handleCheckForUpdates() {
+        UpdateNotification.checkForUpdate(true);
+    }
+
+    function _handleAboutDialog() {
+        // If we've successfully determined a "build number" via .git metadata, add it to dialog
+        var bracketsSHA = BuildInfoUtils.getBracketsSHA(),
+            bracketsAppSHA = BuildInfoUtils.getBracketsAppSHA(),
+            versionLabel = "";
+        if (bracketsSHA) {
+            versionLabel += " (" + bracketsSHA.substr(0, 7) + ")";
+        }
+        if (bracketsAppSHA) {
+            versionLabel += " (shell " + bracketsAppSHA.substr(0, 7) + ")";
+        }
+        $("#about-build-number").text(versionLabel);
+        
+        Dialogs.showModalDialog(Dialogs.DIALOG_ID_ABOUT);
+    }
+
+    function _handleForum() {
+        if (!brackets.config.forum_url) {
+            return;
+        }
+
+        NativeApp.openURLInDefaultBrowser(brackets.config.forum_url);
+    }
+    
+    CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.HELP_SHOW_EXT_FOLDER,      _handleShowExtensionsFolder);
+    CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE,       Commands.HELP_CHECK_FOR_UPDATE,     _handleCheckForUpdates);
+    CommandManager.register(Strings.CMD_FORUM,                  Commands.HELP_FORUM,                _handleForum);
+    CommandManager.register(Strings.CMD_ABOUT,                  Commands.HELP_ABOUT,                _handleAboutDialog);
+});

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Brackets</title>
+    <title></title>
 
     <!-- CSS/LESS -->
 

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_JSLINT, Commands.TOGGLE_JSLINT, _handleToggleJSLint);
     
     // Init PreferenceStorage
-    _prefs = PreferencesManager.getPreferenceStorage(module.id, { enabled: brackets.config.enable_jslint || false});
+    _prefs = PreferencesManager.getPreferenceStorage(module.id, { enabled: !!brackets.config.enable_jslint });
     _setEnabled(_prefs.getValue("enabled"));
     
     // Define public API

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, JSLINT, PathUtils */
+/*global define, $, brackets, JSLINT, PathUtils */
 
 /**
  * Allows JSLint to run on the current document and report results in a UI panel.
@@ -37,13 +37,14 @@ define(function (require, exports, module) {
     require("thirdparty/jslint/jslint");
     
     // Load dependent modules
-    var Commands                = require("command/Commands"),
+    var Global                  = require("utils/Global"),
+        Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
         DocumentManager         = require("document/DocumentManager"),
+        EditorManager           = require("editor/EditorManager"),
         PreferencesManager      = require("preferences/PreferencesManager"),
         PerfUtils               = require("utils/PerfUtils"),
-        Strings                 = require("strings"),
-        EditorManager           = require("editor/EditorManager");
+        Strings                 = require("strings");
     
     /**
      * @private
@@ -204,7 +205,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_JSLINT, Commands.TOGGLE_JSLINT, _handleToggleJSLint);
     
     // Init PreferenceStorage
-    _prefs = PreferencesManager.getPreferenceStorage(module.id, { enabled: true });
+    _prefs = PreferencesManager.getPreferenceStorage(module.id, { enabled: brackets.config.enable_jslint || false});
     _setEnabled(_prefs.getValue("enabled"));
     
     // Define public API

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -190,7 +190,9 @@ define({
     "CMD_CHECK_FOR_UPDATE"                : "Check for Updates",
 
     // Help menu commands
+    "HELP_MENU"                           : "Help",
     "CMD_ABOUT"                           : "About",
+    "CMD_FORUM"                           : "{APP_NAME} Forum",
 
     // Special commands invoked by the native shell
     "CMD_CLOSE_WINDOW"                    : "Close Window",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -56,8 +56,8 @@ define({
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the file <span class='dialog-filename'>{0}</span>. {1}",
 
     // Application error strings
-    "ERROR_BRACKETS_IN_BROWSER_TITLE"   : "Oops! Brackets doesn't run in browsers yet.",
-    "ERROR_BRACKETS_IN_BROWSER"         : "Brackets is built in HTML, but right now it runs as a desktop app so you can use it to edit local files. Please use the application shell in the <b>github.com/adobe/brackets-app</b> repo to run Brackets.",
+    "ERROR_IN_BROWSER_TITLE"            : "Oops! {APP_NAME} doesn't run in browsers yet.",
+    "ERROR_IN_BROWSER"                  : "{APP_NAME} is built in HTML, but right now it runs as a desktop app so you can use it to edit local files. Please use the application shell in the <b>github.com/adobe/brackets-shell</b> repo to run {APP_NAME}.",
 
     // FileIndexManager error string
     "ERROR_MAX_FILES_TITLE"             : "Error Indexing Files",
@@ -84,8 +84,8 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Do you want to save the changes you made in the document <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Do you want to save your changes to the following files?",
     "EXT_MODIFIED_TITLE"                : "External Changes",
-    "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> has been modified on disk, but also has unsaved changes in Brackets.<br /><br />Which version do you want to keep?",
-    "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> has been deleted on disk, but has unsaved changes in Brackets.<br /><br />Do you want to keep your changes?",
+    "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> has been modified on disk, but also has unsaved changes in {APP_NAME}.<br /><br />Which version do you want to keep?",
+    "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> has been deleted on disk, but has unsaved changes in {APP_NAME}.<br /><br />Do you want to keep your changes?",
     
     // Find, Replace, Find in Files
     "SEARCH_REGEXP_INFO"                : "Use /re/ syntax for regexp search",
@@ -99,7 +99,7 @@ define({
 
     "RELEASE_NOTES"                     : "Release Notes",
     "NO_UPDATE_TITLE"                   : "You're up to date!",
-    "NO_UPDATE_MESSAGE"                 : "You are running the latest version of Brackets.",
+    "NO_UPDATE_MESSAGE"                 : "You are running the latest version of {APP_NAME}.",
     
     "FIND_IN_FILES_TITLE"               : "- {0} {1} in {2} {3}",
     "FIND_IN_FILES_FILE"                : "file",
@@ -116,7 +116,7 @@ define({
     // Switch language
     "LANGUAGE_TITLE"                    : "Switch Language",
     "LANGUAGE_MESSAGE"                  : "Please select the desired language from the list below:",
-    "LANGUAGE_SUBMIT"                   : "Reload Brackets",
+    "LANGUAGE_SUBMIT"                   : "Reload {APP_NAME}",
     "LANGUAGE_CANCEL"                   : "Cancel",
 
     /**
@@ -178,12 +178,12 @@ define({
     
     // Debug menu commands
     "DEBUG_MENU"                          : "Debug",
-    "CMD_REFRESH_WINDOW"                  : "Reload Brackets",
+    "CMD_REFRESH_WINDOW"                  : "Reload {APP_NAME}",
     "CMD_SHOW_DEV_TOOLS"                  : "Show Developer Tools",
     "CMD_RUN_UNIT_TESTS"                  : "Run Tests",
     "CMD_JSLINT"                          : "Enable JSLint",
     "CMD_SHOW_PERF_DATA"                  : "Show Performance Data",
-    "CMD_NEW_BRACKETS_WINDOW"             : "New Brackets Window",
+    "CMD_NEW_BRACKETS_WINDOW"             : "New {APP_NAME} Window",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Show Extensions Folder",
     "CMD_USE_TAB_CHARS"                   : "Use Tab Characters",
     "CMD_SWITCH_LANGUAGE"                 : "Switch Language",
@@ -211,11 +211,11 @@ define({
     "ABOUT"                                : "About",
     "APP_NAME"                             : "Brackets",
     "CLOSE"                                : "Close",
-    "ABOUT_TEXT_LINE1"                     : "sprint 13 experimental build ",
+    "ABOUT_TEXT_LINE1"                     : "sprint 14 experimental build ",
     "ABOUT_TEXT_LINE3"                     : "Notices, terms and conditions pertaining to third party software are located at <span class=\"non-clickble-link\">http://www.adobe.com/go/thirdparty/</span> and incorporated by reference herein.",
     "ABOUT_TEXT_LINE4"                     : "Documentation and source at <span class=\"non-clickble-link\">https://github.com/adobe/brackets/</span>",
-    "UPDATE_NOTIFICATION_TOOLTIP"          : "There's a new build of Brackets available! Click here for details.",
+    "UPDATE_NOTIFICATION_TOOLTIP"          : "There's a new build of {APP_NAME} available! Click here for details.",
     "UPDATE_AVAILABLE_TITLE"               : "Update Available",
-    "UPDATE_MESSAGE"                       : "Hey, there's a new build of Brackets available. Here are some of the new features:",
+    "UPDATE_MESSAGE"                       : "Hey, there's a new build of {APP_NAME} available. Here are some of the new features:",
     "GET_IT_NOW"                           : "Get it now!"
 });

--- a/src/package.json
+++ b/src/package.json
@@ -1,14 +1,17 @@
 {
-    "name"      : "Brackets",
-    "homepage"  : "http://brackets.io",
-    "issues"    : {
-        "url"       : "http://github.com/adobe/brackets/issues"
+    "name"                  : "Brackets",
+    "homepage"              : "http://brackets.io",
+    "issues"                :
+    {
+        "url"               : "http://github.com/adobe/brackets/issues"
     },
-    "repository"    : {
-        "type"  : "git",
-        "url"   : "https://github.com/adobe/brackets.git"
+    "repository"            :
+    {
+        "type"              : "git",
+        "url"               : "https://github.com/adobe/brackets.git"
     },
-    "config"    : {
+    "config"                :
+    {
         "show_debug_menu"   : true,
         "enable_jslint"     : true,
         "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev"

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,16 @@
+{
+    "name"      : "Brackets",
+    "homepage"  : "http://brackets.io",
+    "issues"    : {
+        "url"       : "http://github.com/adobe/brackets/issues"
+    },
+    "repository"    : {
+        "type"  : "git",
+        "url"   : "https://github.com/adobe/brackets.git"
+    },
+    "config"    : {
+        "show_debug_menu"   : true,
+        "enable_jslint"     : true,
+        "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev"
+    }
+}

--- a/src/strings.js
+++ b/src/strings.js
@@ -37,8 +37,6 @@ define(function (require, exports, module) {
         StringUtils = require("utils/StringUtils");
     
     // Convert {APP_NAME}
-    var str;
-    
     Object.keys(strings).forEach(function (key) {
         strings[key] = strings[key].replace(/\{APP_NAME\}/g, strings.APP_NAME);
     });

--- a/src/strings.js
+++ b/src/strings.js
@@ -40,8 +40,7 @@ define(function (require, exports, module) {
     var str;
     
     Object.keys(strings).forEach(function (key) {
-        str = strings[key];
-        strings[key] = str.replace(/\{APP_NAME\}/g, strings.APP_NAME);
+        strings[key] = strings[key].replace(/\{APP_NAME\}/g, strings.APP_NAME);
     });
 
     module.exports = strings;

--- a/src/strings.js
+++ b/src/strings.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
+/*global define, brackets */
 
 /**
  * This file provides the interface to user visible strings in Brackets. Code that needs
@@ -34,7 +34,10 @@ define(function (require, exports, module) {
     "use strict";
     
     var strings     = require("i18n!nls/strings"),
+        Global      = require("utils/Global"),
         StringUtils = require("utils/StringUtils");
+    
+    strings.APP_NAME = brackets.config.app_name || strings.APP_NAME;
     
     // Convert {APP_NAME}
     Object.keys(strings).forEach(function (key) {

--- a/src/strings.js
+++ b/src/strings.js
@@ -32,7 +32,18 @@
  */
 define(function (require, exports, module) {
     "use strict";
+    
+    var strings     = require("i18n!nls/strings"),
+        StringUtils = require("utils/StringUtils");
+    
+    // Convert {APP_NAME}
+    var str;
+    
+    Object.keys(strings).forEach(function (key) {
+        str = strings[key];
+        strings[key] = str.replace(/\{APP_NAME\}/g, strings.APP_NAME);
+    });
 
-    module.exports = require("i18n!nls/strings");
+    module.exports = strings;
 
 });

--- a/src/strings.js
+++ b/src/strings.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         Global      = require("utils/Global"),
         StringUtils = require("utils/StringUtils");
     
-    strings.APP_NAME = brackets.config.app_name || strings.APP_NAME;
+    strings.APP_NAME = brackets.config.name || strings.APP_NAME;
     
     // Convert {APP_NAME}
     Object.keys(strings).forEach(function (key) {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -34,7 +34,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var config = require("text!config.json");
+    var config = require("text!package.json");
     
     // Define core brackets namespace if it isn't already defined
     //
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
     
     // Parse src/config.json
     try {
-        global.brackets.config = JSON.parse(config);
+        global.brackets.config = JSON.parse(config).config;
     } catch (err) {
         console.log(err);
     }

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -34,6 +34,8 @@
 define(function (require, exports, module) {
     "use strict";
     
+    var config = require("text!config.json");
+    
     // Define core brackets namespace if it isn't already defined
     //
     // We can't simply do 'brackets = {}' to define it in the global namespace because
@@ -46,6 +48,13 @@ define(function (require, exports, module) {
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
         global.brackets = {};
+    }
+    
+    // Parse src/config.json
+    try {
+        global.brackets.config = JSON.parse(config);
+    } catch (err) {
+        console.log(err);
     }
         
     // Uncomment the following line to force all low level file i/o routines to complete


### PR DESCRIPTION
- Replace `Brackets` with `{APP_NAME}`
- Preprocess `{APP_NAME}` in `strings` module so that clients do not need to call an additional `StringUtils.format()`
- Created Help menu (moved menu items from Debug)
- Add config.json to control app initialization config options
- Remove "Brackets" string from index.html
