### PR TITLE
Use a more reliable way to determine whether focus is in an inline widget

### DIFF
--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -98,8 +98,9 @@ define(function (require, exports, module) {
     
     /** @return {boolean} True if any part of the inline widget is focused */
     InlineWidget.prototype.hasFocus = function () {
-        // True if anything in widget's DOM tree has focus (find() excludes root node, hence the extra check)
-        return this.$htmlContent.find(":focus").length > 0 || this.$htmlContent.is(":focus");
+        var focusedItem = window.document.activeElement,
+            htmlContent = this.$htmlContent[0];
+        return $.contains(htmlContent, focusedItem) || htmlContent === focusedItem;
     };
     
     /**


### PR DESCRIPTION
Unit tests for inline widgets fail intermittently when run as part of the entire test suite. The problem appears to be that the way we're determining whether a widget currently has focus isn't entirely reliable for some reason. This pull request uses a different method that seems like it ought to be reasonably foolproof.
