### PR TITLE
Add "displayStr" param to native menu APIs

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -550,11 +550,16 @@ define(function (require, exports, module) {
         if (!_isHTMLMenu(this.id)) {
             var bindings = KeyBindingManager.getKeyBindings(commandID),
                 binding,
-                bindingStr = "";
+                bindingStr = "",
+                displayStr = "";
             
             if (bindings && bindings.length > 0) {
                 binding = bindings[bindings.length - 1];
                 bindingStr = binding.displayKey || binding.key;
+            }
+            
+            if (bindingStr.length > 0) {
+                displayStr = KeyBindingManager.formatKeyDescriptor(bindingStr);
             }
             
             if (position === FIRST_IN_SECTION || position === LAST_IN_SECTION) {
@@ -567,7 +572,7 @@ define(function (require, exports, module) {
                 relativeID = relativeID.sectionMarker;
             }
             
-            brackets.app.addMenuItem(this.id, name, commandID, bindingStr, position, relativeID, function (err) {
+            brackets.app.addMenuItem(this.id, name, commandID, bindingStr, displayStr, position, relativeID, function (err) {
                 if (err) {
                     console.error("addMenuItem() -- error: " + err + " when adding command: " + commandID);
                 } else {
@@ -577,11 +582,16 @@ define(function (require, exports, module) {
                             if (err) {
                                 console.error("setMenuTitle() -- error: " + err + " when adding command: " + commandID);
                             } else {
-                                brackets.app.setMenuItemShortcut(commandID, bindingStr, function (err) {
-                                    if (err) {
-                                        console.error("setMenuItemShortcut() -- error: " + err + " when adding command: " + commandID);
+                                brackets.app.setMenuItemShortcut(
+                                    commandID,
+                                    bindingStr,
+                                    displayStr,
+                                    function (err) {
+                                        if (err) {
+                                            console.error("setMenuItemShortcut() -- error: " + err + " when adding command: " + commandID);
+                                        }
                                     }
-                                });
+                                );
                             }
                         });
                     }
@@ -739,7 +749,8 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._keyBindingAdded = function (event, keyBinding) {
         if (this.isNative) {
-            brackets.app.setMenuItemShortcut(this.id, keyBinding.displayKey || keyBinding.key, function (err) {
+            var shortcutKey = keyBinding.displayKey || keyBinding.key;
+            brackets.app.setMenuItemShortcut(this.id, shortcutKey, KeyBindingManager.formatKeyDescriptor(shortcutKey), function (err) {
                 if (err) {
                     console.error("Error setting menu item shortcut: " + err);
                 }
@@ -755,7 +766,7 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._keyBindingRemoved = function (event, keyBinding) {
         if (this.isNative) {
-            brackets.app.setMenuItemShortcut(this.id, "", function (err) {
+            brackets.app.setMenuItemShortcut(this.id, "", "", function (err) {
                 if (err) {
                     console.error("Error setting menu item shortcut: " + err);
                 }

--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -501,7 +501,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", "", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -541,7 +541,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     error = 0;
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", 42, "", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", 42, "", "", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -580,7 +580,7 @@ define(function (require, exports, module) {
                 // Add a menu item into the empty menu
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", "", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -621,7 +621,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 1", "Menu-test.command01", "", "first", "", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 1", "Menu-test.command01", "", "", "first", "", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -684,7 +684,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 2", "Menu-test.command02", "", "last", "", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 2", "Menu-test.command02", "", "", "last", "", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -748,7 +748,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 3", "Menu-test.command03", "", "after", TEST_MENU_ITEM_ID, function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 3", "Menu-test.command03", "", "", "after", TEST_MENU_ITEM_ID, function (err) {
                         complete = true;
                         error = err;
                     });
@@ -811,7 +811,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 4", "Menu-test.command04", "", "before", TEST_MENU_ITEM_ID, function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 4", "Menu-test.command04", "", "", "before", TEST_MENU_ITEM_ID, function (err) {
                         complete = true;
                         error = err;
                     });
@@ -874,7 +874,7 @@ define(function (require, exports, module) {
                 error = 0;
                 runs(function () {
                     complete = false;
-                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 5", "Menu-test.command05", "", "before", "NONEXISTANT", function (err) {
+                    brackets.app.addMenuItem(TEST_MENU_ID, "Brackets Test Command Custom 5", "Menu-test.command05", "", "", "before", "NONEXISTANT", function (err) {
                         complete = true;
                         error = err;
                     });
@@ -1017,7 +1017,7 @@ define(function (require, exports, module) {
                             complete = true;
                             error = err;
                         } else {
-                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, ITEM_ID, "", "", "", function (err) {
+                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, ITEM_ID, "", "", "", "", function (err) {
                                 complete = true;
                                 error = err;
                             });
@@ -1135,7 +1135,7 @@ define(function (require, exports, module) {
                             complete = true;
                             error = err;
                         } else {
-                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, ITEM_ID, "", "", "", function (err) {
+                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, ITEM_ID, "", "", "", "", function (err) {
                                 complete = true;
                                 error = err;
                             });
@@ -1308,7 +1308,7 @@ define(function (require, exports, module) {
                             complete = true;
                             error = err;
                         } else {
-                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", function (err) {
+                            brackets.app.addMenuItem(TEST_MENU_ID, TEST_MENU_ITEM, TEST_MENU_ITEM_ID, "", "", "", "", function (err) {
                                 complete = true;
                                 error = err;
                             });


### PR DESCRIPTION
**NOTE: Requires adobe/brackets-shell#194**

Update the native menu calls to add the new `displayStr` parameter.

Hook up the `keyBindingAdded` and `keyBindingRemoved` handlers to update shortcuts in native menus.

Fixes #2610 & #2597
