### PR TITLE
Trap status from XMLHttpRequest and fail accordingly

### DIFF
--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -177,8 +177,13 @@ define(function DOMAgent(require, exports, module) {
         var request = new XMLHttpRequest();
         request.open("GET", exports.url);
         request.onload = function onLoad() {
-            _mapDocumentToSource(request.response);
-            _load.resolve();
+            if ((request.status >= 200 && request.status < 300) || request.status === 304) {
+                _mapDocumentToSource(request.response);
+                _load.resolve();
+            } else {
+                var msg = "Received status " + request.status + " from XMLHttpRequest while attempting to load source file at " + exports.url;
+                _load.reject(msg, { message: msg });
+            }
         };
         request.onerror = function onError() {
             _load.reject("Could not load source file at " + exports.url);

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -367,6 +367,7 @@ define(function LiveDevelopment(require, exports, module) {
 
         // Show the message, but include the error object for further information (e.g. error code)
         console.error(message, error);
+        _setStatus(STATUS_ERROR);
     }
 
     /** Run when all agents are loaded */
@@ -389,7 +390,7 @@ define(function LiveDevelopment(require, exports, module) {
         // res.reason, e.g. "replaced_with_devtools", "target_closed", "canceled_by_user"
         // Sample list taken from https://chromiumcodereview.appspot.com/10947037/patch/12001/13004
         // However, the link refers to the Chrome Extension API, it may not apply 100% to the Inspector API
-    }    
+    }
 
     /** Triggered by Inspector.connect */
     function _onConnect(event) {


### PR DESCRIPTION
Good catch. This is for issue #2067.
