### PR TITLE
Use CodeMirror compoundChange to ensure batch operation can be undone

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -773,7 +773,10 @@ define(function (require, exports, module) {
      */
     Document.prototype.batchOperation = function (doOperation) {
         this._ensureMasterEditor();
-        this._masterEditor._codeMirror.operation(doOperation);
+        var codeMirror = this._masterEditor._codeMirror;
+        codeMirror.compoundChange(function () {
+            codeMirror.operation(doOperation);
+        });
     };
     
     /**


### PR DESCRIPTION
This is to fix Issue #1957
