### PR TITLE
registerHintProvider api change in Code Hint Manager

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
 
         if (count === 0) {
             this.close();
-        } else {
+        } else if (this.currentProvider.wantInitialSelection()) {
             // Select the first item in the list
             this.setSelectedIndex(0);
         }
@@ -243,6 +243,13 @@ define(function (require, exports, module) {
         
         // Up arrow, down arrow and enter key are always handled here
         if (event.type !== "keypress") {
+            // If we don't have a selection in the list, then just update the list and
+            // show it at the new location for Return and Tab keys.
+            if (this.selectedIndex === -1 && (keyCode === KeyEvent.DOM_VK_RETURN || keyCode === KeyEvent.DOM_VK_TAB)) {
+                this.updateQueryAndList();
+                return;
+            }
+            
             if (keyCode === KeyEvent.DOM_VK_RETURN || keyCode === KeyEvent.DOM_VK_TAB ||
                     keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN ||
                     keyCode === KeyEvent.DOM_VK_PAGE_UP || keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
@@ -497,7 +504,8 @@ define(function (require, exports, module) {
      * @param {Object.< getQueryInfo: function(editor, cursor),
      *                  search: function(string),
      *                  handleSelect: function(string, Editor, cursor),
-     *                  shouldShowHintsOnKey: function(string)>}
+     *                  shouldShowHintsOnKey: function(string),
+     *                  wantInitialSelection: function()>}
      *
      * Parameter Details:
      * - getQueryInfo - examines cursor location of editor and returns an object representing
@@ -509,6 +517,7 @@ define(function (require, exports, module) {
      *      position. It should return true by default to close the hint list, but if the code hint provider
      *      can return false if it wants to keep the hint list open and continue with a updated list. 
      * - shouldShowHintsOnKey - inspects the char code and returns true if it wants to show code hints on that key.
+     * - wantInitialSelection - return true if the provider wants to select the first hint item by default.
      *
      * @param {Array.<string>} modes  An array of mode strings in which the provider can show code hints or "all" 
      *      if it can show code hints in any mode.

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
     }
 
     /** 
-     *  If there is any providers for all modes, then add them to each individual
+     *  If there is any provider for all modes, then add it to each individual
      *  mode providers list and re-sort them based on their specificity.
      */
     function _mergeAllModeToIndividualMode() {
@@ -73,11 +73,11 @@ define(function (require, exports, module) {
     /** 
      *  Return the array of hint providers for the given mode.
      *  If this is called for the first time, then we check if any provider wants to show
-     *  hints on all modes. If there is any, then we merge them into each individual
+     *  hints on all modes. If there is any, then we merge it into each individual
      *  mode provider list.
      *
-     * @param {string | Object<name: string>} mode
-     * @return {!Array.<{provider:Object, modes:Array, specificity: number}>}
+     * @param {(string|Object<name: string>)} mode
+     * @return {Array.<{provider: Object, modes: Array.<string>, specificity: number}>}
      */
     function _getEnabledHintProviders(mode) {
         if (hintProviders.all) {
@@ -512,7 +512,6 @@ define(function (require, exports, module) {
      *
      * @param {Array.<string>} modes  An array of mode strings in which the provider can show code hints or "all" 
      *      if it can show code hints in any mode.
-     * @param {!Array.<string>} triggerKeys  An array of all the keys that the provider can be triggered to show hints.
      * @param {number} specificity  A positive number to indicate the priority of the provider. The larger the number, 
      *      the higher priority the provider has. Zero if it has the lowest priority in displaying its code hints.
      */

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -84,8 +84,8 @@ define(function (require, exports, module) {
             _mergeAllModeToIndividualMode();
         }
         
-        mode = (typeof mode === "string") ? mode : mode.name;
-        return hintProviders[mode] || [];
+        var modeStr = (typeof mode === "string") ? mode : mode.name;
+        return hintProviders[modeStr] || [];
     }
     
     /**

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -84,8 +84,8 @@ define(function (require, exports, module) {
             _mergeAllModeToIndividualMode();
         }
         
-        var modeStr = (typeof mode === "string") ? mode : mode.name;
-        return hintProviders[modeStr] || [];
+        var modeName = (typeof mode === "string") ? mode : mode.name;
+        return hintProviders[modeName] || [];
     }
     
     /**

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -121,6 +121,15 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Check whether to show hints on a specific key.
+     * @param {string} key -- the character for the key user just presses.
+     * @return {boolean} return true/false to indicate whether hinting should be triggered by this key.
+     */
+    TagHints.prototype.shouldShowHintsOnKey = function (key) {
+        return key === "<";
+    };
+
+    /**
      * @constructor
      */
     function AttrHints() {
@@ -460,10 +469,19 @@ define(function (require, exports, module) {
         return result;
     };
 
+    /**
+     * Check whether to show hints on a specific key.
+     * @param {string} key -- the character for the key user just presses.
+     * @return {boolean} return true/false to indicate whether hinting should be triggered by this key.
+     */
+    AttrHints.prototype.shouldShowHintsOnKey = function (key) {
+        return (key === " " || key === "'" || key === "\"" || key === "=");
+    };
+
     var tagHints = new TagHints();
     var attrHints = new AttrHints();
-    CodeHintManager.registerHintProvider(tagHints, ["html"], ["<"], 0);
-    CodeHintManager.registerHintProvider(attrHints, ["html"], [" ", "'", "\"", "="], 0);
+    CodeHintManager.registerHintProvider(tagHints, ["html"], 0);
+    CodeHintManager.registerHintProvider(attrHints, ["html"], 0);
     
     // For unit testing
     exports.tagHintProvider = tagHints;

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -121,15 +121,6 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Check whether to show hints on a specific key.
-     * @param {string} key -- the character for the key user just presses.
-     * @return {boolean} return true/false to indicate whether hinting should be triggered by this key.
-     */
-    TagHints.prototype.shouldShowHintsOnKey = function (key) {
-        return key === "<";
-    };
-
-    /**
      * @constructor
      */
     function AttrHints() {
@@ -469,19 +460,10 @@ define(function (require, exports, module) {
         return result;
     };
 
-    /**
-     * Check whether to show hints on a specific key.
-     * @param {string} key -- the character for the key user just presses.
-     * @return {boolean} return true/false to indicate whether hinting should be triggered by this key.
-     */
-    AttrHints.prototype.shouldShowHintsOnKey = function (key) {
-        return (key === " " || key === "'" || key === "\"" || key === "=");
-    };
-
     var tagHints = new TagHints();
     var attrHints = new AttrHints();
-    CodeHintManager.registerHintProvider(tagHints);
-    CodeHintManager.registerHintProvider(attrHints);
+    CodeHintManager.registerHintProvider(tagHints, ["html"], ["<"], 0);
+    CodeHintManager.registerHintProvider(attrHints, ["html"], [" ", "'", "\"", "="], 0);
     
     // For unit testing
     exports.tagHintProvider = tagHints;

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -130,6 +130,14 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Check whether to select the first item in the list by default
+     * @return {boolean} return true to highlight the first item.
+     */
+    TagHints.prototype.wantInitialSelection = function () {
+        return true;
+    };
+
+    /**
      * @constructor
      */
     function AttrHints() {
@@ -476,6 +484,14 @@ define(function (require, exports, module) {
      */
     AttrHints.prototype.shouldShowHintsOnKey = function (key) {
         return (key === " " || key === "'" || key === "\"" || key === "=");
+    };
+
+    /**
+     * Check whether to select the first item in the list by default
+     * @return {boolean} return true to highlight the first item.
+     */
+    AttrHints.prototype.wantInitialSelection = function () {
+        return true;
     };
 
     var tagHints = new TagHints();


### PR DESCRIPTION
Implement registerHintProvider api with extra parameters suggested by Glenn. <del>This change also makes the problematic shouldShowHintsOnKey api no longer needed.</del> It also resolves the conflicts between two or more providers by allowing each provider to register its specificity.

The new api has two extra parameters -- modes for an array of supported modes, and a number to set the priority of the provider when there are more than one provider to show code hints in the same context.

We also add a new api for code hints providers. The new api, wantInitialSelection, let the providers to decide whether to select the first hint by default or not.
