### PR TITLE
Add .no-focus style and implementation

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -306,6 +306,13 @@ define(function (require, exports, module) {
         }
     });
     
+    // The .no-focus style is added to clickable elements that should
+    // not steal focus. Calling preventDefault() on mousedown prevents
+    // focus from going to the click target.
+    $("html").on("mousedown", ".no-focus", function (e) {
+        e.preventDefault();
+    });
+    
     // Localize MainViewHTML and inject into <BODY> tag
     var templateVars    = $.extend({
         ABOUT_ICON          : brackets.config.about_icon,

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -96,14 +96,14 @@
                 </div>
             </div>
             
-            <div id="jslint-results" class="bottom-panel vert-resizable top-resizer">
+            <div id="jslint-results" class="bottom-panel vert-resizable top-resizer no-focus">
                 <div class="toolbar simple-toolbar-layout">
                     <div class="title">{{JSLINT_ERRORS}}</div>
                 </div>
                 <div class="table-container resizable-content"></div>
             </div>
             
-            <div id="search-results" class="bottom-panel vert-resizable top-resizer">
+            <div id="search-results" class="bottom-panel vert-resizable top-resizer no-focus">
                 <div class="toolbar simple-toolbar-layout">
                     <div class="title">{{SEARCH_RESULTS}}</div>
                     <div class="title" id="search-result-summary"></div>

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -71,7 +71,7 @@
          -->
         <div class="content">
             <!-- Toolbar containing menus, filename, and icons -->
-            <div id="main-toolbar" class="toolbar">
+            <div id="main-toolbar" class="toolbar no-focus">
                 <!-- Menu bar -->
                 <ul class="nav" data-dropdown="dropdown">
                 </ul>

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -99,16 +99,6 @@ a, img {
     }
 }
 
-/* 
-    semantic style that makes an element *not* get focus when clicked.
-    This is useful to add to things like toolbar buttons, where you
-    want the item to be clickable, but don't want it to steal focus.
-  
-    The actual implementation of the focus blocking is in brackets.js.
-*/
-.no-focus {
-}
-
 .toolbar {
     /* make sure the shadow goes above other items */
     z-index: @z-index-brackets-toolbar;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -99,6 +99,16 @@ a, img {
     }
 }
 
+/* 
+    semantic style that makes an element *not* get focus when clicked.
+    This is useful to add to things like toolbar buttons, where you
+    want the item to be clickable, but don't want it to steal focus.
+  
+    The actual implementation of the focus blocking is in brackets.js.
+*/
+.no-focus {
+}
+
 .toolbar {
     /* make sure the shadow goes above other items */
     z-index: @z-index-brackets-toolbar;

--- a/src/widgets/StatusBar.html
+++ b/src/widgets/StatusBar.html
@@ -1,4 +1,4 @@
-<div id="status-bar" class="statusbar">
+<div id="status-bar" class="statusbar no-focus">
     <div id="status-info" class="info" >
         <div id="status-cursor"></div>
     </div>


### PR DESCRIPTION
Fix for #2161 and a bunch of other focus-related bugs.

Add a new `.no-focus` semantic style. Add this class to any object that should _not_ get focus when clicked. You can put this on a container and it will apply to all children.

The `.no-focus` style is added to the main toolbar and the status bar. 

Note: this will _not_ block focus from going into editable text fields. For example, the edit field for entering tab/space size will receive focus.
