### PR TITLE
More createMockEditor() cleanup

### DIFF
--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -336,6 +336,11 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
+
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
+            });
             
             it("should find the selector at a document pos", function () {
                 var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 9, ch: 0});
@@ -372,6 +377,11 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
+
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
+            });
             
             it("should ignore rules inside comments", function () {
                 var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 45, ch: 22});
@@ -398,6 +408,11 @@ define(function (require, exports, module) {
                 runs(function () {
                     editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
+            });
+
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
             });
             
             it("should find a simple pseudo selector", function () {
@@ -431,6 +446,11 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
             });
+
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
+            });
             
             it("should find pseudo selectors", function () {
                 var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 72, ch: 0});
@@ -462,6 +482,11 @@ define(function (require, exports, module) {
                 runs(function () {
                     editor = SpecRunnerUtils.createMockEditor(this.fileCssContent, "css").editor;
                 });
+            });
+
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
             });
             
             it("should find selector when pos is at beginning of selector name", function () {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -502,6 +502,10 @@ define(function (require, exports, module) {
             afterEach(function () {
                 LiveDevelopmentModule.config = liveDevelopmentConfig;
                 InspectorModule.config = inspectorConfig;
+                
+                SpecRunnerUtils.destroyMockEditor(testDocument);
+                testDocument = null;
+                testEditor = null;
             });
             
             it("should toggle the highlight via a command", function () {


### PR DESCRIPTION
I found some more places in the unit tests where calls to createMockEditor() did not have matching calls to destroyMockEditor(). You can see evidence of this by doing this:
1. Debug Run > Tests
2. Run CSSUtils tests
3. Run Live Development tests

Results
Notice that Spec Runner window now has a scrollbar that indicates the window grew in height. Scroll down to see Dom objects left behind. Or open Dev Tools Elements inspector to see the &lt;div id="mock-editor-holder"&gt; objects.
