### PR TITLE
revert pull #1555 (Fixed reload problem for extensions) -- using nocache causes problems with breakpoints

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -68,7 +68,6 @@ define(function (require, exports, module) {
             extensionRequire = brackets.libRequire.config({
                 context: name,
                 baseUrl: config.baseUrl,
-                urlArgs: "nocache=" + (new Date()).getTime(),
                 /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */
                 paths: globalConfig,
                 locale: window.localStorage.getItem("locale") || brackets.app.language

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -68,7 +68,6 @@ define(function (require, exports, module) {
             extensionRequire = brackets.libRequire.config({
                 context: name,
                 baseUrl: config.baseUrl,
-                // Force extensions to not be cached by passing a unique value (time) as a URL argument
                 urlArgs: "nocache=" + (new Date()).getTime(),
                 /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */
                 paths: globalConfig,


### PR DESCRIPTION
Using 'nocache' causes difficulties in setting breakpoints (because file urls change every reload).

Cache can be disabled in the developer tools settings:
  https://groups.google.com/d/topic/brackets-dev/E5iqcD8VqD4/discussion
