### PR TITLE
Add smart "Home" for mac users. Fixes #2432

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -327,6 +327,7 @@ define(function (require, exports, module) {
             "Esc": function (instance) {
                 self.removeAllInlineWidgets();
             },
+            "Cmd-Left": "goLineStartSmart",
             "'>'": function (cm) { cm.closeTag(cm, '>'); },
             "'/'": function (cm) { cm.closeTag(cm, '/'); }
         };


### PR DESCRIPTION
Sorry that I didn't make separate pull-request for different bugs (now I got smarter)
But this case was discussed in the issue #2432 itself
and in my previous bulk pull-request: #2435

Just in case @peterflynn 's comment will gone when I made changes to the original pull-request:

> I wonder about this... it seems like most Mac editors don't have this behavior. In Coda, TextMate, and > Espresso, Cmd+left always goes to column 1 regardless of whether there's leading whitespace; 
> instead, Fn+left has the "smart home" behavior (Fn+left also does "smart home" in Brackets already). 
> But to throw a wrench in that, Sublime differs: Cmd+left means "smart home" and Fn+left means "go to 
> start of document" (more like non-code-editor Mac apps).
> 
> It might be worth separating this out into its own pull request so we can discuss it separately and 
> neither one will hold up the other one from landing...
