### PR TITLE
Fix issue #2306 (Recent projects close arrow fail to close without mouse move)

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
      */
     function renderDelete() {
         return $("<div id='recent-folder-delete' class='trash-icon'></div>")
-            .click(function (e) {
+            .mouseup(function (e) {
                 // Don't let the click bubble upward.
                 e.stopPropagation();
                 


### PR DESCRIPTION
This is a possible fix for issue #2306. It changes `click` to `mouseup` as the event to close an entry in the list of recent projects.

It seems that jquery `click` event is not triggered if the mouse is already over the svg element when the old one is removed and the new one rendered, but `mouseup` is.

I'd say it has something to do with the lack of `mouseenter`, but I haven't been able to replicate it anywhere else outside this.
