### PR TITLE
Fix for dropping projects when cancelling switch (#1780)

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
                     .click(function () {
                         ProjectManager.openProject(root)
                             .fail(function () {
-                                // Remove the project from the list.
+                                // Remove the project from the list only if it does not exist on disk
                                 var index = recentProjects.indexOf(root);
                                 if (index !== -1) {
                                     NativeFileSystem.requestNativeFileSystem(root,

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
         SidebarView             = brackets.getModule("project/SidebarView"),
         Menus                   = brackets.getModule("command/Menus"),
         PopUpManager            = brackets.getModule("widgets/PopUpManager"),
-        FileUtils               = brackets.getModule("file/FileUtils");
+        FileUtils               = brackets.getModule("file/FileUtils"),
+        NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem;
     
     var $dropdownToggle;
     var MAX_PROJECTS = 20;
@@ -148,7 +149,11 @@ define(function (require, exports, module) {
                                 // Remove the project from the list.
                                 var index = recentProjects.indexOf(root);
                                 if (index !== -1) {
-                                    recentProjects.splice(index, 1);
+                                    NativeFileSystem.requestNativeFileSystem(root,
+                                        function () {},
+                                        function () {
+                                            recentProjects.splice(index, 1);
+                                        });
                                 }
                             });
                         closeDropdown();


### PR DESCRIPTION
Possible fix for https://github.com/adobe/brackets/issues/1780

As @pthiess pointed out, checking to see if the folder exists to prevent it from being dropped.
