### PR TITLE
Disable horizontal scrolling in working set view.

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -381,6 +381,9 @@ define(function (require, exports, module) {
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);
         ViewUtils.sidebarList($openFilesContainer);
         
+        // Disable horizontal scrolling until WebKit bug #99379 is fixed
+        $openFilesContainer.css("overflow-x", "hidden");
+        
         _redraw();
     }
     


### PR DESCRIPTION
This is a workaround for #1789. 

Due to [WebKit bug 99379](https://bugs.webkit.org/show_bug.cgi?id=99379), on OSX, when scrollbars are set to auto-hide, any item that is placed where the horizontal scrollbar will appear cannot be clicked.

Turning off horizontal scrolling doesn't seem too bad since there is no hierarchy in the working set list, so every item is aligned to the left side. I considered adding tooltips to the items, but that was distracting. 

We could limit this change to OSX only if needed.
