### PR TITLE
Update color picker when user makes edits in host editor

### DIFF
--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -62,20 +62,22 @@ define(function (require, exports, module) {
         
         end = this.endBookmark.find();
         if (!end || start.ch === end.ch) {
-            // Try to re-locate the end by matching the color regex.
-            var endCh,
+            // Try to re-locate the end by matching the color regex. If we can't locate the end,
+            // collapse the range so we'll rethink the bookmark on the next edit.
+            var endCh = start.ch,
+                updateBookmark = false,
                 matches = this.editor.document.getLine(start.line).slice(start.ch).match(InlineColorEditor.colorRegEx);
             if (matches) {
-                endCh = start.ch + matches[0].length;
-            } else {
-                // Couldn't match a color. Assume our current color length.
-                endCh = start.ch + (this.color ? this.color.length : 0);
+                updateBookmark = true;
+                endCh += matches[0].length;
             }
             end = { line: start.line, ch: endCh };
             
             // Update our end bookmark.
             this.endBookmark.clear();
-            this.endBookmark = this.editor._codeMirror.setBookmark(end);
+            if (updateBookmark) {
+                this.endBookmark = this.editor._codeMirror.setBookmark(end);
+            }
         }
         
         return {start: start, end: end};

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -37,10 +37,11 @@ define(function (require, exports, module) {
         this.color = color;
         this.startBookmark = startBookmark;
         this.endBookmark = endBookmark;
-        this.setColor = this.setColor.bind(this);
-        this.handleHostDocumentChange = this.handleHostDocumentChange.bind(this);
         this.isOwnChange = false;
         this.isHostChange = false;
+
+        this.setColor = this.setColor.bind(this);
+        this.handleHostDocumentChange = this.handleHostDocumentChange.bind(this);
 
         InlineWidget.call(this);
     }
@@ -51,6 +52,12 @@ define(function (require, exports, module) {
     InlineColorEditor.prototype.constructor = InlineColorEditor;
     InlineColorEditor.prototype.parentClass = InlineWidget.prototype;
     InlineColorEditor.prototype.$wrapperDiv = null;
+    
+    InlineColorEditor.prototype.color = null;
+    InlineColorEditor.prototype.startBookmark = null;
+    InlineColorEditor.prototype.endBookmark = null;
+    InlineColorEditor.prototype.isOwnChange = null;
+    InlineColorEditor.prototype.isHostChange = null;
     
     InlineColorEditor.prototype.getCurrentRange = function () {
         var start, end;
@@ -74,8 +81,10 @@ define(function (require, exports, module) {
         // CodeMirror v2, markText() isn't robust enough for this case.)
         
         var line = this.editor.document.getLine(start.line),
-            matches = line.slice(start.ch).match(InlineColorEditor.colorRegEx);
+            matches = line.substr(start.ch).match(InlineColorEditor.colorRegEx);
         
+        // Note that end.ch is exclusive, so we don't need to add 1 before comparing to
+        // the matched length here.
         if (matches && (end.ch === undefined || end.ch - start.ch < matches[0].length)) {
             end.ch = start.ch + matches[0].length;
             this.endBookmark.clear();

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
     };
         
     InlineColorEditor.prototype.setColor = function (colorLabel) {
-        if (this.isHostChange || !colorLabel) {
+        if (!colorLabel) {
             return;
         }
         
@@ -91,14 +91,18 @@ define(function (require, exports, module) {
             if (!range) {
                 return;
             }
+
+            // Don't push the change back into the host editor if it came from the host editor.
+            if (!this.isHostChange) {
+                this.isOwnChange = true;
+                this.editor.document.replaceRange(colorLabel, range.start, range.end);
+                this.isOwnChange = false;
+                this.editor.setSelection(range.start, {
+                    line: range.start.line,
+                    ch: range.start.ch + colorLabel.length
+                });
+            }
             
-            this.isOwnChange = true;
-            this.editor.document.replaceRange(colorLabel, range.start, range.end);
-            this.isOwnChange = false;
-            this.editor.setSelection(range.start, {
-                line: range.start.line,
-                ch: range.start.ch + colorLabel.length
-            });
             this.color = colorLabel;
         }
     };
@@ -193,6 +197,7 @@ define(function (require, exports, module) {
     };
     
     InlineColorEditor.prototype.handleHostDocumentChange = function () {
+        // Don't push the change into the color editor if it came from the color editor.
         if (this.isOwnChange) {
             return;
         }

--- a/src/extensions/default/InlineColorEditor/unittests.css
+++ b/src/extensions/default/InlineColorEditor/unittests.css
@@ -1,0 +1,3 @@
+.bg-rule {
+    background: #abcdef;
+}

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -125,11 +125,22 @@ define(function (require, exports, module) {
             });
         });
         
-        it("should not update the end bookmark to a shorter valid match if the color becomes invalid", function () {
+        it("should not update the end bookmark to a shorter valid match if the bookmark still exists color becomes invalid", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
                 testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
                 expect(inline.color).toBe("#abcde");
             });
         });
+        
+        // The following test fails because if the end bookmark is deleted, we match the shorter
+        // #xxx string at the beginning of the color and assume that's valid, and then reset the bookmark
+        // to the end of that location. Filed as #2166.
+//        it("should not update the end bookmark to a shorter valid match if the bookmark no longer exists and the color becomes invalid", function () {
+//            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+//                testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 24});
+//                expect(inline.color).toBe("#abcde");
+//            });
+//        });
+       
     });
 });

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -106,5 +106,26 @@ define(function (require, exports, module) {
                 expect(inline.colorEditor.color.toHexString().toLowerCase()).toEqual("#a0cdef");
             });
         });
+        
+        it("should properly apply a change after edit is made that destroys end bookmark", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                // Replace everything including the semicolon, so it crosses the bookmark boundary.
+                testDocument.replaceRange("rgb(255, 255, 255);", {line: 1, ch: 16}, {line: 1, ch: 24});
+                expect(inline.color).toBe("rgb(255, 255, 255)");
+                inline.colorEditor.commitColor("rgb(0, 0, 0)", true);
+                expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
+            });
+        });
+        it("should properly apply a change after multiple edits are made that destroys end bookmark", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                // This simulates deleting the existing color (and semicolon) and then retyping it in pieces.
+                testDocument.replaceRange("", {line: 1, ch: 16}, {line: 1, ch: 24});
+                testDocument.replaceRange("rgb(255,", {line: 1, ch: 16}, {line: 1, ch: 16});
+                testDocument.replaceRange(" 255, 255);", {line: 1, ch: 24}, {line: 1, ch: 24});
+                expect(inline.color).toBe("rgb(255, 255, 255)");
+                inline.colorEditor.commitColor("rgb(0, 0, 0)", true);
+                expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
+            });
+        });
     });
 });

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, spyOn */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    // Modules from the SpecRunner window
+    var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
+        Editor          = brackets.getModule("editor/Editor").Editor,
+        CodeHintManager = brackets.getModule("editor/CodeHintManager"),
+        DocumentManager = brackets.getModule("editor/DocumentManager"),
+        testContent     = require("text!unittests.css"),
+        tinycolor       = require("thirdparty/tinycolor-min"),
+        provider        = require("main").inlineColorEditorProvider;
+
+    describe("Inline Color Editor", function () {
+
+        var defaultContent = "";
+        
+        var testWindow;
+        var testDocument, testEditor;
+        
+        function makeColorEditor(cursor) {
+            var result = new $.Deferred(), editorPromise, inline;
+            runs(function () {
+                editorPromise = provider(this.editor, {line: 1, ch: 18})
+                    .done(function (result) {
+                        inline = result;
+                    });
+            });
+            waitsForDone(editorPromise, "open color editor", 500);
+            runs(function () {
+                result.resolve(inline);
+            });
+            return result;
+        }
+        
+        beforeEach(function () {
+            // create dummy Document for the Editor
+            testDocument = SpecRunnerUtils.createMockDocument(testContent);
+            
+            // create Editor instance (containing a CodeMirror instance)
+            $("body").append("<div id='editor'/>");
+            testEditor = new Editor(testDocument, true, "css", $("#editor").get(0), {});
+        });
+        
+        afterEach(function () {
+            testEditor.destroy();
+            testEditor = null;
+            $("#editor").remove();
+            testDocument = null;
+        });
+ 
+        it("should show the correct color when opened on an #rrggbb color", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                expect(inline).toBeTruthy();
+                expect(inline.color).toBe("#abcdef");
+            });
+        });
+        
+        it("should properly add/remove ref to document when opened/closed", function () {
+            runs(function () {
+                spyOn(this.testDocument, "addRef").andCallThrough();
+                spyOn(this.testDocument, "releaseRef").andCallThrough();
+            });
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                expect(this.testDocument.addRef).toHaveBeenCalled();
+                expect(this.testDocument.addRef.callCount).toBe(1);
+                
+                inline.onClosed();
+                expect(this.testDocument.releaseRef).toHaveBeenCalled();
+                expect(this.testDocument.releaseRef.callCount).toBe(1);
+            });
+        });
+        
+        it("should update when edit is made to color range in host editor", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                this.testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
+                expect(inline.color).toBe("#ab0def");
+                expect(inline.colorEditor.color.toHexString().toLowerCase()).toEqual("#ab0def");
+            });
+        });
+    });
+});

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -38,9 +38,6 @@ define(function (require, exports, module) {
 
     describe("Inline Color Editor", function () {
 
-        var defaultContent = "";
-        
-        var testWindow;
         var testDocument, testEditor;
         
         function makeColorEditor(cursor) {
@@ -51,7 +48,7 @@ define(function (require, exports, module) {
                         result.onAdded();
                         inline = result;
                     });
-                waitsForDone(editorPromise, "open color editor", 500);
+                waitsForDone(editorPromise, "open color editor");
             });
             runs(function () {
                 result.resolve(inline);
@@ -60,18 +57,14 @@ define(function (require, exports, module) {
         }
         
         beforeEach(function () {
-            // create dummy Document for the Editor
-            testDocument = SpecRunnerUtils.createMockDocument(testContent);
-            
-            // create Editor instance (containing a CodeMirror instance)
-            $("body").append("<div id='editor'/>");
-            testEditor = new Editor(testDocument, true, "css", $("#editor").get(0), {});
+            var mock = SpecRunnerUtils.createMockEditor(testContent, "css");
+            testDocument = mock.doc;
+            testEditor = mock.editor;
         });
         
         afterEach(function () {
-            testEditor.destroy();
+            SpecRunnerUtils.destroyMockEditor(testDocument);
             testEditor = null;
-            $("#editor").remove();
             testDocument = null;
         });
  
@@ -103,11 +96,11 @@ define(function (require, exports, module) {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
                 testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
                 expect(inline.color).toBe("#a0cdef");
-                expect(inline.colorEditor.color.toHexString().toLowerCase()).toEqual("#a0cdef");
+                expect(inline.colorEditor.color.toHexString().toLowerCase()).toBe("#a0cdef");
             });
         });
         
-        it("should close if edit is made that destroys end bookmark and leaves color invalid", function () {
+        it("should close itself if edit is made that destroys end bookmark and leaves color invalid", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
                 spyOn(inline, "close");
                 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -116,6 +116,7 @@ define(function (require, exports, module) {
                 expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
             });
         });
+        
         it("should properly apply a change after multiple edits are made that destroys end bookmark", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
                 // This simulates deleting the existing color (and semicolon) and then retyping it in pieces.
@@ -125,6 +126,21 @@ define(function (require, exports, module) {
                 expect(inline.color).toBe("rgb(255, 255, 255)");
                 inline.colorEditor.commitColor("rgb(0, 0, 0)", true);
                 expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
+            });
+        });
+        
+        it("should maintain the range if the user deletes the last character of the color and types a new one", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
+                testDocument.replaceRange("0", {line: 1, ch: 22}, {line: 1, ch: 22});
+                expect(inline.color).toBe("#abcde0");
+            });
+        });
+        
+        it("should not update the end bookmark to a shorter valid match if the color becomes invalid", function () {
+            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
+                expect(inline.color).toBe("#abcde");
             });
         });
     });

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -94,9 +94,12 @@ define(function (require, exports, module) {
         
         it("should update when edit is made to color range in host editor", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                spyOn(inline, "close");
+
                 testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
                 expect(inline.color).toBe("#a0cdef");
                 expect(inline.colorEditor.color.toHexString().toLowerCase()).toBe("#a0cdef");
+                expect(inline.close).not.toHaveBeenCalled();
             });
         });
         
@@ -112,9 +115,12 @@ define(function (require, exports, module) {
         
         it("should maintain the range if the user deletes the last character of the color and types a new one", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                spyOn(inline, "close");
+
                 testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
                 testDocument.replaceRange("0", {line: 1, ch: 22}, {line: 1, ch: 22});
                 expect(inline.color).toBe("#abcde0");
+                expect(inline.close).not.toHaveBeenCalled();
             });
         });
         

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -107,25 +107,13 @@ define(function (require, exports, module) {
             });
         });
         
-        it("should properly apply a change after edit is made that destroys end bookmark", function () {
+        it("should close if edit is made that destroys end bookmark and leaves color invalid", function () {
             makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                spyOn(inline, "close");
+                
                 // Replace everything including the semicolon, so it crosses the bookmark boundary.
-                testDocument.replaceRange("rgb(255, 255, 255);", {line: 1, ch: 16}, {line: 1, ch: 24});
-                expect(inline.color).toBe("rgb(255, 255, 255)");
-                inline.colorEditor.commitColor("rgb(0, 0, 0)", true);
-                expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
-            });
-        });
-        
-        it("should properly apply a change after multiple edits are made that destroys end bookmark", function () {
-            makeColorEditor({line: 1, ch: 18}).done(function (inline) {
-                // This simulates deleting the existing color (and semicolon) and then retyping it in pieces.
-                testDocument.replaceRange("", {line: 1, ch: 16}, {line: 1, ch: 24});
-                testDocument.replaceRange("rgb(255,", {line: 1, ch: 16}, {line: 1, ch: 16});
-                testDocument.replaceRange(" 255, 255);", {line: 1, ch: 24}, {line: 1, ch: 24});
-                expect(inline.color).toBe("rgb(255, 255, 255)");
-                inline.colorEditor.commitColor("rgb(0, 0, 0)", true);
-                expect(testDocument.getLine(1).slice(16)).toEqual("rgb(0, 0, 0);");
+                testDocument.replaceRange("rgb(255, 25", {line: 1, ch: 16}, {line: 1, ch: 24});
+                expect(inline.close).toHaveBeenCalled();
             });
         });
         

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -54,6 +54,10 @@ define(function (require, exports, module) {
     // Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
     
+    // TODO (#2155): These are used by extensions via brackets.getModule(), so tests that run those
+    // extensions need these to be required up front. We need a better solution for this eventually.
+    require("utils/ExtensionUtils");
+    
     // Load both top-level suites. Filtering is applied at the top-level as a filter to BootstrapReporter.
     require("test/UnitTestSuite");
     require("test/PerformanceTestSuite");


### PR DESCRIPTION
In addition to that behavior change, I also factored out logic for getting the current host editor range associated with the inline editor. I also tweaked that logic to make it a little more robust to host edits--if the end bookmark goes stale, instead of just assuming that the relevant range still corresponds to the original color length, we first re-check the color regex to try to determine the end.

Note that this is currently independent of #2142. We might want to reuse the logic from that pull request that avoids synchronizing when the text input field contains an invalid color value, and apply that to changes from the host editor as well. However, this pull could be reviewed independently of that, and we could merge the implementations later; the change would be to make `handleHostEditorChange()` call that factored-out logic instead of directly calling `commitColor()`.
