### PR TITLE
Fixes #2496 (simple caching to speed up quickopen/go to definition)

### DIFF
--- a/src/extensions/default/QuickOpenCSS/main.js
+++ b/src/extensions/default/QuickOpenCSS/main.js
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        matcher.basicMatchSort(filteredList);
+        QuickOpen.basicMatchSort(filteredList);
 
         return filteredList;
     }

--- a/src/extensions/default/QuickOpenCSS/main.js
+++ b/src/extensions/default/QuickOpenCSS/main.js
@@ -36,29 +36,19 @@ define(function (require, exports, module) {
 
 
     /**
-     * Contains a list of information about selectors for a single document. This array is populated
+     * Returns a list of information about selectors for a single document. This array is populated
      * by createSelectorList()
-     * @type {?Array.<FileLocation>}
+     * @return {?Array.<FileLocation>}
      */
-    var selectorList = null;
-
-    /** clears selectorList */
-    function done() {
-        selectorList = null;
-    }
-
-    // create function list and caches it in FileIndexMangager
     function createSelectorList() {
         var doc = DocumentManager.getCurrentDocument();
         if (!doc) {
             return;
         }
 
-        if (!selectorList) {
-            selectorList = [];
-            var docText = doc.getText();
-            selectorList = CSSUtils.extractAllSelectors(docText);
-        }
+        var selectorList = [];
+        var docText = doc.getText();
+        return CSSUtils.extractAllSelectors(docText);
     }
 
 
@@ -66,13 +56,17 @@ define(function (require, exports, module) {
      * @param {string} query what the user is searching for
      * @returns {Array.<SearchResult>} sorted and filtered results that match the query
      */
-    function search(query) {
-        createSelectorList();
+    function search(query, matcher) {
+        var selectorList = matcher.selectorList;
+        if (!selectorList) {
+            selectorList = createSelectorList();
+            matcher.selectorList = selectorList;
+        }
         query = query.slice(query.indexOf("@") + 1, query.length);
         
         // Filter and rank how good each match is
         var filteredList = $.map(selectorList, function (itemInfo) {
-            var searchResult = QuickOpen.stringMatch(itemInfo.selector, query);
+            var searchResult = matcher.match(itemInfo.selector, query);
             if (searchResult) {
                 searchResult.selectorInfo = itemInfo;
             }
@@ -80,7 +74,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        QuickOpen.basicMatchSort(filteredList);
+        matcher.basicMatchSort(filteredList);
 
         return filteredList;
     }
@@ -123,7 +117,7 @@ define(function (require, exports, module) {
         {
             name: "CSS Selectors",
             fileTypes: ["css"],
-            done: done,
+            done: function () {},
             search: search,
             match: match,
             itemFocus: itemFocus,

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -52,45 +52,36 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Contains a list of information about ID's for a single document. This array is populated
+     * Returns a list of information about ID's for a single document. This array is populated
      * by createIDList()
      * @type {?Array.<FileLocation>}
      */
-    var idList = null;
-
-    /** clears idList */
-    function done() {
-        idList = null;
-    }
-
-    // create list of ids found in html file
     function createIDList() {
         var doc = DocumentManager.getCurrentDocument();
         if (!doc) {
             return;
         }
+        
+        var idList = [];
+        var docText = doc.getText();
+        var lines = docText.split("\n");
 
-        if (!idList) {
-            idList = [];
-            var docText = doc.getText();
-            var lines = docText.split("\n");
-
-            var regex = new RegExp(/\s+id\s*?=\s*?["'](.*?)["']/gi);
-            var id, chFrom, chTo, i, line;
-            for (i = 0; i < lines.length; i++) {
-                line = lines[i];
-                var info;
-                while ((info = regex.exec(line)) !== null) {
-                    id = info[1];
-                    // TODO: this doesn't handle id's that share the 
-                    // same portion of a name on the same line or when
-                    // the id and value are on different lines
-                    chFrom = line.indexOf(id);
-                    chTo = chFrom + id.length;
-                    idList.push(new FileLocation(null, i, chFrom, chTo, id));
-                }
+        var regex = new RegExp(/\s+id\s*?=\s*?["'](.*?)["']/gi);
+        var id, chFrom, chTo, i, line;
+        for (i = 0; i < lines.length; i++) {
+            line = lines[i];
+            var info;
+            while ((info = regex.exec(line)) !== null) {
+                id = info[1];
+                // TODO: this doesn't handle id's that share the 
+                // same portion of a name on the same line or when
+                // the id and value are on different lines
+                chFrom = line.indexOf(id);
+                chTo = chFrom + id.length;
+                idList.push(new FileLocation(null, i, chFrom, chTo, id));
             }
         }
+        return idList;
     }
 
 
@@ -98,13 +89,17 @@ define(function (require, exports, module) {
      * @param {string} query what the user is searching for
      * @returns {Array.<SearchResult>} sorted and filtered results that match the query
      */
-    function search(query) {
-        createIDList();
+    function search(query, matcher) {
+        var idList = matcher.idList;
+        if (!idList) {
+            idList = createIDList();
+            matcher.idList = idList;
+        }
         query = query.slice(query.indexOf("@") + 1, query.length);
         
         // Filter and rank how good each match is
         var filteredList = $.map(idList, function (fileLocation) {
-            var searchResult = QuickOpen.stringMatch(fileLocation.id, query);
+            var searchResult = matcher.match(fileLocation.id, query);
             if (searchResult) {
                 searchResult.fileLocation = fileLocation;
             }
@@ -112,7 +107,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        QuickOpen.basicMatchSort(filteredList);
+        matcher.basicMatchSort(filteredList);
 
         return filteredList;
     }
@@ -155,7 +150,7 @@ define(function (require, exports, module) {
         {
             name: "html ids",
             fileTypes: ["html"],
-            done: done,
+            done: function () {},
             search: search,
             match: match,
             itemFocus: itemFocus,

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        matcher.basicMatchSort(filteredList);
+        QuickOpen.basicMatchSort(filteredList);
 
         return filteredList;
     }

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -53,18 +53,17 @@ define(function (require, exports, module) {
     }
 
     function createFunctionList() {
-        /**
-         * Contains a list of information about functions for a single document. This array is populated
-         * by createFunctionList()
-         * @type {?Array.<FileLocation>}
-         */
-        var functionList = null;
         var doc = DocumentManager.getCurrentDocument();
         if (!doc) {
             return;
         }
 
-        functionList = [];
+        /**
+         * Contains a list of information about functions for a single document. This array is populated
+         * by createFunctionList()
+         * @type {?Array.<FileLocation>}
+         */
+        var functionList = [];
         var docText = doc.getText();
         var lines = docText.split("\n");
         var functions = JSUtils.findAllMatchingFunctionsInText(docText, "*");

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        QuickOpen.basicMatchSort(filteredList);
+        matcher.basicMatchSort(filteredList);
 
         return filteredList;
     }

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -52,17 +52,17 @@ define(function (require, exports, module) {
         this.functionName = functionName;
     }
 
+    /**
+     * Contains a list of information about functions for a single document.
+     *
+     * @return {?Array.<FileLocation>}
+     */
     function createFunctionList() {
         var doc = DocumentManager.getCurrentDocument();
         if (!doc) {
             return;
         }
 
-        /**
-         * Contains a list of information about functions for a single document. This array is populated
-         * by createFunctionList()
-         * @type {?Array.<FileLocation>}
-         */
         var functionList = [];
         var docText = doc.getText();
         var lines = docText.split("\n");
@@ -79,6 +79,7 @@ define(function (require, exports, module) {
 
     /**
      * @param {string} query what the user is searching for
+     * @param {StringMatch.StringMatcher} matcher object that caches search-in-progress data
      * @returns {Array.<SearchResult>} sorted and filtered results that match the query
      */
     function search(query, matcher) {
@@ -99,7 +100,7 @@ define(function (require, exports, module) {
         });
         
         // Sort based on ranking & basic alphabetical order
-        matcher.basicMatchSort(filteredList);
+        QuickOpen.basicMatchSort(filteredList);
 
         return filteredList;
     }
@@ -143,8 +144,8 @@ define(function (require, exports, module) {
         {
             name: "JavaScript functions",
             fileTypes: ["js"],
-            search: search,
             done: function () {},
+            search: search,
             match: match,
             itemFocus: itemFocus,
             itemSelect: itemSelect,

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -166,8 +166,9 @@ define(function (require, exports, module) {
         this._filterCallback           = this._filterCallback.bind(this);
         this._resultsFormatterCallback = this._resultsFormatterCallback.bind(this);
         
-        this.filenameMatcher           = new StringMatch.StringMatcher();
-        this.matchers                  = {};
+        // StringMatchers that cache in-progress query data.
+        this._filenameMatcher           = new StringMatch.StringMatcher();
+        this._matchers                  = {};
     }
 
     function _filenameFromPath(path, includeExtension) {
@@ -517,10 +518,12 @@ define(function (require, exports, module) {
                 var extensionMatch = plugin.fileTypes.indexOf(extension) !== -1 || plugin.fileTypes.length === 0;
                 if (extensionMatch &&  plugin.match && plugin.match(query)) {
                     currentPlugin = plugin;
-                    var matcher = this.matchers[currentPlugin.name];
+                    
+                    // Look up the StringMatcher for this plugin.
+                    var matcher = this._matchers[currentPlugin.name];
                     if (!matcher) {
                         matcher = new StringMatch.StringMatcher();
-                        this.matchers[currentPlugin.name] = matcher;
+                        this._matchers[currentPlugin.name] = matcher;
                     }
                     return plugin.search(query, matcher);
                 }
@@ -529,7 +532,7 @@ define(function (require, exports, module) {
         
         // No matching plugin: use default file search mode
         currentPlugin = null;
-        return searchFileList(query, this.filenameMatcher);
+        return searchFileList(query, this._filenameMatcher);
     };
 
     /**

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
      * @param { name: string, 
      *          fileTypes:Array.<string>,
      *          done: function(),
-     *          search: function(string):Array.<SearchResult|string>,
+     *          search: function(string, ?StringMatch.StringMatcher):Array.<SearchResult|string>,
      *          match: function(string):boolean,
      *          itemFocus: function(?SearchResult|string),
      *          itemSelect: funciton(?SearchResult|string),
@@ -116,11 +116,11 @@ define(function (require, exports, module) {
      *
      * Parameter Documentation:
      *
-     * name - plug-in name
+     * name - plug-in name, **must be unique**
      * fileTypes - file types array. Example: ["js", "css", "txt"]. An empty array
      *      indicates all file types.
      * done - called when quick open is complete. Plug-in should clear its internal state.
-     * search - takes a query string and returns an array of strings that match the query.
+     * search - takes a query string and optional StringMatcher and returns an array of strings that match the query.
      * match - takes a query string and returns true if this plug-in wants to provide
      *      results for this query.
      * itemFocus - performs an action when a result has been highlighted (via arrow keys, mouseover, etc.).
@@ -170,6 +170,23 @@ define(function (require, exports, module) {
         this._filenameMatcher           = new StringMatch.StringMatcher();
         this._matchers                  = {};
     }
+    
+    /**
+     * Handles caching of filename search information for the lifetime of a 
+     * QuickNavigateDialog (a single search until the dialog is dismissed)
+     *
+     * @type {StringMatch.StringMatcher}
+     */
+    QuickNavigateDialog.prototype._filenameMatcher = null;
+    
+    /**
+     * StringMatcher caches for each QuickOpen plugin that keep track of search
+     * information for the lifetime of a QuickNavigateDialog (a single search
+     * until the dialog is dismissed)
+     *
+     * @type {Object.<string, StringMatch.StringMatcher>}
+     */
+    QuickNavigateDialog.prototype._matchers = null;
 
     function _filenameFromPath(path, includeExtension) {
         var end;
@@ -451,7 +468,7 @@ define(function (require, exports, module) {
                 // a stale query. Guard from that by checking that filter text hasn't changed while we were waiting:
                 if (!queryIsStale(query)) {
                     // We're still the current query. Synchronously re-run the search call and resolve with its results
-                    asyncResult.resolve(searchFileList(matcher, query));
+                    asyncResult.resolve(searchFileList(query, matcher));
                 } else {
                     asyncResult.reject();
                 }

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
      * @param { name: string, 
      *          fileTypes:Array.<string>,
      *          done: function(),
-     *          search: function(string, ?StringMatch.StringMatcher):Array.<SearchResult|string>,
+     *          search: function(string, !StringMatch.StringMatcher):Array.<SearchResult|string>,
      *          match: function(string):boolean,
      *          itemFocus: function(?SearchResult|string),
      *          itemSelect: funciton(?SearchResult|string),
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
      * fileTypes - file types array. Example: ["js", "css", "txt"]. An empty array
      *      indicates all file types.
      * done - called when quick open is complete. Plug-in should clear its internal state.
-     * search - takes a query string and optional StringMatcher and returns an array of strings that match the query.
+     * search - takes a query string and a StringMatcher (the use of which is optional but can speed up your searches) and returns an array of strings that match the query.
      * match - takes a query string and returns true if this plug-in wants to provide
      *      results for this query.
      * itemFocus - performs an action when a result has been highlighted (via arrow keys, mouseover, etc.).

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -809,11 +809,6 @@ define(function (require, exports, module) {
         return result;
     };
     
-    // Add the sorting functions to StringMatcher for convenience.
-    // (This will eliminate QuickOpen plugins importing this functions from QuickOpen.)
-    StringMatcher.prototype.basicMatchSort = basicMatchSort;
-    StringMatcher.prototype.multiFieldSort = multiFieldSort;
-    
     exports._findSpecialCharacters  = findSpecialCharacters;
     exports._wholeStringSearch      = _wholeStringSearch;
     exports._lastSegmentSearch      = _lastSegmentSearch;

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -592,5 +592,44 @@ define(function (require, exports, module) {
                 expect(result.scoreDebug.lastSegment).toBeGreaterThan(0);
             });
         });
+        
+        describe("StringMatcher", function () {
+            it("should manage its caches properly", function () {
+                this.addMatchers({
+                    toBeInCache: function (matcher, cacheName) {
+                        var value = matcher[cacheName][this.actual];
+                        var notText = this.isNot ? " not" : "";
+                        
+                        this.message = function () {
+                            return "Expected " + cacheName + " to" + notText + " contain key " + this.actual;
+                        };
+                        
+                        return value !== undefined;
+                    }
+                });
+                
+                var matcher = new StringMatch.StringMatcher();
+                expect(matcher._noMatchCache).toEqual({});
+                expect(matcher._specialsCache).toEqual({});
+                
+                matcher.match("test/spec/LiveDevelopment-test.js", "spec/live");
+                expect("test/spec/LiveDevelopment-test.js").toBeInCache(matcher, "_specialsCache");
+                expect("test/spec/LiveDevelopment-test.js").not.toBeInCache(matcher, "_noMatchCache");
+                
+                matcher.match("foo", "spec/live");
+                expect("foo").toBeInCache(matcher, "_specialsCache");
+                expect("foo").toBeInCache(matcher, "_noMatchCache");
+                
+                matcher.match("test/spec/LiveDevelopment-test.js", "spec/lived");
+                // verify that the noMatchCache is still populated
+                expect("foo").toBeInCache(matcher, "_noMatchCache");
+                
+                // a shorter/different string should invalidate the noMatchCache
+                // but not the specialsCache
+                matcher.match("test/spec/LiveDevelopment-test.js", "spec/liv");
+                expect("foo").toBeInCache(matcher, "_specialsCache");
+                expect("foo").not.toBeInCache(matcher, "_noMatchCache");
+            });
+        });
     });
 });


### PR DESCRIPTION
Improves the speed of quickopen/go to definition #2496 by adding simple caching for StringMatch and in the go to definition extensions. Take a look at go to definition for codemirror.js with the devtools open and you'll see the biggest improvement, but this change does just generally make quickopen and goto definition snappier.
