### PR TITLE
Fix Quick Open async bugs

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
     var fileList;
     
     /** @type $.Promise */
-    var pendingFileList;
+    var fileListPromise;
 
     /**
      * Remembers the current document that was displayed when showDialog() was called
@@ -487,7 +487,7 @@ define(function (require, exports, module) {
         if (!fileList) {
             // Smart Autocomplete allows us to return a Deferred instead
             var asyncResult = new $.Deferred();
-            pendingFileList.done(function () {
+            fileListPromise.done(function () {
                 // Make sure filter text hasn't changed while we were waiting
                 var currentQuery = $("input#quickOpenSearch").val();
                 if (currentQuery === query) {
@@ -681,10 +681,10 @@ define(function (require, exports, module) {
         // Start fetching the file list, which will be needed the first time the user enters an un-prefixed query. If FileIndexManager's
         // caches are out of date, this list might take some time to asynchronously build. See searchFileList() for how this is handled.
         fileList = null;
-        pendingFileList = FileIndexManager.getFileInfoList("all")
+        fileListPromise = FileIndexManager.getFileInfoList("all")
             .done(function (files) {
                 fileList = files;
-                pendingFileList = null;
+                fileListPromise = null;
             });
     };
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -31,8 +31,6 @@
 * 
 * TODO (issue 333) - currently jquery smart auto complete is used for the pop-up list. While it mostly works
 * it has several issues, so it should be replace with an alternative. Issues:
-* - only accepts an array of strings. A list of objects is preferred to avoid some workarounds to display 
-*   both the path and filename.
 * - the pop-up position logic has flaws that require CSS workarounds
 * - the pop-up properties cannot be modified once the object is constructed
 */
@@ -59,6 +57,9 @@ define(function (require, exports, module) {
 
     /** @type Array.<FileInfo>*/
     var fileList;
+    
+    /** @type $.Promise */
+    var pendingFileList;
 
     /**
      * Remembers the current document that was displayed when showDialog() was called
@@ -482,6 +483,23 @@ define(function (require, exports, module) {
     
     
     function searchFileList(query) {
+        // FileIndexManager may still be loading asynchronously - if so, can't return a result yet
+        if (!fileList) {
+            // Smart Autocomplete allows us to return a Deferred instead
+            var asyncResult = new $.Deferred();
+            pendingFileList.done(function () {
+                // Make sure filter text hasn't changed while we were waiting
+                var currentQuery = $("input#quickOpenSearch").val();
+                if (currentQuery === query) {
+                    // This is still the query. Synchronously re-run the search call and resolve with its results.
+                    asyncResult.resolve(searchFileList(query));
+                } else {
+                    asyncResult.reject();
+                }
+            });
+            return asyncResult.promise();
+        }
+        
         // First pass: filter based on search string; convert to SearchResults containing extra info
         // for sorting & display
         var filteredList = $.map(fileList, function (fileInfo) {
@@ -613,6 +631,7 @@ define(function (require, exports, module) {
         }
         dialogOpen = true;
 
+        // Global listener to hide search bar & popup
         this.handleDocumentMouseDown = this.handleDocumentMouseDown.bind(this);
         $(window.document).on("mousedown", this.handleDocumentMouseDown);
 
@@ -621,6 +640,7 @@ define(function (require, exports, module) {
         // To improve performance during list selection disable JSLint until a document is chosen or dialog is closed
         //JSLintUtils.setEnabled(false);
 
+        // Record current document & cursor pos so we can restore it if search is canceled
         var curDoc = DocumentManager.getCurrentDocument();
         origDocPath = curDoc ? curDoc.file.fullPath : null;
         if (curDoc) {
@@ -628,38 +648,43 @@ define(function (require, exports, module) {
         } else {
             origSelection = null;
         }
+        
+        // Show the search bar ("dialog")
+        var dialogHTML = Strings.CMD_QUICK_OPEN + ": <input type='text' autocomplete='off' id='quickOpenSearch' style='width: 30em'>";
+        that._createDialogDiv(dialogHTML);
+        that.$searchField = $("input#quickOpenSearch");
 
-        // Get the file list and initialize the smart auto completes
-        FileIndexManager.getFileInfoList("all")
+
+        that.$searchField.smartAutoComplete({
+            source: [],
+            maxResults: 20,
+            minCharLimit: 0,
+            autocompleteFocused: true,
+            forceSelect: false,
+            typeAhead: false,   // won't work right now because smart auto complete 
+                                // using internal raw results instead of filtered results for matching
+            filter: _handleFilter,
+            resultFormatter: _handleResultsFormatter
+        });
+
+        that.$searchField.bind({
+            itemSelect: function (e, selectedItem) { that._handleItemSelect(selectedItem); },
+            itemFocus: function (e, selectedItem) { that._handleItemFocus(selectedItem); },
+            keydown: function (e) { that._handleKeyDown(e); },
+            keyup: function (e, query) { that._handleKeyUp(e); }
+            // Note: lostFocus event DOESN'T work because auto smart complete catches the key up from shift-command-o and immediately
+            // triggers lostFocus
+        });
+
+        setSearchFieldValue(prefix, initialString);
+        
+        // Start fetching the file list, which will be needed the first time the user enters an un-prefixed query. If FileIndexManager's
+        // caches are out of date, this list might take some time to asynchronously build. See searchFileList() for how this is handled.
+        fileList = null;
+        pendingFileList = FileIndexManager.getFileInfoList("all")
             .done(function (files) {
                 fileList = files;
-                var dialogHTML = Strings.CMD_QUICK_OPEN + ": <input type='text' autocomplete='off' id='quickOpenSearch' style='width: 30em'>";
-                that._createDialogDiv(dialogHTML);
-                that.$searchField = $("input#quickOpenSearch");
-
-
-                that.$searchField.smartAutoComplete({
-                    source: files,
-                    maxResults: 20,
-                    minCharLimit: 0,
-                    autocompleteFocused: true,
-                    forceSelect: false,
-                    typeAhead: false,   // won't work right now because smart auto complete 
-                                        // using internal raw results instead of filtered results for matching
-                    filter: _handleFilter,
-                    resultFormatter: _handleResultsFormatter
-                });
-        
-                that.$searchField.bind({
-                    itemSelect: function (e, selectedItem) { that._handleItemSelect(selectedItem); },
-                    itemFocus: function (e, selectedItem) { that._handleItemFocus(selectedItem); },
-                    keydown: function (e) { that._handleKeyDown(e); },
-                    keyup: function (e, query) { that._handleKeyUp(e); }
-                    // Note: lostFocus event DOESN'T work because auto smart complete catches the key up from shift-command-o and immediately
-                    // triggers lostFocus
-                });
-        
-                setSearchFieldValue(prefix, initialString);
+                pendingFileList = null;
             });
     };
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -485,13 +485,15 @@ define(function (require, exports, module) {
     function searchFileList(query) {
         // FileIndexManager may still be loading asynchronously - if so, can't return a result yet
         if (!fileList) {
-            // Smart Autocomplete allows us to return a Deferred instead
+            // Smart Autocomplete allows us to return a Promise instead...
             var asyncResult = new $.Deferred();
             fileListPromise.done(function () {
-                // Make sure filter text hasn't changed while we were waiting
+                // ...but it's not very robust. If a previous Promise is obsoleted by the query string changing, it
+                // keeps listening to it anyway. So the last Promise to resolve "wins" the UI update even if it's for
+                // a stale query. Guard from that by checking that filter text hasn't changed while we were waiting:
                 var currentQuery = $("input#quickOpenSearch").val();
                 if (currentQuery === query) {
-                    // This is still the query. Synchronously re-run the search call and resolve with its results.
+                    // We're still the current query. Synchronously re-run the search call and resolve with its results
                     asyncResult.resolve(searchFileList(query));
                 } else {
                     asyncResult.reject();


### PR DESCRIPTION
Fix bug #1462 (Typing quickly after first access of Quick Open sends some characters to editor)
and #1579 (Quick Open breaks if you click anywhere before it opens)

The problem was that the Quick Open UI wasn't opened until FileIndexManager had returned a list of files in the project (which might take some async time). In the meantime, typing still went  to the editor and clicks crashed (because the Quick Open toolbar is only half-constructed).

The fix is to open the UI immediately, but defer showing results that depend on the file index until it's ready. Smart Autocomplete makes this surprisingly easy since it accepts a Promise in lieu of synchronous results from the search/filter function.

Note that _only_ the file search mode (unprefixed search strings) depends on the file index. The other modes still return synchronous results, and actually now feel a bit snappier since they're not forced to wait on a file index they'll never use.
