### PR TITLE
#2628 - CSS hints insert rather than replace

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -137,11 +137,11 @@ define(function (require, exports, module) {
             cursor = this.editor.getCursorPos(),
             closure = "",
             start = {line: -1, ch: -1},
-            end = {line: -1, ch: -1},
-            keepHints = true;
+            keepHints = false;
         
         if (this.info.context === CSSUtils.PROP_NAME) {
             closure = ":";
+            keepHints = true;
         } else if (this.info.context === CSSUtils.PROP_VALUE) {
             closure = ";";
         } else {
@@ -150,12 +150,11 @@ define(function (require, exports, module) {
         
         hint = hint + closure;
         
-        start.line = end.line = cursor.line;
-        start.ch = cursor.ch - offset;
-        end.ch = start.ch + hint.length;
+        start.line = cursor.line;
+        start.ch = cursor.ch;
         
-        this.editor.document.replaceRange(hint, start, end);
-        
+        this.editor.document.replaceRange(hint.substr(offset), start);
+
         return keepHints;
     };
     


### PR DESCRIPTION
Straight forward, remove the end parameter to replaceRange so it inserts instead. Also minor refactor to the `keepHints` return value, causing a new hint list to appear only after `:` and not `;` as noted in #2627. I'd vote to keep that one open as I agree with @njx that this is a pretty narrow 'fix' and a more general solution would be nicer for that issue.
