### PR TITLE
temporarily use letter-spacing:-1px for code font on Windows

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -121,6 +121,7 @@
 .code-font-win() {
     .code-font();
     font-size: 13px;    /* < > chars look horrible at 12px  */
+    letter-spacing: -1px; /* temporary until spacing is fixed */
 }
 
 .code-font-mac() {


### PR DESCRIPTION
Temporary fix for Windows letter spacing issue
