### PR TITLE
Unit tests for Find

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -77,7 +77,7 @@
     <script src="thirdparty/jquery-1.7.min.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
     
-    <!-- JS for CodeMirror search support, currently for debugging only -->
+    <!-- JS for CodeMirror search support -->
     <script src="thirdparty/CodeMirror2/lib/util/dialog.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
     <script src="thirdparty/CodeMirror2/lib/util/search.js"></script>

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -36,6 +36,9 @@
   <!-- Pre-load third party scripts that cannot be async loaded. -->
   <script src="../src/thirdparty/jquery-1.7.min.js"></script>
   <script src="../src/thirdparty/CodeMirror2/lib/codemirror.js"></script>
+  <script src="../src/thirdparty/CodeMirror2/lib/util/dialog.js"></script>
+  <script src="../src/thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
+  <script src="../src/thirdparty/CodeMirror2/lib/util/search.js"></script>
   <script src="../src/thirdparty/mustache/mustache.js"></script>
   <script src="thirdparty/bootstrap2/js/bootstrap.min.js"></script>
     

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -38,7 +38,6 @@
   <script src="../src/thirdparty/CodeMirror2/lib/codemirror.js"></script>
   <script src="../src/thirdparty/CodeMirror2/lib/util/dialog.js"></script>
   <script src="../src/thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/lib/util/search.js"></script>
   <script src="../src/thirdparty/mustache/mustache.js"></script>
   <script src="thirdparty/bootstrap2/js/bootstrap.min.js"></script>
     

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
     require("spec/EditorCommandHandlers-test");
     require("spec/ExtensionUtils-test");
     require("spec/FileIndexManager-test");
+    require("spec/FindReplace-test");
     require("spec/InlineEditorProviders-test");
     require("spec/KeyBindingManager-test");
     require("spec/LiveDevelopment-test");

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
                 // simulate Ctrl+space keystroke to invoke code hints menu
                 runs(function () {
                     var e = $.Event("keydown");
-                    e.keyCode = KeyEvent.DOM_VK_SPACE;      // spacebar key
+                    e.keyCode = KeyEvent.DOM_VK_SPACE;
                     e.ctrlKey = true;
 
                     editor = EditorManager.getCurrentFullEditor();
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
                 // simulate Enter key to insert code hint into doc
                 runs(function () {
                     var e = $.Event("keydown");
-                    e.keyCode = 13;      // Enter/return key
+                    e.keyCode = KeyEvent.DOM_VK_RETURN;
 
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
                 // simulate Ctrl+space keystroke to invoke code hints menu
                 runs(function () {
                     var e = $.Event("keydown");
-                    e.keyCode = 32;      // spacebar key
+                    e.keyCode = KeyEvent.DOM_VK_SPACE;
                     e.ctrlKey = true;
 
                     editor = EditorManager.getCurrentFullEditor();
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
 
                 // simulate Esc key to dismiss code hints menu
                 runs(function () {
-                    var key = 27,   // Esc key
+                    var key = KeyEvent.DOM_VK_ESCAPE,
                         element = testWindow.$(".dropdown.open")[0];
                     SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -29,11 +29,9 @@ define(function (require, exports, module) {
     
     var Editor                = require("editor/Editor").Editor,
         EditorCommandHandlers = require("editor/EditorCommandHandlers"),
-        EditorManager         = require("editor/EditorManager"),
         Commands              = require("command/Commands"),
         CommandManager        = require("command/CommandManager"),
-        SpecRunnerUtils       = require("spec/SpecRunnerUtils"),
-        EditorUtils           = require("editor/EditorUtils");
+        SpecRunnerUtils       = require("spec/SpecRunnerUtils");
 
     describe("EditorCommandHandlers", function () {
         

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
                 expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
             });
             
-            it("should Find Next after search bar closed", function () {
+            it("should Find Next after search bar closed, including wraparound", function () {
                 myEditor.setCursorPos(0, 0);
                 
                 CommandManager.execute(Commands.EDIT_FIND);
@@ -171,8 +171,41 @@ define(function (require, exports, module) {
                 
                 expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
                 
+                // Simple linear Find Next
                 CommandManager.execute(Commands.EDIT_FIND_NEXT);
                 expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 8, ch: 8}, end: {line: 8, ch: 11}});
+                
+                // Wrap around to first result
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+            });
+            
+            it("should Find Previous after search bar closed, including wraparound", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("foo");
+                pressEnter();
+                expectSearchBarClosed();
+                
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+                
+                // Wrap around to last result
+                CommandManager.execute(Commands.EDIT_FIND_PREVIOUS);
+                expectSelection({start: {line: 8, ch: 8}, end: {line: 8, ch: 11}});
+                
+                // Simple linear Find Previous
+                CommandManager.execute(Commands.EDIT_FIND_PREVIOUS);
+                expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
+                CommandManager.execute(Commands.EDIT_FIND_PREVIOUS);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
+                CommandManager.execute(Commands.EDIT_FIND_PREVIOUS);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
             });
             
             it("shouldn't Find Next after search bar reopened", function () {
@@ -203,6 +236,7 @@ define(function (require, exports, module) {
                 expectSearchBarOpen();
                 expectCursorAt({line: 0, ch: 0});
             });
+            
         });
         
         

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -419,7 +419,7 @@ define(function (require, exports, module) {
                 expectSelection({start: {line: 8, ch: 8}, end: {line: 8, ch: 11}});
             });
             
-            it("should support case-insenseitive regexps via /.../i", function () {
+            it("should support case-insensitive regexps via /.../i", function () {
                 myEditor.setCursorPos(0, 0);
                 
                 CommandManager.execute(Commands.EDIT_FIND);
@@ -436,6 +436,17 @@ define(function (require, exports, module) {
                 // This should be interpreted as a non-RegExp search, which actually does have a result thanks to "modules/Bar"
                 enterSearchText("/Ba");
                 expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 30}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 33}});
+            });
+            
+            it("shouldn't choke on invalid regexp", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                // This is interpreted as a regexp (has both "/"es) but is invalid; should show error message
+                enterSearchText("/+/");
+                expect($(".CodeMirror-dialog .alert-message").length).toBe(1);
+                expectCursorAt({line: 0, ch: 0}); // no change
             });
             
             it("shouldn't choke on empty regexp", function () {

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, $ */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    var Editor                = require("editor/Editor").Editor,
+        FindReplace           = require("search/FindReplace"),
+        Commands              = require("command/Commands"),
+        CommandManager        = require("command/CommandManager"),
+        KeyEvent              = require("utils/KeyEvent"),
+        SpecRunnerUtils       = require("spec/SpecRunnerUtils");
+
+    describe("FindReplace", function () {
+        
+        var defaultContent = "/* Test comment */\n" +
+                             "define(function (require, exports, module) {\n" +
+                             "    var Foo = require(\"modules/Foo\"),\n" +
+                             "        Bar = require(\"modules/Bar\"),\n" +
+                             "        Baz = require(\"modules/Baz\");\n" +
+                             "    \n" +
+                             "    function callFoo() {\n" +
+                             "        \n" +
+                             "        foo();\n" +
+                             "        \n" +
+                             "    }\n" +
+                             "\n" +
+                             "}";
+        
+        var LINE_FIRST_REQUIRE = 2;
+        var LINE_AFTER_REQUIRES = 5;
+        var CH_REQUIRE_START = 14;
+        var CH_REQUIRE_PAREN = CH_REQUIRE_START + "require".length;
+        
+
+        var myDocument, myEditor;
+        
+        function setupFullEditor() {
+            // create dummy Document and Editor
+            var mocks = SpecRunnerUtils.createMockEditor(defaultContent, "javascript");
+            myDocument = mocks.doc;
+            myEditor = mocks.editor;
+            
+            myEditor.focus();
+        }
+        
+        afterEach(function () {
+            SpecRunnerUtils.destroyMockEditor(myDocument);
+            myEditor = null;
+            myDocument = null;
+        });
+        
+        
+        // Helper functions for testing cursor position / selection range
+        // TODO: duplicated from EditorCommandHandlers-test
+        function expectCursorAt(pos) {
+            var selection = myEditor.getSelection();
+            expect(selection.start).toEqual(selection.end);
+            expect(selection.start).toEqual(pos);
+        }
+        function expectSelection(sel) {
+            expect(myEditor.getSelection()).toEqual(sel);
+        }
+        
+        
+        function getSearchBar() {
+            return $(".CodeMirror-dialog");
+        }
+        function getSearchField() {
+            return $(".CodeMirror-dialog input[type='text']");
+        }
+        
+        function expectSearchBarOpen() {
+            expect(getSearchBar()[0]).toBeDefined();
+        }
+        function expectSearchBarClosed() {
+            expect(getSearchBar()[0]).not.toBeDefined();
+        }
+        
+        function enterSearchText(str) {
+            expectSearchBarOpen();
+            var $input = getSearchField();
+            $input.val(str);
+            $input.trigger("input");
+        }
+        
+        function pressEnter() {
+            expectSearchBarOpen();
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", getSearchField()[0]);
+        }
+        function pressEscape() {
+            expectSearchBarOpen();
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", getSearchField()[0]);
+        }
+        
+
+        
+        describe("Search", function () {
+            beforeEach(setupFullEditor);
+            
+            it("should find all case-insensitive matches", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("foo");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 8, ch: 8}, end: {line: 8, ch: 11}});
+                
+                // wraparound
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+            });
+            
+            it("should find all case-sensitive matches", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("Foo");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
+                // note the lowercase "foo()" is NOT matched
+                
+                // wraparound
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+            });
+            
+            it("should Find Next after search bar closed", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("foo");
+                pressEnter();
+                expectSearchBarClosed();
+                
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
+            });
+            
+            it("shouldn't Find Next after search bar reopened", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("foo");
+                pressEnter();
+                expectSearchBarClosed();
+                
+                // Open search bar a second time
+                myEditor.setCursorPos(0, 0);
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                expectSearchBarOpen();
+                expectCursorAt({line: 0, ch: 0});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectCursorAt({line: 0, ch: 0});
+            });
+            
+            it("should open search bar on Find Next with no previous search", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                
+                expectSearchBarOpen();
+                expectCursorAt({line: 0, ch: 0});
+            });
+        });
+        
+        
+        describe("Incremental search", function () {
+            beforeEach(setupFullEditor);
+            
+            it("should re-search from original position when text changes", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("baz");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 2, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 2, ch: 11}});
+                
+                enterSearchText("bar");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 11}});
+            });
+            
+            it("should re-search from original position when text changes, even after Find Next", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("foo");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+                
+                // get search highlight down below where the "bar" match will be
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
+                
+                enterSearchText("bar");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 11}});
+            });
+            
+            it("should extend original selection when appending to prepopulated text", function () {
+                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expect(getSearchField().val()).toEqual("require");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                enterSearchText("require(");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN + 1}});
+            });
+            
+            it("should clear selection when appending to prepopulated text causes no result", function () {
+                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                enterSearchText("requireX");
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+            });
+        });
+        
+        
+        describe("Terminating search", function () {
+            beforeEach(setupFullEditor);
+            
+            it("should go to next on Enter with prepopulated text & no Find Nexts", function () {
+                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                pressEnter();
+                
+                expectSearchBarClosed();
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_PAREN}});
+            });
+            
+            it("shouldn't change selection on Esc with prepopulated text & no Find Nexts", function () {
+                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                pressEscape();
+                
+                expectSearchBarClosed();
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+            });
+            
+            it("shouldn't change selection on Enter with prepopulated text & after Find Next", function () {
+                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN});
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_PAREN}});
+                
+                pressEnter();
+                
+                expectSearchBarClosed();
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_PAREN}});
+            });
+            
+            it("shouldn't change selection on Enter after typing text, no Find Nexts", function () {
+                myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: 0});
+                
+                enterSearchText("require");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                pressEnter();
+                
+                expectSearchBarClosed();
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+            });
+            
+            it("shouldn't change selection on Enter after typing text & Find Next", function () {
+                myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: 0});
+                
+                enterSearchText("require");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_PAREN}});
+                
+                pressEnter();
+                
+                expectSearchBarClosed();
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE + 1, ch: CH_REQUIRE_PAREN}});
+            });
+            
+            it("should no-op on Enter with blank search", function () {
+                myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: 0});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: 0}); // no change
+                
+                pressEnter();
+                
+                expectSearchBarClosed();
+                expectCursorAt({line: LINE_FIRST_REQUIRE, ch: 0}); // no change
+            });
+        });
+        
+        
+        describe("RegExp Search", function () {
+            beforeEach(setupFullEditor);
+            
+            it("should find based on regexp", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("/Ba./");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 11}});
+                
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 31}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 34}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 2, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 2, ch: 11}});
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 2, ch: 31}, end: {line: LINE_FIRST_REQUIRE + 2, ch: 34}});
+                
+                // wraparound
+                CommandManager.execute(Commands.EDIT_FIND_NEXT);
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 8}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 11}});
+            });
+            
+            it("should be a case-sensitive regexp by default", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("/foo/");
+                expectSelection({start: {line: 8, ch: 8}, end: {line: 8, ch: 11}});
+            });
+            
+            it("should support case-insenseitive regexps via /.../i", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("/foo/i");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
+            });
+            
+            it("shouldn't choke on partial regexp", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                // This should be interpreted as a non-RegExp search, which actually does have a result thanks to "modules/Bar"
+                enterSearchText("/Ba");
+                expectSelection({start: {line: LINE_FIRST_REQUIRE + 1, ch: 30}, end: {line: LINE_FIRST_REQUIRE + 1, ch: 33}});
+            });
+            
+            it("shouldn't choke on empty regexp", function () {
+                myEditor.setCursorPos(0, 0);
+                
+                CommandManager.execute(Commands.EDIT_FIND);
+                
+                enterSearchText("//");
+                expectCursorAt({line: 0, ch: 0}); // no change
+            });
+        });
+    });
+    
+});

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
         FileViewController, // loaded from brackets.test
         Dialogs          = require("widgets/Dialogs"),
         NativeFileSystem = require("file/NativeFileSystem").NativeFileSystem,
+        KeyEvent         = require("utils/KeyEvent"),
         FileUtils        = require("file/FileUtils"),
         SpecRunnerUtils  = require("spec/SpecRunnerUtils");
 
@@ -337,7 +338,7 @@ define(function (require, exports, module) {
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
 
                     // close the editor by simulating Esc key
-                    var key = 27,   // Esc key
+                    var key = KeyEvent.DOM_VK_ESCAPE,
                         doc = testWindow.document,
                         element = doc.getElementsByClassName("inline-widget")[0];
                     SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -32,8 +32,7 @@ define(function (require, exports, module) {
         KeyBindingManager,
         Menus,
         SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
-        StringsUtils        = require("utils/StringUtils"),
-        Strings             = require("strings");
+        KeyEvent            = require("utils/KeyEvent");
 
 
 
@@ -696,7 +695,7 @@ define(function (require, exports, module) {
                 expect($menus.length).toBe(1);
 
                 // close the context menu by simulating Esc key
-                var key = 27,   // Esc key
+                var key = KeyEvent.DOM_VK_ESCAPE,
                     element = $menus[0];
                 SpecRunnerUtils.simulateKeyEvent(key, "keydown", element);
 


### PR DESCRIPTION
New suite of unit tests for Find (but not Replace, yet).

Also cleans up a few other test suites to use KeyEvent consts instead of magic numbers, and to remove unused dependencies.

@njx or @gruehle since you're currently mucking around Find code?
