### PR TITLE
Clear editor holder

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -200,6 +200,9 @@ define(function (require, exports, module) {
      */
     function destroyMockEditor(doc) {
         EditorManager._destroyEditorIfUnneeded(doc);
+
+        // Clear editor holder so EditorManager doesn't try to resize destroyed object
+        EditorManager.setEditorHolder(null);
         $("#mock-editor-holder").remove();
     }
 


### PR DESCRIPTION
This is for #2379. EditorManager._editorHolder is set to a temporary DOM object in createMockEditor(), but it is not cleared in destroyMockEditor() after temporary DOM object is destroyed, and EditorManager holds on to this object (because Brackets only ever has a single, permanent _editorHolder) that it uses for all resizing events.

EditorManager._editorHolder is now cleared before actual DOM object is destroyed.

@peterflynn : I think you also looked at this, so care to review it?
