### PR TITLE
height:auto fix for #2517

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -565,6 +565,11 @@ a, img {
     background-color:   @inline-background-color-1;
     min-width: 250px;
     
+    .CodeMirror {
+        /* remove CodeMirror default height: 300px */
+        height: auto;
+    }
+    
     .inline-editor-header {
         padding: 10px 10px 0px 10px;
         

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -20,11 +20,6 @@
 
 /* Brackets / CodeMirror Code Formatting */
 
-.CodeMirror {
-    /* remove CodeMirror default height: 300px */
-    height: auto;
-}
-
 /*
  * TODO This can be removed next time we update CodeMirror2.
  * Marijn made this change to codemirror.css, but I need it now
@@ -116,6 +111,11 @@
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {
+    .CodeMirror {
+        /* remove CodeMirror default height: 300px */
+        height: auto;
+    }
+    
     .CodeMirror pre.CodeMirror-cursor {
         visibility: hidden;
     }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -111,11 +111,6 @@
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {
-    .CodeMirror {
-        /* remove CodeMirror default height: 300px */
-        height: auto;
-    }
-    
     .CodeMirror pre.CodeMirror-cursor {
         visibility: hidden;
     }


### PR DESCRIPTION
Fix for #2517.

Use height:auto only for inline editors to fix rendering time for large files in full editors
