### PR TITLE
Toggle Block Comment

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -66,6 +66,7 @@ define(function (require, exports, module) {
     exports.EDIT_DUPLICATE              = "edit.duplicate";
     exports.EDIT_DELETE_LINES           = "edit.deletelines";
     exports.EDIT_LINE_COMMENT           = "edit.lineComment";
+    exports.EDIT_BLOCK_COMMENT          = "edit.blockComment";
     exports.EDIT_LINE_UP                = "edit.lineUp";
     exports.EDIT_LINE_DOWN              = "edit.lineDown";
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -916,6 +916,8 @@ define(function (require, exports, module) {
                                                           platform: "mac"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
+        menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT,   [{key: "Ctrl-Shift-/", platform: "win"},
+                                                         {key: "Ctrl-Alt-/",   platform: "mac"}]);
 
         /*
          * View menu

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -904,22 +904,21 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_REPLACE,             [{key: "Ctrl-H",     platform: "win"},
                                                              {key: "Cmd-Alt-F", platform: "mac"}]);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.EDIT_INDENT,          [{key: "Indent", displayKey: "Tab"}]);
-        menu.addMenuItem(Commands.EDIT_UNINDENT,        [{key: "Unindent", displayKey: "Shift-Tab"}]);
-        menu.addMenuItem(Commands.EDIT_DUPLICATE,       "Ctrl-D");
-        menu.addMenuItem(Commands.EDIT_DELETE_LINES,    "Ctrl-Shift-D");
-        menu.addMenuItem(Commands.EDIT_LINE_UP,         [{key: "Ctrl-Shift-Up", displayKey: "Ctrl-Shift-\u2191",
-                                                          platform: "win"},
-                                                         {key:  "Cmd-Ctrl-Up", displayKey: "Cmd-Ctrl-\u2191",
-                                                          platform: "mac"}]);
-        menu.addMenuItem(Commands.EDIT_LINE_DOWN,       [{key: "Ctrl-Shift-Down", displayKey: "Ctrl-Shift-\u2193",
-                                                          platform: "win"},
-                                                         {key:  "Cmd-Ctrl-Down", displayKey: "Cmd-Ctrl-\u2193",
-                                                          platform: "mac"}]);
+        menu.addMenuItem(Commands.EDIT_INDENT,              [{key: "Indent", displayKey: "Tab"}]);
+        menu.addMenuItem(Commands.EDIT_UNINDENT,            [{key: "Unindent", displayKey: "Shift-Tab"}]);
+        menu.addMenuItem(Commands.EDIT_DUPLICATE,           "Ctrl-D");
+        menu.addMenuItem(Commands.EDIT_DELETE_LINES,        "Ctrl-Shift-D");
+        menu.addMenuItem(Commands.EDIT_LINE_UP,             [{key: "Ctrl-Shift-Up", displayKey: "Ctrl-Shift-\u2191",
+                                                              platform: "win"},
+                                                             {key:  "Cmd-Ctrl-Up", displayKey: "Cmd-Ctrl-\u2191",
+                                                              platform: "mac"}]);
+        menu.addMenuItem(Commands.EDIT_LINE_DOWN,           [{key: "Ctrl-Shift-Down", displayKey: "Ctrl-Shift-\u2193",
+                                                              platform: "win"},
+                                                             {key:  "Cmd-Ctrl-Down", displayKey: "Cmd-Ctrl-\u2193",
+                                                              platform: "mac"}]);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
-        menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT,   [{key: "Ctrl-Shift-/", platform: "win"},
-                                                         {key: "Ctrl-Alt-/",   platform: "mac"}]);
+        menu.addMenuItem(Commands.EDIT_LINE_COMMENT,        "Ctrl-/");
+        menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT,       "Ctrl-Shift-/");
 
         /*
          * View menu
@@ -927,10 +926,10 @@ define(function (require, exports, module) {
         menu = addMenu(Strings.VIEW_MENU, AppMenuBar.VIEW_MENU);
         menu.addMenuItem(Commands.VIEW_HIDE_SIDEBAR,        "Ctrl-Shift-H");
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE, [{key: "Ctrl-=", displayKey: "Ctrl-+"},
-                                                            {key: "Ctrl-+", displayKey: "Ctrl-+"}]);
-        menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE, [{key: "Ctrl--", displayKey: "Ctrl-\u2212"}]);
-        menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE, "Ctrl-0");
+        menu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE,  [{key: "Ctrl-=", displayKey: "Ctrl-+"},
+                                                             {key: "Ctrl-+", displayKey: "Ctrl-+"}]);
+        menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE,  [{key: "Ctrl--", displayKey: "Ctrl-\u2212"}]);
+        menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE,   "Ctrl-0");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_JSLINT);
 

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -49,11 +49,11 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Searchs for an uncommented line in between startLine and endLine
+     * Searchs for an uncommented line between startLine and endLine
      * @param {!Editor} editor
      * @param {!number} startLine - valid line inside the document
      * @param {!number} endLine - valid line inside the document
-     * @return {boolean} true if there is at least one uncomented line
+     * @return {boolean} true if there is at least one uncommented line
      */
     function _containsUncommented(editor, startLine, endLine) {
         var containsUncommented = false;
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
         while (result && !ctx.token.string.match(prefixExp)) {
             result = TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, ctx);
         }
-        return !result ? null : {line: ctx.pos.line, ch: ctx.token.start};
+        return result ? {line: ctx.pos.line, ch: ctx.token.start} : null;
     }
     
     /**
@@ -180,7 +180,7 @@ define(function (require, exports, module) {
         while (result && !ctx.token.string.match(suffixExp)) {
             result = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx);
         }
-        return !result ? null : {line: ctx.pos.line, ch: ctx.token.end - suffixLen};
+        return result ? {line: ctx.pos.line, ch: ctx.token.end - suffixLen} : null;
     }
     
     /**

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -229,13 +229,13 @@ define(function (require, exports, module) {
      * and cursor position. Applies to the currently focused Editor.
      * 
      * If the selection is inside a block-comment or one block-comment is inside or partially 
-     * inside the selection we we uncomment; otherwise we comment out.
-     * Commenting out adds the prefix before the selection and the suffix after
+     * inside the selection we uncomment; otherwise we comment out.
+     * Commenting out adds the prefix before the selection and the suffix after.
      * Uncommenting removes them.
      * 
      * If slashComment is true and the start or end of the selection is inside a line-comment it 
-     * will try to do a line uncomment if all the lines in the selection are line-commented and
-     * will do nothing if at least one line is not line-commented.
+     * will try to do a line uncomment if is not actually inside a bigger block comment and all
+     * the lines in the selection are line-commented.
      *
      * @param {!Editor} editor
      * @param {!String} prefix

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
                 result = TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, startCtx);
             }
             
-            if (!result || startCtx.token.className !== "comment") {
+            if (!result || startCtx.token.className !== "comment" || startCtx.token.string.match(suffixExp)) {
                 if (!_containsUncommented(editor, sel.start.line, sel.end.line)) {
                     lineCommentSlashSlash(editor);
                     return;

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
      * 
      * If the selection is inside a block-comment or one block-comment is inside or partially 
      * inside the selection we we uncomment; otherwise we comment out.
-     * Commenting out adds the prefix before the selection and the suffix after
+     * Commenting out adds the prefix before the selection and the suffix after.
      * Uncommenting removes them.
      * 
      * If slashComment is true and the start or end of the selection is inside a line-comment it 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -186,6 +186,7 @@ define({
     "CMD_DUPLICATE"                       : "Duplicate",
     "CMD_DELETE_LINES"                    : "Delete Line",
     "CMD_COMMENT"                         : "Toggle Line Comment",
+    "CMD_BLOCK_COMMENT"                   : "Toggle Block Comment",
     "CMD_LINE_UP"                         : "Move Line Up",
     "CMD_LINE_DOWN"                       : "Move Line Down",
      


### PR DESCRIPTION
This pull would add a new prefix/suffix type of block-comment feature that works similar to sublime text 2. 

Block-comment/uncomment depends on: If the selection is inside a block-comment or one block-comment is inside or partially inside the selection we uncomment; otherwise we comment out. Commenting out adds the prefix before the selection and the suffix after. Uncommenting removes them.

A third possibility comes in languages that support both line and block comments. In this cases if the start or end of the selection is inside a line-comment it will try to do a line uncomment if all the lines in the selection are line-commented and will do nothing if at least one line is not line-commented. It might be missing the alternative, using a line-comment command to uncomment a block-comment when possible, but wasn't sure if this was wanted.

Note that some block comment could not actually create a comment, like commenting inside a string or a line comment (in cases the first and last lines are commented but one in the middle isn't), and in other cases it could break other comments. But I believe that it was better to show a result and let the user rollback than do nothing and letting the user suspect that something is broken.

There is still a problem that a uncommenting a multi-line block comment requires 2 undos. For commenting was easily fixed, but for uncommenting it because re-selecting the previous selection had several possibilities to do something about it. I read that in CodeMirror v3, this would be easily fixable, so I left it like that.
