### PR TITLE
Add support for opening files at startup.

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -218,6 +218,15 @@ define(function (require, exports, module) {
                     
                     PerfUtils.addMeasurement("Application Startup");
                 });
+                
+                // See if any startup files were passed to the application
+                if (brackets.app.getPendingFilesToOpen) {
+                    brackets.app.getPendingFilesToOpen(function (err, files) {
+                        files.forEach(function (filename) {
+                            CommandManager.execute(Commands.FILE_OPEN, { fullPath: filename });
+                        });
+                    });
+                }
             });
         });
         


### PR DESCRIPTION
**NOTE: Requires adobe/brackets-shell#190**

Add support for opening files at launch time. The brackets-shell code is required for this code to function, but the code is written so that it will silently fail if the brackets-shell API is not present.
