### PR TITLE
Remove unnecessary extrakey for CodeMirror

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -320,9 +320,6 @@ define(function (require, exports, module) {
             "Esc": function (instance) {
                 self.removeAllInlineWidgets();
             },
-            "Shift-Delete": "cut",
-            "Ctrl-Insert": "copy",
-            "Shift-Insert": "paste",
             "'>'": function (cm) { cm.closeTag(cm, '>'); },
             "'/'": function (cm) { cm.closeTag(cm, '/'); }
         };


### PR DESCRIPTION
CodeMirror do not have "copy", "cut" and "paste" commands. These extrakeys are ignored by CodeMirror.
