### PR TITLE
When loading extension unit tests, load from dev directory instead of user directory

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -110,16 +110,6 @@ define(function (require, exports, module) {
     require("search/FindReplace");
     require("utils/ExtensionUtils");
     
-    /**
-     * Returns the full path of the default user extensions directory. This is in the users
-     * application support directory, which is typically
-     * /Users/<user>/Application Support/Brackets/extensions/user on the mac, and
-     * C:\Users\<user>\AppData\Roaming\Brackets\extensions\user on windows.
-     */
-    function _getUserExtensionPath() {
-        return brackets.app.getApplicationSupportDirectory() + "/extensions/user";
-    }
-    
     // TODO: (issue 1029) Add timeout to main extension loading promise, so that we always call this function
     // Making this fix will fix a warning (search for issue 1029) related to the global brackets 'ready' event.
     function _initExtensions() {
@@ -127,7 +117,7 @@ define(function (require, exports, module) {
         var paths = params.get("extensions");
         
         if (!paths) {
-            paths = "default,dev," + _getUserExtensionPath();
+            paths = "default,dev," + ExtensionLoader.getUserExtensionPath();
         }
         
         return Async.doInParallel(paths.split(","), function (item) {
@@ -278,7 +268,8 @@ define(function (require, exports, module) {
             // loading will work correctly without this directory.
             // If the directory *does* exist, nothing else needs to be done. It will be scanned normally
             // during extension loading.
-            new NativeFileSystem.DirectoryEntry().getDirectory(_getUserExtensionPath(), {create: true});
+            new NativeFileSystem.DirectoryEntry().getDirectory(ExtensionLoader.getUserExtensionPath(),
+                                                               {create: true});
             
             // WARNING: AppInit.appReady won't fire if ANY extension fails to
             // load or throws an error during init. To fix this, we need to

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -50,6 +50,16 @@ define(function (require, exports, module) {
         };
     
     /**
+     * Returns the full path of the default user extensions directory. This is in the users
+     * application support directory, which is typically
+     * /Users/<user>/Application Support/Brackets/extensions/user on the mac, and
+     * C:\Users\<user>\AppData\Roaming\Brackets\extensions\user on windows.
+     */
+    function getUserExtensionPath() {
+        return brackets.app.getApplicationSupportDirectory() + "/extensions/user";
+    }
+    
+    /**
      * Returns the require.js require context used to load an extension
      *
      * @param {!string} name, used to identify the extension
@@ -221,6 +231,7 @@ define(function (require, exports, module) {
         return _loadAll(directory, config, "unittests", testExtension);
     }
     
+    exports.getUserExtensionPath = getUserExtensionPath;
     exports.getRequireContextForExtension = getRequireContextForExtension;
     exports.loadExtension = loadExtension;
     exports.testExtension = testExtension;

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, $, beforeEach, afterEach, jasmine, brackets */
+/*global require, define, $, beforeEach, afterEach, jasmine, brackets, PathUtils */
 
 // Set the baseUrl to brackets/src
 require.config({
@@ -75,18 +75,33 @@ define(function (require, exports, module) {
         var bracketsPath = FileUtils.getNativeBracketsDirectoryPath(),
             paths = ["default"];
         
-        // load dev extensions only when running the extension test suite
+        // load dev and user extensions only when running the extension test suite
         if (suite === "ExtensionTestSuite") {
             paths.push("dev");
+            paths.push(ExtensionLoader.getUserExtensionPath());
         }
         
         // This returns path to test folder, so convert to src
         bracketsPath = bracketsPath.replace(/\/test$/, "/src");
 
         return Async.doInParallel(paths, function (dir) {
+            var extensionPath,
+                relativePath;
+            
+            // If the item has "/" in it, assume it is a full path. Otherwise, load
+            // from our source path + "/extensions/".
+            if (dir.indexOf("/") === -1) {
+                extensionPath = bracketsPath + "/extensions/" + dir;
+                relativePath = "extensions/" + dir;
+            } else {
+                extensionPath = dir;
+                relativePath = PathUtils.makePathRelative(extensionPath,
+                                                          FileUtils.getNativeBracketsDirectoryPath() + "/");
+            }
+            
             return ExtensionLoader.testAllExtensionsInNativeDirectory(
-                bracketsPath + "/extensions/" + dir,
-                "extensions/" + dir
+                extensionPath,
+                relativePath
             );
         });
     }

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -75,11 +75,11 @@ define(function (require, exports, module) {
         var bracketsPath = FileUtils.getNativeBracketsDirectoryPath(),
             paths = ["default"];
         
-        // load user extensions only when running the extension test suite
+        // load dev extensions only when running the extension test suite
         if (suite === "ExtensionTestSuite") {
-            paths.push("user");
+            paths.push("dev");
         }
-
+        
         // This returns path to test folder, so convert to src
         bracketsPath = bracketsPath.replace(/\/test$/, "/src");
 

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
         DocumentManager     = require("document/DocumentManager"),
         Editor              = require("editor/Editor").Editor,
         EditorManager       = require("editor/EditorManager"),
+        ExtensionLoader     = require("utils/ExtensionLoader"),
         UrlParams           = require("utils/UrlParams").UrlParams;
     
     var TEST_PREFERENCES_KEY    = "com.adobe.brackets.test.preferences",
@@ -168,7 +169,9 @@ define(function (require, exports, module) {
             var params = new UrlParams();
             
             // setup extension loading in the test window
-            params.put("extensions", _doLoadExtensions ? "default,dev" : "default");
+            params.put("extensions", _doLoadExtensions ?
+                        "default,dev," + ExtensionLoader.getUserExtensionPath() :
+                        "default");
             
             // disable update check in test windows
             params.put("skipUpdateCheck", true);

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
             var params = new UrlParams();
             
             // setup extension loading in the test window
-            params.put("extensions", _doLoadExtensions ? "default,user" : "default");
+            params.put("extensions", _doLoadExtensions ? "default,dev" : "default");
             
             // disable update check in test windows
             params.put("skipUpdateCheck", true);


### PR DESCRIPTION
This fixes the extension unit tests.

Unit tests will be loaded for extensions in the "dev" and "default" directories, and will _not_ be loaded for extensions in the "user" directory. 
