### PR TITLE
Use for loop instead of for..in

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -310,7 +310,7 @@ function RemoteFunctions(experimental) {
             }
             
             this.clear();
-            for (i in highlighted) {
+            for (i = 0; i < highlighted.length; i++) {
                 this.add(highlighted[i], false);
             }
         }


### PR DESCRIPTION
`document.querySelectorAll()` returns an Array-like object that has a `length` property in addition to the elements. When using a `for .. in` loop, the `length` property was being treated like an element.

Fix for #2230
