### PR TITLE
Restore focusedEditorChange to be synchronous

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -344,6 +344,11 @@ define(function (require, exports, module) {
             extraKeys: codeMirrorKeyMap
         });
         
+        // Can't get CodeMirror's focused state without searching for
+        // CodeMirror-focused. Instead, track focus via onFocus and onBlur
+        // options and track state with this._focused
+        this._focused = false;
+        
         this._installEditorListeners();
         
         $(this)
@@ -602,9 +607,15 @@ define(function (require, exports, module) {
 
         // Convert CodeMirror onFocus events to EditorManager focusedEditorChanged
         this._codeMirror.setOption("onFocus", function () {
+            self._focused = true;
+            
             if (!self._internalFocus) {
                 EditorManager._doFocusedEditorChanged(self);
             }
+        });
+        
+        this._codeMirror.setOption("onBlur", function () {
+            self._focused = false;
         });
     };
     
@@ -944,8 +955,7 @@ define(function (require, exports, module) {
     
     /** Returns true if the editor has focus */
     Editor.prototype.hasFocus = function () {
-        // The CodeMirror instance wrapper has a "CodeMirror-focused" class set when focused
-        return $(this.getScrollerElement()).hasClass("CodeMirror-focused");
+        return this._focused;
     };
     
     /**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -337,6 +337,14 @@ define(function (require, exports, module) {
             $(_currentEditor.getScrollerElement()).height(_editorHolder.height());
         }
     }
+
+    function _kickCurrentEditor() {
+        // Window may have been resized since last time editor was visible, so kick it now
+        if (_currentEditor) {
+            _currentEditor.setVisible(true);
+            resizeEditor();
+        }
+    }
     
     /**
      * @private
@@ -345,6 +353,7 @@ define(function (require, exports, module) {
         // Skip if the new editor is already the focused editor.
         // This may happen if the window loses then regains focus.
         if (previous === current) {
+            _kickCurrentEditor();
             return;
         }
 
@@ -358,17 +367,13 @@ define(function (require, exports, module) {
         if (!current || (current && !current._visibleRange)) {
             _currentEditor = current;
         }
+        
+        _kickCurrentEditor();
 
         // Fire focusedEditorChange asynchronously to allow CodeMirror to
         // completely update focused state. CodeMirror fires it's "onFocus"
         // event prior to setting it's internal state.
         window.setTimeout(function () {
-            // Window may have been resized since last time editor was visible, so kick it now
-            if (_currentEditor) {
-                _currentEditor.setVisible(true);
-                resizeEditor();
-            }
-            
             $(exports).triggerHandler("focusedEditorChange", [current, previous]);
         });
     }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -35,8 +35,8 @@
  * must have some knowledge about Document's internal state (we access its _editor property).
  *
  * This module dispatches the following events:
- *    - focusedEditorChange -- Fires asynchronously after the focused editor
- *                             (full or inline) changes and size/visibility are complete.
+ *    - focusedEditorChange -- Fires after the focused editor (full or inline)
+ *                             changes and size/visibility are complete.
  */
 define(function (require, exports, module) {
     "use strict";
@@ -337,14 +337,6 @@ define(function (require, exports, module) {
             $(_currentEditor.getScrollerElement()).height(_editorHolder.height());
         }
     }
-
-    function _kickCurrentEditor() {
-        // Window may have been resized since last time editor was visible, so kick it now
-        if (_currentEditor) {
-            _currentEditor.setVisible(true);
-            resizeEditor();
-        }
-    }
     
     /**
      * @private
@@ -353,7 +345,6 @@ define(function (require, exports, module) {
         // Skip if the new editor is already the focused editor.
         // This may happen if the window loses then regains focus.
         if (previous === current) {
-            _kickCurrentEditor();
             return;
         }
 
@@ -367,15 +358,14 @@ define(function (require, exports, module) {
         if (!current || (current && !current._visibleRange)) {
             _currentEditor = current;
         }
-        
-        _kickCurrentEditor();
 
-        // Fire focusedEditorChange asynchronously to allow CodeMirror to
-        // completely update focused state. CodeMirror fires it's "onFocus"
-        // event prior to setting it's internal state.
-        window.setTimeout(function () {
-            $(exports).triggerHandler("focusedEditorChange", [current, previous]);
-        });
+        // Window may have been resized since last time editor was visible, so kick it now
+        if (_currentEditor) {
+            _currentEditor.setVisible(true);
+            resizeEditor();
+        }
+
+        $(exports).triggerHandler("focusedEditorChange", [current, previous]);
     }
     
     /**
@@ -666,6 +656,7 @@ define(function (require, exports, module) {
     
     // Initialize: status bar focused listener
     $(exports).on("focusedEditorChange", _onFocusedEditorChange);
+    
     AppInit.htmlReady(function () {
         $modeInfo           = $("#status-mode");
         $cursorInfo         = $("#status-cursor");


### PR DESCRIPTION
Changed how focus is tracked in editor. Instead of relying on `CodeMirror-focused` style, use `onFocus` on `onBlur` events from CodeMirror to track focused state in `Editor`. Fixes #1776, #1782 and #1779.
