### PR TITLE
Show a message with a url to troubleshooting page in Live Development error dialog.

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -443,7 +443,7 @@ define(function LiveDevelopment(require, exports, module) {
                             
                             // Append a message to direct users to the troubleshooting page.
                             if (message) {
-                                message += "\n\n\n" + StringUtils.format(Strings.LIVE_DEVELOPMENT_TROUBLESHOOTING, brackets.config.troubleshoot_url);
+                                message += " " + StringUtils.format(Strings.LIVE_DEVELOPMENT_TROUBLESHOOTING, brackets.config.troubleshoot_url);
                             }
 
                             Dialogs.showModalDialog(

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -440,6 +440,11 @@ define(function LiveDevelopment(require, exports, module) {
                             } else {
                                 message = StringUtils.format(Strings.ERROR_LAUNCHING_BROWSER, err);
                             }
+                            
+                            // Append a message to direct users to the troubleshooting page.
+                            if (message) {
+                                message += "\n\n\n" + StringUtils.format(Strings.LIVE_DEVELOPMENT_TROUBLESHOOTING, brackets.config.troubleshoot_url);
+                            }
 
                             Dialogs.showModalDialog(
                                 Dialogs.DIALOG_ID_ERROR,

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -77,6 +77,7 @@ define({
     "LIVE_DEV_NEED_HTML_MESSAGE"        : "Open an HTML file in order to launch live preview.",
     "LIVE_DEVELOPMENT_INFO_TITLE"       : "Welcome to Live Preview!",
     "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS files</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
+    "LIVE_DEVELOPMENT_TROUBLESHOOTING"  : "Check <a class=\"clickable-link\" data-href=\"{0}\">troubleshooting wiki page</a> to fix the Chorme installation issue.",
     
     "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live Preview",
     "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live Preview: Connecting...",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -77,7 +77,7 @@ define({
     "LIVE_DEV_NEED_HTML_MESSAGE"        : "Open an HTML file in order to launch live preview.",
     "LIVE_DEVELOPMENT_INFO_TITLE"       : "Welcome to Live Preview!",
     "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Live Preview connects {APP_NAME} to your browser. It launches a preview of your HTML file in the browser, then updates the preview instantly as you edit your code.<br /><br />In this early version of {APP_NAME}, Live Preview only works for edits to <strong>CSS files</strong> and only with <strong>Google Chrome</strong>. We'll be implementing it for HTML and JavaScript soon!<br /><br />(You'll only see this message once.)",
-    "LIVE_DEVELOPMENT_TROUBLESHOOTING"  : "Check <a class=\"clickable-link\" data-href=\"{0}\">troubleshooting wiki page</a> to fix the Chorme installation issue.",
+    "LIVE_DEVELOPMENT_TROUBLESHOOTING"  : "For more information, see <a class=\"clickable-link\" data-href=\"{0}\">Troubleshooting Live Development connection errors</a>.",
     
     "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Live Preview",
     "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Live Preview: Connecting...",

--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,6 @@
         "enable_jslint"     : true,
         "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev",
         "update_info_url"   : "http://dev.brackets.io/updates/stable/",
-        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting"
+        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting#livedev"
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,6 @@
         "enable_jslint"     : true,
         "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev",
         "update_info_url"   : "http://dev.brackets.io/updates/stable/",
-        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting#livedev"
+        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev"
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -21,6 +21,7 @@
         "show_debug_menu"   : true,
         "enable_jslint"     : true,
         "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev",
-        "update_info_url"   : "http://dev.brackets.io/updates/stable/"
+        "update_info_url"   : "http://dev.brackets.io/updates/stable/",
+        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting"
     }
 }


### PR DESCRIPTION
This fixes issue #1898 for Brackets.

Still need to update troubleshooting wiki page and add a new link for Edge Code in package.json.
