### PR TITLE
Fix bug #1109 (Quick Open JS: can't access second function with same name)

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         EDIT_MENU       : "edit-menu",
         VIEW_MENU       : "view-menu",
         NAVIGATE_MENU   : "navigate-menu",
-        DEBUG_MENU      : "debug-menu",
+        DEBUG_MENU      : "debug-menu",     // Note: not present in some configurations of Brackets (getMenu() will return null)
         HELP_MENU       : "help-menu"
     };
 

--- a/src/extensions/default/QuickOpenCSS/main.js
+++ b/src/extensions/default/QuickOpenCSS/main.js
@@ -61,23 +61,6 @@ define(function (require, exports, module) {
         }
     }
 
-    function getLocationFromSelectorName(selector) {
-        if (!selectorList) {
-            return null;
-        }
-        
-        // TODO: handle multiple selectors with same name in CSS file
-        var i, result;
-        for (i = 0; i < selectorList.length; i++) {
-            var selectorInfo = selectorList[i];
-            if (selectorInfo.selector === selector) {
-                result = selectorInfo;
-                break;
-            }
-        }
-
-        return result;
-    }
 
     /**
      * @param {string} query what the user is searching for
@@ -89,7 +72,11 @@ define(function (require, exports, module) {
         
         // Filter and rank how good each match is
         var filteredList = $.map(selectorList, function (itemInfo) {
-            return QuickOpen.stringMatch(itemInfo.selector, query);
+            var searchResult = QuickOpen.stringMatch(itemInfo.selector, query);
+            if (searchResult) {
+                searchResult.selectorInfo = itemInfo;
+            }
+            return searchResult;
         });
         
         // Sort based on ranking & basic alphabetical order
@@ -119,12 +106,11 @@ define(function (require, exports, module) {
         if (!selectedItem) {
             return;
         }
-        var selectorInfo = getLocationFromSelectorName(selectedItem.label);
-        if (selectorInfo) {
-            var from = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorStartChar};
-            var to = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorEndChar};
-            EditorManager.getCurrentFullEditor().setSelection(from, to);
-        }
+        var selectorInfo = selectedItem.selectorInfo;
+
+        var from = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorStartChar};
+        var to = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorEndChar};
+        EditorManager.getCurrentFullEditor().setSelection(from, to);
     }
 
     function itemSelect(selectedItem) {

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -93,22 +93,6 @@ define(function (require, exports, module) {
         }
     }
 
-    function getLocationFromID(id) {
-        if (!idList) {
-            return null;
-        }
-
-        var i, result;
-        for (i = 0; i < idList.length; i++) {
-            var fileLocation = idList[i];
-            if (fileLocation.id === id) {
-                result = fileLocation;
-                break;
-            }
-        }
-
-        return result;
-    }
 
     /**
      * @param {string} query what the user is searching for
@@ -119,8 +103,12 @@ define(function (require, exports, module) {
         query = query.slice(query.indexOf("@") + 1, query.length);
         
         // Filter and rank how good each match is
-        var filteredList = $.map(idList, function (itemInfo) {
-            return QuickOpen.stringMatch(itemInfo.id, query);
+        var filteredList = $.map(idList, function (fileLocation) {
+            var searchResult = QuickOpen.stringMatch(fileLocation.id, query);
+            if (searchResult) {
+                searchResult.fileLocation = fileLocation;
+            }
+            return searchResult;
         });
         
         // Sort based on ranking & basic alphabetical order
@@ -151,12 +139,11 @@ define(function (require, exports, module) {
         if (!selectedItem) {
             return;
         }
-        var fileLocation = getLocationFromID(selectedItem.label);
-        if (fileLocation) {
-            var from = {line: fileLocation.line, ch: fileLocation.chFrom};
-            var to = {line: fileLocation.line, ch: fileLocation.chTo};
-            EditorManager.getCurrentFullEditor().setSelection(from, to);
-        }
+        var fileLocation = selectedItem.fileLocation;
+        
+        var from = {line: fileLocation.line, ch: fileLocation.chFrom};
+        var to = {line: fileLocation.line, ch: fileLocation.chTo};
+        EditorManager.getCurrentFullEditor().setSelection(from, to);
     }
 
     function itemSelect(selectedItem) {

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
 
     <!-- HTML content is dynamically loaded and rendered by brackets.js.
          Any modules that depend on or modify HTML during load should 
-         require the "utils/Ready" modules and install a callback for
+         require the "utils/AppInit" module and install a callback for
          "htmlReady" (e.g. AppInit.htmlReady(handler)) before touching the DOM.
     -->
     


### PR DESCRIPTION
Fix bug #1109 (Quick Open JS: can't access second function with same name), and equivalent bug for CSS & HTML Quick Open. Simplifies logic at the same time, taking advantage of #1565.

Plus two tiny docs fixes.
