### PR TITLE
Consistent use of exceptions/errors/asserts/logs

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -179,7 +179,8 @@ define(function (require, exports, module) {
             return null;
         }
         if (!name || !id || !commandFn) {
-            throw new Error("Attempting to register a command with a missing name, id, or command function:" + name + " " + id);
+            console.error("Attempting to register a command with a missing name, id, or command function:" + name + " " + id);
+            return null;
         }
 
         var command = new Command(name, id, commandFn);

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -399,6 +399,7 @@ define(function (require, exports, module) {
             var commandObj = CommandManager.get(command);
             if (!commandObj) {
                 console.error("removeMenuItem(): command not found: " + command);
+                return;
             }
 
             menuItemID = this._getMenuItemId(command);
@@ -770,6 +771,7 @@ define(function (require, exports, module) {
 
         if (!mouseOrLocation || !mouseOrLocation.hasOwnProperty("pageX") || !mouseOrLocation.hasOwnProperty("pageY")) {
             console.error("ContextMenu open(): missing required parameter");
+            return;
         }
 
         var $window = $(window),
@@ -844,6 +846,7 @@ define(function (require, exports, module) {
     function registerContextMenu(id) {
         if (!id) {
             console.error("call to registerContextMenu() is missing required parameters");
+            return null;
         }
         
         // Guard against duplicate menu ids

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -391,13 +391,14 @@ define(function (require, exports, module) {
         var menuItemID;
 
         if (!command) {
-            throw new Error("removeMenuItem(): missing required parameters: command");
+            console.error("removeMenuItem(): missing required parameters: command");
+            return;
         }
 
         if (typeof (command) === "string") {
             var commandObj = CommandManager.get(command);
             if (!commandObj) {
-                throw new Error("removeMenuItem(): command not found: " + command);
+                console.error("removeMenuItem(): command not found: " + command);
             }
 
             menuItemID = this._getMenuItemId(command);
@@ -446,7 +447,8 @@ define(function (require, exports, module) {
             commandID;
 
         if (!command) {
-            throw new Error("addMenuItem(): missing required parameters: command");
+            console.error("addMenuItem(): missing required parameters: command");
+            return null;
         }
 
         if (typeof (command) === "string") {
@@ -457,7 +459,8 @@ define(function (require, exports, module) {
                 commandID = command;
                 command = CommandManager.get(commandID);
                 if (!command) {
-                    throw new Error("addMenuItem(): commandID not found: " + commandID);
+                    console.error("addMenuItem(): commandID not found: " + commandID);
+                    return null;
                 }
                 name = command.getName();
             }
@@ -681,7 +684,8 @@ define(function (require, exports, module) {
             menu;
 
         if (!name || !id) {
-            throw new Error("call to addMenu() is missing required parameters");
+            console.error("call to addMenu() is missing required parameters");
+            return null;
         }
         
         // Guard against duplicate menu ids
@@ -765,7 +769,7 @@ define(function (require, exports, module) {
     ContextMenu.prototype.open = function (mouseOrLocation) {
 
         if (!mouseOrLocation || !mouseOrLocation.hasOwnProperty("pageX") || !mouseOrLocation.hasOwnProperty("pageY")) {
-            throw new Error("ContextMenu open(): missing required parameter");
+            console.error("ContextMenu open(): missing required parameter");
         }
 
         var $window = $(window),
@@ -839,7 +843,7 @@ define(function (require, exports, module) {
      */
     function registerContextMenu(id) {
         if (!id) {
-            throw new Error("call to registerContextMenu() is missing required parameters");
+            console.error("call to registerContextMenu() is missing required parameters");
         }
         
         // Guard against duplicate menu ids

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -325,7 +325,7 @@ define(function (require, exports, module) {
         if (relativeID) {
             if (position === FIRST_IN_SECTION || position === LAST_IN_SECTION) {
                 if (!relativeID.hasOwnProperty("sectionMarker")) {
-                    console.log("Bad Parameter in _getRelativeMenuItem(): relativeID must be a MenuSection when position refers to a menu section");
+                    console.error("Bad Parameter in _getRelativeMenuItem(): relativeID must be a MenuSection when position refers to a menu section");
                     return null;
                 }
 
@@ -334,8 +334,8 @@ define(function (require, exports, module) {
                 // TODO: simplify using nextUntil()/prevUntil()
                 var $sectionMarker = this._getMenuItemForCommand(CommandManager.get(relativeID.sectionMarker));
                 if (!$sectionMarker) {
-                    console.log("_getRelativeMenuItem(): MenuSection " + relativeID.sectionMarker +
-                                " not found in Menu " + this.id);
+                    console.error("_getRelativeMenuItem(): MenuSection " + relativeID.sectionMarker +
+                                  " not found in Menu " + this.id);
                     return null;
                 }
                 var $listElem = $sectionMarker;
@@ -353,7 +353,7 @@ define(function (require, exports, module) {
                 
             } else {
                 if (relativeID.hasOwnProperty("sectionMarker")) {
-                    console.log("Bad Parameter in _getRelativeMenuItem(): if relativeID is a MenuSection, position must be FIRST_IN_SECTION or LAST_IN_SECTION");
+                    console.error("Bad Parameter in _getRelativeMenuItem(): if relativeID is a MenuSection, position must be FIRST_IN_SECTION or LAST_IN_SECTION");
                     return null;
                 }
                 
@@ -365,8 +365,8 @@ define(function (require, exports, module) {
                     $relativeElement = this._getMenuItemForCommand(command);
                 }
                 if (!$relativeElement) {
-                    console.log("_getRelativeMenuItem(): MenuItem with Command id " + relativeID +
-                                " not found in Menu " + this.id);
+                    console.error("_getRelativeMenuItem(): MenuItem with Command id " + relativeID +
+                                  " not found in Menu " + this.id);
                     return null;
                 }
             }
@@ -374,7 +374,7 @@ define(function (require, exports, module) {
             return $relativeElement;
             
         } else if (position && position !== FIRST && position !== LAST) {
-            console.log("Bad Parameter in _getRelativeMenuItem(): relative position specified with no relativeID");
+            console.error("Bad Parameter in _getRelativeMenuItem(): relative position specified with no relativeID");
             return null;
         }
         

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -398,7 +398,8 @@ define(function (require, exports, module) {
      */
     function getNextPrevFile(inc) {
         if (inc !== -1 && inc !== +1) {
-            throw new Error("Illegal argument: inc = " + inc);
+            console.error("Illegal argument: inc = " + inc);
+            return null;
         }
         
         if (_currentDocument) {
@@ -659,7 +660,8 @@ define(function (require, exports, module) {
         if (this._refCount === 0) {
             //console.log("+++ adding to open list");
             if (_openDocuments[this.file.fullPath]) {
-                throw new Error("Document for this path already in _openDocuments!");
+                console.error("Document for this path already in _openDocuments!");
+                return;
             }
 
             _openDocuments[this.file.fullPath] = this;
@@ -673,12 +675,14 @@ define(function (require, exports, module) {
 
         this._refCount--;
         if (this._refCount < 0) {
-            throw new Error("Document ref count has fallen below zero!");
+            console.error("Document ref count has fallen below zero!");
+            return;
         }
         if (this._refCount === 0) {
             //console.log("--- removing from open list");
             if (!_openDocuments[this.file.fullPath]) {
-                throw new Error("Document with references was not in _openDocuments!");
+                console.error("Document with references was not in _openDocuments!");
+                return;
             }
 
             $(exports).triggerHandler("beforeDocumentDelete", this);
@@ -694,7 +698,7 @@ define(function (require, exports, module) {
      */
     Document.prototype._makeEditable = function (masterEditor) {
         if (this._masterEditor) {
-            throw new Error("Document is already editable");
+            console.error("Document is already editable");
         } else {
             this._text = null;
             this._masterEditor = masterEditor;
@@ -709,7 +713,7 @@ define(function (require, exports, module) {
      */
     Document.prototype._makeNonEditable = function () {
         if (!this._masterEditor) {
-            throw new Error("Document is already non-editable");
+            console.error("Document is already non-editable");
         } else {
             // _text represents the raw text, so fetch without normalized line endings
             this._text = this.getText(true);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -489,7 +489,7 @@ define(function (require, exports, module) {
                 newText = change.text.join('\n');
                 if (!change.from || !change.to) {
                     if (change.from || change.to) {
-                        console.assert(false, "Change record received with only one end undefined--replacing entire text");
+                        console.error("Change record received with only one end undefined--replacing entire text");
                     }
                     cm.setValue(newText);
                 } else {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -519,7 +519,7 @@ define(function (require, exports, module) {
      */
     function setEditorHolder(holder) {
         if (_currentEditor) {
-            throw new Error("Cannot change editor area after an editor has already been created!");
+            console.error("Cannot change editor area after an editor has already been created!");
         }
         
         _editorHolder = holder;

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -520,6 +520,7 @@ define(function (require, exports, module) {
     function setEditorHolder(holder) {
         if (_currentEditor) {
             console.error("Cannot change editor area after an editor has already been created!");
+            return;
         }
         
         _editorHolder = holder;

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -487,7 +487,7 @@ define(function (require, exports, module) {
             // http://www.w3.org/TR/2011/WD-file-writer-api-20110419/#widl-FileWriter-write
             
             if (data === null || data === undefined) {
-                throw new Error();
+                console.error("FileWriter.write() called with null or undefined data.");
             }
 
             if (this.readyState === NativeFileSystem.FileSaver.WRITING) {

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -54,10 +54,12 @@ define(function (require, exports, module) {
             if (!error && (temp[key] !== undefined)) {
                 return true;
             } else {
-                throw new Error("Value '" + value + "' for key '" + key + "' must be a valid JSON value");
+                console.error("Value '" + value + "' for key '" + key + "' must be a valid JSON value");
+                return false;
             }
         } else {
-            throw new Error("Preference key '" + key + "' must be a string");
+            console.error("Preference key '" + key + "' must be a string");
+            return false;
         }
     }
     
@@ -130,7 +132,7 @@ define(function (require, exports, module) {
     
     /**
      * Writes name-value pairs from a JSON object as preference properties.
-     * Invalid JSON values throw an error and all changes are discarded.
+     * Invalid JSON values report an error and all changes are discarded.
      *
      * @param {!object} obj A JSON object with zero or more preference properties to write.
      * @param {boolean} append Defaults to false. When true, properties in the JSON object
@@ -154,7 +156,8 @@ define(function (require, exports, module) {
         
         // skip changes if any error is detected
         if (error) {
-            throw error;
+            console.error(error);
+            return;
         }
         
         // delete all exiting properties if not appending

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -51,7 +51,8 @@ define(function (require, exports, module) {
      */
     function getPreferenceStorage(clientID, defaults) {
         if ((clientID === undefined) || (clientID === null)) {
-            throw new Error("Invalid clientID");
+            console.error("Invalid clientID");
+            return;
         }
 
         var prefs = prefStorage[clientID];

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -100,10 +100,12 @@ define(function (require, exports, module) {
     */
     function _addIndex(indexName, filterFunction) {
         if (_indexList.hasOwnProperty(indexName)) {
-            throw new Error("Duplicate index name");
+            console.error("Duplicate index name");
+            return;
         }
         if (typeof filterFunction !== "function") {
-            throw new Error("Invalid arguments");
+            console.error("Invalid arguments");
+            return;
         }
 
         _indexList[indexName] = new FileIndex(indexName, filterFunction);
@@ -158,7 +160,8 @@ define(function (require, exports, module) {
     */
     function _scanDirectorySubTree(dirEntry) {
         if (!dirEntry) {
-            throw new Error("Bad dirEntry passed to _scanDirectorySubTree");
+            console.error("Bad dirEntry passed to _scanDirectorySubTree");
+            return;
         }
 
         // keep track of directories as they are asynchronously read. We know we are done
@@ -287,7 +290,8 @@ define(function (require, exports, module) {
 
         // TODO (issue 330) - allow multiple calls to syncFileIndex to be batched up so that this code isn't necessary
         if (_syncFileIndexReentracyGuard) {
-            throw new Error("syncFileIndex cannot be called Recursively");
+            console.error("syncFileIndex cannot be called Recursively");
+            return;
         }
 
         _syncFileIndexReentracyGuard = true;
@@ -322,7 +326,8 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
 
         if (!_indexList.hasOwnProperty(indexName)) {
-            throw new Error("indexName not found");
+            console.error("indexName not found");
+            return;
         }
 
         syncFileIndex()
@@ -344,7 +349,8 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
 
         if (!_indexList.hasOwnProperty(indexName)) {
-            throw new Error("indexName not found");
+            console.error("indexName not found");
+            return;
         }
 
         syncFileIndex()

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -123,7 +123,8 @@ define(function (require, exports, module) {
      */
     function setFileViewFocus(fileSelectionFocus) {
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
-            throw new Error("Bad parameter passed to FileViewController.setFileViewFocus");
+            console.error("Bad parameter passed to FileViewController.setFileViewFocus");
+            return;
         }
 
         _fileSelectionFocus = fileSelectionFocus;
@@ -141,7 +142,8 @@ define(function (require, exports, module) {
         var result;
 
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {
-            throw new Error("Bad parameter passed to FileViewController.openAndSelectDocument");
+            console.error("Bad parameter passed to FileViewController.openAndSelectDocument");
+            return;
         }
 
         // Opening files are asynchronous and we want to know when this function caused a file

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -92,11 +92,11 @@ define(function (require, exports, module) {
             });
         contexts[name] = extensionRequire;
 
-        console.log("[Extension] starting to load " + config.baseUrl);
+        // console.log("[Extension] starting to load " + config.baseUrl);
         
         extensionRequire([entryPoint],
             function () {
-                console.log("[Extension] finished loading " + config.baseUrl);
+                // console.log("[Extension] finished loading " + config.baseUrl);
                 result.resolve();
             },
             function errback(err) {
@@ -134,9 +134,9 @@ define(function (require, exports, module) {
                     paths: $.extend({}, config.paths, globalConfig)
                 });
     
-                console.log("[Extension] loading unit test " + config.baseUrl);
+                // console.log("[Extension] loading unit test " + config.baseUrl);
                 extensionRequire([entryPoint], function () {
-                    console.log("[Extension] loaded unit tests " + config.baseUrl);
+                    // console.log("[Extension] loaded unit tests " + config.baseUrl);
                     result.resolve();
                 });
             } else {

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -223,7 +223,8 @@ define(function (require, exports, module) {
             .clone()
             .removeClass("template");
         if ($template.length === 0) {
-            throw new Error("Dialog id " + dlgClass + " does not exist");
+            console.error("Dialog id " + dlgClass + " does not exist");
+            return;
         }
         return showModalDialogUsingTemplate($template, title, message);
     }

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -60,9 +60,9 @@ define(function (require, exports, module) {
             expect(CommandManager.register("test command", commandID, testCommandFn)).toBeFalsy();
 
             // missing arguments
-            expect(function () { CommandManager.register(null, "test-command-id2", testCommandFn); }).toThrow();
-            expect(function () { CommandManager.register("test command", null, testCommandFn); }).toThrow();
-            expect(function () { CommandManager.register("test command", "test-command-id2", null); }).toThrow();
+            expect(CommandManager.register(null, "test-command-id2", testCommandFn)).toBe(null);
+            expect(CommandManager.register("test command", null, testCommandFn)).toBe(null);
+            expect(CommandManager.register("test command", "test-command-id2", null)).toBe(null);
 
         });
 

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -370,14 +370,8 @@ define(function (require, exports, module) {
 
 
                     // unregistered command
-                    menuItem = null;
-                    var exceptionThrown = false;
-                    try {
-                        menuItem = menu.addMenuItem("UNREGISTERED_COMMAND");
-                    } catch (e) {
-                        exceptionThrown = true;
-                    }
-                    expect(exceptionThrown).toBeTruthy();
+                    menuItem = menu.addMenuItem("UNREGISTERED_COMMAND");
+                    expect(menuItem).toBe(null);
 
                     $listItems = testWindow.$(listSelector).children();
                     expect($listItems.length).toBe(1);
@@ -450,13 +444,8 @@ define(function (require, exports, module) {
                     var menuItemId = "menu-test-removeMenuItem2";
                     var menu = Menus.addMenu("Custom", menuItemId);
 
-                    var exceptionThrown = false;
-                    try {
-                        menu.removeMenuItem(commandId);
-                    } catch (e) {
-                        exceptionThrown = true;
-                    }
-                    expect(exceptionThrown).toBeTruthy();
+                    menu.removeMenuItem(commandId);
+                    expect(menu).toBeTruthy();   // Verify that we got this far...
                 });
             });
 
@@ -465,13 +454,8 @@ define(function (require, exports, module) {
                     var menuItemId = "menu-test-removeMenuItem3";
                     var menu = Menus.addMenu("Custom", menuItemId);
 
-                    var exceptionThrown = false;
-                    try {
-                        menu.removeMenuItem();
-                    } catch (e) {
-                        exceptionThrown = true;
-                    }
-                    expect(exceptionThrown).toBeTruthy();
+                    menu.removeMenuItem();
+                    expect(menu).toBeTruthy();   // Verify that we got this far...
                 });
             });
         });

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -85,28 +85,17 @@ define(function (require, exports, module) {
         });
         
         it("should throw errors for invalid values", function () {
-            var store = new PreferenceStorage(CLIENT_ID, {});
+            var store = new PreferenceStorage(CLIENT_ID, {"foo":42});
             var error = null;
             
-            try {
-                // function data is not valid JSON
-                store.setValue("foo", function () {});
-            } catch (err1) {
-                error = err1;
-            }
-            
-            expect(error).not.toBeNull();
-            expect(error.message).toBe("Value 'function () {}' for key 'foo' must be a valid JSON value");
-            
-            try {
-                // number key is not valid JSON
-                store.setValue(42, "bar");
-            } catch (err2) {
-                error = err2;
-            }
-            
-            expect(error).not.toBeNull();
-            expect(error.message).toBe("Preference key '42' must be a string");
+            expect(store.getValue("foo")).toBe(42);
+            // function data is not valid JSON
+            store.setValue("foo", function () {});
+            expect(store.getValue("foo")).toBe(42);
+                        
+            // number key is not valid JSON
+            store.setValue(42, "bar");
+            expect(store.getValue(42)).toBe(undefined);
         });
         
     });

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
         });
         
         it("should throw errors for invalid values", function () {
-            var store = new PreferenceStorage(CLIENT_ID, {"foo":42});
+            var store = new PreferenceStorage(CLIENT_ID, {"foo": 42});
             var error = null;
             
             expect(store.getValue("foo")).toBe(42);


### PR DESCRIPTION
Issue #568 

This pull request implements our [conventions for error handling](https://github.com/adobe/brackets/wiki/Brackets-Coding-Conventions#wiki-error_handling) in all core Brackets code.

There are 3 primary commits:
3add1c8 - Scrub all thrown exceptions. Most of these are converted to `console.error()` since they are non-fatal errors.
e7e2bff - Scrub `console.assert()` calls. One was changed to `console.error()`.
0fe5d69 - Scrub `console.log()` calls. Some were changed to `console.error()`; some were commented out.

All calls to `console.error()` were scrubbed and no changes were deemed necessary. Unit tests have been updated to check for expected functionality in failure cases. 
