### PR TITLE
Don't execute commands from the shell when a modal dialog is open.

### DIFF
--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -39,6 +39,11 @@ define(function (require, exports, module) {
      * calling Brackets commands from the native shell.
      */
     function executeCommand(eventName) {
+        // Temporary fix for #2616 - don't execute the command if a modal dialog is open.
+        // This should really be fixed with proper menu enabling.
+        if ($(".modal.instance").length) {
+            return false;
+        }
         var promise = CommandManager.execute(eventName);
         return (promise && promise.state() === "rejected") ? false : true;
     }


### PR DESCRIPTION
This is a temporary quick fix for #2616 

If a modal HTML dialog is open, don't execute commands that originate from the shell. The proper long-term solution is actually disabling command when a modal dialog is open, but that is a much bigger effort that should be a user story.
