### PR TITLE
Fix working set unit test

### DIFF
--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -204,7 +204,7 @@ define(function (require, exports, module) {
                     didClose = true;
                 });
 
-                closeIcon.trigger('click');
+                closeIcon.trigger('mousedown');
             });
             
             waitsFor(function () { return didClose; }, "click on working set close icon timeout", 1000);


### PR DESCRIPTION
The close icon is now triggered on mousedown with working set drag/drop changes.
