### PR TITLE
Fix extensions unit tests when run from symlinked directory

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
             extensionPath = FileUtils.getNativeBracketsDirectoryPath();
         
         // Assumes the caller's window.location context is /test/SpecRunner.html
-        extensionPath = extensionPath.replace("brackets/test", "brackets/src"); // convert from "test" to "src"
+        extensionPath = extensionPath.replace(/\/test$/, "/src"); // convert from "test" to "src"
         extensionPath += "/" + config.baseUrl + "/" + entryPoint + ".js";
 
         var fileExists = false, statComplete = false;


### PR DESCRIPTION
Fix for issue #1640

Related to #1595

I searched the rest of the brackets code for paths that include "brackets/". The only hits are in links in the readme, which are fine, and in sample files used for unit tests, which are also fine.
