### PR TITLE
Fix unit tests when run from symlinked directory

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
         }
 
         // This returns path to test folder, so convert to src
-        bracketsPath = bracketsPath.replace("brackets/test", "brackets/src");
+        bracketsPath = bracketsPath.replace("/test", "/src");
 
         return Async.doInParallel(paths, function (dir) {
             return ExtensionLoader.testAllExtensionsInNativeDirectory(

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
         }
 
         // This returns path to test folder, so convert to src
-        bracketsPath = bracketsPath.replace("/test", "/src");
+        bracketsPath = bracketsPath.replace(/\/test$/, "/src");
 
         return Async.doInParallel(paths, function (dir) {
             return ExtensionLoader.testAllExtensionsInNativeDirectory(


### PR DESCRIPTION
With the recent changes to the dev environment setup, there is no guarantee that our root folder is named "brackets". This updates the unit test runner accordingly.
