### PR TITLE
Keep recent projects dropdown open when deleting a project. 

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -45,6 +45,7 @@ define(function (require, exports, module) {
         NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem;
     
     var $dropdownToggle,
+        $dropdown,
         $settings;
     
     var MAX_PROJECTS = 20;
@@ -81,6 +82,56 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Create the "delete" button that shows up when you hover over a project.
+     */
+    function renderDelete() {
+        return $("<div id='recent-folder-delete'></div>")
+            .addClass("trash-icon")
+            .click(function (e) {
+                // Don't let the click bubble upward.
+                e.stopPropagation();
+                
+                // Remove the project from the preferences.
+                var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY),
+                    recentProjects = getRecentProjects(),
+                    index = recentProjects.indexOf($(this).data("path")),
+                    newProjects = [],
+                    i;
+                for (i = 0; i < recentProjects.length; i++) {
+                    if (i !== index) {
+                        newProjects.push(recentProjects[i]);
+                    }
+                }
+                prefs.setValue("recentProjects", newProjects);
+                
+                // Recreate the dropdown list.
+                renderList();
+            });
+    }
+    
+    /**
+     * Close the dropdown.
+     */
+    function closeDropdown() {
+        // Since we passed "true" for autoRemove to addPopUp(), this will
+        // automatically remove the dropdown from the DOM. Also, PopUpManager
+        // will call cleanupDropdown().
+        PopUpManager.removePopUp($dropdown);
+    }
+    
+    /**
+     * Remove the various event handlers that close the dropdown. This is called by the
+     * PopUpManager when the dropdown is closed.
+     */
+    function cleanupDropdown() {
+        $("html").off("click", closeDropdown);
+        $("#project-files-container").off("scroll", closeDropdown);
+        $(SidebarView).off("hide", closeDropdown);
+        $("#main-toolbar .nav").off("click", closeDropdown);
+        $dropdown = null;
+    }
+    
+    /**
      * Create the DOM node for a single recent folder path in the dropdown menu.
      * @param {string} path The full path to the folder.
      */
@@ -99,107 +150,59 @@ define(function (require, exports, module) {
         
         var folderSpan = $("<span></span>").addClass("recent-folder").text(folder),
             restSpan = $("<span></span>").addClass("recent-folder-path").text(rest);
-        return $("<a></a>").addClass("recent-folder-link").append(folderSpan).append(restSpan).data("path", path);
-    }
-  
-    function renderDelete() {
-        return $("<div id='recent-folder-delete'></div>").addClass("trash-icon");
-    }
-    
-    /**
-     * Show or hide the recent projects dropdown.
-     * @param {object} e The event object that triggered the toggling.
-     */
-    function toggle(e) {
-        // If the dropdown is already visible, just return (so the root click handler on html
-        // will close it).
-        if ($("#project-dropdown").length) {
-            return;
-        }
-        
-        Menus.closeAll();
-        
-        // TODO: Can't just use Bootstrap 1.4 dropdowns for this since they're hard-coded to
-        // assume that the dropdown is inside a top-level menubar created using <li>s.
-        // Have to do this stopProp to avoid the html click handler from firing when this returns.
-        e.stopPropagation();
-        
-        var recentProjects = getRecentProjects(),
-            $dropdown = $("<ul id='project-dropdown' class='dropdown-menu'></ul>"),
-            toggleOffset = $dropdownToggle.offset();
+        return $("<a></a>").addClass("recent-folder-link").append(folderSpan).append(restSpan).data("path", path)
+            .click(function () {
+                ProjectManager.openProject(path)
+                    .fail(function () {
+                        // Remove the project from the list only if it does not exist on disk
+                        var recentProjects = getRecentProjects(),
+                            index = recentProjects.indexOf(path);
+                        if (index !== -1) {
+                            NativeFileSystem.requestNativeFileSystem(path,
+                                function () {},
+                                function () {
+                                    recentProjects.splice(index, 1);
+                                });
+                        }
+                    });
+                closeDropdown();
+            })
+            .mouseenter(function (e) {
+                var $target = $(e.currentTarget),
+                    $del = renderDelete();
+                
+                $(this).append($del);
 
-        function closeDropdown() {
-            // Since we passed "true" for autoRemove to addPopUp(), this will
-            // automatically remove the dropdown from the DOM.
-            PopUpManager.removePopUp($dropdown);
-        }
-        
-        function cleanupDropdown() {
-            $("html").off("click", closeDropdown);
-            $("#project-files-container").off("scroll", closeDropdown);
-            $(SidebarView).off("hide", closeDropdown);
-            $("#main-toolbar .nav").off("click", closeDropdown);
-        }
-        
-        var currentProject = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
+                $del.css("right", 5);
+                $del.css("top", $target.position().top + 6);
+                $del.css("display", "inline-block");
+                $del.data("path", $(this).data("path"));
+            })
+            .mouseleave(function () {
+                $("#recent-folder-delete").remove();
+            });
+    }
+
+    /**
+     * Create the list of projects in the dropdown menu.
+     */
+    function renderList() {
+        var recentProjects = getRecentProjects(),
+            currentProject = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
             hasProject = false;
+        
+        $dropdown.children().remove();
 
         recentProjects.forEach(function (root) {
             if (root !== currentProject) {
-                var $link = renderPath(root)
-                    .click(function () {
-                        ProjectManager.openProject(root)
-                            .fail(function () {
-                                // Remove the project from the list only if it does not exist on disk
-                                var index = recentProjects.indexOf(root);
-                                if (index !== -1) {
-                                    NativeFileSystem.requestNativeFileSystem(root,
-                                        function () {},
-                                        function () {
-                                            recentProjects.splice(index, 1);
-                                        });
-                                }
-                            });
-                        closeDropdown();
-                    })
-                    .mouseenter(function (e) {
-                        var $target = $(e.currentTarget),
-                            $del =  renderDelete()
-                                .click(function () {
-                                 // remove the project from the preferences.
-                                    var prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY),
-                                        recentProjects = getRecentProjects(),
-                                        index = recentProjects.indexOf($(this).data("path")),
-                                        newProjects = [],
-                                        i;
-                                    for (i = 0; i < recentProjects.length; i++) {
-                                        if (i !== index) {
-                                            newProjects.push(recentProjects[i]);
-                                        }
-                                    }
-                                    prefs.setValue("recentProjects", newProjects);
-                                    closeDropdown();
-                                });
-                        
-                        $(this).append($del);
-
-                        $del.css("right", 5);
-                        $del.css("top", $target.position().top + 6);
-                        $del.css("display", "inline-block");
-                        $del.data("path", $(this).data("path"));
-                    })
-                    .mouseleave(function () {
-                        $("#recent-folder-delete").remove();
-                    });
-                
+                var $link = renderPath(root);
                 $("<li></li>")
                     .append($link)
                     .appendTo($dropdown);
                 hasProject = true;
             }
         });
-       
-       
+
         if (hasProject) {
             $("<li class='divider'>").appendTo($dropdown);
         }
@@ -214,7 +217,30 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_OPEN_FOLDER);
             })
             .appendTo($dropdown);
+    }
+    
+    /**
+     * Show or hide the recent projects dropdown.
+     * @param {object} e The event object that triggered the toggling.
+     */
+    function toggle(e) {
+        // If the dropdown is already visible, just return (so the root click handler on html
+        // will close it).
+        if ($dropdown) {
+            return;
+        }
         
+        Menus.closeAll();
+        
+        // TODO: Can't just use Bootstrap 1.4 dropdowns for this since they're hard-coded to
+        // assume that the dropdown is inside a top-level menubar created using <li>s.
+        // Have to do this stopProp to avoid the html click handler from firing when this returns.
+        e.stopPropagation();
+        
+        $dropdown = $("<ul id='project-dropdown' class='dropdown-menu'></ul>");
+        renderList();
+        
+        var toggleOffset = $dropdownToggle.offset();
         $dropdown.css({
             left: toggleOffset.left,
             top: toggleOffset.top + $dropdownToggle.outerHeight()

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -103,9 +103,7 @@ define(function (require, exports, module) {
                     }
                 }
                 prefs.setValue("recentProjects", newProjects);
-                
-                // Recreate the dropdown list.
-                renderList();
+                $(this).remove();
             });
     }
     


### PR DESCRIPTION
Fixes #1888.

As part of this, refactored the code to be less nested by breaking out the various rendering functions out of the `toggle()` closure.

Note that this introduces a JSLint error due to the circular dependency between `renderList()` and `renderDelete()` (via `renderPath()`). I can't think of a good way to resolve this that doesn't make the organization of the code actually worse--the way I have it factored right now seems logical to me (`renderList()` is a series of `renderPath()`s; the hover handler in `renderPath()` calls `renderDelete()`; when the delete button is clicked the list needs to be re-rendered). 

If I completely refactored this into a model/view, I could avoid that problem, but that really seems like overkill here. (On the other hand, we've talked about being more MV-ish in general.)
