### PR TITLE
Disable Rename on Second Click

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -229,7 +229,8 @@ define(function (require, exports, module) {
             if (!moved) {
                 if (!fromClose) {
                     if (selected) {
-                        CommandManager.execute(Commands.FILE_RENAME);
+                        // Disabling for Sprint 18 due to issues described in #2394, #2411
+                        //CommandManager.execute(Commands.FILE_RENAME);
                     } else {
                         FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
                     }

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -228,12 +228,16 @@ define(function (require, exports, module) {
             // If file wasnt moved open or close it
             if (!moved) {
                 if (!fromClose) {
+                /***/
+                    FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
+                /***
+                    // Backing out for Sprint 18 due to issues described in #2394, #2411
                     if (selected) {
-                        // Disabling for Sprint 18 due to issues described in #2394, #2411
-                        //CommandManager.execute(Commands.FILE_RENAME);
+                        CommandManager.execute(Commands.FILE_RENAME);
                     } else {
                         FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
                     }
+                ***/
                 } else {
                     CommandManager.execute(Commands.FILE_CLOSE, {file: $listItem.data(_FILE_KEY)});
                 }


### PR DESCRIPTION
We decided to disable this new feature due to issues described in #2394 and #2411. I attempted to fix these issues in pull request #2412, but ran out of time.

@gabriellcardoso I want to give you a head's up that we're disabling this for Sprint 18 due to issues described above. You're welcome to try to fix them for Sprint 19. FYI, I think the trickiest problem to fix will be fixing the click handler to pause long enough to verify it's not a double-click. let me know if you have any questions.
