### PR TITLE
Ctrl+up/down scrolls editor

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -73,6 +73,8 @@ define(function (require, exports, module) {
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";
     exports.VIEW_DECREASE_FONT_SIZE     = "view.decreaseFontSize";
     exports.VIEW_RESTORE_FONT_SIZE      = "view.restoreFontSize";
+    exports.VIEW_SCROLL_LINE_UP         = "view.scrollLineUp";
+    exports.VIEW_SCROLL_LINE_DOWN       = "view.scrollLineDown";
     exports.TOGGLE_JSLINT               = "debug.jslint";
     
     // Navigate

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -906,6 +906,9 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE, [{key: "Ctrl--", displayKey: "Ctrl-\u2212"}]);
         menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE, "Ctrl-0");
         menu.addMenuDivider();
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_UP,   [{key: "Ctrl-Alt-Up", displayKey: "Ctrl-Alt-\u2191"}]);
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_DOWN, [{key: "Ctrl-Alt-Down", displayKey: "Ctrl-Alt-\u2193"}]);
+        menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_JSLINT);
 
         /*

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -906,8 +906,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE, [{key: "Ctrl--", displayKey: "Ctrl-\u2212"}]);
         menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE, "Ctrl-0");
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_UP,   [{key: "Ctrl-Alt-Up", displayKey: "Ctrl-Alt-\u2191"}]);
-        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_DOWN, [{key: "Ctrl-Alt-Down", displayKey: "Ctrl-Alt-\u2193"}]);
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_UP,   [{key: "Ctrl-Up", displayKey: "Ctrl-\u2191"}]);
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_DOWN, [{key: "Ctrl-Down", displayKey: "Ctrl-\u2193"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_JSLINT);
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -191,8 +191,8 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Increase Font Size",
     "CMD_DECREASE_FONT_SIZE"              : "Decrease Font Size",
     "CMD_RESTORE_FONT_SIZE"               : "Restore Font Size",
-    "CMD_SCROLL_LINE_UP"                  : "Scroll one line Up",
-    "CMD_SCROLL_LINE_DOWN"                : "Scroll one line down",
+    "CMD_SCROLL_LINE_UP"                  : "Scroll Line Up",
+    "CMD_SCROLL_LINE_DOWN"                : "Scroll Line Down",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navigate",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -191,6 +191,8 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Increase Font Size",
     "CMD_DECREASE_FONT_SIZE"              : "Decrease Font Size",
     "CMD_RESTORE_FONT_SIZE"               : "Restore Font Size",
+    "CMD_SCROLL_LINE_UP"                  : "Scroll one line Up",
+    "CMD_SCROLL_LINE_DOWN"                : "Scroll one line down",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navigate",

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -126,7 +126,36 @@ define(function (require, exports, module) {
         _removeDynamicFontSize(true);
     }
     
+    /**
+     * @private
+     * Scroll de code one line up or down.
+     * @param {number} -1 to scroll one line up; 1 to scroll one line down.
+     */
+    function _scrollLine(direction) {
+        var editor = EditorManager.getCurrentFullEditor();
+        var scrollPos = editor.getScrollPos();
+        var lhStyle = $(".CodeMirror-scroll").css("line-height");
+        var lhValue = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
+        var lhUnits = lhStyle.substring(lhStyle.length - 2, lhStyle.length);
+        
+        if (lhUnits === 'em') {
+            lhValue *= 10;
+        }
+        
+        editor.setScrollPos(scrollPos.x, scrollPos.y + (lhValue * direction));
+    }
+    
+    function _handleScrollLineUp() {
+		_scrollLine(-1);
+	}
+	
+	function _handleScrollLineDown() {
+		_scrollLine(1);
+	}
+    
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE, _handleIncreaseFontSize);
     CommandManager.register(Strings.CMD_DECREASE_FONT_SIZE, Commands.VIEW_DECREASE_FONT_SIZE, _handleDecreaseFontSize);
     CommandManager.register(Strings.CMD_RESTORE_FONT_SIZE,  Commands.VIEW_RESTORE_FONT_SIZE,  _handleRestoreFontSize);
+    CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,     _handleScrollLineUp);
+	CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
 });

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -146,16 +146,16 @@ define(function (require, exports, module) {
     }
     
     function _handleScrollLineUp() {
-		_scrollLine(-1);
-	}
-	
-	function _handleScrollLineDown() {
-		_scrollLine(1);
-	}
+        _scrollLine(-1);
+    }
+    
+    function _handleScrollLineDown() {
+        _scrollLine(1);
+    }
     
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE, _handleIncreaseFontSize);
     CommandManager.register(Strings.CMD_DECREASE_FONT_SIZE, Commands.VIEW_DECREASE_FONT_SIZE, _handleDecreaseFontSize);
     CommandManager.register(Strings.CMD_RESTORE_FONT_SIZE,  Commands.VIEW_RESTORE_FONT_SIZE,  _handleRestoreFontSize);
     CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,     _handleScrollLineUp);
-	CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
+    CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
 });

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -136,7 +136,7 @@ define(function (require, exports, module) {
         var scrollPos = editor.getScrollPos();
         var lineCount = editor.lineCount();
         var totalHeight = editor.totalHeight();
-        var scrollDeltaY = Math.round(totalHeight / lineCount);
+        var scrollDeltaY = totalHeight / lineCount;
         
         editor.setScrollPos(scrollPos.x, scrollPos.y + (scrollDeltaY * direction));
     }

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -128,21 +128,17 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Scroll de code one line up or down.
+     * Scroll the viewport one line up or down.
      * @param {number} -1 to scroll one line up; 1 to scroll one line down.
      */
     function _scrollLine(direction) {
         var editor = EditorManager.getCurrentFullEditor();
         var scrollPos = editor.getScrollPos();
-        var lhStyle = $(".CodeMirror-scroll").css("line-height");
-        var lhValue = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
-        var lhUnits = lhStyle.substring(lhStyle.length - 2, lhStyle.length);
+        var lineCount = editor.lineCount();
+        var totalHeight = editor.totalHeight();
+        var scrollDeltaY = Math.round(totalHeight / lineCount);
         
-        if (lhUnits === 'em') {
-            lhValue *= 10;
-        }
-        
-        editor.setScrollPos(scrollPos.x, scrollPos.y + (lhValue * direction));
+        editor.setScrollPos(scrollPos.x, scrollPos.y + (scrollDeltaY * direction));
     }
     
     function _handleScrollLineUp() {


### PR DESCRIPTION
I saw this feature and thought it could be easy enough as a start feature, and it was.

Using Ctrl+Up/Down moves the editor one line up or down, without moving the cursor position as expected.
