### PR TITLE
Remove tooltips from colorpicker sliders, color square, and text field

### DIFF
--- a/src/extensions/default/InlineColorEditor/InlineColorEditorTemplate.html
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditorTemplate.html
@@ -2,19 +2,19 @@
 <div class="color_editor">
   <section>
     <div class="sliders">
-      <div class="color_selection_field" title="{{COLOR_EDITOR_SELECTION_FIELD_TIP}}">
+      <div class="color_selection_field">
         <div class="saturation_gradient gradient_overlay"></div>
         <div class="luminosity_gradient gradient_overlay"></div>
         <div tabindex="0" class="selector_base">
           <div class="selector"></div>
         </div>
       </div>
-      <div class="hue_slider slider" title="{{COLOR_EDITOR_HUE_SLIDER_TIP}}">
+      <div class="hue_slider slider">
         <div tabindex="0" class="selector_base">
           <div class="selector"></div>
         </div>
       </div>
-      <div class="opacity_slider slider" title="{{COLOR_EDITOR_OPACITY_SLIDER_TIP}}">
+      <div class="opacity_slider slider">
         <div class="opacity_gradient gradient_overlay"></div>
         <div tabindex="0" class="selector_base">
           <div class="selector"></div>
@@ -22,7 +22,7 @@
       </div>
     </div>
     <footer>
-      <input class="color_value" title="{{COLOR_EDITOR_COLOR_INPUT_TIP}}" />
+      <input class="color_value" />
       <ul class="button-bar">
         <li class="selected" title="{{COLOR_EDITOR_RGBA_BUTTON_TIP}}"><a href="#" tabindex="0" class="rgba">RGBa</a></li>
         <li title="{{COLOR_EDITOR_HEX_BUTTON_TIP}}"><a href="#" tabindex="0" class="hex">HEX</a></li>


### PR DESCRIPTION
In those locations, the tooltips appear quickly enough that they get in your way when you're trying to interact using the mouse (especially on Win, where the default delay is ~400 ms). And conversely, these are the most self-explanatory controls in the colorpicker, so the value of tooltips here is pretty minimal.

Tooltips remain on the other controls, e.g. the clickable swatches.
