### PR TITLE
Uncache file codehints when switching projects (#2182)

### DIFF
--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -337,7 +337,8 @@ define(function (require, exports, module) {
             if (!this.cachedHints.query ||
                     this.cachedHints.query.tag !== query.tag ||
                     this.cachedHints.query.attrName !== query.attrName ||
-                    this.cachedHints.queryDir !== queryDir) {
+                    this.cachedHints.queryDir !== queryDir ||
+                    this.cachedHints.docDir !== docDir) {
 
                 // delete stale cache
                 this.cachedHints = null;
@@ -373,6 +374,7 @@ define(function (require, exports, module) {
                     self.cachedHints.unfiltered = unfiltered;
                     self.cachedHints.query      = query;
                     self.cachedHints.queryDir   = queryDir;
+                    self.cachedHints.docDir     = docDir;
 
                     // If the editor has not changed, then re-initiate code hints. Cached data
                     // is still valid for folder even if we're not going to show it now.


### PR DESCRIPTION
This provides a fix for #2182 by adding an additional check to uncache the previous codehints results if the base dir changes (i.e. when switching projects).
