### PR TITLE
fixes #2625: don't auto append semicolon after selecting a property value

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -142,9 +142,7 @@ define(function (require, exports, module) {
         
         if (this.info.context === CSSUtils.PROP_NAME) {
             closure = ":";
-        } else if (this.info.context === CSSUtils.PROP_VALUE) {
-            closure = ";";
-        } else {
+        } else if (this.info.context !== CSSUtils.PROP_VALUE) {
             return false;
         }
         

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -175,12 +175,11 @@ define(function (require, exports, module) {
                 expectCursorAt({ line: 7, ch: 8 });
             });
             
-            it("should insert semicolon followed by newline after prop-value selected", function () {
-                // insert semicolon after previous rule to avoid incorrect tokenizing
+            it("should not insert semicolon after prop-value selected", function () {
                 testDocument.replaceRange(";", { line: 12, ch: 5 });
                 testEditor.setCursorPos({ line: 13, ch: 10 });   // cursor after 'display: '
                 selectHint(CSSCodeHints.cssPropHintProvider, "block");
-                expect(testDocument.getLine(13)).toBe(" display: block;");
+                expect(testDocument.getLine(13)).toBe(" display: block");
             });
             
             it("should insert prop-name directly after semicolon", function () {


### PR DESCRIPTION
Fix for #2625 with a minor change to CSS code hinting so that semicolons are not added when you select a property value.
