### PR TITLE
Fix bug #1724 (Reset Find in Files / JSLint scroll position to top when list contents are refreshed)

### DIFF
--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -136,7 +136,9 @@ define(function (require, exports, module) {
 
                 $("#jslint-results .table-container")
                     .empty()
-                    .append($errorTable);
+                    .append($errorTable)
+                    .scrollTop(0);  // otherwise scroll pos from previous contents is remembered
+                
                 $lintResults.show();
                 $goldStar.hide();
                 if (JSLINT.errors.length === 1) {

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -247,7 +247,8 @@ define(function (require, exports, module) {
             
             $("#search-results .table-container")
                 .empty()
-                .append($resultTable);
+                .append($resultTable)
+                .scrollTop(0);  // otherwise scroll pos from previous contents is remembered
             
             $("#search-results .close")
                 .one("click", function () {


### PR DESCRIPTION
Fix bug #1724 (Reset Find in Files / JSLint scroll position to top when list contents are refreshed)

Even though the entire table is getting blown away, webkit is smart and keeps the scroll position by default. Need to explicitly reset it.
