### PR TITLE
Don't close dropdowns on a scroll event in a hidden editor

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -585,8 +585,12 @@ define(function (require, exports, module) {
             $(self).triggerHandler("cursorActivity", [self]);
         });
         this._codeMirror.setOption("onScroll", function (instance) {
-            // close all dropdowns on scroll
-            Menus.closeAll();
+            // If this editor is visible, close all dropdowns on scroll.
+            // (We don't want to do this if we're just scrolling in a non-visible editor
+            // in response to some document change event.)
+            if (self.isFullyVisible()) {
+                Menus.closeAll();
+            }
 
             $(self).triggerHandler("scroll", [self]);
         


### PR DESCRIPTION
@RaymondLim 

If you have both an inline editor and a full editor open on a given file, and you make an edit in a full editor that should pop up a code hint, in some cases it will cause the hidden editor to generate a scroll event (because its size is 0 when it's hidden, and when it handles the change event for the document, CM will try to scroll the cursor into view). I'm not sure why this only happens sometimes, but this seems like a safe fix.
