### PR TITLE
Issue 1508

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -86,15 +86,15 @@ define(function (require, exports, module) {
             lastSlash = path.slice(0, path.length - 1).lastIndexOf("/");
         }
         if (lastSlash >= 0) {
-            rest = path.slice(0, lastSlash);
+            rest = " - " + path.slice(0, lastSlash);
             folder = path.slice(lastSlash + 1);
         } else {
-            rest = "";
+            rest = "/";
             folder = path;
         }
         
         var folderSpan = $("<span></span>").addClass("recent-folder").text(folder),
-            restSpan = $("<span></span>").addClass("recent-folder-path").text(" - " + rest);
+            restSpan = $("<span></span>").addClass("recent-folder-path").text(rest);
         return $("<a></a>").addClass("recent-folder-link").append(folderSpan).append(restSpan).data("path", path);
     }
   

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
             lastSlash = path.slice(0, path.length - 1).lastIndexOf("/");
         }
         if (lastSlash >= 0) {
-            rest = " - " + path.slice(0, lastSlash);
+            rest = rest = " - " + (lastSlash ? path.slice(0, lastSlash) : "/");
             folder = path.slice(lastSlash + 1);
         } else {
             rest = "/";

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -63,8 +63,15 @@ define(function (require, exports, module) {
      * Update project title when the project root changes
      */
     function _updateProjectTitle() {
-        $projectTitle.html(ProjectManager.getProjectRoot().name);
-        $projectTitle.attr("title", ProjectManager.getProjectRoot().fullPath);
+        var displayName = ProjectManager.getProjectRoot().name;
+        var fullPath = ProjectManager.getProjectRoot().fullPath;
+        
+        if (displayName === "" && fullPath === "/") {
+            displayName = "/";
+        }
+        
+        $projectTitle.html(displayName);
+        $projectTitle.attr("title", fullPath);
     }
     
     /**


### PR DESCRIPTION
For the recent projects dropdown, it will now just show "/" (with no "-" after it) if you select the entire hard-drive in OSX. Same thing for the current project.
