### PR TITLE
Simple fix to make the experimental features of Live Development work with the latest Chrome version

### DIFF
--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -88,7 +88,7 @@ define(function GotoAgent(require, exports, module) {
             var target = {};
             var url = rule.sourceURL;
             url += ":" + rule.style.range.start;
-            var name = rule.selectorText;
+            var name = rule.selectorList.text;
             var file = _fileFromURL(url);
             targets.push({"type": "css", "url": url, "name": name, "file": file});
         }
@@ -130,7 +130,7 @@ define(function GotoAgent(require, exports, module) {
                 _makeJSTarget(targets, trace.callFrames[0]);
             }
             for (i in res.matchedCSSRules.reverse()) {
-                _makeCSSTarget(targets, res.matchedCSSRules[i]);
+                _makeCSSTarget(targets, res.matchedCSSRules[i].rule);
             }
             RemoteAgent.call("showGoto", targets);
         });


### PR DESCRIPTION
This has no effect on Brackets with disabled experimental features.
