### PR TITLE
Prevent horizontal scrollbars in code hints

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -288,7 +288,7 @@
             a {
                 // Less padding than on menus. More padding on top than bottom
                 // to center font within its bg highlight better.
-                padding: 2px 0px 0px 0px;
+                padding: 2px 20px 0px 0px;
 
                 // Don't show highlighting on hover for code hints...
                 &:hover {


### PR DESCRIPTION
This is for #2532.

Thank you @WebsiteDeveloper for helping me to notice that the horizontal scroll amount was exactly the width of the vertical scroll bar. I used padding-right the width of the vertical scroll bar to fix it.
