### PR TITLE
Simple change to allow TestQuickly to properly switch which tests are running

### DIFF
--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -47,7 +47,11 @@ define(function (require, exports, module) {
         var queryString = spec ? "?spec=" + spec : "";
         if (_testWindow) {
             try {
-                _testWindow.location.reload(true);
+                if (_testWindow.location.search !== queryString) {
+                    _testWindow.location.href = "../test/SpecRunner.html" + queryString;
+                } else {
+                    _testWindow.location.reload(true);
+                }
             } catch (e) {
                 _testWindow = null;  // the window was probably closed
             }


### PR DESCRIPTION
If the test window was already open, the test window would just reload without selecting the test suite that was passed in.
