### PR TITLE
Be smarter about key event propagation

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -88,6 +88,8 @@ define(function (require, exports, module) {
         
         var result = this._commandFn.apply(this, arguments);
         if (!result) {
+            // If command does not return a promise, assume that it handled the
+            // command and return a resolved promise
             return (new $.Deferred()).resolve().promise();
         } else {
             return result;

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -469,8 +469,11 @@ define(function (require, exports, module) {
      */
     function handleKey(key) {
         if (_enabled && _keyMap[key]) {
-            CommandManager.execute(_keyMap[key].commandID);
-            return true;
+            // The execute() function returns a promise because some commands are async.
+            // Generally, commands decide whether they can run or not synchronously,
+            // and reject immediately, so we can test for that synchronously.
+            var promise = CommandManager.execute(_keyMap[key].commandID);
+            return (promise.state() === "rejected") ? false : true;
         }
         return false;
     }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -233,10 +233,17 @@ define(function (require, exports, module) {
     }
 
     function _handleSelectAll() {
-        var editor = EditorManager.getFocusedEditor();
+        var result = new $.Deferred(),
+            editor = EditorManager.getFocusedEditor();
+
         if (editor) {
             editor._selectAllVisible();
+            result.resolve();
+        } else {
+            result.reject();    // command not handled
         }
+
+        return result.promise();
     }
     
     /**


### PR DESCRIPTION
This fixes the Brackets side of #2353

There is also a bug in the Emmet extension, so let me know if want you a copy of the fixed (and un-minified) main.js for Emmet.

There could be commands that cannot decide synchronously whether or not they should handle a command. We could put code in here to write something to console log if that is detected. Let me know if you think that is worth adding.
