### PR TITLE
For #2229, don't prevent default on arrow keys when focus is in the colo...

### DIFF
--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -545,10 +545,7 @@ define(function (require, exports, module) {
                     
                 // If the input has no "type" attribute, it defaults to text. So we
                 // have to check for both possibilities.
-                if (!$target.is("input:not([type])") && !$target.is("input[type=text]")) {
-                    // Not a text input control, so we want to prevent default.
-                    preventDefault = true;
-                } else {
+                if ($target.is("input:not([type])") || $target.is("input[type=text]")) {
                     // Text input control. In WebKit, if the cursor gets to the start
                     // or end of a text field and can't move any further, the default 
                     // action doesn't take place in the text field, so the event is handled
@@ -557,7 +554,11 @@ define(function (require, exports, module) {
                             (event.keyCode === KeyEvent.DOM_VK_RIGHT && $target[0].selectionEnd === $target.val().length)) {
                         preventDefault = true;
                     }
+                } else {
+                    // Not a text input control, so we want to prevent default.
+                    preventDefault = true;
                 }
+
                 if (preventDefault) {
                     event.stopPropagation();
                     return false; // equivalent to event.preventDefault()

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -550,8 +550,9 @@ define(function (require, exports, module) {
                     // or end of a text field and can't move any further, the default 
                     // action doesn't take place in the text field, so the event is handled
                     // by the outer scroller. We have to prevent in that case too.
-                    if ((event.keyCode === KeyEvent.DOM_VK_LEFT && $target[0].selectionStart === 0) ||
-                            (event.keyCode === KeyEvent.DOM_VK_RIGHT && $target[0].selectionEnd === $target.val().length)) {
+                    if ($target[0].selectionStart === $target[0].selectionEnd &&
+                            ((event.keyCode === KeyEvent.DOM_VK_LEFT && $target[0].selectionStart === 0) ||
+                             (event.keyCode === KeyEvent.DOM_VK_RIGHT && $target[0].selectionEnd === $target.val().length))) {
                         preventDefault = true;
                     }
                 } else {

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -535,10 +535,34 @@ define(function (require, exports, module) {
             case KeyEvent.DOM_VK_RIGHT:
             case KeyEvent.DOM_VK_UP:
             case KeyEvent.DOM_VK_DOWN:
-                // Prevent arrow keys that weren't handled by a child control from bubbling
-                // up to an outer element (e.g. a scroller).
-                event.stopPropagation();
-                return false;
+                // Prevent arrow keys that weren't handled by a child control 
+                // from being handled by a parent, either through bubbling or 
+                // through default native behavior. There isn't a good general
+                // way to tell if the target would handle this event by default,
+                // so we look to see if the target is a text input control.
+                var preventDefault = false,
+                    $target = $(event.target);
+                    
+                // If the input has no "type" attribute, it defaults to text. So we
+                // have to check for both possibilities.
+                if (!$target.is("input:not([type])") && !$target.is("input[type=text]")) {
+                    // Not a text input control, so we want to prevent default.
+                    preventDefault = true;
+                } else {
+                    // Text input control. In WebKit, if the cursor gets to the start
+                    // or end of a text field and can't move any further, the default 
+                    // action doesn't take place in the text field, so the event is handled
+                    // by the outer scroller. We have to prevent in that case too.
+                    if ((event.keyCode === KeyEvent.DOM_VK_LEFT && $target[0].selectionStart === 0) ||
+                            (event.keyCode === KeyEvent.DOM_VK_RIGHT && $target[0].selectionEnd === $target.val().length)) {
+                        preventDefault = true;
+                    }
+                }
+                if (preventDefault) {
+                    event.stopPropagation();
+                    return false; // equivalent to event.preventDefault()
+                }
+                break;
             }
         }
     };

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -331,7 +331,7 @@ define(function (require, exports, module) {
              *     none is supplied, a dummy function is passed.
              * @param {?Array.<{value:string, count:number}>} swatches An optional array of swatches to display.
              *     If none is supplied, a default set of two swatches is passed.
-             * @param {boolean} hide Whether to hide the color picker; default is true.
+             * @param {boolean=} hide Whether to hide the color picker; default is true.
              */
             function makeUI(initialColor, callback, swatches, hide) {
                 colorEditor = new ColorEditor($(document.body),
@@ -737,7 +737,7 @@ define(function (require, exports, module) {
                  * @param {object} opts The parameters to test:
                  *     color: An optional initial value to set in the ColorEditor. Defaults to "hsla(50, 25%, 50%, 0.5)".
                  *     item: The (string) name of the member of ColorEditor that references the element to test.
-                 *     selection: An optional initial selection [start, end] to set in the given element.
+                 *     selection: An optional array ([start, end]) specifying the selection to set in the given element.
                  *     key: The KeyEvent key code to simulate.
                  *     shiftKey: Optional boolean specifying whether to simulate the shift key being down (default false).
                  *     expected: Whether the default is expected to be prevented.
@@ -1129,12 +1129,48 @@ define(function (require, exports, module) {
                         expected:  true
                     });
                 });
+                it("should prevent default on left arrow at the start of the text field", function () {
+                    testPreventDefault({
+                        color:     "#8e8247",
+                        item:      "$colorValue",
+                        selection: [0, 0],
+                        key:       KeyEvent.DOM_VK_LEFT,
+                        expected:  true
+                    });
+                });
                 it("should not prevent default on left arrow in the middle of the text field", function () {
                     testPreventDefault({
                         color:     "#8e8247",
                         item:      "$colorValue",
                         selection: [3, 3],
                         key:       KeyEvent.DOM_VK_LEFT,
+                        expected:  false
+                    });
+                });
+                it("should not prevent default on left arrow at the end of the text field", function () {
+                    testPreventDefault({
+                        color:     "#8e8247",
+                        item:      "$colorValue",
+                        selection: [7, 7],
+                        key:       KeyEvent.DOM_VK_LEFT,
+                        expected:  false
+                    });
+                });
+                it("should not prevent default on left arrow with a range selection", function () {
+                    testPreventDefault({
+                        color:     "#8e8247",
+                        item:      "$colorValue",
+                        selection: [0, 7],
+                        key:       KeyEvent.DOM_VK_LEFT,
+                        expected:  false
+                    });
+                });
+                it("should not prevent default on right arrow at the start of the text field", function () {
+                    testPreventDefault({
+                        color:     "#8e8247",
+                        item:      "$colorValue",
+                        selection: [0, 0],
+                        key:       KeyEvent.DOM_VK_RIGHT,
                         expected:  false
                     });
                 });
@@ -1147,15 +1183,6 @@ define(function (require, exports, module) {
                         expected:  false
                     });
                 });
-                it("should prevent default on left arrow at the start of the text field", function () {
-                    testPreventDefault({
-                        color:     "#8e8247",
-                        item:      "$colorValue",
-                        selection: [0, 0],
-                        key:       KeyEvent.DOM_VK_LEFT,
-                        expected:  true
-                    });
-                });
                 it("should prevent default on right arrow at the end of the text field", function () {
                     testPreventDefault({
                         color:     "#8e8247",
@@ -1163,6 +1190,15 @@ define(function (require, exports, module) {
                         selection: [7, 7],
                         key:       KeyEvent.DOM_VK_RIGHT,
                         expected:  true
+                    });
+                });
+                it("should not prevent default on right arrow with a range selection", function () {
+                    testPreventDefault({
+                        color:     "#8e8247",
+                        item:      "$colorValue",
+                        selection: [0, 7],
+                        key:       KeyEvent.DOM_VK_RIGHT,
+                        expected:  false
                     });
                 });
 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -739,7 +739,7 @@ define(function (require, exports, module) {
                  *     item: The (string) name of the member of ColorEditor that references the element to test.
                  *     selection: An optional array ([start, end]) specifying the selection to set in the given element.
                  *     key: The KeyEvent key code to simulate.
-                 *     shiftKey: Optional boolean specifying whether to simulate the shift key being down (default false).
+                 *     shift: Optional boolean specifying whether to simulate the shift key being down (default false).
                  *     expected: Whether the default is expected to be prevented.
                  */
                 function testPreventDefault(opts) {


### PR DESCRIPTION
...r picker text field, unless the arrow key would be left unhandled because the cursor is at the start or end.

@peterflynn 
