### PR TITLE
fix #1974 and #2413: center the line of interest

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -687,10 +687,29 @@ define(function (require, exports, module) {
     /**
      * Sets the cursor position within the editor. Removes any selection.
      * @param {number} line The 0 based line number.
-     * @param {number=} ch  The 0 based character position; treated as 0 if unspecified.
+     * @param {number} ch  The 0 based character position; treated as 0 if unspecified.
+     * @param {boolean} center  true if the view should be centered on the new cursor position
      */
-    Editor.prototype.setCursorPos = function (line, ch) {
+    Editor.prototype.setCursorPos = function (line, ch, center) {
         this._codeMirror.setCursor(line, ch);
+        if (center) {
+            this.centerOnCursor();
+        }
+    };
+    
+    var PADDING_ADJUSTMENT = 60;
+    
+    /**
+     * Scrolls the editor viewport to vertically center the line with the cursor.
+     * This does not alter the horizontal scroll position.
+     */
+    Editor.prototype.centerOnCursor = function () {
+        var coords = this._codeMirror.cursorCoords(null, "local");
+        // TODO fix the magic number 50 below... I'm not sure where
+        // it comes from.
+        this.setScrollPos(null, coords.bottom -
+                          this.getScrollerElement().clientHeight / 2 +
+                          PADDING_ADJUSTMENT);
     };
 
     /**
@@ -746,12 +765,18 @@ define(function (require, exports, module) {
     
     /**
      * Sets the current selection. Start is inclusive, end is exclusive. Places the cursor at the
-     * end of the selection range.
+     * end of the selection range. Optionally centers the around the cursor after
+     * making the selection
+     *
      * @param {!{line:number, ch:number}} start
      * @param {!{line:number, ch:number}} end
+     * @param {boolean} center true to center the viewport
      */
-    Editor.prototype.setSelection = function (start, end) {
+    Editor.prototype.setSelection = function (start, end, center) {
         this._codeMirror.setSelection(start, end);
+        if (center) {
+            this.centerOnCursor();
+        }
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -698,17 +698,28 @@ define(function (require, exports, module) {
     };
     
     var PADDING_ADJUSTMENT = 60;
+    var CENTERING_MARGIN = 0.1;
     
     /**
-     * Scrolls the editor viewport to vertically center the line with the cursor.
+     * Scrolls the editor viewport to vertically center the line with the cursor,
+     * but only if the cursor is currently near the edges of the viewport or
+     * entirely outside the viewport.
+     *
      * This does not alter the horizontal scroll position.
      */
     Editor.prototype.centerOnCursor = function () {
-        var coords = this._codeMirror.cursorCoords(null, "local");
+        var localCoords = this._codeMirror.cursorCoords(null, "local");
+        var pageCoords = this._codeMirror.cursorCoords(null, "page");
+        var clientHeight = this.getScrollerElement().clientHeight;
         
-        this.setScrollPos(null, coords.bottom -
-                          this.getScrollerElement().clientHeight / 2 +
-                          PADDING_ADJUSTMENT);
+        // If the cursor is already reasonably centered, we won't
+        // make any change.
+        if (pageCoords.bottom < clientHeight * CENTERING_MARGIN + PADDING_ADJUSTMENT ||
+                pageCoords.bottom > clientHeight * (1 - CENTERING_MARGIN) + PADDING_ADJUSTMENT) {
+            this.setScrollPos(null, localCoords.bottom -
+                                clientHeight / 2 +
+                                PADDING_ADJUSTMENT);
+        }
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -697,8 +697,7 @@ define(function (require, exports, module) {
         }
     };
     
-    var PADDING_ADJUSTMENT = 60;
-    var CENTERING_MARGIN = 0.1;
+    var CENTERING_MARGIN = 0.15;
     
     /**
      * Scrolls the editor viewport to vertically center the line with the cursor,
@@ -708,20 +707,25 @@ define(function (require, exports, module) {
      * This does not alter the horizontal scroll position.
      */
     Editor.prototype.centerOnCursor = function () {
+        var $scrollerElement = $(this.getScrollerElement());
+        var editorHeight = $scrollerElement.height();
+        
+        // we need to make adjustments for the statusbar's padding on the bottom and the menu bar on top. 
+        var statusBarHeight = $scrollerElement.outerHeight() - editorHeight;
+        var menuBarHeight = $scrollerElement.offset().top;
+        
         var documentCursorPosition = this._codeMirror.cursorCoords(null, "local").bottom;
-        var screenCursorPosition = this._codeMirror.cursorCoords(null, "page").bottom;
-        var editorHeight = this.getScrollerElement().clientHeight;
+        var screenCursorPosition = this._codeMirror.cursorCoords(null, "page").bottom - menuBarHeight;
         
         // If the cursor is already reasonably centered, we won't
         // make any change. "Reasonably centered" is defined as
         // not being within CENTERING_MARGIN of the top or bottom
         // of the editor (where CENTERING_MARGIN is a percentage
         // of the editor height).
-        if (screenCursorPosition < editorHeight * CENTERING_MARGIN + PADDING_ADJUSTMENT ||
-                screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN) + PADDING_ADJUSTMENT) {
+        if (screenCursorPosition < editorHeight * CENTERING_MARGIN ||
+                screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)) {
             this.setScrollPos(null, documentCursorPosition -
-                                editorHeight / 2 +
-                                PADDING_ADJUSTMENT);
+                                editorHeight / 2 + statusBarHeight);
         }
     };
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -705,8 +705,7 @@ define(function (require, exports, module) {
      */
     Editor.prototype.centerOnCursor = function () {
         var coords = this._codeMirror.cursorCoords(null, "local");
-        // TODO fix the magic number 50 below... I'm not sure where
-        // it comes from.
+        
         this.setScrollPos(null, coords.bottom -
                           this.getScrollerElement().clientHeight / 2 +
                           PADDING_ADJUSTMENT);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -708,16 +708,19 @@ define(function (require, exports, module) {
      * This does not alter the horizontal scroll position.
      */
     Editor.prototype.centerOnCursor = function () {
-        var localCoords = this._codeMirror.cursorCoords(null, "local");
-        var pageCoords = this._codeMirror.cursorCoords(null, "page");
-        var clientHeight = this.getScrollerElement().clientHeight;
+        var documentCursorPosition = this._codeMirror.cursorCoords(null, "local").bottom;
+        var screenCursorPosition = this._codeMirror.cursorCoords(null, "page").bottom;
+        var editorHeight = this.getScrollerElement().clientHeight;
         
         // If the cursor is already reasonably centered, we won't
-        // make any change.
-        if (pageCoords.bottom < clientHeight * CENTERING_MARGIN + PADDING_ADJUSTMENT ||
-                pageCoords.bottom > clientHeight * (1 - CENTERING_MARGIN) + PADDING_ADJUSTMENT) {
-            this.setScrollPos(null, localCoords.bottom -
-                                clientHeight / 2 +
+        // make any change. "Reasonably centered" is defined as
+        // not being within CENTERING_MARGIN of the top or bottom
+        // of the editor (where CENTERING_MARGIN is a percentage
+        // of the editor height).
+        if (screenCursorPosition < editorHeight * CENTERING_MARGIN + PADDING_ADJUSTMENT ||
+                screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN) + PADDING_ADJUSTMENT) {
+            this.setScrollPos(null, documentCursorPosition -
+                                editorHeight / 2 +
                                 PADDING_ADJUSTMENT);
         }
     };

--- a/src/extensions/default/QuickOpenCSS/main.js
+++ b/src/extensions/default/QuickOpenCSS/main.js
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
 
         var from = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorStartChar};
         var to = {line: selectorInfo.selectorStartLine, ch: selectorInfo.selectorEndChar};
-        EditorManager.getCurrentFullEditor().setSelection(from, to);
+        EditorManager.getCurrentFullEditor().setSelection(from, to, true);
     }
 
     function itemSelect(selectedItem) {

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -143,7 +143,7 @@ define(function (require, exports, module) {
         
         var from = {line: fileLocation.line, ch: fileLocation.chFrom};
         var to = {line: fileLocation.line, ch: fileLocation.chTo};
-        EditorManager.getCurrentFullEditor().setSelection(from, to);
+        EditorManager.getCurrentFullEditor().setSelection(from, to, true);
     }
 
     function itemSelect(selectedItem) {

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
 
         var from = {line: fileLocation.line, ch: fileLocation.chFrom};
         var to = {line: fileLocation.line, ch: fileLocation.chTo};
-        EditorManager.getCurrentFullEditor().setSelection(from, to);
+        EditorManager.getCurrentFullEditor().setSelection(from, to, true);
     }
 
     function itemSelect(selectedItem) {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -75,7 +75,8 @@ define(function (require, exports, module) {
         }
     }
 
-    function findNext(cm, rev) {
+    function findNext(editor, rev) {
+        var cm = editor._codeMirror;
         var found = true;
         cm.operation(function () {
             var state = getSearchState(cm);
@@ -91,7 +92,7 @@ define(function (require, exports, module) {
                     return;
                 }
             }
-            cm.setSelection(cursor.from(), cursor.to());
+            editor.setSelection(cursor.from(), cursor.to(), true);
             state.posFrom = cursor.from();
             state.posTo = cursor.to();
             state.findNextCalled = true;
@@ -128,8 +129,7 @@ define(function (require, exports, module) {
         var cm = editor._codeMirror;
         var state = getSearchState(cm);
         if (state.query) {
-            findNext(cm, rev);
-            editor.centerOnCursor();
+            findNext(editor, rev);
             return;
         }
         
@@ -162,10 +162,7 @@ define(function (require, exports, module) {
                 }
                 
                 state.posFrom = state.posTo = searchStartPos;
-                var foundAny = findNext(cm, rev);
-                if (foundAny) {
-                    editor.centerOnCursor();
-                }
+                var foundAny = findNext(editor, rev);
                 
                 getDialogTextField(modalBar).toggleClass("no-results", !foundAny);
             });
@@ -197,7 +194,6 @@ define(function (require, exports, module) {
             // Clear the "findNextCalled" flag here so we have a clean start
             state.findNextCalled = false;
         }
-        editor.centerOnCursor();
     }
 
     var replaceQueryDialog = Strings.CMD_REPLACE +
@@ -254,8 +250,7 @@ define(function (require, exports, module) {
                                 return;
                             }
                         }
-                        cm.setSelection(cursor.from(), cursor.to());
-                        editor.centerOnCursor();
+                        editor.setSelection(cursor.from(), cursor.to(), true);
                         modalBar = new ModalBar(doReplaceConfirm, true);
                         modalBar.getRoot().on("click", function (e) {
                             modalBar.close();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -180,7 +180,6 @@ define(function (require, exports, module) {
                 // *after* the current selection so we find the next occurrence.
                 searchStartPos = cm.getCursor(false);
                 findFirst(query, modalBar);
-                editor.centerOnCursor();
             }
         });
         

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -124,10 +124,13 @@ define(function (require, exports, module) {
      * If no search pending, opens the search dialog. If search is already open, moves to
      * next/prev result (depending on 'rev')
      */
-    function doSearch(cm, rev, initialQuery) {
+    function doSearch(editor, rev, initialQuery) {
+        var cm = editor._codeMirror;
         var state = getSearchState(cm);
         if (state.query) {
-            return findNext(cm, rev);
+            findNext(cm, rev);
+            editor.centerOnCursor();
+            return;
         }
         
         // Use the selection start as the searchStartPos. This way if you
@@ -160,6 +163,9 @@ define(function (require, exports, module) {
                 
                 state.posFrom = state.posTo = searchStartPos;
                 var foundAny = findNext(cm, rev);
+                if (foundAny) {
+                    editor.centerOnCursor();
+                }
                 
                 getDialogTextField(modalBar).toggleClass("no-results", !foundAny);
             });
@@ -174,6 +180,7 @@ define(function (require, exports, module) {
                 // *after* the current selection so we find the next occurrence.
                 searchStartPos = cm.getCursor(false);
                 findFirst(query, modalBar);
+                editor.centerOnCursor();
             }
         });
         
@@ -191,6 +198,7 @@ define(function (require, exports, module) {
             // Clear the "findNextCalled" flag here so we have a clean start
             state.findNextCalled = false;
         }
+        editor.centerOnCursor();
     }
 
     var replaceQueryDialog = Strings.CMD_REPLACE +
@@ -205,7 +213,8 @@ define(function (require, exports, module) {
             '</button> <button id="replace-no"' + style + '>' + Strings.BUTTON_NO +
             '</button> <button' + style + '>' + Strings.BUTTON_STOP + '</button>';
 
-    function replace(cm, all) {
+    function replace(editor, all) {
+        var cm = editor._codeMirror;
         var modalBar = new ModalBar(replaceQueryDialog, true);
         $(modalBar).on("closeOk", function (e, query) {
             if (!query) {
@@ -247,6 +256,7 @@ define(function (require, exports, module) {
                             }
                         }
                         cm.setSelection(cursor.from(), cursor.to());
+                        editor.centerOnCursor();
                         modalBar = new ModalBar(doReplaceConfirm, true);
                         modalBar.getRoot().on("click", function (e) {
                             modalBar.close();
@@ -272,7 +282,7 @@ define(function (require, exports, module) {
             .attr("value", cm.getSelection())
             .get(0).select();
     }
-
+    
     function _launchFind() {
         var editor = EditorManager.getActiveEditor();
         if (editor) {
@@ -280,28 +290,28 @@ define(function (require, exports, module) {
 
             // Bring up CodeMirror's existing search bar UI
             clearSearch(codeMirror);
-            doSearch(codeMirror, false, codeMirror.getSelection());
+            doSearch(editor, false, codeMirror.getSelection());
         }
     }
 
     function _findNext() {
         var editor = EditorManager.getActiveEditor();
         if (editor) {
-            doSearch(editor._codeMirror);
+            doSearch(editor);
         }
     }
 
     function _findPrevious() {
         var editor = EditorManager.getActiveEditor();
         if (editor) {
-            doSearch(editor._codeMirror, true);
+            doSearch(editor, true);
         }
     }
 
     function _replace() {
         var editor = EditorManager.getActiveEditor();
         if (editor) {
-            replace(editor._codeMirror);
+            replace(editor);
         }
     }
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -252,12 +252,8 @@ define(function (require, exports, module) {
         } else {
 
             // extract line number, if any
-            var cursor,
-                query = this.$searchField.val(),
+            var query = this.$searchField.val(),
                 gotoLine = extractLineNumber(query);
-            if (!isNaN(gotoLine)) {
-                cursor = {line: gotoLine, ch: 0};
-            }
 
             // Navigate to file and line number
             var fullPath = selectedItem && selectedItem.fullPath;
@@ -265,11 +261,12 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath})
                     .done(function () {
                         if (!isNaN(gotoLine)) {
-                            EditorManager.getCurrentFullEditor().setCursorPos(cursor);
+                            var editor = EditorManager.getCurrentFullEditor();
+                            editor.setCursorPos(gotoLine, 0, true);
                         }
                     });
             } else if (!isNaN(gotoLine)) {
-                EditorManager.getCurrentFullEditor().setCursorPos(cursor);
+                EditorManager.getCurrentFullEditor().setCursorPos(gotoLine, 0, true);
             }
         }
 
@@ -314,7 +311,7 @@ define(function (require, exports, module) {
             var from = {line: gotoLine, ch: 0};
             var to = {line: gotoLine, ch: 99999};
             
-            EditorManager.getCurrentFullEditor().setSelection(from, to);
+            EditorManager.getCurrentFullEditor().setSelection(from, to, true);
         }
 
         // Remove current plugin if the query stops matching


### PR DESCRIPTION
(targeting the correct branch)

fixes for #1974 and #2413 

this change adds editor.centerOnCursor and a center option to
editor.setCursorPos and editor.setSelection and then uses that
API to center find/replace results, go to line results and
go to definition results for JS, CSS and HTML.
