### PR TITLE
[cmv3] Decouple horiz scrolling in inline text editors from outer editor.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -886,7 +886,8 @@ define(function (require, exports, module) {
      */
     Editor.prototype.addInlineWidget = function (pos, inlineWidget) {
         var self = this;
-        inlineWidget.info = this._codeMirror.addLineWidget(pos.line, inlineWidget.htmlContent, { coverGutter: true });
+        inlineWidget.info = this._codeMirror.addLineWidget(pos.line, inlineWidget.htmlContent,
+                                                           { coverGutter: true, noHScroll: true });
         CodeMirror.on(inlineWidget.info.line, "delete", function () {
             self._removeInlineWidgetInternal(inlineWidget);
             inlineWidget.onClosed();

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -51,8 +51,6 @@ define(function (require, exports, module) {
                 e.stopImmediatePropagation();
             }
         });
-        
-        this.updateWidth = this.updateWidth.bind(this);
     }
     InlineWidget.prototype.htmlContent = null;
     InlineWidget.prototype.$htmlContent = null;
@@ -66,29 +64,6 @@ define(function (require, exports, module) {
     InlineWidget.prototype.height = 0;
     
     /**
-     * Automatically updates the width of the inline editor when the parent editor's width changes due to
-     * edits or window resizes.
-     */
-    InlineWidget.prototype.updateWidth = function () {
-        // Set the minimum width of the widget (which doesn't include the padding) to the width
-        // of CodeMirror's linespace, so that the total width will be at least as large as the
-        // width of the host editor's code plus any internal padding required by the widget.
-        // We can't just set the min-width to 100% because that would be 100% of the clientWidth of
-        // the host editor, rather than the overall scroll width.
-        // We also can't just use the host editor's scrollWidth, because if the host editor's own
-        // content becomes less wide, our own width will continue to prop open the host editor's
-        // scrollWidth.
-        // So instead, we peg our width to the right edge of CodeMirror's lineSpace (which is its
-        // width plus its offset from the left edge of the $htmlContent container).
-        // If the lineSpace is less than the scroller's clientWidth, we want to use the clientWidth instead.
-        // This is a bit of a hack since it relies on knowing some detail about the innards of CodeMirror.
-        var lineSpace = this.hostEditor._getLineSpaceElement(),
-            scroller = this.hostEditor.getScrollerElement(),
-            minWidth = Math.max(scroller.clientWidth, $(lineSpace).offset().left - this.$htmlContent.offset().left + lineSpace.scrollWidth);
-        this.$htmlContent.css("min-width", minWidth + "px");
-    };
-    
-    /**
      * Closes this inline widget and all its contained Editors
      */
     InlineWidget.prototype.close = function () {
@@ -98,11 +73,10 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Called any time inline is closed, whether manually or automatically
+     * Called any time inline is closed, whether manually or automatically.
      */
     InlineWidget.prototype.onClosed = function () {
-        $(this.hostEditor).off("change", this.updateWidth);
-        $(window).off("resize", this.updateWidth);
+        // Does nothing in base implementation.
     };
 
     /**
@@ -110,10 +84,7 @@ define(function (require, exports, module) {
      * focus or measuring content, which require htmlContent to be in the DOM tree.
      */
     InlineWidget.prototype.onAdded = function () {
-        // Autosize the inline widget to the scrollable width of the main editor.
-        $(window).on("resize", this.updateWidth);
-        $(this.hostEditor).on("change", this.updateWidth);
-        window.setTimeout(this.updateWidth, 0);
+        // Does nothing in base implementation.
     };
 
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -119,21 +119,19 @@ define(function (require, exports, module) {
         var self = this;
 
         // Bind event handlers
-        this._updateRelatedContainer = this._updateRelatedContainer.bind(this);
         this._ensureCursorVisible = this._ensureCursorVisible.bind(this);
-        this._handleChange = this._handleChange.bind(this);
         this._onClick = this._onClick.bind(this);
 
         // Create DOM to hold editors and related list
         this.$editorsDiv = $(window.document.createElement("div")).addClass("inlineEditorHolder");
         
+        // Prevent touch scroll events from bubbling up to the parent editor.
+        this.$editorsDiv.on("mousewheel", function (e) {
+            e.stopPropagation();
+        });
+        
         // Outer container for border-left and scrolling
         this.$relatedContainer = $(window.document.createElement("div")).addClass("related-container");
-        this._relatedContainerInserted = false;
-        this._relatedContainerInsertedHandler = this._relatedContainerInsertedHandler.bind(this);
-        
-        // FIXME (jasonsj): deprecated event http://www.w3.org/TR/DOM-Level-3-Events/
-        this.$relatedContainer.on("DOMNodeInserted", this._relatedContainerInsertedHandler);
         
         // List "selection" highlight
         this.$selectedMarker = $(window.document.createElement("div")).appendTo(this.$relatedContainer).addClass("selection");
@@ -171,24 +169,8 @@ define(function (require, exports, module) {
         self.setSelectedIndex(0);
         
         // attach to main container
-        this.$htmlContent.append(this.$editorsDiv).append(this.$relatedContainer);
-        
-        // initialize position based on the main #editor-holder
-        window.setTimeout(this._updateRelatedContainer, 0);
-        
-        // Changes to the host editor should update the relatedContainer
-        // Note: normally it's not kosher to listen to changes on a specific editor,
-        // but in this case we're specifically concerned with changes in the given
-        // editor, not general document changes.
-        $(this.hostEditor).on("change", this._updateRelatedContainer);
-        
-        // Update relatedContainer when this widget's position changes
-        $(this).on("offsetTopChanged", this._updateRelatedContainer);
-        
-        // Listen to the window resize event to reposition the relatedContainer
-        // when the hostEditor's scrollbars visibility changes
-        $(window).on("resize", this._updateRelatedContainer);
-        
+        this.$htmlContent.append(this.$relatedContainer).append(this.$editorsDiv);
+                
         // Listen for clicks directly on us, so we can set focus back to the editor
         this.$htmlContent.on("click", this._onClick);
     };
@@ -219,8 +201,6 @@ define(function (require, exports, module) {
         this._ranges[this._selectedRangeIndex].$listItem.toggleClass("selected", true);
 
         // Remove previous editors
-        $(this.editors[0]).off("change", this._updateRelatedContainer);
-
         this.editors.forEach(function (editor) {
             editor.destroy(); //release ref on Document
         });
@@ -233,21 +213,13 @@ define(function (require, exports, module) {
         this.createInlineEditorFromText(range.textRange.document, range.textRange.startLine, range.textRange.endLine, this.$editorsDiv.get(0));
         this.editors[0].focus();
 
-        // Changes in size to the inline editor should update the relatedContainer
-        // Note: normally it's not kosher to listen to changes on a specific editor,
-        // but in this case we're specifically concerned with changes in the given
-        // editor, not general document changes.
-        $(this.editors[0]).on("change", this._handleChange);
-        
-        // Cursor activity in the inline editor may cause us to horizontally scroll.
-        $(this.editors[0]).on("cursorActivity", this._ensureCursorVisible);
-
-        
         this.editors[0].refresh();
         
+        // Ensure the cursor position is visible in the host editor as the user is arrowing around.
+        $(this.editors[0]).on("cursorActivity", this._ensureCursorVisible);
+
         // ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a view
         this.sizeInlineWidgetToContents(true, false);
-        this._updateRelatedContainer();
 
         this._updateSelectedMarker();
     };
@@ -322,26 +294,13 @@ define(function (require, exports, module) {
         // Superclass onClosed() destroys editor
         MultiRangeInlineEditor.prototype.parentClass.onClosed.apply(this, arguments);
         
-        // remove resize handlers for relatedContainer
-        $(this.hostEditor).off("change", this._updateRelatedContainer);
-        $(this.editors[0]).off("change", this._handleChange);
+        // Remove event handlers
         $(this.editors[0]).off("cursorActivity", this._ensureCursorVisible);
-        $(this).off("offsetTopChanged", this._updateRelatedContainer);
-        $(window).off("resize", this._updateRelatedContainer);
-        
+       
         // de-ref all the Documents in the search results
         this._ranges.forEach(function (searchResult) {
             searchResult.textRange.dispose();
         });
-    };
-    
-    /**
-     * @private
-     * Set _relatedContainerInserted flag once the $relatedContainer is inserted in the DOM.
-     */
-    MultiRangeInlineEditor.prototype._relatedContainerInsertedHandler = function () {
-        this.$relatedContainer.off("DOMNodeInserted", this._relatedContainerInsertedHandler);
-        this._relatedContainerInserted = true;
     };
     
     /**
@@ -374,89 +333,24 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Set the size, position, and clip rect of the range list.
-     */
-    MultiRangeInlineEditor.prototype._updateRelatedContainer = function () {
-        var borderThickness = (this.$htmlContent.outerHeight() - this.$htmlContent.innerHeight()) / 2;
-        this.$relatedContainer.css("top", this.$htmlContent.offset().top + borderThickness);
-        this.$relatedContainer.height(this.$htmlContent.height());
-        
-        // Because we're using position: fixed, we need to explicitly clip the range list if it crosses
-        // out of the top or bottom of the scroller area.
-        var hostScroller = this.hostEditor.getScrollerElement(),
-            rcTop = this.$relatedContainer.offset().top,
-            rcHeight = this.$relatedContainer.outerHeight(),
-            rcBottom = rcTop + rcHeight,
-            scrollerOffset = $(hostScroller).offset(),
-            scrollerTop = scrollerOffset.top,
-            // To calculate the actual visible height of the hostScroller, we have to take the margin into
-            // account. This is because CodeMirror sets a negative margin on the scroller as a hack to
-            // push the "real" scrollbar offscreen.
-            scrollerBottom = scrollerTop + $(hostScroller).outerHeight(true),
-            scrollerLeft = scrollerOffset.left,
-            rightOffset = $(window.document.body).outerWidth() - (scrollerLeft + hostScroller.clientWidth);
-        if (rcTop < scrollerTop || rcBottom > scrollerBottom) {
-            this.$relatedContainer.css("clip", "rect(" + Math.max(scrollerTop - rcTop, 0) + "px, auto, " +
-                                       (rcHeight - Math.max(rcBottom - scrollerBottom, 0)) + "px, auto)");
-        } else {
-            this.$relatedContainer.css("clip", "");
-        }
-        
-        // Constrain relatedContainer width to half of the scroller width
-        var relatedContainerWidth = this.$relatedContainer.width();
-        if (this._relatedContainerInserted) {
-            if (this._relatedContainerDefaultWidth === undefined) {
-                this._relatedContainerDefaultWidth = relatedContainerWidth;
-            }
-            
-            var halfWidth = Math.floor(hostScroller.clientWidth / 2);
-            relatedContainerWidth = Math.min(this._relatedContainerDefaultWidth, halfWidth);
-            this.$relatedContainer.width(relatedContainerWidth);
-        }
-        
-        // Position immediately to the left of the main editor's scrollbar.
-        this.$relatedContainer.css("right", rightOffset + "px");
-
-        // Add extra padding to the right edge of the widget to account for the range list.
-        this.$htmlContent.css("padding-right", this.$relatedContainer.outerWidth() + "px");
-    };
-    
-    /**
      * Based on the position of the cursor in the inline editor, determine whether we need to change the
-     * scroll position of the host editor to ensure that the cursor is visible.
+     * vertical scroll position of the host editor to ensure that the cursor is visible.
      */
     MultiRangeInlineEditor.prototype._ensureCursorVisible = function () {
         if ($.contains(this.editors[0].getRootElement(), window.document.activeElement)) {
-            var cursorCoords = this.editors[0]._codeMirror.cursorCoords(),
-                inlineLineSpaceOffset = $(this.editors[0]._getLineSpaceElement()).offset(),
-                rangeListOffset = this.$relatedContainer.offset();
-            // If we're off the left-hand side, we just want to scroll it into view normally. But
-            // if we're underneath the range list on the right, we want to ask the host editor to 
-            // scroll far enough that the current cursor position is visible to the left of the range 
-            // list. (Because we always add extra padding for the range list, this is always possible.)
-            if (cursorCoords.left >= rangeListOffset.left) {
-                cursorCoords.left += this.$relatedContainer.outerWidth();
-            }
+            var hostScrollPos = this.hostEditor.getScrollPos(),
+                cursorCoords = this.editors[0]._codeMirror.cursorCoords();
             
             // Vertically, we want to set the scroll position relative to the overall host editor, not
-            // the lineSpace of the widget itself.
+            // the lineSpace of the widget itself. We don't want to modify the horizontal scroll position.
             var scrollerTop = this.hostEditor.getVirtualScrollAreaTop();
             this.hostEditor._codeMirror.scrollIntoView({
-                left: cursorCoords.left - inlineLineSpaceOffset.left,
+                left: hostScrollPos.x,
                 top: cursorCoords.top - scrollerTop,
-                right: cursorCoords.left - inlineLineSpaceOffset.left,
+                right: hostScrollPos.x,
                 bottom: cursorCoords.bottom - scrollerTop
             });
         }
-    };
-    
-    /**
-     * Handle a change event from the editor. Update the related container and make sure the
-     * cursor is visible.
-     */
-    MultiRangeInlineEditor.prototype._handleChange = function () {
-        this._updateRelatedContainer();
-        this._ensureCursorVisible();
     };
 
     /**
@@ -511,10 +405,6 @@ define(function (require, exports, module) {
         // Size the widget height to the max between the editor content and the related ranges list
         var widgetHeight = Math.max(this.$relatedContainer.find(".related").height(), this.$editorsDiv.height());
         this.hostEditor.setInlineWidgetHeight(this, widgetHeight, ensureVisibility);
-
-        // The related ranges container size itself based on htmlContent which is set by setInlineWidgetHeight above.
-        // Use setTimeout to trigger a layout update before accessing positions, heights, etc.
-        window.setTimeout(this._updateRelatedContainer);
     };
     
     /**
@@ -524,7 +414,6 @@ define(function (require, exports, module) {
     MultiRangeInlineEditor.prototype.refresh = function () {
         MultiRangeInlineEditor.prototype.parentClass.refresh.apply(this, arguments);
         this.sizeInlineWidgetToContents(true);
-        this._updateRelatedContainer();
         this.editors.forEach(function (editor, j, arr) {
             editor.refresh();
         });

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -563,6 +563,7 @@ a, img {
 /* Styles for inline editors */
 .inline-widget {
     background-color:   @inline-background-color-1;
+    min-width: 250px;
     
     .inline-editor-header {
         padding: 10px 10px 0px 10px;
@@ -610,9 +611,11 @@ a, img {
     }
     
     .CodeMirror-scroll {
-        /* Don't show horizontal scrollbars within an inline editor--we want to scroll the outer editor */
-        overflow-x: hidden;
         background-color: transparent;
+        
+        .CodeMirror-linenumbers {
+            background-color: @inline-background-color-1;
+        }
     }
 }
 
@@ -620,16 +623,14 @@ a, img {
 .related-container {
     @top-margin: 12px;
     
-    /*width: 0;*/
+    float: right;
+    position: relative;
+    min-height: 100%;
     font-family: @fontstack-sans-serif;
-    position: fixed;
     width: 250px;
+    max-width: 50%;
     overflow: hidden;
-    /*-webkit-transition: width 0.15s ease-out;*/
     background: @inline-background-color-2;
-    
-    /* CodeMirror sets widgets that overlap the gutter to have a z-index of 5. We need to be in front of this. */
-    z-index: 6;
     
     .selection {
         width: 100%;


### PR DESCRIPTION
@jasonsanjose 

Our original scheme for tying horizontal scrolling in inline editors to the outer editor, which involved just letting the inline editor take up its natural width, won't work with the new CodeMirror because of the fixed gutter; we need the inline editor to handle its own horizontal scrolling.

Luckily, CodeMirror v3 has an option for inline widgets not to horizontally scroll with the parent. So we simply turn that on, which makes the nested editor's client width fit into the parent's client width, and then let it scroll itself.

This also means that we can get rid of all the weird stuff we were doing with the rule list container; it can now just be a float-right child of the widget, with the nested editor fitting to its left. This gets rid of a whole bunch of logic, and as a side-effect, it seems that typing in inline editors is much faster now.

I'll add notes on some of the deleted code to indicate why it's no longer necessary.
