### PR TITLE
Bugfix: run AppInit._dispatchReady AFTER loading the extensions

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -245,7 +245,9 @@ define(function (require, exports, module) {
             // WARNING: AppInit.appReady won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to
             // make a change to _initExtensions (filed as issue 1029)
-            _initExtensions().always(AppInit._dispatchReady(AppInit.APP_READY));
+            _initExtensions().always(function () {
+                AppInit._dispatchReady(AppInit.APP_READY);
+            });
             
             // If this is the first launch, and we have an index.html file in the project folder (which should be
             // the samples folder on first launch), open it automatically. (We explicitly check for the


### PR DESCRIPTION
This restores the intended behavior of what once was `brackets.ready`.
It could therefore be considered a fix for #1526, but please note the comments there.
