### PR TITLE
Cleanup native menu unit tests

### DIFF
--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -945,8 +945,7 @@ define(function (require, exports, module) {
                     brackets.app.addMenu("Section Test", "menuitem-sectiontest", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 10", "Menu-test.command10", "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 11", "Menu-test.command11", "", "", "", "", function (err) {});
-                    // String(Date.now()) is used as a temporary measure until bug #2613 is fixed.
-                    brackets.app.addMenuItem(SECTION_MENU, "---", String(Date.now()), "", "", "", "", function (err) {});
+                    brackets.app.addMenuItem(SECTION_MENU, "---", "", "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 12", "Menu-test.command12", "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 13", "Menu-test.command13", "", "", "", "", function (err) {});
                 });


### PR DESCRIPTION
**NOTE: Should be merged _after_ adobe/brackets-shell#199**

Native menu unit test cleanup now that separators are handled correctly.
