### PR TITLE
remove 'use tab characters' menu item

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -66,7 +66,6 @@ define(function (require, exports, module) {
     exports.EDIT_LINE_COMMENT           = "edit.lineComment";
     exports.EDIT_LINE_UP                = "edit.lineUp";
     exports.EDIT_LINE_DOWN              = "edit.lineDown";
-    exports.TOGGLE_USE_TAB_CHARS        = "debug.useTabChars";
 
     // VIEW
     exports.VIEW_HIDE_SIDEBAR           = "view.hideSidebar";

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -893,8 +893,6 @@ define(function (require, exports, module) {
                                                           platform: "mac"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.TOGGLE_USE_TAB_CHARS);
 
         /*
          * View menu

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -287,15 +287,6 @@ define(function (require, exports, module) {
         
         editor._codeMirror.execCommand("indentLess");
     }
-    
-    /**
-     * Toggles tabs/spaces preferences
-     */
-    function toggleUseTabChars() {
-        var useTabs = !Editor.getUseTabChar();
-        Editor.setUseTabChar(useTabs);
-        CommandManager.get(Commands.TOGGLE_USE_TAB_CHARS).setChecked(useTabs);
-    }
         
     // Register commands
     CommandManager.register(Strings.CMD_INDENT,         Commands.EDIT_INDENT,           indentText);
@@ -305,6 +296,4 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_DELETE_LINES,   Commands.EDIT_DELETE_LINES,     deleteCurrentLines);
     CommandManager.register(Strings.CMD_LINE_UP,        Commands.EDIT_LINE_UP,          moveLineUp);
     CommandManager.register(Strings.CMD_LINE_DOWN,      Commands.EDIT_LINE_DOWN,        moveLineDown);
-    CommandManager.register(Strings.CMD_USE_TAB_CHARS,  Commands.TOGGLE_USE_TAB_CHARS,  toggleUseTabChars)
-        .setChecked(Editor.getUseTabChar());
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -214,7 +214,6 @@ define({
     "CMD_SHOW_PERF_DATA"                  : "Show Performance Data",
     "CMD_NEW_BRACKETS_WINDOW"             : "New {APP_NAME} Window",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Show Extensions Folder",
-    "CMD_USE_TAB_CHARS"                   : "Use Tab Characters",
     "CMD_SWITCH_LANGUAGE"                 : "Switch Language",
     "CMD_CHECK_FOR_UPDATE"                : "Check for Updates",
 


### PR DESCRIPTION
Removes the menu item for "Use Tab Characters" now that we have the statusbar UI. Fixes #1893.
