### PR TITLE
Improved error message when trying to use a modifier twice in a shortcut

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -126,13 +126,13 @@ define(function (require, exports, module) {
             right = right.trim().toLowerCase();
             var matched = (left.length > 0 && left === right);
             if (matched && previouslyFound) {
-                console.log("KeyBindingManager normalizeKeyDescriptorString() - Modifier defined twice: " + origDescriptor);
+                console.log("KeyBindingManager normalizeKeyDescriptorString() - Modifier " + left + " defined twice: " + origDescriptor);
             }
             return matched;
         }
         
         origDescriptor.split("-").forEach(function parseDescriptor(ele, i, arr) {
-            if (_compareModifierString("ctrl", ele, hasCtrl)) {
+            if (_compareModifierString("ctrl", ele, hasCtrl, origDescriptor)) {
                 if (brackets.platform === "mac") {
                     hasMacCtrl = true;
                 } else {


### PR DESCRIPTION
Before:
`Modifier defined twice: undefined`
After:
`Modifier ctrl defined twice: Cmd-Ctrl-Up`
