### PR TITLE
Fix for renaming files with a superstring of the old name (#1971)

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -254,7 +254,7 @@ define(function (require, exports, module) {
      * @return {boolean} Returns true if the file entry was updated
      */
     function updateFileEntryPath(entry, oldName, newName) {
-        if (entry.fullPath.indexOf(oldName) === 0) {
+        if (entry.fullPath === oldName) {
             var fullPath = entry.fullPath.replace(oldName, newName);
             
             entry.fullPath = fullPath;


### PR DESCRIPTION
This is a possible fix for https://github.com/adobe/brackets/issues/1971

Currently there's an issue in `DocumentManager` where the files of documents in the working set get updated twice. If the newName is a superstring of the old one, then the second time it gets called, the `indexOf(oldName)` check is still true but `entry.fullPath` is already `newName`, so the `replace` results in seeing the oldName appended with the difference with the new one.

See https://github.com/adobe/brackets/issues/1971 for further discussion
