### PR TITLE
Add info dialog for live development and improve wording

### DIFF
--- a/samples/root/Getting Started/index.html
+++ b/samples/root/Getting Started/index.html
@@ -77,7 +77,7 @@
 
 <samp>
     If you have Google Chrome installed, you can try this out yourself. Click on the lightning bolt 
-    icon in the top right or hit <kbd>Cmd/Ctrl + Alt + P</kbd>. When Live File Preview is enabled on 
+    icon in the top right or hit <kbd>Cmd/Ctrl + Alt + P</kbd>. When Live Preview is enabled on 
     an HTML document, all linked CSS documents can be edited in real-time. The icon will change from 
     gray to gold when Brackets establishes a connection to your browser.
     

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -376,7 +376,7 @@ define(function LiveDevelopment(require, exports, module) {
                     _setStatus(STATUS_ERROR);
                     Dialogs.showModalDialog(
                         Dialogs.DIALOG_ID_LIVE_DEVELOPMENT,
-                        Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
+                        Strings.LIVE_DEVELOPMENT_RELAUNCH_TITLE,
                         Strings.LIVE_DEVELOPMENT_ERROR_MESSAGE
                     ).done(function (id) {
                         if (id === Dialogs.DIALOG_BTN_OK) {

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -38,14 +38,18 @@
 define(function main(require, exports, module) {
     "use strict";
 
-    var DocumentManager = require("document/DocumentManager"),
-        Commands        = require("command/Commands"),
-        AppInit         = require("utils/AppInit"),
-        LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
-        Inspector       = require("LiveDevelopment/Inspector/Inspector"),
-        CommandManager  = require("command/CommandManager"),
-        Strings = require("strings");
+    var DocumentManager     = require("document/DocumentManager"),
+        Commands            = require("command/Commands"),
+        AppInit             = require("utils/AppInit"),
+        LiveDevelopment     = require("LiveDevelopment/LiveDevelopment"),
+        Inspector           = require("LiveDevelopment/Inspector/Inspector"),
+        CommandManager      = require("command/CommandManager"),
+        PreferencesManager  = require("preferences/PreferencesManager"),
+        Dialogs             = require("widgets/Dialogs"),
+        Strings             = require("strings");
 
+    var PREFERENCES_KEY = "com.adobe.brackets.live-development";
+    var prefs;
     var config = {
         experimental: false, // enable experimental features
         debug: true, // enable debug output and helpers
@@ -114,7 +118,18 @@ define(function main(require, exports, module) {
             LiveDevelopment.close();
             // TODO Ty: when checkmark support lands, remove checkmark
         } else {
-            LiveDevelopment.open();
+            if (!prefs.getValue("afterFirstLaunch")) {
+                prefs.setValue("afterFirstLaunch", "true");
+                Dialogs.showModalDialog(
+                    Dialogs.DIALOG_ID_INFO,
+                    Strings.LIVE_DEVELOPMENT_INFO_TITLE,
+                    Strings.LIVE_DEVELOPMENT_INFO_MESSAGE
+                ).done(function (id) {
+                    LiveDevelopment.open();
+                });
+            } else {
+                LiveDevelopment.open();
+            }
             // TODO Ty: when checkmark support lands, add checkmark
         }
     }
@@ -167,6 +182,8 @@ define(function main(require, exports, module) {
 
     /** Initialize LiveDevelopment */
     function init() {
+        prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY);
+
         Inspector.init(config);
         LiveDevelopment.init(config);
         _loadStyles();

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -71,9 +71,12 @@ define({
     "ERROR_CANT_FIND_CHROME"            : "The Google Chrome browser could not be found. Please make sure it is installed.",
     "ERROR_LAUNCHING_BROWSER"           : "An error occurred when launching the browser. (error {0})",
     
-    "LIVE_DEVELOPMENT_ERROR_TITLE"      : "Live Development Error",
-    "LIVE_DEVELOPMENT_ERROR_MESSAGE"    : "A live development connection to Chrome could not be established. For live development to work, Chrome needs to be started with remote debugging enabled.<br /><br />Would you like to relaunch Chrome and enable remote debugging?",
+    "LIVE_DEVELOPMENT_ERROR_TITLE"      : "Live Preview Error",
+    "LIVE_DEVELOPMENT_RELAUNCH_TITLE"   : "Connecting to Browser",
+    "LIVE_DEVELOPMENT_ERROR_MESSAGE"    : "In order for Live Preview to connect, Chrome needs to be relaunched with remote debugging enabled.<br /><br />Would you like to relaunch Chrome and enable remote debugging?",
     "LIVE_DEV_NEED_HTML_MESSAGE"        : "Open an HTML file in order to launch live preview.",
+    "LIVE_DEVELOPMENT_INFO_TITLE"       : "Welcome to Live Preview!",
+    "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS code</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
     
     "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live File Preview",
     "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live File Preview: Connecting...",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -78,10 +78,10 @@ define({
     "LIVE_DEVELOPMENT_INFO_TITLE"       : "Welcome to Live Preview!",
     "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS code</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
     
-    "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live File Preview",
-    "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live File Preview: Connecting...",
-    "LIVE_DEV_STATUS_TIP_PROGRESS2"     : "Live File Preview: Initializing...",
-    "LIVE_DEV_STATUS_TIP_CONNECTED"     : "Disconnect Live File Preview",
+    "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live Preview",
+    "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live Preview: Connecting...",
+    "LIVE_DEV_STATUS_TIP_PROGRESS2"     : "Live Preview: Initializing...",
+    "LIVE_DEV_STATUS_TIP_CONNECTED"     : "Disconnect Live Preview",
     
     "SAVE_CLOSE_TITLE"                  : "Save Changes",
     "SAVE_CLOSE_MESSAGE"                : "Do you want to save the changes you made in the document <span class='dialog-filename'>{0}</span>?",
@@ -142,7 +142,7 @@ define({
     "CMD_FILE_CLOSE_ALL"                  : "Close All",
     "CMD_FILE_SAVE"                       : "Save",
     "CMD_FILE_SAVE_ALL"                   : "Save All",
-    "CMD_LIVE_FILE_PREVIEW"               : "Live File Preview",
+    "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
     "CMD_QUIT"                            : "Quit",
 
     // Edit menu commands

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -76,7 +76,7 @@ define({
     "LIVE_DEVELOPMENT_ERROR_MESSAGE"    : "In order for Live Preview to connect, Chrome needs to be relaunched with remote debugging enabled.<br /><br />Would you like to relaunch Chrome and enable remote debugging?",
     "LIVE_DEV_NEED_HTML_MESSAGE"        : "Open an HTML file in order to launch live preview.",
     "LIVE_DEVELOPMENT_INFO_TITLE"       : "Welcome to Live Preview!",
-    "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS code</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
+    "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS files</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
     
     "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live Preview",
     "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live Preview: Connecting...",

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
     // TODO: (issue #258) In future, we should templatize the HTML for the dialogs rather than having 
     // it live directly in the HTML.
     var DIALOG_ID_ERROR = "error-dialog",
+        DIALOG_ID_INFO = "error-dialog", // uses the same template for now--could be different in future
         DIALOG_ID_SAVE_CLOSE = "save-close-dialog",
         DIALOG_ID_EXT_CHANGED = "ext-changed-dialog",
         DIALOG_ID_EXT_DELETED = "ext-deleted-dialog",
@@ -218,6 +219,7 @@ define(function (require, exports, module) {
     exports.DIALOG_BTN_DOWNLOAD = DIALOG_BTN_DOWNLOAD;
     
     exports.DIALOG_ID_ERROR = DIALOG_ID_ERROR;
+    exports.DIALOG_ID_INFO = DIALOG_ID_INFO;
     exports.DIALOG_ID_SAVE_CLOSE = DIALOG_ID_SAVE_CLOSE;
     exports.DIALOG_ID_EXT_CHANGED = DIALOG_ID_EXT_CHANGED;
     exports.DIALOG_ID_EXT_DELETED = DIALOG_ID_EXT_DELETED;


### PR DESCRIPTION
Fixes #1050 and #1537.
- Adds an info dialog the first time you use Live Preview that explains what it does and that it only works for CSS files with Chrome right now.
- Improves the wording in the "relaunch Chrome" dialog that makes it clear that it's not an error.
- Changes the command name from "Live File Preview" to "Live Preview" (we might change it again, but this at least makes it consistent everywhere right now).
