### PR TITLE
Use console.error instead of throw in PerfUtils

### DIFF
--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
      */
     function createPerfMeasurement(id, name) {
         if (perfMeasurementIds[id]) {
-            throw new Error("Performance measurement " + id + " is already defined");
+            console.error("Performance measurement " + id + " is already defined");
         }
         
         var pm = new PerfMeasurement(id, name);
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
      */
     function _markStart(name, time) {
         if (activeTests[name]) {
-            throw new Error("Recursive tests with the same name are not supported. Timer name: " + name);
+            console.error("Recursive tests with the same name are not supported. Timer name: " + name);
         }
         
         activeTests[name] = { startTime: time };


### PR DESCRIPTION
Fix for issue #1963

Recursive tests will still show up as errors, but won't interfere with normal program operation.
