### PR TITLE
shims for app.showDeveloperTools and app.getElapsedMilliseconds

### DIFF
--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
         }
     };
     
-				// Create empty app namespace if running in-browser
+    // Create empty app namespace if running in-browser
     if (!global.brackets.app) {
         global.brackets.app = {};
     }

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -90,18 +90,9 @@ define(function (require, exports, module) {
         }
     };
     
-    // Shims for brackets.app when running in-browser
+				// Create empty app namespace if running in-browser
     if (!global.brackets.app) {
-        var app = {},
-            startTime = new Date().getMilliseconds();
-        
-        app.showDeveloperTools = false;
-        
-        app.getElapsedMilliseconds = function () {
-            return new Date().getMilliseconds() - startTime;
-        };
-        
-        global.brackets.app = app;
+        global.brackets.app = {};
     }
     
     // Loading extensions requires creating new require.js contexts, which

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -90,6 +90,20 @@ define(function (require, exports, module) {
         }
     };
     
+    // Shims for brackets.app when running in-browser
+    if (!global.brackets.app) {
+        var app = {},
+            startTime = new Date().getMilliseconds();
+        
+        app.showDeveloperTools = false;
+        
+        app.getElapsedMilliseconds = function () {
+            return new Date().getMilliseconds() - startTime;
+        };
+        
+        global.brackets.app = app;
+    }
+    
     // Loading extensions requires creating new require.js contexts, which
     // requires access to the global 'require' object that always gets hidden
     // by the 'require' in the AMD wrapper. We store this in the brackets

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -29,12 +29,14 @@
  */
 define(function (require, exports, module) {
     "use strict";
+    
+    var Global = require("utils/Global");
 
     /**
      * Flag to enable/disable performance data gathering. Default is true (enabled)
      * @type {boolean} enabled
      */
-    var enabled = true;
+    var enabled = brackets && !!brackets.app.getElapsedMilliseconds;
     
     /**
      * Peformance data is stored in this hash object. The key is the name of the


### PR DESCRIPTION
Additional fix for #1632 so that brackets can initialize in-browser without console errors.
