### PR TITLE
Add tools to help users setup a brackets dev environment

### DIFF
--- a/tools/restore_installed_build.bat
+++ b/tools/restore_installed_build.bat
@@ -4,11 +4,15 @@ REM - Check for parameter
 IF %1.==. GOTO Error
 
 REM - Remove 'dev' directory
-rmdir %1\\dev
+ECHO Removing %1\dev
+rmdir %1\dev
 
 GOTO Exit
 
 :Error
-ECHO Usage: restore_installed_build.bat  \path\to\Brackets\
+ECHO Usage: restore_installed_build.bat application_path
+ECHO Restore Brackets to use the installed HTML/CSS/JS files.
+ECHO Parameters: application_path - path that contains the Brackets application
+ECHO Example: restore_installed_build.bat "c:\Program Files (x86)\Brackets Sprint 14"
 
 :Exit

--- a/tools/restore_installed_build.bat
+++ b/tools/restore_installed_build.bat
@@ -1,0 +1,14 @@
+@ECHO OFF
+
+REM - Check for parameter
+IF %1.==. GOTO Error
+
+REM - Remove 'dev' directory
+rmdir %1\\dev
+
+GOTO Exit
+
+:Error
+ECHO Usage: restore_installed_build.bat  \path\to\Brackets\
+
+:Exit

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -2,7 +2,11 @@
 
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then
-  echo "Usage: restore_installed_build.sh /path/to/Brackets.app"
+  echo "Usage: restore_installed_build.sh <application>"
+  echo "Restore Brackets to use the installed HTML/CSS/JS files."
+  echo ""
+  echo "Parameters: application - full path to the Brackets application"
+  echo "Example: ./restore_installed_build.sh \"/Applications/Brackets Sprint 14.app\""
   exit;
 fi
 

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Make sure the appname was passed in and is valid
+if [[ ${1} == "" ]]; then
+  echo "Usage: restore_installed_build.sh /path/to/Brackets.app"
+  exit;
+fi
+
+if [ ! -d ${1} ]; then
+  echo "$1 not found."
+  exit;
+fi
+
+if [ -d "${1}/Contents/dev" ]; then
+  rm "${1}/Contents/dev"
+  echo "$1 has been restored to the installed configuration."
+fi

--- a/tools/setup_for_hacking.bat
+++ b/tools/setup_for_hacking.bat
@@ -1,0 +1,22 @@
+@ECHO OFF
+
+REM - Check for parameter
+IF %1.==. GOTO Error
+
+REM - Use full path of this batch file to determine root directory
+set root_path=%~f0
+set root_path=%root_path:~0,-27%
+ECHO %root_path%
+
+REM - Remove existing 'dev' directory (if present)
+rmdir %1\\dev
+
+REM - Make symlink
+mklink /d %1\\dev %root_path%
+
+GOTO Exit
+
+:Error
+ECHO Usage: setup_for_hacking.bat  \path\to\Brackets\
+
+:Exit

--- a/tools/setup_for_hacking.bat
+++ b/tools/setup_for_hacking.bat
@@ -1,22 +1,35 @@
 @ECHO OFF
 
-REM - Check for parameter
-IF %1.==. GOTO Error
-
 REM - Use full path of this batch file to determine root directory
 set root_path=%~f0
 set root_path=%root_path:~0,-27%
-ECHO %root_path%
+
+REM - Check for OS. This script works in Vista or later.
+ver | findstr /i "5\.1\." > nul
+IF %ERRORLEVEL% EQU 0 GOTO XPNotSupported
+
+REM - Check for parameter
+IF %1.==. GOTO Error
 
 REM - Remove existing 'dev' directory (if present)
-rmdir %1\\dev
+rmdir %1\dev
 
 REM - Make symlink
-mklink /d %1\\dev %root_path%
+mklink /d %1\dev %root_path%
 
 GOTO Exit
 
 :Error
-ECHO Usage: setup_for_hacking.bat  \path\to\Brackets\
+ECHO Usage: setup_for_hacking.bat application_path
+ECHO Setup Brackets to use the HTML/CSS/JS files pulled from GitHub.
+ECHO Parameters: application_path - path that contains the Brackets application
+ECHO Example: setup_for_hacking.bat "c:\Program Files (x86)\Brackets Sprint 14"
+GOTO Exit
+
+:XPNotSupported
+ECHO Sorry, this script doesn't run in Windows XP.
+ECHO To enable hacking, make a shortcut to 
+ECHO %root_path%, name it
+ECHO "dev", and put it next to your Brackets.exe file
 
 :Exit

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Make sure the appname was passed in and is valid
+if [[ ${1} == "" ]]; then
+  echo "Usage: setup_for_hacking.sh /path/to/Brackets.app"
+  exit;
+fi
+
+if [ ! -d ${1} ]; then
+  echo "$1 not found."
+  exit;
+fi
+
+# Get the full path of this script
+if [[ ${0} == /* ]]; then
+  full_path="$0"
+else
+  full_path="${PWD}/${0#./}"
+fi;
+
+# Remove /tools/setup_for_hacking.sh to get the root directory
+root_dir=${full_path%/*/*}
+
+# Remove existing "dev" symlink, if present
+if [ -d "${1}/Contents/dev" ]; then
+  rm "${1}/Contents/dev"
+fi
+
+# Make new symlink
+ln -s "$root_dir" "${1}/Contents/dev"
+
+echo "Brackets will now use the files in $root_dir"
+echo "Run the restore_installed_build.sh script to revert back to the installed source files"

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -2,7 +2,11 @@
 
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then
-  echo "Usage: setup_for_hacking.sh /path/to/Brackets.app"
+  echo "Usage: setup_for_hacking.sh <application>"
+  echo "Setup Brackets to use the HTML/CSS/JS files pulled from GitHub."
+  echo ""
+  echo "Parameters: application - full path to the Brackets application"
+  echo "Example: ./setup_for_hacking.sh \"/Applications/Brackets Sprint 14.app\""
   exit;
 fi
 


### PR DESCRIPTION
**\* **Depends on adobe/brackets-shell#105** ***

Add a new `tools` directory with 2 new tools:
1. **setup_for_hacking.sh/.bat** - Run this tool to install shortcuts into your brackets app that make brackets use the HTML/CSS/JS files pulled from the GitHub repo.
2. **restore_installed_build.sh/.bat** - Removes the shortcuts installed by the first tool.

Here are the steps to setup Brackets for hacking (this applies to hacking on HTML/CSS/JS files only, and does not apply to hacking on brackets-shell).
- Install the latest version of Brackets
- Clone (or fork) the brackets github repo
- On the Mac, run `tools/setup_for_hacking.sh` and pass the full path to Brackets.app. For example:

```
> tools/setup_for_hacking.sh "/Applications/Brackets Sprint 14.app"
```
- On Windows, run `tools\setup_for_hacking.bat` and pass the directory that holds Brackets.exe. For example:

```
> tools\setup_for_hacking.bat "\Program Files (x86)\Brackets\"
```

To restore Brackets back to the installed HTML/CSS/JS files, run the `restore_installed_build` script, passing the same value that was passed to `setup_for_hacking`.
