### PR TITLE
Redraw CSS Highlights when Brackets is focused

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -192,7 +192,7 @@ function RemoteFunctions(experimental) {
         this.color = color;
         this.trigger = !!trigger;
         this.elements = [];
-        this.orgColors = [];
+        this.selector = "";
     }
 
     Highlight.prototype = {
@@ -296,7 +296,13 @@ function RemoteFunctions(experimental) {
         },
         
         redraw: function () {
-            var i, highlighted = this.elements.slice(0);
+            var i, highlighted;
+            
+            if (this.selector) {
+                highlighted = window.document.querySelectorAll(this.selector);
+            } else {
+                this.elements.slice(0);
+            }
             
             this.clear();
             for (i in highlighted) {
@@ -423,6 +429,7 @@ function RemoteFunctions(experimental) {
         for (i = 0; i < nodes.length; i++) {
             highlight(nodes[i]);
         }
+        _remoteHighlight.selector = rule;
     }
     
     // redraw active highlights

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -298,6 +298,8 @@ function RemoteFunctions(experimental) {
         redraw: function () {
             var i, highlighted;
             
+            // When redrawing a selector-based highlight, run a new selector
+            // query to ensure we have the latest set of elements to highlight.
             if (this.selector) {
                 highlighted = window.document.querySelectorAll(this.selector);
             } else {

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -303,7 +303,7 @@ function RemoteFunctions(experimental) {
             if (this.selector) {
                 highlighted = window.document.querySelectorAll(this.selector);
             } else {
-                this.elements.slice(0);
+                highlighted = this.elements.slice(0);
             }
             
             this.clear();

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -623,6 +623,13 @@ define(function LiveDevelopment(require, exports, module) {
             agents.highlight.hide();
         }
     }
+    
+    /** Redraw highlights **/
+    function redrawHighlight() {
+        if (Inspector.connected() && agents.highlight) {
+            agents.highlight.redraw();
+        }
+    }
 
     /** Triggered by a document change from the DocumentManager */
     function _onDocumentChange() {
@@ -697,5 +704,6 @@ define(function LiveDevelopment(require, exports, module) {
     exports.getLiveDocForPath   = getLiveDocForPath;
     exports.showHighlight       = showHighlight;
     exports.hideHighlight       = hideHighlight;
+    exports.redrawHighlight     = redrawHighlight;
     exports.init                = init;
 });

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -212,7 +212,8 @@ define(function main(require, exports, module) {
             });
         }
         
-        // Redraw highlights when window gets focus. 
+        // Redraw highlights when window gets focus. This ensures that the highlights
+        // will be in sync with any DOM changes that may have occurred.
         $(window).focus(function () {
             if (Inspector.connected() && config.highlight) {
                 LiveDevelopment.redrawHighlight();

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -211,6 +211,13 @@ define(function main(require, exports, module) {
                 }
             });
         }
+        
+        // Redraw highlights when window gets focus. 
+        $(window).focus(function () {
+            if (Inspector.connected() && config.highlight) {
+                LiveDevelopment.redrawHighlight();
+            }
+        });
     }
     
     // init prefs


### PR DESCRIPTION
This is a partial workaround for #2188. Whenever Brackets is re-focused, any existing CSS Highlights will be redrawn. 

Whenever CSS highlights are redrawn, a new `querySelectorAll()` call is made so any elements added (or removed) since the last query will be properly updated.

As a side effect of this change, scrolling or resizing the browser will also re-run the query, which will catch any elements that have been added/removed since the last update.
