### PR TITLE
Fix issue #1916 - Menu Name Inconsistency

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -180,10 +180,10 @@ define({
     "CMD_INDENT"                          : "Indent",
     "CMD_UNINDENT"                        : "Unindent",
     "CMD_DUPLICATE"                       : "Duplicate",
-    "CMD_DELETE_LINES"                    : "Delete Lines",
+    "CMD_DELETE_LINES"                    : "Delete Line",
     "CMD_COMMENT"                         : "Comment/Uncomment Lines",
-    "CMD_LINE_UP"                         : "Move Lines Up",
-    "CMD_LINE_DOWN"                       : "Move Lines Down",
+    "CMD_LINE_UP"                         : "Move Line Up",
+    "CMD_LINE_DOWN"                       : "Move Line Down",
      
     // View menu commands
     "VIEW_MENU"                           : "View",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -181,7 +181,7 @@ define({
     "CMD_UNINDENT"                        : "Unindent",
     "CMD_DUPLICATE"                       : "Duplicate",
     "CMD_DELETE_LINES"                    : "Delete Line",
-    "CMD_COMMENT"                         : "Comment/Uncomment Line",
+    "CMD_COMMENT"                         : "Toggle Line Comment",
     "CMD_LINE_UP"                         : "Move Line Up",
     "CMD_LINE_DOWN"                       : "Move Line Down",
      

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -180,10 +180,10 @@ define({
     "CMD_INDENT"                          : "Indent",
     "CMD_UNINDENT"                        : "Unindent",
     "CMD_DUPLICATE"                       : "Duplicate",
-    "CMD_DELETE_LINES"                    : "Delete Line(s)",
+    "CMD_DELETE_LINES"                    : "Delete Lines",
     "CMD_COMMENT"                         : "Comment/Uncomment Lines",
-    "CMD_LINE_UP"                         : "Move Line(s) Up",
-    "CMD_LINE_DOWN"                       : "Move Line(s) Down",
+    "CMD_LINE_UP"                         : "Move Lines Up",
+    "CMD_LINE_DOWN"                       : "Move Lines Down",
      
     // View menu commands
     "VIEW_MENU"                           : "View",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -181,7 +181,7 @@ define({
     "CMD_UNINDENT"                        : "Unindent",
     "CMD_DUPLICATE"                       : "Duplicate",
     "CMD_DELETE_LINES"                    : "Delete Line",
-    "CMD_COMMENT"                         : "Comment/Uncomment Lines",
+    "CMD_COMMENT"                         : "Comment/Uncomment Line",
     "CMD_LINE_UP"                         : "Move Line Up",
     "CMD_LINE_DOWN"                       : "Move Line Down",
      


### PR DESCRIPTION
issue #1916

Minor Fix - Modified text for ''Delete/Move Lines" to use standard English
pluralization as opposed to "(s)"
