### PR TITLE
Don't collapse project folders if a rename fails

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1115,7 +1115,7 @@ define(function (require, exports, module) {
                 
                 var _resetOldFilename = function () {
                     _projectTree.jstree("set_text", selected, data.rslt.old_name);
-                    _projectTree.jstree("refresh", -1);
+                    _projectTree.jstree("sort", selected.parent());
                 };
                 
                 if (!_checkForValidFilename(data.rslt.new_name)) {


### PR DESCRIPTION
Fixes issue #1786

Use `sort` instead of `refresh` if a rename fails. There are two ways a rename can fail:
1. Entering an invalid character in the filename. This is caught early, before the file system item is renamed.
2. Error returned from the file system rename command.

The sort/refresh is included to ensure the tree is re-sorted in condition 2.
