### PR TITLE
Resolves #2688 - Incorrect JSLINT status bar count

### DIFF
--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -174,7 +174,11 @@ define(function (require, exports, module) {
                 } else {
                     //return the number of non-null errors
                     var numberOfErrors = JSLINT.errors.filter(function (err) { return err !== null; }).length;
-                    
+                    //if there was a null value it means there was a stop notice and an indertiminate
+                    //upper bound on the number of JSLint errors, which we'll represent by appending a '+'
+                    if (numberOfErrors !== JSLINT.errors.length) {
+                        numberOfErrors += "+";
+                    }
                     StatusBar.updateIndicator(module.id, true, "jslint-errors", StringUtils.format(Strings.JSLINT_ERRORS_INFORMATION, numberOfErrors));
                 }
                 _setGotoEnabled(true);

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -172,7 +172,10 @@ define(function (require, exports, module) {
                 if (JSLINT.errors.length === 1) {
                     StatusBar.updateIndicator(module.id, true, "jslint-errors", Strings.JSLINT_ERROR_INFORMATION);
                 } else {
-                    StatusBar.updateIndicator(module.id, true, "jslint-errors", StringUtils.format(Strings.JSLINT_ERRORS_INFORMATION, JSLINT.errors.length));
+                    //return the number of non-null errors
+                    var numberOfErrors = JSLINT.errors.filter(function (err) { return err !== null; }).length;
+                    
+                    StatusBar.updateIndicator(module.id, true, "jslint-errors", StringUtils.format(Strings.JSLINT_ERRORS_INFORMATION, numberOfErrors));
                 }
                 _setGotoEnabled(true);
             } else {

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -177,6 +177,8 @@ define(function (require, exports, module) {
                     //if there was a null value it means there was a stop notice and an indertiminate
                     //upper bound on the number of JSLint errors, which we'll represent by appending a '+'
                     if (numberOfErrors !== JSLINT.errors.length) {
+                        //first discard the stop notice
+                        numberOfErrors -= 1;
                         numberOfErrors += "+";
                     }
                     StatusBar.updateIndicator(module.id, true, "jslint-errors", StringUtils.format(Strings.JSLINT_ERRORS_INFORMATION, numberOfErrors));


### PR DESCRIPTION
Resolves #2688 - Currently jslint will push a `null` value onto `JSLINT.errors` at line [6597](https://github.com/douglascrockford/JSLint/blob/2347ec449b14eb3a4935daeaaa3ef036d42dd96d/jslint.js#L6597). This means an accurate status bar needs to only count non-null jslint warnings. 

This would be more elegant by using `Array.prototype.filter`, but as this is only implemented in JS versions 1.6 onwards I'll prefer the uglier `for` loop version for higher compatibility.
