### PR TITLE
Adding rename on double click. fixes #1976

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -355,6 +355,11 @@ define(function (require, exports, module) {
         _updateFileStatusIcon($newItem, isOpenAndDirty(file), false);
         _updateListItemSelection($newItem, curDoc);
 
+        $newItem.dblclick(function (e) {
+            CommandManager.execute(Commands.FILE_RENAME);
+            _redraw();
+        });
+
         $newItem.mousedown(function (e) {
             _reorderListItem(e, $(this));
             e.preventDefault();


### PR DESCRIPTION
This allows renaming of a file in the working set by double clicking it.
