### PR TITLE
Prevent live preview from reloading the just opened page

### DIFF
--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -307,7 +307,6 @@ define(function DOMAgent(require, exports, module) {
             .on("childNodeInserted.DOMAgent", _onChildNodeInserted)
             .on("childNodeRemoved.DOMAgent", _onChildNodeRemoved);
         Inspector.Page.enable();
-        Inspector.Page.reload();
         return _load.promise();
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -407,14 +407,12 @@ define(function LiveDevelopment(require, exports, module) {
         $.when.apply(undefined, promises).then(_onLoad, _onError);
         
         // Load the right document (some agents are waiting for the page's load event)
-        Inspector.DOM.getDocument(function onGetDocument(res) {
-            var doc = _getCurrentDocument();
-            if (doc && res.root.documentURL === launcherUrl) {
-                Inspector.Page.navigate(doc.root.url);
-            } else {
-                Inspector.Page.reload();
-            }
-        });
+        var doc = _getCurrentDocument();
+        if (doc) {
+            Inspector.Page.navigate(doc.root.url);
+        } else {
+            Inspector.Page.reload();
+        }
     }
 
     /** Triggered by Inspector.disconnect */
@@ -521,7 +519,7 @@ define(function LiveDevelopment(require, exports, module) {
                 retryCount++;
 
                 if (!browserStarted && exports.status !== STATUS_ERROR) {
-                    url = launcherUrl;
+                    url = launcherUrl + '?' + encodeURIComponent(url);
 
                     // If err === FileError.ERR_NOT_FOUND, it means a remote debugger connection
                     // is available, but the requested URL is not loaded in the browser. In that

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -387,7 +387,7 @@ define(function LiveDevelopment(require, exports, module) {
         if (doc.isDirty && _classForDocument(doc) !== CSSDocument) {
             status = STATUS_OUT_OF_SYNC;
         }
-        _setStatus(status);   
+        _setStatus(status);
     }
 
     /** Triggered by Inspector.detached */

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -575,7 +575,7 @@ define(function LiveDevelopment(require, exports, module) {
     /** Close the Connection */
     function close() {
         if (Inspector.connected()) {
-            Inspector.Runtime.evaluate("window.close()");
+            Inspector.Runtime.evaluate("window.open('', '_self').close();");
         }
         Inspector.disconnect();
         _setStatus(STATUS_INACTIVE);

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Waiting...</title>
+	<style type="text/css">
+		html,body {
+			width: 100%;
+			height: 100%;
+			padding: 0;
+			margin: 0;
+		}
+		body {
+			background-image: url(../styles/images/brackets_icon.svg);
+			background-repeat: no-repeat;
+			background-position: center center;
+		}
+	</style>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -1,8 +1,47 @@
 <!DOCTYPE html>
+
+<!-- 
+  Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+   
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"), 
+  to deal in the Software without restriction, including without limitation 
+  the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+  and/or sell copies of the Software, and to permit persons to whom the 
+  Software is furnished to do so, subject to the following conditions:
+   
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+   
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+  DEALINGS IN THE SOFTWARE.
+-->
+
 <html>
 
 <head>
 	<title>Waiting...</title>
+	<script type="application/javascript">
+        /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+        /*global window: true */
+		
+		(function () {
+			"use strict";
+			
+			if (!window.location.search) {
+				return;
+			}
+			var url = decodeURIComponent(window.location.search.slice(1));
+			window.setTimeout(function () {
+				window.location.href = url;
+			}, 2500);
+		}());
+	</script>
 	<style type="text/css">
 		html, body {
 			width: 100%;

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -48,32 +48,42 @@
 			height: 100%;
 			padding: 0;
 			margin: 0;
+			background: #E6E6E6;
 		}
-		
-		img {
-			position: absolute;
-			left: 50%;
+		#loading-image {
+			background: url('../styles/images/no_content_bg.svg');
+			width: 55px;
+			height: 55px;
+			position: relative;
+			margin: -55px auto 0;
 			top: 50%;
-			width: 120px;
-			height: 120px;
-			margin-left: -60px;
-			margin-top: -60px;
-			-webkit-animation-name:            pulse; 
-			-webkit-animation-duration:        1s; 
-			-webkit-animation-iteration-count: infinite;
-			-webkit-animation-timing-function: ease-in-out;
+		}
+		#spinner {
+			position: absolute;
+			top: 64px;
+			left: 22px;
+			width: 12px;
+			height: 12px;
+			background: url('../styles/images/small_spinner.svg');
+			-webkit-animation: rotating 1.5s linear infinite;
+		}
+		@-webkit-keyframes rotating {
+		    0% {
+		        -webkit-transform: rotate(0deg);
+		    }
+
+		    100% {
+		        -webkit-transform: rotate(360deg);
+		    }
 		}
 		
-		@-webkit-keyframes pulse {
-			0%   { -webkit-transform: scale(0.8); }
-			50%  { -webkit-transform: scale(1.0); }
-			100% { -webkit-transform: scale(0.8); }
-		}
+		
 	</style>
 </head>
-
 <body>
-	<img src="../styles/images/brackets_icon.svg">
+	<div id="loading-image">
+		<div id="spinner"></div>
+	</div>
 </body>
 
 </html>

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -4,21 +4,37 @@
 <head>
 	<title>Waiting...</title>
 	<style type="text/css">
-		html,body {
+		html, body {
 			width: 100%;
 			height: 100%;
 			padding: 0;
 			margin: 0;
 		}
-		body {
-			background-image: url(../styles/images/brackets_icon.svg);
-			background-repeat: no-repeat;
-			background-position: center center;
+		
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			width: 120px;
+			height: 120px;
+			margin-left: -60px;
+			margin-top: -60px;
+			-webkit-animation-name:            pulse; 
+			-webkit-animation-duration:        1s; 
+			-webkit-animation-iteration-count: infinite;
+			-webkit-animation-timing-function: ease-in-out;
+		}
+		
+		@-webkit-keyframes pulse {
+			0%   { -webkit-transform: scale(0.8); }
+			50%  { -webkit-transform: scale(1.0); }
+			100% { -webkit-transform: scale(0.8); }
 		}
 	</style>
 </head>
 
 <body>
+	<img src="../styles/images/brackets_icon.svg">
 </body>
 
 </html>

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -25,65 +25,63 @@
 <html>
 
 <head>
-	<title>Waiting...</title>
-	<script type="application/javascript">
+    <title>Waiting...</title>
+    <script type="application/javascript">
         /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
         /*global window: true */
-		
-		(function () {
-			"use strict";
-			
-			if (!window.location.search) {
-				return;
-			}
-			var url = decodeURIComponent(window.location.search.slice(1));
-			window.setTimeout(function () {
-				window.location.href = url;
-			}, 2500);
-		}());
-	</script>
-	<style type="text/css">
-		html, body {
-			width: 100%;
-			height: 100%;
-			padding: 0;
-			margin: 0;
-			background: #E6E6E6;
-		}
-		#loading-image {
-			background: url('../styles/images/no_content_bg.svg');
-			width: 55px;
-			height: 55px;
-			position: relative;
-			margin: -55px auto 0;
-			top: 50%;
-		}
-		#spinner {
-			position: absolute;
-			top: 64px;
-			left: 22px;
-			width: 12px;
-			height: 12px;
-			background: url('../styles/images/small_spinner.svg');
-			-webkit-animation: rotating 1.5s linear infinite;
-		}
-		@-webkit-keyframes rotating {
-		    0% {
-		        -webkit-transform: rotate(0deg);
-		    }
+        
+        (function () {
+            "use strict";
+            
+            if (!window.location.search) {
+                return;
+            }
+            var url = decodeURIComponent(window.location.search.slice(1));
+            window.setTimeout(function () {
+                window.location.href = url;
+            }, 2500);
+        }());
+    </script>
+    <style type="text/css">
+        html, body {
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+            background: #E6E6E6;
+        }
+        #loading-image {
+            background: url("../styles/images/no_content_bg.svg");
+            width: 55px;
+            height: 55px;
+            position: relative;
+            margin: -55px auto 0;
+            top: 50%;
+        }
+        #spinner {
+            position: absolute;
+            top: 64px;
+            left: 22px;
+            width: 12px;
+            height: 12px;
+            background: url("../styles/images/small_spinner.svg");
+            -webkit-animation: rotating 1.5s linear infinite;
+        }
+        @-webkit-keyframes rotating {
+            0% {
+                -webkit-transform: rotate(0deg);
+            }
 
-		    100% {
-		        -webkit-transform: rotate(360deg);
-		    }
-		}
-		
-		
-	</style>
+            100% {
+                -webkit-transform: rotate(360deg);
+            }
+        }
+    </style>
 </head>
 <body>
-	<div id="loading-image">
-		<div id="spinner"></div>
-	</div>
+    <div id="loading-image">
+        <div id="spinner"></div>
+    </div>
 </body>
 
 </html>

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -74,9 +74,7 @@ define(function (require, exports, module) {
         if (isNaN(pid)) {
             pid = 0;
         }
-        console.log("calling to close: " + pid);
         brackets.app.closeLiveBrowser(function (err) {
-            console.log("called closing: " + pid + " with err: " + err);
             if (!err) {
                 var i = liveBrowserOpenedPIDs.indexOf(pid);
                 if (i !== -1) {


### PR DESCRIPTION
New technique: open a basically empty HTML file that does not have side effects, connect the debugger, then switch to the actual target site.

Fixes #1879
