### PR TITLE
Handle selector combinators with no whitespace after them when parsing CSS

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -430,8 +430,8 @@ define(function (require, exports, module) {
         }
         
         if (!classOrIdSelector) {
-            // Tag selectors must have nothing or whitespace before it.
-            selector = "(^|\\s)" + selector;
+            // Tag selectors must have nothing, whitespace, or a combinator before it.
+            selector = "(^|[\\s>+~])" + selector;
         }
         
         var re = new RegExp(selector + "(\\[[^\\]]*\\]|:{1,2}[\\w-()]+|\\.[\\w-]+|#[\\w-]+)*\\s*$", classOrIdSelector ? "" : "i");

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1014,6 +1014,22 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(1);
                 
             });
+            
+            // Issue #1699
+            it("should find the target of combinators with no whitespace", function () {
+                // Child combinator
+                var result = match("foo>section { color: red }", { tag: "section" });
+                expect(result.length).toBe(1);
+                // Adjacent sibling combinator
+                result = match("foo+section { color: red }", { tag: "section" });
+                expect(result.length).toBe(1);
+                // General sibling combinator
+                result = match("foo~section { color: red }", { tag: "section" });
+                expect(result.length).toBe(1);
+                // Invalid combinator
+                result = match("foo!section { color: red }", { tag: "section" });
+                expect(result.length).toBe(0);
+            });
         }); // describe("Combinators")        
         
         


### PR DESCRIPTION
Fixes #1699.
