### PR TITLE
For Review Issue#1598: Added search query in search results label for 'Find In Files'

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -104,7 +104,7 @@ define({
     "NO_UPDATE_TITLE"                   : "You're up to date!",
     "NO_UPDATE_MESSAGE"                 : "You are running the latest version of {APP_NAME}.",
     
-    "FIND_IN_FILES_TITLE"               : "- {0} {1} in {2} {3}",
+    "FIND_IN_FILES_TITLE"               : "for \"{4}\" - {0} {1} in {2} {3}",
     "FIND_IN_FILES_FILE"                : "file",
     "FIND_IN_FILES_FILES"               : "files",
     "FIND_IN_FILES_MATCH"               : "match",

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
             $("#search-result-summary")
                 .text(summary +
                      (numMatches > FIND_IN_FILES_MAX ? StringUtils.format(Strings.FIND_IN_FILES_MAX, FIND_IN_FILES_MAX) : ""))
-                .prepend("&nbsp;" + "for: " + query + "&nbsp;");  // putting a normal space before the "-" is not enough
+                .prepend("&nbsp;" + "for: \"" + query + "\"&nbsp;");  // putting a normal space before the "-" is not enough
             
             var resultsDisplayed = 0;
             

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -182,13 +182,14 @@ define(function (require, exports, module) {
                 numMatches,
                 (numMatches > 1) ? Strings.FIND_IN_FILES_MATCHES : Strings.FIND_IN_FILES_MATCH,
                 searchResults.length,
-                (searchResults.length > 1 ? Strings.FIND_IN_FILES_FILES : Strings.FIND_IN_FILES_FILE)
+                (searchResults.length > 1 ? Strings.FIND_IN_FILES_FILES : Strings.FIND_IN_FILES_FILE),
+                query
             );
             
             $("#search-result-summary")
                 .text(summary +
                      (numMatches > FIND_IN_FILES_MAX ? StringUtils.format(Strings.FIND_IN_FILES_MAX, FIND_IN_FILES_MAX) : ""))
-                .prepend("&nbsp;" + "for: \"" + query + "\"&nbsp;");  // putting a normal space before the "-" is not enough
+                .prepend("&nbsp;"); // putting a normal space before the "-" is not enough
             
             var resultsDisplayed = 0;
             

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
         return matches;
     }
         
-    function _showSearchResults(searchResults) {
+    function _showSearchResults(searchResults, query) {
         var $searchResultsDiv = $("#search-results");
         
         if (searchResults && searchResults.length) {
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
             $("#search-result-summary")
                 .text(summary +
                      (numMatches > FIND_IN_FILES_MAX ? StringUtils.format(Strings.FIND_IN_FILES_MAX, FIND_IN_FILES_MAX) : ""))
-                .prepend("&nbsp;");  // putting a normal space before the "-" is not enough
+                .prepend("&nbsp;" + "for: " + query + "&nbsp;");  // putting a normal space before the "-" is not enough
             
             var resultsDisplayed = 0;
             
@@ -321,7 +321,7 @@ define(function (require, exports, module) {
                                 return result.promise();
                             })
                                 .done(function () {
-                                    _showSearchResults(searchResults);
+                                    _showSearchResults(searchResults, query);
                                 })
                                 .fail(function () {
                                     console.log("find in files failed.");


### PR DESCRIPTION
Hello,

I have made a small modification in `search/FindInFiles.js` to add the search query in search results bar's label as `Search Results for: "<query>" - X matches in X files`. This is related to the Issue: adobe/brackets#1598 . 

There are 2 commits here because I forgot to add `quotes` around the search query in the first commit!

Kindly look into this! 
( I'm new to open source contributions, apologies if I am not following the protocol :) )

Thank you.
Sincerely,
Sagar Sane
