### PR TITLE
Fixes #1606

### DIFF
--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -471,7 +471,8 @@ define(function (require, exports, module) {
         this.hostEditor.setInlineWidgetHeight(this, widgetHeight, ensureVisibility);
 
         // The related ranges container size itself based on htmlContent which is set by setInlineWidgetHeight above.
-        this._updateRelatedContainer();
+        // Use setTimeout to trigger a layout update before accessing positions, heights, etc.
+        window.setTimeout(this._updateRelatedContainer);
     };
 
     /**


### PR DESCRIPTION
Fixes #1606 - Inline CSS editor UI breaks if menu bar height changes when switching files
