### PR TITLE
Add one-step undo/redo to color editor

### DIFF
--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
 
         this.color = tinycolor(color);
         this.lastColor = color;
+        this.redoColor = null;
         this.$element = $(this.element);
         this.$colorValue = this.$element.find(".color_value");
         this.$buttonList = this.$element.find("ul.button-bar");
@@ -336,6 +337,7 @@ define(function (require, exports, module) {
             this.hsv = colorObj.toHsv();
             this.color = colorObj;
         }
+        this.redoColor = null;
         this.synchronize();
     };
 
@@ -397,16 +399,35 @@ define(function (require, exports, module) {
             $(window).bind("mouseup", mouseupHandler);
         });
     };
+    
+    ColorEditor.prototype.undo = function () {
+        if (!tinycolor.equals(this.lastColor, this.color)) {
+            var curColor = this.color.toString();
+            this.commitColor(this.lastColor, true);
+            this.redoColor = curColor;
+        }
+    };
+
+    ColorEditor.prototype.redo = function () {
+        if (this.redoColor) {
+            this.commitColor(this.redoColor, true);
+            this.redoColor = null;
+        }
+    };
 
     ColorEditor.prototype.handleKeydown = function (event) {
         var hasCtrl = (brackets.platform === "win") ? (event.ctrlKey) : (event.metaKey);
         if (hasCtrl) {
             switch (event.keyCode) {
             case KeyEvent.DOM_VK_Z:
-                // TODO
+                if (event.shiftKey) {
+                    this.redo();
+                } else {
+                    this.undo();
+                }
                 break;
             case KeyEvent.DOM_VK_Y:
-                // TODO
+                this.redo();
                 break;
             }
         }

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -425,10 +425,10 @@ define(function (require, exports, module) {
                 } else {
                     this.undo();
                 }
-                break;
+                return false;
             case KeyEvent.DOM_VK_Y:
                 this.redo();
-                break;
+                return false;
             }
         }
     };
@@ -439,7 +439,7 @@ define(function (require, exports, module) {
             if (!event.shiftKey) {
                 this.$selectionBase.focus();
             }
-            break;
+            return false;
         default:
             this.handleKeydown(event);
             break;
@@ -462,7 +462,7 @@ define(function (require, exports, module) {
             xOffset = Math.min(100, Math.max(0, adjustedOffset));
             hsv.s = xOffset / 100;
             this.setColorAsHsv(hsv, false);
-            break;
+            return false;
         case KeyEvent.DOM_VK_DOWN:
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
@@ -471,7 +471,7 @@ define(function (require, exports, module) {
             yOffset = Math.min(100, Math.max(0, adjustedOffset));
             hsv.v = yOffset / 100;
             this.setColorAsHsv(hsv, false);
-            break;
+            return false;
         case KeyEvent.DOM_VK_TAB:
             if (event.shiftKey) {
                 if ($(this.$swatches).children().length === 0) {
@@ -480,7 +480,7 @@ define(function (require, exports, module) {
                     $(this.$swatches).find(".value:last").focus();
                 }
             }
-            break;
+            return false;
         default:
             this.handleKeydown(event);
             break;
@@ -499,14 +499,14 @@ define(function (require, exports, module) {
                 hsv.h = (hue - step) <= 0 ? 360 - step : hue - step;
                 this.setColorAsHsv(hsv);
             }
-            break;
+            return false;
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (hue < 360) {
                 hsv.h = (hue + step) >= 360 ? step : hue + step;
                 this.setColorAsHsv(hsv);
             }
-            break;
+            return false;
         default:
             this.handleKeydown(event);
             break;
@@ -525,14 +525,14 @@ define(function (require, exports, module) {
                 hsv.a = (alpha - step) <= 0 ? 0 : alpha - step;
                 this.setColorAsHsv(hsv);
             }
-            break;
+            return false;
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (alpha < 100) {
                 hsv.a = (alpha + step) >= 1 ? 1 : alpha + step;
                 this.setColorAsHsv(hsv);
             }
-            break;
+            return false;
         default:
             this.handleKeydown(event);
             break;

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         this.swatches = swatches;
         this.bindKeyHandler = this.bindKeyHandler.bind(this);
 
+        this.handleKeydown = this.handleKeydown.bind(this);
         this.handleOpacityKeydown = this.handleOpacityKeydown.bind(this);
         this.handleHueKeydown = this.handleHueKeydown.bind(this);
         this.handleSelectionKeydown = this.handleSelectionKeydown.bind(this);
@@ -90,10 +91,18 @@ define(function (require, exports, module) {
         this.bindKeyHandler(this.$hueBase, this.handleHueKeydown);
         this.bindKeyHandler(this.$opacitySelector, this.handleOpacityKeydown);
         
+        // Bind the undo/redo key handler to other buttons that take focus but
+        // don't have their own key handlers.
+        this.bindKeyHandler(this.$colorValue, this.handleKeydown);
+        this.bindKeyHandler(this.$rgbaButton, this.handleKeydown);
+        this.bindKeyHandler(this.$hexButton, this.handleKeydown);
+        
         // Bind key handler to HSLa button only if we don't have any color swatches
         // and this becomes the last UI element in the tab loop.
         if ($(this.$swatches).children().length === 0) {
             this.bindKeyHandler(this.$hslButton, this.handleHslKeydown);
+        } else {
+            this.bindKeyHandler(this.$hslButton, this.handleKeydown);
         }
     };
 
@@ -286,6 +295,8 @@ define(function (require, exports, module) {
                     _this.$selectionBase.focus();
                     return false;
                 }
+            } else {
+                return _this.handleKeydown(event);
             }
         });
 
@@ -401,7 +412,7 @@ define(function (require, exports, module) {
     };
     
     ColorEditor.prototype.undo = function () {
-        if (!tinycolor.equals(this.lastColor, this.color)) {
+        if (this.lastColor.toString() !== this.color.toString()) {
             var curColor = this.color.toString();
             this.commitColor(this.lastColor, true);
             this.redoColor = curColor;
@@ -442,8 +453,7 @@ define(function (require, exports, module) {
             }
             break;
         default:
-            this.handleKeydown(event);
-            break;
+            return this.handleKeydown(event);
         }
     };
 
@@ -484,8 +494,7 @@ define(function (require, exports, module) {
             }
             break;
         default:
-            this.handleKeydown(event);
-            break;
+            return this.handleKeydown(event);
         }
     };
 
@@ -510,8 +519,7 @@ define(function (require, exports, module) {
             }
             return false;
         default:
-            this.handleKeydown(event);
-            break;
+            return this.handleKeydown(event);
         }
     };
 
@@ -536,8 +544,7 @@ define(function (require, exports, module) {
             }
             return false;
         default:
-            this.handleKeydown(event);
-            break;
+            return this.handleKeydown(event);
         }
     };
 

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -438,8 +438,9 @@ define(function (require, exports, module) {
         case KeyEvent.DOM_VK_TAB:
             if (!event.shiftKey) {
                 this.$selectionBase.focus();
+                return false;
             }
-            return false;
+            break;
         default:
             this.handleKeydown(event);
             break;
@@ -479,8 +480,9 @@ define(function (require, exports, module) {
                 } else {
                     $(this.$swatches).find(".value:last").focus();
                 }
+                return false;
             }
-            return false;
+            break;
         default:
             this.handleKeydown(event);
             break;

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -398,13 +398,29 @@ define(function (require, exports, module) {
         });
     };
 
+    ColorEditor.prototype.handleKeydown = function (event) {
+        var hasCtrl = (brackets.platform === "win") ? (event.ctrlKey) : (event.metaKey);
+        if (hasCtrl) {
+            switch (event.keyCode) {
+            case KeyEvent.DOM_VK_Z:
+                // TODO
+                break;
+            case KeyEvent.DOM_VK_Y:
+                // TODO
+                break;
+            }
+        }
+    };
+
     ColorEditor.prototype.handleHslKeydown = function (event) {
         switch (event.keyCode) {
         case KeyEvent.DOM_VK_TAB:
             if (!event.shiftKey) {
                 this.$selectionBase.focus();
-                return false;
             }
+            break;
+        default:
+            this.handleKeydown(event);
             break;
         }
     };
@@ -425,7 +441,7 @@ define(function (require, exports, module) {
             xOffset = Math.min(100, Math.max(0, adjustedOffset));
             hsv.s = xOffset / 100;
             this.setColorAsHsv(hsv, false);
-            return false;
+            break;
         case KeyEvent.DOM_VK_DOWN:
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
@@ -434,7 +450,7 @@ define(function (require, exports, module) {
             yOffset = Math.min(100, Math.max(0, adjustedOffset));
             hsv.v = yOffset / 100;
             this.setColorAsHsv(hsv, false);
-            return false;
+            break;
         case KeyEvent.DOM_VK_TAB:
             if (event.shiftKey) {
                 if ($(this.$swatches).children().length === 0) {
@@ -442,8 +458,10 @@ define(function (require, exports, module) {
                 } else {
                     $(this.$swatches).find(".value:last").focus();
                 }
-                return false;
             }
+            break;
+        default:
+            this.handleKeydown(event);
             break;
         }
     };
@@ -460,14 +478,17 @@ define(function (require, exports, module) {
                 hsv.h = (hue - step) <= 0 ? 360 - step : hue - step;
                 this.setColorAsHsv(hsv);
             }
-            return false;
+            break;
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (hue < 360) {
                 hsv.h = (hue + step) >= 360 ? step : hue + step;
                 this.setColorAsHsv(hsv);
             }
-            return false;
+            break;
+        default:
+            this.handleKeydown(event);
+            break;
         }
     };
 
@@ -483,14 +504,17 @@ define(function (require, exports, module) {
                 hsv.a = (alpha - step) <= 0 ? 0 : alpha - step;
                 this.setColorAsHsv(hsv);
             }
-            return false;
+            break;
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (alpha < 100) {
                 hsv.a = (alpha + step) >= 1 ? 1 : alpha + step;
                 this.setColorAsHsv(hsv);
             }
-            return false;
+            break;
+        default:
+            this.handleKeydown(event);
+            break;
         }
     };
 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -45,42 +45,26 @@ define(function (require, exports, module) {
 
     describe("Inline Color Editor - unit", function () {
 
-        var testDocument, testEditor;
+        var testDocument, testEditor, inline;
         
         /**
          * Creates an inline color editor connected to the given cursor position in the test editor.
          * Note that this does *not* actually open it as an inline editor in the test editor.
+         * Tests that use this must wrap their contents in a runs() block.
          * @param {!{line:number, ch: number}} cursor Position for which to open the inline editor.
-         * @return {object} A promise that is resolved with the created inline editor, or rejected
          * if the provider did not create an inline editor.
          */
         function makeColorEditor(cursor) {
-            var result = new $.Deferred(),
-                editorPromise,
-                inline;
-            
             runs(function () {
-                editorPromise = provider(testEditor, cursor);
-                if (editorPromise) {
-                    editorPromise.done(function (inlineResult) {
+                var promise = provider(testEditor, cursor);
+                if (promise) {
+                    promise.done(function (inlineResult) {
                         inlineResult.onAdded();
                         inline = inlineResult;
                     });
-                    waitsForDone(editorPromise, "open color editor");
-                } else {
-                    result.reject();
+                    waitsForDone(promise, "open color editor");
                 }
             });
-            
-            // This runs block will execute after either the waitsForDone() in the block above
-            // completes, or the result is already rejected (because no promise was returned
-            // from the provider).
-            runs(function () {
-                if (!result.isRejected()) {
-                    result.resolve(inline);
-                }
-            });
-            return result.promise();
         }
             
         /**
@@ -90,7 +74,8 @@ define(function (require, exports, module) {
          * @param {string} color The expected color.
          */
         function testOpenColor(cursor, color) {
-            makeColorEditor(cursor).done(function (inline) {
+            makeColorEditor(cursor);
+            runs(function () {
                 expect(inline).toBeTruthy();
                 expect(inline.color).toBe(color);
             });
@@ -108,6 +93,7 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.destroyMockEditor(testDocument);
                 testEditor = null;
                 testDocument = null;
+                inline = null;
             });
          
             describe("simple open cases", function () {
@@ -144,18 +130,21 @@ define(function (require, exports, module) {
                 });
                 
                 it("should not open when not on a color", function () {
-                    makeColorEditor({line: 1, ch: 6}).done(function (inline) {
-                        expect(inline).toBeNull();
+                    makeColorEditor({line: 1, ch: 6});
+                    runs(function () {
+                        expect(inline).toEqual(null);
                     });
                 });
                 it("should not open when on an invalid color", function () {
-                    makeColorEditor({line: 25, ch: 18}).done(function (inline) {
-                        expect(inline).toBeNull();
+                    makeColorEditor({line: 25, ch: 18});
+                    runs(function () {
+                        expect(inline).toEqual(null);
                     });
                 });
                 it("should not open when on an hsl color with missing percent signs", function () {
-                    makeColorEditor({line: 37, ch: 18}).done(function (inline) {
-                        expect(inline).toBeNull();
+                    makeColorEditor({line: 37, ch: 18});
+                    runs(function (inline) {
+                        expect(inline).toEqual(null);
                     });
                 });
                 
@@ -168,15 +157,14 @@ define(function (require, exports, module) {
                         spyOn(testDocument, "addRef").andCallThrough();
                         spyOn(testDocument, "releaseRef").andCallThrough();
                     });
+                    makeColorEditor({line: 1, ch: 18});
                     runs(function () {
-                        makeColorEditor({line: 1, ch: 18}).done(function (inline) {
-                            expect(testDocument.addRef).toHaveBeenCalled();
-                            expect(testDocument.addRef.callCount).toBe(1);
-                            
-                            inline.onClosed();
-                            expect(testDocument.releaseRef).toHaveBeenCalled();
-                            expect(testDocument.releaseRef.callCount).toBe(1);
-                        });
+                        expect(testDocument.addRef).toHaveBeenCalled();
+                        expect(testDocument.addRef.callCount).toBe(1);
+                        
+                        inline.onClosed();
+                        expect(testDocument.releaseRef).toHaveBeenCalled();
+                        expect(testDocument.releaseRef.callCount).toBe(1);
                     });
                 });
                 
@@ -185,21 +173,24 @@ define(function (require, exports, module) {
             describe("update host document on edit in color editor", function () {
                 
                 it("should update host document when change is committed in color editor", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         inline.colorEditor.commitColor("#c0c0c0", false);
                         expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
                     });
                 });
                 
                 it("should update correct range of host document with color format of different length", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         inline.colorEditor.commitColor("rgb(20, 20, 20)", false);
                         expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 31})).toBe("rgb(20, 20, 20)");
                     });
                 });
     
                 it("should not invalidate range when change is committed", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         inline.colorEditor.commitColor("rgb(20, 20, 20)", false);
                         expect(inline.getCurrentRange()).not.toBeNull();
                     });
@@ -210,7 +201,8 @@ define(function (require, exports, module) {
             describe("update color editor on edit in host editor", function () {
                 
                 it("should update when edit is made to color range in host editor", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         spyOn(inline, "close");
         
                         testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
@@ -222,7 +214,8 @@ define(function (require, exports, module) {
                 });
                 
                 it("should close itself if edit is made that destroys end bookmark and leaves color invalid", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         spyOn(inline, "close");
                         
                         // Replace everything including the semicolon, so it crosses the bookmark boundary.
@@ -232,7 +225,8 @@ define(function (require, exports, module) {
                 });
                 
                 it("should maintain the range if the user deletes the last character of the color and types a new one", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         spyOn(inline, "close");
         
                         testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
@@ -244,7 +238,8 @@ define(function (require, exports, module) {
                 });
                 
                 it("should not update the end bookmark to a shorter valid match if the bookmark still exists and the color becomes invalid", function () {
-                    makeColorEditor({line: 1, ch: 18}).done(function (inline) {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
                         testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
                         expect(inline.color).toBe("#abcde");
                         expect(inline.getCurrentRange()).toEqual({start: {line: 1, ch: 16}, end: {line: 1, ch: 22}});
@@ -330,7 +325,7 @@ define(function (require, exports, module) {
                                               swatches || defaultSwatches);
                 $(document.body).append($container);
             }
-            
+                        
             afterEach(function () {
                 $container.remove();
             });
@@ -1092,6 +1087,74 @@ define(function (require, exports, module) {
                     expect(colorEditor._normalizeColorString("rgb(25%,50%,75%)")).toBe("rgb(64, 128, 191)");
                     expect(colorEditor._normalizeColorString("rgb(10,20,   30)")).toBe("rgb(10, 20, 30)");
                 });
+            });
+            
+            describe("undo/redo", function () {
+                
+                function triggerCtrlKey($element, key, shift) {
+                    var ctrlKeyProperty = (brackets.platform === "win" ? "ctrlKey" : "metaKey"),
+                        eventProps = {keyCode: key, shiftKey: shift};
+                    eventProps[ctrlKeyProperty] = true;
+                    $element.trigger($.Event("keydown", eventProps));
+                }
+                
+                it("should undo when Ctrl-Z is pressed on a focused element in the color editor", function () {
+                    makeUI("#abcdef");
+                    runs(function () {
+                        colorEditor.commitColor("#a0a0a0", true);
+                        colorEditor.$hueBase.focus();
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        expect(tinycolor(colorEditor.color).toString()).toBe("#abcdef");
+                    });
+                });
+
+                it("should redo when Ctrl-Shift-Z is pressed on a focused element in the color editor", function () {
+                    makeUI("#abcdef");
+                    runs(function () {
+                        colorEditor.commitColor("#a0a0a0", true);
+                        colorEditor.$hueBase.focus();
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z, true);
+                        expect(tinycolor(colorEditor.color).toString()).toBe("#a0a0a0");
+                    });
+                });
+                
+                it("should redo when Ctrl-Y is pressed on a focused element in the color editor", function () {
+                    makeUI("#abcdef");
+                    runs(function () {
+                        colorEditor.commitColor("#a0a0a0", true);
+                        colorEditor.$hueBase.focus();
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                        expect(tinycolor(colorEditor.color).toString()).toBe("#a0a0a0");
+                    });
+                });
+                
+                it("should redo when Ctrl-Y is pressed after two Ctrl-Zs (only one Ctrl-Z should take effect)", function () {
+                    makeUI("#abcdef");
+                    runs(function () {
+                        colorEditor.commitColor("#a0a0a0", true);
+                        colorEditor.$hueBase.focus();
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                        expect(tinycolor(colorEditor.color).toString()).toBe("#a0a0a0");
+                    });
+                });
+
+                it("should undo when Ctrl-Z is pressed after two Ctrl-Ys (only one Ctrl-Y should take effect)", function () {
+                    makeUI("#abcdef");
+                    runs(function () {
+                        colorEditor.commitColor("#a0a0a0", true);
+                        colorEditor.$hueBase.focus();
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                        expect(tinycolor(colorEditor.color).toString()).toBe("#abcdef");
+                    });
+                });
+
             });
         });
     });


### PR DESCRIPTION
For #2183, make it so you can do a one-step undo/redo in the color editor. Hitting Undo will revert back to the original color when the editor was first opened. Hitting Redo will switch to the color you had when you hit Undo. Making an edit after undoing kills redo.

Some caveats:
- This is hardcoded to Ctrl/Cmd-Z for undo and Ctrl/Cmd-Shift-Z and Ctrl/Cmd-Y for redo. Eventually, we need a more general way to do contextual keybindings for pieces of UI like this (where it doesn't make sense to create an app-global command).
- It might have been a little better to just pass undos/redos through to CodeMirror, but in our current inline editor implementation those undos actually cause the editor to collapse, since they destroy the underlying bookmark that tracks the position of the editor. This could be a viable option in v3, but changes to the way undos are batched there will probably mean that we'd need to request an API for control over undo batching across separate real edits.
- Eventually, we should have a more sophisticated multi-step undo system for inline editors like this that tries to be smart about when we record undos and integrates properly with the CodeMirror undo system.
