### PR TITLE
Use position:relative for main content div

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -95,6 +95,7 @@ a, img {
 
     .content {
         height: 100%;
+        position: relative;
     }
 }
 


### PR DESCRIPTION
Fix for issue #1973

The underlying bug _appears_ to be a browser bug, but I wasn't able to isolate it to a simple test case. While messing around with ideas, I discovered that simply setting `position: relative` on the main content div fixes (avoids?) the problem.
