### PR TITLE
Add branch and sha to package.json repository info

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,9 @@
     "repository"            :
     {
         "type"              : "git",
-        "url"               : "https://github.com/adobe/brackets.git"
+        "url"               : "https://github.com/adobe/brackets.git",
+        "branch"            : "",
+        "SHA"               : ""
     },
     "config"                :
     {


### PR DESCRIPTION
The values are filled in by the build scripts.
