### PR TITLE
disable bold on cm-header

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -139,7 +139,7 @@
 span.cm-em {
     font-style: normal;
 }
-span.cm-strong {
+span.cm-header, span.cm-strong {
     font-weight: normal;
 }
 span.cm-emstrong {


### PR DESCRIPTION
This is for issue #1646. I was looking at brackets/README.md but I missed the case for headers which can be seen in brackets-shell/README.md.
