### PR TITLE
Partial fix for #2015 (Bottom panels get messed up if resized to max height)

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -346,7 +346,9 @@ define(function (require, exports, module) {
                 availableHt -= $elem.outerHeight();
             }
         });
-        return availableHt;
+        
+        // Clip value to 0 (it could be negative if a panel wants more space than we have)
+        return Math.max(availableHt, 0);
     }
     
     /** 


### PR DESCRIPTION
Partial fix for #2015 -- fixes the originally reported bug, but not several related issues that are listed lower down in the bug thread.

About this fix:
When panel size > the available area (which can happen several ways, including a bug in Resizer that allows drags to overshoot the max size that would fit), we were computing a negative size for the #editor-holder. This was a problem because jQuery no-ops on negative sizes; clipping to 0 gives much better results.
#2015 should remain open to track the other panel-oversize-related bugs mentioned there.
