### PR TITLE
Make mode string in statusbar more presentable

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -614,7 +614,7 @@ define(function (require, exports, module) {
     }
     
     function _updateModeInfo(editor) {
-        $modeInfo.text(editor.getModeForSelection());
+        $modeInfo.text(StatusBar.getModeDisplayString(editor.getModeForSelection()));
     }
     
     function _updateFileInfo(editor) {

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -198,21 +198,17 @@ define(function (require, exports, module) {
             return "CSS";
         } else if (s === "text/plain") {
             return "Text";
+        } else if (s === "xml") {
+            return "XML";
         }
 
         // Generic case
 
         // Strip "text/" or "application/" from beginning
-        if (s.indexOf("text/") === 0) {
-            s = s.substr(5);
-        } else if (s.indexOf("application/") === 0) {
-            s = s.substr(12);
-        }
+        s = s.replace(/^(text\/|application\/)/, "");
 
         // Strip "x-" from beginning
-        if (s.indexOf("x-") === 0) {
-            s = s.substr(2);
-        }
+        s = s.replace(/^x-/, "");
 
         // Strip any remaining "/" sections from end
         slash = s.indexOf("/");

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -196,8 +196,12 @@ define(function (require, exports, module) {
             return "HTML";
         } else if (s === "css") {
             return "CSS";
+        } else if (s === "less") {
+            return "LESS";
         } else if (s === "text/plain") {
             return "Text";
+        } else if (s === "php") {
+            return "PHP";
         } else if (s === "xml") {
             return "XML";
         }

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -180,12 +180,44 @@ define(function (require, exports, module) {
         // hide on init
         hide();
     }
+
+    function getModeDisplayString(mode) {
+        // mode is either a string or an object with a name property string
+        var s = (typeof mode === "string") ? mode : mode.name,
+            slash,
+            result;
+
+        s = s.toLowerCase();
+
+        // Handle special cases
+        if (s === "javascript") {
+            return "JavaScript";
+        } else if (s === "html") {
+            return "HTML";
+        } else if (s === "css") {
+            return "CSS";
+        }
+
+        // Generic case. First strip / and everything after
+        slash = s.indexOf("/");
+
+        if (slash !== -1) {
+            s = s.substr(0, slash);
+        }
+
+        // Uppercase first char and rest is (already) lowercase
+        result = s[0].toUpperCase();
+        result += s.substr(1);
+
+        return result;
+    }
     
     exports.init = init;
     exports.showBusyIndicator = showBusyIndicator;
     exports.hideBusyIndicator = hideBusyIndicator;
     exports.addIndicator = addIndicator;
     exports.updateIndicator = updateIndicator;
+    exports.getModeDisplayString = getModeDisplayString;
     exports.hide = hide;
     exports.show = show;
 });

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -196,11 +196,26 @@ define(function (require, exports, module) {
             return "HTML";
         } else if (s === "css") {
             return "CSS";
+        } else if (s === "text/plain") {
+            return "Text";
         }
 
-        // Generic case. First strip / and everything after
-        slash = s.indexOf("/");
+        // Generic case
 
+        // Strip "text/" or "application/" from beginning
+        if (s.indexOf("text/") === 0) {
+            s = s.substr(5);
+        } else if (s.indexOf("application/") === 0) {
+            s = s.substr(12);
+        }
+
+        // Strip "x-" from beginning
+        if (s.indexOf("x-") === 0) {
+            s = s.substr(2);
+        }
+
+        // Strip any remaining "/" sections from end
+        slash = s.indexOf("/");
         if (slash !== -1) {
             s = s.substr(0, slash);
         }


### PR DESCRIPTION
This is for #1826

This fixes exception with many modes such as JSON. Mode can be either a string or an Object with a name property, but it was assumed to be a string.

Handled as a special case: JavaScript, HTML, CSS. Any others we should handle?

For remaining cases, we strip "/" and everything after it, and then capitalize what's left. Most of these are simply  "Text".
