### PR TITLE
Fix rename issue 2348

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1280,7 +1280,7 @@ define(function (require, exports, module) {
                     }
                     
                     var oldName = selected.data("entry").fullPath;
-                    var newName = oldName.replace(data.rslt.old_name, data.rslt.new_name);
+                    var newName = oldName.replace(new RegExp(data.rslt.old_name + "$"), data.rslt.new_name);
                     
                     renameItem(oldName, newName, isFolder)
                         .done(function () {


### PR DESCRIPTION
When creating the full path for a rename, use an anchored regex to make sure the match is the last match of the path. If the file being renamed matched _any_ portion of the path, the rename would fail.

Fix for #2348 
