### PR TITLE
Properly clip rule list to status bar

### DIFF
--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -389,7 +389,10 @@ define(function (require, exports, module) {
             rcBottom = rcTop + rcHeight,
             scrollerOffset = $(hostScroller).offset(),
             scrollerTop = scrollerOffset.top,
-            scrollerBottom = scrollerTop + hostScroller.clientHeight,
+            // To calculate the actual visible height of the hostScroller, we have to take the margin into
+            // account. This is because CodeMirror sets a negative margin on the scroller as a hack to
+            // push the "real" scrollbar offscreen.
+            scrollerBottom = scrollerTop + $(hostScroller).outerHeight(true),
             scrollerLeft = scrollerOffset.left,
             rightOffset = $(window.document.body).outerWidth() - (scrollerLeft + hostScroller.clientWidth);
         if (rcTop < scrollerTop || rcBottom > scrollerBottom) {


### PR DESCRIPTION
For #2396. To @gruehle 

Our calculation of the client height of the scroller has to be different in v3 because of the negative margin trick CodeMirror is doing to hide the native scrollbars.
