### PR TITLE
Globally prevent middle clicks from triggering native behavior

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -271,6 +271,14 @@ define(function (require, exports, module) {
         }
     }
     
+    // Prevent unhandled middle button clicks from triggering native behavior
+    // Example: activating AutoScroll (see #510)
+    $("html").on("mousedown", ".inline-widget", function (e) {
+        if (e.button === 1) {
+            e.preventDefault();
+        }
+    });
+    
     // Localize MainViewHTML and inject into <BODY> tag
     var templateVars    = $.extend({
         ABOUT_ICON          : brackets.config.about_icon,


### PR DESCRIPTION
Restricts #1751 to middle clicks, fixes #510, does not regress #1794 or #1883 (only tested with Garth's color picker).

However, **please consider [my comment](https://github.com/adobe/brackets/issues/510#issuecomment-9593466) before merging**.
