### PR TITLE
Remove extraneous whitespace from SHA

### DIFF
--- a/src/utils/BuildInfoUtils.js
+++ b/src/utils/BuildInfoUtils.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
                         branch      = text.substr(16).trim();
                     
                     _loadSHA(basePath + "/" + refRelPath, callback).done(function (data) {
-                        result.resolve({ branch: branch, sha: data.sha });
+                        result.resolve({ branch: branch, sha: data.sha.trim() });
                     }).fail(function () {
                         result.resolve({ branch: branch });
                     });

--- a/test/spec/LiveDevelopment-test-files/simple1.html
+++ b/test/spec/LiveDevelopment-test-files/simple1.html
@@ -8,6 +8,6 @@
 </head>
 
 <body>
-<p id="testId" class="testClass">Brackets is awesome!</p>
+<p id="testId" class="testClass">Live Preview in Brackets is awesome!</p>
 </body>
 </html>

--- a/test/spec/LowLevelFileIO-test-files/file_one.txt
+++ b/test/spec/LowLevelFileIO-test-files/file_one.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/test/spec/LowLevelFileIO-test-files/file_one.txt
+++ b/test/spec/LowLevelFileIO-test-files/file_one.txt
@@ -1,1 +1,0 @@
-Hello world


### PR DESCRIPTION
Unit test results JSON file contains a `\n`, see http://webauthoringbuild.corp.adobe.com/Brackets_Test/4188/results.json
