### PR TITLE
Improved error message when trying to overwrite an existing key binding

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -326,7 +326,7 @@ define(function (require, exports, module) {
         // skip if the key is already assigned
         if (_isKeyAssigned(normalized)) {
             console.log("Cannot assign " + normalized + " to " + commandID +
-                        ". It is already assigned to " + _keyMap[normalized]);
+                        ". It is already assigned to " + _keyMap[normalized].commandID);
             return null;
         }
         


### PR DESCRIPTION
Before:
"Cannot assign Shift-Cmd-E to i10.extension_manager.show. It is already assigned to **[object Object]**"

Now:
"Cannot assign Shift-Cmd-E to i10.extension_manager.show. It is already assigned to **pflynn.searchWorkingSetFiles**"
