### PR TITLE
Sidebar resize refactorization (2)

### DIFF
--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -40,8 +40,7 @@
 
 <!-- Main UI -->
     <div class="main-view">
-        <div id="sidebar-resizer"></div>
-        <div id="sidebar" class="sidebar quiet-scrollbars">
+        <div id="sidebar" class="sidebar quiet-scrollbars horz-resizable right-resizer collapsable" data-minsize="0" data-forcemargin=".content">
             <!-- Left-hand 'Project panel' -->
             <div id="projects" class="panel">
                 <div id="project-header"></div>

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -40,7 +40,7 @@
 
 <!-- Main UI -->
     <div class="main-view">
-        <div id="sidebar" class="sidebar quiet-scrollbars horz-resizable right-resizer collapsable" data-minsize="0" data-forcemargin=".content">
+        <div id="sidebar" class="sidebar quiet-scrollbars horz-resizable right-resizer collapsible" data-minsize="0" data-forcemargin=".content">
             <!-- Left-hand 'Project panel' -->
             <div id="projects" class="panel">
                 <div id="project-header"></div>

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         EditorManager       = require("editor/EditorManager"),
         Global              = require("utils/Global"),
-        Resizer				= require("utils/Resizer");
+        Resizer             = require("utils/Resizer");
 
     // These vars are initialized by the htmlReady handler
     // below since they refer to DOM elements

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -40,14 +40,9 @@ define(function (require, exports, module) {
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
-        PreferencesManager  = require("preferences/PreferencesManager"),
         EditorManager       = require("editor/EditorManager"),
-        Global              = require("utils/Global");
-
-    var isSidebarClosed         = false;
-
-    var PREFERENCES_CLIENT_ID = "com.adobe.brackets.SidebarView",
-        defaultPrefs = { sidebarWidth: 200, sidebarClosed: false };
+        Global              = require("utils/Global"),
+		Resizer				= require("utils/Resizer");
 
     // These vars are initialized by the htmlReady handler
     // below since they refer to DOM elements
@@ -68,200 +63,50 @@ define(function (require, exports, module) {
     }
     
     /**
-     * @private
-     * Sets sidebar width and resizes editor. Does not change internal sidebar open/closed state.
-     * @param {number} width Optional width in pixels. If null or undefined, the default width is used.
-     * @param {!boolean} updateMenu Updates "View" menu label to indicate current sidebar state.
-     * @param {!boolean} displayTriangle Display selection marker triangle in the active view.
-     */
-    function _setWidth(width, updateMenu, displayTriangle) {
-        // if we specify a width with the handler call, use that. Otherwise use
-        // the greater of the current width or 200 (200 is the minimum width we'd snap back to)
-        
-        var prefs                   = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs),
-            sidebarWidth            = Math.max(prefs.getValue("sidebarWidth"), 10);
-        
-        width = width || Math.max($sidebar.width(), sidebarWidth);
-        
-        if (typeof displayTriangle === "boolean") {
-            var display = (displayTriangle) ? "block" : "none";
-            $sidebar.find(".sidebar-selection-triangle").css("display", display);
-        }
-        
-        if (isSidebarClosed) {
-            $sidebarResizer.css("left", 0);
-            
-            // Adjust content area left/width - see below
-            $(".content", $sidebar.parent()).css("margin-left", 0);
-            
-        } else {
-            $sidebar.width(width);
-            $sidebarResizer.css("left", width - 1);
-            
-            // This maintains the content area's position to the right of the sidebar. (A simple float is not enough
-            // because the non-floated content technically underlaps the floated sidebar; this breaks CodeMirror
-            // listeners and relative positioning).
-            // TODO: Ultimately this should go into EditorManager.js, triggered via an event we dispatch
-            $(".content", $sidebar.parent()).css("margin-left", width);
-            
-            // This helps resize things within the sidebar when it's shown.
-            // TODO: Ultimately this should go into ProjectManager.js, triggered via an event we dispatch
-            $sidebar.find(".sidebar-selection").width(width);
-            
-            if (width > 10) {
-                prefs.setValue("sidebarWidth", width);
-            }
-        }
-        
-        if (updateMenu) {
-            var text = (isSidebarClosed) ? Strings.CMD_SHOW_SIDEBAR : Strings.CMD_HIDE_SIDEBAR;
-            CommandManager.get(Commands.VIEW_HIDE_SIDEBAR).setName(text);
-        }
-        EditorManager.resizeEditor();
-    }
-    
-    /**
      * Toggle sidebar visibility.
      */
     function toggleSidebar(width) {
-        if (isSidebarClosed) {
-            $sidebar.show();
-            $(exports).triggerHandler("show");
-        } else {
-            $sidebar.hide();
-            $(exports).triggerHandler("hide");
-        }
-        
-        isSidebarClosed = !isSidebarClosed;
-        
-        var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs);
-        prefs.setValue("sidebarClosed", isSidebarClosed);
-        _setWidth(width, true, !isSidebarClosed);
-    }
-    
-    /**
-     * @private
-     * Install sidebar resize handling.
-     */
-    function _initSidebarResizer() {
-        var $mainView               = $(".main-view"),
-            $body                   = $(document.body),
-            prefs                   = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs),
-            sidebarWidth            = prefs.getValue("sidebarWidth"),
-            startingSidebarPosition = sidebarWidth,
-            animationRequest        = null,
-            isMouseDown             = false;
-        
-        $sidebarResizer.css("left", sidebarWidth - 1);
-        
-        // Initially size sidebar at app startup
-        if (prefs.getValue("sidebarClosed")) {
-            toggleSidebar(sidebarWidth);
-        } else {
-            _setWidth(sidebarWidth, true, true);
-        }
-        
-        $sidebarResizer.on("dblclick", function () {
-            if ($sidebar.width() < 10) {
-                //mousedown is fired first. Sidebar is already toggeled open to at least 10px.
-                _setWidth(null, true, true);
-                $projectFilesContainer.triggerHandler("scroll");
-                $openFilesContainer.triggerHandler("scroll");
-            } else {
-                toggleSidebar(sidebarWidth);
-            }
-        });
-        $sidebarResizer.on("mousedown.sidebar", function (e) {
-            var startX = e.clientX,
-                newWidth = Math.max(e.clientX, 0),
-                doResize = true;
-            
-            isMouseDown = true;
-
-            // take away the shadows (for performance reasons during sidebar movement)
-            $sidebar.find(".scroller-shadow").css("display", "none");
-            
-            $body.toggleClass("resizing");
-            
-            // check to see if we're currently in hidden mode
-            if (isSidebarClosed) {
-                toggleSidebar(1);
-            }
-                        
-            
-            animationRequest = window.webkitRequestAnimationFrame(function doRedraw() {
-                // only run this if the mouse is down so we don't constantly loop even 
-                // after we're done resizing.
-                if (!isMouseDown) {
-                    return;
-                }
-                    
-                // if we've gone below 10 pixels on a mouse move, and the
-                // sidebar is shrinking, hide the sidebar automatically an
-                // unbind the mouse event. 
-                if ((startX > 10) && (newWidth < 10)) {
-                    toggleSidebar(startingSidebarPosition);
-                    $mainView.off("mousemove.sidebar");
-                        
-                    // turn off the mouseup event so that it doesn't fire twice and retoggle the 
-                    // resizing class
-                    $mainView.off("mouseup.sidebar");
-                    $body.toggleClass("resizing");
-                    doResize = false;
-                    startX = 0;
-                        
-                    // force isMouseDown so that we don't keep calling requestAnimationFrame
-                    // this keeps the sidebar from stuttering
-                    isMouseDown = false;
-                        
-                }
-                
-                if (doResize) {
-                    // for right now, displayTriangle is always going to be false for _setWidth
-                    // because we want to hide it when we move, and _setWidth only gets called
-                    // on mousemove now.
-                    _setWidth(newWidth, false, false);
-                }
-                
-                animationRequest = window.webkitRequestAnimationFrame(doRedraw);
-            });
-            
-            $mainView.on("mousemove.sidebar", function (e) {
-                newWidth = Math.max(e.clientX, 0);
-                
-                e.preventDefault();
-            });
-                
-            $mainView.one("mouseup.sidebar", function (e) {
-                isMouseDown = false;
-                
-                // replace shadows and triangle
-                $sidebar.find(".sidebar-selection-triangle").css("display", "block");
-                $sidebar.find(".scroller-shadow").css("display", "block");
-                
-                $projectFilesContainer.triggerHandler("scroll");
-                $openFilesContainer.triggerHandler("scroll");
-                $mainView.off("mousemove.sidebar");
-                $body.toggleClass("resizing");
-                startingSidebarPosition = $sidebar.width();
-            });
-            
-            e.preventDefault();
-        });
+        Resizer.toggle($sidebar);
     }
 
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         $sidebar                = $("#sidebar");
         $sidebarMenuText        = $("#menu-view-hide-sidebar span");
-        $sidebarResizer         = $("#sidebar-resizer");
         $openFilesContainer     = $("#open-files-container");
         $projectTitle           = $("#project-title");
         $projectFilesContainer  = $("#project-files-container");
 
         // init
         WorkingSetView.create($openFilesContainer);
-        _initSidebarResizer();
+        
+        $sidebar.on("panelResizeStart", function (evt, width) {
+            $sidebar.find(".sidebar-selection-triangle").css("display", "none");
+            $sidebar.find(".scroller-shadow").css("display", "none");
+        });
+        
+        $sidebar.on("panelResizeUpdate", function (evt, width) {
+            $sidebar.find(".sidebar-selection").width(width);
+        });
+        
+        $sidebar.on("panelResizeEnd", function (evt, width) {
+            $sidebar.find(".sidebar-selection").width(width);
+            $sidebar.find(".sidebar-selection-triangle").css("display", "block").css("left", width);
+            $sidebar.find(".scroller-shadow").css("display", "block");
+            $projectFilesContainer.triggerHandler("scroll");
+            $openFilesContainer.triggerHandler("scroll");
+        });
+		
+        $sidebar.on("panelCollapsed", function (evt, width) {
+            CommandManager.get(Commands.VIEW_HIDE_SIDEBAR).setName(Strings.CMD_SHOW_SIDEBAR);
+        });
+        
+        $sidebar.on("panelExpanded", function (evt, width) {
+            $sidebar.find(".sidebar-selection-triangle").css("left", width);
+            $projectFilesContainer.triggerHandler("scroll");
+            $openFilesContainer.triggerHandler("scroll");
+            CommandManager.get(Commands.VIEW_HIDE_SIDEBAR).setName(Strings.CMD_HIDE_SIDEBAR);
+        });
     });
     
     $(ProjectManager).on("projectOpen", _updateProjectTitle);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -48,7 +48,6 @@ define(function (require, exports, module) {
     // below since they refer to DOM elements
     var $sidebar,
         $sidebarMenuText,
-        $sidebarResizer,
         $openFilesContainer,
         $projectTitle,
         $projectFilesContainer;
@@ -102,11 +101,19 @@ define(function (require, exports, module) {
         });
         
         $sidebar.on("panelExpanded", function (evt, width) {
+            $sidebar.find(".sidebar-selection").width(width);
+            $sidebar.find(".scroller-shadow").css("display", "block");
             $sidebar.find(".sidebar-selection-triangle").css("left", width);
             $projectFilesContainer.triggerHandler("scroll");
             $openFilesContainer.triggerHandler("scroll");
             CommandManager.get(Commands.VIEW_HIDE_SIDEBAR).setName(Strings.CMD_HIDE_SIDEBAR);
         });
+        
+        // AppInit.htmlReady in utils/Resizer executes before, so it's possible that the sidebar
+        // is collapsed before we add the event. Check here initially
+        if (!$sidebar.is(":visible")) {
+            $sidebar.trigger("panelCollapsed");
+        }
     });
     
     $(ProjectManager).on("projectOpen", _updateProjectTitle);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         EditorManager       = require("editor/EditorManager"),
         Global              = require("utils/Global"),
-		Resizer				= require("utils/Resizer");
+        Resizer				= require("utils/Resizer");
 
     // These vars are initialized by the htmlReady handler
     // below since they refer to DOM elements

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -61,10 +61,6 @@ html, body {
 
 body {
     height: 100%;
-    
-    &.resizing a, &.resizing #projects a, &.resizing .main-view, &.resizing .CodeMirror-lines {
-        cursor: col-resize;   
-    }
 }
 
 .resizing-container {

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -135,7 +135,7 @@ define(function (require, exports, module) {
      * @param {int} minSize Minimum size (width or height) of the element.
      * @param {boolean} collapsable True indicates the panel is collapsable on double click
      *                              on the resizer.
-     * @param {string} forcemargin
+     * @param {string} forcemargin Classes which margins need to be pushed when the element resizes
      */
     function makeResizable(element, direction, position, minSize, collapsable, forcemargin) {
         
@@ -260,15 +260,13 @@ define(function (require, exports, module) {
                     
                         if (newSize < 10) {
                             toggle($element);
+                        } else {
+                            forceMargins(newSize);
                         }
                     } else if (newSize > 10) {
                         elementSizeFunction.apply($element, [newSize]);
                         toggle($element);
                         $element.trigger("panelResizeStart", [elementSizeFunction.apply($element)]);
-                    }
-                    
-                    if (forcemargin !== undefined) {
-                        $(forcemargin, $element.parent()).css("margin-left", elementSizeFunction.apply($element));
                     }
     
                     EditorManager.resizeEditor();
@@ -279,6 +277,8 @@ define(function (require, exports, module) {
             
             $resizeCont.on("mousemove", function (e) {
                 
+                // Trigger resizeStarted only if we move the mouse to avoid a resizeStarted event
+                // when double clicking for collapse/expand functionality
                 if (!resizeStarted) {
                     resizeStarted = true;
                     $element.trigger("panelResizeStart", [elementSizeFunction.apply($element)]);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -133,11 +133,11 @@ define(function (require, exports, module) {
      * @param {string} position The position of the resizer on the element. Can be "top" or "bottom"
      *                          for vertical resizing and "left" or "right" for horizontal resizing.
      * @param {int} minSize Minimum size (width or height) of the element.
-     * @param {boolean} collapsable True indicates the panel is collapsable on double click
+     * @param {boolean} collapsible True indicates the panel is collapsible on double click
      *                              on the resizer.
      * @param {string} forcemargin Classes which margins need to be pushed when the element resizes
      */
-    function makeResizable(element, direction, position, minSize, collapsable, forcemargin) {
+    function makeResizable(element, direction, position, minSize, collapsible, forcemargin) {
         
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),
             $element            = $(element),
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             contentSizeFunction = direction === DIRECTION_HORIZONTAL ? $resizableElement.width : $resizableElement.height;
 		
         minSize = minSize || 0;
-        collapsable = collapsable || false;
+        collapsible = collapsible || false;
         
         $element.prepend($resizer);
         
@@ -171,13 +171,13 @@ define(function (require, exports, module) {
             $element.show();
             elementPrefs.visible = true;
             
-            if (collapsable) {
+            if (collapsible) {
                 $element.prepend($resizer);
                 
                 if (position === POSITION_TOP) {
                     $resizer.css(resizerCSSPosition, "");
                 } else if (position === POSITION_RIGHT) {
-                    $resizer.css(resizerCSSPosition, elementOffset[resizerCSSPosition] + elementSize - resizerSize);
+                    $resizer.css(resizerCSSPosition, elementOffset[resizerCSSPosition] + elementSize);
                 }
             }
             
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
             
             $element.hide();
             elementPrefs.visible = false;
-            if (collapsable) {
+            if (collapsible) {
                 $resizer.insertBefore($element);
                 if (position === POSITION_RIGHT) {
                     $resizer.css(resizerCSSPosition, "");
@@ -212,7 +212,7 @@ define(function (require, exports, module) {
         // If the resizer is positioned right or bottom of the panel, we need to listen to 
         // reposition it if the element size changes externally		
         function repositionResizer(elementSize) {
-            var resizerPosition = elementSize ? elementSize - elementSizeFunction.apply($resizer) : 1;
+            var resizerPosition = elementSize || 1;
             if (position === POSITION_RIGHT || position === POSITION_BOTTOM) {
                 $resizer.css(resizerCSSPosition, resizerPosition);
             }
@@ -292,9 +292,9 @@ define(function (require, exports, module) {
                 e.preventDefault();
             });
             
-            // If the element is marked as collapsable, check for double click
+            // If the element is marked as collapsible, check for double click
             // to toggle the element visibility
-            if (collapsable) {
+            if (collapsible) {
                 $resizeCont.on("mousedown", function (e) {
                     toggle($element);
                 });
@@ -367,7 +367,7 @@ define(function (require, exports, module) {
             }
 			
             if ($(element).hasClass("top-resizer")) {
-                makeResizable(element, DIRECTION_VERTICAL, POSITION_TOP, minSize, $(element).hasClass("collapsable"));
+                makeResizable(element, DIRECTION_VERTICAL, POSITION_TOP, minSize, $(element).hasClass("collapsible"));
             }
             
             //if ($(element).hasClass("bottom-resizer")) {
@@ -386,7 +386,7 @@ define(function (require, exports, module) {
             //}
 
             if ($(element).hasClass("right-resizer")) {
-                makeResizable(element, DIRECTION_HORIZONTAL, POSITION_RIGHT, minSize, $(element).hasClass("collapsable"), $(element).data().forcemargin);
+                makeResizable(element, DIRECTION_HORIZONTAL, POSITION_RIGHT, minSize, $(element).hasClass("collapsible"), $(element).data().forcemargin);
             }
         });
     });

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
             
             forceMargins(elementSize);
             EditorManager.resizeEditor();
-            $element.trigger("panelExpanded");
+            $element.trigger("panelExpanded", [elementSize]);
             _prefs.setValue(elementID, elementPrefs);
         });
                       
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
             
             forceMargins(0);
             EditorManager.resizeEditor();
-            $element.trigger("panelCollapsed");
+            $element.trigger("panelCollapsed", [elementSize]);
             _prefs.setValue(elementID, elementPrefs);
         });
         


### PR DESCRIPTION
This is the final step (hopefully) on the sidebar resize refactorization proposed initially in https://github.com/adobe/brackets/pull/1811 and developed in several steps in https://github.com/adobe/brackets/pull/1820, https://github.com/adobe/brackets/pull/1838 and https://github.com/adobe/brackets/pull/1899

It moves almost all the resize functionality for the sidebar into the `utils/Resizer` module.

Due to the last changes on flexbox, it also adds a new `data-forcemargin` to control the margins that need to be pushed while resizing an element.

@redmunds With a bit of luck this could be the end of the Resizer chapter for now ;)
