### PR TITLE
Enable hardware compositing for smoother scrolling

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -90,6 +90,7 @@ define(function (require, exports, module) {
     exports.DEBUG_NEW_BRACKETS_WINDOW   = "debug.newBracketsWindow";
     exports.DEBUG_SHOW_EXT_FOLDER       = "debug.showExtensionsFolder";
     exports.DEBUG_SWITCH_LANGUAGE       = "debug.switchLanguage";
+    exports.TOGGLE_HARDWARE_ACCELERATION = "debug.hardware";
     exports.CHECK_FOR_UPDATE            = "app.checkForUpdate";
 
 	// Command that does nothing. Can be used for place holder menuItems

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -933,6 +933,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.DEBUG_RUN_UNIT_TESTS);
         menu.addMenuItem(Commands.DEBUG_SHOW_PERF_DATA);
         menu.addMenuDivider();
+        menu.addMenuItem(Commands.TOGGLE_HARDWARE_ACCELERATION);
+        menu.addMenuDivider();
         menu.addMenuItem(Commands.CHECK_FOR_UPDATE);
 
 

--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -277,6 +277,13 @@ define(function (require, exports, module) {
         );
     }
     
+    var _hardwareAccelerated = false;
+    function _handleEnableHardwareCompositing() {
+        $("#main-toolbar").toggleClass("hardware");
+        _hardwareAccelerated = !_hardwareAccelerated;
+        CommandManager.get(Commands.TOGGLE_HARDWARE_ACCELERATION).setChecked(_hardwareAccelerated);
+    }
+    
     /* Register all the command handlers */
     
     // Show Developer Tools (optionally enabled)
@@ -295,7 +302,8 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_USE_TAB_CHARS,       Commands.TOGGLE_USE_TAB_CHARS,         _handleUseTabChars)
         .setChecked(Editor.getUseTabChar());
     
+    CommandManager.register(Strings.CMD_HARDWARE_ACCELERATION, Commands.TOGGLE_HARDWARE_ACCELERATION, _handleEnableHardwareCompositing).setChecked(false);
+
     CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE,    Commands.CHECK_FOR_UPDATE,             _handleCheckForUpdates);
-    
     _enableRunTestsMenuItem();
 });

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -188,7 +188,6 @@ define({
 	"CMD_USE_TAB_CHARS": "Utiliser les caractères de tabulation",
 	"CMD_SWITCH_LANGUAGE": "Changer de langue",
 	"CMD_CHECK_FOR_UPDATE": "[B7] !é=Check for Updates=!",
-    "CMD_HARDWARE_ACCELERATION": "Activer l'accélération matérielle",
 
     // Help menu commands
 	"CMD_ABOUT": "A propos",

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -188,6 +188,7 @@ define({
 	"CMD_USE_TAB_CHARS": "Utiliser les caractères de tabulation",
 	"CMD_SWITCH_LANGUAGE": "Changer de langue",
 	"CMD_CHECK_FOR_UPDATE": "[B7] !é=Check for Updates=!",
+    "CMD_HARDWARE_ACCELERATION": "Activer l'accélération matérielle",
 
     // Help menu commands
 	"CMD_ABOUT": "A propos",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -187,6 +187,7 @@ define({
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Show Extensions Folder",
     "CMD_USE_TAB_CHARS"                   : "Use Tab Characters",
     "CMD_SWITCH_LANGUAGE"                 : "Switch Language",
+    "CMD_HARDWARE_ACCELERATION"           : "Enable Hardware Compositing",
     "CMD_CHECK_FOR_UPDATE"                : "Check for Updates",
 
     // Help menu commands

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -602,3 +602,8 @@ li.smart_autocomplete_highlight {
     background-color: #5fa3e0;
 
 }
+
+/* Any 3d transform triggers hardware acceleration in Chromium */
+.hardware {
+    -webkit-transform: translateZ(0);
+}


### PR DESCRIPTION
I added the option to force hardware acceleratied compositing by adding a 3d transform ( translateZ(0) ) in the page. The scrolling is quite smoother on my computer.
