### PR TITLE
update recent projects extension. remove reference to settings button.

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -253,10 +253,5 @@ define(function (require, exports, module) {
             .wrap("<div id='project-dropdown-toggle'></div>")
             .after("<span class='dropdown-arrow'></span>");
         $dropdownToggle = $("#project-dropdown-toggle").click(toggle);
-        
-        $settings = $("#sidebar").find(".settings");
-        $("#sidebar").on("panelResizeEnd panelResizeUpdate panelResizeExpanded", function (evt, width) {
-            $dropdownToggle.width($settings.position().left - $dropdownToggle.position().left);
-        });
     });
 });


### PR DESCRIPTION
See pull #2040 and issue #1548.

The project settings button was removed recently. This RecentProjects extension was referencing a settings button that no longer exists.
