### PR TITLE
Update isDevBuild check

### DIFF
--- a/src/strings.js
+++ b/src/strings.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
     additionalGlobals.VERSION_MINOR = parsedVersion[2];
     additionalGlobals.VERSION_PATCH = parsedVersion[3];
 
-    var isDevBuild = StringUtils.endsWith(decodeURI(window.location.pathname), "/dev/src/index.html");
+    var isDevBuild = !StringUtils.endsWith(decodeURI(window.location.pathname), "/www/index.html");
     additionalGlobals.BUILD_TYPE    = (isDevBuild ? strings.DEVELOPMENT_BUILD : strings.EXPERIMENTAL_BUILD);
     
     // Insert application strings


### PR DESCRIPTION
@njx 

Update the isDevBuild check to explicitly look for production builds (`www/index.html`) instead of explicitly looking for a dev build.

If you hold the shift key during startup and select a different index.html file, it should show as a development build.
