### PR TITLE
Refine find logic with pre-selected query string

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -134,6 +134,19 @@ define(function (require, exports, module) {
         });
     }
     
+    function setInitialSearchQuery(cm, query, pos) {
+        getDialogTextField()
+            .attr("value", query)
+            .get(0).select();
+        
+        var state = getSearchState(cm);
+        state.query = parseQuery(query);
+        state.posFrom = state.posTo = pos;
+        if (state.query) {
+            findNext(cm);
+        }
+    }
+    
     var queryDialog = Strings.CMD_FIND +
             ': <input type="text" style="width: 10em"/> <span style="color: #888">(' +
             Strings.SEARCH_REGEXP_INFO  + ')</span>';
@@ -179,16 +192,7 @@ define(function (require, exports, module) {
             });
         }
         
-        dialog(cm, queryDialog, Strings.CMD_FIND, function (query) {
-            // If the dialog is closed and the query string is not empty,
-            // make sure we have called findFirst at least once. This way
-            // if the Find dialog is opened with pre-populated text, pressing
-            // enter will find the next occurance of the text and store
-            // the query for subsequent "Find Next" commands.
-            if (query && !state.query) {
-                findFirst(query);
-            }
-        });
+        dialog(cm, queryDialog, Strings.CMD_FIND, function () {});
         getDialogTextField().on("input", function () {
             findFirst(getDialogTextField().attr("value"));
         });
@@ -257,10 +261,10 @@ define(function (require, exports, module) {
             });
         });
         
-        // Prepopulate the replace field with the current selection, if any
-        getDialogTextField()
-            .attr("value", cm.getSelection())
-            .get(0).select();
+        // Prepopulate the replace field with the current selection, if any.
+        // When replacing, use the selection start pos as the search cursor. This
+        // way the initially selected text will be replaced first.
+        setInitialSearchQuery(cm, cm.getSelection(), cm.getCursor(true));
     }
 
     function _launchFind() {
@@ -273,9 +277,7 @@ define(function (require, exports, module) {
             doSearch(codeMirror);
 
             // Prepopulate the search field with the current selection, if any
-            getDialogTextField()
-                .attr("value", codeMirror.getSelection())
-                .get(0).select();
+            setInitialSearchQuery(codeMirror, codeMirror.getSelection(), codeMirror.getCursor());
         }
     }
 


### PR DESCRIPTION
@peterflynn 

Fix for issue #2104

Here are the various scenarios I tested:
1. No text selected, open find, enter string, hit return. The first occurrence of the query string is selected.
2. No text selected, open find, enter string, hit Cmd-G to highlight the next occurrence, hit return. The second (highlighted) occurrence is selected.
3. Text selected, open find. The selected string is highlighted. Hit return to close the dialog and the _next_ occurrence is selected.
4. Text selected, open find. The selected string is highlighted. Press Cmd-G to highlight the _next_ occurrence. Hit return the close the dialog and select the highlighted text.

This also fixes another un-reported problem:
1. Select text
2. Open Find dialog (selected text should be used as the query string)
3. Append to the end of the find string to extend selection (for example, select "require" and append "(")

Results: The next occurrence is found.
Expected: The existing selection should be expanded.
