### PR TITLE
Fixes #2600 (comment toggling not working).

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -857,9 +857,7 @@ define(function (require, exports, module) {
         this._ensureMasterEditor();
         
         var self = this;
-        this._masterEditor._codeMirror.compoundChange(function () {
-            self._masterEditor._codeMirror.operation(doOperation);
-        });
+        self._masterEditor._codeMirror.operation(doOperation);
     };
     
     /**


### PR DESCRIPTION
In cmv3, calling operation will group the changes into a single undo,
avoiding the need for compoundChange. The EditorCommandHandlers test
now passes.
