### PR TITLE
Add "New Folder" and "Rename" features

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_WINDOW           = "file.close_window"; // string must MATCH string in native code (brackets_extensions)
     exports.FILE_ADD_TO_WORKING_SET     = "file.addToWorkingSet";
     exports.FILE_LIVE_FILE_PREVIEW      = "file.liveFilePreview";
+    exports.FILE_RENAME                 = "file.rename";
     exports.FILE_QUIT                   = "file.quit"; // string must MATCH string in native code (brackets_extensions)
 
     // EDIT

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
 
     // FILE
     exports.FILE_NEW                    = "file.new";
+    exports.FILE_NEW_FOLDER             = "file.newFolder";
     exports.FILE_OPEN                   = "file.open";
     exports.FILE_OPEN_FOLDER            = "file.openFolder";
     exports.FILE_SAVE                   = "file.save";

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -964,6 +964,7 @@ define(function (require, exports, module) {
         var project_cmenu = registerContextMenu(ContextMenuIds.PROJECT_MENU);
         project_cmenu.addMenuItem(Commands.FILE_NEW);
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
+        project_cmenu.addMenuItem(Commands.FILE_RENAME);
 
         var editor_cmenu = registerContextMenu(ContextMenuIds.EDITOR_MENU);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -848,6 +848,7 @@ define(function (require, exports, module) {
         var menu;
         menu = addMenu(Strings.FILE_MENU, AppMenuBar.FILE_MENU);
         menu.addMenuItem(Commands.FILE_NEW,                 "Ctrl-N");
+        menu.addMenuItem(Commands.FILE_NEW_FOLDER);
         menu.addMenuItem(Commands.FILE_OPEN,                "Ctrl-O");
         menu.addMenuItem(Commands.FILE_OPEN_FOLDER);
         menu.addMenuItem(Commands.FILE_CLOSE,               "Ctrl-W");
@@ -962,6 +963,7 @@ define(function (require, exports, module) {
          */
         var project_cmenu = registerContextMenu(ContextMenuIds.PROJECT_MENU);
         project_cmenu.addMenuItem(Commands.FILE_NEW);
+        project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
 
         var editor_cmenu = registerContextMenu(ContextMenuIds.EDITOR_MENU);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
         }
     }
     
-    function resetDocumentTitle() {
+    function updateDocumentTitle() {
         var newDocument = DocumentManager.getCurrentDocument();
 
         // TODO: This timer is causing a "Recursive tests with the same name are not supporte"
@@ -833,7 +833,7 @@ define(function (require, exports, module) {
         
         // Listen for changes that require updating the editor titlebar
         $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
-        $(DocumentManager).on("currentDocumentChange fileNameChange", resetDocumentTitle);
+        $(DocumentManager).on("currentDocumentChange fileNameChange", updateDocumentTitle);
     }
 
     // Define public API

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -97,7 +97,11 @@ define(function (require, exports, module) {
     
     function resetDocumentTitle() {
         var newDocument = DocumentManager.getCurrentDocument();
-        var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
+
+        // TODO: This timer is causing a "Recursive tests with the same name are not supporte"
+        // exception. This code should be removed (if not needed), or updated with a unique
+        // timer name (if needed).
+        // var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
         
         if (newDocument) {
             var fullPath = newDocument.file.fullPath;
@@ -113,7 +117,7 @@ define(function (require, exports, module) {
         // Update title text & "dirty dot" display
         updateTitle();
 
-        PerfUtils.addMeasurement(perfTimerName);
+        // PerfUtils.addMeasurement(perfTimerName);
     }
     
     function handleDirtyChange(event, changedDoc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -97,7 +97,7 @@ define(function (require, exports, module) {
     
     function resetDocumentTitle() {
         var newDocument = DocumentManager.getCurrentDocument();
-//        var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
+        var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
         
         if (newDocument) {
             var fullPath = newDocument.file.fullPath;
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
         // Update title text & "dirty dot" display
         updateTitle();
 
-//        PerfUtils.addMeasurement(perfTimerName);
+        PerfUtils.addMeasurement(perfTimerName);
     }
     
     function handleDirtyChange(event, changedDoc) {

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -64,6 +64,8 @@
  *      2nd arg to the listener is the removed FileEntry.
  *    - workingSetRemoveList -- When a list of files is to be removed from the working set (e.g. project close).
  *      The 2nd arg to the listener is the array of removed FileEntry objects.
+ *    - fileNameChange -- When the name of a file or folder has changed. The 2nd arg is the old name.
+ *      The 3rd arg is the new name.
  *
  * These are jQuery events, so to listen for them you do something like this:
  *    $(DocumentManager).on("eventname", handler);
@@ -1061,7 +1063,49 @@ define(function (require, exports, module) {
         }
     }
 
-
+    /**
+     * Called after a file or folder name has changed. This function is responsible
+     * for updating underlying model data and notifying all views of the change.
+     *
+     * @param {string} oldName The old name of the file/folder
+     * @param {string} newName The new name of the file/folder
+     */
+    function notifyFileNameChanged(oldName, newName) {
+        var i, path;
+        
+        // Update currentDocument
+        FileUtils.updateFileEntryPath(_currentDocument.file, oldName, newName);
+        
+        // Update open documents
+        var keysToDelete = [];
+        for (path in _openDocuments) {
+            if (_openDocuments.hasOwnProperty(path)) {
+                if (path.indexOf(oldName) === 0) {
+                    // Copy value to new key
+                    var newKey = path.replace(oldName, newName);
+                    
+                    _openDocuments[newKey] = _openDocuments[path];
+                    keysToDelete.push(path);
+                    
+                    // Update document file
+                    FileUtils.updateFileEntryPath(_openDocuments[newKey].file, oldName, newName);
+                }
+            }
+        }
+        // Delete the old keys
+        for (i = 0; i < keysToDelete.length; i++) {
+            delete _openDocuments[keysToDelete[i]];
+        }
+        
+        // Update working set
+        for (i = 0; i < _workingSet.length; i++) {
+            FileUtils.updateFileEntryPath(_workingSet[i], oldName, newName);
+        }
+        
+        // Send a "fileNameChanged" event. This will trigger the views to update.
+        $(exports).triggerHandler("fileNameChange", [oldName, newName]);
+    }
+    
     // Define public API
     exports.Document = Document;
     exports.getCurrentDocument = getCurrentDocument;
@@ -1080,10 +1124,11 @@ define(function (require, exports, module) {
     exports.closeFullEditor = closeFullEditor;
     exports.closeAll = closeAll;
     exports.notifyFileDeleted = notifyFileDeleted;
+    exports.notifyFileNameChanged = notifyFileNameChanged;
 
     // Setup preferences
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID);
-    $(exports).bind("currentDocumentChange workingSetAdd workingSetAddList workingSetRemove workingSetRemoveList", _savePreferences);
+    $(exports).bind("currentDocumentChange workingSetAdd workingSetAddList workingSetRemove workingSetRemoveList fileNameChange", _savePreferences);
     
     // Performance measurements
     PerfUtils.createPerfMeasurement("DOCUMENT_MANAGER_GET_DOCUMENT_FOR_PATH", "DocumentManager.getDocumentForPath()");

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1074,7 +1074,9 @@ define(function (require, exports, module) {
         var i, path;
         
         // Update currentDocument
-        FileUtils.updateFileEntryPath(_currentDocument.file, oldName, newName);
+        if (_currentDocument) {
+            FileUtils.updateFileEntryPath(_currentDocument.file, oldName, newName);
+        }
         
         // Update open documents
         var keysToDelete = [];

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1069,8 +1069,9 @@ define(function (require, exports, module) {
      *
      * @param {string} oldName The old name of the file/folder
      * @param {string} newName The new name of the file/folder
+     * @param {boolean} isFolder True if path is a folder; False if it is a file.
      */
-    function notifyFileNameChanged(oldName, newName) {
+    function notifyPathNameChanged(oldName, newName, isFolder) {
         var i, path;
         
         // Update currentDocument
@@ -1091,6 +1092,12 @@ define(function (require, exports, module) {
                     
                     // Update document file
                     FileUtils.updateFileEntryPath(_openDocuments[newKey].file, oldName, newName);
+                        
+                    if (!isFolder) {
+                        // If the path name is a file, there can only be one matched entry in the open document
+                        // list, which we just updated. Break out of the for .. in loop. 
+                        break;
+                    }
                 }
             }
         }
@@ -1126,7 +1133,7 @@ define(function (require, exports, module) {
     exports.closeFullEditor = closeFullEditor;
     exports.closeAll = closeAll;
     exports.notifyFileDeleted = notifyFileDeleted;
-    exports.notifyFileNameChanged = notifyFileNameChanged;
+    exports.notifyPathNameChanged = notifyPathNameChanged;
 
     // Setup preferences
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID);

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -267,6 +267,7 @@ define(function (require, exports, module) {
      * @param {FileEntry} entry The FileEntry or DirectoryEntry to update
      * @param {string} oldName The full path of the old name
      * @param {string} newName The full path of the new name
+     * @return {boolean} Returns true if the file entry was updated
      */
     function updateFileEntryPath(entry, oldName, newName) {
         if (entry.fullPath.indexOf(oldName) === 0) {
@@ -284,7 +285,11 @@ define(function (require, exports, module) {
                     entry.name = pathParts.pop();
                 }
             }
+            
+            return true;
         }
+        
+        return false;
     }
 
     // Define public API

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -261,6 +261,31 @@ define(function (require, exports, module) {
         }
         return path;
     }
+    
+    /**
+     * Update a file entry path after a file/folder name change.
+     * @param {FileEntry} entry The FileEntry or DirectoryEntry to update
+     * @param {string} oldName The full path of the old name
+     * @param {string} newName The full path of the new name
+     */
+    function updateFileEntryPath(entry, oldName, newName) {
+        if (entry.fullPath.indexOf(oldName) === 0) {
+            var fullPath = entry.fullPath.replace(oldName, newName);
+            
+            entry.fullPath = fullPath;
+            
+            // TODO: Should this be a method on Entry instead?
+            entry.name = null; // default if extraction fails
+            if (fullPath) {
+                var pathParts = fullPath.split("/");
+                
+                // Extract name from the end of the fullPath (account for trailing slash(es))
+                while (!entry.name && pathParts.length) {
+                    entry.name = pathParts.pop();
+                }
+            }
+        }
+    }
 
     // Define public API
     exports.LINE_ENDINGS_CRLF              = LINE_ENDINGS_CRLF;
@@ -276,4 +301,5 @@ define(function (require, exports, module) {
     exports.getNativeBracketsDirectoryPath = getNativeBracketsDirectoryPath;
     exports.getNativeModuleDirectoryPath   = getNativeModuleDirectoryPath;
     exports.canonicalizeFolderPath         = canonicalizeFolderPath;
+    exports.updateFileEntryPath            = updateFileEntryPath;
 });

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -578,7 +578,9 @@ define(function (require, exports, module) {
 
                 // create the file
                 if (options.create) {
-                    brackets.fs.makedir(directoryFullPath, 0 /* TODO - should be 0777 */, function (err) {
+                    // TODO: Pass permissions. The current implementation of fs.makedir() always 
+                    // creates the directory with the full permissions available to the current user. 
+                    brackets.fs.makedir(directoryFullPath, 0, function (err) {
                         if (err) {
                             createDirectoryError(err);
                         } else {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -517,8 +517,86 @@ define(function (require, exports, module) {
     };
     
     NativeFileSystem.DirectoryEntry.prototype.getDirectory = function (path, options, successCallback, errorCallback) {
-        // TODO (issue #241)
-        // http://www.w3.org/TR/2011/WD-file-system-api-20110419/#widl-DirectoryEntry-getDirectory
+        var directoryFullPath = path;
+        
+        function isRelativePath(path) {
+            // If the path contains a colons it must be a full path on Windows (colons are
+            // not valid path characters on mac or in URIs)
+            if (path.indexOf(":") !== -1) {
+                return false;
+            }
+            
+            // For everyone else, absolute paths start with a "/"
+            return path[0] !== "/";
+        }
+
+        // resolve relative paths relative to the DirectoryEntry
+        if (isRelativePath(path)) {
+            directoryFullPath = this.fullPath + path;
+        }
+
+        var createDirectoryEntry = function () {
+            if (successCallback) {
+                successCallback(new NativeFileSystem.DirectoryEntry(directoryFullPath));
+            }
+        };
+
+        var createDirectoryError = function (err) {
+            if (errorCallback) {
+                errorCallback(NativeFileSystem._nativeToFileError(err));
+            }
+        };
+
+        // Use stat() to check if file exists
+        brackets.fs.stat(directoryFullPath, function (err, stats) {
+            if ((err === brackets.fs.NO_ERROR)) {
+                // NO_ERROR implies the path already exists
+
+                // throw error if the file the path is not a directory
+                if (!stats.isDirectory()) {
+                    if (errorCallback) {
+                        errorCallback(new NativeFileSystem.FileError(FileError.TYPE_MISMATCH_ERR));
+                    }
+
+                    return;
+                }
+
+                // throw error if the file exists but create is exclusive
+                if (options.create && options.exclusive) {
+                    if (errorCallback) {
+                        errorCallback(new NativeFileSystem.FileError(FileError.PATH_EXISTS_ERR));
+                    }
+
+                    return;
+                }
+
+                // Create a file entry for the existing directory. If create == true,
+                // a file entry is created without error.
+                createDirectoryEntry();
+            } else if (err === brackets.fs.ERR_NOT_FOUND) {
+                // ERR_NOT_FOUND implies we write a new, empty file
+
+                // create the file
+                if (options.create) {
+                    brackets.fs.makedir(directoryFullPath, 0 /* TODO - should be 0777 */, function (err) {
+                        if (err) {
+                            createDirectoryError(err);
+                        } else {
+                            createDirectoryEntry();
+                        }
+                    });                    
+                    return;
+                }
+
+                // throw error if file not found and the create == false
+                if (errorCallback) {
+                    errorCallback(new NativeFileSystem.FileError(FileError.NOT_FOUND_ERR));
+                }
+            } else {
+                // all other brackets.fs.stat() errors
+                createDirectoryError(err);
+            }
+        });
     };
     
     NativeFileSystem.DirectoryEntry.prototype.removeRecursively = function (successCallback, errorCallback) {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -584,7 +584,7 @@ define(function (require, exports, module) {
                         } else {
                             createDirectoryEntry();
                         }
-                    });                    
+                    });
                     return;
                 }
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -140,6 +140,7 @@ define({
     // File menu commands
     "FILE_MENU"                           : "File",
     "CMD_FILE_NEW"                        : "New",
+    "CMD_FILE_NEW_FOLDER"                 : "New Folder",
     "CMD_FILE_OPEN"                       : "Open\u2026",
     "CMD_ADD_TO_WORKING_SET"              : "Add To Working Set",
     "CMD_OPEN_FOLDER"                     : "Open Folder\u2026",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -142,7 +142,7 @@ define({
 
     // File menu commands
     "FILE_MENU"                           : "File",
-    "CMD_FILE_NEW"                        : "New",
+    "CMD_FILE_NEW"                        : "New File",
     "CMD_FILE_NEW_FOLDER"                 : "New Folder",
     "CMD_FILE_OPEN"                       : "Open\u2026",
     "CMD_ADD_TO_WORKING_SET"              : "Add To Working Set",
@@ -152,7 +152,7 @@ define({
     "CMD_FILE_SAVE"                       : "Save",
     "CMD_FILE_SAVE_ALL"                   : "Save All",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
-    "CMD_FILE_RENAME"                     : "Rename\u2026",
+    "CMD_FILE_RENAME"                     : "Rename",
     "CMD_QUIT"                            : "Quit",
 
     // Edit menu commands

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -35,6 +35,7 @@ define({
     "NOT_READABLE_ERR"                  : "The file could not be read.",
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
+    "FILE_EXISTS_ERR"                   : "The file already exists.",
 
     // Project error strings
     "ERROR_LOADING_PROJECT"             : "Error loading project",
@@ -49,6 +50,8 @@ define({
     "ERROR_RELOADING_FILE"              : "An error occurred when trying to reload the file <span class='dialog-filename'>{0}</span>. {1}",
     "ERROR_SAVING_FILE_TITLE"           : "Error saving file",
     "ERROR_SAVING_FILE"                 : "An error occurred when trying to save the file <span class='dialog-filename'>{0}</span>. {1}",
+    "ERROR_RENAMING_FILE_TITLE"         : "Error renaming file",
+    "ERROR_RENAMING_FILE"               : "An error occurred when trying to rename the file <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid file name",
     "INVALID_FILENAME_MESSAGE"          : "Filenames cannot contain the following characters: /?*:;{}<>\\|",
     "FILE_ALREADY_EXISTS"               : "The file <span class='dialog-filename'>{0}</span> already exists.",
@@ -149,6 +152,7 @@ define({
     "CMD_FILE_SAVE"                       : "Save",
     "CMD_FILE_SAVE_ALL"                   : "Save All",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
+    "CMD_FILE_RENAME"                     : "Rename\u2026",
     "CMD_QUIT"                            : "Quit",
 
     // Edit menu commands

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -395,7 +395,7 @@ define(function (require, exports, module) {
         }
     );
     
-    $(ProjectManager).on("projectOpen", function (event, projectRoot) {
+    $(ProjectManager).on("projectOpen projectFilesChange", function (event, projectRoot) {
         markDirty();
     });
     

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -938,7 +938,7 @@ define(function (require, exports, module) {
                     // If the new item is a folder, force a re-sort here. Windows sorts folders
                     // and files separately.
                     if (isFolder) {
-                        _projectTree.jstree("sort", _projectTree);
+                        _projectTree.jstree("sort", data.rslt.obj.parent());
                     }
                     
                     // Notify listeners that the project model has changed

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -933,14 +933,15 @@ define(function (require, exports, module) {
                         data.rslt.obj.removeClass("jstree-leaf jstree-closed jstree-open")
                             .addClass("jstree-closed");
                     }
-                    _projectTree.jstree("select_node", data.rslt.obj, true);
                     
                     // If the new item is a folder, force a re-sort here. Windows sorts folders
                     // and files separately.
                     if (isFolder) {
                         _projectTree.jstree("sort", data.rslt.obj.parent());
                     }
-                    
+
+                    _projectTree.jstree("select_node", data.rslt.obj, true);
+
                     // Notify listeners that the project model has changed
                     $(exports).triggerHandler("projectFilesChange");
                     

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -333,6 +333,18 @@ define(function (require, exports, module) {
 
     }
 
+    /**
+     * @private
+     * @param {string} oldName
+     * @param {string} newName
+     */
+    function _handleFileNameChanged(oldName, newName) {
+        // Rebuild the working set if any file or folder name changed.
+        // We could be smarter about this and only update the
+        // nodes that changed, if needed...
+        _rebuildWorkingSet();
+    }
+    
     function create(element) {
         // Init DOM element
         $openFilesContainer = element;
@@ -359,6 +371,10 @@ define(function (require, exports, module) {
             _handleDirtyFlagChanged(doc);
         });
     
+        $(DocumentManager).on("fileNameChange", function (event, oldName, newName) {
+            _handleFileNameChanged(oldName, newName);
+        });
+        
         $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange);
         
         // Show scroller shadows when open-files-container scrolls

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -52,6 +52,7 @@ define(function (require, exports, module) {
         FileIndexManager    = require("project/FileIndexManager"),
         KeyEvent            = require("utils/KeyEvent");
 
+    var searchResults = [];
     
     var FIND_IN_FILES_MAX = 100;
 
@@ -287,11 +288,12 @@ define(function (require, exports, module) {
     function doFindInFiles() {
 
         var dialog = new FindInFilesDialog();
-        var searchResults = [];
         
         // Default to searching for the current selection
         var currentEditor = EditorManager.getFocusedEditor();
         var initialString = currentEditor && currentEditor.getSelectedText();
+        
+        searchResults = [];
                             
         dialog.showDialog(initialString)
             .done(function (query) {
@@ -333,5 +335,16 @@ define(function (require, exports, module) {
             });
     }
 
+    function _fileNameChangeHandler(event, oldName, newName) {
+        if ($("#search-results").is(":visible")) {
+            // Update the search results
+            searchResults.forEach(function (item) {
+                item.fullPath = item.fullPath.replace(oldName, newName);
+            });
+            _showSearchResults(searchResults);
+        }
+    }
+    
+    $(DocumentManager).on("fileNameChange", _fileNameChangeHandler);
     CommandManager.register(Strings.CMD_FIND_IN_FILES,  Commands.EDIT_FIND_IN_FILES,    doFindInFiles);
 });

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -464,6 +464,7 @@ ins.jstree-icon {
 }
 
 // TODO (Issue #1615): Remove this hack when we get a new CEF
+/*
 @media all and (-webkit-min-device-pixel-ratio:2),(min-device-pixel-ratio:2) {
 .inline-widget {
     .shadow.top {
@@ -474,6 +475,7 @@ ins.jstree-icon {
     }
 }
 }
+*/
 
 /* CSSInlineEditor rule list */
 .related-container {

--- a/test/spec/LowLevelFileIO-test-files/rename_me/hello.txt
+++ b/test/spec/LowLevelFileIO-test-files/rename_me/hello.txt
@@ -1,0 +1,1 @@
+Hello, World.

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -504,5 +504,176 @@ define(function (require, exports, module) {
             });
 
         }); // describe("unlink")
+        
+        describe("mkdir", function () {
+            it("should make a new directory", function () {
+                // TODO: Write this test once we have a function to delete the directory
+            });
+        });
+        
+        describe("rename", function () {
+            var error, complete;
+            
+            it("should rename a file", function () {
+                var oldName = baseDir + "file_one.txt",
+                    newName = baseDir + "file_one_renamed.txt";
+                
+                complete = false;
+                
+                brackets.fs.rename(oldName, newName, function (err) {
+                    error = err;
+                    complete = true;
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Verify new file is found and old one is missing
+                runs(function () {
+                    complete = false;
+                    brackets.fs.stat(oldName, function (err, stat) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                });
+
+                runs(function () {
+                    complete = false;
+                    brackets.fs.stat(newName, function (err, stat) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Rename the file back to the old name
+                runs(function () {
+                    complete = false;
+                    brackets.fs.rename(newName, oldName, function (err) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                    
+            });
+            it("should rename a folder", function () {
+                var oldName = baseDir + "rename_me",
+                    newName = baseDir + "renamed_folder";
+                
+                complete = false;
+                
+                brackets.fs.rename(oldName, newName, function (err) {
+                    error = err;
+                    complete = true;
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Verify new folder is found and old one is missing
+                runs(function () {
+                    complete = false;
+                    brackets.fs.stat(oldName, function (err, stat) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                });
+
+                runs(function () {
+                    complete = false;
+                    brackets.fs.stat(newName, function (err, stat) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Rename the folder back to the old name
+                runs(function () {
+                    complete = false;
+                    brackets.fs.rename(newName, oldName, function (err) {
+                        complete = true;
+                        error = err;
+                    });
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+            });
+            it("should return an error if the new name already exists", function () {
+                var oldName = baseDir + "file_one.txt",
+                    newName = baseDir + "file_two.txt";
+                
+                complete = false;
+                
+                brackets.fs.rename(oldName, newName, function (err) {
+                    error = err;
+                    complete = true;
+                });
+                
+                waitsFor(function () { return complete; }, 1000);
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_FILE_EXISTS);
+                });
+            });
+            it("should return an error if the parent folder is read only (Mac only)", function () {
+                if (brackets.platform === "mac") {
+                    var oldName = baseDir + "cant_write_here/readme.txt",
+                        newName = baseDir + "cant_write_here/readme_renamed.txt";
+                    
+                    complete = false;
+                    
+                    brackets.fs.rename(oldName, newName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                    
+                    waitsFor(function () { return complete; }, 1000);
+                    
+                    runs(function () {
+                        expect(error).toBe(brackets.fs.ERR_CANT_WRITE);
+                    });
+                }
+            });
+            // TODO: More testing of error cases? 
+        });
     });
 });


### PR DESCRIPTION
This pull request adds two new features: New Folder, and Rename file/folder.

**IMPORTANT: This pull request requires adobe/brackets-shell#120**

USAGE

The _New Folder_ command is added to the File menu and the project context menu. When selected, a new folder is created at the same level as the current selection in the project tree. If nothing in the project tree is selected (for example, if a file in the working set is selected), the folder is created at the root of the project folder.

The _Rename_ command is added to the project context menu. It will rename the selected file or folder. Note that the _Rename_ command will only work on project tree items. You cannot rename a file in the working set.

API NOTES

`DocumentManager` dispatches a new `fileNameChange` event whenever the name of a file or folder has changed. 

`DirectoryEntry.getDirectory()` is now implemented. This will return a reference to an existing directory or create a new directory if needed.

UNIT TESTS

Unit tests are added for rename(), but not directory creation. We need an API to remove a directory before we can add unit tests that create a directory.
