### PR TITLE
Continue initialization even if initial project can't be loaded

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
         
         // finish UI initialization before loading extensions
         var initialProjectPath = ProjectManager.getInitialProjectPath();
-        ProjectManager.openProject(initialProjectPath).done(function () {
+        ProjectManager.openProject(initialProjectPath).always(function () {
             _initTest();
 
             // WARNING: AppInit.appReady won't fire if ANY extension fails to

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -749,8 +749,12 @@ define(function (require, exports, module) {
                         // project directory.
                         // TODO (issue #267): When Brackets supports having no project directory
                         // defined this code will need to change
-                        result.reject();
-                        return _loadProject(_getWelcomeProjectPath());
+                        _loadProject(_getWelcomeProjectPath()).always(function () {
+                            // Make sure not to reject the original deferred until the fallback
+                            // project is loaded, so we don't violate expectations that there is always
+                            // a current project before continuing after _loadProject().
+                            result.reject();
+                        });
                     });
                 }
                 );


### PR DESCRIPTION
For #1667.

The primary bug fix is the one in brackets.js. The change to ProjectManager was just to make it so that if the initial project load does fail, we don't continue with initialization until the welcome project is actually loaded. I don't know if it would break anything to continue anyway, but various bits of Brackets might currently assume that you always have a current project. (We plan to fix this in the future, but for now I don't want to take any chances.)

Note that in the original ProjectManager code, there was a `return loadProject(...)` in the failure case. I don't think the "return" makes sense because it's in a promise `done()` callback, so there's nothing that would look at the return value anyway, unless I'm missing something.
