### PR TITLE
Fixed reload problem for extensions

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
             extensionRequire = brackets.libRequire.config({
                 context: name,
                 baseUrl: config.baseUrl,
+                urlArgs: "nocache=" + (new Date()).getTime(),
                 /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */
                 paths: globalConfig,
                 locale: window.localStorage.getItem("locale") || brackets.app.language

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
             extensionRequire = brackets.libRequire.config({
                 context: name,
                 baseUrl: config.baseUrl,
+                // Force extensions to not be cached by passing a unique value (time) as a URL argument
                 urlArgs: "nocache=" + (new Date()).getTime(),
                 /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */
                 paths: globalConfig,


### PR DESCRIPTION
Fixes issue #1551 but extensions will never be cached. Not sure if there are any real world performance implications, but it could be made optional on build versions.
