### PR TITLE
Remove indentation setting from CSSCodeHints/unittests.js

### DIFF
--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -5,13 +5,9 @@ define(function (require, exports, module) {
     "use strict";
    
     var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
-        Editor          = brackets.getModule("editor/Editor").Editor,
         CodeHintManager = brackets.getModule("editor/CodeHintManager"),
         CSSCodeHints    = require("main");
-    
-    /* set indentation to one, to make use of tabs for the following testContent */
-    Editor.setIndentUnit(1);
-    
+       
     describe("CSS Code Hinting", function () {
 
         var defaultContent = "@media screen { \n" +


### PR DESCRIPTION
This is a likely fix for #2612. I was unable to reproduce
that issue, but it is true that this code was no longer needed.
