### PR TITLE
Add "keep alive" test for Live Preview

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -110,9 +110,11 @@ define(function RemoteAgent(require, exports, module) {
         _load = new $.Deferred();
         $(Inspector.Page).on("loadEventFired.RemoteAgent", _onLoadEventFired);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
-        _intervalId = window.setInterval(function () {
-            call("keepAlive");
-        }, 1000);
+        _load.done(function () {
+            _intervalId = window.setInterval(function () {
+                call("keepAlive");
+            }, 1000);
+        });
         return _load.promise();
     }
 
@@ -120,7 +122,9 @@ define(function RemoteAgent(require, exports, module) {
     function unload() {
         $(Inspector.Page).off(".RemoteAgent");
         $(Inspector.DOM).off(".RemoteAgent");
-        window.clearInterval(_intervalId);
+        if (_intervalId) {
+            window.clearInterval(_intervalId);
+        }
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, XMLHttpRequest */
+/*global define, $, XMLHttpRequest, window */
 
 /**
  * RemoteAgent defines and provides an interface for custom remote functions
@@ -42,6 +42,7 @@ define(function RemoteAgent(require, exports, module) {
 
     var _load; // deferred load
     var _objectId; // the object id of the remote object
+    var _intervalId; // interval used to send keepAlive events
 
     // WebInspector Event: Page.loadEventFired
     function _onLoadEventFired(event, res) {
@@ -109,6 +110,9 @@ define(function RemoteAgent(require, exports, module) {
         _load = new $.Deferred();
         $(Inspector.Page).on("loadEventFired.RemoteAgent", _onLoadEventFired);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
+        _intervalId = window.setInterval(function () {
+            call("keepAlive");
+        }, 1000);
         return _load.promise();
     }
 
@@ -116,6 +120,7 @@ define(function RemoteAgent(require, exports, module) {
     function unload() {
         $(Inspector.Page).off(".RemoteAgent");
         $(Inspector.DOM).off(".RemoteAgent");
+        window.clearInterval(_intervalId);
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -35,7 +35,8 @@ function RemoteFunctions(experimental) {
 
     var lastKeepAliveTime = Date.now();
     
-    var HIGHLIGHT_CLASSNAME = "__brackets-ld-highlight";
+    var HIGHLIGHT_CLASSNAME = "__brackets-ld-highlight",
+        KEEP_ALIVE_TIMEOUT  = 3000;   // Keep alive timeout value, in milliseconds
     
     // determine the color for a type
     function _typeColor(type, highlight) {
@@ -477,7 +478,7 @@ function RemoteFunctions(experimental) {
     window.addEventListener("scroll", _scrollHandler, true);
     
     var aliveTest = window.setInterval(function () {
-        if (Date.now() > lastKeepAliveTime + 3000) {
+        if (Date.now() > lastKeepAliveTime + KEEP_ALIVE_TIMEOUT) {
             // Remove highlights
             hideHighlight();
             

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -488,7 +488,7 @@ function RemoteFunctions(experimental) {
             // Clear this interval
             window.clearInterval(aliveTest);
         }
-    }, 2000);
+    }, 1000);
 
     return {
         "keepAlive": keepAlive,


### PR DESCRIPTION
Fix for #2267 

Add a "keep alive" test to Live Preview. 

Once a second, Brackets will call the `keepAlive()` function on the live preview page. Once a second the live preview page checks to see if `keepAlive()` was called within the past 3 seconds (the 3 second test is to account for delays like a large "find in files" operation). If `keepAlive()` hasn't been called in the past 3 seconds, clear any CSS highlights and remove any event listeners that were added. This effectively disables all code that was injected into the page.

This is a bit of a hack, but unfortunately it's necessary since there is no way the live preview page can be notified when the connection has severed. 
