### PR TITLE
FileSystem Implementation (#247)

### DIFF
--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -128,8 +128,8 @@ define(function (require, exports, module) {
 
     function _handleSwitchLanguage() {
         var stringsPath = FileUtils.getNativeBracketsDirectoryPath() + "/nls";
-        NativeFileSystem.requestNativeFileSystem(stringsPath, function (dirEntry) {
-            dirEntry.createReader().readEntries(function (entries) {
+        NativeFileSystem.requestNativeFileSystem(stringsPath, function (fs) {
+            fs.root.createReader().readEntries(function (entries) {
 
                 var $activeLanguage,
                     $submit,

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -356,8 +356,9 @@ define(function (require, exports, module) {
             self.cachedHints = {};
             self.cachedHints.unfiltered = [];
 
-            NativeFileSystem.requestNativeFileSystem(targetDir, function (dirEntry) {
-                dirEntry.createReader().readEntries(function (entries) {
+            NativeFileSystem.requestNativeFileSystem(targetDir, function (fs) {
+                console.log(fs);
+                fs.root.createReader().readEntries(function (entries) {
 
                     entries.forEach(function (entry) {
                         if (ProjectManager.shouldShow(entry)) {

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -357,7 +357,6 @@ define(function (require, exports, module) {
             self.cachedHints.unfiltered = [];
 
             NativeFileSystem.requestNativeFileSystem(targetDir, function (fs) {
-                console.log(fs);
                 fs.root.createReader().readEntries(function (entries) {
 
                     entries.forEach(function (entry) {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -208,8 +208,9 @@ define(function (require, exports, module) {
     
     /** class: Entry
      *
-     * @param {string} name
-     * @param {string} isFile
+     * @param {string} fullPath
+     * @param {boolean} isDirectory
+     * @param {FileSystem} fs
      * @constructor
      */
     NativeFileSystem.Entry = function (fullPath, isDirectory, fs) {
@@ -291,6 +292,7 @@ define(function (require, exports, module) {
      * This interface represents a file on a file system.
      *
      * @param {string} name
+     * @param {FileSystem} fs
      * @constructor
      * @extends {Entry}
      */
@@ -524,6 +526,7 @@ define(function (require, exports, module) {
      *
      * @constructor
      * @param {string} name
+     * @param {FileSystem} fs
      * @extends {Entry}
      */
     NativeFileSystem.DirectoryEntry = function (name, fs) {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -739,7 +739,8 @@ define(function (require, exports, module) {
         if (!brackets.inBrowser) {
             // Point at a real folder structure on local disk
             NativeFileSystem.requestNativeFileSystem(rootPath,
-                function (rootEntry) {
+                function (fs) {
+                    var rootEntry = fs.root;
                     var projectRootChanged = (!_projectRoot || !rootEntry)
                         || _projectRoot.fullPath !== rootEntry.fullPath;
 

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -162,8 +162,8 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
         
         NativeFileSystem.requestNativeFileSystem(directory,
-            function (rootEntry) {
-                rootEntry.createReader().readEntries(
+            function (fs) {
+                fs.root.createReader().readEntries(
                     function (entries) {
                         var i,
                             extensions = [];

--- a/test/spec/LiveDevelopment-test-files/simple1.html
+++ b/test/spec/LiveDevelopment-test-files/simple1.html
@@ -8,6 +8,6 @@
 </head>
 
 <body>
-<p id="testId" class="testClass">Brackets is awesome!</p>
+<p id="testId" class="testClass">Live Preview in Brackets is awesome!</p>
 </body>
 </html>

--- a/test/spec/LiveDevelopment-test-files/simple1.html
+++ b/test/spec/LiveDevelopment-test-files/simple1.html
@@ -8,6 +8,6 @@
 </head>
 
 <body>
-<p id="testId" class="testClass">Live Preview in Brackets is awesome!</p>
+<p id="testId" class="testClass">Brackets is awesome!</p>
 </body>
 </html>

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -214,7 +214,6 @@ define(function (require, exports, module) {
                         // TODO: (issue #241): implement FileEntry.remove()
                         // once NativeFileSystem has a delete/unlink, should use that
                         brackets.fs.unlink(placeholderPath, function (err) {
-                            console.log(err);
                             if (!err) {
                                 placeholderDeleted = true;
                             }

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
                     deferred = new $.Deferred();
                 
                 function requestNativeFileSystemSuccessCB(nfs) {
-                    var reader = nfs.createReader();
+                    var reader = nfs.root.createReader();
 
                     var successCallback = function (e) { entries = e; deferred.resolve(); };
                     var errorCallback = function () { deferred.reject(); };
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
                     deferred = new $.Deferred();
                 
                 function requestNativeFileSystemSuccessCB(nfs) {
-                    var reader = nfs.createReader();
+                    var reader = nfs.root.createReader();
 
                     var successCallback = function (e) { entries = e; deferred.resolve(); };
                     var errorCallback = function () { deferred.reject(); };
@@ -190,14 +190,14 @@ define(function (require, exports, module) {
                     accessedFolder = true;
                 
                     function recreatePlaceholder(deferred) {
-                        nfs.getFile("placeholder",
+                        nfs.root.getFile("placeholder",
                                     { create: true, exclusive: true },
                                     function () { placeholderRecreated = true; deferred.resolve(); },
                                     function () { placeholderRecreated = false; deferred.reject(); });
                     }
 
                     function readDirectory() {
-                        var reader = nfs.createReader();
+                        var reader = nfs.root.createReader();
                         var successCallback = function (e) {
                             entries = e;
                             recreatePlaceholder(deferred);
@@ -214,6 +214,7 @@ define(function (require, exports, module) {
                         // TODO: (issue #241): implement FileEntry.remove()
                         // once NativeFileSystem has a delete/unlink, should use that
                         brackets.fs.unlink(placeholderPath, function (err) {
+                            console.log(err);
                             if (!err) {
                                 placeholderDeleted = true;
                             }
@@ -254,7 +255,7 @@ define(function (require, exports, module) {
                 this.after(function () { brackets.fs.stat = oldStat; });
                 
                 function requestNativeFileSystemSuccessCB(nfs) {
-                    var reader = nfs.createReader();
+                    var reader = nfs.root.createReader();
                     
                     var successCallback = function (e) { readComplete = true; };
                     var errorCallback = function (error) { readComplete = true; gotError = true; theError = error; };
@@ -472,8 +473,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    // FIXME (issue #247): NativeFileSystem.root is missing
-                    this.nfs.getFile("new-zero-length-file.txt", { create: true, exclusive: true }, successCallback, errorCallback);
+                    this.nfs.root.getFile("new-zero-length-file.txt", { create: true, exclusive: true }, successCallback, errorCallback);
                 });
 
                 waitsFor(function () { return writeComplete; }, 1000);
@@ -526,8 +526,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    // FIXME (issue #247): NativeFileSystem.root is missing
-                    this.nfs.getFile("does-not-exist.txt", { create: false }, successCallback, errorCallback);
+                    this.nfs.root.getFile("does-not-exist.txt", { create: false }, successCallback, errorCallback);
                 });
 
                 waitsFor(function () { return writeComplete; }, 1000);
@@ -555,8 +554,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    // FIXME (issue #247): NativeFileSystem.root is missing
-                    this.nfs.getFile("file1", { create: true, exclusive: true }, successCallback, errorCallback);
+                    this.nfs.root.getFile("file1", { create: true, exclusive: true }, successCallback, errorCallback);
                 });
 
                 // wait for success or error to return
@@ -587,8 +585,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    // FIXME (issue #247): NativeFileSystem.root is missing
-                    this.nfs.getFile("dir1", { create: false }, successCallback, errorCallback);
+                    this.nfs.root.getFile("dir1", { create: false }, successCallback, errorCallback);
                 });
 
                 // wait for success or error to return
@@ -628,7 +625,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    this.nfs.getFile("file1", { create: false }, successCallback, errorCallback);
+                    this.nfs.root.getFile("file1", { create: false }, successCallback, errorCallback);
                 });
 
                 waitsFor(function () { return writeComplete && fileEntry; }, 1000);
@@ -685,7 +682,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    this.nfs.getFile("file1", { create: false }, successCallback, errorCallback);
+                    this.nfs.root.getFile("file1", { create: false }, successCallback, errorCallback);
                 });
 
                 waitsFor(function () { return writeComplete && fileEntry; }, 1000);
@@ -726,7 +723,7 @@ define(function (require, exports, module) {
 
                 // createWriter() should return an error for files it can't read
                 runs(function () {
-                    this.nfs.getFile(
+                    this.nfs.root.getFile(
                         "cant_read_here.txt",
                         { create: false },
                         function (entry) {
@@ -768,7 +765,7 @@ define(function (require, exports, module) {
                         writeComplete = true;
                     };
 
-                    this.nfs.getFile("cant_write_here.txt", { create: false }, successCallback, errorCallback);
+                    this.nfs.root.getFile("cant_write_here.txt", { create: false }, successCallback, errorCallback);
                 });
 
                 // fileWriter.onerror handler should be invoked for read only files


### PR DESCRIPTION
This pull request implements the `FileSystem` interface described in http://www.w3.org/TR/file-system-api/#the-filesystem-interface and modifies `NativeFileSystem.requestNativeFileSystem` to return a `FileSystem` object with a root `DirectoryEntry` following the [specs](http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-requestFileSystem-void-unsigned-short-type-unsigned-long-long-size-FileSystemCallback-successCallback-ErrorCallback-errorCallback).

As indicated in #247, it also updates all existing calls to `requestNativeFileSystem` (tests included) to get the root DirectoryEntry.

This is a dangerous change that could potentially break several extensions so we may want to implement this in a more backward compatible manner. However, I've done a global find in all the extensions listed in the wiki and only [brackets-snippets](https://github.com/jrowny/brackets-snippets) seems to be calling `requestNativeFileSystem` directly, so it looks less disruptive than I originally thought...
