### PR TITLE
Spanish strings for sprint19

### DIFF
--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -177,6 +177,11 @@ define({
 
     // Edit menu commands
     "EDIT_MENU"                           : "Edición",
+    "CMD_UNDO"                            : "Deshacer",
+    "CMD_REDO"                            : "Rehacer",
+    "CMD_CUT"                             : "Cortar",
+    "CMD_COPY"                            : "Copiar",
+    "CMD_PASTE"                           : "Pegar",
     "CMD_SELECT_ALL"                      : "Seleccionar todo",
     "CMD_SELECT_LINE"                     : "Seleccionar línea",
     "CMD_FIND"                            : "Buscar",
@@ -211,6 +216,7 @@ define({
     "CMD_QUICK_OPEN"                      : "Apertura rápida",
     "CMD_GOTO_LINE"                       : "Ir a línea",
     "CMD_GOTO_DEFINITION"                 : "Ir a definición",
+    "CMD_JSLINT_FIRST_ERROR"              : "Ir al primer error de JSLint",
     "CMD_TOGGLE_QUICK_EDIT"               : "Edición rápida",
     "CMD_QUICK_EDIT_PREV_MATCH"           : "Coincidencia anterior",
     "CMD_QUICK_EDIT_NEXT_MATCH"           : "Coincidencia siguiente",


### PR DESCRIPTION
New spanish strings for sprint 19, menu commands and go to jslint error.
