### PR TITLE
Add Preview Highlight functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ src/brackets.min.css
 src/extensions/dev/*
 !src/extensions/dev/README
 
+src/extensions/disabled
+
 #OSX .DS_Store files
 .DS_Store

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -101,6 +101,13 @@ define(function HighlightAgent(require, exports, module) {
         _highlight = {type: "css", ref: name};
         RemoteAgent.call("highlightRule", name);
     }
+    
+    /**
+     * Redraw active highlights
+     */
+    function redraw() {
+        RemoteAgent.call("redrawHighlights");
+    }
 
     /** Initialize the agent */
     function load() {
@@ -117,6 +124,7 @@ define(function HighlightAgent(require, exports, module) {
     exports.hide = hide;
     exports.node = node;
     exports.rule = rule;
+    exports.redraw = redraw;
     exports.load = load;
     exports.unload = unload;
 });

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -94,7 +94,7 @@ define(function HighlightAgent(require, exports, module) {
      * @param {string} rule selector
      */
     function rule(name) {
-        if (_highlight.rule === name) {
+        if (_highlight.ref === name) {
             return;
         }
         hide();

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -34,9 +34,10 @@
 define(function HighlightAgent(require, exports, module) {
     "use strict";
 
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
-    var RemoteAgent = require("LiveDevelopment/Agents/RemoteAgent");
-    var DOMAgent = require("LiveDevelopment/Agents/DOMAgent");
+    var DOMAgent        = require("LiveDevelopment/Agents/DOMAgent"),
+        Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
+        RemoteAgent     = require("LiveDevelopment/Agents/RemoteAgent");
 
     var _highlight; // active highlight
 
@@ -66,6 +67,10 @@ define(function HighlightAgent(require, exports, module) {
      * @param {DOMNode} node
      */
     function node(n) {
+        if (!LiveDevelopment.config.experimental) {
+            return;
+        }
+        
         if (!Inspector.config.highlight) {
             return;
         }
@@ -112,12 +117,16 @@ define(function HighlightAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _highlight = {};
-        $(RemoteAgent).on("highlight.HighlightAgent", _onRemoteHighlight);
+        if (LiveDevelopment.config.experimental) {
+            $(RemoteAgent).on("highlight.HighlightAgent", _onRemoteHighlight);
+        }
     }
 
     /** Clean up */
     function unload() {
-        $(RemoteAgent).off(".HighlightAgent");
+        if (LiveDevelopment.config.experimental) {
+            $(RemoteAgent).off(".HighlightAgent");
+        }
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -223,7 +223,7 @@ function RemoteFunctions(experimental) {
             highlight.style.setProperty("pointer-events", "none");
             if (skipAnimation) {
                 highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
-                highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+                highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.6), inset 0 0 4px 1px rgba(255,255,255,0.8)");
             } else {
                 highlight.style.setProperty("background", "rgba(94,167,255, 0.5)");
                 highlight.style.setProperty("box-shadow", "0 0 2px 1px rgba(94,167,255, 1), inset 0 0 4px 1px rgba(255,255,255,1)");
@@ -241,7 +241,7 @@ function RemoteFunctions(experimental) {
                 window.setTimeout(function () {
                     highlight.style.setProperty("opacity", 1);
                     highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
-                    highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+                    highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.6), inset 0 0 4px 1px rgba(255,255,255,0.8)");
                 }, 0);
             }
         

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -221,8 +221,8 @@ function RemoteFunctions(experimental) {
                 highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
                 highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
             } else {
-                highlight.style.setProperty("background", "rgba(94,167,255, 0.3)");
-                highlight.style.setProperty("box-shadow", "0 0 16px 2px rgba(94,167,255, 0.8), inset 0 0 4px 1px rgba(255,255,255,1)");
+                highlight.style.setProperty("background", "rgba(94,167,255, 0.5)");
+                highlight.style.setProperty("box-shadow", "0 0 16px 2px rgba(94,167,255, 1), inset 0 0 4px 1px rgba(255,255,255,1)");
             }
             highlight.style.setProperty("border-top-left-radius", styles.borderTopLeftRadius);
             highlight.style.setProperty("border-top-right-radius", styles.borderTopRightRadius);
@@ -232,7 +232,7 @@ function RemoteFunctions(experimental) {
             if (!skipAnimation) {
                 highlight.style.setProperty("opacity", 0);
                 highlight.style.setProperty("-webkit-transition-property", "opacity, box-shadow, background");
-                highlight.style.setProperty("-webkit-transition-duration", "0.3s, 0.6s, 0.6s");
+                highlight.style.setProperty("-webkit-transition-duration", "0.3s, 0.4s, 0.4s");
                 
                 window.setTimeout(function () {
                     highlight.style.setProperty("opacity", 1);

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -49,6 +49,10 @@ function RemoteFunctions(experimental) {
 
     // compute the screen offset of an element
     function _screenOffset(element, key) {
+        if (element === document.body) {
+            var bounds = element.getBoundingClientRect();
+            return (key === "offsetLeft" ? bounds.left : bounds.top);
+        }
         var value = 0;
         while (element) {
             value += element[key];

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -217,8 +217,8 @@ function RemoteFunctions(experimental) {
             highlight.style.setProperty("z-index", 2000000);
             highlight.style.setProperty("position", "absolute");
             highlight.style.setProperty("pointer-events", "none");
-            highlight.style.setProperty("background", "rgba(94,167,255, 0.2)");
-            highlight.style.setProperty("box-shadow", "0 0 4px 2px rgba(94,167,255, 0.5)");
+            highlight.style.setProperty("background","rgba(94,167,255, 0.1)");
+            highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
             highlight.style.setProperty("border-top-left-radius", styles.borderTopLeftRadius);
             highlight.style.setProperty("border-top-right-radius", styles.borderTopRightRadius);
             highlight.style.setProperty("border-bottom-left-radius", styles.borderBottomLeftRadius);

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -354,12 +354,6 @@ function RemoteFunctions(experimental) {
         }
     }
 
-    function updateHighlights(event) {
-        if (_remoteHighlight) {
-            _remoteHighlight.redraw();
-        }
-    }
-
     /** Public Commands **********************************************************/
 
     // show goto
@@ -401,24 +395,32 @@ function RemoteFunctions(experimental) {
             highlight(nodes[i]);
         }
     }
+    
+    // redraw active highlights
+    function redrawHighlights() {
+        if (_remoteHighlight) {
+            _remoteHighlight.redraw();
+        }
+    }
 
     // init
     if (experimental) {
         window.document.addEventListener("keydown", onKeyDown);
     }
     
-    window.addEventListener("resize", updateHighlights);
+    window.addEventListener("resize", redrawHighlights);
     
     // Scrolling a div can interfere with highlighting. 
     var i, divs = window.document.getElementsByTagName("div");
     for (i = 0; i < divs.length; i++) {
-        divs[i].addEventListener("scroll", updateHighlights);
+        divs[i].addEventListener("scroll", redrawHighlights);
     }
 
     return {
         "showGoto": showGoto,
         "hideHighlight": hideHighlight,
         "highlight": highlight,
-        "highlightRule": highlightRule
+        "highlightRule": highlightRule,
+        "redrawHighlights": redrawHighlights
     };
 }

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -223,10 +223,10 @@ function RemoteFunctions(experimental) {
             highlight.style.setProperty("pointer-events", "none");
             if (skipAnimation) {
                 highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
-                highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+                highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
             } else {
                 highlight.style.setProperty("background", "rgba(94,167,255, 0.5)");
-                highlight.style.setProperty("box-shadow", "0 0 16px 2px rgba(94,167,255, 1), inset 0 0 4px 1px rgba(255,255,255,1)");
+                highlight.style.setProperty("box-shadow", "0 0 2px 1px rgba(94,167,255, 1), inset 0 0 4px 1px rgba(255,255,255,1)");
             }
             highlight.style.setProperty("border-top-left-radius", styles.borderTopLeftRadius);
             highlight.style.setProperty("border-top-right-radius", styles.borderTopRightRadius);
@@ -241,7 +241,7 @@ function RemoteFunctions(experimental) {
                 window.setTimeout(function () {
                     highlight.style.setProperty("opacity", 1);
                     highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
-                    highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+                    highlight.style.setProperty("box-shadow", "0 0 1px 1px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
                 }, 0);
             }
         

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -204,7 +204,7 @@ function RemoteFunctions(experimental) {
             return false;
         },
 
-        _makeHighlightDiv: function (element) {
+        _makeHighlightDiv: function (element, skipAnimation) {
             var elementBounds = element.getBoundingClientRect(),
                 highlight = window.document.createElement("div"),
                 styles = window.getComputedStyle(element);
@@ -217,17 +217,34 @@ function RemoteFunctions(experimental) {
             highlight.style.setProperty("z-index", 2000000);
             highlight.style.setProperty("position", "absolute");
             highlight.style.setProperty("pointer-events", "none");
-            highlight.style.setProperty("background","rgba(94,167,255, 0.1)");
-            highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+            if (skipAnimation) {
+                highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
+                highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+            } else {
+                highlight.style.setProperty("background", "rgba(94,167,255, 0.3)");
+                highlight.style.setProperty("box-shadow", "0 0 16px 2px rgba(94,167,255, 0.8), inset 0 0 4px 1px rgba(255,255,255,1)");
+            }
             highlight.style.setProperty("border-top-left-radius", styles.borderTopLeftRadius);
             highlight.style.setProperty("border-top-right-radius", styles.borderTopRightRadius);
             highlight.style.setProperty("border-bottom-left-radius", styles.borderBottomLeftRadius);
             highlight.style.setProperty("border-bottom-right-radius", styles.borderBottomRightRadius);
-    
+            
+            if (!skipAnimation) {
+                highlight.style.setProperty("opacity", 0);
+                highlight.style.setProperty("-webkit-transition-property", "opacity, box-shadow, background");
+                highlight.style.setProperty("-webkit-transition-duration", "0.3s, 0.6s, 0.6s");
+                
+                window.setTimeout(function () {
+                    highlight.style.setProperty("opacity", 1);
+                    highlight.style.setProperty("background", "rgba(94,167,255, 0.1)");
+                    highlight.style.setProperty("box-shadow", "0 0 8px 2px rgba(94,167,255, 0.3), inset 0 0 4px 1px rgba(255,255,255,0.6)");
+                }, 0);
+            }
+        
             window.document.body.appendChild(highlight);
         },
         
-        add: function (element) {
+        add: function (element, skipAnimation) {
             if (this._elementExists(element) || element === document) {
                 return;
             }
@@ -236,7 +253,7 @@ function RemoteFunctions(experimental) {
             }
             this.elements.push(element);
             
-            this._makeHighlightDiv(element);
+            this._makeHighlightDiv(element, skipAnimation);
         },
 
         clear: function () {
@@ -255,7 +272,7 @@ function RemoteFunctions(experimental) {
             
             this.clear();
             for (i in highlighted) {
-                this.add(highlighted[i]);
+                this.add(highlighted[i], true);
             }
         }
     };

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -171,6 +171,9 @@ define(function CSSDocumentModule(require, exports, module) {
         // brute force: update the CSS
         CSSAgent.reloadCSSForDocument(this.doc);
         this.reloadRules();
+        if (Inspector.config.highlight) {
+            HighlightAgent.redraw();
+        }
     };
     /** Triggered if the Document's file is deleted */
     CSSDocument.prototype.onDeleted = function onDeleted(event, editor, change) {

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -80,16 +80,11 @@ define(function CSSDocumentModule(require, exports, module) {
         // get the style sheet
         this.styleSheet = CSSAgent.styleForURL(this.doc.url);
 
-        // WebInspector Command: CSS.getStyleSheet
-        Inspector.CSS.getStyleSheet(this.styleSheet.styleSheetId, function callback(res) {
-            // res = {styleSheet}
-            this.rules = res.styleSheet.rules;
-        }.bind(this));
-
         // If the CSS document is dirty, push the changes into the browser now
         if (doc.isDirty) {
             CSSAgent.reloadCSSForDocument(this.doc);
         }
+        this.reloadRules();
     };
 
     /** Get the browser version of the StyleSheet object */
@@ -135,6 +130,13 @@ define(function CSSDocumentModule(require, exports, module) {
         }
     };
 
+    // Reload rules
+    CSSDocument.prototype.reloadRules = function () {
+        this.getStyleSheetFromBrowser().done(function (styleSheet) {
+            this.rules = styleSheet.rules;
+        }.bind(this));
+    };
+    
     // find a rule in the given rules
     CSSDocument.prototype.ruleAtLocation = function ruleAtLocation(location) {
         var i, rule;
@@ -168,9 +170,7 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.onChange = function onChange(event, editor, change) {
         // brute force: update the CSS
         CSSAgent.reloadCSSForDocument(this.doc);
-        this.getStyleSheetFromBrowser().done(function (styleSheet) {
-            this.rules = styleSheet.rules;
-        });
+        this.reloadRules();
     };
     /** Triggered if the Document's file is deleted */
     CSSDocument.prototype.onDeleted = function onDeleted(event, editor, change) {

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -168,6 +168,9 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.onChange = function onChange(event, editor, change) {
         // brute force: update the CSS
         CSSAgent.reloadCSSForDocument(this.doc);
+        this.getStyleSheetFromBrowser().done(function (styleSheet) {
+            this.rules = styleSheet.rules;
+        });
     };
     /** Triggered if the Document's file is deleted */
     CSSDocument.prototype.onDeleted = function onDeleted(event, editor, change) {

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -132,7 +132,6 @@ define(function CSSDocumentModule(require, exports, module) {
 
     // Reload rules
     CSSDocument.prototype.reloadRules = function () {
-        console.assert(!this.loadRulePromise, "Rule promise has not resolved.");
         this.loadRulePromise = this.getStyleSheetFromBrowser().done(function (styleSheet) {
             this.rules = styleSheet.rules;
             this.loadRulePromise = null;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -563,11 +563,11 @@ define(function LiveDevelopment(require, exports, module) {
     
     /** Enable highlighting */
     function showHighlight() {
-        // Trigger an "onCursorChange" in the main editor to
-        // kick highlighting
-        var editor = EditorManager.getActiveEditor();
-        if (editor) {
-            $(editor).trigger("cursorActivity");
+        var doc = _getCurrentDocument();
+        
+        // Force cursor activity to kick highlighting
+        if (_liveDocument instanceof CSSDocument) {
+            _liveDocument.onCursorActivity();
         }
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -104,7 +104,8 @@ define(function LiveDevelopment(require, exports, module) {
         "remote"    : true,
         "network"   : true,
         "dom"       : true,
-        "css"       : true
+        "css"       : true,
+        "highlight" : true
     };
 
     // store the names (matching property names in the 'agent' object) of agents that we've loaded
@@ -569,6 +570,7 @@ define(function LiveDevelopment(require, exports, module) {
         }
 
         if (Inspector.connected()) {
+            hideHighlight();
             if (agents.network && agents.network.wasURLRequested(doc.url)) {
                 _closeDocument();
                 var editor = EditorManager.getCurrentFullEditor();

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -563,8 +563,6 @@ define(function LiveDevelopment(require, exports, module) {
     
     /** Enable highlighting */
     function showHighlight() {
-        var doc = _getCurrentDocument();
-        
         // Force cursor activity to kick highlighting
         if (_liveDocument instanceof CSSDocument) {
             _liveDocument.onCursorActivity();

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -560,6 +560,23 @@ define(function LiveDevelopment(require, exports, module) {
         Inspector.disconnect();
         _setStatus(STATUS_INACTIVE);
     }
+    
+    /** Enable highlighting */
+    function showHighlight() {
+        // Trigger an "onCursorChange" in the main editor to
+        // kick highlighting
+        var editor = EditorManager.getActiveEditor();
+        if (editor) {
+            $(editor).trigger("cursorActivity");
+        }
+    }
+
+    /** Hide any active highlighting */
+    function hideHighlight() {
+        if (Inspector.connected() && agents.highlight) {
+            agents.highlight.hide();
+        }
+    }
 
     /** Triggered by a document change from the DocumentManager */
     function _onDocumentChange() {
@@ -630,13 +647,6 @@ define(function LiveDevelopment(require, exports, module) {
         return foundDoc;
     }
 
-    /** Hide any active highlighting */
-    function hideHighlight() {
-        if (Inspector.connected() && agents.highlight) {
-            agents.highlight.hide();
-        }
-    }
-
     /** Initialize the LiveDevelopment Session */
     function init(theConfig) {
         exports.config = theConfig;
@@ -659,6 +669,7 @@ define(function LiveDevelopment(require, exports, module) {
     exports.enableAgent         = enableAgent;
     exports.disableAgent        = disableAgent;
     exports.getLiveDocForPath   = getLiveDocForPath;
+    exports.showHighlight       = showHighlight;
     exports.hideHighlight       = hideHighlight;
     exports.init                = init;
 });

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -56,7 +56,7 @@ define(function main(require, exports, module) {
         experimental: false, // enable experimental features
         debug: true, // enable debug output and helpers
         autoconnect: false, // go live automatically after startup?
-        highlight: false, // enable highlighting?
+        highlight: true, // enable highlighting?
         highlightConfig: { // the highlight configuration for the Inspector
             borderColor:  {r: 255, g: 229, b: 153, a: 0.66},
             contentColor: {r: 111, g: 168, b: 220, a: 0.55},

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -183,6 +183,21 @@ define(function main(require, exports, module) {
         }
     }
 
+    function _setHighlightCheckmark() {
+        CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setChecked(config.highlight);
+    }
+    
+    function _handlePreviewHighlightCommand() {
+        config.highlight = !config.highlight;
+        _setHighlightCheckmark();
+        if (config.highlight) {
+            LiveDevelopment.showHighlight();
+        } else {
+            LiveDevelopment.hideHighlight();
+        }
+        prefs.setValue("highlight", config.highlight);
+    }
+    
     /** Setup window references to useful LiveDevelopment modules */
     function _setupDebugHelpers() {
         window.ld = LiveDevelopment;
@@ -192,9 +207,10 @@ define(function main(require, exports, module) {
 
     /** Initialize LiveDevelopment */
     function init() {
-        prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY);
+        prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY, {highlight: true});
         params.parse();
 
+        config.highlight = prefs.getValue("highlight");
         Inspector.init(config);
         LiveDevelopment.init(config);
         _loadStyles();
@@ -202,6 +218,8 @@ define(function main(require, exports, module) {
         _setupGoLiveMenu();
 
         /* _setupHighlightButton(); FUTURE - Highlight button */
+        _setHighlightCheckmark();
+        
         if (config.debug) {
             _setupDebugHelpers();
         }
@@ -218,6 +236,7 @@ define(function main(require, exports, module) {
     window.setTimeout(init);
    
     CommandManager.register(Strings.CMD_LIVE_FILE_PREVIEW,  Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
+    CommandManager.register(Strings.CMD_LIVE_HIGHLIGHT, Commands.FILE_LIVE_HIGHLIGHT, _handlePreviewHighlightCommand);
 
     // Export public functions
     exports.init = init;

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -161,6 +161,7 @@ define(function main(require, exports, module) {
             // Update the checkmark next to 'Live Preview' menu item
             // Add checkmark when status is STATUS_ACTIVE; otherwise remove it 
             CommandManager.get(Commands.FILE_LIVE_FILE_PREVIEW).setChecked(status === LiveDevelopment.STATUS_ACTIVE);
+            CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setEnabled(status === LiveDevelopment.STATUS_ACTIVE);
         });
     }
 
@@ -217,6 +218,7 @@ define(function main(require, exports, module) {
    
     CommandManager.register(Strings.CMD_LIVE_FILE_PREVIEW,  Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
     CommandManager.register(Strings.CMD_LIVE_HIGHLIGHT, Commands.FILE_LIVE_HIGHLIGHT, _handlePreviewHighlightCommand);
+    CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setEnabled(false);
 
     // Export public functions
     exports.init = init;

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -164,32 +164,13 @@ define(function main(require, exports, module) {
         });
     }
 
-    /** Create the menu item "Highlight" */
-    function _setupHighlightButton() {
-        // TODO: this should be moved into index.html like the Go Live button once it's re-enabled
-        _$btnHighlight = $("<a href=\"#\">Highlight </a>");
-        $(".nav").append($("<li>").append(_$btnHighlight));
-        _$btnHighlight.click(function onClick() {
-            config.highlight = !config.highlight;
-            if (config.highlight) {
-                _setLabel(_$btnHighlight, _checkMark, "success");
-            } else {
-                _setLabel(_$btnHighlight);
-                LiveDevelopment.hideHighlight();
-            }
-        });
-        if (config.highlight) {
-            _setLabel(_$btnHighlight, _checkMark, "success");
-        }
-    }
-
-    function _setHighlightCheckmark() {
+    function _updateHighlightCheckmark() {
         CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setChecked(config.highlight);
     }
     
     function _handlePreviewHighlightCommand() {
         config.highlight = !config.highlight;
-        _setHighlightCheckmark();
+        _updateHighlightCheckmark();
         if (config.highlight) {
             LiveDevelopment.showHighlight();
         } else {
@@ -217,8 +198,7 @@ define(function main(require, exports, module) {
         _setupGoLiveButton();
         _setupGoLiveMenu();
 
-        /* _setupHighlightButton(); FUTURE - Highlight button */
-        _setHighlightCheckmark();
+        _updateHighlightCheckmark();
         
         if (config.debug) {
             _setupDebugHelpers();

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_WINDOW           = "file.close_window"; // string must MATCH string in native code (brackets_extensions)
     exports.FILE_ADD_TO_WORKING_SET     = "file.addToWorkingSet";
     exports.FILE_LIVE_FILE_PREVIEW      = "file.liveFilePreview";
+    exports.FILE_LIVE_HIGHLIGHT         = "file.previewHighlight";
     exports.FILE_PROJECT_SETTINGS       = "file.projectSettings";
     exports.FILE_RENAME                 = "file.rename";
     exports.FILE_QUIT                   = "file.quit"; // string must MATCH string in native code (brackets_extensions)

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -880,6 +880,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_SAVE_ALL,            "Ctrl-Alt-S");
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW,   "Ctrl-Alt-P");
+        menu.addMenuItem(Commands.FILE_LIVE_HIGHLIGHT,      "Ctrl-Alt-Shift-H");
         menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_QUIT,                "Ctrl-Q");

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -170,7 +170,7 @@ define({
     "CMD_FILE_SAVE"                       : "Save",
     "CMD_FILE_SAVE_ALL"                   : "Save All",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
-    "CMD_LIVE_HIGHLIGHT"                  : "Enable Live Highlight",
+    "CMD_LIVE_HIGHLIGHT"                  : "Live Highlight",
     "CMD_PROJECT_SETTINGS"                : "Project Settings\u2026",
     "CMD_FILE_RENAME"                     : "Rename",
     "CMD_QUIT"                            : "Quit",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -170,6 +170,7 @@ define({
     "CMD_FILE_SAVE"                       : "Save",
     "CMD_FILE_SAVE_ALL"                   : "Save All",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
+    "CMD_LIVE_HIGHLIGHT"                  : "Enable Live Highlight",
     "CMD_PROJECT_SETTINGS"                : "Project Settings\u2026",
     "CMD_FILE_RENAME"                     : "Rename",
     "CMD_QUIT"                            : "Quit",


### PR DESCRIPTION
This pull request adds a new "Preview Highlight" feature. When enabled, putting the cursor in a CSS rule will highlight all instances of that rule in the Live Preview browser. This highlighting is only done if a Live Preview connection has been established.

**Menu Item**
There is a new _File > Enable Live Highlight_ menu item, which is checked by default. This setting is stored in prefs and is remembered across launches.

**Highlighting**
The highlighting is done by overlaying a styled `<div>` element on top of the element being highlighted. The highlight div is updated whenever the window is resized, any div is scrolled, or the contents of the style rule have changed. 

**Limitations**
Highlighting only works from .CSS files open in the main editor. There is a separate backlog story to make it work in `<style>` tags in .html files. 

Highlighting is not working in inline editors. This will be resolved in a subsequent pull request.
