### PR TITLE
Fix sizing and scrolling issues from latest upstream-master

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -613,9 +613,6 @@ define(function (require, exports, module) {
             }
 
             $(self).triggerHandler("scroll", [self]);
-        
-            // notify all inline widgets of a position change
-            self._fireWidgetOffsetTopChanged(self.getFirstVisibleLine() - 1);
         });
 
         // Convert CodeMirror onFocus events to EditorManager activeEditorChanged
@@ -627,6 +624,10 @@ define(function (require, exports, module) {
         this._codeMirror.on("blur", function () {
             self._focused = false;
             // EditorManager only cares about other Editors gaining focus, so we don't notify it of anything here
+        });
+
+        this._codeMirror.on("update", function (instance) {
+            $(self).triggerHandler("update", [self]);
         });
     };
     
@@ -860,9 +861,6 @@ define(function (require, exports, module) {
             {collapsed: true, inclusiveLeft: true, inclusiveRight: true}
         );
         
-        // when this line is hidden, notify all following inline widgets of a position change
-        this._fireWidgetOffsetTopChanged(from);
-        
         return value;
     };
 
@@ -948,9 +946,6 @@ define(function (require, exports, module) {
 
         // Callback to widget once parented to the editor
         inlineWidget.onAdded();
-        
-        // once this widget is added, notify all following inline widgets of a position change
-        this._fireWidgetOffsetTopChanged(pos.line);
     };
     
     /**
@@ -975,9 +970,6 @@ define(function (require, exports, module) {
         this._codeMirror.removeLineWidget(inlineWidget.info);
         this._removeInlineWidgetInternal(inlineWidget);
         inlineWidget.onClosed();
-        
-        // once this widget is removed, notify all following inline widgets of a position change
-        this._fireWidgetOffsetTopChanged(lineNum);
     };
     
     /**
@@ -1051,7 +1043,8 @@ define(function (require, exports, module) {
     Editor.prototype.setInlineWidgetHeight = function (inlineWidget, height, ensureVisible) {
         var self = this,
             node = inlineWidget.htmlContent,
-            oldHeight = (node && $(node).height()) || 0;
+            oldHeight = (node && $(node).height()) || 0,
+            changed = (oldHeight !== height);
         
         $(node).height(height);
 
@@ -1061,7 +1054,9 @@ define(function (require, exports, module) {
         }
 
         // notify CodeMirror for the height change
-        inlineWidget.info.changed();
+        if (changed) {
+            inlineWidget.info.changed();
+        }
 
         if (ensureVisible) {
             var offset = $(node).offset(), // offset relative to document
@@ -1075,12 +1070,6 @@ define(function (require, exports, module) {
                 bottom: offset.top + height - scrollerTop
             });
         }
-        
-        // update position for all following inline editors
-        if (oldHeight !== height) {
-            var lineNum = this._getInlineWidgetLineNumber(inlineWidget);
-            this._fireWidgetOffsetTopChanged(lineNum);
-        }
     };
     
     /**
@@ -1091,25 +1080,6 @@ define(function (require, exports, module) {
      */
     Editor.prototype._getInlineWidgetLineNumber = function (inlineWidget) {
         return this._codeMirror.getLineNumber(inlineWidget.info.line);
-    };
-    
-    /**
-     * @private
-     * Fire "offsetTopChanged" events when inline editor positions change due to
-     * height changes of other inline editors.
-     * @param {!InlineWidget} inlineWidget 
-     */
-    Editor.prototype._fireWidgetOffsetTopChanged = function (lineNum) {
-        var self = this,
-            otherLineNum;
-        
-        this.getInlineWidgets().forEach(function (other) {
-            otherLineNum = self._getInlineWidgetLineNumber(other);
-            
-            if (otherLineNum > lineNum) {
-                $(other).triggerHandler("offsetTopChanged");
-            }
-        });
     };
     
     /** Gives focus to the editor control */
@@ -1135,11 +1105,6 @@ define(function (require, exports, module) {
         this._codeMirror.refresh();
         if (restoreFocus) {
             focusedItem.focus();
-        }
-        if (handleResize) {
-            // If the editor has been resized, the position of inline widgets relative to the
-            // browser window might have changed.
-            this._fireWidgetOffsetTopChanged(0);
         }
     };
     

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1044,22 +1044,19 @@ define(function (require, exports, module) {
         var self = this,
             node = inlineWidget.htmlContent,
             oldHeight = (node && $(node).height()) || 0,
-            changed = (oldHeight !== height);
+            changed = (oldHeight !== height)
+            isAttached = inlineWidget.info !== undefined;
 
         if (changed) {
             $(node).height(height);
+
+            if (isAttached) {
+                // Notify CodeMirror for the height change
+                inlineWidget.info.changed();
+            }
         }
 
-        // Check if the widget is attached to the host editor
-        if (changed && inlineWidget.info !== undefined) {
-            // Notify CodeMirror for the height change
-            inlineWidget.info.changed();
-        } else {
-            // Do nothing if not attached to host editor
-            return;
-        }
-
-        if (ensureVisible) {
+        if (ensureVisible && isAttached) {
             var offset = $(node).offset(), // offset relative to document
                 position = $(node).position(), // position within parent linespace
                 scrollerTop = self.getVirtualScrollAreaTop();

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1064,20 +1064,16 @@ define(function (require, exports, module) {
         inlineWidget.info.changed();
 
         if (ensureVisible) {
-            // FIXME (issue #2515): addLineWidget() async updates the scroll
-            // position if the widget is above the viewport.
-            window.setTimeout(function () {
-                var offset = $(node).offset(), // offset relative to document
-                    position = $(node).position(), // position within parent linespace
-                    scrollerTop = self.getVirtualScrollAreaTop();
+            var offset = $(node).offset(), // offset relative to document
+                position = $(node).position(), // position within parent linespace
+                scrollerTop = self.getVirtualScrollAreaTop();
 
-                self._codeMirror.scrollIntoView({
-                    left: position.left,
-                    top: offset.top - scrollerTop,
-                    right: position.left, // don't try to make the right edge visible
-                    bottom: offset.top + height - scrollerTop
-                });
-            }, 0);
+            self._codeMirror.scrollIntoView({
+                left: position.left,
+                top: offset.top - scrollerTop,
+                right: position.left, // don't try to make the right edge visible
+                bottom: offset.top + height - scrollerTop
+            });
         }
         
         // update position for all following inline editors

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1051,7 +1051,7 @@ define(function (require, exports, module) {
         }
 
         // Check if the widget is attached to the host editor
-        if (inlineWidget.info !== undefined) {
+        if (changed && inlineWidget.info !== undefined) {
             // Notify CodeMirror for the height change
             inlineWidget.info.changed();
         } else {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1045,17 +1045,18 @@ define(function (require, exports, module) {
             node = inlineWidget.htmlContent,
             oldHeight = (node && $(node).height()) || 0,
             changed = (oldHeight !== height);
-        
-        $(node).height(height);
 
-        // Check if the widget is attached to the host editor
-        if (!inlineWidget.info) {
-            return;
+        if (changed) {
+            $(node).height(height);
         }
 
-        // notify CodeMirror for the height change
-        if (changed) {
+        // Check if the widget is attached to the host editor
+        if (inlineWidget.info !== undefined) {
+            // Notify CodeMirror for the height change
             inlineWidget.info.changed();
+        } else {
+            // Do nothing if not attached to host editor
+            return;
         }
 
         if (ensureVisible) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1044,7 +1044,7 @@ define(function (require, exports, module) {
         var self = this,
             node = inlineWidget.htmlContent,
             oldHeight = (node && $(node).height()) || 0,
-            changed = (oldHeight !== height)
+            changed = (oldHeight !== height),
             isAttached = inlineWidget.info !== undefined;
 
         if (changed) {

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -153,10 +153,16 @@ define(function (require, exports, module) {
      *  editor is constructed and added to the DOM
      */
     InlineTextEditor.prototype.onAdded = function () {
+        var self = this;
+
         InlineTextEditor.prototype.parentClass.onAdded.apply(this, arguments);
         
         this.editors.forEach(function (editor) {
             editor.refresh();
+        });
+
+        CodeMirror.on(this.info, "redraw", function () {
+            self.editors[0].refresh();
         });
         
         _syncGutterWidths(this.hostEditor);

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -161,16 +161,12 @@ define(function (require, exports, module) {
             editor.refresh();
         });
 
+        // Update display of inline editors when the hostEditor signals a redraw
         CodeMirror.on(this.info, "redraw", function () {
             self.editors[0].refresh();
         });
         
         _syncGutterWidths(this.hostEditor);
-        
-        // Set initial size
-        // Note that the second argument here (ensureVisibility) is only used by CSSInlineEditor.
-        // FUTURE: Should clean up this API so it's consistent between the two.
-        this.sizeInlineWidgetToContents(true, true);
         
         this.editors[0].focus();
     };
@@ -242,6 +238,12 @@ define(function (require, exports, module) {
         // Init line number display
         this._updateLineRange = this._updateLineRange.bind(this);
         this._updateLineRange(inlineInfo.editor);
+
+        // Always update the widget height when an inline editor completes a
+        // display update
+        $(inlineInfo.editor).on("update.InlineTextEditor", function (event, editor) {
+            self.sizeInlineWidgetToContents(true);
+        });
 
         // Size editor to content whenever text changes (via edits here or any
         // other view of the doc: Editor fires "change" any time its text

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -196,7 +196,7 @@ define(function (require, exports, module) {
         // the editor(s) after the list is laid out by in sequence by (1) the
         // float within the inline-widget container and (2) by the host
         // editor's vertical scroll bar.
-        window.setTimeout(this._updateSize, 0);
+        //window.setTimeout(this._updateSize, 0);
     };
 
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -186,17 +186,6 @@ define(function (require, exports, module) {
 
         // Editor must be at least as tall as the related list
         this._updateEditorMinHeight();
-
-        // Resize the widget when scrollbars are added
-        this._updateSize = this._updateSize.bind(this);
-        $(window).on("resize.MultiRangeInlineEditor", this._updateSize);
-
-        // Kick the layout again to redraw scrollbars after the related list
-        // is floated. This is necessary because the related list may overlap
-        // the editor(s) after the list is laid out by in sequence by (1) the
-        // float within the inline-widget container and (2) by the host
-        // editor's vertical scroll bar.
-        //window.setTimeout(this._updateSize, 0);
     };
 
     /**
@@ -249,13 +238,6 @@ define(function (require, exports, module) {
         this.sizeInlineWidgetToContents(true, false);
 
         this._updateSelectedMarker();
-    };
-
-    /**
-     * Resize the widget to handle adding/removing scrollbars
-     */
-    MultiRangeInlineEditor.prototype._updateSize = function () {
-        this.sizeInlineWidgetToContents();
     };
     
     /**
@@ -358,7 +340,6 @@ define(function (require, exports, module) {
         });
 
         // Remove event handlers
-        $(window).off("resize", this._updateSize);
         this.$htmlContent.off(".MultiRangeInlineEditor");
         this.$editorsDiv.off(".MultiRangeInlineEditor");
     };


### PR DESCRIPTION
@njx Fixes #2655, #2523, #2521.
- Handle `redraw` event on the widget (from the host editor) and refresh inline instances of CodeMirror
- Consolidate `sizeInlineWidgetToContents()` calls into an `update` event listener. Whenever an inline editor update's it's display, we force a new height on the inline widget container

I'm also seeing #2657 fixed in my branch. But I'm not sure how my changes would have affected horizontal scrolling.
