### PR TITLE
Add expand/collapse triangle icons to Find in Files search results headings

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -282,11 +282,14 @@ define(function (require, exports, module) {
                     
                     // Add row for file name
                     $("<tr class='file-section' />")
-                        .append("<td colspan='3'>" + StringUtils.format(Strings.FIND_IN_FILES_FILE_PATH, StringUtils.breakableUrl(esc(item.fullPath))) + "</td>")
+                        .append("<td colspan='3'><span class='disclosure-triangle expanded'></span>" + StringUtils.format(Strings.FIND_IN_FILES_FILE_PATH, StringUtils.breakableUrl(esc(item.fullPath))) + "</td>")
                         .click(function () {
                             // Clicking file section header collapses/expands result rows for that file
                             var $fileHeader = $(this);
                             $fileHeader.nextUntil(".file-section").toggle();
+                            
+                            var $triangle = $(".disclosure-triangle", $fileHeader);
+                            $triangle.toggleClass("expanded").toggleClass("collapsed");
                         })
                         .appendTo($resultTable);
                     

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -281,8 +281,10 @@ define(function (require, exports, module) {
                     };
                     
                     // Add row for file name
+                    var displayFileName = StringUtils.format(Strings.FIND_IN_FILES_FILE_PATH,
+                                                             StringUtils.breakableUrl(esc(item.fullPath)));
                     $("<tr class='file-section' />")
-                        .append("<td colspan='3'><span class='disclosure-triangle expanded'></span>" + StringUtils.format(Strings.FIND_IN_FILES_FILE_PATH, StringUtils.breakableUrl(esc(item.fullPath))) + "</td>")
+                        .append("<td colspan='3'><span class='disclosure-triangle expanded'></span>" + displayFileName + "</td>")
                         .click(function () {
                             // Clicking file section header collapses/expands result rows for that file
                             var $fileHeader = $(this);

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -500,7 +500,7 @@ a, img {
 }
 
 
-@sprite-size-18: 4px;
+@jstree-sprite-size: 18px;  // this is hardcoded in jsTree's JS code
 
 /** Classes for icons from jsTreeSprites.svg 
 */
@@ -509,27 +509,12 @@ a, img {
     background-repeat: no-repeat;
     background-color: transparent;
     vertical-align: middle;
-    width: @sprite-size-18;
-    height: @sprite-size-18;
+    width: @jstree-sprite-size;
+    height: @jstree-sprite-size;
 }
 
-.disclosure-arrow-opened {
-    .jstree-sprite;
-    display: inline-block;
-    background-position: -@sprite-size-18 0px;
-}
-
-.disclosure-arrow-closed {
-    .jstree-sprite;
-    display: inline-block;
-    background-position: 0px 0px;
-}
-ins.jstree-icon {
-    left: -12px !important;
-}
 /** Classes for icons from bracketSprites.png 
 */
-
 .bracket-sprite {
     background-image: url("images/close_btn.svg");
     background-repeat: no-repeat;
@@ -708,6 +693,21 @@ ins.jstree-icon {
     .code-font();
 }
 
+
+/* Find in Files results panel - temporary UI, to be replaced with a richer search feature later */
+
+#search-results .disclosure-triangle {
+    .jstree-sprite;
+    display: inline-block;
+    &.expanded {
+        // Unfortunately, the way jsTree sprites are aligned within their 18px boxes doesn't look good in
+        // other contexts, so we need some tweaks here instead of straight multiples of @jstree-sprite-size
+        background-position: -(@jstree-sprite-size*1 - 2px) -(@jstree-sprite-size*1 - 1px);
+    }
+    &.collapsed {
+        background-position: -(@jstree-sprite-size*0 - 2px) -@jstree-sprite-size*1;
+    }
+}
 
 /* Find & Replace search bars - temporary UI, to be replaced with a richer search feature later */
 

--- a/src/styles/images/jsTreeSprites.svg
+++ b/src/styles/images/jsTreeSprites.svg
@@ -3,10 +3,24 @@
 		<filter id="blur" x="-10" y="-10" width="12" height="12">
 			<feGaussianBlur in="SourceGraphic" stdDeviation=".25"/>
 		</filter>
+        <polyline id="arrow-r-shadow" points="11,10.5 5,7 5,14 11,10.5" filter="url(#blur)" opacity=".5" transform="translate(0, 1)"/>
+        <polyline id="arrow-r" points="11,10.5 5,7 5,14 11,10.5"/>
+        <polyline id="arrow-d-shadow" points="25.5,13 29,7 22,7 25.5,13" filter="url(#blur)" opacity=".5" transform="translate(0, 1)"/>
+        <polyline id="arrow-d" points="25.5,13 29,7 22,7 25.5,13"/>
 	</defs>
 
-	<polyline points="11,10.5 5,7 5,14 11,10.5" filter="url(#blur)" opacity=".5" transform="translate(0, 1)"/>
-	<polyline points="25.5,13 29,7 22,7 25.5,13" filter="url(#blur)" opacity=".5" transform="translate(0, 1)"/>
-	<polyline fill="#878787" points="11,10.5 5,7 5,14 11,10.5"/>
-	<polyline fill="#fff" points="25.5,13 29,7 22,7 25.5,13"/>
+    <!-- Project tree: dark background -->
+    <use xlink:href="#arrow-r-shadow" />
+    <use xlink:href="#arrow-r" fill="#878787" />
+    
+    <use xlink:href="#arrow-d-shadow" />
+    <use xlink:href="#arrow-d" fill="#fff" />
+    
+    <!-- Elsewhere: light background -->
+    <use xlink:href="#arrow-r-shadow" y="14" />
+    <use xlink:href="#arrow-r" y="14" fill="#878787" />
+    
+    <use xlink:href="#arrow-d-shadow" y="14" />
+    <use xlink:href="#arrow-d" y="14" fill="#555" />
+    
 </svg>

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -33,15 +33,18 @@
 .jstree-brackets .jstree-closed > ins { background-position:-54px 0; }
 .jstree-brackets .jstree-leaf > ins { background-position:-36px 0; }
 
+@jstree-icon-backindent: 12px;
+
 /* Make the links in the JS tree the width of the container
  * by shifting the off the screen by negative margin and moving the
  * content back by pushing the padding. The icons are positioned absolute
- * relative to the containing list item so the sit above the a's background. 
+ * relative to the containing list item so they sit above the a's background.
  * This also means we need to include the size of the sprite in the padding
  * so the text ends up back in the same spot visually
  */
 .jstree-brackets li > a {
-    padding-left: @sprite-size-18 + 10000;
+    @jstree-icon-text-overlap: 2px;
+    padding-left: (@jstree-sprite-size - @jstree-icon-backindent - @jstree-icon-text-overlap) + 10000px;
     margin-left: -10000px;
     display: block;
 }
@@ -79,6 +82,9 @@
 .jstree ins {
     position: absolute;
 }
+ins.jstree-icon {
+    left: -@jstree-icon-backindent !important;
+}
 
 .jstree-brackets a .jstree-icon { background-position:-56px -19px; }
 .jstree-brackets a.jstree-loading .jstree-icon { background:url("images/throbber.gif") center center no-repeat !important; }
@@ -92,6 +98,7 @@
     margin-bottom: 2px;
 }
 
+// These styles control the expand/collapse arrow icons. Most other styles in this file with background-position are unused.
 .jstree-brackets .jstree-no-dots li, 
 .jstree-brackets .jstree-no-dots .jstree-leaf > ins { background:transparent; }
 .jstree-brackets .jstree-no-dots .jstree-open > ins { background-position:-18px 0; }


### PR DESCRIPTION
Although this is "bonus work," I'm hoping to squeeze it into Sprint 17 to aid discoverability of the existing expand/collapse feature.

This also cleans up how jsTreeSprites.svg is used:
- Use `<defs>` to reduce SVG code duplication
- Use clearer named sprite size/offset constants
- Remove unused (& broken) "disclosure-arrow-*" styles
- Move "ins.jstree-icon" style into jsTreeTheme.less.

I've compared screenshots of the project tree to verify that this doesn't affect the appearance of its triangles at all.
