### PR TITLE
Add more special mode types

### DIFF
--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
 
         s = s.toLowerCase();
 
-        // Handle special cases
+        // Handle special cases (in order of likely occurrance)
         if (s === "javascript") {
             return "JavaScript";
         } else if (s === "html" || s === "htmlmixed") {
@@ -204,6 +204,12 @@ define(function (require, exports, module) {
             return "PHP";
         } else if (s === "xml") {
             return "XML";
+        } else if (s === "yaml") {
+            return "YAML";
+        } else if (s === "coffeescript") {
+            return "CoffeeScript";
+        } else if (s === "mysql") {
+            return "SQL";
         }
 
         // Generic case


### PR DESCRIPTION
More fixes for issue #1826

I added mappings for SQL, CoffeeScript, and YAML.

@peterflynn JSON files show up as "JavaScript" for me. Where are you seeing "Json"?

Editing C, C++, and C# files seems like it's pretty rare in Brackets. OK to punt on those?
