### PR TITLE
Use absolute paths when loading extensions

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -121,24 +121,15 @@ define(function (require, exports, module) {
         }
         
         return Async.doInParallel(paths.split(","), function (item) {
-            var extensionPath,
-                relativePath;
+            var extensionPath = item;
             
             // If the item has "/" in it, assume it is a full path. Otherwise, load
             // from our source path + "/extensions/".
             if (item.indexOf("/") === -1) {
                 extensionPath = FileUtils.getNativeBracketsDirectoryPath() + "/extensions/" + item;
-                relativePath = "extensions/" + item;
-            } else {
-                extensionPath = item;
-                relativePath = PathUtils.makePathRelative(extensionPath,
-                                                          FileUtils.getNativeBracketsDirectoryPath() + "/");
             }
             
-            return ExtensionLoader.loadAllExtensionsInNativeDirectory(
-                extensionPath,
-                relativePath
-            );
+            return ExtensionLoader.loadAllExtensionsInNativeDirectory(extensionPath);
         });
     }
     

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -230,33 +230,18 @@ define(function (require, exports, module) {
     
     /**
      * Given the module object passed to JS module define function,
-     * convert the path (which is relative to the current window)
-     * to a native absolute path.
+     * convert the path to a native absolute path.
      * Returns a native absolute path to the module folder.
      * @return {string}
      */
     function getNativeModuleDirectoryPath(module) {
-        var path, relPath, index, pathname;
-
+        var path;
+        
         if (module && module.uri) {
-
-            // Remove window name from base path. Maintain trailing slash.
-            path = getNativeBracketsDirectoryPath() + "/";
-
-            // Remove module name from relative path. Remove trailing slash.
-            pathname = decodeURI(module.uri);
-            relPath = pathname.substr(0, pathname.lastIndexOf("/"));
-
-            // handle leading "../" in relative directory
-            while (relPath.substr(0, 3) === "../") {
-                path = path.substr(0, path.length - 1); // strip trailing slash from base path
-                index = path.lastIndexOf("/");          // find next slash from end
-                if (index !== -1) {
-                    path = path.substr(0, index + 1);   // remove last dir while maintaining slash
-                }
-                relPath = relPath.substr(3);            // remove leading "../" from relative path
-            }
-            path += relPath;
+            path = decodeURI(module.uri);
+            
+            // Remove module name and trailing slash from path.
+            path = path.substr(0, path.lastIndexOf("/"));
         }
         return path;
     }

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
      * Loads the extension that lives at baseUrl into its own Require.js context
      *
      * @param {!string} name, used to identify the extension
-     * TODO: FIXME @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
+     * @param {!{baseUrl: string}} config object with baseUrl property containing absolute path of extension
      * @param {!string} entryPoint, name of the main js file to load
      * @return {!$.Promise} A promise object that is resolved when the extension is loaded.
      */
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
      * Runs unit tests for the extension that lives at baseUrl into its own Require.js context
      *
      * @param {!string} name, used to identify the extension
-     * TODO: FIXME @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
+     * @param {!{baseUrl: string}} config object with baseUrl property containing absolute path of extension
      * @param {!string} entryPoint, name of the main js file to load
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
      */
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
      *
      * @param {!string} directory, an absolute native path that contains a directory of extensions.
      *                  each subdirectory is interpreted as an independent extension
-     * @param {!string} baseUrl, URL path relative to index.html that maps to the same place as directory
+     * @param {!{baseUrl: string}} config object with baseUrl property containing absolute path of extension folder
      * @param {!string} entryPoint Module name to load (without .js suffix)
      * @param {function} processExtension 
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
      * Loads the extension that lives at baseUrl into its own Require.js context
      *
      * @param {!string} name, used to identify the extension
-     * @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
+     * TODO: FIXME @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
      * @param {!string} entryPoint, name of the main js file to load
      * @return {!$.Promise} A promise object that is resolved when the extension is loaded.
      */
@@ -104,17 +104,13 @@ define(function (require, exports, module) {
      * Runs unit tests for the extension that lives at baseUrl into its own Require.js context
      *
      * @param {!string} name, used to identify the extension
-     * @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
+     * TODO: FIXME @param {!string} baseUrl, URL path relative to index.html, where the main JS file can be found
      * @param {!string} entryPoint, name of the main js file to load
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
      */
     function testExtension(name, config, entryPoint) {
         var result = new $.Deferred(),
-            extensionPath = FileUtils.getNativeBracketsDirectoryPath();
-        
-        // Assumes the caller's window.location context is /test/SpecRunner.html
-        extensionPath = extensionPath.replace(/\/test$/, "/src"); // convert from "test" to "src"
-        extensionPath += "/" + config.baseUrl + "/" + entryPoint + ".js";
+            extensionPath = config.baseUrl + "/" + entryPoint + ".js";
 
         var fileExists = false, statComplete = false;
         brackets.fs.stat(extensionPath, function (err, stat) {
@@ -123,7 +119,7 @@ define(function (require, exports, module) {
                 // unit test file exists
                 var extensionRequire = brackets.libRequire.config({
                     context: name,
-                    baseUrl: "../src/" + config.baseUrl,
+                    baseUrl: config.baseUrl,
                     paths: $.extend({}, config.paths, globalConfig)
                 });
     
@@ -202,11 +198,10 @@ define(function (require, exports, module) {
      *
      * @param {!string} directory, an absolute native path that contains a directory of extensions.
      *                  each subdirectory is interpreted as an independent extension
-     * @param {!string} baseUrl, URL path relative to index.html that maps to the same place as directory
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
      */
-    function loadAllExtensionsInNativeDirectory(directory, baseUrl) {
-        return _loadAll(directory, {baseUrl: baseUrl}, "main", loadExtension);
+    function loadAllExtensionsInNativeDirectory(directory) {
+        return _loadAll(directory, {baseUrl: directory}, "main", loadExtension);
     }
     
     /**
@@ -214,13 +209,12 @@ define(function (require, exports, module) {
      *
      * @param {!string} directory, an absolute native path that contains a directory of extensions.
      *                  each subdirectory is interpreted as an independent extension
-     * @param {!string} baseUrl, URL path relative to index.html that maps to the same place as directory
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
      */
-    function testAllExtensionsInNativeDirectory(directory, baseUrl) {
+    function testAllExtensionsInNativeDirectory(directory) {
         var bracketsPath = FileUtils.getNativeBracketsDirectoryPath(),
             config = {
-                baseUrl: baseUrl
+                baseUrl: directory
             };
         
         config.paths = {

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -86,24 +86,15 @@ define(function (require, exports, module) {
         bracketsPath = bracketsPath.replace(/\/test$/, "/src");
 
         return Async.doInParallel(paths, function (dir) {
-            var extensionPath,
-                relativePath;
+            var extensionPath = dir;
             
             // If the item has "/" in it, assume it is a full path. Otherwise, load
             // from our source path + "/extensions/".
             if (dir.indexOf("/") === -1) {
                 extensionPath = bracketsPath + "/extensions/" + dir;
-                relativePath = "extensions/" + dir;
-            } else {
-                extensionPath = dir;
-                relativePath = PathUtils.makePathRelative(extensionPath,
-                                                          FileUtils.getNativeBracketsDirectoryPath() + "/");
             }
             
-            return ExtensionLoader.testAllExtensionsInNativeDirectory(
-                extensionPath,
-                relativePath
-            );
+            return ExtensionLoader.testAllExtensionsInNativeDirectory(extensionPath);
         });
     }
     


### PR DESCRIPTION
When loading extensions, always use absolute paths. This avoids the need for the `baseUrl` parameter to `loadAllExtensionsInNativeDirectory()` and `testAllExtensionsInNativeDirectory()`.

This fixes issues #1953 and #1955.
