### PR TITLE
Only query hint providers that have offered to show hints

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
 
     var hintProviders = [],
         enabledHintProviders = [],
-        queryAllProviders,
+        queryAllProviders = true,
         hintList,
         keyDownEditor;
 

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -428,10 +428,6 @@ define(function (require, exports, module) {
         if (enabledHintProviders.length > 0 && keyDownEditor === editor) {
             keyDownEditor = null;
             showHint(editor);
-        } else {
-            if (hintList) {
-                hintList.close();
-            }
         }
     }
 


### PR DESCRIPTION
@raymondlim @gruehle @joelrbrandt

Partially addresses adobe/brackets#2258 by way of solution #2. The shouldShowHintsOnChange flag, which indicated that some provider was willing to provide hints, is removed in favor of a list, enabledHintProviders, that is populated with hint providers for which shouldShowHintsOnKey returns true. Consequently, only those providers that have offered to provide hints are queried. If the hint list is requested explicitly via Ctrl-Space, the individual providers are not initially queried with shouldShowHintsOnKey, and so an additional flag queryAllProviders indicates in this case that hints should be elicited from all providers instead of just those that are enabled. 
