### PR TITLE
Update JSLint results after document is synced

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -56,6 +56,8 @@
  *      Document whose flag changed.
  *    - documentSaved -- When a Document's changes have been saved. The 2nd arg to the listener is the 
  *      Document that has been saved.
+ *    - documentRefreshed -- When a Document's contents have been reloaded from disk. The 2nd arg to the
+ *      listener is the Document that has been refreshed.
  *
  *    - currentDocumentChange -- When the value of getCurrentDocument() changes.
  *
@@ -804,6 +806,8 @@ define(function (require, exports, module) {
         if (!this._lineEndings) {
             this._lineEndings = FileUtils.getPlatformLineEndings();
         }
+        
+        $(exports).triggerHandler("documentRefreshed", this);
 
         PerfUtils.addMeasurement(perfTimerName);
     };

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
                 .on("currentDocumentChange.jslint", function () {
                     run();
                 })
-                .on("documentSaved.jslint", function (event, document) {
+                .on("documentSaved.jslint documentRefreshed.jslint", function (event, document) {
                     if (document === DocumentManager.getCurrentDocument()) {
                         run();
                     }


### PR DESCRIPTION
Fix for #315

This request adds a new `documentRefreshed` event that is dispatched whenever a document is loaded from disk. This event is sent when the document is first created, and any time the `refreshText()` method is called.

Update JSLintUtils to listen for this event, and re-run JSLint if the current document was refreshed.
