### PR TITLE
Set default cursor on all inline editors

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -560,6 +560,7 @@ a, img {
 .inline-widget {
     background-color:   @inline-background-color-1;
     min-width: 250px;
+    cursor: default;
     
     .CodeMirror {
         /* remove CodeMirror default height: 300px */
@@ -632,7 +633,6 @@ a, img {
     max-width: 50%;
     overflow: hidden;
     background: @inline-background-color-2;
-    cursor: default;
     
     .selection {
         width: 100%;


### PR DESCRIPTION
Fix for #2722.

Generalizes the fix for #2566 by simply moving the `cursor: default` to the `.inline-widget` rule. Tested in both the color picker and the CSS inline editor, and we still seem to get the correct cursors in the CSS rule list, as well as over the textfield and RGB/HSV/Hex buttons in the color picker.
