### PR TITLE
CodeHintList shouldn't get keyboard events if closed

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -447,7 +447,7 @@ define(function (require, exports, module) {
                 }
                 // Begin a new explicit session
                 _beginSession(editor);
-            } else if (_inSession(editor)) {
+            } else if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
                 hintList.handleKeyEvent(event);
             }


### PR DESCRIPTION
If a code hint provider initially (upon hinting session creation) returns deferred hints, the CodeHintList is not opened until those deferred hints have resolved to an actual list of hints. Until this resolution, the CodeHintManager should not forward keyboard events to the CodeHintList, which captures some navigation events to handle scrolling and paging through the list. This tiny pull request just ensures that the CodeHintList is actually open, and not just in a hinting session, before the CodeHintManager passes it any keyboard events. 
