### PR TITLE
Add a new flag "isNewItem" to css info object used in CSS Utils API.

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -304,13 +304,6 @@ define(function (require, exports, module) {
         
         // Scan forward to collect all succeeding property values and append to all propValues.
         propValues = propValues.concat(_getSucceedingPropValues(forwardCtx, lastValue));
-
-        // If current index is more than the propValues size, then the cursor is 
-        // at the end of the existing property values and ready for adding another one.
-        // So add a new empty string for the new one in propValues.
-        if (index === propValues.length) {
-            propValues.push("");
-        }
                
         return createInfo(PROP_VALUE, offset, propName, index, propValues, canAddNewOne);
     }

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -116,11 +116,7 @@ define(function (require, exports, module) {
                          name: name || "",
                          index: -1,
                          values: [],
-                         isNewItem: false };
-        
-        if (isNewItem !== undefined) {
-            ruleInfo.isNewItem = isNewItem;
-        }
+                         isNewItem: (isNewItem) ? true : false };
         
         if (context === PROP_VALUE || context === SELECTOR) {
             ruleInfo.index = index;

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -96,12 +96,12 @@ define(function (require, exports, module) {
     /**
      * @private
      * Creates a context info object
-     * @param {string} context A constant string 
-     * @param {number} offset The offset of the token for a given cursor position
-     * @param {string} name Property name of the context 
-     * @param {number} index The index of the property value for a given cursor position
-     * @param {Array.<string>} values An array of property values 
-     * @param {boolean} isNewItem If this is true, then the value in index refers to the index at which a new item  
+     * @param {string=} context A constant string 
+     * @param {number=} offset The offset of the token for a given cursor position
+     * @param {string=} name Property name of the context 
+     * @param {number=} index The index of the property value for a given cursor position
+     * @param {Array.<string>=} values An array of property values 
+     * @param {boolean=} isNewItem If this is true, then the value in index refers to the index at which a new item  
      *     is going to be inserted and should not be used for accessing an existing value in values array. 
      * @return {{context: string,
      *           offset: number,
@@ -304,7 +304,13 @@ define(function (require, exports, module) {
         
         // Scan forward to collect all succeeding property values and append to all propValues.
         propValues = propValues.concat(_getSucceedingPropValues(forwardCtx, lastValue));
-               
+        
+        // If current index is more than the propValues size, then the cursor is 
+        // at the end of the existing property values and is ready for adding another one.
+        if (index === propValues.length) {
+            canAddNewOne = true;
+        }
+        
         return createInfo(PROP_VALUE, offset, propName, index, propValues, canAddNewOne);
     }
     

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -101,18 +101,26 @@ define(function (require, exports, module) {
      * @param {string} name Property name of the context 
      * @param {number} index The index of the property value for a given cursor position
      * @param {Array.<string>} values An array of property values 
+     * @param {boolean} isNewItem If this is true, then the value in index refers to the index at which a new item  
+     *     is going to be inserted and should not be used for accessing an existing value in values array. 
      * @return {{context: string,
      *           offset: number,
      *           name: string,
      *           index: number,
-     *           values: Array.<string>}} A CSS context info object.
+     *           values: Array.<string>,
+     *           isNewItem: boolean}} A CSS context info object.
      */
-    function createInfo(context, offset, name, index, values) {
+    function createInfo(context, offset, name, index, values, isNewItem) {
         var ruleInfo = { context: context || "",
                          offset: offset || 0,
                          name: name || "",
                          index: -1,
-                         values: [] };
+                         values: [],
+                         isNewItem: false };
+        
+        if (isNewItem !== undefined) {
+            ruleInfo.isNewItem = isNewItem;
+        }
         
         if (context === PROP_VALUE || context === SELECTOR) {
             ruleInfo.index = index;
@@ -239,7 +247,8 @@ define(function (require, exports, module) {
      *           offset: number,
      *           name: string,
      *           index: number,
-     *           values: Array.<string>}} A CSS context info object.
+     *           values: Array.<string>,
+     *           isNewItem: boolean}} A CSS context info object.
      */
     function _getRuleInfoStartingFromPropValue(ctx, editor) {
         var backwardCtx = $.extend({}, ctx),
@@ -278,14 +287,18 @@ define(function (require, exports, module) {
                 lastValue = ctx.token.string.trim();
                 if (lastValue.length === 0) {
                     canAddNewOne = true;
+                    if (index > 0) {
+                        // Append all spaces before the cursor to the previous value in values array
+                        propValues[index - 1] += ctx.token.string.substr(0, offset);
+                    }
                 }
             }
         }
         
         if (canAddNewOne) {
             offset = 0;
-            if (testToken.string.length > 0 && !testToken.string.match(/\S/)) {
-                propValues.push("");
+            if (testToken.string.length === 0 || testToken.string.match(/\S/)) {
+                canAddNewOne = false;
             }
         }
         
@@ -299,7 +312,7 @@ define(function (require, exports, module) {
             propValues.push("");
         }
                
-        return createInfo(PROP_VALUE, offset, propName, index, propValues);
+        return createInfo(PROP_VALUE, offset, propName, index, propValues, canAddNewOne);
     }
     
     /**
@@ -310,7 +323,8 @@ define(function (require, exports, module) {
      *           offset: number,
      *           name: string,
      *           index: number,
-     *           values: Array.<string>}} A CSS context info object.
+     *           values: Array.<string>,
+     *           isNewItem: boolean}} A CSS context info object.
      */
     function getInfoAtPos(editor, constPos) {
         // We're going to be changing pos a lot, but we don't want to mess up


### PR DESCRIPTION
If the new flag is true, then it indicates a new insertion at the location of "index". Otherwise, the value of "index" points to the existing item in the "values" array. 
