### PR TITLE
mac menu cleanup

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -98,12 +98,6 @@
     "edit.deletelines":  [
         "Ctrl-Shift-D"
     ],
-    "edit.indent": [
-        "Tab"
-    ],
-    "edit.unindent": [
-        "Shift-Tab"
-    ],
     "edit.lineUp":  [
         {
             "key": "Ctrl-Shift-Up",

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -34,7 +34,7 @@
             "key": "Ctrl-Y"
         },
         {
-            "key": "Ctrl-Shift-Z",
+            "key": "Cmd-Shift-Z",
             "platform": "mac"
         }
     ],
@@ -97,6 +97,12 @@
     ],
     "edit.deletelines":  [
         "Ctrl-Shift-D"
+    ],
+    "edit.indent": [
+        "Tab"
+    ],
+    "edit.unindent": [
+        "Shift-Tab"
     ],
     "edit.lineUp":  [
         {

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -982,8 +982,12 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW);
         menu.addMenuItem(Commands.FILE_LIVE_HIGHLIGHT);
         menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.FILE_QUIT);
+        
+        // supress redundant quit menu item on mac
+        if (brackets.platform !== "mac") {
+            menu.addMenuDivider();
+            menu.addMenuItem(Commands.FILE_QUIT);
+        }
 
         /*
          * Edit  menu

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -984,7 +984,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
         
         // supress redundant quit menu item on mac
-        if (brackets.platform !== "mac") {
+        if (brackets.platform !== "mac" && !brackets.inBrowser) {
             menu.addMenuDivider();
             menu.addMenuItem(Commands.FILE_QUIT);
         }


### PR DESCRIPTION
- Mac: Fix redo shortcut
- Mac: Remove redundant quit menu item
- All: Add shortcuts for indent/unindent
