### PR TITLE
Support Live Highlight from inline editors

### DIFF
--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -219,9 +219,7 @@ define(function CSSDocumentModule(require, exports, module) {
 
     /** Triggered when the active editor changes */
     CSSDocument.prototype.onActiveEditorChange = function (event, newActive, oldActive) {
-        if (oldActive && oldActive === this.editor) {
-            this.detachFromEditor();
-        }
+        this.detachFromEditor();
         
         if (newActive && newActive.document === this.doc) {
             this.attachToEditor(newActive);

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -48,27 +48,21 @@
 define(function CSSDocumentModule(require, exports, module) {
     "use strict";
 
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
-    var CSSAgent = require("LiveDevelopment/Agents/CSSAgent");
-    var HighlightAgent = require("LiveDevelopment/Agents/HighlightAgent");
+    var CSSAgent        = require("LiveDevelopment/Agents/CSSAgent"),
+        EditorManager   = require("editor/EditorManager"),
+        HighlightAgent  = require("LiveDevelopment/Agents/HighlightAgent"),
+        Inspector       = require("LiveDevelopment/Inspector/Inspector");
 
     /** Constructor
      *
      * @param Document the source document from Brackets
      */
-    var CSSDocument = function CSSDocument(doc, editor, inspector) {
+    var CSSDocument = function CSSDocument(doc, editor) {
         this.doc = doc;
 
-        // only enable highlighting if this document is attached to the main editor
-        this.editor = editor;
         this._highlight = [];
-        if (this.editor) {
-            this.onHighlight = this.onHighlight.bind(this);
-            this.onCursorActivity = this.onCursorActivity.bind(this);
-            $(HighlightAgent).on("highlight", this.onHighlight);
-            $(this.editor).on("cursorActivity", this.onCursorActivity);
-            this.onCursorActivity();
-        }
+        this.onHighlight = this.onHighlight.bind(this);
+        this.onCursorActivity = this.onCursorActivity.bind(this);
 
         // Add a ref to the doc since we're listening for change events
         this.doc.addRef();
@@ -85,6 +79,14 @@ define(function CSSDocumentModule(require, exports, module) {
             CSSAgent.reloadCSSForDocument(this.doc);
         }
         this.reloadRules();
+        
+        this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
+        $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
+        
+        if (editor) {
+            // Attach now
+            this.attachToEditor(editor);
+        }
     };
 
     /** Get the browser version of the StyleSheet object */
@@ -116,20 +118,35 @@ define(function CSSDocumentModule(require, exports, module) {
 
         return deferred.promise();
     };
-
+ 
     /** Close the document */
     CSSDocument.prototype.close = function close() {
         $(this.doc).off("change", this.onChange);
         $(this.doc).off("deleted", this.onDeleted);
         this.doc.releaseRef();
+        this.detachFromEditor();
+    };
 
+    CSSDocument.prototype.attachToEditor = function (editor) {
+        this.editor = editor;
+        
         if (this.editor) {
+            $(HighlightAgent).on("highlight", this.onHighlight);
+            $(this.editor).on("cursorActivity", this.onCursorActivity);
+            this.updateHighlight();
+        }
+    };
+    
+    CSSDocument.prototype.detachFromEditor = function () {
+        if (this.editor) {
+            HighlightAgent.hide();
             $(HighlightAgent).off("highlight", this.onHighlight);
             $(this.editor).off("cursorActivity", this.onCursorActivity);
             this.onHighlight();
+            this.editor = null;
         }
     };
-
+    
     // Reload rules
     CSSDocument.prototype.reloadRules = function () {
         this.loadRulePromise = this.getStyleSheetFromBrowser().done(function (styleSheet) {
@@ -154,11 +171,7 @@ define(function CSSDocumentModule(require, exports, module) {
         return null;
     };
 
-
-    /** Event Handlers *******************************************************/
-
-    /** Triggered on cursor activity of the editor */
-    CSSDocument.prototype.onCursorActivity = function onCursorActivity(event, editor) {
+    CSSDocument.prototype.updateHighlight = function () {
         if (Inspector.config.highlight) {
             // If there is an active loadRulePromise, we can't accurately get the rule
             // at the location. Set a flag here so we can get called again once the
@@ -176,6 +189,13 @@ define(function CSSDocumentModule(require, exports, module) {
                 HighlightAgent.hide();
             }
         }
+    };
+
+    /** Event Handlers *******************************************************/
+
+    /** Triggered on cursor activity of the editor */
+    CSSDocument.prototype.onCursorActivity = function onCursorActivity(event, editor) {
+        this.updateHighlight();
     };
 
     /** Triggered whenever the Document is edited */
@@ -197,6 +217,17 @@ define(function CSSDocumentModule(require, exports, module) {
         $(this).triggerHandler("deleted", [this]);
     };
 
+    /** Triggered when the active editor changes */
+    CSSDocument.prototype.onActiveEditorChange = function (event, newActive, oldActive) {
+        if (oldActive && oldActive === this.editor) {
+            this.detachFromEditor();
+        }
+        
+        if (newActive && newActive.document === this.doc) {
+            this.attachToEditor(newActive);
+        }
+    };
+    
     /** Triggered by the HighlightAgent to highlight a node in the editor */
     CSSDocument.prototype.onHighlight = function onHighlight(event, node) {
         // clear an existing highlight

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -246,24 +246,7 @@ define(function LiveDevelopment(require, exports, module) {
         if (!editor) {
             return null;
         }
-        
-        var docsToSearch = [];
-        if (_relatedDocuments) {
-            docsToSearch = docsToSearch.concat(_relatedDocuments);
-        }
-        if (_liveDocument) {
-            docsToSearch = docsToSearch.concat(_liveDocument);
-        }
-        var foundDoc;
-        docsToSearch.some(function matchesEditor(ele) {
-            if (ele.doc === editor.document) {
-                foundDoc = ele;
-                return true;
-            }
-            return false;
-        });
-
-        return foundDoc;
+        return getLiveDocForPath(editor.document.file.fullPath);
     }
     
     /**
@@ -611,7 +594,7 @@ define(function LiveDevelopment(require, exports, module) {
     function showHighlight() {
         var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
         
-        if (doc && doc instanceof CSSDocument) {
+        if (doc instanceof CSSDocument) {
             doc.updateHighlight();
         }
     }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -222,6 +222,50 @@ define(function LiveDevelopment(require, exports, module) {
         return null;
     }
 
+    function getLiveDocForPath(path) {
+        var docsToSearch = [];
+        if (_relatedDocuments) {
+            docsToSearch = docsToSearch.concat(_relatedDocuments);
+        }
+        if (_liveDocument) {
+            docsToSearch = docsToSearch.concat(_liveDocument);
+        }
+        var foundDoc;
+        docsToSearch.some(function matchesPath(ele) {
+            if (ele.doc.file.fullPath === path) {
+                foundDoc = ele;
+                return true;
+            }
+            return false;
+        });
+
+        return foundDoc;
+    }
+    
+    function getLiveDocForEditor(editor) {
+        if (!editor) {
+            return null;
+        }
+        
+        var docsToSearch = [];
+        if (_relatedDocuments) {
+            docsToSearch = docsToSearch.concat(_relatedDocuments);
+        }
+        if (_liveDocument) {
+            docsToSearch = docsToSearch.concat(_liveDocument);
+        }
+        var foundDoc;
+        docsToSearch.some(function matchesEditor(ele) {
+            if (ele.doc === editor.document) {
+                foundDoc = ele;
+                return true;
+            }
+            return false;
+        });
+
+        return foundDoc;
+    }
+    
     /**
      * Removes the given CSS/JSDocument from _relatedDocuments. Signals that the
      * given file is no longer associated with the HTML document that is live (e.g.
@@ -275,11 +319,13 @@ define(function LiveDevelopment(require, exports, module) {
             // stuff from happening while we wait to add these listeners
             DocumentManager.getDocumentForPath(_urlToPath(url))
                 .done(function (doc) {
-                    _setDocInfo(doc);
-                    var liveDoc = _createDocument(doc);
-                    if (liveDoc) {
-                        _relatedDocuments.push(liveDoc);
-                        $(liveDoc).on("deleted", _handleRelatedDocumentDeleted);
+                    if (!_liveDocument || (doc !== _liveDocument.doc)) {
+                        _setDocInfo(doc);
+                        var liveDoc = _createDocument(doc);
+                        if (liveDoc) {
+                            _relatedDocuments.push(liveDoc);
+                            $(liveDoc).on("deleted", _handleRelatedDocumentDeleted);
+                        }
                     }
                 });
         });
@@ -563,9 +609,10 @@ define(function LiveDevelopment(require, exports, module) {
     
     /** Enable highlighting */
     function showHighlight() {
-        // Force cursor activity to kick highlighting
-        if (_liveDocument instanceof CSSDocument) {
-            _liveDocument.onCursorActivity();
+        var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
+        
+        if (doc && doc instanceof CSSDocument) {
+            doc.updateHighlight();
         }
     }
 
@@ -623,26 +670,6 @@ define(function LiveDevelopment(require, exports, module) {
             // Set status to out of sync if dirty. Otherwise, set it to active status.
             _setStatus(doc.isDirty ? STATUS_OUT_OF_SYNC : STATUS_ACTIVE);
         }
-    }
-
-    function getLiveDocForPath(path) {
-        var docsToSearch = [];
-        if (_relatedDocuments) {
-            docsToSearch = docsToSearch.concat(_relatedDocuments);
-        }
-        if (_liveDocument) {
-            docsToSearch = docsToSearch.concat(_liveDocument);
-        }
-        var foundDoc;
-        docsToSearch.some(function matchesPath(ele) {
-            if (ele.doc.file.fullPath === path) {
-                foundDoc = ele;
-                return true;
-            }
-            return false;
-        });
-
-        return foundDoc;
     }
 
     /** Initialize the LiveDevelopment Session */


### PR DESCRIPTION
CSSDocument now listens for `activeEditorChange` events, and hooks up cursor change handlers to any active editor that is associated with the same document.

This pull request also includes a few small code cleanups:
- Remove the unused `inspector` parameter from the `CSSDocument()` constructor
- Factor the highlight update code out of `onCursorActivity()` so it can be called independently
- When initializing `_relatedDocuments`, make sure none of the related documents are duplicates of `_liveDocument`.
