### PR TITLE
Adding MS PGothic as a fallback font to fix Kanji characters in Japanese version.

### DIFF
--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -74,4 +74,4 @@
 
 /* Font Stacks */
 
-@fontstack-sans-serif: 'SourceSans', Helvetica, Arial, sans-serif;
+@fontstack-sans-serif: 'SourceSans', Helvetica, Arial, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -116,7 +116,7 @@
     // Sizing via em will cause the code and line numbers to misalign
     line-height: 15px;
     font-size: 12px;
-    font-family: 'SourceCodePro', monospace;
+    font-family: 'SourceCodePro', "ＭＳ ゴシック", "MS Gothic", monospace;
 }
 
 .code-font-win() {


### PR DESCRIPTION
This fixes issue #2371, but it also forces Chinese version to use MS PGothic font.
