### PR TITLE
Implicit hint requests only on enter and tab keydown events

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -450,7 +450,10 @@ define(function (require, exports, module) {
             } else if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
                 hintList.handleKeyEvent(event);
-            } else {
+            } else if (!(event.ctrlKey || event.altKey || event.metaKey) &&
+                        (event.keyCode === KeyEvent.DOM_VK_ENTER ||
+                         event.keyCode === KeyEvent.DOM_VK_RETURN ||
+                         event.keyCode === KeyEvent.DOM_VK_TAB)) {
                 lastChar = String.fromCharCode(event.keyCode);
             }
         } else if (event.type === "keypress") {


### PR DESCRIPTION
Addresses #2561 by setting lastChar on keydown events only when the key code describes an enter, return or tab key without modifiers.

This prevents lastChar from being set incorrectly on compound key events. E.g., lastChar is now not set to 'V' on a command-V keydown event. 

CC @redmunds
