### PR TITLE
Show code hints on change instead of keyup

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -39,7 +39,7 @@ define(function (require, exports, module) {
 
     var hintProviders = [],
         hintList,
-        shouldShowHintsOnKeyUp = false;
+        shouldShowHintsOnChange = false;
 
 
     /**
@@ -295,7 +295,7 @@ define(function (require, exports, module) {
         this.$hintMenu.remove();
         if (hintList === this) {
             hintList = null;
-            shouldShowHintsOnKeyUp = false;
+            shouldShowHintsOnChange = false;
         }
     };
         
@@ -384,17 +384,23 @@ define(function (require, exports, module) {
                 }
             });
             
-            shouldShowHintsOnKeyUp = !!provider;
-        } else if (event.type === "keyup") {
-            if (shouldShowHintsOnKeyUp) {
-                shouldShowHintsOnKeyUp = false;
-                showHint(editor);
-            }
+            shouldShowHintsOnChange = !!provider;
         }
 
         // Pass to the hint list, if it's open
         if (hintList && hintList.isOpen()) {
+            shouldShowHintsOnChange = false;
             hintList.handleKeyEvent(editor, event);
+        }
+    }
+    
+    /**
+     *
+     */
+    function handleChange(editor) {
+        if (shouldShowHintsOnChange) {
+            shouldShowHintsOnChange = false;
+            showHint(editor);
         }
     }
 
@@ -434,6 +440,7 @@ define(function (require, exports, module) {
     
     // Define public API
     exports.handleKeyEvent          = handleKeyEvent;
+    exports.handleChange            = handleChange;
     exports.showHint                = showHint;
     exports._getCodeHintList        = _getCodeHintList;
     exports.registerHintProvider    = registerHintProvider;

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -389,7 +389,6 @@ define(function (require, exports, module) {
 
         // Pass to the hint list, if it's open
         if (hintList && hintList.isOpen()) {
-            shouldShowHintsOnChange = false;
             hintList.handleKeyEvent(editor, event);
         }
     }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -521,6 +521,8 @@ define(function (require, exports, module) {
                 throw new Error("ERROR: Typing in Editor should not destroy its own _visibleRange");
             }
         }
+        
+        CodeHintManager.handleChange(this);
     };
     
     /**


### PR DESCRIPTION
UPDATED: Ready for final review.

The change is the one Peter proposed in #1415--show the code hints on change instead of on keyup. A couple of questions about the fix:
- With the original setup, there was never any danger that you wouldn't eventually process the "showCodeHintsOnKeyUp" flag, because the browser (presumably) guarantees that you get a keyup for every keydown. However, with this fix, there's no guarantee you'll get a CodeMirror "change" event after a keydown. In general, you always should, because any key that would trigger code hints should theoretically cause a change event to happen eventually. But I just wanted another set of eyes on this to make sure there wasn't some other way to get into a state where "showCodeHintsOnChange" would end up being left hanging and not processed until some later unrelated change event.
- The way CodeHintManager is currently set up, it doesn't actually attach to/detach from the current editor to handle key events. Instead, there's just a hardcoded call to the CodeHintManager from Editor. I followed that same pattern for the change event handling, but it seems like a bad inverse dependency. Is there a reason we did it this way originally? Should we change it to attach/detach listeners as the current editor changes?
