### PR TITLE
Simpler fix for #1512

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
             var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID);
             if (!params.get("skipSampleProjectLoad") && !prefs.getValue("afterFirstLaunch")) {
                 prefs.setValue("afterFirstLaunch", "true");
-                if (ProjectManager.isDefaultProjectPath(initialProjectPath)) {
+                if (ProjectManager.isWelcomeProjectPath(initialProjectPath)) {
                     var dirEntry = new NativeFileSystem.DirectoryEntry(initialProjectPath);
                     dirEntry.getFile("index.html", {}, function (fileEntry) {
                         CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fileEntry.fullPath });

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -39,18 +39,32 @@ define(function (require, exports, module) {
         Strings                 = brackets.getModule("strings"),
         SidebarView             = brackets.getModule("project/SidebarView"),
         Menus                   = brackets.getModule("command/Menus"),
-        PopUpManager            = brackets.getModule("widgets/PopUpManager");
+        PopUpManager            = brackets.getModule("widgets/PopUpManager"),
+        FileUtils               = brackets.getModule("file/FileUtils");
     
     var $dropdownToggle;
     var MAX_PROJECTS = 20;
+
+    /**
+     * Get the stored list of recent projects, canonicalizing and updating paths as appropriate.
+     */
+    function getRecentProjects() {
+        var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY),
+            recentProjects = prefs.getValue("recentProjects") || [],
+            i;
+        for (i = 0; i < recentProjects.length; i++) {
+            recentProjects[i] = FileUtils.canonicalizeFolderPath(ProjectManager.updateWelcomeProjectPath(recentProjects[i]));
+        }
+        return recentProjects;
+    }
     
     /**
      * Add a project to the stored list of recent projects, up to MAX_PROJECTS.
      */
     function add() {
-        var root = ProjectManager.getProjectRoot().fullPath,
+        var root = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
             prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY),
-            recentProjects = prefs.getValue("recentProjects") || [],
+            recentProjects = getRecentProjects(),
             index = recentProjects.indexOf(root);
         if (index !== -1) {
             recentProjects.splice(index, 1);
@@ -67,10 +81,6 @@ define(function (require, exports, module) {
      * @param {string} path The full path to the folder.
      */
     function renderPath(path) {
-        if (path.length && path[path.length - 1] === "/") {
-            path = path.slice(0, path.length - 1);
-        }
-        
         var lastSlash = path.lastIndexOf("/"), folder, rest;
         if (lastSlash === path.length - 1) {
             lastSlash = path.slice(0, path.length - 1).lastIndexOf("/");
@@ -106,8 +116,7 @@ define(function (require, exports, module) {
         // Have to do this stopProp to avoid the html click handler from firing when this returns.
         e.stopPropagation();
         
-        var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY),
-            recentProjects = prefs.getValue("recentProjects") || [],
+        var recentProjects = getRecentProjects(),
             $dropdown = $("<ul id='project-dropdown' class='dropdown-menu'></ul>"),
             toggleOffset = $dropdownToggle.offset();
 
@@ -124,7 +133,7 @@ define(function (require, exports, module) {
             $("#main-toolbar .nav").off("click", closeDropdown);
         }
         
-        var currentProject = ProjectManager.getProjectRoot().fullPath,
+        var currentProject = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
             hasProject = false;
         recentProjects.forEach(function (root) {
             if (root !== currentProject) {

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -202,6 +202,19 @@ define(function (require, exports, module) {
         
         return path;
     }
+    
+    /**
+     * Canonicalizes a folder path to not include a trailing slash.
+     * @param {string} path
+     * @return {string}
+     */
+    function canonicalizeFolderPath(path) {
+        if (path.length > 0 && path[path.length - 1] === "/") {
+            return path.slice(0, -1);
+        } else {
+            return path;
+        }
+    }
 
     /**
      * Returns a native absolute path to the 'brackets' source directory.
@@ -262,4 +275,5 @@ define(function (require, exports, module) {
     exports.convertToNativePath            = convertToNativePath;
     exports.getNativeBracketsDirectoryPath = getNativeBracketsDirectoryPath;
     exports.getNativeModuleDirectoryPath   = getNativeModuleDirectoryPath;
+    exports.canonicalizeFolderPath         = canonicalizeFolderPath;
 });

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -77,6 +77,14 @@ define(function (require, exports, module) {
      */
     var _projectTree = null;
     
+    function canonicalize(path) {
+        if (path.length > 0 && path[path.length - 1] === "/") {
+            return path.slice(0, -1);
+        } else {
+            return path;
+        }
+    }
+    
     /**
      * @private
      * Reference to previous selected jstree leaf node when ProjectManager had
@@ -264,7 +272,7 @@ define(function (require, exports, module) {
                 fullPath = entry.fullPath;
 
                 // Truncate project path prefix, remove the trailing slash
-                shortPath = FileUtils.canonicalizeFolderPath(fullPath);
+                shortPath = fullPath.slice(projectPathLength, -1);
 
                 // Determine depth of the node by counting path separators.
                 // Children at the root have depth of zero
@@ -998,15 +1006,15 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_OPEN_FOLDER,    Commands.FILE_OPEN_FOLDER,  openProject);
 
     // Define public API
-    exports.getProjectRoot          = getProjectRoot;
-    exports.isWithinProject         = isWithinProject;
+    exports.getProjectRoot           = getProjectRoot;
+    exports.isWithinProject          = isWithinProject;
     exports.makeProjectRelativeIfPossible = makeProjectRelativeIfPossible;
-    exports.shouldShow              = shouldShow;
-    exports.openProject             = openProject;
-    exports.getSelectedItem         = getSelectedItem;
-    exports.getInitialProjectPath   = getInitialProjectPath;
-    exports.isWelcomeProjectPath    = isWelcomeProjectPath;
+    exports.shouldShow               = shouldShow;
+    exports.openProject              = openProject;
+    exports.getSelectedItem          = getSelectedItem;
+    exports.getInitialProjectPath    = getInitialProjectPath;
+    exports.isWelcomeProjectPath     = isWelcomeProjectPath;
     exports.updateWelcomeProjectPath = updateWelcomeProjectPath;
-    exports.createNewItem           = createNewItem;
-    exports.forceFinishRename       = forceFinishRename;
+    exports.createNewItem            = createNewItem;
+    exports.forceFinishRename        = forceFinishRename;
 });


### PR DESCRIPTION
@gruehle 

Whenever we load the welcome project for the current build, we add it to a list stored in prefs. If in the future we relaunch a different build, and the welcome project is the last visited project or in the recent projects dropdown, we substitute the new build's welcome project for the old one.
