### PR TITLE
Fix #1883 (Can't type into text input fields in extentions)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -271,12 +271,6 @@ define(function (require, exports, module) {
         }
     }
     
-    // Prevent unhandled mousedown events from triggering native behavior
-    // Example: activating AutoScroll when clicking the middle mouse button (see #510)
-    $("html").on("mousedown", function (event) {
-        event.preventDefault();
-    });
-    
     // Localize MainViewHTML and inject into <BODY> tag
     var templateVars    = $.extend({
         ABOUT_ICON          : brackets.config.about_icon,


### PR DESCRIPTION
Fix bug #1883, and also #1794.

Reverts commit b07a892 (& its follow-up 57cc31c), aka pull request #1751, aka the fix for #510.

Preventing default on mousedown blocks all built-in browser behavior, including focusing native textfields on click and moving the cursor within textfields on click/drag.  The only reason this wasn't more immediately noticeable (e.g. in the Find bar) was that we programmatically focus most textfields when they're first shown, so you rarely ever try to focus them via click.
