### PR TITLE
Update hidden lines when syncing a change from the current editor into the document

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -443,6 +443,10 @@ define(function (require, exports, module) {
                           {line: endLine, ch: this.document.getLine(endLine).length});
     };
     
+    /**
+     * Ensures that the lines that are actually hidden in the inline editor correspond to
+     * the desired visible range.
+     */
     Editor.prototype._updateHiddenLines = function () {
         if (this._visibleRange) {
             var cm = this._codeMirror,
@@ -464,13 +468,11 @@ define(function (require, exports, module) {
     };
     
     Editor.prototype._applyChanges = function (changeList) {
-        var self = this;
-        
         // _visibleRange has already updated via its own Document listener. See if this change caused
         // it to lose sync. If so, our whole view is stale - signal our owner to close us.
         if (this._visibleRange) {
             if (this._visibleRange.startLine === null || this._visibleRange.endLine === null) {
-                $(self).triggerHandler("lostContent");
+                $(this).triggerHandler("lostContent");
                 return;
             }
         }
@@ -524,12 +526,11 @@ define(function (require, exports, module) {
             // what the right Document API would be, though.
             this._duringSync = true;
             this.document._masterEditor._applyChanges(changeList);
+            this._duringSync = false;
             
             // Update which lines are hidden inside our editor, since we're not going to go through
             // _applyChanges() in our own editor.
             this._updateHiddenLines();
-            
-            this._duringSync = false;
         }
         // Else, Master editor:
         // we're the ground truth; nothing else to do, since Document listens directly to us

--- a/test/spec/InlineEditorProviders-test-files/test1.html
+++ b/test/spec/InlineEditorProviders-test-files/test1.html
@@ -8,6 +8,6 @@
     <div{{0}} class="{{1}}foo" id="myDiv{{2}}">{{3}}</div>
     <!--<div{{4}}>-->
     <div id="anotherDiv{{6}}"></div>
-    <div {{7}}class="foo"></div>
+    <div{{8}} {{7}}class="foo"></div>
 </body>
 </html>

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -1065,6 +1065,52 @@ define(function (require, exports, module) {
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(fullEditor).toBe(editedText);
                 });
+                
+            });
+            
+            describe("Multiple inline editor interaction", function () {
+                var hostEditor, inlineEditor;
+                beforeEach(function () {
+                    initInlineTest("test1.html", 1, true, ["test1.css"]);
+                    
+                    runs(function () {
+                        hostEditor = EditorManager.getCurrentFullEditor();
+                        inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
+                    });
+                });
+            
+
+                it("should keep range consistent after undo/redo (bug #1031)", function () {
+                    var secondInlineOpen = false, secondInlineEditor;
+                    
+                    // open inline editor at specified offset index
+                    runs(function () {
+                        hostEditor.focus();
+                        SpecRunnerUtils.toggleQuickEditAtOffset(
+                            hostEditor,
+                            this.infos["test1.html"].offsets[8]
+                        ).done(function (isOpen) {
+                            secondInlineOpen = isOpen;
+                        });
+                    });
+                    
+                    waitsFor(function () { return secondInlineOpen; }, "second inline open timeout", 1000);
+                    
+                    // Not sure why we have to wait in between these for the bug to occur, but we do.
+                    runs(function () {
+                        secondInlineEditor = hostEditor.getInlineWidgets()[1].editors[0];
+                        secondInlineEditor._codeMirror.replaceRange("\n\n\n\n\n", { line: 0, ch: 0 });
+                    });
+                    waits(500);
+                    runs(function () {
+                        secondInlineEditor._codeMirror.undo();
+                    });
+                    waits(500);
+                    runs(function () {
+                        inlineEditor._codeMirror.undo();
+                        expect(inlineEditor).toHaveInlineEditorRange(toRange(10, 12));
+                    });
+                });
             });
             
             


### PR DESCRIPTION
After edits that affect an inline editor, we try to resync the set of hidden/shown lines in CodeMirror to match what we think the visible range to be. But we were only doing that in the case where the edit came from a different editor. We also need to do it when the edit comes from our own editor. Ordinary edits can't affect lines outside of the visible range, but undo/redo can (because they can cause changes to other areas of the underlying document).
