### PR TITLE
Prevent reflow in the project name title (#1548)

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -43,7 +43,9 @@ define(function (require, exports, module) {
         FileUtils               = brackets.getModule("file/FileUtils"),
         NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem;
     
-    var $dropdownToggle;
+    var $dropdownToggle,
+        $settings;
+    
     var MAX_PROJECTS = 20;
 
     /**
@@ -243,5 +245,10 @@ define(function (require, exports, module) {
             .wrap("<div id='project-dropdown-toggle'></div>")
             .after("<span class='dropdown-arrow'></span>");
         $dropdownToggle = $("#project-dropdown-toggle").click(toggle);
+        
+        $settings = $("#sidebar").find(".settings");
+        $("#sidebar").on("panelResizeEnd panelResizeUpdate panelResizeExpanded", function (evt, width) {
+            $dropdownToggle.width($settings.position().left - $dropdownToggle.position().left);
+        });
     });
 });

--- a/src/extensions/default/RecentProjects/styles.css
+++ b/src/extensions/default/RecentProjects/styles.css
@@ -13,6 +13,11 @@
 	position: absolute;
 }
 
+#project-dropdown-toggle {
+    height: 18px;
+    overflow: hidden;
+}
+
 #project-dropdown-toggle:hover {
     color: #a0a0a0;
     text-decoration: none;

--- a/src/extensions/default/RecentProjects/styles.css
+++ b/src/extensions/default/RecentProjects/styles.css
@@ -16,6 +16,7 @@
 #project-dropdown-toggle {
     height: 18px;
     overflow: hidden;
+    white-space: nowrap;
 }
 
 #project-dropdown-toggle:hover {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -384,6 +384,7 @@ a, img {
             position: absolute;
             right: 8px;
             margin-top: 3px;
+            margin-left: 3px;
             .sprite-icon(0, 0, 14px, 14px, "images/settings_small.svg");
 
             &:hover {


### PR DESCRIPTION
This is a possible fix for Issue #1548

It uses the sidebar resize events to update the title width and prevent reflow by setting a fixed height and hidden overflow.
