### PR TITLE
Fix bug #2137 (Pressing Ctrl+E again does not close color picker)

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -1058,6 +1058,8 @@ define(function (require, exports, module) {
                     //e.pageY += 6;
                 }
                 
+                // Inline text editors have a different context menu (safe to assume it's not some other
+                // type of inline widget since we already know an Editor has focus)
                 if (inlineWidget) {
                     inline_editor_cmenu.open(e);
                 } else {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -184,11 +184,10 @@ define(function (require, exports, module) {
      * is). The widget's onClosed() callback will be run as a result.
      * @param {!Editor} hostEditor The editor containing the widget.
      * @param {!InlineWidget} inlineWidget The inline widget to close.
-     * @param {!boolean} moveFocus  If true, focuses hostEditor and ensures the cursor position lies
-     *      near the inline's location.
      */
-    function closeInlineWidget(hostEditor, inlineWidget, moveFocus) {
-        if (moveFocus) {
+    function closeInlineWidget(hostEditor, inlineWidget) {
+        // If widget has focus, return it to the hostEditor & move the cursor to where the inline used to be
+        if (inlineWidget.hasFocus()) {
             // Place cursor back on the line just above the inline (the line from which it was opened)
             // If cursor's already on that line, leave it be to preserve column position
             var widgetLine = hostEditor._codeMirror.getInlineWidgetInfo(inlineWidget.id).line;
@@ -529,20 +528,16 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Returns the currently focused inline widget.
-     * @returns {?{widget:!InlineTextEditor, editor:!Editor}}
+     * Returns the currently focused inline widget, if any.
+     * @return {?InlineWidget}
      */
     function getFocusedInlineWidget() {
         var result = null;
         
         if (_currentEditor) {
             _currentEditor.getInlineWidgets().forEach(function (widget) {
-                if (widget instanceof InlineTextEditor) {
-                    widget.editors.forEach(function (editor) {
-                        if (editor.hasFocus()) {
-                            result = { widget: widget, editor: editor };
-                        }
-                    });
+                if (widget.hasFocus()) {
+                    result = widget;
                 }
             });
         }
@@ -550,12 +545,15 @@ define(function (require, exports, module) {
         return result;
     }
 
+    /**
+     * Returns the focused Editor within an inline text editor, or null if something else has focus
+     * @return {?Editor}
+     */
     function _getFocusedInlineEditor() {
-        var focusedInline = getFocusedInlineWidget();
-        if (focusedInline) {
-            return focusedInline.editor;
+        var focusedWidget = getFocusedInlineWidget();
+        if (focusedWidget instanceof InlineTextEditor) {
+            return focusedWidget.getFocusedEditor();
         }
-
         return null;
     }
     
@@ -566,7 +564,7 @@ define(function (require, exports, module) {
      * getActiveEditor() will return the last visible editor that was given focus (but
      * may not currently have focus because, for example, a dialog with editable text
      * is open).
-     * @returns {Editor}
+     * @returns {?Editor}
      */
     function getFocusedEditor() {
         if (_currentEditor) {
@@ -591,7 +589,7 @@ define(function (require, exports, module) {
      * have focus at the moment, but it is visible and was the last editor that was given 
      * focus. Returns null if no editors are active.
      * @see getFocusedEditor()
-     * @returns {Editor}
+     * @returns {?Editor}
      */
     function getActiveEditor() {
         return _lastFocusedEditor;
@@ -607,12 +605,7 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
         
         if (_currentEditor) {
-            var inlineWidget = null,
-                focusedWidgetResult = getFocusedInlineWidget();
-            
-            if (focusedWidgetResult) {
-                inlineWidget = focusedWidgetResult.widget;
-            }
+            var inlineWidget = getFocusedInlineWidget();
             
             if (inlineWidget) {
                 // an inline widget's editor has focus, so close it

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         EditorManager       = require("editor/EditorManager"),
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
-        InlineWidget        = require("editor/InlineWidget").InlineWidget;
+        InlineWidget        = require("editor/InlineWidget").InlineWidget,
+        CollectionUtils     = require("utils/CollectionUtils");
 
     /**
      * Returns editor holder width (not CodeMirror's width).
@@ -187,6 +188,17 @@ define(function (require, exports, module) {
         
         this.editors[0].focus();
     };
+    
+    /**
+     * @return {?Editor} If an Editor within this inline editor has focus, returns it. Otherwise returns null.
+     */
+    InlineTextEditor.prototype.getFocusedEditor = function () {
+        var focusedI = CollectionUtils.indexOf(this.editors, function (editor) {
+            return editor.hasFocus();
+        });
+        return this.editors[focusedI];  // returns undefined if -1, which works
+    };
+
 
     /**
      *
@@ -280,12 +292,6 @@ define(function (require, exports, module) {
         // we don't actually resize the inline editor while its host is invisible (see
         // isFullyVisible() check in sizeInlineWidgetToContents()).
         this.sizeInlineWidgetToContents(true);
-    };
-    
-    InlineTextEditor.prototype._editorHasFocus = function () {
-        return this.editors.some(function (editor) {
-            return editor.hasFocus();
-        });
     };
         
     /**

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
     InlineWidget.prototype.hasFocus = function () {
         // True if anything in widget's DOM tree has focus (find() excludes root node, hence the extra check)
         return this.$htmlContent.find(":focus").length > 0 || this.$htmlContent.is(":focus");
-    }
+    };
     
     /**
      * Called any time inline is closed, whether manually or automatically

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -92,10 +92,15 @@ define(function (require, exports, module) {
      * Closes this inline widget and all its contained Editors
      */
     InlineWidget.prototype.close = function () {
-        var shouldMoveFocus = this._editorHasFocus();
-        EditorManager.closeInlineWidget(this.hostEditor, this, shouldMoveFocus);
+        EditorManager.closeInlineWidget(this.hostEditor, this);
         // closeInlineWidget() causes our onClosed() handler to be called
     };
+    
+    /** @return {boolean} True if any part of the inline widget is focused */
+    InlineWidget.prototype.hasFocus = function () {
+        // True if anything in widget's DOM tree has focus (find() excludes root node, hence the extra check)
+        return this.$htmlContent.find(":focus").length > 0 || this.$htmlContent.is(":focus");
+    }
     
     /**
      * Called any time inline is closed, whether manually or automatically

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -533,17 +533,12 @@ define(function (require, exports, module) {
      * @returns {MultiRangeInlineEditor}
      */
     function _getFocusedMultiRangeInlineEditor() {
-        var focusedMultiRangeInlineEditor = null,
-            result = EditorManager.getFocusedInlineWidget();
-        
-        if (result) {
-            var focusedWidget = result.widget;
-            if (focusedWidget && focusedWidget instanceof MultiRangeInlineEditor) {
-                focusedMultiRangeInlineEditor = focusedWidget;
-            }
+        var focusedWidget = EditorManager.getFocusedInlineWidget();
+        if (focusedWidget instanceof MultiRangeInlineEditor) {
+            return focusedWidget;
+        } else {
+            return null;
         }
-        
-        return focusedMultiRangeInlineEditor;
     }
 
     /**

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -176,11 +176,6 @@ define(function (require, exports, module) {
         this.colorEditor = new ColorEditor(this.$htmlContent, this._color, this._handleColorChange, swatchInfo);
     };
 
-    /** @override */
-    InlineColorEditor.prototype._editorHasFocus = function () {
-        return true;
-    };
-        
     /**
      * @override
      * Perform sizing & focus once we've been added to Editor's DOM

--- a/src/extensions/samples/InlineImageViewer/InlineImageViewer.js
+++ b/src/extensions/samples/InlineImageViewer/InlineImageViewer.js
@@ -65,10 +65,6 @@ define(function (require, exports, module) {
         this.$htmlContent.click(this.close.bind(this));
     };
 
-    InlineImageViewer.prototype.close = function () {
-        this.hostEditor.removeInlineWidget(this);
-    };
-    
     InlineImageViewer.prototype.onAdded = function () {
         InlineImageViewer.prototype.parentClass.onAdded.apply(this, arguments);
         window.setTimeout(this._sizeEditorToContent.bind(this));

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -298,17 +298,20 @@ define(function (require, exports, module) {
                     inlineWidget = hostEditor.getInlineWidgets()[0];
                     inlinePos = inlineWidget.editors[0].getCursorPos();
                     
-                    // verify cursor position in inline editor
+                    // verify cursor position & focus in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+                    expect(inlineWidget.hasFocus()).toEqual(true);
+                    expect(hostEditor.hasFocus()).toEqual(false);
                     
                     // close the editor
-                    EditorManager.closeInlineWidget(hostEditor, inlineWidget, true);
+                    EditorManager.closeInlineWidget(hostEditor, inlineWidget);
                     
                     // verify no inline widgets 
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                     
-                    // verify full editor cursor restored
+                    // verify full editor cursor & focus restored
                     expect(savedPos).toEqual(hostEditor.getCursorPos());
+                    expect(hostEditor.hasFocus()).toEqual(true);
                 });
             });
 


### PR DESCRIPTION
Fix bug #2137 (Pressing Ctrl+E again does not close color picker)

Simplify focus-related inline editor APIs:
- add InlineWidget.hasFocus() & InlineTextEditor.getFocusedEditor()
- remove moveFocus arg from EditorManager.closeInlineWidget() (since it can now just ask the widget via the above API)
- fix InlineWidget.close() to not assume _editorHasFocus() exists (& eliminate InlineTextEditor._editorHasFocus()) - no longer need to compute a value for moveFocus
- remove hacky fake _editorHasFocus() impl in InlineColorEditor
- remove hacky close() override in InlineImageViewer (as noted in #2285)
- make EditorManager.getFocusedInlineWidget() return any focused widget, not just InlineTextEditors; returns widget directly instead of a bag wrapper
