### PR TITLE
Use scrollTop instead of scrollIntoView for #2130

### DIFF
--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -302,12 +302,13 @@ define(function (require, exports, module) {
             elementOffset = $element.offset();
 
         // scroll minimum amount
-        if (elementOffset.top + $element.height() >= (viewOffset.top + $view.height())) {
+        var bottomDelta = (elementOffset.top + $element.height()) - (viewOffset.top + $view.height());
+        if (bottomDelta > 0) {
             // below viewport
-            element.scrollIntoView(false);
+            $view.scrollTop($view.scrollTop() + bottomDelta);
         } else if (elementOffset.top <= viewOffset.top) {
             // above viewport
-            element.scrollIntoView(true);
+            $view.scrollTop($view.scrollTop() - (viewOffset.top - elementOffset.top));
         }
 
         if (scrollHorizontal) {

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -302,13 +302,18 @@ define(function (require, exports, module) {
             elementOffset = $element.offset();
 
         // scroll minimum amount
-        var bottomDelta = (elementOffset.top + $element.height()) - (viewOffset.top + $view.height());
-        if (bottomDelta > 0) {
+        var delta = (elementOffset.top + $element.height()) - (viewOffset.top + $view.height());
+        
+        if (delta > 0) {
             // below viewport
-            $view.scrollTop($view.scrollTop() + bottomDelta);
-        } else if (elementOffset.top <= viewOffset.top) {
-            // above viewport
-            $view.scrollTop($view.scrollTop() - (viewOffset.top - elementOffset.top));
+            $view.scrollTop($view.scrollTop() + delta);
+        } else {
+            delta = viewOffset.top - elementOffset.top;
+            
+            if (delta > 0) {
+                // above viewport
+                $view.scrollTop($view.scrollTop() - delta);
+            }
         }
 
         if (scrollHorizontal) {


### PR DESCRIPTION
Explicitly set `scrollTop` instead of relying on the DOM Element `scrollIntoView()` to determine scroll position. Fix for #2130.
