### PR TITLE
Use CSSUtils to lookup selector at specified position

### DIFF
--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -152,18 +152,6 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.reloadRules = function () {
         this.rules = CSSUtils.extractAllSelectors(this.doc.getText());
     };
-    
-    // find a rule in the given rules
-    CSSDocument.prototype.ruleAtLocation = function ruleAtLocation(location) {
-        var i, rule;
-        for (i in this.rules) {
-            rule = this.rules[i];
-            if (rule.selectorRange.start <= location && location <= rule.style.range.end) {
-                return rule;
-            }
-        }
-        return null;
-    };
 
     CSSDocument.prototype.updateHighlight = function () {
         if (Inspector.config.highlight) {

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -79,7 +79,6 @@ define(function CSSDocumentModule(require, exports, module) {
         if (doc.isDirty) {
             CSSAgent.reloadCSSForDocument(this.doc);
         }
-        this.reloadRules();
         
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
         $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
@@ -147,16 +146,11 @@ define(function CSSDocumentModule(require, exports, module) {
             this.editor = null;
         }
     };
-    
-    // Reload rules
-    CSSDocument.prototype.reloadRules = function () {
-        this.rules = CSSUtils.extractAllSelectors(this.doc.getText());
-    };
 
     CSSDocument.prototype.updateHighlight = function () {
-        if (Inspector.config.highlight) {
+        if (Inspector.config.highlight && this.editor) {
             var codeMirror = this.editor._codeMirror;
-            var selector = CSSUtils.selectorAtPos(this.rules, codeMirror.getCursor());
+            var selector = CSSUtils.findSelectorAtDocumentPos(this.editor, codeMirror.getCursor());
             if (selector) {
                 HighlightAgent.rule(selector);
             } else {
@@ -176,7 +170,6 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.onChange = function onChange(event, editor, change) {
         // brute force: update the CSS
         CSSAgent.reloadCSSForDocument(this.doc);
-        this.reloadRules();
         if (Inspector.config.highlight) {
             HighlightAgent.redraw();
         }

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -593,9 +593,9 @@ define(function (require, exports, module) {
             return selector;
         }
         
-        // Extract a selector. Assumes ctx is pointing at the opening
+        // Parse a selector. Assumes ctx is pointing at the opening
         // { that is after the selector name.
-        function _extractSelector(ctx) {
+        function _parseSelector(ctx) {
             var selector = "";
             
             // Skip over {
@@ -623,7 +623,7 @@ define(function (require, exports, module) {
                 if (ctx.token.string === "}") {
                     break;
                 } else if (ctx.token.string === "{") {
-                    selector = _extractSelector(ctx);
+                    selector = _parseSelector(ctx);
                     break;
                 } else {
                     if (ctx.token.string.trim() !== "") {
@@ -658,7 +658,7 @@ define(function (require, exports, module) {
             while (true) {
                 if (ctx.token.className !== "comment") {
                     if (ctx.token.string === "{") {
-                        selector = _extractSelector(ctx);
+                        selector = _parseSelector(ctx);
                         break;
                     } else if (ctx.token.string === "}" || ctx.token.string === ";") {
                         break;

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -570,20 +570,20 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Returns the selector(s) of the rule at the specified document pos, or "" if the position is 
+     * Returns the selector(s) of the rule at the specified document pos, or "" if the position
      * is not within a style rule.
      *
-     * @param {!Document} doc Document to search
+     * @param {Array.<Object>} rules Array of rules, as returned by extractAllSelectors()
      * @param {!{line: number, ch: number}} pos Position to search
      * @return {string} Selector(s) for the rule at the specified position, or "" if the position
      *          is not within a style rule. If the rule has multiple selectors, a comma-separated
      *          selector string is returned.
      */
-    function findSelectorAtDocumentPos(doc, pos) {
-        var i, allRules = extractAllSelectors(doc.getText()), result = "";
+    function selectorAtPos(rules, pos) {
+        var i, result = "";
         
-        for (i = 0; i < allRules.length; i++) {
-            var rule = allRules[i];
+        for (i = 0; i < rules.length; i++) {
+            var rule = rules[i];
             
             if ((rule.selectorGroupStartLine < pos.line ||
                     (rule.selectorGroupStartLine === pos.line && rule.selectorGroupStartChar <= pos.ch))
@@ -607,8 +607,23 @@ define(function (require, exports, module) {
         return result;
     }
     
+    /**
+     * Returns the selector(s) of the rule at the specified document pos, or "" if the position is 
+     * is not within a style rule.
+     *
+     * @param {!Document} doc Document to search
+     * @param {!{line: number, ch: number}} pos Position to search
+     * @return {string} Selector(s) for the rule at the specified position, or "" if the position
+     *          is not within a style rule. If the rule has multiple selectors, a comma-separated
+     *          selector string is returned.
+     */
+    function findSelectorAtDocumentPos(doc, pos) {
+        return selectorAtPos(extractAllSelectors(doc.getText()), pos);
+    }
+    
     exports._findAllMatchingSelectorsInText = _findAllMatchingSelectorsInText; // For testing only
     exports.findMatchingRules = findMatchingRules;
     exports.extractAllSelectors = extractAllSelectors;
+    exports.selectorAtPos = selectorAtPos;
     exports.findSelectorAtDocumentPos = findSelectorAtDocumentPos;
 });

--- a/test/spec/CSSUtils-test-files/offsets.css
+++ b/test/spec/CSSUtils-test-files/offsets.css
@@ -41,3 +41,11 @@ a {
         color: maroon;
     }
 }
+
+/* rules inside a comment */
+/* p { color: "black" } */
+div {
+    color: "white";
+    /* nested comment */
+    /* border: none */
+}

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -326,6 +326,37 @@ define(function (require, exports, module) {
             });
         });
         
+        describe("findSelectorAtDocumentPos", function () {
+            var doc;
+            
+            beforeEach(function () {
+                init(this, groupsFileEntry);
+                runs(function () {
+                    doc = SpecRunnerUtils.createMockDocument(this.fileCssContent);
+                });
+            });
+            
+            it("should find the selector at a document pos", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 9, ch: 0});
+                expect(selector).toEqual("h1");
+            });
+            
+            it("should return empty string if selection is not in a style rule", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 11, ch: 0});
+                expect(selector).toEqual("");
+            });
+            
+            it("should return a comma separated string of all selectors for the rule", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 13, ch: 0});
+                expect(selector).toEqual("h3, h2, h1");
+            });
+            
+            it("should support multiple rules on the same line", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 31, ch: 24});
+                expect(selector).toEqual(".g, .h");
+            });
+        });
+        
     }); // describe("CSSUtils")
 
     

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -453,6 +453,38 @@ define(function (require, exports, module) {
             
         });
         
+        describe("findSelectorAtDocumentPos beginning, middle and end of selector", function () {
+            var editor;
+            
+            beforeEach(function () {
+                init(this, groupsFileEntry);
+                runs(function () {
+                    editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
+                });
+            });
+            
+            it("should find selector when pos is at beginning of selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 12, ch: 0});
+                expect(selector).toEqual("h3, h2, h1");
+            });
+            
+            it("should find selector when pos is in the middle of selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 12, ch: 3});
+                expect(selector).toEqual('h3, h2, h1');
+            });
+            
+            it("should find selector when pos is at the end of a selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 12, ch: 10});
+                expect(selector).toEqual("h3, h2, h1");
+            });
+            
+            it("should not find selector when pos is before a selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 11, ch: 0});
+                expect(selector).toEqual("");
+            });
+            
+        });
+        
     }); // describe("CSSUtils")
 
     

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -327,127 +327,127 @@ define(function (require, exports, module) {
         });
         
         describe("findSelectorAtDocumentPos selector groups", function () {
-            var doc;
+            var editor;
             
             beforeEach(function () {
                 init(this, groupsFileEntry);
                 runs(function () {
-                    doc = SpecRunnerUtils.createMockDocument(this.fileCssContent);
+                    editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
             
             it("should find the selector at a document pos", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 9, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 9, ch: 0});
                 expect(selector).toEqual("h1");
             });
             
             it("should return empty string if selection is not in a style rule", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 11, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 11, ch: 0});
                 expect(selector).toEqual("");
             });
             
             it("should return a comma separated string of all selectors for the rule", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 13, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 13, ch: 0});
                 expect(selector).toEqual("h3, h2, h1");
             });
             
             it("should support multiple rules on the same line", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 31, ch: 24});
-                expect(selector).toEqual(".g, .h");
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 31, ch: 24});
+                expect(selector).toEqual(".g,.h");
             });
             
             it("should support multiple rules on multiple lines", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 28, ch: 0});
-                expect(selector).toEqual(".a, .b, .c, .d");
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 28, ch: 0});
+                expect(selector).toEqual(".a,.b, .c,.d");
             });
         });
         
         describe("findSelectorAtDocumentPos comments", function () {
-            var doc;
+            var editor;
             
             beforeEach(function () {
                 init(this, offsetsCssFileEntry);
                 runs(function () {
-                    doc = SpecRunnerUtils.createMockDocument(this.fileCssContent);
+                    editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
             
             it("should ignore rules inside comments", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 45, ch: 22});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 45, ch: 22});
                 expect(selector).toEqual("");
             });
             
             it("should find rules adjacent to comments", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 47, ch: 4});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 47, ch: 4});
                 expect(selector).toEqual("div");
             });
             
             it("should find rules when the position is inside a nested comment", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 49, ch: 14});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 49, ch: 14});
                 expect(selector).toEqual("div");
             });
             
         });
         
         describe("findSelectorAtDocumentPos pseudo-classes and at-rules", function () {
-            var doc;
+            var editor;
             
             beforeEach(function () {
                 init(this, offsetsCssFileEntry);
                 runs(function () {
-                    doc = SpecRunnerUtils.createMockDocument(this.fileCssContent);
+                    editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
             
             it("should find a simple pseudo selector", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 8, ch: 11});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 8, ch: 11});
                 expect(selector).toEqual("a:visited");
             });
             
             it("should find a selector with a preceding at-rule", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 18, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 18, ch: 0});
                 expect(selector).toEqual("a");
             });
             
             it("should not find a selector when inside an at-rule", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 15, ch: 12});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 15, ch: 12});
                 expect(selector).toEqual("");
                 
-                selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 28, ch: 31});
+                selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 28, ch: 31});
                 expect(selector).toEqual("");
                 
-                selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 22, ch: 16});
+                selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 22, ch: 16});
                 expect(selector).toEqual("");
             });
         });
         
         describe("findSelectorAtDocumentPos complex selectors", function () {
-            var doc;
+            var editor;
             
             beforeEach(function () {
                 init(this, bootstrapCssFileEntry);
                 runs(function () {
-                    doc = SpecRunnerUtils.createMockDocument(this.fileCssContent);
+                    editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
             
             it("should find pseudo selectors", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 72, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 72, ch: 0});
                 expect(selector).toEqual("button::-moz-focus-inner, input::-moz-focus-inner");
             });
             
             it("should find attribute selectors", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 83, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 83, ch: 0});
                 expect(selector).toEqual('input[type="search"]');
             });
             
             it("should find structural pseudo-classes", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 1053, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 1053, ch: 0});
                 expect(selector).toEqual(".table-striped tbody tr:nth-child(odd) td, .table-striped tbody tr:nth-child(odd) th");
             });
             
             it("should find combinators", function () {
-                var selector = CSSUtils.findSelectorAtDocumentPos(doc, {line: 2073, ch: 0});
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 2073, ch: 0});
                 expect(selector).toEqual(".alert-block p + p");
             });
             


### PR DESCRIPTION
The Remote Debugging APIs for retrieving stylesheet information do not always return offsets (the range properties are all marked `optional` in the api). So, instead of relying on the information returned from these APIs, we now use a new CSSUtils function for getting the selector at a specified document position.

Fixes bug #2173.
