### PR TITLE
remove whitespace from SHA

### DIFF
--- a/src/utils/BuildInfoUtils.js
+++ b/src/utils/BuildInfoUtils.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
                         branch      = text.substr(16).trim();
                     
                     _loadSHA(basePath + "/" + refRelPath, callback).done(function (data) {
-                        result.resolve({ branch: branch, sha: data.sha });
+                        result.resolve({ branch: branch, sha: data.sha.trim() });
                     }).fail(function () {
                         result.resolve({ branch: branch });
                     });


### PR DESCRIPTION
Unit test results JSON file contains a `\n`, see http://webauthoringbuild.corp.adobe.com/Brackets_Test/4188/results.json
