### PR TITLE
Add support for Undo, Redo, Cut, Copy, Paste, and Select All from native menus

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -162,10 +162,10 @@
     ],
     "navigate.gotoJSLintError":  [
         {
-            "key": "Ctrl-J"
+            "key": "F2"
         },
         {
-            "key": "Ctrl-J",
+            "key": "Cmd-'",
             "platform": "mac"
         }
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -162,7 +162,7 @@
     ],
     "navigate.gotoJSLintError":  [
         {
-            "key": "F2"
+            "key": "F8"
         },
         {
             "key": "Cmd-'",

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -30,7 +30,13 @@
         "Ctrl-Z"
     ],
     "edit.redo": [
-        "Ctrl-Shift-Z"
+        {
+            "key": "Ctrl-Y"
+        },
+        {
+            "key": "Ctrl-Shift-Z",
+            "platform": "mac"
+        }
     ],
     "edit.cut": [
         "Ctrl-X"

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -26,6 +26,21 @@
     "file.quit":  [
         "Ctrl-Q"
     ],
+    "edit.undo": [
+        "Ctrl-Z"
+    ],
+    "edit.redo": [
+        "Ctrl-Shift-Z"
+    ],
+    "edit.cut": [
+        "Ctrl-X"
+    ],
+    "edit.copy": [
+        "Ctrl-C"
+    ],
+    "edit.paste": [
+        "Ctrl-V"
+    ],
     "edit.selectAll":  [
         "Ctrl-A"
     ],
@@ -69,18 +84,6 @@
         {
             "key": "Cmd-Alt-F",
             "platform": "mac"
-        }
-    ],
-    "edit.indent":  [
-        {
-            "key": "Indent",
-            "displayKey": "Tab"
-        }
-    ],
-    "edit.unindent":  [
-        {
-            "key": "Unindent",
-            "displayKey": "Shift-Tab"
         }
     ],
     "edit.duplicate":  [

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -160,6 +160,15 @@
     "navigate.gotoDefinition":  [
         "Ctrl-T"
     ],
+    "navigate.gotoJSLintError":  [
+        {
+            "key": "Ctrl-J"
+        },
+        {
+            "key": "Ctrl-J",
+            "platform": "mac"
+        }
+    ],
     "navigate.nextDoc":  [
         {
             "key": "Ctrl-Tab"

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -89,6 +89,7 @@ define(function (require, exports, module) {
     exports.NAVIGATE_SHOW_IN_FILE_TREE  = "navigate.showInFileTree";
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";
     exports.NAVIGATE_GOTO_DEFINITION    = "navigate.gotoDefinition";
+    exports.NAVIGATE_GOTO_JSLINT_ERROR  = "navigate.gotoJSLintError";
     exports.NAVIGATE_GOTO_LINE          = "navigate.gotoLine";
     exports.TOGGLE_QUICK_EDIT           = "navigate.toggleQuickEdit";
     exports.QUICK_EDIT_NEXT_MATCH       = "navigate.nextMatch";

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -936,6 +936,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.NAVIGATE_GOTO_LINE);
 
         menu.addMenuItem(Commands.NAVIGATE_GOTO_DEFINITION);
+        menu.addMenuItem(Commands.NAVIGATE_GOTO_JSLINT_ERROR);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC);

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -787,7 +787,6 @@ define(function (require, exports, module) {
                     console.error("addMenu() -- error: " + err + " when adding menu with ID: " + id);
                 } else {
                     // Make sure name is up to date
-                    console.log("setting menu " + id + " title to " + name);
                     brackets.app.setMenuTitle(id, name, function (err) {
                         if (err) {
                             console.error("setMenuTitle() -- error: " + err);

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -560,6 +560,15 @@ define(function (require, exports, module) {
             brackets.app.addMenuItem(this.id, name, commandID, bindingStr, position, relativeID, function (err) {
                 if (err) {
                     console.error("addMenuItem() -- error: " + err + " when adding command: " + commandID);
+                } else {
+                    // Make sure the name is up to date
+                    if (!menuItem.isDivider) {
+                        brackets.app.setMenuTitle(commandID, name, function (err) {
+                            if (err) {
+                                console.error("setMenuTitle() -- error: " + err);
+                            }
+                        });
+                    }
                 }
             });
             menuItem.isNative = true;
@@ -776,6 +785,14 @@ define(function (require, exports, module) {
             brackets.app.addMenu(name, id, position, relativeID, function (err) {
                 if (err) {
                     console.error("addMenu() -- error: " + err + " when adding menu with ID: " + id);
+                } else {
+                    // Make sure name is up to date
+                    console.log("setting menu " + id + " title to " + name);
+                    brackets.app.setMenuTitle(id, name, function (err) {
+                        if (err) {
+                            console.error("setMenuTitle() -- error: " + err);
+                        }
+                    });
                 }
             });
             return menu;

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -972,6 +972,13 @@ define(function (require, exports, module) {
          * Edit  menu
          */
         menu = addMenu(Strings.EDIT_MENU, AppMenuBar.EDIT_MENU);
+        menu.addMenuItem(Commands.EDIT_UNDO);
+        menu.addMenuItem(Commands.EDIT_REDO);
+        menu.addMenuDivider();
+        menu.addMenuItem(Commands.EDIT_CUT);
+        menu.addMenuItem(Commands.EDIT_COPY);
+        menu.addMenuItem(Commands.EDIT_PASTE);
+        menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_SELECT_ALL);
         menu.addMenuItem(Commands.EDIT_SELECT_LINE);
         menu.addMenuDivider();

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -447,7 +447,7 @@ define(function (require, exports, module) {
                 }
                 // Begin a new explicit session
                 _beginSession(editor);
-            } else if (_inSession(editor)) {
+            } else if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
                 hintList.handleKeyEvent(event);
             }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1019,6 +1019,16 @@ define(function (require, exports, module) {
         });
     };
     
+    /** Undo the last edit. */
+    Editor.prototype.undo = function () {
+        this._codeMirror.undo();
+    };
+    
+    /** Redo the last un-done edit. */
+    Editor.prototype.redo = function () {
+        this._codeMirror.redo();
+    };
+    
     /**
      * Shows or hides the editor within its parent. Does not force its ancestors to
      * become visible.

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -672,12 +672,12 @@ define(function (require, exports, module) {
         }
     }
 
-    function handleUndo() {
+    function handleUndoRedo(operation) {
         var editor = EditorManager.getFocusedEditor();
         var result = new $.Deferred();
         
         if (editor) {
-            editor.undo();
+            editor[operation]();
             result.resolve();
         } else {
             result.reject();
@@ -686,16 +686,12 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
+    function handleUndo() {
+        return handleUndoRedo("undo");
+    }
+
     function handleRedo() {
-        var editor = EditorManager.getFocusedEditor();
-        
-        if (editor) {
-            editor.redo();
-            return;
-        }
-        
-        // No editor, return a rejected promise so the system will handle the command
-        return (new $.Deferred()).reject().promise();
+        return handleUndoRedo("redo");
     }
 
     /**
@@ -719,8 +715,8 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_LINE_DOWN,      Commands.EDIT_LINE_DOWN,        moveLineDown);
     CommandManager.register(Strings.CMD_SELECT_LINE,    Commands.EDIT_SELECT_LINE,      selectLine);
 
-    CommandManager.register(Strings.CMD_UNDO,           Commands.EDIT_UNDO,             ignoreCommand);
-    CommandManager.register(Strings.CMD_REDO,           Commands.EDIT_REDO,             ignoreCommand);
+    CommandManager.register(Strings.CMD_UNDO,           Commands.EDIT_UNDO,             handleUndo);
+    CommandManager.register(Strings.CMD_REDO,           Commands.EDIT_REDO,             handleRedo);
     CommandManager.register(Strings.CMD_CUT,            Commands.EDIT_CUT,              ignoreCommand);
     CommandManager.register(Strings.CMD_COPY,           Commands.EDIT_COPY,             ignoreCommand);
     CommandManager.register(Strings.CMD_PASTE,          Commands.EDIT_PASTE,            ignoreCommand);

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -672,10 +672,36 @@ define(function (require, exports, module) {
         }
     }
 
+    function handleUndo() {
+        var editor = EditorManager.getFocusedEditor();
+        var result = new $.Deferred();
+        
+        if (editor) {
+            editor.undo();
+            result.resolve();
+        } else {
+            result.reject();
+        }
+        
+        return result.promise();
+    }
+
+    function handleRedo() {
+        var editor = EditorManager.getFocusedEditor();
+        
+        if (editor) {
+            editor.redo();
+            return;
+        }
+        
+        // No editor, return a rejected promise so the system will handle the command
+        return (new $.Deferred()).reject().promise();
+    }
+
     /**
-     * Special command handler that just ignores the command. This is used for Undo, Redo, Cut, Copy,
-     * Paste, and Select All. These menu items are handled natively, but need to be registered in our
-     * JavaScript code so the menu items can be created.
+     * Special command handler that just ignores the command. This is used for Cut, Copy, and Paste.
+     * These menu items are handled natively, but need to be registered in our JavaScript code so the 
+     * menu items can be created.
      */
     function ignoreCommand() {
         // Do nothing. The shell will call the native handler for the command.

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -671,6 +671,16 @@ define(function (require, exports, module) {
             editor.setSelection(from, to);
         }
     }
+
+    /**
+     * Special command handler that just ignores the command. This is used for Undo, Redo, Cut, Copy,
+     * Paste, and Select All. These menu items are handled natively, but need to be registered in our
+     * JavaScript code so the menu items can be created.
+     */
+    function ignoreCommand() {
+        // Do nothing. The shell will call the native handler for the command.
+        return (new $.Deferred()).reject().promise();
+    }
         
     // Register commands
     CommandManager.register(Strings.CMD_INDENT,         Commands.EDIT_INDENT,           indentText);
@@ -682,4 +692,10 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_LINE_UP,        Commands.EDIT_LINE_UP,          moveLineUp);
     CommandManager.register(Strings.CMD_LINE_DOWN,      Commands.EDIT_LINE_DOWN,        moveLineDown);
     CommandManager.register(Strings.CMD_SELECT_LINE,    Commands.EDIT_SELECT_LINE,      selectLine);
+
+    CommandManager.register(Strings.CMD_UNDO,           Commands.EDIT_UNDO,             ignoreCommand);
+    CommandManager.register(Strings.CMD_REDO,           Commands.EDIT_REDO,             ignoreCommand);
+    CommandManager.register(Strings.CMD_CUT,            Commands.EDIT_CUT,              ignoreCommand);
+    CommandManager.register(Strings.CMD_COPY,           Commands.EDIT_COPY,             ignoreCommand);
+    CommandManager.register(Strings.CMD_PASTE,          Commands.EDIT_PASTE,            ignoreCommand);
 });

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -243,18 +243,17 @@ define(function (require, exports, module) {
         setEnabled(!getEnabled());
     }
     
+    /** Command to go to the first JSLint Error */
+    function _handleGotoJSLintError() {
+        run();
+        if (_gotoFirstErrorFunction) {
+            _gotoFirstErrorFunction();
+        }
+    }
+    
     // Register command handlers
     CommandManager.register(Strings.CMD_JSLINT, Commands.TOGGLE_JSLINT, _handleToggleJSLint);
-    CommandManager.register(
-        Strings.CMD_JSLINT_FIRST_ERROR,
-        Commands.NAVIGATE_GOTO_JSLINT_ERROR,
-        function () {
-            run();
-            if (_gotoFirstErrorFunction) {
-                _gotoFirstErrorFunction();
-            }
-        }
-    );
+    CommandManager.register(Strings.CMD_JSLINT_FIRST_ERROR, Commands.NAVIGATE_GOTO_JSLINT_ERROR, _handleGotoJSLintError);
     
     // Init PreferenceStorage
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs);

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -249,6 +249,7 @@ define(function (require, exports, module) {
         Strings.CMD_JSLINT_FIRST_ERROR,
         Commands.NAVIGATE_GOTO_JSLINT_ERROR,
         function () {
+            run();
             if (_gotoFirstErrorFunction) {
                 _gotoFirstErrorFunction();
             }

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -72,6 +72,27 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @private
+     * @type {function()}
+     * Holds a pointer to the function that selects the first error in the 
+     * list. Stored when running JSLint and used by the "Go to First JSLint
+     * Error" command
+     */
+    var _gotoFirstErrorFunction = null;
+    
+    /**
+     * @private
+     * Enable or disable the "Go to First JSLint Error" command
+     * @param {boolean} gotoEnabled Whether it is enabled.
+     */
+    function _setGotoEnabled(gotoEnabled) {
+        CommandManager.get(Commands.NAVIGATE_GOTO_JSLINT_ERROR).setEnabled(gotoEnabled);
+        if (!gotoEnabled) {
+            _gotoFirstErrorFunction = null;
+        }
+    }
+    
+    /**
      * Run JSLint on the current document. Reports results to the main UI. Displays
      * a gold star when no errors are found.
      */
@@ -123,7 +144,7 @@ define(function (require, exports, module) {
                             .append(makeCell(item.evidence || ""))
                             .appendTo($errorTable);
                         
-                        $row.click(function () {
+                        var clickCallback = function () {
                             if ($selectedRow) {
                                 $selectedRow.removeClass("selected");
                             }
@@ -133,7 +154,11 @@ define(function (require, exports, module) {
                             var editor = EditorManager.getCurrentFullEditor();
                             editor.setCursorPos(item.line - 1, item.character - 1);
                             EditorManager.focusEditor();
-                        });
+                        };
+                        $row.click(clickCallback);
+                        if (i === 0) { // first result, so store callback for goto command
+                            _gotoFirstErrorFunction = clickCallback;
+                        }
                     }
                 });
 
@@ -149,10 +174,12 @@ define(function (require, exports, module) {
                 } else {
                     StatusBar.updateIndicator(module.id, true, "jslint-errors", StringUtils.format(Strings.JSLINT_ERRORS_INFORMATION, JSLINT.errors.length));
                 }
+                _setGotoEnabled(true);
             } else {
                 $lintResults.hide();
                 $goldStar.show();
                 StatusBar.updateIndicator(module.id, true, "jslint-valid", Strings.JSLINT_NO_ERRORS);
+                _setGotoEnabled(false);
             }
 
             PerfUtils.addMeasurement(perfTimerDOM);
@@ -163,6 +190,7 @@ define(function (require, exports, module) {
             $lintResults.hide();
             $goldStar.hide();
             StatusBar.updateIndicator(module.id, true, "jslint-disabled", Strings.JSLINT_DISABLED);
+            _setGotoEnabled(false);
         }
         
         EditorManager.resizeEditor();
@@ -217,6 +245,15 @@ define(function (require, exports, module) {
     
     // Register command handlers
     CommandManager.register(Strings.CMD_JSLINT, Commands.TOGGLE_JSLINT, _handleToggleJSLint);
+    CommandManager.register(
+        Strings.CMD_JSLINT_FIRST_ERROR,
+        Commands.NAVIGATE_GOTO_JSLINT_ERROR,
+        function () {
+            if (_gotoFirstErrorFunction) {
+                _gotoFirstErrorFunction();
+            }
+        }
+    );
     
     // Init PreferenceStorage
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaultPrefs);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -211,6 +211,7 @@ define({
     "CMD_QUICK_OPEN"                      : "Quick Open",
     "CMD_GOTO_LINE"                       : "Go to Line",
     "CMD_GOTO_DEFINITION"                 : "Go to Definition",
+    "CMD_JSLINT_FIRST_ERROR"              : "Go to First JSLint Error",
     "CMD_TOGGLE_QUICK_EDIT"               : "Quick Edit",
     "CMD_QUICK_EDIT_PREV_MATCH"           : "Previous Match",
     "CMD_QUICK_EDIT_NEXT_MATCH"           : "Next Match",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -177,6 +177,11 @@ define({
 
     // Edit menu commands
     "EDIT_MENU"                           : "Edit",
+    "CMD_UNDO"                            : "Undo",
+    "CMD_REDO"                            : "Redo",
+    "CMD_CUT"                             : "Cut",
+    "CMD_COPY"                            : "Copy",
+    "CMD_PASTE"                           : "Paste",
     "CMD_SELECT_ALL"                      : "Select All",
     "CMD_SELECT_LINE"                     : "Select Line",
     "CMD_FIND"                            : "Find",


### PR DESCRIPTION
**NOTE: This pull request depends on adobe/brackets-shell#183**

These edit commands are handled differently than other menu items.

First, they are sent to the JavaScript code. If the JavaScript code does not handle the command, the shell calls the browser versions of these commands. This way, commands like Undo can be overridden by CodeMirror when an editor has focus, but fall through to the default implementation when a text field has focus.

This pull request also resets the name whenever a new menu or item is created. This makes the menus load correctly when reloading Brackets after changing the language.
