### PR TITLE
Remove CSS hacks for fixing gradient drawing on retina screens

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -480,11 +480,7 @@ a, img {
 }
 
 .scroller-shadow {
-    // TODO (Issue #1615): background-size should really be 100%, but due to a bug in WebKit,
-    // that makes the drop shadows look bad on retina displays. This value
-    // should be changed to 100% once we've upgraded to a newer CEF that includes
-    // the WebKit fix.
-    background-size: 99.99%;
+    background-size: 100%;
     background-repeat: no-repeat;
     height: 5px;
     position: fixed;
@@ -623,20 +619,6 @@ ins.jstree-icon {
         background-color: transparent;
     }
 }
-
-// TODO (Issue #1615): Remove this hack when we get a new CEF
-/*
-@media all and (-webkit-min-device-pixel-ratio:2),(min-device-pixel-ratio:2) {
-.inline-widget {
-    .shadow.top {
-        background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0));
-    }
-    .shadow.bottom {
-        background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
-    }
-}
-}
-*/
 
 /* CSSInlineEditor rule list */
 .related-container {


### PR DESCRIPTION
These are no longer needed now that we have upgraded to CEF 3.1180.823.
