### PR TITLE
Fix LiveDevelopment unit tests so they don't pop up the initial info dialog

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -46,10 +46,12 @@ define(function main(require, exports, module) {
         CommandManager      = require("command/CommandManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         Dialogs             = require("widgets/Dialogs"),
+        UrlParams           = require("utils/UrlParams").UrlParams,
         Strings             = require("strings");
 
     var PREFERENCES_KEY = "com.adobe.brackets.live-development";
     var prefs;
+    var params = new UrlParams();
     var config = {
         experimental: false, // enable experimental features
         debug: true, // enable debug output and helpers
@@ -118,7 +120,7 @@ define(function main(require, exports, module) {
             LiveDevelopment.close();
             // TODO Ty: when checkmark support lands, remove checkmark
         } else {
-            if (!prefs.getValue("afterFirstLaunch")) {
+            if (!params.get("skipLiveDevelopmentInfo") && !prefs.getValue("afterFirstLaunch")) {
                 prefs.setValue("afterFirstLaunch", "true");
                 Dialogs.showModalDialog(
                     Dialogs.DIALOG_ID_INFO,
@@ -183,6 +185,7 @@ define(function main(require, exports, module) {
     /** Initialize LiveDevelopment */
     function init() {
         prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY);
+        params.parse();
 
         Inspector.init(config);
         LiveDevelopment.init(config);

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -142,6 +142,9 @@ define(function (require, exports, module) {
             // disable loading of sample project
             params.put("skipSampleProjectLoad", true);
             
+            // disable initial dialog for live development
+            params.put("skipLiveDevelopmentInfo", true);
+            
             _testWindow = window.open(getBracketsSourceRoot() + "/index.html?" + params.toString(), "_blank", optionsStr);
             
             _testWindow.executeCommand = function executeCommand(cmd, args) {


### PR DESCRIPTION
Just realized that the initial modal dialog breaks the unit tests. This fixes it so the dialog doesn't pop up in the test window.
