### PR TITLE
Fix: Adding tooltip to JSLint star on start-up with JSLint disabled

### DIFF
--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
         var $jslintResults  = $("#jslint-results"),
             $jslintContent  = $("#jslint-results .table-container");
         
-        StatusBar.addIndicator(module.id, $("#gold-star"), true);
+        StatusBar.addIndicator(module.id, $("#gold-star"), true, "", Strings.JSLINT_DISABLED);
     });
 
     // Define public API

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -220,14 +220,16 @@ define(function (require, exports, module) {
     
     // Init PreferenceStorage
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs);
-    _setEnabled(_prefs.getValue("enabled"));
     
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         var $jslintResults  = $("#jslint-results"),
             $jslintContent  = $("#jslint-results .table-container");
         
-        StatusBar.addIndicator(module.id, $("#gold-star"), true, "", Strings.JSLINT_DISABLED);
+        StatusBar.addIndicator(module.id, $("#gold-star"));
+        
+        // Called on HTML ready to trigger the initial UI state
+        _setEnabled(_prefs.getValue("enabled"));
     });
 
     // Define public API


### PR DESCRIPTION
This is a fix for adobe/brackets#2270 and follow-up pull request of adobe/brackets#2100
