### PR TITLE
Better output for setup_for_hacking.bat

### DIFF
--- a/tools/setup_for_hacking.bat
+++ b/tools/setup_for_hacking.bat
@@ -12,7 +12,7 @@ ver | findstr /i "5\.1\." > nul
 IF %ERRORLEVEL% EQU 0 GOTO XPNotSupported
 
 REM - Remove existing 'dev' directory (if present)
-rmdir %1\dev
+if exist %1\dev rmdir %1\dev
 
 REM - Make symlink
 REM   (doesn't work on XP - see instructions below)


### PR DESCRIPTION
@joelrbrandt 

Fix for #2468

Check if directory exists before trying to delete it, eliminating the confusing "The system cannot find the file specified." message.
