### PR TITLE
Fix shadow appearance on retina screens.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -319,7 +319,11 @@ a, img {
 }
 
 .scroller-shadow {
-    background-size: 100% 5px;
+    // TODO: background-size should really be 100%, but due to a bug in WebKit,
+    // that makes the drop shadows look bad on retina displays. This value
+    // should be changed to 100% once we've upgraded to a newer CEF that includes
+    // the WebKit fix.
+    background-size: 99.99%;
     background-repeat: no-repeat;
     height: 5px;
     position: fixed;


### PR DESCRIPTION
Due to a WebKit bug, the shadows in the editor and project panel look bad on retina displays. This pull request works around the bug by setting background-size to 99.99%. 

Gotta love CSS hacks.
