### PR TITLE
Add more server file extensions to Live Preview

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -278,7 +278,7 @@ define(function (require, exports, module) {
 
     /** @const - hard-coded for now, but may want to make these preferences */
     var _staticHtmlFileExts = ["htm", "html"],
-        _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "shtm", "shtml"];
+        _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "asp", "aspx", "jsp", "jspx", "shtm", "shtml"];
 
     /**
      * Determine if file extension is a static html file extension.


### PR DESCRIPTION
Add asp, aspx, jsp, jspx file extensions to server file list.

@peterflynn Here's the change you requested for issue #2103. It feels weird that the new server file extensions are _not_ supported modes. I think that simply adding those file extensions to the "htmlmixed" mode will cause more problems than it fixes because those are script-based markup languages, so the code can easily break all subsequent syntax coloring in page.

You won't hurt my feelings if you reject this change :)
