### PR TITLE
Enabled Haxe mode (with syntax highlighting)

### DIFF
--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror2/mode/diff/diff");
     require("thirdparty/CodeMirror2/mode/markdown/markdown");
     require("thirdparty/CodeMirror2/mode/yaml/yaml");
+    require("thirdparty/CodeMirror2/mode/haxe/haxe");
 
     /**
      * @private
@@ -158,6 +159,9 @@ define(function (require, exports, module) {
         case "yaml":
         case "yml":
             return "yaml";
+        
+        case "hx":
+            return "haxe";
 
         default:
             console.log("Called EditorUtils.js _getModeFromFileExtensions with an unhandled file extension: " + ext);


### PR DESCRIPTION
Just enabled a "Haxe mode" that use Haxe syntax highlight from CodeMirror >3.0beta or >2.31.
It is required for my plan of developing a Haxe support extension.
