### PR TITLE
Handle Tab key the same way as Enter key for all code hint providers.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -73,22 +73,15 @@ define(function (require, exports, module) {
 
     /**
      * @private
-     * Enters the code completion text into the editor and closes list
+     * Enters the code completion text into the editor and closes list if the provider 
+     * returns true. Otherwise, get a new query and update the list based on the new query.
      * @string {string} completion - text to insert into current code editor
      */
     CodeHintList.prototype._handleItemClick = function (completion) {
-        this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), false);
-        this.close();
-    };
-
-    /**
-     * @private
-     * Enters the code completion text into the editor without closing list
-     * @string {string} completion - text to insert into current code editor
-     */
-    CodeHintList.prototype._handleItemSelect = function (completion) {
-        if (this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), true)) {
+        if (this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos())) {
             this.close();
+        } else {
+            this.updateQueryAndList();
         }
     };
 
@@ -109,12 +102,6 @@ define(function (require, exports, module) {
                 // bootstrap-dropdown).
                 e.stopPropagation();
                 self._handleItemClick(name);
-            })
-            .on("select", function (e) {
-                // Don't let the "select" propagate upward (otherwise it will hit the close handler in
-                // bootstrap-dropdown).
-                e.stopPropagation();
-                self._handleItemSelect(name);
             });
 
         this.$hintMenu.find("ul.dropdown-menu")
@@ -187,6 +174,21 @@ define(function (require, exports, module) {
         }
     };
     
+    
+    /**
+     * Gets the new query from the current provider and rebuilds the hint list based on the new one.
+     */
+    CodeHintList.prototype.updateQueryAndList = function () {
+        this.query = this.currentProvider.getQueryInfo(this.editor, this.editor.getCursorPos());
+        this.updateList();
+
+        // Update the CodeHintList location
+        if (this.displayList.length) {
+            var hintPos = this.calcHintListLocation();
+            this.$hintMenu.css({"left": hintPos.left, "top": hintPos.top});
+        }
+    };
+
     /**
      * Handles key presses when the hint list is being displayed
      * @param {Editor} editor
@@ -198,9 +200,11 @@ define(function (require, exports, module) {
         // Up arrow, down arrow and enter key are always handled here
         if (event.type !== "keypress") {
 
-            if (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN || keyCode === KeyEvent.DOM_VK_RETURN ||
+            if (keyCode === KeyEvent.DOM_VK_RETURN || keyCode === KeyEvent.DOM_VK_TAB ||
+                    keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN ||
                     keyCode === KeyEvent.DOM_VK_PAGE_UP || keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
 
+                var isNavigationKey = (keyCode !== KeyEvent.DOM_VK_RETURN && keyCode !== KeyEvent.DOM_VK_TAB);
                 if (event.type === "keydown") {
                     if (keyCode === KeyEvent.DOM_VK_UP) {
                         // Up arrow
@@ -215,7 +219,7 @@ define(function (require, exports, module) {
                         // Page Down
                         this.setSelectedIndex(this.selectedIndex + this.getItemsPerPage());
                     } else {
-                        // Enter/return key
+                        // Enter/return key or Tab key
                         // Trigger a click handler to commmit the selected item
                         $(this.$hintMenu.find("li")[this.selectedIndex]).triggerHandler("click");
                     }
@@ -223,29 +227,13 @@ define(function (require, exports, module) {
 
                 event.preventDefault();
                 return;
-
-            } else if (keyCode === KeyEvent.DOM_VK_TAB) {
-                // Tab key is used for "select and continue hinting"
-                if (event.type === "keydown") {
-                    $(this.$hintMenu.find("li")[this.selectedIndex]).triggerHandler("select");
-                }
-                event.preventDefault();
             }
         }
         
         // All other key events trigger a rebuild of the list, but only
         // on keyup events
-        if (event.type !== "keyup") {
-            return;
-        }
-
-        this.query = this.currentProvider.getQueryInfo(this.editor, this.editor.getCursorPos());
-        this.updateList();
-
-        // Update the CodeHintList location
-        if (this.displayList.length) {
-            var hintPos = this.calcHintListLocation();
-            this.$hintMenu.css({"left": hintPos.left, "top": hintPos.top});
+        if (event.type === "keyup") {
+            this.updateQueryAndList();
         }
     };
 
@@ -446,7 +434,7 @@ define(function (require, exports, module) {
      *
      * @param {Object.< getQueryInfo: function(editor, cursor),
      *                  search: function(string),
-     *                  handleSelect: function(string, Editor, cursor, tabSelect),
+     *                  handleSelect: function(string, Editor, cursor),
      *                  shouldShowHintsOnKey: function(string)>}
      *
      * Parameter Details:
@@ -456,9 +444,8 @@ define(function (require, exports, module) {
      * - search - takes a query object and returns an array of hint strings based on the queryStr property
      *      of the query object.
      * - handleSelect - takes a completion string and inserts it into the editor near the cursor
-     *      position. It should return true by default to close the hint list, but the code hint provider can 
-     *      check tabSelect parameter and then return false if it wants to keep the hint list open on selection 
-     *      with Tab key.
+     *      position. It should return true by default to close the hint list, but if the code hint provider
+     *      can return false if it wants to keep the hint list open and continue with a updated list. 
      * - shouldShowHintsOnKey - inspects the char code and returns true if it wants to show code hints on that key.
      */
     function registerHintProvider(providerInfo) {

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
      * @string {string} completion - text to insert into current code editor
      */
     CodeHintList.prototype._handleItemClick = function (completion) {
-        this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), true);
+        this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), false);
         this.close();
     };
 
@@ -87,7 +87,9 @@ define(function (require, exports, module) {
      * @string {string} completion - text to insert into current code editor
      */
     CodeHintList.prototype._handleItemSelect = function (completion) {
-        this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), false);
+        if (this.currentProvider.handleSelect(completion, this.editor, this.editor.getCursorPos(), true)) {
+            this.close();
+        }
     };
 
     /**
@@ -224,7 +226,9 @@ define(function (require, exports, module) {
 
             } else if (keyCode === KeyEvent.DOM_VK_TAB) {
                 // Tab key is used for "select and continue hinting"
-                $(this.$hintMenu.find("li")[this.selectedIndex]).triggerHandler("select");
+                if (event.type === "keydown") {
+                    $(this.$hintMenu.find("li")[this.selectedIndex]).triggerHandler("select");
+                }
                 event.preventDefault();
             }
         }
@@ -442,7 +446,7 @@ define(function (require, exports, module) {
      *
      * @param {Object.< getQueryInfo: function(editor, cursor),
      *                  search: function(string),
-     *                  handleSelect: function(string, Editor, cursor, closeHints),
+     *                  handleSelect: function(string, Editor, cursor, tabSelect),
      *                  shouldShowHintsOnKey: function(string)>}
      *
      * Parameter Details:
@@ -452,7 +456,9 @@ define(function (require, exports, module) {
      * - search - takes a query object and returns an array of hint strings based on the queryStr property
      *      of the query object.
      * - handleSelect - takes a completion string and inserts it into the editor near the cursor
-     *      position
+     *      position. It should return true by default to close the hint list, but the code hint provider can 
+     *      check tabSelect parameter and then return false if it wants to keep the hint list open on selection 
+     *      with Tab key.
      * - shouldShowHintsOnKey - inspects the char code and returns true if it wants to show code hints on that key.
      */
     function registerHintProvider(providerInfo) {

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -93,10 +93,9 @@ define(function (require, exports, module) {
      * @param {string} completion - text to insert into current code editor
      * @param {Editor} editor
      * @param {Cursor} current cursor location
-     * @param {boolean} tabSelect - true if invoked from Tab key down, false if invoked by mouse clicks or Enter key down
      * @return {boolean} true to close the hint list, false to keep the hint list open.
      */
-    TagHints.prototype.handleSelect = function (completion, editor, cursor, tabSelect) {
+    TagHints.prototype.handleSelect = function (completion, editor, cursor) {
         var start = {line: -1, ch: -1},
             end = {line: -1, ch: -1},
             tagInfo = HTMLUtils.getTagInfo(editor, cursor),
@@ -160,10 +159,9 @@ define(function (require, exports, module) {
      * @param {string} completion - text to insert into current code editor
      * @param {Editor} editor
      * @param {Cursor} current cursor location
-     * @param {boolean} tabSelect - true if invoked from Tab key down, false if invoked by mouse clicks or Enter key down
      * @return {boolean} true to close the hint list, false to keep the hint list open.
      */
-    AttrHints.prototype.handleSelect = function (completion, editor, cursor, tabSelect) {
+    AttrHints.prototype.handleSelect = function (completion, editor, cursor) {
         var start = {line: -1, ch: -1},
             end = {line: -1, ch: -1},
             tagInfo = HTMLUtils.getTagInfo(editor, cursor),
@@ -219,7 +217,7 @@ define(function (require, exports, module) {
             }
         }
 
-        if (tabSelect && this.closeOnSelect === false) {
+        if (this.closeOnSelect === false) {
             return false;
         }
         

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
             
             // Special handling for URL hinting -- if the completion is a file name
             // and not a folder, then close the code hint list.
-            if (this.closeOnSelect === false && completion.match(/\/$/) === null) {
+            if (!this.closeOnSelect && completion.match(/\/$/) === null) {
                 this.closeOnSelect = true;
             }
             
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
             }
         }
 
-        if (this.closeOnSelect === false) {
+        if (!this.closeOnSelect) {
             return false;
         }
         
@@ -440,6 +440,7 @@ define(function (require, exports, module) {
                     if (attrInfo.type === "boolean") {
                         unfiltered = ["false", "true"];
                     } else if (attrInfo.type === "url") {
+                        // Default behavior for url hints is do not close on select.
                         this.closeOnSelect = false;
                         unfiltered = this._getUrlList(query);
                         sortFunc = StringUtils.urlSort;

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -187,8 +187,7 @@ define(function (require, exports, module) {
             charCount = tagInfo.attr.value.length;
             
             // Special handling for URL hinting -- if the completion is a file name
-            // and not a folder, then close the code hint list even if this is invoked
-            // from a Tab key down.
+            // and not a folder, then close the code hint list.
             if (this.closeOnSelect === false && completion.match(/\/$/) === null) {
                 this.closeOnSelect = true;
             }


### PR DESCRIPTION
URL hinting is an exception. Add a new flag in AttrHintsProvider so that we can specially handle URL hinting when the user select a folder with Tab key. This fixes issue #1885.

Also fix the issue #1881 by triggering onSelect events on Tab key down only.
