### PR TITLE
Add pyc files to a list of ignored extensions.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -558,7 +558,14 @@ define(function (require, exports, module) {
     
     /** @param {Entry} entry File or directory to filter */
     function shouldShow(entry) {
-        return [".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db"].indexOf(entry.name) === -1;
+        if ([".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db"].indexOf(entry.name) > -1) {
+            return false;
+        }
+        var extension = entry.name.split('.').slice(-1);
+        if (["pyc"].indexOf(extension) > -1) {
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Ideally, this would be exposed in some manner that people could edit (or some plugin could touch).

If you have any suggestions on how best to handle the management of ignored extensions / file names, I'm happy to put in the work.  I looked around the UI for preferences, but didn't see much other than live preview url.
