### PR TITLE
INITIAL REVIEW: Update path to welcome project in newer builds

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -236,8 +236,8 @@ define(function (require, exports, module) {
         PerfUtils.addMeasurement("Application Startup");
         
         // finish UI initialization before loading extensions
-        var initialProjectPath = ProjectManager.getInitialProjectPath();
-        ProjectManager.openProject(initialProjectPath).done(function () {
+        var initialProjectInfo = ProjectManager.getInitialProjectInfo();
+        ProjectManager.openProject(initialProjectInfo.root, initialProjectInfo.type).done(function () {
             _initTest();
 
             // WARNING: AppInit.appReady won't fire if ANY extension fails to
@@ -252,8 +252,8 @@ define(function (require, exports, module) {
             var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID);
             if (!params.get("skipSampleProjectLoad") && !prefs.getValue("afterFirstLaunch")) {
                 prefs.setValue("afterFirstLaunch", "true");
-                if (ProjectManager.isDefaultProjectPath(initialProjectPath)) {
-                    var dirEntry = new NativeFileSystem.DirectoryEntry(initialProjectPath);
+                if (initialProjectInfo.type === ProjectManager.TYPE_WELCOME) {
+                    var dirEntry = new NativeFileSystem.DirectoryEntry(initialProjectInfo.root);
                     dirEntry.getFile("index.html", {}, function (fileEntry) {
                         CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fileEntry.fullPath });
                     });


### PR DESCRIPTION
@gruehle 

This is a proposed fix for #1512. It's a little more code change than I'd like, so I'm just putting this up for initial review now.

The overall changes are:
- Instead of storing projects as just a path string, we store them as a "project info" object, which has the root path as well as a "type". Currently, the only types are "welcome" and "localFolder" (the idea being that in the future we could have other project types, with additional metadata). This applies to the pref for the last opened project as well as the list of recent projects maintained by the recent projects extension.
- When accessing either the last opened project or the recent projects list, we check for the welcome project, and change its root path to be whatever the welcome project is for the currently running source folder.

Note that we don't detect welcome projects from before this sprint, so people upgrading from Sprint 13 to Sprint 14 will still have the old welcome project in their last opened project/recent projects list. (However, the last opened project/recent projects list from older sprints will still be recognized even though they're in a different format.) We'll need to release note this.

The main concerns I have are that there are a fair number of cases that are affected, and the logic in the recent projects dropdown has changed enough that we really need to do a thorough retest. I've tested the ones I could think of, but there might be more. 

Here are the cases I can think of, along with their expected behavior:
1. Trash prefs and launch Brackets to get the Getting Started project. Quit Brackets. Restart Brackets with a new source folder. You should see the Getting Started project from the new folder.
2. Trash prefs and launch Brackets to get the Getting Started project. Open another folder, so the recent projects dropdown now has the Getting Started project in it. Quit Brackets. Restart Brackets with a new source folder. The recent projects dropdown should now have the Getting Started project from the new folder.
3. Like (1), but instead of restarting Brackets with a new source folder, just switch the language before relaunching. You should see the Getting Started project for the new language.
4. Like (2), but instead of restarting Brackets with a new source folder, just switch the language before relaunching. You should see the Getting Started project for the new language in the recent projects dropdown.
5. Trash prefs and launch Brackets Sprint 13. Open some folders. Quit Brackets. Launch Brackets Sprint 14. The last opened project and recent projects dropdown should still show what they showed in Sprint 13. (However, the Getting Started project from Sprint 13 will still be there.)

Note that this also means that the last opened project/recent projects won't be saved if you downgrade from >=Sprint 14 to <Sprint 14.

We need to add some unit tests for all this stuff. Some of these cases will be tricky to unit test, as it involves prefs being set up in certain ways and different source folders. Probably the only way to do it is to manually synthesize the prefs for each test. (Also, there weren't any unit tests for the recent projects dropdown to begin with...a by-product of the fact that the criteria for the last sprint were "just check it in" :) We probably need to write some.)
