### PR TITLE
Create files on collapsed empty folders (#2085)

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -660,6 +660,13 @@ define(function (require, exports, module) {
                     
                     treeNode.removeClass("jstree-leaf jstree-closed jstree-open")
                             .addClass(classToAdd);
+                    
+                    // This is a workaround for a part of issue #2085, where the file creation process
+                    // depends on the open_node.jstree event being triggered, which doesn't happen on 
+                    // empty folders
+                    if (!wasNodeOpen) {
+                        treeNode.trigger("open_node.jstree");
+                    }
                 }
             },
             function (error) {


### PR DESCRIPTION
This is a followup on issue #2085, to fix an issue where the input to create new files won't work on collapsed empty folders.

It triggers a `open_node.jstree` when an empty folder is opened. 
