### PR TITLE
Fix: No gray JSLint star when Brackets launched with JSLint disabled

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -66,6 +66,7 @@ define(function (require, exports, module) {
     exports.EDIT_DUPLICATE              = "edit.duplicate";
     exports.EDIT_DELETE_LINES           = "edit.deletelines";
     exports.EDIT_LINE_COMMENT           = "edit.lineComment";
+    exports.EDIT_BLOCK_COMMENT          = "edit.blockComment";
     exports.EDIT_LINE_UP                = "edit.lineUp";
     exports.EDIT_LINE_DOWN              = "edit.lineDown";
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -916,6 +916,8 @@ define(function (require, exports, module) {
                                                           platform: "mac"}]);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_LINE_COMMENT,    "Ctrl-/");
+        menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT,   [{key: "Ctrl-Shift-/", platform: "win"},
+                                                         {key: "Ctrl-Alt-/",   platform: "mac"}]);
 
         /*
          * View menu

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -229,13 +229,13 @@ define(function (require, exports, module) {
      * and cursor position. Applies to the currently focused Editor.
      * 
      * If the selection is inside a block-comment or one block-comment is inside or partially 
-     * inside the selection we we uncomment; otherwise we comment out.
-     * Commenting out adds the prefix before the selection and the suffix after
+     * inside the selection we uncomment; otherwise we comment out.
+     * Commenting out adds the prefix before the selection and the suffix after.
      * Uncommenting removes them.
      * 
      * If slashComment is true and the start or end of the selection is inside a line-comment it 
-     * will try to do a line uncomment if all the lines in the selection are line-commented and
-     * will do nothing if at least one line is not line-commented.
+     * will try to do a line uncomment if is not actually inside a bigger block comment and all
+     * the lines in the selection are line-commented.
      *
      * @param {!Editor} editor
      * @param {!String} prefix

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
                 result = TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, startCtx);
             }
             
-            if (!result || startCtx.token.className !== "comment") {
+            if (!result || startCtx.token.className !== "comment" || startCtx.token.string.match(suffixExp)) {
                 if (!_containsUncommented(editor, sel.start.line, sel.end.line)) {
                     lineCommentSlashSlash(editor);
                     return;

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
      * 
      * If the selection is inside a block-comment or one block-comment is inside or partially 
      * inside the selection we we uncomment; otherwise we comment out.
-     * Commenting out adds the prefix before the selection and the suffix after
+     * Commenting out adds the prefix before the selection and the suffix after.
      * Uncommenting removes them.
      * 
      * If slashComment is true and the start or end of the selection is inside a line-comment it 

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
         var $jslintResults  = $("#jslint-results"),
             $jslintContent  = $("#jslint-results .table-container");
         
-        StatusBar.addIndicator(module.id, $("#gold-star"), false);
+        StatusBar.addIndicator(module.id, $("#gold-star"), true);
     });
 
     // Define public API

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -186,6 +186,7 @@ define({
     "CMD_DUPLICATE"                       : "Duplicate",
     "CMD_DELETE_LINES"                    : "Delete Line",
     "CMD_COMMENT"                         : "Toggle Line Comment",
+    "CMD_BLOCK_COMMENT"                   : "Toggle Block Comment",
     "CMD_LINE_UP"                         : "Move Line Up",
     "CMD_LINE_DOWN"                       : "Move Line Down",
      


### PR DESCRIPTION
An easy fix to adobe/brackets#2061
