### PR TITLE
Load extensions before loading project, then fire APP_READY.

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -188,7 +188,7 @@ define(function main(require, exports, module) {
     }
 
     /** Initialize LiveDevelopment */
-    function init() {
+    AppInit.appReady(function () {
         params.parse();
 
         Inspector.init(config);
@@ -204,12 +204,10 @@ define(function main(require, exports, module) {
         }
 
         // trigger autoconnect
-        if (config.autoconnect && window.sessionStorage.getItem("live.enabled") === "true") {
-            AppInit.appReady(function () {
-                if (DocumentManager.getCurrentDocument()) {
-                    _handleGoLiveCommand();
-                }
-            });
+        if (config.autoconnect &&
+                window.sessionStorage.getItem("live.enabled") === "true" &&
+                DocumentManager.getCurrentDocument()) {
+            _handleGoLiveCommand();
         }
         
         // Redraw highlights when window gets focus. This ensures that the highlights
@@ -219,7 +217,7 @@ define(function main(require, exports, module) {
                 LiveDevelopment.redrawHighlight();
             }
         });
-    }
+    });
     
     // init prefs
     prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_KEY, {highlight: true});
@@ -231,5 +229,4 @@ define(function main(require, exports, module) {
     CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setEnabled(false);
 
     // Export public functions
-    exports.init = init;
 });

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -33,7 +33,8 @@ define(function (require, exports, module) {
 
     require("utils/Global");
 
-    var CommandManager = require("command/CommandManager"),
+    var AppInit        = require("utils/AppInit"),
+        CommandManager = require("command/CommandManager"),
         KeyEvent       = require("utils/KeyEvent"),
         Strings        = require("strings");
 
@@ -573,11 +574,8 @@ define(function (require, exports, module) {
         }
     }
 
-    /**
-     * Install keydown event listener.
-     */
-    function init() {
-        // init
+    AppInit.htmlReady(function () {
+        // Install keydown event listener.
         window.document.body.addEventListener(
             "keydown",
             function (event) {
@@ -591,7 +589,7 @@ define(function (require, exports, module) {
         
         exports.useWindowsCompatibleBindings = (brackets.platform !== "mac")
             && (brackets.platform !== "win");
-    }
+    });
     
     $(CommandManager).on("commandRegistered", _handleCommandRegistered);
 
@@ -599,7 +597,6 @@ define(function (require, exports, module) {
     exports._reset = _reset;
 
     // Define public API
-    exports.init = init;
     exports.getKeymap = getKeymap;
     exports.handleKey = handleKey;
     exports.setEnabled = setEnabled;

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -29,14 +29,15 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var Global                  = require("utils/Global"),
-        Commands                = require("command/Commands"),
-        KeyBindingManager       = require("command/KeyBindingManager"),
-        EditorManager           = require("editor/EditorManager"),
-        Strings                 = require("strings"),
-        StringUtils             = require("utils/StringUtils"),
-        CommandManager          = require("command/CommandManager"),
-        PopUpManager            = require("widgets/PopUpManager");
+    var AppInit             = require("utils/AppInit"),
+        Global              = require("utils/Global"),
+        Commands            = require("command/Commands"),
+        KeyBindingManager   = require("command/KeyBindingManager"),
+        EditorManager       = require("editor/EditorManager"),
+        Strings             = require("strings"),
+        StringUtils         = require("utils/StringUtils"),
+        CommandManager      = require("command/CommandManager"),
+        PopUpManager        = require("widgets/PopUpManager");
 
     /**
      * Brackets Application Menu Constants
@@ -866,10 +867,8 @@ define(function (require, exports, module) {
     // function removeMenu(id) {
     //     NOT IMPLEMENTED
     // }
-
-
-    function init() {
-
+    
+    AppInit.htmlReady(function () {
         /*
          * File menu
          */
@@ -1102,10 +1101,9 @@ define(function (require, exports, module) {
                 $(this).addClass("open");
             }
         });
-    }
+    });
 
     // Define public API
-    exports.init = init;
     exports.AppMenuBar = AppMenuBar;
     exports.ContextMenuIds = ContextMenuIds;
     exports.MenuSection = MenuSection;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -31,7 +31,8 @@ define(function (require, exports, module) {
     require("thirdparty/path-utils/path-utils.min");
     
     // Load dependent modules
-    var CommandManager      = require("command/CommandManager"),
+    var AppInit             = require("utils/AppInit"),
+        CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         KeyBindingManager   = require("command/KeyBindingManager"),
         NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
@@ -823,42 +824,40 @@ define(function (require, exports, module) {
         ProjectManager.showInTree(DocumentManager.getCurrentDocument().file);
     }
     
-
-    function init($titleContainerToolbar) {
+    // Init DOM elements
+    AppInit.htmlReady(function () {
+        var $titleContainerToolbar = $("#main-toolbar");
         _$titleContainerToolbar = $titleContainerToolbar;
         _$titleWrapper = $(".title-wrapper", _$titleContainerToolbar);
         _$title = $(".title", _$titleWrapper);
         _$dirtydot = $(".dirty-dot", _$titleWrapper);
+    });
 
-        // Register global commands
-        CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
-        CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET, Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
-        // TODO: (issue #274) For now, hook up File > New to the "new in project" handler. Eventually
-        // File > New should open a new blank tab, and handleFileNewInProject should
-        // be called from a "+" button in the project
-        CommandManager.register(Strings.CMD_FILE_NEW,           Commands.FILE_NEW, handleFileNewInProject);
-        CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,    Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
-        CommandManager.register(Strings.CMD_FILE_SAVE,          Commands.FILE_SAVE, handleFileSave);
-        CommandManager.register(Strings.CMD_FILE_SAVE_ALL,      Commands.FILE_SAVE_ALL, handleFileSaveAll);
-        CommandManager.register(Strings.CMD_FILE_RENAME,        Commands.FILE_RENAME, handleFileRename);
-        
-        CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
-        CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
-        CommandManager.register(Strings.CMD_CLOSE_WINDOW,       Commands.FILE_CLOSE_WINDOW, handleFileCloseWindow);
-        CommandManager.register(Strings.CMD_QUIT,               Commands.FILE_QUIT, handleFileQuit);
-        CommandManager.register(Strings.CMD_REFRESH_WINDOW,     Commands.DEBUG_REFRESH_WINDOW, handleFileReload);
-        CommandManager.register(Strings.CMD_ABORT_QUIT,         Commands.APP_ABORT_QUIT, _handleAbortQuit);
-        
-        CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
-        CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
-        CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
-        
-        // Listen for changes that require updating the editor titlebar
-        $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
-        $(DocumentManager).on("currentDocumentChange fileNameChange", updateDocumentTitle);
-    }
-
-    // Define public API
-    exports.init = init;
+    // Register global commands
+    CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET, Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
+    // TODO: (issue #274) For now, hook up File > New to the "new in project" handler. Eventually
+    // File > New should open a new blank tab, and handleFileNewInProject should
+    // be called from a "+" button in the project
+    CommandManager.register(Strings.CMD_FILE_NEW,           Commands.FILE_NEW, handleFileNewInProject);
+    CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,    Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
+    CommandManager.register(Strings.CMD_FILE_SAVE,          Commands.FILE_SAVE, handleFileSave);
+    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,      Commands.FILE_SAVE_ALL, handleFileSaveAll);
+    CommandManager.register(Strings.CMD_FILE_RENAME,        Commands.FILE_RENAME, handleFileRename);
+    
+    CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
+    CommandManager.register(Strings.CMD_CLOSE_WINDOW,       Commands.FILE_CLOSE_WINDOW, handleFileCloseWindow);
+    CommandManager.register(Strings.CMD_QUIT,               Commands.FILE_QUIT, handleFileQuit);
+    CommandManager.register(Strings.CMD_REFRESH_WINDOW,     Commands.DEBUG_REFRESH_WINDOW, handleFileReload);
+    CommandManager.register(Strings.CMD_ABORT_QUIT,         Commands.APP_ABORT_QUIT, _handleAbortQuit);
+    
+    CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
+    CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
+    CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
+    
+    // Listen for changes that require updating the editor titlebar
+    $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
+    $(DocumentManager).on("currentDocumentChange fileNameChange", updateDocumentTitle);
 });
 

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1094,7 +1094,7 @@ define(function (require, exports, module) {
      * @private
      * Initializes the working set.
      */
-    function _projectOpen() {
+    function _projectOpen(e) {
         _isProjectChanging = false;
         
         // file root is appended for each project
@@ -1124,7 +1124,9 @@ define(function (require, exports, module) {
         }
 
         if (activeFile) {
-            CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile });
+            var promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: activeFile });
+            // Add this promise to the event's promises to signal that this handler isn't done yet
+            e.promises.push(promise);
         }
     }
 

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
     "use strict";
 
     // Load dependent modules
-    var CodeHintManager     = brackets.getModule("editor/CodeHintManager"),
+    var AppInit             = brackets.getModule("utils/AppInit"),
+        CodeHintManager     = brackets.getModule("editor/CodeHintManager"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
         EditorManager       = brackets.getModule("editor/EditorManager"),
         HTMLUtils           = brackets.getModule("language/HTMLUtils"),
@@ -38,8 +39,8 @@ define(function (require, exports, module) {
         StringUtils         = brackets.getModule("utils/StringUtils"),
         HTMLTags            = require("text!HtmlTags.json"),
         HTMLAttributes      = require("text!HtmlAttributes.json"),
-        tags                = JSON.parse(HTMLTags),
-        attributes          = JSON.parse(HTMLAttributes);
+        tags,
+        attributes;
 
     /**
      * @constructor
@@ -622,12 +623,19 @@ define(function (require, exports, module) {
         return false;
     };
 
-    var tagHints = new TagHints();
-    var attrHints = new AttrHints();
-    CodeHintManager.registerHintProvider(tagHints, ["html"], 0);
-    CodeHintManager.registerHintProvider(attrHints, ["html"], 0);
+    AppInit.appReady(function () {
+        // Parse JSON files
+        tags = JSON.parse(HTMLTags);
+        attributes = JSON.parse(HTMLAttributes);
+        
+        // Register code hint providers
+        var tagHints = new TagHints();
+        var attrHints = new AttrHints();
+        CodeHintManager.registerHintProvider(tagHints, ["html"], 0);
+        CodeHintManager.registerHintProvider(attrHints, ["html"], 0);
     
-    // For unit testing
-    exports.tagHintProvider = tagHints;
-    exports.attrHintProvider = attrHints;
+        // For unit testing
+        exports.tagHintProvider = tagHints;
+        exports.attrHintProvider = attrHints;
+    });
 });

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -299,10 +299,12 @@ define(function (require, exports, module) {
     }
     
     // Initialize extension
-    ExtensionUtils.loadStyleSheet(module, "styles.css");
-    
-    $(ProjectManager).on("projectOpen", add);
-    $(ProjectManager).on("beforeProjectClose", add);
+    AppInit.appReady(function () {
+        ExtensionUtils.loadStyleSheet(module, "styles.css");
+        
+        $(ProjectManager).on("projectOpen", add);
+        $(ProjectManager).on("beforeProjectClose", add);
+    });
 
     AppInit.htmlReady(function () {
         $("#project-title")

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -28,7 +28,8 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var Global                  = require("utils/Global"),
+    var AppInit                 = require("utils/AppInit"),
+        Global                  = require("utils/Global"),
         BuildInfoUtils          = require("utils/BuildInfoUtils"),
         Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
@@ -73,14 +74,16 @@ define(function (require, exports, module) {
         Dialogs.showModalDialogUsingTemplate(Mustache.render(AboutDialogTemplate, templateVars));
     }
 
-    // Read "build number" SHAs off disk immediately at load time, instead
+    // Read "build number" SHAs off disk immediately at APP_READY, instead
     // of later, when they may have been updated to a different version
-    BuildInfoUtils.getBracketsSHA().done(function (branch, sha, isRepo) {
-        // If we've successfully determined a "build number" via .git metadata, add it to dialog
-        sha = sha ? sha.substr(0, 9) : "";
-        if (branch || sha) {
-            buildInfo = StringUtils.format("({0} {1})", branch, sha).trim();
-        }
+    AppInit.appReady(function () {
+        BuildInfoUtils.getBracketsSHA().done(function (branch, sha, isRepo) {
+            // If we've successfully determined a "build number" via .git metadata, add it to dialog
+            sha = sha ? sha.substr(0, 9) : "";
+            if (branch || sha) {
+                buildInfo = StringUtils.format("({0} {1})", branch, sha).trim();
+            }
+        });
     });
 
     CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE,       Commands.HELP_CHECK_FOR_UPDATE,     _handleCheckForUpdates);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -782,10 +782,13 @@ define(function (require, exports, module) {
 
                     resultRenderTree.done(function () {
                         if (projectRootChanged) {
-                            $(exports).triggerHandler("projectOpen", _projectRoot);
+                            // Allow asynchronous event handlers to finish before resolving result by collecting promises from them
+                            var promises = [];
+                            $(exports).triggerHandler({ type: "projectOpen", promises: promises }, [_projectRoot, promises]);
+                            $.when.apply($, promises).pipe(result.resolve, result.reject);
+                        } else {
+                            result.resolve();
                         }
-                        
-                        result.resolve();
                     });
                     resultRenderTree.fail(function () {
                         PerfUtils.terminateMeasurement(perfTimerName);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -785,7 +785,7 @@ define(function (require, exports, module) {
                             // Allow asynchronous event handlers to finish before resolving result by collecting promises from them
                             var promises = [];
                             $(exports).triggerHandler({ type: "projectOpen", promises: promises }, [_projectRoot, promises]);
-                            $.when(promises).pipe(result.resolve, result.reject);
+                            $.when.apply($, promises).pipe(result.resolve, result.reject);
                         } else {
                             result.resolve();
                         }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1318,6 +1318,8 @@ define(function (require, exports, module) {
         $(".jstree-rename-input").blur();
     }
 
+    function init() {
+    }
 
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
@@ -1343,6 +1345,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PROJECT_SETTINGS, Commands.FILE_PROJECT_SETTINGS, _projectSettings);
 
     // Define public API
+    exports.init                     = init;
     exports.getProjectRoot           = getProjectRoot;
     exports.getBaseUrl               = getBaseUrl;
     exports.setBaseUrl               = setBaseUrl;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -785,7 +785,7 @@ define(function (require, exports, module) {
                             // Allow asynchronous event handlers to finish before resolving result by collecting promises from them
                             var promises = [];
                             $(exports).triggerHandler({ type: "projectOpen", promises: promises }, [_projectRoot, promises]);
-                            $.when.apply($, promises).pipe(result.resolve, result.reject);
+                            $.when(promises).pipe(result.resolve, result.reject);
                         } else {
                             result.resolve();
                         }
@@ -1318,9 +1318,6 @@ define(function (require, exports, module) {
         $(".jstree-rename-input").blur();
     }
 
-    function init() {
-    }
-
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
         $projectTreeContainer = $("#project-files-container");
@@ -1345,7 +1342,6 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PROJECT_SETTINGS, Commands.FILE_PROJECT_SETTINGS, _projectSettings);
 
     // Define public API
-    exports.init                     = init;
     exports.getProjectRoot           = getProjectRoot;
     exports.getBaseUrl               = getBaseUrl;
     exports.setBaseUrl               = setBaseUrl;

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -36,9 +36,11 @@ define(function (require, exports, module) {
 
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils           = require("file/FileUtils"),
-        Async               = require("utils/Async"),
-        contexts            = {},
-        srcPath             = FileUtils.getNativeBracketsDirectoryPath();
+        Async               = require("utils/Async");
+    
+    var _init       = false,
+        contexts    = {},
+        srcPath     = FileUtils.getNativeBracketsDirectoryPath();
     
     // The native directory path ends with either "test" or "src". We need "src" to
     // load the text and i18n modules.
@@ -238,6 +240,63 @@ define(function (require, exports, module) {
         return _loadAll(directory, config, "unittests", testExtension);
     }
     
+    /**
+     * Load extensions.
+     *
+     * @param {?string} A list containing references to extension source
+     *      location. A source location may be either (a) a folder path
+     *      relative to src/extensions or (b) an absolute path.
+     * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
+     */
+    function init(paths) {
+        if (_init) {
+            // Only init once. Return a resolved promise.
+            return new $.Deferred().resolve().promise();
+        }
+        
+        if (!paths) {
+            paths = "default,dev," + getUserExtensionPath();
+        }
+
+        // Load extensions before restoring the project
+        
+        // Create a new DirectoryEntry and call getDirectory() on the user extension
+        // directory. If the directory doesn't exist, it will be created.
+        // Note that this is an async call and there are no success or failure functions passed
+        // in. If the directory *doesn't* exist, it will be created. Extension loading may happen
+        // before the directory is finished being created, but that is okay, since the extension
+        // loading will work correctly without this directory.
+        // If the directory *does* exist, nothing else needs to be done. It will be scanned normally
+        // during extension loading.
+        var extensionPath = getUserExtensionPath();
+        new NativeFileSystem.DirectoryEntry().getDirectory(extensionPath,
+                                                           {create: true});
+        
+        // Create the extensions/disabled directory, too.
+        var disabledExtensionPath = extensionPath.replace(/\/user$/, "/disabled");
+        new NativeFileSystem.DirectoryEntry().getDirectory(disabledExtensionPath,
+                                                           {create: true});
+        
+        var promise = Async.doInParallel(paths.split(","), function (item) {
+            var extensionPath = item;
+            
+            // If the item has "/" in it, assume it is a full path. Otherwise, load
+            // from our source path + "/extensions/".
+            if (item.indexOf("/") === -1) {
+                extensionPath = FileUtils.getNativeBracketsDirectoryPath() + "/extensions/" + item;
+            }
+            
+            return loadAllExtensionsInNativeDirectory(extensionPath);
+        });
+        
+        promise.done(function () {
+            _init = true;
+        });
+        
+        return promise;
+    }
+    
+    exports.init = init;
     exports.getUserExtensionPath = getUserExtensionPath;
     exports.getRequireContextForExtension = getRequireContextForExtension;
     exports.loadExtension = loadExtension;

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
             return loadAllExtensionsInNativeDirectory(extensionPath);
         });
         
-        promise.done(function () {
+        promise.always(function () {
             _init = true;
         });
         

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -29,7 +29,7 @@
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
  * (a) the module requires this module, i.e. require("utils/Global") or
- * (b) the module receives a "ready" callback from the utils/AppReady module.
+ * (b) the module receives a "appReady" callback from the utils/AppReady module.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
     'use strict';
     
     // Utility dependency
-    var Global                  = require("utils/Global"),
+    var AppInit                 = require("utils/AppInit"),
+        Global                  = require("utils/Global"),
         SpecRunnerUtils         = require("spec/SpecRunnerUtils"),
         ExtensionLoader         = require("utils/ExtensionLoader"),
         Async                   = require("utils/Async"),
@@ -116,6 +117,8 @@ define(function (require, exports, module) {
         });
         
         $("#" + suite).closest("li").toggleClass("active", true);
+        
+        AppInit._dispatchReady(AppInit.APP_READY);
         
         jasmine.getEnv().execute();
     }


### PR DESCRIPTION
Fix for #1951

Change app initialization to load extensions first, then load the project and initialize the working set before firing the `APP_READY` event. Many thanks to @DennisKehrig.

While cleaning up the startup process, I opportunistically cleaned up a lot of startup code by deferring some initialization out of the module init (implicit and/or explicit) and into `APP_READY` and `HTML_READY` handlers as appropriate. 

Unit, performance and extension tests are passing.
