### PR TITLE
Copy unit test files into a temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ src/extensions/disabled
 
 #OSX .DS_Store files
 .DS_Store
+
+# unit test working directory
+test/temp

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -41,33 +41,24 @@ define(function (require, exports, module) {
 
     var extensionPath = FileUtils.getNativeModuleDirectoryPath(module),
         testPath = extensionPath + "/unittest-files/syntax",
+        tempPath = SpecRunnerUtils.getTempDirectory(),
         testWindow,
         initInlineTest;
 
     function rewriteProject(spec) {
-        var result = new $.Deferred();
-    
-        FileIndexManager.getFileInfoList("all").done(function (allFiles) {
-            // convert fileInfos to fullPaths
-            allFiles = allFiles.map(function (fileInfo) {
-                return fileInfo.fullPath;
-            });
-            
-            // parse offsets and save
-            SpecRunnerUtils.saveFilesWithoutOffsets(allFiles).done(function (offsetInfos) {
-                spec.infos = offsetInfos;
+        var result = new $.Deferred(),
+            infos = {},
+            options = {
+                parseOffsets    : true,
+                infos           : infos,
+                removePrefix    : true
+            };
         
-                // install after function to restore file content
-                spec.after(function () {
-                    runs(function () {
-                        waitsForDone(SpecRunnerUtils.saveFilesWithOffsets(spec.infos), "saveFilesWithOffsets");
-                    });
-                });
-                
-                result.resolve();
-            }).fail(function () {
-                result.reject();
-            });
+        SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
+            spec.infos = infos;
+            result.resolve();
+        }).fail(function () {
+            result.reject();
         });
         
         return result.promise();
@@ -92,11 +83,11 @@ define(function (require, exports, module) {
         workingSet = workingSet || [];
         expectInline = (expectInline !== undefined) ? expectInline : true;
         
-        SpecRunnerUtils.loadProjectInTestWindow(testPath);
-        
         runs(function () {
             waitsForDone(rewriteProject(spec), "rewriteProject");
         });
+        
+        SpecRunnerUtils.loadProjectInTestWindow(tempPath);
         
         runs(function () {
             workingSet.push(openFile);

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
                 removePrefix    : true
             };
         
-        SpecRunnerUtils.copyDirectoryPath(testPath, tempPath, options).done(function () {
+        SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
             spec.infos = infos;
             result.resolve();
         }).fail(function () {

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
                 removePrefix    : true
             };
         
-        SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
+        SpecRunnerUtils.copyDirectory(testPath, tempPath, options).done(function () {
             spec.infos = infos;
             result.resolve();
         }).fail(function () {

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
                 removePrefix    : true
             };
         
-        SpecRunnerUtils.copyDirectory(testPath, tempPath, options).done(function () {
+        SpecRunnerUtils.copyDirectoryPath(testPath, tempPath, options).done(function () {
             spec.infos = infos;
             result.resolve();
         }).fail(function () {

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
          *
          * @param {!string} path
          * @param {!function(DirectoryEntry)} successCallback
-         * @param {!function(number)} errorCallback (TODO #2057: should pass a FileError)
+         * @param {!function(FileError)} errorCallback (TODO #2057: should pass a DOMError)
          */
         requestNativeFileSystem: function (path, successCallback, errorCallback) {
             brackets.fs.stat(path, function (err, data) {
@@ -116,6 +116,31 @@ define(function (require, exports, module) {
                     // FIXME (issue #247): return a NativeFileSystem object
                     var root = new NativeFileSystem.DirectoryEntry(path);
                     successCallback(root);
+                } else if (errorCallback) {
+                    errorCallback(NativeFileSystem._nativeToFileError(err));
+                }
+            });
+        },
+        
+        /**
+         * NativeFileSystem implementation of LocalFileSystem.resolveLocalFileSystemURL()
+         *
+         * @param {!string} url
+         * @param {!function(Entry)} successCallback
+         * @param {!function(FileError)} errorCallback (TODO #2057: should pass a DOMError)
+         */
+        resolveNativeFileSystemPath: function (path, successCallback, errorCallback) {
+            brackets.fs.stat(path, function (err, stats) {
+                if (!err) {
+                    var entry;
+                    
+                    if (stats.isDirectory()) {
+                        entry = new NativeFileSystem.DirectoryEntry(path);
+                    } else {
+                        entry = new NativeFileSystem.FileEntry(path);
+                    }
+                    
+                    successCallback(entry);
                 } else if (errorCallback) {
                     errorCallback(NativeFileSystem._nativeToFileError(err));
                 }

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -783,6 +783,12 @@ define(function (require, exports, module) {
                 var entries = [];
                 var lastError = null;
 
+                // call success immediately if this directory has no files
+                if (filelist.length === 0) {
+                    successCallback(entries);
+                    return;
+                }
+
                 // stat() to determine type of each entry, then populare entries array with objects
                 var masterPromise = Async.doInParallel(filelist, function (filename, index) {
                     

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -207,11 +207,11 @@ define(function (require, exports, module) {
                 
                 // clean up
                 runs(function () {
-                    promise = SpecRunnerUtils.deleteFile(crlfPath);
+                    promise = SpecRunnerUtils.deletePath(crlfPath);
                     waitsForDone(promise, "Remove CRLF test file");
                 });
                 runs(function () {
-                    promise = SpecRunnerUtils.deleteFile(lfPath);
+                    promise = SpecRunnerUtils.deletePath(lfPath);
                     waitsForDone(promise, "Remove LF test file");
                 });
             });

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
                     removePrefix    : true
                 };
             
-            SpecRunnerUtils.copyDirectory(testPath, tempPath, options).done(function () {
+            SpecRunnerUtils.copyDirectoryPath(testPath, tempPath, options).done(function () {
                 spec.infos = infos;
                 result.resolve();
             }).fail(function () {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
                 //debug visual confirmation of inline editor
                 //waits(1000);
                 runs(function () {
-                    SpecRunnerUtils.deleteFile(tempPath);
+                    SpecRunnerUtils.deletePath(tempPath);
                 });
                 
                 // revert files to original content with offset markup
@@ -564,7 +564,7 @@ define(function (require, exports, module) {
                     
                     // Delete the file
                     runs(function () {
-                        waitsForDone(SpecRunnerUtils.deleteFile(fileToWrite.fullPath));
+                        waitsForDone(SpecRunnerUtils.deletePath(fileToWrite.fullPath));
                     });
                     
                     // Ping FileSyncManager to recognize the deletion

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
                     removePrefix    : true
                 };
             
-            SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
+            SpecRunnerUtils.copyDirectory(testPath, tempPath, options).done(function () {
                 spec.infos = infos;
                 result.resolve();
             }).fail(function () {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -31,7 +31,6 @@ define(function (require, exports, module) {
     var Commands,           // loaded from brackets.test
         EditorManager,      // loaded from brackets.test
         FileSyncManager,    // loaded from brackets.test
-        FileIndexManager,   // loaded from brackets.test
         DocumentManager,    // loaded from brackets.test
         FileViewController, // loaded from brackets.test
         Dialogs          = require("widgets/Dialogs"),
@@ -42,6 +41,7 @@ define(function (require, exports, module) {
     describe("InlineEditorProviders", function () {
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
+            tempPath = SpecRunnerUtils.getTempDirectory(),
             testWindow,
             initInlineTest;
         
@@ -50,42 +50,26 @@ define(function (require, exports, module) {
         }
         
         function rewriteProject(spec) {
-            var result = new $.Deferred();
-        
-            FileIndexManager.getFileInfoList("all").done(function (allFiles) {
-                // convert fileInfos to fullPaths
-                allFiles = allFiles.map(function (fileInfo) {
-                    return fileInfo.fullPath;
-                });
-                
-                // parse offsets and save
-                SpecRunnerUtils.saveFilesWithoutOffsets(allFiles).done(function (offsetInfos) {
-                    spec.infos = offsetInfos;
+            var result = new $.Deferred(),
+                infos = {},
+                options = {
+                    parseOffsets    : true,
+                    infos           : infos,
+                    removePrefix    : true
+                };
             
-                    // install after function to restore file content
-                    spec.after(function () {
-                        var done = false;
-                        
-                        runs(function () {
-                            SpecRunnerUtils.saveFilesWithOffsets(spec.infos).done(function () {
-                                done = true;
-                            });
-                        });
-                        
-                        waitsFor(function () { return done; }, "saveFilesWithOffsets timeout", 1000);
-                    });
-                    
-                    result.resolve();
-                }).fail(function () {
-                    result.reject();
-                });
+            SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
+                spec.infos = infos;
+                result.resolve();
+            }).fail(function () {
+                result.reject();
             });
             
             return result.promise();
         }
         
         /**
-         * Performs setup for an inline editor test. Parses offsets (saved to Spec.offsets) for all files in
+         * Performs setup for an inline editor test. Parses offsets (saved to Spec.infos) for all files in
          * the test project (testPath) and saves files back to disk without offset markup.
          * When finished, open an editor for the specified project relative file path
          * then attempts opens an inline editor at the given offset. Installs an after()
@@ -108,8 +92,6 @@ define(function (require, exports, module) {
             
             expectInline = (expectInline !== undefined) ? expectInline : true;
             
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-            
             // load project to set CSSUtils scope
             runs(function () {
                 rewriteProject(spec)
@@ -118,6 +100,8 @@ define(function (require, exports, module) {
             });
             
             waitsFor(function () { return rewriteDone && !rewriteErr; }, "rewriteProject timeout", 1000);
+            
+            SpecRunnerUtils.loadProjectInTestWindow(tempPath);
             
             runs(function () {
                 workingSet.push(openFile);
@@ -176,7 +160,6 @@ define(function (require, exports, module) {
                     Commands            = testWindow.brackets.test.Commands;
                     EditorManager       = testWindow.brackets.test.EditorManager;
                     FileSyncManager     = testWindow.brackets.test.FileSyncManager;
-                    FileIndexManager    = testWindow.brackets.test.FileIndexManager;
                     DocumentManager     = testWindow.brackets.test.DocumentManager;
                     FileViewController  = testWindow.brackets.test.FileViewController;
                 });
@@ -246,6 +229,9 @@ define(function (require, exports, module) {
             afterEach(function () {
                 //debug visual confirmation of inline editor
                 //waits(1000);
+                runs(function () {
+                    SpecRunnerUtils.deleteFile(tempPath);
+                });
                 
                 // revert files to original content with offset markup
                 SpecRunnerUtils.closeTestWindow();
@@ -553,11 +539,13 @@ define(function (require, exports, module) {
                 
                 it("should close inline editor when file deleted on disk", function () {
                     // Create an expendable CSS file
-                    var fileToWrite = new NativeFileSystem.FileEntry(testPath + "/tempCSS.css");
-                    var savedTempCSSFile = false;
+                    var fileToWrite,
+                        savedTempCSSFile = false;
+
                     runs(function () {
-                        FileUtils.writeText(fileToWrite, "#anotherDiv {}")
-                            .done(function () {
+                        SpecRunnerUtils.createTextFile(tempPath + "/tempCSS.css", "#anotherDiv {}")
+                            .done(function (entry) {
+                                fileToWrite = entry;
                                 savedTempCSSFile = true;
                             });
                     });
@@ -569,19 +557,15 @@ define(function (require, exports, module) {
                     });
                     // initInlineTest() inserts a waitsFor() automatically, so must end runs() block here
                     
-                    // Delete the file
-                    var fileDeleted = false;
                     runs(function () {
                         var hostEditor = EditorManager.getCurrentFullEditor();
                         expect(hostEditor.getInlineWidgets().length).toBe(1);
-                        
-                        brackets.fs.unlink(fileToWrite.fullPath, function (err) {
-                            if (!err) {
-                                fileDeleted = true;
-                            }
-                        });
                     });
-                    waitsFor(function () { return fileDeleted; }, 1000);
+                    
+                    // Delete the file
+                    runs(function () {
+                        waitsForDone(SpecRunnerUtils.deleteFile(fileToWrite.fullPath));
+                    });
                     
                     // Ping FileSyncManager to recognize the deletion
                     runs(function () {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
                     removePrefix    : true
                 };
             
-            SpecRunnerUtils.copyDirectoryPath(testPath, tempPath, options).done(function () {
+            SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
                 spec.infos = infos;
                 result.resolve();
             }).fail(function () {

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         beforeEach(function () {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/LowLevelFileIO-test-files");
-                waitsForDone(SpecRunnerUtils.copyDirectory(testFiles, baseDir));
+                waitsForDone(SpecRunnerUtils.copyDirectoryPath(testFiles, baseDir));
             });
 
             runs(function () {

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         beforeEach(function () {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/LowLevelFileIO-test-files");
-                waitsForDone(SpecRunnerUtils.copyDirectoryPath(testFiles, baseDir));
+                waitsForDone(SpecRunnerUtils.copyPath(testFiles, baseDir));
             });
 
             runs(function () {

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         beforeEach(function () {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/LowLevelFileIO-test-files");
-                waitsForDone(SpecRunnerUtils.copyPath(testFiles, baseDir));
+                waitsForDone(SpecRunnerUtils.copyDirectory(testFiles, baseDir));
             });
 
             runs(function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/NativeFileSystem-test-files");
                 self.path = SpecRunnerUtils.getTempDirectory();
-                waitsForDone(SpecRunnerUtils.copyPath(testFiles, self.path));
+                waitsForDone(SpecRunnerUtils.copyDirectory(testFiles, self.path));
             });
 
             runs(function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -42,8 +42,17 @@ define(function (require, exports, module) {
         var _err;
 
         beforeEach(function () {
-            this.path = SpecRunnerUtils.getTestPath("/spec/NativeFileSystem-test-files");
-            this.file1content = "Here is file1";
+            var self = this;
+
+            runs(function () {
+                var testFiles = SpecRunnerUtils.getTestPath("/spec/NativeFileSystem-test-files");
+                self.path = SpecRunnerUtils.getTempDirectory();
+                waitsForDone(SpecRunnerUtils.copyPath(testFiles, self.path));
+            });
+
+            runs(function () {
+                self.file1content = "Here is file1";
+            });
         });
 
         describe("Reading a directory", function () {
@@ -418,7 +427,6 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 var nfs = null;
-                var chmodDone = false;
 
                 runs(function () {
                     NativeFileSystem.requestNativeFileSystem(this.path, function (fs) {
@@ -431,31 +439,19 @@ define(function (require, exports, module) {
                     this.nfs = nfs;
                 });
 
-                // set read-only permissions
+                // set permissions
                 runs(function () {
-                    brackets.fs.chmod(this.path + "/cant_read_here.txt", parseInt("222", 8), function (err) {
-                        _err = err;
-                        chmodDone = true;
-                    });
-                    brackets.fs.chmod(this.path + "/cant_write_here.txt", parseInt("444", 8), function (err) {
-                        _err = err;
-                        chmodDone = true;
-                    });
+                    waitsForDone(SpecRunnerUtils.chmod(this.path + "/cant_read_here.txt", "222"));
+                    waitsForDone(SpecRunnerUtils.chmod(this.path + "/cant_write_here.txt", "444"));
                 });
-                waitsFor(function () { return chmodDone && (_err === brackets.fs.NO_ERROR); }, 1000);
             });
 
             afterEach(function () {
-                var chmodDone = false;
-
-                // restore permissions for git
+                // restore permissions
                 runs(function () {
-                    brackets.fs.chmod(this.path + "/cant_read_here.txt", parseInt("777", 8), function (err) {
-                        _err = err;
-                        chmodDone = true;
-                    });
+                    waitsForDone(SpecRunnerUtils.chmod(this.path + "/cant_read_here.txt", "644"));
+                    waitsForDone(SpecRunnerUtils.chmod(this.path + "/cant_write_here.txt", "644"));
                 });
-                waitsFor(function () { return chmodDone && (_err === brackets.fs.NO_ERROR); }, 1000);
             });
 
             it("should create new, zero-length files", function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/NativeFileSystem-test-files");
                 self.path = SpecRunnerUtils.getTempDirectory();
-                waitsForDone(SpecRunnerUtils.copyDirectory(testFiles, self.path));
+                waitsForDone(SpecRunnerUtils.copyDirectoryPath(testFiles, self.path));
             });
 
             runs(function () {

--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
             runs(function () {
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/NativeFileSystem-test-files");
                 self.path = SpecRunnerUtils.getTempDirectory();
-                waitsForDone(SpecRunnerUtils.copyDirectoryPath(testFiles, self.path));
+                waitsForDone(SpecRunnerUtils.copyPath(testFiles, self.path));
             });
 
             runs(function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -543,29 +543,6 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Copy a file source path to a destination
-     * @param {!string} source Path for the source file to copy
-     * @param {!string} destination Destination path to copy the source file
-     * @param {?{parseOffsets:boolean}} options parseOffsets allows optional
-     *     offset markup parsing. File is written to the destination path
-     *     without offsets. Offset data is passed to the doneCallbacks of the
-     *     promise.
-     * @return {$.Promise} A promise resolved when the file is copied to the
-     *     destination.
-     */
-    function copyFilePath(source, destination, options) {
-        var deferred = new $.Deferred();
-        
-        resolveNativeFileSystemPath(source).done(function (entry) {
-            copyFileEntry(entry, destination, options).pipe(deferred.resolve, deferred.reject);
-        }).fail(function () {
-            deferred.reject();
-        });
-        
-        return deferred.promise();
-    }
-    
-    /**
      * Copy a directory source to a destination
      * @param {!DirectoryEntry} source Entry for the source directory to copy
      * @param {!string} destination Destination path to copy the source directory
@@ -651,9 +628,9 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Copy a directory source path to a destination
-     * @param {!string} source Path for the source directory to copy
-     * @param {!string} destination Destination path to copy the source directory
+     * Copy a file or directory source path to a destination
+     * @param {!string} source Path for the source file or directory to copy
+     * @param {!string} destination Destination path to copy the source file or directory
      * @param {?{parseOffsets:boolean, infos:Object, removePrefix:boolean}}} options
      *     parseOffsets - allows optional offset markup parsing. File is written to the
      *       destination path without offsets. Offset data is passed to the
@@ -667,11 +644,19 @@ define(function (require, exports, module) {
      *     contents are copied to the destination or rejected immediately
      *     upon the first error.
      */
-    function copyDirectoryPath(source, destination, options) {
+    function copyPath(source, destination, options) {
         var deferred = new $.Deferred();
         
         resolveNativeFileSystemPath(source).done(function (entry) {
-            copyDirectoryEntry(entry, destination, options).pipe(deferred.resolve, deferred.reject);
+            var promise;
+            
+            if (entry.isDirectory) {
+                promise = copyDirectoryEntry(entry, destination, options);
+            } else {
+                promise = copyFileEntry(entry, destination, options);
+            }
+            
+            promise.pipe(deferred.resolve, deferred.reject);
         }).fail(function () {
             deferred.reject();
         });
@@ -823,9 +808,8 @@ define(function (require, exports, module) {
     exports.toggleQuickEditAtOffset         = toggleQuickEditAtOffset;
     exports.createTextFile                  = createTextFile;
     exports.copyDirectoryEntry              = copyDirectoryEntry;
-    exports.copyDirectoryPath               = copyDirectoryPath;
     exports.copyFileEntry                   = copyFileEntry;
-    exports.copyFilePath                    = copyFilePath;
+    exports.copyPath                        = copyPath;
     exports.deletePath                      = deletePath;
     exports.getTestWindow                   = getTestWindow;
     exports.simulateKeyEvent                = simulateKeyEvent;

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -49,12 +49,12 @@ define(function (require, exports, module) {
         var deferred = new $.Deferred();
         
         if (nfs) {
-            deferred.resolve(nfs);
+            deferred.resolve(nfs.root);
         }
         
         NativeFileSystem.requestNativeFileSystem("/", function success(nativeFileSystem) {
             nfs = nativeFileSystem;
-            deferred.resolve(nfs);
+            deferred.resolve(nfs.root);
         }, function error(err) {
             deferred.reject();
         });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -636,7 +636,7 @@ define(function (require, exports, module) {
             });
         });
 
-        deferred.always(function () {               
+        deferred.always(function () {
             // remove destination path prefix
             if (removePrefix && options.infos) {
                 var shortKey;
@@ -645,7 +645,7 @@ define(function (require, exports, module) {
                     options.infos[shortKey] = options.infos[key];
                 });
             }
-        })
+        });
         
         return deferred.promise();
     }


### PR DESCRIPTION
Fix for #517

Replaces `SpecRunnerUtils. saveFilesWithoutOffsets()` and related methods with a generic `SpecRunnerUtils.copyPath()` method that accepts a few options, including parsing offsets.

Targeted unit test suites (JavaScriptQuickEdit, InlineEditorProviders, LowLevelFileIO and NativeFileSystem) copy these modified files to a temporary folder `/path/to/brackets/test/temp`.

Introduces `NativeFileSystem. resolveNativeFileSystemPath()` to mimic `LocalFileSystem.resolveLocalFileSystemURL` from W3C File API.

Fixes async issues in LowLevelFileIO.
