### PR TITLE
Override .no-focus for children that are actually text input fields

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -309,7 +309,18 @@ define(function (require, exports, module) {
     // not steal focus. Calling preventDefault() on mousedown prevents
     // focus from going to the click target.
     $("html").on("mousedown", ".no-focus", function (e) {
-        e.preventDefault();
+        // Text fields should always be focusable.
+        var $target = $(e.target),
+            isTextField =
+                $target.is("input[type=text]") ||
+                $target.is("input[type=number]") ||
+                $target.is("input[type=password]") ||
+                $target.is("input:not([type])") || // input with no type attribute defaults to text
+                $target.is("textarea");
+
+        if (!isTextField) {
+            e.preventDefault();
+        }
     });
     
     // Localize MainViewHTML and inject into <BODY> tag


### PR DESCRIPTION
For #2377. To @gruehle for review.
