### PR TITLE
Show syntax errors when entering regex for find/find in files

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
             try {
                 return new RegExp(isRE[1], flags);
             } catch (e) {
-                $(".CodeMirror-dialog span").append("<div class='alert-message' style='margin-bottom: 0'>" + e.message + "</div>");
+                $(".CodeMirror-dialog div").append("<div class='alert-message' style='margin-bottom: 0'>" + e.message + "</div>");
                 return null;
             }
         }
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
         // Query is a string. Turn it into a case-insensitive regexp
         
         // Escape regex special chars
-        query = query.replace(/([(){}\[\].\^$|?+*\\])/g, "\\$1");
+        query = StringUtils.regexEscape(query);
         return new RegExp(query, "gi");
     }
     

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -59,13 +59,6 @@ define(function (require, exports, module) {
     var FIND_IN_FILES_MAX = 100,
         maxHitsFoundInFile = false;
     
-    var PREFERENCES_CLIENT_ID = module.id,
-        defaultPrefs = { height: 200 };
-    
-    /** @type {Number} Height of the FIF panel header in pixels. Hardcoded to avoid race 
-                       condition when measuring it on htmlReady*/
-    var HEADER_HEIGHT = 27;
-
     function _getQueryRegExp(query) {
         // Clear any pending RegEx error message
         $(".CodeMirror-dialog .alert-message").remove();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -85,7 +85,13 @@ define(function (require, exports, module) {
 
     function parseQuery(query) {
         var isRE = query.match(/^\/(.*)\/([a-z]*)$/);
-        return isRE ? new RegExp(isRE[1], isRE[2].indexOf("i") === -1 ? "" : "i") : query;
+        try {
+            $(".CodeMirror-dialog .alert-message").remove();
+            return isRE ? new RegExp(isRE[1], isRE[2].indexOf("i") === -1 ? "" : "i") : query;
+        } catch (e) {
+            $(".CodeMirror-dialog span").append("<div class='alert-message' style='margin-bottom: 0'>" + e.message + "</div>");
+            return "";
+        }
     }
 
     function findNext(cm, rev) {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -85,11 +85,11 @@ define(function (require, exports, module) {
 
     function parseQuery(query) {
         var isRE = query.match(/^\/(.*)\/([a-z]*)$/);
+        $(".CodeMirror-dialog .alert-message").remove();
         try {
-            $(".CodeMirror-dialog .alert-message").remove();
             return isRE ? new RegExp(isRE[1], isRE[2].indexOf("i") === -1 ? "" : "i") : query;
         } catch (e) {
-            $(".CodeMirror-dialog span").append("<div class='alert-message' style='margin-bottom: 0'>" + e.message + "</div>");
+            $(".CodeMirror-dialog div").append("<div class='alert-message' style='margin-bottom: 0'>" + e.message + "</div>");
             return "";
         }
     }


### PR DESCRIPTION
@redmunds 

This is a better fix for #1850

When entering a regular expression in either the Find or Find in Files dialog, syntax errors are show immediately below the input field. 

There is some duplicate code between FindReplace.js and FindInFiles.js, but since the UI is temporary anyway, it didn't seem worth the extra effort to try to consolidate it.
