### PR TITLE
Editor.refreshAll() shouldn't assume all inline widgets are MultiRangeInlineEditors

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1001,12 +1001,8 @@ define(function (require, exports, module) {
      */
     Editor.prototype.refreshAll = function () {
         this.refresh();
-        this.getInlineWidgets().forEach(function (multilineEditor, i, arr) {
-            multilineEditor.sizeInlineWidgetToContents(true);
-            multilineEditor._updateRelatedContainer();
-            multilineEditor.editors.forEach(function (editor, j, arr) {
-                editor.refresh();
-            });
+        this.getInlineWidgets().forEach(function (inlineWidget, i, arr) {
+            inlineWidget.refresh();
         });
     };
     

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1001,7 +1001,7 @@ define(function (require, exports, module) {
      */
     Editor.prototype.refreshAll = function () {
         this.refresh();
-        this.getInlineWidgets().forEach(function (inlineWidget, i, arr) {
+        this.getInlineWidgets().forEach(function (inlineWidget) {
             inlineWidget.refresh();
         });
     };

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -98,14 +98,20 @@ define(function (require, exports, module) {
         // that just shows a range of text. See CSSInlineEditor.css for an implementation of load()
     };
     
-
     /**
      * Called when the editor containing the inline is made visible.
      */
     InlineWidget.prototype.onParentShown = function () {
         // do nothing - base implementation
     };
-
+    
+    /**
+     * Called when the parent editor does a full refresh--for example, when the font size changes.
+     */
+    InlineWidget.prototype.refresh = function () {
+        // do nothing - base implementation
+    };
+    
     exports.InlineWidget = InlineWidget;
 
 });

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -524,6 +524,17 @@ define(function (require, exports, module) {
         // Use setTimeout to trigger a layout update before accessing positions, heights, etc.
         window.setTimeout(this._updateRelatedContainer);
     };
+    
+    /**
+     * Refreshes the height of the inline editor and all child editors.
+     */
+    MultiRangeInlineEditor.prototype.refresh = function () {
+        this.sizeInlineWidgetToContents(true);
+        this._updateRelatedContainer();
+        this.editors.forEach(function (editor, j, arr) {
+            editor.refresh();
+        });
+    };
 
     /**
      * Returns the currently focused MultiRangeInlineEditor.

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -527,6 +527,7 @@ define(function (require, exports, module) {
     
     /**
      * Refreshes the height of the inline editor and all child editors.
+     * @override
      */
     MultiRangeInlineEditor.prototype.refresh = function () {
         this.sizeInlineWidgetToContents(true);


### PR DESCRIPTION
For #2184. The issue is that `Editor.refreshAll()` was calling methods on all inline widgets that are only available on `MultiRangeInlineEditor`. I changed it so that it just delegates the refresh to the inline widget, and pushed the existing code down into `MultiRangeInlineEditor.refresh()`.
