### PR TITLE
Fixes #510

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -267,6 +267,12 @@ define(function (require, exports, module) {
         }
     }
     
+    // Prevent unhandled mousedown events from triggering native behavior
+    // Example: activating AutoScroll when clicking the middle mouse button (see #510)
+    $("html").on("mousedown", function(event) {
+        event.preventDefault();
+    });
+    
     // Localize MainViewHTML and inject into <BODY> tag
     var templateVars    = $.extend({
         ABOUT_ICON          : brackets.config.about_icon,


### PR DESCRIPTION
Fixes #510: Middle-click in inline editor's chrome scrolls view & breaks editor
