### PR TITLE
Get rid of empty parens when we don't have a SHA in the about dialog

### DIFF
--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
     BuildInfoUtils.getBracketsSHA().done(function (branch, sha, isRepo) {
         // If we've successfully determined a "build number" via .git metadata, add it to dialog
         sha = sha ? sha.substr(0, 9) : "";
-        buildInfo = StringUtils.format("{0} {1}", branch, sha).trim();
+        buildInfo = StringUtils.format("({0} {1})", branch, sha).trim();
     });
     
     CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.HELP_SHOW_EXT_FOLDER,      _handleShowExtensionsFolder);

--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -6,7 +6,7 @@
         <img class="about-icon" src="{{ABOUT_ICON}}">
         <div class="about-text">
             <h2>{{APP_NAME_ABOUT_BOX}}</h2>
-            <p class="dialog-message">{{ABOUT_TEXT_LINE1}} <span id="about-build-number">({{BUILD_INFO}})</span></p>
+            <p class="dialog-message">{{ABOUT_TEXT_LINE1}} <span id="about-build-number">{{BUILD_INFO}}</span></p>
             <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2012 Adobe Systems Incorporated and its licensors. All rights reserved.</p>
             <p class="dialog-message">{{{ABOUT_TEXT_LINE3}}}</p>
             <p class="dialog-message">{{{ABOUT_TEXT_LINE4}}}</p>


### PR DESCRIPTION
@jasonsanjose Just a little oversight from the previous refactoring.
