### PR TITLE
[cmv3] Use pointer cursor in rule list

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -632,6 +632,7 @@ a, img {
     max-width: 50%;
     overflow: hidden;
     background: @inline-background-color-2;
+    cursor: default;
     
     .selection {
         width: 100%;

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -143,6 +143,10 @@
     .CodeMirror-scroll {
         outline: none;
     }
+    
+    .CodeMirror .CodeMirror-vscrollbar, .CodeMirror .CodeMirror-hscrollbar {
+        cursor: default;
+    }
 }
 
 /*


### PR DESCRIPTION
For #2566. The parentage of the rule list has changed--it's now inside the CodeMIrror linespace, so we need to explicitly set it to use the pointer cursor.
