### PR TITLE
Set min width on color editor so swatches don't wrap if window is small

### DIFF
--- a/src/extensions/default/InlineColorEditor/css/main.css
+++ b/src/extensions/default/InlineColorEditor/css/main.css
@@ -24,6 +24,7 @@
 .color_editor {
     -webkit-text-size-adjust: none;
     font-size: 12px;
+    min-width: 450px;
     height: 190px;
     padding: 16px 16px 14px 38px;
 }


### PR DESCRIPTION
This min-width leaves enough room for a fairly long swatch color value.

Fixes #2088.
