### PR TITLE
Brackets should recognize Linux as a platform

### DIFF
--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -69,7 +69,12 @@ define(function (require, exports, module) {
     
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
     
-    global.brackets.platform = (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") ? "mac" : "win";
+    if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") 
+            global.brackets.platform = "mac";
+    else if (global.navigator.platform.indexOf("Linux")
+            global.brackets.platform = "linux";
+    else
+            global.brackets.platform = "win";
     
     global.brackets.getLocale = function () {
         // By default use the locale that was determined in brackets.js

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -69,12 +69,13 @@ define(function (require, exports, module) {
     
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
     
-    if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") 
-            global.brackets.platform = "mac";
-    else if (global.navigator.platform.indexOf("Linux")
-            global.brackets.platform = "linux";
-    else
-            global.brackets.platform = "win";
+    if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") {
+        global.brackets.platform = "mac";
+    } else if (global.navigator.platform.indexOf("Linux") >= 0) {
+        global.brackets.platform = "linux";
+    } else {
+        global.brackets.platform = "win";
+    }
     
     global.brackets.getLocale = function () {
         // By default use the locale that was determined in brackets.js


### PR DESCRIPTION
Absolutely neccessary for Live Development to function, as an extra /(forward-
slash) is added when brackets.platform="win"
