### PR TITLE
Fix to Shift or Ctrl sort-of multi selects in project tree

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -337,6 +337,7 @@ define(function (require, exports, module) {
             .jstree(
                 {
                     plugins : ["ui", "themes", "json_data", "crrm", "sort"],
+                    ui : { select_limit: 1, select_multiple_modifier: "", select_range_modifier: "" },
                     json_data : { data: treeDataProvider, correct_state: false },
                     core : { animation: 0 },
                     themes : { theme: "brackets", url: "styles/jsTreeTheme.css", dots: false, icons: false },


### PR DESCRIPTION
This fix allows to select on the project tree clicking and holding down Shift or Ctrl but does not highlights any file besides the one selected.

adobe/brackets#1917
