### PR TITLE
Map key code for digit keys to the corresponding digits.

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -185,7 +185,7 @@ define(function (require, exports, module) {
         // If keycode represents one of the digit keys (0-9), then return the corresponding digit
         // by subtracting KeyEvent.DOM_VK_0 from keycode. ie. [48-57] --> [0-9]
         if (keycode >= KeyEvent.DOM_VK_0 && keycode <= KeyEvent.DOM_VK_9) {
-            return Number(keycode - KeyEvent.DOM_VK_0).toString();
+            return String(keycode - KeyEvent.DOM_VK_0);
         }
         
         switch (keycode) {

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -182,6 +182,12 @@ define(function (require, exports, module) {
      * @return {string} If the key is OS-inconsistent, the correct key; otherwise, the original key.
      **/
     function _mapKeycodeToKey(keycode, key) {
+        // If keycode represents one of the digit keys (0-9), then return the corresponding digit
+        // by subtracting KeyEvent.DOM_VK_0 from keycode. ie. [48-57] --> [0-9]
+        if (keycode >= KeyEvent.DOM_VK_0 && keycode <= KeyEvent.DOM_VK_9) {
+            return keycode - KeyEvent.DOM_VK_0;
+        }
+        
         switch (keycode) {
         case KeyEvent.DOM_VK_SEMICOLON:
             return ";";

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -185,7 +185,7 @@ define(function (require, exports, module) {
         // If keycode represents one of the digit keys (0-9), then return the corresponding digit
         // by subtracting KeyEvent.DOM_VK_0 from keycode. ie. [48-57] --> [0-9]
         if (keycode >= KeyEvent.DOM_VK_0 && keycode <= KeyEvent.DOM_VK_9) {
-            return keycode - KeyEvent.DOM_VK_0;
+            return Number(keycode - KeyEvent.DOM_VK_0).toString();
         }
         
         switch (keycode) {

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -889,7 +889,7 @@ define(function (require, exports, module) {
                                                          {key:  "Cmd-Ctrl-Down", displayKey: "Cmd-Ctrl-\u2193",
                                                           platform: "mac"}]);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
+        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-Shift-1");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_USE_TAB_CHARS);
 
@@ -918,7 +918,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC,        [{key: "Ctrl-Tab", platform: "win"},
                                                              {key: "Ctrl-Tab", platform: "mac"}]);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC,        [{key: "Ctrl-Shift-Tab", platform: "win"},
-                                                             {key: "Ctrl-Shift-Tab", platform: "mac"}]);
+                                                             {key: "Ctrl-Shift-4", platform: "mac"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_QUICK_EDIT,        "Ctrl-E");
         menu.addMenuItem(Commands.QUICK_EDIT_PREV_MATCH,    {key: "Alt-Up", displayKey: "Alt-\u2191"});

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -889,7 +889,7 @@ define(function (require, exports, module) {
                                                          {key:  "Cmd-Ctrl-Down", displayKey: "Cmd-Ctrl-\u2193",
                                                           platform: "mac"}]);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-Shift-1");
+        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_USE_TAB_CHARS);
 
@@ -918,7 +918,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC,        [{key: "Ctrl-Tab", platform: "win"},
                                                              {key: "Ctrl-Tab", platform: "mac"}]);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC,        [{key: "Ctrl-Shift-Tab", platform: "win"},
-                                                             {key: "Ctrl-Shift-4", platform: "mac"}]);
+                                                             {key: "Ctrl-Shift-Tab", platform: "mac"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_QUICK_EDIT,        "Ctrl-E");
         menu.addMenuItem(Commands.QUICK_EDIT_PREV_MATCH,    {key: "Alt-Up", displayKey: "Alt-\u2191"});


### PR DESCRIPTION
This fixes issue #1745 for all keyboard layouts including French which has digit keys as shifted keys.
