### PR TITLE
Temporarily remove test that is reading drive.

### DIFF
--- a/test/spec/NativeFileSystem-test.js
+++ b/test/spec/NativeFileSystem-test.js
@@ -91,7 +91,10 @@ define(function (require, exports, module) {
                 });
             });
 
-            it("should be able to read a drive", function () {
+            // This test is intermittently failing on the build machine, and 
+            // *only* on the build machine. Removing for now. Issue
+            // #2333 logged to resolve this.
+            xit("should be able to read a drive", function () {
                 var entries = null,
                     deferred = new $.Deferred();
                 


### PR DESCRIPTION
#2333 has been logged to resolve the issue. In the meantime, the test is removed.
