### PR TITLE
Fix unit tests.

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -133,8 +133,8 @@ define(function (require, exports, module) {
         
         // Initialize EditorManager
         var $editorHolder = $("<div id='mock-editor-holder'/>");
-        EditorManager._init();
         EditorManager.setEditorHolder($editorHolder);
+        EditorManager._init();
         $("body").append($editorHolder);
         
         // create dummy Document for the Editor


### PR DESCRIPTION
Change the initialization order when creating mock editors. Thanks to @peterflynn for the fix.
