### PR TITLE
Return an empty tag info for an empty space entered inside plain text.

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -197,6 +197,14 @@ define(function (require, exports, module) {
         var offset = TokenUtils.offsetInToken(ctx);
         
         if (!TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx) || ctx.token.string !== "=") {
+            // If we're checking for a prior attribute and the next token we get is a tag or an html coment or
+            // an undefined token class, then we've already scanned past our original cursor location. 
+            // So just return an empty tag info.
+            if (isPriorAttr &&
+                    (!ctx.token.className ||
+                    (ctx.token.className !== "attribute" && ctx.token.string.indexOf("<") !== -1))) {
+                return createTagInfo();
+            }
             return createTagInfo(ATTR_NAME, offset, tagName, attrName);
         }
         

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
         var offset = TokenUtils.offsetInToken(ctx);
         
         if (!TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx) || ctx.token.string !== "=") {
-            // If we're checking for a prior attribute and the next token we get is a tag or an html coment or
+            // If we're checking for a prior attribute and the next token we get is a tag or an html comment or
             // an undefined token class, then we've already scanned past our original cursor location. 
             // So just return an empty tag info.
             if (isPriorAttr &&


### PR DESCRIPTION
This fixes the remaining issue in #1519.

You can test with the following test cases.

First case

```
<p>
some plain text followed by some empty lines


 |
</p>
```

Second case

```
<p>
some plain text followed by some empty lines


  |
<!-- some html comment -->

</p>
```

Third case

```
<html>
<body>
Type a space after the empty line at the end of this html page
</body>
</html>

   |

```
