### PR TITLE
Fix problem where _currentDocument.file.fullPath was being updated twice...

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1071,12 +1071,8 @@ define(function (require, exports, module) {
     function notifyPathNameChanged(oldName, newName, isFolder) {
         var i, path;
         
-        // Update currentDocument
-        if (_currentDocument) {
-            FileUtils.updateFileEntryPath(_currentDocument.file, oldName, newName);
-        }
-        
-        // Update open documents
+        // Update open documents. This will update _currentDocument too, since 
+        // the current document is always open.
         var keysToDelete = [];
         for (path in _openDocuments) {
             if (_openDocuments.hasOwnProperty(path)) {


### PR DESCRIPTION
Fix for issue #1870

When updating full paths after a rename, there is no need to update _currentDocument since we also update all open documents, and the current document is always in the open document list.

The problem occurred when a new filename was exactly the same as the old, but had additional characters at the end (for example, renaming index.htm to index.html).
