### PR TITLE
HTML attributes code hinting filter

### DIFF
--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -172,8 +172,6 @@ define(function (require, exports, module) {
             endQuote = "",
             shouldReplace = true;
 
-        var tagInfo2 = HTMLUtils.getTagInfo(editor, {ch: 1, line: cursor.line});
-        
         if (tokenType === HTMLUtils.ATTR_NAME) {
             charCount = tagInfo.attr.name.length;
             // Append an equal sign and two double quotes if the current attr is not an empty attr
@@ -250,7 +248,7 @@ define(function (require, exports, module) {
         var tagInfo = HTMLUtils.getTagInfo(editor, cursor),
             query = {queryStr: null},
             tokenType = tagInfo.position.tokenType;
-         
+ 
         if (tokenType === HTMLUtils.ATTR_NAME || tokenType === HTMLUtils.ATTR_VALUE) {
             query.tag = tagInfo.tagName;
             
@@ -424,7 +422,6 @@ define(function (require, exports, module) {
 
         if (query.tag && query.queryStr !== null) {
             var tagName = query.tag,
-                self = this,
                 attrName = query.attrName,
                 filter = query.queryStr,
                 unfiltered = [],
@@ -457,12 +454,7 @@ define(function (require, exports, module) {
             } else if (tags && tags[tagName] && tags[tagName].attributes) {
                 unfiltered = tags[tagName].attributes.concat(this.globalAttributes);
                 filtered = $.grep(unfiltered, function (attr, i) {
-                    if ($.inArray(attr, query.usedAttr) >= 0) {
-                        console.log(attr);
-                        console.log(query.usedAttr);
-                        console.log($.inArray(attr, query.usedAttr));
-                    }
-                    return ($.inArray(attr, query.usedAttr) < 0);
+                    return $.inArray(attr, query.usedAttr) < 0;
                 });
             }
             

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -425,7 +425,7 @@ define(function (require, exports, module) {
                 attrName = query.attrName,
                 filter = query.queryStr,
                 unfiltered = [],
-                filtered = [],
+                hints = [],
                 sortFunc = null;
 
             this.closeOnSelect = true;
@@ -441,26 +441,26 @@ define(function (require, exports, module) {
                 
                 if (attrInfo) {
                     if (attrInfo.type === "boolean") {
-                        unfiltered = ["false", "true"];
+                        hints = ["false", "true"];
                     } else if (attrInfo.type === "url") {
                         // Default behavior for url hints is do not close on select.
                         this.closeOnSelect = false;
-                        unfiltered = this._getUrlList(query);
+                        hints = this._getUrlList(query);
                         sortFunc = StringUtils.urlSort;
                     } else if (attrInfo.attribOption) {
-                        unfiltered = attrInfo.attribOption;
+                        hints = attrInfo.attribOption;
                     }
                 }
             } else if (tags && tags[tagName] && tags[tagName].attributes) {
                 unfiltered = tags[tagName].attributes.concat(this.globalAttributes);
-                filtered = $.grep(unfiltered, function (attr, i) {
+                hints = $.grep(unfiltered, function (attr, i) {
                     return $.inArray(attr, query.usedAttr) < 0;
                 });
             }
             
-            if (filtered.length) {
+            if (hints.length) {
                 console.assert(!result.length);
-                result = $.map(filtered, function (item) {
+                result = $.map(hints, function (item) {
                     if (item.indexOf(filter) === 0) {
                         return item;
                     }

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -172,6 +172,8 @@ define(function (require, exports, module) {
             endQuote = "",
             shouldReplace = true;
 
+        var tagInfo2 = HTMLUtils.getTagInfo(editor, {ch: 1, line: cursor.line});
+        
         if (tokenType === HTMLUtils.ATTR_NAME) {
             charCount = tagInfo.attr.name.length;
             // Append an equal sign and two double quotes if the current attr is not an empty attr
@@ -248,7 +250,7 @@ define(function (require, exports, module) {
         var tagInfo = HTMLUtils.getTagInfo(editor, cursor),
             query = {queryStr: null},
             tokenType = tagInfo.position.tokenType;
- 
+         
         if (tokenType === HTMLUtils.ATTR_NAME || tokenType === HTMLUtils.ATTR_VALUE) {
             query.tag = tagInfo.tagName;
             
@@ -267,7 +269,7 @@ define(function (require, exports, module) {
                 query.attrName = tagInfo.attr.name;
             }
 
-            // TODO: get existing attributes for the current tag and add them to query.usedAttr
+            query.usedAttr = HTMLUtils.getTagAttributes(editor, cursor);
         }
 
         return query;
@@ -422,9 +424,11 @@ define(function (require, exports, module) {
 
         if (query.tag && query.queryStr !== null) {
             var tagName = query.tag,
+                self = this,
                 attrName = query.attrName,
                 filter = query.queryStr,
                 unfiltered = [],
+                filtered = [],
                 sortFunc = null;
 
             this.closeOnSelect = true;
@@ -452,13 +456,19 @@ define(function (require, exports, module) {
                 }
             } else if (tags && tags[tagName] && tags[tagName].attributes) {
                 unfiltered = tags[tagName].attributes.concat(this.globalAttributes);
-
-                // TODO: exclude existing attributes from unfiltered array
+                filtered = $.grep(unfiltered, function (attr, i) {
+                    if ($.inArray(attr, query.usedAttr) >= 0) {
+                        console.log(attr);
+                        console.log(query.usedAttr);
+                        console.log($.inArray(attr, query.usedAttr));
+                    }
+                    return ($.inArray(attr, query.usedAttr) < 0);
+                });
             }
-
-            if (unfiltered.length) {
+            
+            if (filtered.length) {
                 console.assert(!result.length);
-                result = $.map(unfiltered, function (item) {
+                result = $.map(filtered, function (item) {
                     if (item.indexOf(filter) === 0) {
                         return item;
                     }

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
             forwardCtx  = $.extend({}, backwardCtx);
         
         if (editor.getModeForSelection() === "html") {
-            if (backwardCtx.token) {
+            if (backwardCtx.token && backwardCtx.token.className !== "tag") {
                 while (TokenUtils.movePrevToken(backwardCtx) && backwardCtx.token.className !== "tag") {
                     if (backwardCtx.token.className === "attribute") {
                         attrs.push(backwardCtx.token.string);

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -82,41 +82,41 @@ define(function (require, exports, module) {
             it("should find an attribute as a tag is getting typed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p class="');
+                    ["<html>", "<body>"],
+                    "<p class='");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class", "", true, '"', false));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "class", "", true, "'", false));
             });
             
             it("should find an attribute as it's added to a tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="', '>test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", "<div class='clearfix'>"],
+                    "<p id='", ">test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "id", "", true, '"', false));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 0, "p", "id", "", true, "'", false));
             });
             
             it("should find an attribute as the value is typed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="one', '>test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p id='one", ">test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "id", "one", true, '"', false));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "id", "one", true, "'", false));
             });
             
             it("should not find an attribute as text is added", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p id="foo">tricky="', '</p>',
-                    [ '</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<p id='foo'>tricky='", "</p>",
+                    [ "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo());
@@ -125,52 +125,52 @@ define(function (require, exports, module) {
             it("should find the attribute value if present", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p class="foo', '"></p>',
-                    [ '</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<p class='foo", "'></p>",
+                    [ "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true, '"', true));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true, "'", true));
             });
             
             it("should find the full attribute as an existing value is changed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p class="foo', ' bar"></p>',
-                    [ '</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<p class='foo", " bar'></p>",
+                    [ "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo bar", true, '"', true));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo bar", true, "'", true));
             });
             
             it("should find the attribute value even when there is space around the =", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p class = "foo', '"></p>',
-                    [ '</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<p class = 'foo", "'></p>",
+                    [ "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true, '"', true));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, 3, "p", "class", "foo", true, "'", true));
             });
             
             it("should find the attribute value when the IP is after the =", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p class=', '"foo"></p>',
-                    [ '</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<p class=", "'foo'></p>",
+                    [ "</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
-                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, -1, "p", "class", "foo", true, '"', true));
+                expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_VALUE, -1, "p", "class", "foo", true, "'", true));
             });
             
             it("should find the tagname as it's typed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<di');
+                    ["<html>", "<body>"],
+                    "<di");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.TAG_NAME, 2, "di"));
@@ -179,8 +179,8 @@ define(function (require, exports, module) {
             it("should hint tagname as the open < is typed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<p>test</p><');
+                    ["<html>", "<body>"],
+                    "<p>test</p><");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.TAG_NAME));
@@ -189,8 +189,8 @@ define(function (require, exports, module) {
             it("should find the tagname of the current tag if two tags are right next to each other", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<div><span');
+                    ["<html>", "<body>"],
+                    "<div><span");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.TAG_NAME, 4, "span"));
@@ -199,8 +199,8 @@ define(function (require, exports, module) {
             it("should hint attributes even if there is a lot of space between the tag name and the next attr name", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<div><li  ', '  id="foo"');
+                    ["<html>", "<body>"],
+                    "<div><li  ", "  id='foo'");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_NAME, 0, "li"));
@@ -209,8 +209,8 @@ define(function (require, exports, module) {
             it("should find the tagname as space is typed before the attr name is added", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<div><span ');
+                    ["<html>", "<body>"],
+                    "<div><span ");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo(HTMLUtils.ATTR_NAME, 0, "span"));
@@ -219,8 +219,8 @@ define(function (require, exports, module) {
             it("should not hint anything after the tag is closed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<div><span>');
+                    ["<html>", "<body>"],
+                    "<div><span>");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo());
@@ -229,9 +229,9 @@ define(function (require, exports, module) {
             it("should not hint anything after a closing tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>'],
-                    '<div><span></span>', '</div>',
-                    ['</body>', '</html>']);
+                    ["<html>", "<body>"],
+                    "<div><span></span>", "</div>",
+                    ["</body>", "</html>"]);
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo());
@@ -240,8 +240,8 @@ define(function (require, exports, module) {
             it("should not hint anything inside a closing tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div id="test" class="foo"></div>'],
-                    '</body></ht', 'ml>');
+                    ["<html>", "<body>", "<div id='test' class='foo'></div>"],
+                    "</body></ht", "ml>");
                 
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo());
@@ -256,9 +256,9 @@ define(function (require, exports, module) {
             it("should not find attributes before the tag is opened", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '', '<p id="pid" class="pclass" lang="plang" align="palign" title="">test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", "<div class='clearfix'>"],
+                    "", "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs).toEqual([]);
             });
@@ -266,9 +266,9 @@ define(function (require, exports, module) {
             it("should not find attributes if there isn't a valid tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<', ' id="pid" class="pclass" lang="plang" align="palign" title="">test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", "<div class='clearfix'>"],
+                    "<", " id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs).toEqual([]);
             });
@@ -276,9 +276,9 @@ define(function (require, exports, module) {
             it("should not find attributes after the tag is closed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="pid" class="pclass" lang="plang" align="palign" title="">test</p>', '',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>", "",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs).toEqual([]);
             });
@@ -286,9 +286,9 @@ define(function (require, exports, module) {
             it("should find all the tag attributes immediately after the tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p ', 'id="pid" class="pclass" lang="plang" align="palign" title="ptitle">test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p ", "id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
             });
@@ -296,9 +296,9 @@ define(function (require, exports, module) {
             it("should find all the tag attributes before closing the tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="pid" class="pclass" lang="plang" align="palign" title="ptitle" ', '>test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle' ", ">test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
             });
@@ -306,9 +306,9 @@ define(function (require, exports, module) {
             it("should find all the tag attributes backward and forward", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="pid" class="pclass" lang="plang" ', 'align="palign" title="ptitle">test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p id='pid' class='pclass' lang='plang' ", "align='palign' title='ptitle'>test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
             });
@@ -316,9 +316,9 @@ define(function (require, exports, module) {
             it("should find valid attributes marked as errors by the tokenizer", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p id="pid" c', ' class="pclass" lang="plang" align="palign" title="ptitle">test</p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p id='pid' c", " class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
             });
@@ -326,9 +326,9 @@ define(function (require, exports, module) {
             it("should not find attributes in nested tags", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ['<html>', '<body>', '<div class="clearfix">'],
-                    '<p ', 'id="pid" class="pclass" lang="plang" align="palign" title="ptitle"><span style="sstyle"></span></p>',
-                    [ '</div>', '</body>', '</html>']);
+                    ["<html>", "<body>", '<div class="clearfix">'],
+                    "<p ", "id='pid' class='pclass' lang='plang' align='palign' title='ptitle'><span style='sstyle'></span></p>",
+                    [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
             });

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -246,6 +246,92 @@ define(function (require, exports, module) {
                 var tag = HTMLUtils.getTagInfo(myEditor, pos);
                 expect(tag).toEqual(HTMLUtils.createTagInfo());
             });
+            
+            it("should not find attributes in an empty editor", function () {
+                var pos = {"ch": 0, "line": 0};
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs).toEqual([]);
+            });
+        
+            it("should not find attributes before the tag is opened", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '', '<p id="pid" class="pclass" lang="plang" align="palign" title="">test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs).toEqual([]);
+            });
+                
+            it("should not find attributes if there isn't a valid tag", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<', ' id="pid" class="pclass" lang="plang" align="palign" title="">test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs).toEqual([]);
+            });
+            
+            it("should not find attributes after the tag is closed", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p id="pid" class="pclass" lang="plang" align="palign" title="">test</p>', '',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs).toEqual([]);
+            });
+                
+            it("should find all the tag attributes immediately after the tag", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p ', 'id="pid" class="pclass" lang="plang" align="palign" title="ptitle">test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
+            });
+            
+            it("should find all the tag attributes before closing the tag", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p id="pid" class="pclass" lang="plang" align="palign" title="ptitle" ', '>test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
+            });
+            
+            it("should find all the tag attributes backward and forward", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p id="pid" class="pclass" lang="plang" ', 'align="palign" title="ptitle">test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
+            });
+            
+            it("should find valid attributes marked as errors by the tokenizer", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p id="pid" c', ' class="pclass" lang="plang" align="palign" title="ptitle">test</p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
+            });
+                
+            it("should not find attributes in nested tags", function () {
+                var pos = {"ch": 0, "line": 0};
+                setContentAndUpdatePos(pos,
+                    ['<html>', '<body>', '<div class="clearfix">'],
+                    '<p ', 'id="pid" class="pclass" lang="plang" align="palign" title="ptitle"><span style="sstyle"></span></p>',
+                    [ '</div>', '</body>', '</html>']);
+                var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
+                expect(attrs.sort()).toEqual(["id", "class", "lang", "align", "title"].sort());
+            });
         });
     });
 });

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
             it("should find an attribute as the value is typed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p id='one", ">test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 
@@ -276,7 +276,7 @@ define(function (require, exports, module) {
             it("should not find attributes after the tag is closed", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>", "test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
@@ -286,7 +286,7 @@ define(function (require, exports, module) {
             it("should find all the tag attributes immediately after the tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p ", "id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
@@ -296,7 +296,7 @@ define(function (require, exports, module) {
             it("should find all the tag attributes before closing the tag", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle' ", ">test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
@@ -306,7 +306,7 @@ define(function (require, exports, module) {
             it("should find all the tag attributes backward and forward", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p id='pid' class='pclass' lang='plang' ", "align='palign' title='ptitle'>test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
@@ -316,7 +316,7 @@ define(function (require, exports, module) {
             it("should find valid attributes marked as errors by the tokenizer", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p id='pid' c", " class='pclass' lang='plang' align='palign' title='ptitle'>test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
@@ -326,7 +326,7 @@ define(function (require, exports, module) {
             it("should not find attributes in nested tags", function () {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
-                    ["<html>", "<body>", '<div class="clearfix">'],
+                    ["<html>", "<body>", "<div class='clearfix'>"],
                     "<p ", "id='pid' class='pclass' lang='plang' align='palign' title='ptitle'><span style='sstyle'></span></p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -277,7 +277,7 @@ define(function (require, exports, module) {
                 var pos = {"ch": 0, "line": 0};
                 setContentAndUpdatePos(pos,
                     ["<html>", "<body>", '<div class="clearfix">'],
-                    "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>test</p>", "",
+                    "<p id='pid' class='pclass' lang='plang' align='palign' title='ptitle'>", "test</p>",
                     [ "</div>", "</body>", "</html>"]);
                 var attrs = HTMLUtils.getTagAttributes(myEditor, pos);
                 expect(attrs).toEqual([]);


### PR DESCRIPTION
This pull requests should cover some of this story about filtering code hints https://trello.com/card/code-hinting-filter/4f90a6d98f77505d7940ce88/592, in particular, filtering HTML attributes already used inside a tag.

It adds a new `getTagAttributes` method inside `HTMLUtils` that compiles a list of all used attributes inside a tag. This list is then used inside `AttrHints` to exclude the already used attributes from the complete list.
