### PR TITLE
Prioritize platform-specific keybindings over generic bindings

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -55,11 +55,6 @@ define(function (require, exports, module) {
      * Allow clients to toggle key binding
      */
     var _enabled = true;
-    
-    /**
-     * Use windows-specific bindings if no other are found (e.g. linux)
-     */
-    var _useWindowsCompatibleBindings = false;
 
     /**
      * @private
@@ -382,7 +377,7 @@ define(function (require, exports, module) {
         }
         
         // for cross-platform compatibility
-        if (_useWindowsCompatibleBindings) {
+        if (exports.useWindowsCompatibleBindings) {
             if (explicitPlatform === "win") {
                 // windows-only key bindings are used as the default binding
                 // only if a default binding wasn't already defined
@@ -416,7 +411,7 @@ define(function (require, exports, module) {
         
         existingBindings.forEach(function (binding) {
             // remove out windows-only bindings in _commandMap
-            isWindowsCompatible = _useWindowsCompatibleBindings &&
+            isWindowsCompatible = exports.useWindowsCompatibleBindings &&
                 binding.explicitPlatform === "win";
             
             // remove existing generic binding
@@ -585,7 +580,7 @@ define(function (require, exports, module) {
             true
         );
         
-        _useWindowsCompatibleBindings = (brackets.platform !== "mac")
+        exports.useWindowsCompatibleBindings = (brackets.platform !== "mac")
             && (brackets.platform !== "win");
     }
     
@@ -603,4 +598,9 @@ define(function (require, exports, module) {
     exports.removeBinding = removeBinding;
     exports.formatKeyDescriptor = formatKeyDescriptor;
     exports.getKeyBindings = getKeyBindings;
+    
+    /**
+     * Use windows-specific bindings if no other are found (e.g. linux)
+     */
+    exports.useWindowsCompatibleBindings = false;
 });

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -410,7 +410,7 @@ define(function (require, exports, module) {
             isReplaceGeneric;
         
         existingBindings.forEach(function (binding) {
-            // remove out windows-only bindings in _commandMap
+            // remove windows-only bindings in _commandMap
             isWindowsCompatible = exports.useWindowsCompatibleBindings &&
                 binding.explicitPlatform === "win";
             

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -600,7 +600,12 @@ define(function (require, exports, module) {
     exports.getKeyBindings = getKeyBindings;
     
     /**
-     * Use windows-specific bindings if no other are found (e.g. linux)
+     * Use windows-specific bindings if no other are found (e.g. Linux). 
+     * Core Brackets modules that use key bindings should always define at
+     * least a generic keybinding that is applied for all platforms. This 
+     * setting effectively creates a compatibility mode for third party
+     * extensions that define explicit key bindings for Windows and Mac, but
+     * not Linux.
      */
     exports.useWindowsCompatibleBindings = false;
 });

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -205,6 +205,13 @@ define(function (require, exports, module) {
             });
             
             it("should use windows key bindings on linux", function () {
+                var original = KeyBindingManager.useWindowsCompatibleBindings;
+                
+                this.after(function () {
+                    KeyBindingManager.useWindowsCompatibleBindings = original;
+                });
+                
+                KeyBindingManager.useWindowsCompatibleBindings = true;
                 brackets.platform = "linux";
                 
                 // create a windows-specific binding
@@ -221,6 +228,35 @@ define(function (require, exports, module) {
                 
                 expected = keyMap([
                     keyBinding("Ctrl-B", "test.cmd", null)
+                ]);
+                
+                expect(KeyBindingManager.getKeymap()).toEqual(expected);
+            });
+            
+            it("should use replace generic key bindings with platform-specific", function () {
+                var original = KeyBindingManager.useWindowsCompatibleBindings;
+                
+                this.after(function () {
+                    KeyBindingManager.useWindowsCompatibleBindings = original;
+                });
+                
+                KeyBindingManager.useWindowsCompatibleBindings = true;
+                brackets.platform = "linux";
+                
+                // create a generic binding
+                KeyBindingManager.addBinding("test.cmd", "Ctrl-A");
+                
+                var expected = keyMap([
+                    keyBinding("Ctrl-A", "test.cmd")
+                ]);
+                
+                expect(KeyBindingManager.getKeymap()).toEqual(expected);
+                
+                // create a linux-only binding to replace the windows binding
+                KeyBindingManager.addBinding("test.cmd", "Ctrl-B", "linux");
+                
+                expected = keyMap([
+                    keyBinding("Ctrl-B", "test.cmd", null, "linux")
                 ]);
                 
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);


### PR DESCRIPTION
Fixes Joel's issue from this morning's standup
