### PR TITLE
Redoing the Scroll Line Up/Down for the cmv3 branch

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -145,6 +145,18 @@
     "view.restoreFontSize":  [
         "Ctrl-0"
     ],
+    "view.scrollLineUp":  [
+        {
+            "key": "Ctrl-Up",
+            "displayKey": "Ctrl-\u2191"
+        }
+    ],
+    "view.scrollLineDown":  [
+        {
+            "key": "Ctrl-Down",
+            "displayKey": "Ctrl-\u2193"
+        }
+    ],
     "navigate.quickOpen":  [
         "Ctrl-Shift-O"
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -148,13 +148,25 @@
     "view.scrollLineUp":  [
         {
             "key": "Ctrl-Up",
-            "displayKey": "Ctrl-\u2191"
+            "displayKey": "Ctrl-\u2191",
+            "platform": "win"
+        },
+        {
+            "key": "Ctrl-Alt-Up",
+            "displayKey": "Ctrl-Alt-\u2191",
+            "platform": "mac"
         }
     ],
     "view.scrollLineDown":  [
         {
             "key": "Ctrl-Down",
-            "displayKey": "Ctrl-\u2193"
+            "displayKey": "Ctrl-\u2193",
+            "platform": "win"
+        },
+        {
+            "key": "Ctrl-Alt-Down",
+            "displayKey": "Ctrl-Alt-\u2193",
+            "platform": "mac"
         }
     ],
     "navigate.quickOpen":  [

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -77,6 +77,8 @@ define(function (require, exports, module) {
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";
     exports.VIEW_DECREASE_FONT_SIZE     = "view.decreaseFontSize";
     exports.VIEW_RESTORE_FONT_SIZE      = "view.restoreFontSize";
+    exports.VIEW_SCROLL_LINE_UP         = "view.scrollLineUp";
+    exports.VIEW_SCROLL_LINE_DOWN       = "view.scrollLineDown";
     exports.TOGGLE_JSLINT               = "debug.jslint";
     exports.SORT_WORKINGSET_BY_ADDED    = "view.sortWorkingSetByAdded";
     exports.SORT_WORKINGSET_BY_NAME     = "view.sortWorkingSetByName";

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -920,6 +920,9 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE);
         menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE);
         menu.addMenuDivider();
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_UP);
+        menu.addMenuItem(Commands.VIEW_SCROLL_LINE_DOWN);
+        menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_JSLINT);
 
         /*

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -850,6 +850,14 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Returns the current text height of the editor.
+     * @returns {number} Height of the text in pixels
+     */
+    Editor.prototype.getTextHeight = function () {
+        return this._codeMirror.defaultTextHeight();
+    };
+    
+    /**
      * Returns the current scroll position of the editor.
      * @returns {{x:number, y:number}} The x,y scroll position in pixels
      */

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -201,6 +201,8 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Increase Font Size",
     "CMD_DECREASE_FONT_SIZE"              : "Decrease Font Size",
     "CMD_RESTORE_FONT_SIZE"               : "Restore Font Size",
+    "CMD_SCROLL_LINE_UP"                  : "Scroll Line Up",
+    "CMD_SCROLL_LINE_DOWN"                : "Scroll Line Down",
     "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sort by Added",
     "CMD_SORT_WORKINGSET_BY_NAME"         : "Sort by Name",
     "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sort by Type",

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -133,10 +133,33 @@ define(function (require, exports, module) {
      * @param {number} -1 to scroll one line up; 1 to scroll one line down.
      */
     function _scrollLine(direction) {
-        var editor     = EditorManager.getCurrentFullEditor();
-        var scrollPos  = editor.getScrollPos();
-        var textHeight = editor.getTextHeight();
+        var editor        = EditorManager.getCurrentFullEditor(),
+            scrollPos     = editor.getScrollPos(),
+            totalHeight   = $("#editor-holder").height(), // editor.getTotalHeight();
+            textHeight    = editor.getTextHeight(),
+            visibleLines  = Math.floor(totalHeight / textHeight),
+            firstLine     = Math.floor(scrollPos.y / textHeight),
+            lastLine      = firstLine + visibleLines - 1,
+            cursorPos     = editor.getCursorPos(),
+            hasSelecction = editor.hasSelection();
         
+        // If there is no selection move the cursor so that is always visible
+        if (!hasSelecction) {
+            // Move the cursor to the first visible line
+            if (direction > 0 && cursorPos.line < firstLine) {
+                editor.setCursorPos({line: firstLine + 1, ch: cursorPos.ch});
+            
+            // Move the cursor to the last visible line
+            } else if (direction < 0 && cursorPos.line > lastLine) {
+                editor.setCursorPos({line: lastLine - 1, ch: cursorPos.ch});
+            
+            // Move the cursor up or down using CodeMirror function
+            } else if ((direction > 0 && cursorPos.line === firstLine) || (direction < 0 && cursorPos.line === lastLine)) {
+                editor._codeMirror.moveV(direction, "line");
+            }
+        }
+        
+        // Scroll the editor
         editor.setScrollPos(scrollPos.x, scrollPos.y + (textHeight * direction));
     }
     

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -126,7 +126,32 @@ define(function (require, exports, module) {
         _removeDynamicFontSize(true);
     }
     
+    
+    /**
+     * @private
+     * Scroll the viewport one line up or down.
+     * @param {number} -1 to scroll one line up; 1 to scroll one line down.
+     */
+    function _scrollLine(direction) {
+        var editor     = EditorManager.getCurrentFullEditor();
+        var scrollPos  = editor.getScrollPos();
+        var textHeight = editor.getTextHeight();
+        
+        editor.setScrollPos(scrollPos.x, scrollPos.y + (textHeight * direction));
+    }
+    
+    function _handleScrollLineUp() {
+        _scrollLine(-1);
+    }
+    
+    function _handleScrollLineDown() {
+        _scrollLine(1);
+    }
+    
+    
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE, _handleIncreaseFontSize);
     CommandManager.register(Strings.CMD_DECREASE_FONT_SIZE, Commands.VIEW_DECREASE_FONT_SIZE, _handleDecreaseFontSize);
     CommandManager.register(Strings.CMD_RESTORE_FONT_SIZE,  Commands.VIEW_RESTORE_FONT_SIZE,  _handleRestoreFontSize);
+    CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,     _handleScrollLineUp);
+    CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
 });


### PR DESCRIPTION
This finally adds the Scroll Line Up/Down feature from adobe/brackets#1837 using the defaultTextHeight function from CodeMirror3.
