### PR TITLE
Properly calculate offset of widget from top of virtual scroll area

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -950,6 +950,19 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Returns the offset of the top of the virtual scroll area relative to the browser window (not the editor
+     * itself). Mainly useful for calculations related to scrollIntoView(), where you're starting with the
+     * offset() of a child widget (relative to the browser window) and need to figure out how far down it is from
+     * the top of the virtual scroll area (excluding the top padding).
+     * @return {number}
+     */
+    Editor.prototype.getVirtualScrollAreaTop = function () {
+        var topPadding = this._getLineSpaceElement().offsetTop, // padding within mover
+            scroller = this.getScrollerElement();
+        return $(scroller).offset().top - scroller.scrollTop + topPadding;
+    };
+
+    /**
      * Sets the height of an inline widget in this editor. 
      * @param {!InlineWidget} inlineWidget The widget whose height should be set.
      * @param {!number} height The height of the widget.
@@ -961,13 +974,14 @@ define(function (require, exports, module) {
         
         $(node).height(height);
         if (ensureVisible) {
-            var offset = $(node).offset(),
-                lineSpaceOffset = $(this._getLineSpaceElement()).offset();
+            var offset = $(node).offset(), // offset relative to document
+                position = $(node).position(), // position within parent linespace
+                scrollerTop = this.getVirtualScrollAreaTop();
             this._codeMirror.scrollIntoView({
-                left: offset.left - lineSpaceOffset.left,
-                top: offset.top - lineSpaceOffset.top,
-                right: offset.left - lineSpaceOffset.left, // don't try to make the right edge visible
-                bottom: offset.top + height - lineSpaceOffset.top
+                left: position.left,
+                top: offset.top - scrollerTop,
+                right: position.left, // don't try to make the right edge visible
+                bottom: offset.top + height - scrollerTop
             });
         }
         

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -437,12 +437,12 @@ define(function (require, exports, module) {
             
             // Vertically, we want to set the scroll position relative to the overall host editor, not
             // the lineSpace of the widget itself.
-            var hostLineSpaceTop = $(this.hostEditor._getLineSpaceElement()).offset().top;
+            var scrollerTop = this.hostEditor.getVirtualScrollAreaTop();
             this.hostEditor._codeMirror.scrollIntoView({
                 left: cursorCoords.left - inlineLineSpaceOffset.left,
-                top: cursorCoords.top - hostLineSpaceTop,
+                top: cursorCoords.top - scrollerTop,
                 right: cursorCoords.left - inlineLineSpaceOffset.left,
-                bottom: cursorCoords.bottom - hostLineSpaceTop
+                bottom: cursorCoords.bottom - scrollerTop
             });
         }
     };


### PR DESCRIPTION
For #2399. To @gruehle 

I was wrong in thinking that the lineSpace actually extends to include the whole virtual scroll area--it's still just part of the mover. We have to calculate the top of the scroll area (excluding padding), as that's what `scrollIntoView()` appears to expect the top coordinate to be relative to.
