### PR TITLE
Spurious requests for code hints

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -420,6 +420,8 @@ define(function (require, exports, module) {
             hintList.onClose(_endSession);
 
             _updateHintList();
+        } else {
+            lastChar = null;
         }
     }
     


### PR DESCRIPTION
The new CodeHintManager in some cases fails to reset the `lastChar` variable, which records the most recently typed character and is passed to a provider's `hasHints` and `getHints` methods, after failing to begin a new hinting session. Failing to reset `lastChar` causes the CodeHintManager to make spurious requests for implicit hinting sessions. This pull request ensures that `lastChar` is reset after failing to start a session. 

In more detail, assume the letter 'a' is typed in some editor context. `lastChar` is set to 'a' in `handleKeyEvent`, and later `handleChange` calls `_beginSession` because `lastChar` is now truthy. But if no provider wishes to provide hints when `lastChar` has value 'a' then the call chain ends without resetting `lastChar`. (`_updateHintList` is otherwise responsible for resetting `lastChar` after passing it to `sessionProvider.getHints`.) It is at this point that `lastChar` ought to be reset. If not, then assume next that the return key is typed. No keypress event is generated, so `lastChar` is not updated and continues to have value 'a'. The return key event causes an editor change and so `handleChange` is called, which again calls `_beginSession` because `lastChar` remains truthy from the last keypress. This request for an implicit hinting session is spurious. 
