### PR TITLE
JSDocs, method name underscores, and code cleanup for Color Editor

### DIFF
--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
         var normalizedColor = color;
                     
         // Convert 6-digit hex to 3-digit hex as tinycolor (#ffaacc -> #fac)
-        if (color.match(/^#[0-9a-f]{6}/)) {
+        if (color.match(/^#[0-9a-fA-F]{6}/)) {
             return tinycolor(color).toString();
         }
         if (color.match(/^(rgb|hsl)/)) {
@@ -356,8 +356,6 @@ define(function (require, exports, module) {
         });
 
         this.$swatches.find("li").click(function (event) {
-            // Set focus to the corresponding value label of the swatch.
-            $(event.currentTarget).find(".value").focus();
             _this._commitColor($(event.currentTarget).find(".value").html());
         });
     };
@@ -389,6 +387,16 @@ define(function (require, exports, module) {
             break;
         }
         this._commitColor(colorVal, commitHsv);
+
+        // Some color values (gray-ish colors) may not get updated with the above 
+        // commitColor call since they are different in hsv values, but still exactly
+        // the same when converting to tiny color object. ie. newColor == oldColor.
+        // So we will update this.hsv here since commitColor call does not update it.
+        // This is necessary to prevent the hue slider from getting stuck when using 
+        // up/down arrow keys (issue #2138).
+        if (this.hsv !== commitHsv) {
+            this.hsv = commitHsv;
+        }
     };
 
     /**
@@ -565,7 +573,7 @@ define(function (require, exports, module) {
                 if (this.$swatches.children().length === 0) {
                     this.$hslButton.focus();
                 } else {
-                    this.$swatches.find(".value:last").focus();
+                    this.$swatches.find("li:last").focus();
                 }
                 return false;
             }

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -50,20 +50,20 @@ define(function (require, exports, module) {
         this.$element = $(Mustache.render(InlineEditorTemplate, Strings));
         $parent.append(this.$element);
         
-        this.callback = callback;
+        this._callback = callback;
 
-        this.handleUndoRedoKeys = this.handleUndoRedoKeys.bind(this);
-        this.handleOpacityKeydown = this.handleOpacityKeydown.bind(this);
-        this.handleHslKeydown = this.handleHslKeydown.bind(this);
-        this.handleHueKeydown = this.handleHueKeydown.bind(this);
-        this.handleSelectionKeydown = this.handleSelectionKeydown.bind(this);
-        this.handleOpacityDrag = this.handleOpacityDrag.bind(this);
-        this.handleHueDrag = this.handleHueDrag.bind(this);
-        this.handleSelectionFieldDrag = this.handleSelectionFieldDrag.bind(this);
+        this._handleUndoRedoKeys = this._handleUndoRedoKeys.bind(this);
+        this._handleOpacityKeydown = this._handleOpacityKeydown.bind(this);
+        this._handleHslKeydown = this._handleHslKeydown.bind(this);
+        this._handleHueKeydown = this._handleHueKeydown.bind(this);
+        this._handleSelectionKeydown = this._handleSelectionKeydown.bind(this);
+        this._handleOpacityDrag = this._handleOpacityDrag.bind(this);
+        this._handleHueDrag = this._handleHueDrag.bind(this);
+        this._handleSelectionFieldDrag = this._handleSelectionFieldDrag.bind(this);
 
-        this.color = tinycolor(color);
-        this.originalColor = color;
-        this.redoColor = null;
+        this._color = tinycolor(color);
+        this._originalColor = color;
+        this._redoColor = null;
         
         this.$colorValue = this.$element.find(".color_value");
         this.$buttonList = this.$element.find("ul.button-bar");
@@ -83,14 +83,14 @@ define(function (require, exports, module) {
         this.$swatches = this.$element.find(".swatches");
         
         // Create quick-access color swatches
-        this.addSwatches(swatches);
+        this._addSwatches(swatches);
         
         // Attach event listeners to main UI elements
-        this.addListeners();
+        this._addListeners();
         
         // Initially selected color
-        this.$lastColor.css("background-color", this.originalColor);
-        this.commitColor(color);
+        this.$lastColor.css("background-color", this._originalColor);
+        this._commitColor(color);
     }
 
     /**
@@ -98,60 +98,60 @@ define(function (require, exports, module) {
      * TODO (#2201): type is unpredictable
      * @type {tinycolor|string}
      */
-    ColorEditor.prototype.color = null;
+    ColorEditor.prototype._color = null;
     
     /**
      * An HSV representation of the currently selected color.
-     * TODO (#2201): type of hsv.s/.v is unpredictable
+     * TODO (#2201): type of _hsv.s/.v is unpredictable
      * @type {!{h:number, s:number|string, v:number|string, a:number}}
      */
-    ColorEditor.prototype.hsv = tinycolor("rgba(0,0,0,1)").toHsv();
+    ColorEditor.prototype._hsv = tinycolor("rgba(0,0,0,1)").toHsv();
     
     /**
      * Color that was selected before undo(), if undo was the last change made. Else null.
      * @type {?string}
      */
-    ColorEditor.prototype.redoColor = null;
+    ColorEditor.prototype._redoColor = null;
     
     /**
      * Initial value the color picker was opened with
      * @type {!string}
      */
-    ColorEditor.prototype.originalColor = null;
+    ColorEditor.prototype._originalColor = null;
     
     
     /** Attach event listeners for main UI elements */
-    ColorEditor.prototype.addListeners = function () {
-        this.bindColorFormatToRadioButton("rgba");
-        this.bindColorFormatToRadioButton("hex");
-        this.bindColorFormatToRadioButton("hsla");
+    ColorEditor.prototype._addListeners = function () {
+        this._bindColorFormatToRadioButton("rgba");
+        this._bindColorFormatToRadioButton("hex");
+        this._bindColorFormatToRadioButton("hsla");
         
-        this.bindInputHandlers();
+        this._bindInputHandlers();
         
-        this.bindOriginalColorButton();
+        this._bindOriginalColorButton();
         
-        this.registerDragHandler(this.$selection, this.handleSelectionFieldDrag);
-        this.registerDragHandler(this.$hueSlider, this.handleHueDrag);
-        this.registerDragHandler(this.$opacitySlider, this.handleOpacityDrag);
-        this.bindKeyHandler(this.$selectionBase, this.handleSelectionKeydown);
-        this.bindKeyHandler(this.$hueBase, this.handleHueKeydown);
-        this.bindKeyHandler(this.$opacitySelector, this.handleOpacityKeydown);
-        this.bindKeyHandler(this.$hslButton, this.handleHslKeydown);
+        this._registerDragHandler(this.$selection, this._handleSelectionFieldDrag);
+        this._registerDragHandler(this.$hueSlider, this._handleHueDrag);
+        this._registerDragHandler(this.$opacitySlider, this._handleOpacityDrag);
+        this._bindKeyHandler(this.$selectionBase, this._handleSelectionKeydown);
+        this._bindKeyHandler(this.$hueBase, this._handleHueKeydown);
+        this._bindKeyHandler(this.$opacitySelector, this._handleOpacityKeydown);
+        this._bindKeyHandler(this.$hslButton, this._handleHslKeydown);
         
         // Undo/redo key handler gets bubbling events from any focusable part of widget
-        this.bindKeyHandler(this.$element, this.handleUndoRedoKeys);
+        this._bindKeyHandler(this.$element, this._handleUndoRedoKeys);
     };
 
     /**
-     * Update all UI elements to reflect the selected color (color and hsv). It is usually
-     * incorrect to call this directly; use commitColor() or setColorAsHsv() instead.
+     * Update all UI elements to reflect the selected color (_color and _hsv). It is usually
+     * incorrect to call this directly; use _commitColor() or setColorAsHsv() instead.
      */
-    ColorEditor.prototype.synchronize = function () {
+    ColorEditor.prototype._synchronize = function () {
         var colorValue = this.getColor().toString(),
             colorObject = tinycolor(colorValue),
-            hueColor = "hsl(" + this.hsv.h + ", 100%, 50%)";
+            hueColor = "hsl(" + this._hsv.h + ", 100%, 50%)";
         
-        this.updateColorTypeRadioButtons(colorObject.format);
+        this._updateColorTypeRadioButtons(colorObject.format);
         this.$colorValue.attr("value", colorValue);
         this.$currentColor.css("background-color", colorValue);
         this.$selection.css("background-color", hueColor);
@@ -162,17 +162,17 @@ define(function (require, exports, module) {
         this.$opacityGradient.css("background-image", "-webkit-gradient(linear, 0% 0%, 0% 100%, from(" + hueColor + "), to(transparent))");
         
         // Upate slider thumb positions
-        this.$hueSelector.css("bottom", (this.hsv.h / 360 * 100) + "%");
-        this.$opacitySelector.css("bottom", (this.hsv.a * 100) + "%");
-        if (!isNaN(this.hsv.s)) {      // TODO (#2201): type of hsv.s is unpredictable
-            this.hsv.s = (this.hsv.s * 100) + "%";
+        this.$hueSelector.css("bottom", (this._hsv.h / 360 * 100) + "%");
+        this.$opacitySelector.css("bottom", (this._hsv.a * 100) + "%");
+        if (!isNaN(this._hsv.s)) {      // TODO (#2201): type of _hsv.s/.v is unpredictable
+            this._hsv.s = (this._hsv.s * 100) + "%";
         }
-        if (!isNaN(this.hsv.v)) {
-            this.hsv.v = (this.hsv.v * 100) + "%";
+        if (!isNaN(this._hsv.v)) {
+            this._hsv.v = (this._hsv.v * 100) + "%";
         }
         this.$selectionBase.css({
-            left: this.hsv.s,
-            bottom: this.hsv.v
+            left: this._hsv.s,
+            bottom: this._hsv.v
         });
     };
 
@@ -187,11 +187,11 @@ define(function (require, exports, module) {
 
     /** @return {tinycolor|string} The currently selected color (TODO (#2201): type is unpredictable) */
     ColorEditor.prototype.getColor = function () {
-        return this.color;
+        return this._color;
     };
 
     /** Update the format button bar's selection */
-    ColorEditor.prototype.updateColorTypeRadioButtons = function (format) {
+    ColorEditor.prototype._updateColorTypeRadioButtons = function (format) {
         this.$buttonList.find("li").removeClass("selected");
         switch (format) {
         case "rgb":
@@ -208,7 +208,7 @@ define(function (require, exports, module) {
     };
 
     /** Add event listeners to the format button bar */
-    ColorEditor.prototype.bindColorFormatToRadioButton = function (buttonClass, propertyName, value) {
+    ColorEditor.prototype._bindColorFormatToRadioButton = function (buttonClass, propertyName, value) {
         var handler,
             _this = this;
         handler = function (event) {
@@ -225,19 +225,19 @@ define(function (require, exports, module) {
                 break;
             case "hex":
                 newColor = colorObject.toHexString();
-                _this.hsv.a = 1;
+                _this._hsv.a = 1;
                 break;
             }
-            _this.commitColor(newColor, false);
+            _this._commitColor(newColor, false);
         };
         this.$element.find("." + buttonClass).click(handler);
     };
 
     /** Add event listener to the "original color value" swatch */
-    ColorEditor.prototype.bindOriginalColorButton = function () {
+    ColorEditor.prototype._bindOriginalColorButton = function () {
         var _this = this;
         this.$lastColor.click(function (event) {
-            _this.commitColor(_this.originalColor, true);
+            _this._commitColor(_this._originalColor, true);
         });
     };
 
@@ -284,7 +284,7 @@ define(function (require, exports, module) {
     };
 
     /** Handle changes in text field */
-    ColorEditor.prototype.syncTextFieldInput = function (losingFocus) {
+    ColorEditor.prototype._handleTextFieldInput = function (losingFocus) {
         var newColor = $.trim(this.$colorValue.val()),
             newColorObj = tinycolor(newColor),
             newColorOk = newColorObj.ok;
@@ -307,19 +307,19 @@ define(function (require, exports, module) {
         
         // Sync only if we have a valid color or we're restoring the previous valid color.
         if (losingFocus || newColorOk) {
-            this.commitColor(newColor, true);
+            this._commitColor(newColor, true);
         }
     };
                     
-    ColorEditor.prototype.bindInputHandlers = function () {
+    ColorEditor.prototype._bindInputHandlers = function () {
         var _this = this;
                     
         this.$colorValue.bind("input", function (event) {
-            _this.syncTextFieldInput(false);
+            _this._handleTextFieldInput(false);
         });
 
         this.$colorValue.bind("change", function (event) {
-            _this.syncTextFieldInput(true);
+            _this._handleTextFieldInput(true);
         });
     };
 
@@ -327,7 +327,7 @@ define(function (require, exports, module) {
      * Populate the UI with the given color swatches and add listeners so they're selectable.
      * @param {!Array.<{value:string, count:number}>} swatches
      */
-    ColorEditor.prototype.addSwatches = function (swatches) {
+    ColorEditor.prototype._addSwatches = function (swatches) {
         var _this = this;
  
         // Create swatches
@@ -345,7 +345,7 @@ define(function (require, exports, module) {
                     event.keyCode === KeyEvent.DOM_VK_ENTER ||
                     event.keyCode === KeyEvent.DOM_VK_SPACE) {
                 // Enter/Space is same as clicking on swatch
-                _this.commitColor($(event.currentTarget).find(".value").html());
+                _this._commitColor($(event.currentTarget).find(".value").html());
             } else if (event.keyCode === KeyEvent.DOM_VK_TAB) {
                 // Tab on last swatch loops back to color square
                 if (!event.shiftKey && $(this).next("li").length === 0) {
@@ -358,12 +358,12 @@ define(function (require, exports, module) {
         this.$swatches.find("li").click(function (event) {
             // Set focus to the corresponding value label of the swatch.
             $(event.currentTarget).find(".value").focus();
-            _this.commitColor($(event.currentTarget).find(".value").html());
+            _this._commitColor($(event.currentTarget).find(".value").html());
         });
     };
 
     /**
-     * Sets hsv and color based on an HSV input, and updates the UI. Attempts to preserve
+     * Sets _hsv and _color based on an HSV input, and updates the UI. Attempts to preserve
      * the previous color format.
      * @param {!{h:number=, s:number=, v:number=}} hsv  Any missing values use the previous color's values.
      * @param {boolean=} commitHsv  Whether to normalize the HSV value via tinycolor. Default: true.
@@ -373,8 +373,8 @@ define(function (require, exports, module) {
         oldFormat = tinycolor(this.getColor()).format;
         
         // Set our state to the new color
-        $.extend(this.hsv, hsv);
-        newColor = tinycolor(this.hsv);
+        $.extend(this._hsv, hsv);
+        newColor = tinycolor(this._hsv);
         
         switch (oldFormat) {
         case "hsl":
@@ -385,32 +385,32 @@ define(function (require, exports, module) {
             break;
         case "hex":
         case "name":
-            colorVal = this.hsv.a < 1 ? newColor.toRgbString() : newColor.toHexString();
+            colorVal = this._hsv.a < 1 ? newColor.toRgbString() : newColor.toHexString();
             break;
         }
-        this.commitColor(colorVal, commitHsv);
+        this._commitColor(colorVal, commitHsv);
     };
 
     /**
-     * Sets color (and optionally hsv) based on a string input, and updates the UI. The string's
+     * Sets _color (and optionally _hsv) based on a string input, and updates the UI. The string's
      * format determines the new selected color's format.
      * @param {!string} colorVal
      * @param {boolean=} resetHsv  Pass false ONLY if hsv set already been modified to match colorVal. Default: true.
      */
-    ColorEditor.prototype.commitColor = function (colorVal, resetHsv) {
+    ColorEditor.prototype._commitColor = function (colorVal, resetHsv) {
         var colorObj;
         if (resetHsv === undefined) {
             resetHsv = true;
         }
-        this.callback(colorVal);
-        this.color = colorVal;
+        this._callback(colorVal);
+        this._color = colorVal;
         if (resetHsv) {
             colorObj = tinycolor(colorVal);
-            this.hsv = colorObj.toHsv();
-            this.color = colorObj;
+            this._hsv = colorObj.toHsv();
+            this._color = colorObj;
         }
-        this.redoColor = null;  // if we had undone, this new value blows away the redo history
-        this.synchronize();
+        this._redoColor = null;  // if we had undone, this new value blows away the redo history
+        this._synchronize();
     };
 
     /** Converts a mouse coordinate to be relative to zeroPos, and clips to [0, maxOffset] */
@@ -421,7 +421,7 @@ define(function (require, exports, module) {
     }
     
     /** Dragging color square's thumb */
-    ColorEditor.prototype.handleSelectionFieldDrag = function (event) {
+    ColorEditor.prototype._handleSelectionFieldDrag = function (event) {
         var height, hsv, width, xOffset, yOffset;
         height = this.$selection.height();
         width = this.$selection.width();
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
     };
 
     /** Dragging hue slider thumb */
-    ColorEditor.prototype.handleHueDrag = function (event) {
+    ColorEditor.prototype._handleHueDrag = function (event) {
         var height, hsv, offset;
         height = this.$hueSlider.height();
         offset = _getNewOffset(event.clientY, this.$hueSlider.offset().top, height);
@@ -450,7 +450,7 @@ define(function (require, exports, module) {
     };
 
     /** Dragging opacity slider thumb */
-    ColorEditor.prototype.handleOpacityDrag = function (event) {
+    ColorEditor.prototype._handleOpacityDrag = function (event) {
         var height, hsv, offset;
         height = this.$opacitySlider.height();
         offset = _getNewOffset(event.clientY, this.$opacitySlider.offset().top, height);
@@ -467,7 +467,7 @@ define(function (require, exports, module) {
      * 'handler' to actually move the element as mouse is dragged.
      * @param {!function(jQuery.event)} handler  Called whenever drag position changes
      */
-    ColorEditor.prototype.registerDragHandler = function ($element, handler) {
+    ColorEditor.prototype._registerDragHandler = function ($element, handler) {
         var mouseupHandler = function (event) {
             $(window).unbind("mousemove", handler);
             $(window).unbind("mouseup", mouseupHandler);
@@ -484,23 +484,23 @@ define(function (require, exports, module) {
      * usual undo logic run since it will destroy our bookmarks.
      */
     ColorEditor.prototype.undo = function () {
-        if (this.originalColor.toString() !== this.color.toString()) {
-            var curColor = this.color.toString();
-            this.commitColor(this.originalColor, true);
-            this.redoColor = curColor;
+        if (this._originalColor.toString() !== this._color.toString()) {
+            var curColor = this._color.toString();
+            this._commitColor(this._originalColor, true);
+            this._redoColor = curColor;
         }
     };
 
     /** Similarly, handle redo gestures while color picker has focus. */
     ColorEditor.prototype.redo = function () {
-        if (this.redoColor) {
-            this.commitColor(this.redoColor, true);
-            this.redoColor = null;
+        if (this._redoColor) {
+            this._commitColor(this._redoColor, true);
+            this._redoColor = null;
         }
     };
 
     /** Detect undo/redo keyboard shortcuts. Returns false to block them from CodeMirror */
-    ColorEditor.prototype.handleUndoRedoKeys = function (event) {
+    ColorEditor.prototype._handleUndoRedoKeys = function (event) {
         var hasCtrl = (brackets.platform === "win") ? (event.ctrlKey) : (event.metaKey);
         if (hasCtrl) {
             switch (event.keyCode) {
@@ -518,7 +518,7 @@ define(function (require, exports, module) {
         }
     };
 
-    ColorEditor.prototype.handleHslKeydown = function (event) {
+    ColorEditor.prototype._handleHslKeydown = function (event) {
         switch (event.keyCode) {
         case KeyEvent.DOM_VK_TAB:
             // If we're the last fosuable element (no color swatches), Tab wraps around to color square
@@ -533,7 +533,7 @@ define(function (require, exports, module) {
     };
 
     /** Key events on the color square's thumb */
-    ColorEditor.prototype.handleSelectionKeydown = function (event) {
+    ColorEditor.prototype._handleSelectionKeydown = function (event) {
         var hsv = {},
             step = 1.5,
             xOffset,
@@ -574,9 +574,9 @@ define(function (require, exports, module) {
     };
 
     /** Key events on the hue slider thumb */
-    ColorEditor.prototype.handleHueKeydown = function (event) {
+    ColorEditor.prototype._handleHueKeydown = function (event) {
         var hsv = {},
-            hue = Number(this.hsv.h),
+            hue = Number(this._hsv.h),
             step = 3.6;
 
         switch (event.keyCode) {
@@ -598,8 +598,8 @@ define(function (require, exports, module) {
     };
 
     /** Key events on the opacity slider thumb */
-    ColorEditor.prototype.handleOpacityKeydown = function (event) {
-        var alpha = this.hsv.a,
+    ColorEditor.prototype._handleOpacityKeydown = function (event) {
+        var alpha = this._hsv.a,
             hsv = {},
             step = 0.01;
 
@@ -621,8 +621,8 @@ define(function (require, exports, module) {
         }
     };
 
-    ColorEditor.prototype.bindKeyHandler = function (element, handler) {
-        element.bind("keydown", handler);
+    ColorEditor.prototype._bindKeyHandler = function ($element, handler) {
+        $element.bind("keydown", handler);
     };
 
     // Prevent clicks on some UI elements (color selection field, slider and large swatch) from taking focus

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -387,16 +387,6 @@ define(function (require, exports, module) {
             break;
         }
         this._commitColor(colorVal, commitHsv);
-
-        // Some color values (gray-ish colors) may not get updated with the above 
-        // commitColor call since they are different in hsv values, but still exactly
-        // the same when converting to tiny color object. ie. newColor == oldColor.
-        // So we will update this.hsv here since commitColor call does not update it.
-        // This is necessary to prevent the hue slider from getting stuck when using 
-        // up/down arrow keys (issue #2138).
-        if (this.hsv !== commitHsv) {
-            this.hsv = commitHsv;
-        }
     };
 
     /**
@@ -592,14 +582,14 @@ define(function (require, exports, module) {
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (hue > 0) {
                 hsv.h = (hue - step) <= 0 ? 360 - step : hue - step;
-                this.setColorAsHsv(hsv);
+                this.setColorAsHsv(hsv, false);
             }
             return false;
         case KeyEvent.DOM_VK_UP:
             step = event.shiftKey ? step * STEP_MULTIPLIER : step;
             if (hue < 360) {
                 hsv.h = (hue + step) >= 360 ? step : hue + step;
-                this.setColorAsHsv(hsv);
+                this.setColorAsHsv(hsv, false);
             }
             return false;
         }

--- a/src/extensions/default/InlineColorEditor/ColorEditorTemplate.html
+++ b/src/extensions/default/InlineColorEditor/ColorEditorTemplate.html
@@ -34,7 +34,7 @@
     <header>
       <div class="large_swatches">
         <div class="current_color large_swatch" title="{{COLOR_EDITOR_CURRENT_COLOR_SWATCH_TIP}}"></div>
-        <div class="last_color large_swatch" title="{{COLOR_EDITOR_ORIGINAL_COLOR_SWATCH_TIP}}"></div>
+        <div class="original_color large_swatch" title="{{COLOR_EDITOR_ORIGINAL_COLOR_SWATCH_TIP}}"></div>
       </div>
     </header>
     <ul class="swatches"></ul>

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -33,8 +33,16 @@ define(function (require, exports, module) {
         InlineEditorTemplate = require("text!InlineColorEditorTemplate.html");
         
 
+    /** @const @type {number} */
     var MAX_USED_COLORS = 7;
     
+    
+    /**
+     * Inline widget containing a ColorEditor control
+     * @param {!string} color  Initially selected color
+     * @param {!CodeMirror.Bookmark} startBookmark
+     * @param {!CodeMirror.Bookmark} endBookmark
+     */
     function InlineColorEditor(color, startBookmark, endBookmark) {
         this.color = color;
         this.startBookmark = startBookmark;
@@ -48,19 +56,46 @@ define(function (require, exports, module) {
         InlineWidget.call(this);
     }
 
-    InlineColorEditor.colorRegEx = /#[a-f0-9]{6}|#[a-f0-9]{3}|rgb\( ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?\)|rgba\( ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b(1|0|0\.[0-9]{1,3}) ?\)|hsl\( ?\b([0-9]{1,2}|[12][0-9]{2}|3[0-5][0-9]|360)\b ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b([0-9]{1,2}|100)\b% ?\)|hsla\( ?\b([0-9]{1,2}|[12][0-9]{2}|3[0-5][0-9]|360)\b ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b(1|0|0\.[0-9]{1,3}) ?\)/gi;
+    /**
+     * Regular expression that matches reasonably well-formed colors in hex format (3 or 6 digits),
+     * rgb()/rgba() function format, or hsl()/hsla() function format.
+     * @const @type {RegExp}
+     */
+    InlineColorEditor.COLOR_REGEX = /#[a-f0-9]{6}|#[a-f0-9]{3}|rgb\( ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?\)|rgba\( ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b ?, ?\b(1|0|0\.[0-9]{1,3}) ?\)|hsl\( ?\b([0-9]{1,2}|[12][0-9]{2}|3[0-5][0-9]|360)\b ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b([0-9]{1,2}|100)\b% ?\)|hsla\( ?\b([0-9]{1,2}|[12][0-9]{2}|3[0-5][0-9]|360)\b ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b([0-9]{1,2}|100)\b% ?, ?\b(1|0|0\.[0-9]{1,3}) ?\)/gi;
     
     InlineColorEditor.prototype = new InlineWidget();
     InlineColorEditor.prototype.constructor = InlineColorEditor;
     InlineColorEditor.prototype.parentClass = InlineWidget.prototype;
     InlineColorEditor.prototype.$wrapperDiv = null;
     
+    /** @type {!string} Current value of the color picker control */
     InlineColorEditor.prototype.color = null;
+    
+    /**
+     * Start of the range of code we're attached to; startBookmark.find() may by null if sync is lost.
+     * @type {!CodeMirror.Bookmark}
+     */
     InlineColorEditor.prototype.startBookmark = null;
+    
+    /**
+     * End of the range of code we're attached to; endBookmark.find() may by null if sync is lost or even
+     * in some cases when it's not. Call getCurrentRange() for the definitive text range we're attached to.
+     * @type {!CodeMirror.Bookmark}
+     */
     InlineColorEditor.prototype.endBookmark = null;
+    
+    /** @type {boolean} True while we're syncing a color picker change into the code editor */
     InlineColorEditor.prototype.isOwnChange = null;
+    
+    /** @type {boolean} True while we're syncing a code editor change into the color picker */
     InlineColorEditor.prototype.isHostChange = null;
     
+    
+    /**
+     * Returns the current text range of the color we're attached to, or null if
+     * we've lost sync with what's in the code.
+     * @return {?{start:{line:number, ch:number}, end:{line:number, ch:number}}}
+     */
     InlineColorEditor.prototype.getCurrentRange = function () {
         var start, end;
         
@@ -83,7 +118,7 @@ define(function (require, exports, module) {
         // CodeMirror v2, markText() isn't robust enough for this case.)
         
         var line = this.editor.document.getLine(start.line),
-            matches = line.substr(start.ch).match(InlineColorEditor.colorRegEx);
+            matches = line.substr(start.ch).match(InlineColorEditor.COLOR_REGEX);
         
         // Note that end.ch is exclusive, so we don't need to add 1 before comparing to
         // the matched length here.
@@ -101,11 +136,11 @@ define(function (require, exports, module) {
         }
     };
         
+    /**
+     * When the color picker's selected color changes, update text in code editor
+     * @param {!string} colorLabel
+     */
     InlineColorEditor.prototype.setColor = function (colorLabel) {
-        if (!colorLabel) {
-            return;
-        }
-        
         if (colorLabel !== this.color) {
             var range = this.getCurrentRange();
             if (!range) {
@@ -114,6 +149,7 @@ define(function (require, exports, module) {
 
             // Don't push the change back into the host editor if it came from the host editor.
             if (!this.isHostChange) {
+                // Replace old color in code with the picker's color, and select it
                 this.isOwnChange = true;
                 this.editor.document.replaceRange(colorLabel, range.start, range.end);
                 this.isOwnChange = false;
@@ -127,21 +163,33 @@ define(function (require, exports, module) {
         }
     };
 
+    /**
+     * @override
+     * @param {!Editor} hostEditor
+     */
     InlineColorEditor.prototype.load = function (hostEditor) {
-        var selectedColors = [];
         this.editor = hostEditor;
         this.parentClass.load.call(this, hostEditor);
-        selectedColors = this.editor.document.getText().match(InlineColorEditor.colorRegEx);
-        selectedColors = this.usedColors(selectedColors, MAX_USED_COLORS);
+        
+        // Build the main UI
         this.$wrapperDiv = $(Mustache.render(InlineEditorTemplate, Strings));
-        this.colorEditor = new ColorEditor(this.$wrapperDiv, this.color, this.setColor, selectedColors);
+        
+        // Create color picker control
+        var allColorsInDoc = this.editor.document.getText().match(InlineColorEditor.COLOR_REGEX);
+        var swatchInfo = this.usedColors(allColorsInDoc, MAX_USED_COLORS);
+        this.colorEditor = new ColorEditor(this.$wrapperDiv, this.color, this.setColor, swatchInfo);
         this.$htmlContent.append(this.$wrapperDiv);
     };
 
+    /** @override */
     InlineColorEditor.prototype._editorHasFocus = function () {
         return true;
     };
         
+    /**
+     * @override
+     * Perform sizing & focus once we've been added to Editor's DOM
+     */
     InlineColorEditor.prototype.onAdded = function () {
         this.parentClass.onAdded.call(this);
         
@@ -149,10 +197,14 @@ define(function (require, exports, module) {
         doc.addRef();
         $(doc).on("change", this.handleHostDocumentChange);
         
-        window.setTimeout(this._sizeEditorToContent.bind(this));
+        window.setTimeout(this._sizeEditorToContent.bind(this), 0);
         this.colorEditor.focus();
     };
     
+    /**
+     * @override
+     * Called whenever the inline widget is closed, whether automatically or explicitly
+     */
     InlineColorEditor.prototype.onClosed = function () {
         if (this.startBookmark) {
             this.startBookmark.clear();
@@ -172,6 +224,7 @@ define(function (require, exports, module) {
         this.hostEditor.setInlineWidgetHeight(this, this.$wrapperDiv.outerHeight(), true);
     };
 
+    /** Sorts by which colors are used the most */
     function _colorSort(a, b) {
         if (a.count === b.count) {
             return 0;
@@ -184,6 +237,13 @@ define(function (require, exports, module) {
         }
     }
 
+    /**
+     * Counts how many times each color in originalArray occurs (ignoring case) and
+     * retuns the top 'maxLength' number of unique colors.
+     * @param {!Array.<string>} originalArray
+     * @param {number} maxLength
+     * @return {!Array.<{value:string, count:number}>}
+     */
     InlineColorEditor.prototype.usedColors = function (originalArray, maxLength) {
         var copyArray,
             compressed = [];
@@ -216,6 +276,9 @@ define(function (require, exports, module) {
         return compressed.slice(0, maxLength);
     };
     
+    /**
+     * When text in the code editor changes, update color picker to reflect it
+     */
     InlineColorEditor.prototype.handleHostDocumentChange = function () {
         // Don't push the change into the color editor if it came from the color editor.
         if (this.isOwnChange) {

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -68,9 +68,6 @@ define(function (require, exports, module) {
     /** @type {!ColorPicker} ColorPicker instance */
     InlineColorEditor.prototype.colorEditor = null;
     
-    /** @type {!jQuery} Root of ColorPicker's UI */
-    InlineColorEditor.prototype.$colorEditorRoot = null;
-    
     /** @type {!string} Current value of the color picker control */
     InlineColorEditor.prototype._color = null;
     
@@ -176,9 +173,8 @@ define(function (require, exports, module) {
         
         // Create color picker control
         var allColorsInDoc = this.editor.document.getText().match(InlineColorEditor.COLOR_REGEX);
-        var swatchInfo = this._topUsedColors(allColorsInDoc, MAX_USED_COLORS);
+        var swatchInfo = this._collateColors(allColorsInDoc, MAX_USED_COLORS);
         this.colorEditor = new ColorEditor(this.$htmlContent, this._color, this._handleColorChange, swatchInfo);
-        this.$colorEditorRoot = this.colorEditor.$element;
     };
 
     /** @override */
@@ -221,10 +217,10 @@ define(function (require, exports, module) {
     };
 
     InlineColorEditor.prototype._sizeEditorToContent = function () {
-        this.hostEditor.setInlineWidgetHeight(this, this.$colorEditorRoot.outerHeight(), true);
+        this.hostEditor.setInlineWidgetHeight(this, this.colorEditor.getRootElement().outerHeight(), true);
     };
 
-    /** Sorts by which colors are used the most */
+    /** Comparator to sort by which colors are used the most */
     function _colorSort(a, b) {
         if (a.count === b.count) {
             return 0;
@@ -244,7 +240,7 @@ define(function (require, exports, module) {
      * @param {number} maxLength
      * @return {!Array.<{value:string, count:number}>}
      */
-    InlineColorEditor.prototype._topUsedColors = function (originalArray, maxLength) {
+    InlineColorEditor.prototype._collateColors = function (originalArray, maxLength) {
         // Maps from lowercase color name to swatch info (user-case color name & occurrence count)
         /* @type {Object.<string, {value:string, count:number}>} */
         var colorInfo = {};
@@ -283,7 +279,7 @@ define(function (require, exports, module) {
             var newColor = this.editor.document.getRange(range.start, range.end);
             if (newColor !== this._color) {
                 this._isHostChange = true;
-                this.colorEditor._commitColor(newColor, true);
+                this.colorEditor.setColorFromString(newColor);
                 this._isHostChange = false;
             }
         } else {

--- a/src/extensions/default/InlineColorEditor/css/main.css
+++ b/src/extensions/default/InlineColorEditor/css/main.css
@@ -64,7 +64,7 @@
     top: 0;
     background-color: rgba(0,187,255,0.8);
 }
-.color_editor aside header .last_color {
+.color_editor aside header .original_color {
     border-radius: 0px 3px 3px 0px;
     background-color: #ccc;
     right: 0;

--- a/src/extensions/default/InlineColorEditor/main.js
+++ b/src/extensions/default/InlineColorEditor/main.js
@@ -32,6 +32,16 @@ define(function (require, exports, module) {
         ExtensionUtils      = brackets.getModule("utils/ExtensionUtils"),
         InlineColorEditor   = require("InlineColorEditor").InlineColorEditor;
     
+    
+    /**
+     * Registered as an inline editor provider: creates an InlineEditorColor when the cursor
+     * is on a color value (in any flavor of code).
+     *
+     * @param {!Editor} hostEditor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {?$.Promise} synchronously resolved with an InlineWidget, or null if there's
+     *      no color at pos.
+     */
     function inlineColorEditorProvider(hostEditor, pos) {
         var colorPicker, colorRegEx, cursorLine, inlineColorEditor, match, result,
             sel, start, end, startBookmark, endBookmark;
@@ -41,7 +51,7 @@ define(function (require, exports, module) {
             return null;
         }
         
-        colorRegEx = new RegExp(InlineColorEditor.colorRegEx);
+        colorRegEx = new RegExp(InlineColorEditor.COLOR_REGEX);
         cursorLine = hostEditor.document.getLine(pos.line);
         
         // Loop through each match of colorRegEx and stop when the one that contains pos is found.
@@ -60,6 +70,7 @@ define(function (require, exports, module) {
         // Adjust pos to the beginning of the match so that the inline editor won't get 
         // dismissed while we're updating the color with the new values from user's inline editing.
         pos.ch = start;
+        
         startBookmark = hostEditor._codeMirror.setBookmark(pos);
         endBookmark = hostEditor._codeMirror.setBookmark({ line: pos.line, ch: end });
         

--- a/src/extensions/default/InlineColorEditor/main.js
+++ b/src/extensions/default/InlineColorEditor/main.js
@@ -84,10 +84,12 @@ define(function (require, exports, module) {
         return result.promise();
     }
     
+    
     // Initialize extension
     ExtensionUtils.loadStyleSheet(module, "css/main.css");
     
     EditorManager.registerInlineEditProvider(inlineColorEditorProvider);
+    
     
     // for unit tests only
     exports.inlineColorEditorProvider = inlineColorEditorProvider;

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, runs, $, brackets, waitsForDone, spyOn, Mustache, tinycolor, KeyEvent */
+/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, $, brackets, waitsForDone, spyOn, tinycolor, KeyEvent */
 
 define(function (require, exports, module) {
     "use strict";
@@ -38,8 +38,7 @@ define(function (require, exports, module) {
         testContentHTML   = require("text!unittests.html"),
         provider          = require("main").inlineColorEditorProvider,
         InlineColorEditor = require("InlineColorEditor").InlineColorEditor,
-        ColorEditor       = require("ColorEditor").ColorEditor,
-        InlineEditorTemplate = require("text!InlineColorEditorTemplate.html");
+        ColorEditor       = require("ColorEditor").ColorEditor;
 
     require("thirdparty/tinycolor-min");
 
@@ -320,8 +319,7 @@ define(function (require, exports, module) {
         });
         
         describe("Color editor UI", function () {
-            var $container,
-                colorEditor,
+            var colorEditor,
                 defaultSwatches = [{value: "#abcdef", count: 3}, {value: "rgba(100, 200, 250, 0.5)", count: 2}];
             
             /**
@@ -334,16 +332,15 @@ define(function (require, exports, module) {
              *     If none is supplied, a default set of two swatches is passed.
              */
             function makeUI(initialColor, callback, swatches) {
-                $container = $(Mustache.render(InlineEditorTemplate, Strings)).css("display", "none");
-                colorEditor = new ColorEditor($container,
+                colorEditor = new ColorEditor($(document.body),
                                               initialColor,
                                               callback || function () { },
                                               swatches || defaultSwatches);
-                $(document.body).append($container);
+                colorEditor.$element.css("display", "none");
             }
                         
             afterEach(function () {
-                $container.remove();
+                colorEditor.$element.remove();
             });
             
             /**
@@ -500,7 +497,7 @@ define(function (require, exports, module) {
                     makeUI("#0000ff");
                     eventAtRatio("mousedown", colorEditor[opts.item], opts.clickAt);
                     checkNear(tinycolor(colorEditor.color).toHsv()[opts.param], opts.expected, opts.tolerance);
-                    colorEditor[opts.item].trigger("mouseup");
+                    colorEditor[opts.item].trigger("mouseup");  // clean up drag state
                 }
 
                 /**
@@ -520,7 +517,7 @@ define(function (require, exports, module) {
                     eventAtRatio("mousedown", colorEditor[opts.item], opts.clickAt);
                     eventAtRatio("mousemove", colorEditor[opts.item], opts.dragTo);
                     checkNear(tinycolor(colorEditor.color).toHsv()[opts.param], opts.expected, opts.tolerance);
-                    colorEditor[opts.item].trigger("mouseup");
+                    colorEditor[opts.item].trigger("mouseup");  // clean up drag state
                 }
                 
                 it("should set saturation on mousedown", function () {
@@ -1186,6 +1183,7 @@ define(function (require, exports, module) {
                         eventAtRatio("mousedown", colorEditor.$selectionBase, [0.5, 0.5]);
                         triggerCtrlKey(colorEditor.$selectionBase, KeyEvent.DOM_VK_Z);
                         expect(tinycolor(colorEditor.color).toString()).toBe("rgba(100, 150, 200, 0.3)");
+                        colorEditor.$selectionBase.trigger("mouseup");  // clean up drag state
                     });
                 });
                 it("should undo a hue change", function () {
@@ -1194,6 +1192,7 @@ define(function (require, exports, module) {
                         eventAtRatio("mousedown", colorEditor.$hueBase, [0, 0.5]);
                         triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
                         expect(tinycolor(colorEditor.color).toString()).toBe("rgba(100, 150, 200, 0.3)");
+                        colorEditor.$hueBase.trigger("mouseup");  // clean up drag state
                     });
                 });
                 it("should undo an opacity change", function () {
@@ -1202,6 +1201,7 @@ define(function (require, exports, module) {
                         eventAtRatio("mousedown", colorEditor.$opacitySelector, [0, 0.5]);
                         triggerCtrlKey(colorEditor.$opacitySelector, KeyEvent.DOM_VK_Z);
                         expect(tinycolor(colorEditor.color).toString()).toBe("rgba(100, 150, 200, 0.3)");
+                        colorEditor.$opacitySelector.trigger("mouseup");  // clean up drag state
                     });
                 });
                 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
                 it("should update host document when change is committed in color editor", function () {
                     makeColorEditor({line: 1, ch: 18});
                     runs(function () {
-                        inline.colorEditor._commitColor("#c0c0c0", false);
+                        inline.colorEditor.setColorFromString("#c0c0c0");
                         expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
                     });
                 });
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
                 it("should update correct range of host document with color format of different length", function () {
                     makeColorEditor({line: 1, ch: 18});
                     runs(function () {
-                        inline.colorEditor._commitColor("rgb(20, 20, 20)", false);
+                        inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
                         expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 31})).toBe("rgb(20, 20, 20)");
                     });
                 });
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
                 it("should not invalidate range when change is committed", function () {
                     makeColorEditor({line: 1, ch: 18});
                     runs(function () {
-                        inline.colorEditor._commitColor("rgb(20, 20, 20)", false);
+                        inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
                         expect(inline.getCurrentRange()).not.toBeNull();
                     });
                 });
@@ -300,7 +300,7 @@ define(function (require, exports, module) {
             
             it("should trim the original array to the given length", function () {
                 var inline = new InlineColorEditor();
-                var result = inline._topUsedColors(["#abcdef", "#fedcba", "#aabbcc", "#bbccdd"], 2);
+                var result = inline._collateColors(["#abcdef", "#fedcba", "#aabbcc", "#bbccdd"], 2);
                 expect(result).toEqual([
                     {value: "#abcdef", count: 1},
                     {value: "#fedcba", count: 1}
@@ -309,7 +309,7 @@ define(function (require, exports, module) {
             
             it("should remove duplicates from the original array and sort it by usage", function () {
                 var inline = new InlineColorEditor();
-                var result = inline._topUsedColors(["#abcdef", "#fedcba", "#123456", "#FEDCBA", "#123456", "#123456", "rgb(100, 100, 100)"], 100);
+                var result = inline._collateColors(["#abcdef", "#fedcba", "#123456", "#FEDCBA", "#123456", "#123456", "rgb(100, 100, 100)"], 100);
                 expect(result).toEqual([
                     {value: "#123456", count: 3},
                     {value: "#fedcba", count: 2},
@@ -337,11 +337,11 @@ define(function (require, exports, module) {
                                               initialColor,
                                               callback || function () { },
                                               swatches || defaultSwatches);
-                colorEditor.$element.css("display", "none");
+                colorEditor.getRootElement().css("display", "none");
             }
                         
             afterEach(function () {
-                colorEditor.$element.remove();
+                colorEditor.getRootElement().remove();
             });
             
             /**
@@ -403,7 +403,7 @@ define(function (require, exports, module) {
                     
                     runs(function () {
                         makeUI("#0a0a0a");
-                        colorEditor._commitColor(colorStr, true);
+                        colorEditor.setColorFromString(colorStr);
                         expect(colorEditor.getColor().toString()).toBe(colorStr);
                         expect(colorEditor.$colorValue.attr("value")).toBe(colorStr);
                         expect(tinycolor.equals(colorEditor.$currentColor.css("background-color"), colorStr)).toBe(true);
@@ -428,7 +428,7 @@ define(function (require, exports, module) {
                     makeUI("rgba(100, 100, 100, 0.5)", function (color) {
                         lastColor = color;
                     });
-                    colorEditor._commitColor("#a0a0a0", true);
+                    colorEditor.setColorFromString("#a0a0a0");
                     expect(lastColor).toBe("#a0a0a0");
                 });
                 
@@ -1087,8 +1087,8 @@ define(function (require, exports, module) {
                 
                 it("should restore to original color when clicked on", function () {
                     makeUI("#abcdef");
-                    colorEditor._commitColor("#0000ff");
-                    colorEditor.$lastColor.trigger("click");
+                    colorEditor.setColorFromString("#0000ff");
+                    colorEditor.$originalColor.trigger("click");
                     expect(tinycolor(colorEditor.getColor()).toHexString()).toBe("#abcdef");
                 });
                 
@@ -1157,7 +1157,7 @@ define(function (require, exports, module) {
                 it("should undo when Ctrl-Z is pressed on a focused element in the color editor", function () {
                     makeUI("#abcdef");
                     runs(function () {
-                        colorEditor._commitColor("#a0a0a0", true);
+                        colorEditor.setColorFromString("#a0a0a0");
                         colorEditor.$hueBase.focus();
                         triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
                         expect(getColorString()).toBe("#abcdef");


### PR DESCRIPTION
It's probably easiest to look at the three commits each separately:
1. First commit adds lots of docs and contains a few smaller code cleanups
2. Second commit contains a few larger cleanups, and fixes #2202
3. Third commit renames many methods to add underscores

The individual commit messages contain more detailed notes.
