### PR TITLE
Remove console.log spam in KeyBindingManager. Allow platform specific bindings to override generic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Thumbs.db
+node_modules
 src/brackets.css
 src/brackets.min.css
 

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
             key = "",
             error = false;
 
-        function _compareModifierString(left, right, origDescriptor) {
+        function _compareModifierString(left, right) {
             if (!left || !right) {
                 return false;
             }
@@ -130,21 +130,20 @@ define(function (require, exports, module) {
             return (left.length > 0 && left === right);
         }
         
-        var ctrlAlreadyFound = false;
         origDescriptor.split("-").forEach(function parseDescriptor(ele, i, arr) {
-            if (_compareModifierString("ctrl", ele, origDescriptor)) {
+            if (_compareModifierString("ctrl", ele)) {
                 if (brackets.platform === "mac") {
                     hasMacCtrl = true;
                 } else {
                     hasCtrl = true;
                 }
-            } else if (_compareModifierString("cmd", ele, origDescriptor)) {
+            } else if (_compareModifierString("cmd", ele)) {
                 hasCtrl = true;
-            } else if (_compareModifierString("alt", ele, origDescriptor)) {
+            } else if (_compareModifierString("alt", ele)) {
                 hasAlt = true;
-            } else if (_compareModifierString("opt", ele, origDescriptor)) {
+            } else if (_compareModifierString("opt", ele)) {
                 hasAlt = true;
-            } else if (_compareModifierString("shift", ele, origDescriptor)) {
+            } else if (_compareModifierString("shift", ele)) {
                 hasShift = true;
             } else if (key.length > 0) {
                 console.log("KeyBindingManager normalizeKeyDescriptorString() - Multiple keys defined. Using key: " + key + " from: " + origDescriptor);

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -120,36 +120,31 @@ define(function (require, exports, module) {
             key = "",
             error = false;
 
-        function _compareModifierString(left, right, previouslyFound, origDescriptor) {
+        function _compareModifierString(left, right, origDescriptor) {
             if (!left || !right) {
                 return false;
             }
             left = left.trim().toLowerCase();
             right = right.trim().toLowerCase();
-            var matched = (left.length > 0 && left === right);
-            if (matched && previouslyFound) {
-                console.log("KeyBindingManager normalizeKeyDescriptorString() - Modifier " + left + " defined twice: " + origDescriptor);
-            }
-            return matched;
+            
+            return (left.length > 0 && left === right);
         }
         
         var ctrlAlreadyFound = false;
         origDescriptor.split("-").forEach(function parseDescriptor(ele, i, arr) {
-            ctrlAlreadyFound = (brackets.platform === "mac") ? hasMacCtrl : hasCtrl;
-            
-            if (_compareModifierString("ctrl", ele, ctrlAlreadyFound, origDescriptor)) {
+            if (_compareModifierString("ctrl", ele, origDescriptor)) {
                 if (brackets.platform === "mac") {
                     hasMacCtrl = true;
                 } else {
                     hasCtrl = true;
                 }
-            } else if (_compareModifierString("cmd", ele, hasCtrl, origDescriptor)) {
+            } else if (_compareModifierString("cmd", ele, origDescriptor)) {
                 hasCtrl = true;
-            } else if (_compareModifierString("alt", ele, hasAlt, origDescriptor)) {
+            } else if (_compareModifierString("alt", ele, origDescriptor)) {
                 hasAlt = true;
-            } else if (_compareModifierString("opt", ele, hasAlt, origDescriptor)) {
+            } else if (_compareModifierString("opt", ele, origDescriptor)) {
                 hasAlt = true;
-            } else if (_compareModifierString("shift", ele, hasShift, origDescriptor)) {
+            } else if (_compareModifierString("shift", ele, origDescriptor)) {
                 hasShift = true;
             } else if (key.length > 0) {
                 console.log("KeyBindingManager normalizeKeyDescriptorString() - Multiple keys defined. Using key: " + key + " from: " + origDescriptor);

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -133,8 +133,11 @@ define(function (require, exports, module) {
             return matched;
         }
         
+        var ctrlAlreadyFound = false;
         origDescriptor.split("-").forEach(function parseDescriptor(ele, i, arr) {
-            if (_compareModifierString("ctrl", ele, hasCtrl, origDescriptor)) {
+            ctrlAlreadyFound = (brackets.platform === "mac") ? hasMacCtrl : hasCtrl;
+            
+            if (_compareModifierString("ctrl", ele, ctrlAlreadyFound, origDescriptor)) {
                 if (brackets.platform === "mac") {
                     hasMacCtrl = true;
                 } else {
@@ -352,8 +355,10 @@ define(function (require, exports, module) {
             targetPlatform = explicitPlatform || brackets.platform,
             command,
             bindingsToDelete = [],
-            existing = _keyMap[key];
+            existing;
         
+        // if the request does not specify an explicit platform, and we're
+        // currently on a mac, then replace Ctrl with Cmd.
         key = (keyBinding.key) || keyBinding;
         if (brackets.platform === "mac" && explicitPlatform === undefined) {
             key = key.replace("Ctrl", "Cmd");
@@ -368,6 +373,9 @@ define(function (require, exports, module) {
             console.log("Failed to normalize " + key);
             return null;
         }
+        
+        // check for duplicate key bindings
+        existing = _keyMap[normalized];
         
         // for cross-platform compatibility
         if (exports.useWindowsCompatibleBindings) {
@@ -394,7 +402,7 @@ define(function (require, exports, module) {
         
         // skip if the key is already assigned explicitly for this platform
         if (existing) {
-            if (!existing.platform) {
+            if (!existing.explicitPlatform) {
                 // remove existing generic bindings, then re-map this binding
                 // to the new command
                 removeBinding(normalized);

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);
             });
             
-            it("should allow generic a key binding to be replaced", function () {
+            it("should allow a generic key binding to be replaced", function () {
                 KeyBindingManager.addBinding("test.foo", "Ctrl-A");
                 KeyBindingManager.addBinding("test.bar", "Ctrl-A");
                 

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -162,12 +162,34 @@ define(function (require, exports, module) {
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);
             });
             
-            it("should prevent a key binding from mapping to multiple commands", function () {
+            it("should allow generic a key binding to be replaced", function () {
                 KeyBindingManager.addBinding("test.foo", "Ctrl-A");
                 KeyBindingManager.addBinding("test.bar", "Ctrl-A");
                 
                 var expected = keyMap([
-                    keyBinding("Ctrl-A", "test.foo")
+                    keyBinding("Ctrl-A", "test.bar")
+                ]);
+                
+                expect(KeyBindingManager.getKeymap()).toEqual(expected);
+            });
+            
+            it("should allow a platform-specific key binding to override a generic binding", function () {
+                KeyBindingManager.addBinding("test.foo", "Ctrl-A");
+                KeyBindingManager.addBinding("test.bar", "Ctrl-A", "test");
+                
+                var expected = keyMap([
+                    keyBinding("Ctrl-A", "test.bar", null, "test")
+                ]);
+                
+                expect(KeyBindingManager.getKeymap()).toEqual(expected);
+            });
+            
+            it("should keep a platform-specific key binding if a generic binding is added later", function () {
+                KeyBindingManager.addBinding("test.foo", "Ctrl-A", "test");
+                KeyBindingManager.addBinding("test.bar", "Ctrl-A");
+                
+                var expected = keyMap([
+                    keyBinding("Ctrl-A", "test.foo", null, "test")
                 ]);
                 
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);
@@ -233,7 +255,7 @@ define(function (require, exports, module) {
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);
             });
             
-            it("should use replace generic key bindings with platform-specific", function () {
+            it("should support windows compatible bindings", function () {
                 var original = KeyBindingManager.useWindowsCompatibleBindings;
                 
                 this.after(function () {


### PR DESCRIPTION
#2415
- Removes console.log for duplicate modifier key check
- Allow existing generic bindings to be overridden by platform-specific bindings
- Bonus: add node_modules to .gitignore
- Update unit tests

Note: There can still be some console spam on mac depending on the order of loading the modules for these commands: edit.findNext, edit.selectLine and navigate.gotoLine. This is by design. 

Basically, if navigate.gotoLine is loaded last, the generic Ctrl-G tries to clobber the platform-specific Cmd-G for edit.findNext. I couldn't come up with an elegant way around this that doesn't violate our best practice for always defining generic key bindings.

```
    "edit.selectLine":  [
        {
            "key": "Ctrl-L"
        },
        {
            "key": "Ctrl-L",
            "platform": "mac"
        }
    ],
    "edit.findNext":  [
        {
            "key": "F3"
        },
        {
            "key": "Cmd-G",
            "platform": "mac"
        }
    ],
    "navigate.gotoLine":  [
        {
            "key": "Ctrl-G"
        },
        {
            "key": "Cmd-L",
            "platform": "mac"
        }
    ],
```
