### PR TITLE
define FileError object for browsers that dont implement the File API

### DIFF
--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -24,6 +24,22 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50*/
 /*global $, define, brackets, FileError, InvalidateStateError */
 
+//define FileError as currently ONLY Chrome implements the FIL API W3C Working Draft
+var FileError = FileError || {
+    NOT_FOUND_ERR: 1,
+    SECURITY_ERR: 2,
+    ABORT_ERR: 3,
+    NOT_READABLE_ERR: 4,
+    ENCODING_ERR: 5,
+    NO_MODIFICATION_ALLOWED_ERR: 6,
+    INVALID_STATE_ERR: 7,
+    SYNTAX_ERR: 8,
+    INVALID_MODIFICATION_ERR: 9,
+    QUOTA_EXCEEDED_ERR: 10,
+    TYPE_MISMATCH_ERR: 11,
+    PATH_EXISTS_ERR: 12
+};
+
 define(function (require, exports, module) {
     "use strict";
     


### PR DESCRIPTION
This prevents an error that stops firefox being able to actually load a file via the node proxy app in the in-browser branch.
