### PR TITLE
Load extensions from the application support directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@ Thumbs.db
 src/brackets.css
 src/brackets.min.css
 
-# ignore everything in the user extension directory EXCEPT the README
+# ignore everything in the dev extension directory EXCEPT the README
 # (so that the directory is non-empty and can be in git)
-src/extensions/user/*
-!src/extensions/user/README
+src/extensions/dev/*
+!src/extensions/dev/README
 
 #OSX .DS_Store files
 .DS_Store

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -112,9 +112,9 @@ define(function (require, exports, module) {
     
     /**
      * Returns the full path of the default user extensions directory. This is in the users
-     * application support directory, which is typically:
-     *  /Users/<user>/Application Support/Brackets/extensions/user on the mac
-     *  C:\Users\<user>\AppData\Roaming\Brackets\extensions\user on windows.
+     * application support directory, which is typically
+     * /Users/<user>/Application Support/Brackets/extensions/user on the mac, and
+     * C:\Users\<user>\AppData\Roaming\Brackets\extensions\user on windows.
      */
     function _getUserExtensionPath() {
         return brackets.app.getApplicationSupportDirectory() + "/extensions/user";

--- a/src/extensions/dev/README.txt
+++ b/src/extensions/dev/README.txt
@@ -1,6 +1,6 @@
 This directory contains extensions that are being developed. User-installed
 extensions are placed in the "user" extensions directory, which can be accessed
-by running the _Help > Show Extensions Folder_ menu command. The contents of
+by running the Help > Show Extensions Folder menu command. The contents of
 this directory (except the README file) are ignored by git.
 
 (README also serves as a dummy file so this directory can be added to git.)

--- a/src/extensions/dev/README.txt
+++ b/src/extensions/dev/README.txt
@@ -1,0 +1,6 @@
+This directory contains extensions that are being developed. User-installed
+extensions are placed in the "user" extensions directory, which can be accessed
+by running the _Help > Show Extensions Folder_ menu command. The contents of
+this directory (except the README file) are ignored by git.
+
+(README also serves as a dummy file so this directory can be added to git.)

--- a/src/extensions/user/README.txt
+++ b/src/extensions/user/README.txt
@@ -1,4 +1,0 @@
-This directory contains extensions enabled by the user. The contents of
-this directory (except the README file) are ignored by git.
-
-(README also serves as a dummy file so this directory can be added to git.)

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -39,8 +39,8 @@ define(function (require, exports, module) {
         Async               = require("utils/Async"),
         contexts            = {},
         globalConfig        = {
-            "text" : "../../../thirdparty/text",
-            "i18n" : "../../../thirdparty/i18n"
+            "text" : FileUtils.getNativeBracketsDirectoryPath() + "/thirdparty/text",
+            "i18n" : FileUtils.getNativeBracketsDirectoryPath() + "/thirdparty/i18n"
         };
     
     /**


### PR DESCRIPTION
@RaymondLim 

**NOTE: Requires adobe/brackets-shell#135**

User extensions are now loaded from the application support directory. This is typically:

`/Users/<user>/Library/Application Support/Brackets/extensions/user` (Mac)
`C:\Users\<user>\AppData\Roaming\Brackets\extensions\user` (Windows)

If this directory doesn't exist, it will be created when Brackets is launched.

The local `extensions/user` directory has been renamed `extensions/dev`. This is a convenience directory for loading extensions that are being developed.

There will be a subsequent pull request to update the functionality of the "Show Extensions Folder" menu command. UPDATE: This functionality made it in after all. All changes are in brackets-shell.
