### PR TITLE
Allow findAllMatchingFunctionsInText to iterate over array-like objects (#1390)

### DIFF
--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -400,19 +400,24 @@ define(function (require, exports, module) {
         var allFunctions = _findAllFunctionsInText(text);
         var result = [];
         var lines = text.split("\n");
+        var key;
         
-        $.each(allFunctions, function (index, functions) {
-            if (index === functionName || functionName === "*") {
-                functions.forEach(function (funcEntry) {
-                    var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
-                    result.push({
-                        name: index,
-                        lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
-                        lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
-                    });
-                });
+        function addFunctionEntry(funcEntry) {
+            var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
+            result.push({
+                name: key,
+                lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
+                lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
+            });
+        }
+        
+        for (key in allFunctions) {
+            if (allFunctions.hasOwnProperty(key)) {
+                if (key === functionName || functionName === "*") {
+                    allFunctions[key].forEach(addFunctionEntry);
+                }
             }
-        });
+        }
          
         return result;
     }

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         DocumentManager         = require("document/DocumentManager"),
         ChangedDocumentTracker  = require("document/ChangedDocumentTracker"),
         NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
+        CollectionUtils         = require("utils/CollectionUtils"),
         PerfUtils               = require("utils/PerfUtils"),
         StringUtils             = require("utils/StringUtils");
 
@@ -400,27 +401,19 @@ define(function (require, exports, module) {
         var allFunctions = _findAllFunctionsInText(text);
         var result = [];
         var lines = text.split("\n");
-        var functionName;
         
-        function makeAddFunction(functionName) {
-            return function (funcEntry) {
-                var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
-                result.push({
-                    name: functionName,
-                    lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
-                    lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
+        CollectionUtils.forEach(allFunctions, function (functionName, functions) {
+            if (functionName === searchName || searchName === "*") {
+                functions.forEach(function (funcEntry) {
+                    var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
+                    result.push({
+                        name: functionName,
+                        lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
+                        lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
+                    });
                 });
-            };
-        }
-        
-        for (functionName in allFunctions) {
-            if (allFunctions.hasOwnProperty(functionName)) {
-                if (functionName === searchName || searchName === "*") {
-                    var addFunctionEntry = makeAddFunction(functionName);
-                    allFunctions[functionName].forEach(addFunctionEntry);
-                }
             }
-        }
+        });
          
         return result;
     }

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -396,25 +396,28 @@ define(function (require, exports, module) {
      * @return {Array.<{offset:number, functionName:string}>}
      *      Array of objects containing the start offset for each matched function name.
      */
-    function findAllMatchingFunctionsInText(text, functionName) {
+    function findAllMatchingFunctionsInText(text, searchName) {
         var allFunctions = _findAllFunctionsInText(text);
         var result = [];
         var lines = text.split("\n");
-        var key;
+        var functionName;
         
-        function addFunctionEntry(funcEntry) {
-            var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
-            result.push({
-                name: key,
-                lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
-                lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
-            });
+        function makeAddFunction(functionName) {
+            return function (funcEntry) {
+                var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
+                result.push({
+                    name: functionName,
+                    lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
+                    lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
+                });
+            };
         }
         
-        for (key in allFunctions) {
-            if (allFunctions.hasOwnProperty(key)) {
-                if (key === functionName || functionName === "*") {
-                    allFunctions[key].forEach(addFunctionEntry);
+        for (functionName in allFunctions) {
+            if (allFunctions.hasOwnProperty(functionName)) {
+                if (functionName === searchName || searchName === "*") {
+                    var addFunctionEntry = makeAddFunction(functionName);
+                    allFunctions[functionName].forEach(addFunctionEntry);
                 }
             }
         }

--- a/src/utils/CollectionUtils.js
+++ b/src/utils/CollectionUtils.js
@@ -46,7 +46,23 @@ define(function (require, exports, module) {
         return -1;
     }
     
+    /**
+     * Iterates over all the properties in an object or elements in an array. Differs from
+     * $.each in that it iterates over array-like objects like regular objects.
+     * @param {*} object The object or array to iterate over.
+     * @param {function(index, value)} callback The function that will be executed on every object.
+     */
+    function forEach(object, callback) {
+        var keys = Object.keys(object),
+            len = keys.length,
+            i;
+        
+        for (i = 0; i < len; i++) {
+            callback(keys[i], object[keys[i]]);
+        }
+    }
     
     // Define public API
     exports.indexOf = indexOf;
+    exports.forEach = forEach;
 });


### PR DESCRIPTION
This is a possible fix for #1390 where no results appear in the Go to Definition dialog.

The root cause is that in this case, there is a `.prototype.length = function ()` which turns the `allFunctions` object in `findAllMatchingFunctionsInText` into an array-like object, and due to the length property it fails to iterate using `$.each`.

The fix substitutes the `$.each` for a `for..in` loop.
