### PR TITLE
Update paths to CodeMirror addon files

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -73,11 +73,11 @@
     <!-- Pre-load third party scripts that cannot be async loaded. -->
     <script src="thirdparty/jquery-1.7.min.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
-    <script src="thirdparty/CodeMirror2/lib/util/matchbrackets.js"></script>
+    <script src="thirdparty/CodeMirror2/addon/edit/closetag.js"></script>
+    <script src="thirdparty/CodeMirror2/addon/edit/matchbrackets.js"></script>
     
     <!-- JS for CodeMirror search support -->
-    <script src="thirdparty/CodeMirror2/lib/util/searchcursor.js"></script>
-    <script src="thirdparty/CodeMirror2/lib/util/closetag.js"></script>
+    <script src="thirdparty/CodeMirror2/addon/search/searchcursor.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
Find/Replace and a couple of other things were broken in cmv3 because the paths to CM addon files have changed.
