### PR TITLE
Fixed spacing for icons in toolbar

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -107,6 +107,16 @@ a, img {
 .busyCursor {
     cursor: wait !important;
 }
+#main-toolbar .buttons {
+    vertical-align: middle;
+}
+#main-toolbar .buttons a {
+    margin: 0px 8px 0px 0px !important;
+    padding: 0 !important;
+    position: static !important;
+    top: 0 !important;
+    left: 0 !important;
+}
 
 #status-bar {
     position: relative;


### PR DESCRIPTION
added spacing rules for the icons in the toolbar. Makes use of !important to overwrite extensions spacing.

Fixes https://github.com/adobe/brackets/issues/2251
