### PR TITLE
Show error message when entering an invalid RegEx in the find in files dialog

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -92,6 +92,8 @@ define({
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> has been deleted on disk, but has unsaved changes in {APP_NAME}.<br /><br />Do you want to keep your changes?",
     
     // Find, Replace, Find in Files
+    "INVALID_REGEX_TITLE"               : "Invalid Regular Expression",
+    "INVALID_REGEX_MESSAGE"             : "<span class='dialog-filename'>/{0}/</span><br/>{1}",
     "SEARCH_REGEXP_INFO"                : "Use /re/ syntax for regexp search",
     "WITH"                              : "With",
     "BUTTON_YES"                        : "Yes",

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -44,7 +44,9 @@ define(function (require, exports, module) {
 
     var CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
+        Dialogs             = require("widgets/Dialogs"),
         Strings             = require("strings"),
+        StringUtils         = require("utils/StringUtils"),
         EditorManager       = require("editor/EditorManager");
 
     function SearchState() {
@@ -84,9 +86,25 @@ define(function (require, exports, module) {
         return $(".CodeMirror-dialog input[type='text']");
     }
 
-    function parseQuery(query) {
+    function parseQuery(cm, query) {
         var isRE = query.match(/^\/(.*)\/([a-z]*)$/);
-        return isRE ? new RegExp(isRE[1], isRE[2].indexOf("i") === -1 ? "" : "i") : query;
+        try {
+            return isRE ? new RegExp(isRE[1], isRE[2].indexOf("i") === -1 ? "" : "i") : query;
+        } catch (e) {
+            Dialogs.showModalDialog(
+                Dialogs.DIALOG_ID_ERROR,
+                Strings.INVALID_REGEX_TITLE,
+                StringUtils.format(
+                    Strings.INVALID_REGEX_MESSAGE,
+                    e.arguments[0],
+                    e.arguments[1]
+                )
+            ).done(function () {
+                // After showing the error, re-open the find dialog
+                doSearch(cm);
+            });
+            return null;
+        }
     }
 
     function findNext(cm, rev) {
@@ -149,7 +167,7 @@ define(function (require, exports, module) {
                 if (state.query) {
                     clearSearch(cm);  // clear highlights from previous query
                 }
-                state.query = parseQuery(query);
+                state.query = parseQuery(cm, query);
                 
                 // Highlight all matches
                 // FUTURE: if last query was prefix of this one, could optimize by filtering existing result set
@@ -188,7 +206,7 @@ define(function (require, exports, module) {
             if (!query) {
                 return;
             }
-            query = parseQuery(query);
+            query = parseQuery(cm, query);
             dialog(cm, replacementQueryDialog, Strings.WITH, function (text) {
                 var match,
                     fnMatch = function (w, i) { return match[i]; };


### PR DESCRIPTION
Fix for #1850

If an invalid RegEx is entered in the Find in Files dialog, alert the user of the error and bail out of the find.
