### PR TITLE
Swatch list focus style tweaks

### DIFF
--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -270,8 +270,8 @@ define(function (require, exports, module) {
         this.swatches.forEach(function (swatch) {
             var stringFormat = (swatch.count > 1) ? Strings.COLOR_EDITOR_USED_COLOR_TIP_PLURAL : Strings.COLOR_EDITOR_USED_COLOR_TIP_SINGULAR,
                 usedColorTip = StringUtils.format(stringFormat, swatch.value, swatch.count);
-            _this.$swatches.append("<li><div class='swatch_bg'><div class='swatch' style='background-color: " +
-                    swatch.value + ";' title='" + usedColorTip + "'></div></div> <span class='value'" + " tabindex='0' title='" +
+            _this.$swatches.append("<li tabindex='0'><div class='swatch_bg'><div class='swatch' style='background-color: " +
+                    swatch.value + ";' title='" + usedColorTip + "'></div></div> <span class='value'" + " title='" +
                     usedColorTip + "'>" + swatch.value + "</span></li>");
         });
 

--- a/src/extensions/default/InlineColorEditor/css/main.css
+++ b/src/extensions/default/InlineColorEditor/css/main.css
@@ -230,7 +230,8 @@
 .color_editor section footer input:focus {
     background: #fff;
     outline: none;
-    box-shadow: 0 0 8px rgba(0,0,0,0.35), inset 0 2px 4px rgba(0,0,0,0.15);
+    outline: none;
+    box-shadow: 0 0 4px 0 rgba(0,136,255,0.8), inset 0 2px 4px rgba(0,0,0,0.15);
     border: 1px solid #1b1d1d;
     z-index: 911;
 }
@@ -300,6 +301,10 @@
     background-image: -webkit-gradient(linear, left top, left bottom, from(#fff), to(#f4f6f7));
     background-image: -webkit-linear-gradient(top, #fff, #f4f6f7);
     background-image: linear-gradient(top, #fff, #f4f6f7);
+}
+.color_editor .button-bar a:focus, .color_editor .button-bar li.selected a:focus{
+    outline: none;
+    box-shadow: 0 0 4px rgba(0,136,255,0.8);
 }
 .color_editor .button-bar li:first-child {
     margin-left: 0;

--- a/src/extensions/default/InlineColorEditor/css/main.css
+++ b/src/extensions/default/InlineColorEditor/css/main.css
@@ -32,7 +32,7 @@
     display: inline-block;
     position: relative;
     height: 100%;
-    overflow: hidden;
+    overflow: visible;
     margin-left: 6px;
     vertical-align: top;
 }
@@ -76,7 +76,14 @@
 .color_editor aside ul.swatches li {
     -webkit-text-size-adjust: none;
     cursor: pointer;
-    height: 20px;
+    height: 18px;
+    margin-bottom: 2px;
+    padding: 0 1px 1px 2px;
+}
+.color_editor aside ul.swatches li:focus {
+    outline: none;
+    box-shadow: 0 0 4px rgba(0,136,255,0.8);
+    border-radius: 2px;
 }
 .color_editor aside ul.swatches li .swatch_bg {
     background-image: url("../img/color_thumb_back.png");
@@ -85,7 +92,7 @@
     height: 15px;
     border-radius: 3px;
     position: relative;
-    top: 3px;
+    top: 2px;
     display: inline-block;
 }
 .color_editor aside ul.swatches li .swatch_bg .swatch {
@@ -95,6 +102,10 @@
     border-radius: 3px;
     box-shadow: 0 -1px 0 rgba(0,0,0,0.2), 0 1px 0 #fff;
     top: 0;
+}
+.color_editor aside ul.swatches li .value {
+    position: relative;
+    top: -2px;
 }
 .color_editor section {
     display: inline-block;


### PR DESCRIPTION
fixed focus halo for swatches in list to display correctly, also moved tab focus to the whole list item, rather than just the label
