### PR TITLE
Fix: No gray JSLint star when Brackets launched with JSLint disabled

### DIFF
--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
         var $jslintResults  = $("#jslint-results"),
             $jslintContent  = $("#jslint-results .table-container");
         
-        StatusBar.addIndicator(module.id, $("#gold-star"), false);
+        StatusBar.addIndicator(module.id, $("#gold-star"), true);
     });
 
     // Define public API


### PR DESCRIPTION
An easy fix to adobe/brackets#2061
