### PR TITLE
Use css height:auto to layout inline editors, cmv3 wrapper element for inline editor height.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -825,12 +825,10 @@ define(function (require, exports, module) {
 
     /**
      * Gets the total height of the document in pixels (not the viewport)
-     * @param {!boolean} includePadding
      * @returns {!number} height in pixels
      */
-    Editor.prototype.totalHeight = function (includePadding) {
-        var $sizer = $(this.getScrollerElement().firstChild);
-        return (includePadding) ? $sizer.outerHeight() : $sizer.height();
+    Editor.prototype.totalHeight = function () {
+        return this.getScrollerElement().scrollHeight;
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -885,8 +885,11 @@ define(function (require, exports, module) {
      * @param {boolean=} scrollLineIntoView Scrolls the associated line into view. Default true.
      */
     Editor.prototype.addInlineWidget = function (pos, inlineWidget, scrollLineIntoView) {
-        var self = this,
-            scrollLineIntoView = (scrollLineIntoView === false) ? false : true;
+        var self = this;
+        
+        if (scrollLineIntoView === undefined) {
+            scrollLineIntoView = true;
+        }
 
         if (scrollLineIntoView) {
             // FIXME (issue #2491): widget height is not set initially if widget is outside viewport
@@ -935,6 +938,7 @@ define(function (require, exports, module) {
         
         this._codeMirror.removeLineWidget(inlineWidget.info);
         this._removeInlineWidgetInternal(inlineWidget);
+        inlineWidget.onClosed();
         
         // once this widget is removed, notify all following inline widgets of a position change
         this._fireWidgetOffsetTopChanged(lineNum);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -829,8 +829,8 @@ define(function (require, exports, module) {
      * @returns {!number} height in pixels
      */
     Editor.prototype.totalHeight = function (includePadding) {
-        var $root = $(this.getRootElement());
-        return (includePadding) ? $root.outerHeight() : $root.height();
+        var $sizer = $(this.getScrollerElement().firstChild);
+        return (includePadding) ? $sizer.outerHeight() : $sizer.height();
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -830,8 +830,10 @@ define(function (require, exports, module) {
      */
     Editor.prototype.totalHeight = function (includePadding) {
         // TODO: need to port totalHeight()
-        // return this._codeMirror.totalHeight(includePadding);        
-        return 400;
+        //console.log(this._codeMirror.totalHeight(includePadding));
+        
+        var $root = $(this.getRootElement());
+        return (includePadding) ? $root.outerHeight() : $root.height();
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -829,9 +829,6 @@ define(function (require, exports, module) {
      * @returns {!number} height in pixels
      */
     Editor.prototype.totalHeight = function (includePadding) {
-        // TODO: need to port totalHeight()
-        //console.log(this._codeMirror.totalHeight(includePadding));
-        
         var $root = $(this.getRootElement());
         return (includePadding) ? $root.outerHeight() : $root.height();
     };

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -158,7 +158,6 @@ define(function (require, exports, module) {
             if (editor.isFullyVisible()) {
                 var height = editor.totalHeight(true);
                 if (force || height !== this.height) {
-                    $(editor.getRootElement()).height(height);
                     this.height = height;
                     editor.refresh();
                 }

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -130,12 +130,14 @@ define(function (require, exports, module) {
         _syncGutterWidths(this.hostEditor);
         
         this.editors.forEach(function (editor) {
+            $(editor).off(".InlineTextEditor");
             editor.destroy(); //release ref on Document
         });
     };
     
     /**
-     * Update the inline editor's height when the number of lines change.
+     * Update the inline editor's height when the number of lines change. The
+     * base implementation of this method does nothing.
      * @param {boolean} force the editor to resize
      */
     InlineTextEditor.prototype.sizeInlineWidgetToContents = function (force) {
@@ -235,7 +237,6 @@ define(function (require, exports, module) {
         // If Document's file is deleted, or Editor loses sync with Document, delegate to this._onLostContent()
         $(inlineInfo.editor).on("lostContent.InlineTextEditor", function () {
             self._onLostContent.apply(self, arguments);
-            $(inlineInfo).off(".InlineTextEditor");
         });
         
         // set dirty indicator state

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
             if (editor.isFullyVisible()) {
                 var height = editor.totalHeight(true);
                 if (force || height !== this.height) {
-                    $(editor.getScrollerElement()).height(height);
+                    $(editor.getRootElement()).height(height);
                     this.height = height;
                     editor.refresh();
                 }

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -229,8 +229,18 @@ define(function (require, exports, module) {
         // other view of the doc: Editor fires "change" any time its text
         // changes, regardless of origin)
         $(inlineInfo.editor).on("change.InlineTextEditor", function (event, editor) {
-            if (self.hostEditor.isFullyVisible() && self._updateLineRange(editor)) {
+            if (self.hostEditor.isFullyVisible()) {
                 self.sizeInlineWidgetToContents(true);
+
+                // Refresh the host editor when the inline editor line range
+                // shrinks. Without this, CodeMirror doesn't update the
+                // viewport properly, causing empty space to appear below
+                // previous last visible line (or near it depending how many
+                // lines were previously cached). This has a negative impact
+                // on performance when rapidly deleting lines.
+                if (self._updateLineRange(editor)) {
+                    self.hostEditor.refresh();
+                }
             }
         });
         
@@ -261,7 +271,7 @@ define(function (require, exports, module) {
             this.$lineNumber.text(this._startLine + 1);
         }
 
-        return (this._lineCount !== oldLineCount);
+        return (this._lineCount < oldLineCount);
     };
 
     /**

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
             this.$lineNumber.text(this._startLine + 1);
         }
 
-        return (this._lineCount < oldLineCount);
+        return (this._lineCount !== oldLineCount);
     };
 
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -505,6 +505,10 @@ define(function (require, exports, module) {
      * @param {boolean} ensureVisibility makes the parent editor scroll to display the inline editor. Default true.
      */
     MultiRangeInlineEditor.prototype.sizeInlineWidgetToContents = function (force, ensureVisibility) {
+        // Size the code mirror editors height to the editor content
+        // We use "call" rather than "apply" here since ensureVisibility was an argument added just for this override.
+        MultiRangeInlineEditor.prototype.parentClass.sizeInlineWidgetToContents.call(this, force);
+        
         // Size the widget height to the max between the editor content and the related ranges list
         var widgetHeight = Math.max(this.$relatedContainer.find(".related").height(), this.$editorsDiv.height());
         this.hostEditor.setInlineWidgetHeight(this, widgetHeight, ensureVisibility);

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -505,9 +505,6 @@ define(function (require, exports, module) {
      * @param {boolean} ensureVisibility makes the parent editor scroll to display the inline editor. Default true.
      */
     MultiRangeInlineEditor.prototype.sizeInlineWidgetToContents = function (force, ensureVisibility) {
-        // Size the code mirror editors height to the editor content
-        // We use "call" rather than "apply" here since ensureVisibility was an argument added just for this override.
-        MultiRangeInlineEditor.prototype.parentClass.sizeInlineWidgetToContents.call(this, force);
         // Size the widget height to the max between the editor content and the related ranges list
         var widgetHeight = Math.max(this.$relatedContainer.find(".related").height(), this.$editorsDiv.height());
         this.hostEditor.setInlineWidgetHeight(this, widgetHeight, ensureVisibility);

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -20,6 +20,11 @@
 
 /* Brackets / CodeMirror Code Formatting */
 
+.CodeMirror {
+    /* remove CodeMirror default height: 300px */
+    height: auto;
+}
+
 /*
  * TODO This can be removed next time we update CodeMirror2.
  * Marijn made this change to codemirror.css, but I need it now

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -370,7 +370,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editors[0];
-                    widgetHeight = inlineEditor.totalHeight(true);
+                    widgetHeight = inlineEditor.totalHeight();
                     
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(12);
@@ -387,7 +387,7 @@ define(function (require, exports, module) {
                     
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(17);
-                    expect(inlineEditor.totalHeight(true)).toBeGreaterThan(widgetHeight);
+                    expect(inlineEditor.totalHeight()).toBeGreaterThan(widgetHeight);
                 });
             });
             
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editors[0];
-                    widgetHeight = inlineEditor.totalHeight(true);
+                    widgetHeight = inlineEditor.totalHeight();
                     
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(12);
@@ -413,7 +413,7 @@ define(function (require, exports, module) {
                     
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(10);
-                    expect(inlineEditor.totalHeight(true)).toBeLessThan(widgetHeight);
+                    expect(inlineEditor.totalHeight()).toBeLessThan(widgetHeight);
                 });
             });
             
@@ -668,7 +668,7 @@ define(function (require, exports, module) {
                     
                     runs(function () {
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editors[0];
-                        widgetHeight = inlineEditor.totalHeight(true);
+                        widgetHeight = inlineEditor.totalHeight();
                         
                         // change inline editor content
                         var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";


### PR DESCRIPTION
Alternate fix for porting `totalHeight()` into cmv3 branch. 

@njx I just found your notes here https://github.com/adobe/brackets/wiki/CodeMirror-v3-integration. I didn't see any issues in full or inline editors when letting CodeMirror lay itself out with the provided `height:auto` change. The only other thing the original `totalHeight` does is account for the height of inline editors which we don't have a use case for. Either (a) nested inline editors and getting the outermost total height or (b) getting the height of a full editor that contains inline editor.

See adobe/CodeMirror2#80 for the proposed cmv3 patch.
