### PR TITLE
Fix Document unit test by avoiding creation of master editor if focus is...

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -665,10 +665,31 @@ define(function (require, exports, module) {
     /**
      * Gets the current cursor position within the editor. If there is a selection, returns whichever
      * end of the range the cursor lies at.
+     * @param {boolean} expandTabs If true, return the actual visual column number instead of the character offset in
+     *      the "ch" property.
      * @return !{line:number, ch:number}
      */
-    Editor.prototype.getCursorPos = function () {
-        return this._codeMirror.getCursor();
+    Editor.prototype.getCursorPos = function (expandTabs) {
+        var cursor = this._codeMirror.getCursor();
+        
+        if (expandTabs) {
+            var line    = this._codeMirror.getRange({line: cursor.line, ch: 0}, cursor),
+                tabSize = Editor.getTabSize(),
+                column  = 0,
+                i;
+
+            for (i = 0; i < line.length; i++) {
+                if (line[i] === '\t') {
+                    column += (tabSize - (column % tabSize));
+                } else {
+                    column++;
+                }
+            }
+            
+            cursor.ch = column;
+        }
+        
+        return cursor;
     };
     
     /**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -610,21 +610,9 @@ define(function (require, exports, module) {
         editor = editor || getFocusedEditor();
 
         // compute columns, account for tab size
-        var cursor          = editor.getCursorPos(),
-            line            = editor.document.getRange({line: cursor.line, ch: 0}, cursor),
-            tabSize         = Editor.getTabSize(),
-            column          = 0,
-            i               = 0;
-
-        for (i = 0; i < line.length; i++) {
-            if (line[i] === '\t') {
-                column += (tabSize - (column % tabSize));
-            } else {
-                column++;
-            }
-        }
+        var cursor = editor.getCursorPos(true);
         
-        $cursorInfo.text(StringUtils.format(Strings.STATUSBAR_CURSOR_POSITION, (cursor.line + 1), column + 1));
+        $cursorInfo.text(StringUtils.format(Strings.STATUSBAR_CURSOR_POSITION, cursor.line + 1, cursor.ch + 1));
     }
     
     function _changeIndentWidth(value) {


### PR DESCRIPTION
... in an inline editor when the status bar requests the cursor position.

The problem was that _updateCursorInfo accessed editor.document.getRange() in order to compute the actual visual column where the cursor was. Calling this API forces the creation of the _masterEditor for the document, which violated an assumption in the unit tests that the master editor for a document wouldn't be created immediately on opening an inline editor for that document. The user-visible effect of this change is to make it so that the cost of creating the backing _masterEditor moves to the point where you open the inline editor, rather than waiting until you actually make an edit. Arguably a minor change, but it seemed best not to change the behavior.

The fix is to factor the logic for calculating the column position into Editor, and having that code call _codeMirror directly to get the range text.
