### PR TITLE
[cmv3] Handle mouseup the same as click in inline editor

### DIFF
--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -169,9 +169,10 @@ define(function (require, exports, module) {
         this.$htmlContent.append(this.$relatedContainer).append(this.$editorsDiv);
                 
         // Listen for clicks directly on us, so we can set focus back to the editor
-        this.$htmlContent.on("click.MultiRangeInlineEditor", this._onClick.bind(this));
+        var clickHandler = this._onClick.bind(this);
+        this.$htmlContent.on("click.MultiRangeInlineEditor", clickHandler);
         // Also handle mouseup in case the user drags a little bit
-        this.$htmlContent.on("mouseup.MultiRangeInlineEditor", this._onClick.bind(this));
+        this.$htmlContent.on("mouseup.MultiRangeInlineEditor", clickHandler);
     };
     
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -170,6 +170,8 @@ define(function (require, exports, module) {
                 
         // Listen for clicks directly on us, so we can set focus back to the editor
         this.$htmlContent.on("click.MultiRangeInlineEditor", this._onClick.bind(this));
+        // Also handle mouseup in case the user drags a little bit
+        this.$htmlContent.on("mouseup.MultiRangeInlineEditor", this._onClick.bind(this));
     };
     
     /**


### PR DESCRIPTION
For #2567. If the user drags the mouse slightly after clicking on a rule in the rule list, it doesn't register as a click. So we make sure to call the special click handling on mouseup in addition to click.
