### PR TITLE
Batch operation Fix

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -824,7 +824,11 @@ define(function (require, exports, module) {
      */
     Document.prototype.batchOperation = function (doOperation) {
         this._ensureMasterEditor();
-        this._masterEditor._codeMirror.operation(doOperation);
+        
+        var self = this;
+        this._masterEditor._codeMirror.compoundChange(function () {
+            self._masterEditor._codeMirror.operation(doOperation);
+        });
     };
     
     /**


### PR DESCRIPTION
This pull was suggested by @peterflynn in adobe/brackets#2108 to fix the edition undo.

Right now there are only 3 functions that use batchOperation:
1. Line comment
2. Block comment
3. Move line up/down

With this pull all 3 functions would work as before, passing all the tests too, and it will also fix the undo issues on both Block comment and Move line up/down, on the main editor.

I did some tests on the cmv3 branch and the undo issues were still there. I implemented this patch on that branch too and after testing, everything worked perfectly, solving the undo issues too.
