### PR TITLE
Resize events consolidation and minor resizer bugs (#2079)

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -324,7 +324,7 @@ define(function (require, exports, module) {
             if (collapsible) {
                 $resizeShield.on("mousedown", function (e) {
                     $(window.document).off("mousemove");
-                    $(window.document).off("mousedown");
+                    $resizeShield.off("mousedown");
                     $resizeShield.remove();
                     animationRequest = null;
                     toggle($element);
@@ -354,7 +354,7 @@ define(function (require, exports, module) {
                     // on the container that would account for double click
                     window.setTimeout(function () {
                         $(window.document).off("mousemove");
-                        $(window.document).off("mousedown");
+                        $resizeShield.off("mousedown");
                         $resizeShield.remove();
                         animationRequest = null;
                     }, 300);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -308,7 +308,7 @@ define(function (require, exports, module) {
                 animationRequest = window.webkitRequestAnimationFrame(doRedraw);
             }
             
-            $(window.document).on("mousemove", function (e) {
+            function onMouseMove(e) {
                 // calculate newSize adding to startSize the difference
                 // between starting and current position, capped at minSize
                 newSize = Math.max(startSize + directionIncrement * (startPosition - e[directionProperty]), minSize);
@@ -317,13 +317,15 @@ define(function (require, exports, module) {
                 if (animationRequest === null) {
                     animationRequest = window.webkitRequestAnimationFrame(doRedraw);
                 }
-            });
+            }
+            
+            $(window.document).on("mousemove", onMouseMove);
             
             // If the element is marked as collapsible, check for double click
             // to toggle the element visibility
             if (collapsible) {
                 $resizeShield.on("mousedown", function (e) {
-                    $(window.document).off("mousemove");
+                    $(window.document).off("mousemove", onMouseMove);
                     $resizeShield.off("mousedown");
                     $resizeShield.remove();
                     animationRequest = null;
@@ -353,7 +355,7 @@ define(function (require, exports, module) {
                     // We wait 300ms to remove the resizer container to capture a mousedown
                     // on the container that would account for double click
                     window.setTimeout(function () {
-                        $(window.document).off("mousemove");
+                        $(window.document).off("mousemove", onMouseMove);
                         $resizeShield.off("mousedown");
                         $resizeShield.remove();
                         animationRequest = null;


### PR DESCRIPTION
This pull request consolidates the resize events dispatched by `utils/Resizer` following the comments on (#2079).

It also fixes some minor resizer bugs such as the one described in #2079 where after dragging the panel shut, it will expand to 10px instead of the original size.

@peterflynn Let me know if this is closer to what you'd expect
