### PR TITLE
Fix for #1886

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -500,9 +500,7 @@ define(function LiveDevelopment(require, exports, module) {
     }
 
     /** Triggered by a document saved from the DocumentManager */
-    function _onDocumentSaved(event, data) {
-        var doc = data || _getCurrentDocument(); // use Document passed in with jQuery event if available
-        
+    function _onDocumentSaved(event, doc) {
         if (doc && Inspector.connected() && _classForDocument(doc) !== CSSDocument) {
             if (agents.network && agents.network.wasURLRequested(doc.url)) {
                 // Reload HTML page

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -500,8 +500,8 @@ define(function LiveDevelopment(require, exports, module) {
     }
 
     /** Triggered by a document saved from the DocumentManager */
-    function _onDocumentSaved() {
-        var doc = _getCurrentDocument();
+    function _onDocumentSaved(event, data) {
+        var doc = data || _getCurrentDocument(); // use Document passed in with jQuery event if available
         
         if (doc && Inspector.connected() && _classForDocument(doc) !== CSSDocument) {
             if (agents.network && agents.network.wasURLRequested(doc.url)) {


### PR DESCRIPTION
The cause of the browser refresh in #1886 is that `_onDocumentSaved()` thinks the Document being saved is an HTML Document, so an HTML live reload is triggered.  But in reality, the Document being saved is a CSS Document in an inline editor.

Previously the `_onDocumentSaved()` method assumed that the Document being saved was the one returned by `_getCurrentDocument()`.  In the case when an inline editor's Document is saved, `_getCurrentDocument()` returns the Document of the primary editor instead of the inline editor.

The actual saved Document is passed along when the `documentSaved` event is triggered in `Document.prototype.notifySaved()`:

```
$(exports).triggerHandler("documentSaved", this) 
```

We just needed to accept the event data into `_onDocumentSaved()` and utilize it to determine the saved Document.

Note: An alternative solution would be to change the behavior of `_getCurrentDocument()` so that it returns the inline editor's Document, but I'm assuming we always want that to return the primary Document.
