### PR TITLE
Fixes for focus handling

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -614,10 +614,10 @@ define(function (require, exports, module) {
             self._fireWidgetOffsetTopChanged(self.getFirstVisibleLine() - 1);
         });
 
-        // Convert CodeMirror onFocus events to EditorManager focusedEditorChanged
+        // Convert CodeMirror onFocus events to EditorManager activeEditorChanged
         this._codeMirror.setOption("onFocus", function () {
             self._focused = true;
-            EditorManager._notifyFocusedEditorChanged(self);
+            EditorManager._notifyActiveEditorChanged(self);
         });
         
         this._codeMirror.setOption("onBlur", function () {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -319,10 +319,14 @@ define(function (require, exports, module) {
         }
     }
 
-    /** Focus the currently visible full-size editor. If no editor visible, does nothing. */
+    /** 
+     * Returns focus to the last visible editor that had focus. 
+     * This function should be called to restore editor focus after it has been temporarily
+     * removed. For example, after a dialog with editable text is closed.
+     */
     function focusEditor() {
-        if (_currentEditor) {
-            _currentEditor.focus();
+        if (_lastFocusedEditor) {
+            _lastFocusedEditor.focus();
         }
     }
     
@@ -403,6 +407,7 @@ define(function (require, exports, module) {
         _currentEditor = document._masterEditor;
         
         _currentEditor.setVisible(true);
+        _currentEditor.focus();
         
         // Window may have been resized since last time editor was visible, so kick it now
         resizeEditor();
@@ -552,6 +557,11 @@ define(function (require, exports, module) {
     
     /**
      * Returns the currently focused editor instance (full-sized OR inline editor).
+     * This function is similar to getActiveEditor(), with one main difference: this
+     * function will only return editors that currently have focus, whereas 
+     * getActiveEditor() will return the last visible editor that was given focus (but
+     * may not currently have focus because, for example, a dialog with editable text
+     * is open).
      * @returns {Editor}
      */
     function getFocusedEditor() {
@@ -572,6 +582,17 @@ define(function (require, exports, module) {
         return null;
     }
  
+    /**
+     * Returns the current active editor (full-sized OR inline editor). This editor may not 
+     * have focus at the moment, but it is visible and was the last editor that was given 
+     * focus. Returns null if no editors are active.
+     * @see getFocusedEditor()
+     * @returns {Editor}
+     */
+    function getActiveEditor() {
+        return _lastFocusedEditor;
+    }
+     
     /**
      * Toggle Quick Edit command handler
      * @return {!Promise} A promise resolved with true if an inline editor
@@ -788,6 +809,7 @@ define(function (require, exports, module) {
     exports.createInlineEditorForDocument = createInlineEditorForDocument;
     exports.focusEditor = focusEditor;
     exports.getFocusedEditor = getFocusedEditor;
+    exports.getActiveEditor = getActiveEditor;
     exports.getFocusedInlineWidget = getFocusedInlineWidget;
     exports.resizeEditor = resizeEditor;
     exports.registerInlineEditProvider = registerInlineEditProvider;

--- a/src/extensions/samples/TypingSpeedLogger/main.js
+++ b/src/extensions/samples/TypingSpeedLogger/main.js
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
             }
         };
         
-        $(EditorManager).on("focusedEditorChange", function (event, focusedEditor) {
+        $(EditorManager).on("activeEditorChange", function (event, focusedEditor) {
             updateFocusedEditor(focusedEditor);
         });
         updateFocusedEditor(EditorManager.getFocusedEditor());

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -322,7 +322,7 @@ define(function (require, exports, module) {
         var dialog = new FindInFilesDialog();
         
         // Default to searching for the current selection
-        var currentEditor = EditorManager.getFocusedEditor();
+        var currentEditor = EditorManager.getActiveEditor();
         var initialString = currentEditor && currentEditor.getSelectedText();
         
         searchResults = [];

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
             });
         }
         
-        dialog(cm, queryDialog, Strings.CMD_FIND, findFirst);
+        dialog(cm, queryDialog, Strings.CMD_FIND, function () {});
         getDialogTextField().on("input", function () {
             findFirst(getDialogTextField().attr("value"));
         });

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -255,7 +255,7 @@ define(function (require, exports, module) {
     }
 
     function _launchFind() {
-        var editor = EditorManager.getFocusedEditor();
+        var editor = EditorManager.getActiveEditor();
         if (editor) {
             var codeMirror = editor._codeMirror;
 
@@ -271,21 +271,21 @@ define(function (require, exports, module) {
     }
 
     function _findNext() {
-        var editor = EditorManager.getFocusedEditor();
+        var editor = EditorManager.getActiveEditor();
         if (editor) {
             doSearch(editor._codeMirror);
         }
     }
 
     function _findPrevious() {
-        var editor = EditorManager.getFocusedEditor();
+        var editor = EditorManager.getActiveEditor();
         if (editor) {
             doSearch(editor._codeMirror, true);
         }
     }
 
     function _replace() {
-        var editor = EditorManager.getFocusedEditor();
+        var editor = EditorManager.getActiveEditor();
         if (editor) {
             replace(editor._codeMirror);
         }

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -179,7 +179,16 @@ define(function (require, exports, module) {
             });
         }
         
-        dialog(cm, queryDialog, Strings.CMD_FIND, function () {});
+        dialog(cm, queryDialog, Strings.CMD_FIND, function (query) {
+            // If the dialog is closed and the query string is not empty,
+            // make sure we have called findFirst at least once. This way
+            // if the Find dialog is opened with pre-populated text, pressing
+            // enter will find the next occurance of the text and store
+            // the query for subsequent "Find Next" commands.
+            if (query && !state.query) {
+                findFirst(query);
+            }
+        });
         getDialogTextField().on("input", function () {
             findFirst(getDialogTextField().attr("value"));
         });

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -617,6 +617,8 @@ define(function (require, exports, module) {
         if ($(this.dialog).find(e.target).length === 0 && $(".smart_autocomplete_container").find(e.target).length === 0) {
             this._close();
         }
+        e.preventDefault();
+        e.stopPropagation();
     };
 
     /**
@@ -670,7 +672,8 @@ define(function (require, exports, module) {
             itemSelect: function (e, selectedItem) { that._handleItemSelect(selectedItem); },
             itemFocus: function (e, selectedItem) { that._handleItemFocus(selectedItem); },
             keydown: function (e) { that._handleKeyDown(e); },
-            keyup: function (e, query) { that._handleKeyUp(e); }
+            keyup: function (e, query) { that._handleKeyUp(e); },
+            blur: function (e) { that._close(); }
             // Note: lostFocus event DOESN'T work because auto smart complete catches the key up from shift-command-o and immediately
             // triggers lostFocus
         });

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -688,7 +688,7 @@ define(function (require, exports, module) {
     };
 
     function getCurrentEditorSelectedText() {
-        var currentEditor = EditorManager.getFocusedEditor();
+        var currentEditor = EditorManager.getActiveEditor();
         return (currentEditor && currentEditor.getSelectedText()) || "";
     }
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -616,9 +616,14 @@ define(function (require, exports, module) {
     QuickNavigateDialog.prototype.handleDocumentMouseDown = function (e) {
         if ($(this.dialog).find(e.target).length === 0 && $(".smart_autocomplete_container").find(e.target).length === 0) {
             this._close();
+        } else {
+            // Allow clicks in the search field to propagate. Clicks in the menu should be 
+            // blocked to prevent focus from leaving the search field.
+            if ($("input#quickOpenSearch").get(0) !== e.target) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
         }
-        e.preventDefault();
-        e.stopPropagation();
     };
 
     /**

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -444,6 +444,9 @@ define(function (require, exports, module) {
                     expect(inlineEditor.document.isDirty).toBeTruthy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
                     
+                    // verify focus is in inline editor
+                    expect(inlineEditor.hasFocus()).toBeTruthy();
+                    
                     // execute file save command
                     testWindow.executeCommand(Commands.FILE_SAVE).done(function () {
                         saved = true;
@@ -455,6 +458,9 @@ define(function (require, exports, module) {
                 waitsFor(function () { return saved && !err; }, "save timeout", 1000);
                 
                 runs(function () {
+                    // verify focus is still in inline editor
+                    expect(inlineEditor.hasFocus()).toBeTruthy();
+                    
                     // read saved file contents
                     FileUtils.readAsText(inlineEditor.document.file).done(function (text) {
                         savedText = text;


### PR DESCRIPTION
@peterflynn 

This pull request has a couple key changes to the way focus is handled and managed.
- `EditorManager.focusEditor()` now returns focus to the last visible
  editor that had focus. We no longer force the focus back to the
  main editor after saving or cancelling an open.
- Add `EditorManager.getActiveEditor()`. This function is similar to
  `getFocusedEditor()`, but will return the last editor that was given
  focus, even if it doesn't have focus at the moment. This is useful
  for commands like Find/Find Next that should work on the active
  document even if the Find dialog has focus.
- Update FindReplace, FindInFiles and QuickOpen to use `getActiveEditor()`

I tested the changes in the following scenarios:
- File Save - If focus is in an inline editor, focus is returned to the editor after saving (logged as issue #547)
- File Open - if the open is cancelled, focus is not forced to the main editor
- Changing indent size - focus is returned to the editor that previously had focus
- Find/Replace - Cmd-G works while the find dialog is open (issue #1935)
