### PR TITLE
Prepopulate replace input with current editor selection

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -222,7 +222,7 @@ define(function (require, exports, module) {
                     });
                 } else {
                     clearSearch(cm);
-                    var cursor = getSearchCursor(cm, query, cm.getCursor());
+                    var cursor = getSearchCursor(cm, query, cm.getCursor(true));
                     var advance = function () {
                         var start = cursor.from(),
                             match = cursor.findNext();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -247,6 +247,11 @@ define(function (require, exports, module) {
                 }
             });
         });
+        
+        // Prepopulate de replace field with the current selection, if any
+        getDialogTextField()
+            .attr("value", cm.getSelection())
+            .get(0).select();
     }
 
     function _launchFind() {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -248,7 +248,7 @@ define(function (require, exports, module) {
             });
         });
         
-        // Prepopulate de replace field with the current selection, if any
+        // Prepopulate the replace field with the current selection, if any
         getDialogTextField()
             .attr("value", cm.getSelection())
             .get(0).select();


### PR DESCRIPTION
Prepopulates the replace input with the current editor selection.

This pull request replaces https://github.com/adobe/brackets/pull/1962 following @peterflynn suggestions.
