### PR TITLE
Fix bug #2418 (Renaming unusual filenames leaves UI in inconsistent state)

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1280,7 +1280,8 @@ define(function (require, exports, module) {
                     }
                     
                     var oldName = selected.data("entry").fullPath;
-                    var newName = oldName.replace(new RegExp(data.rslt.old_name + "$"), data.rslt.new_name);
+                    var oldNameRegex = new RegExp(StringUtils.regexEscape(data.rslt.old_name) + "$");
+                    var newName = oldName.replace(oldNameRegex, data.rslt.new_name);
                     
                     renameItem(oldName, newName, isFolder)
                         .done(function () {


### PR DESCRIPTION
Fix bug #2418 (Renaming certain unusual filenames throws exception, leaves UI in inconsistent state)

Escape filename before using as part of a regex.
