### PR TITLE
Fix selection colors in main and inline editors

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -45,10 +45,6 @@
 @code-padding: 1.2em;
 
 .cm-s-default {
-    .CodeMirror-cursor {
-        .code-cursor();
-    }
-
     span.cm-keyword {color: @accent-keyword;}
     span.cm-atom {color: @accent-atom;}
     span.cm-number {color: @accent-number;}
@@ -80,12 +76,14 @@
     span.CodeMirror-nonmatchingbracket {color: @accent-bracket !important;}
 
     .CodeMirror-cursor {
+        .code-cursor();
+
         /* Ensure the cursor shows up in front of code spans with a background color
          * (e.g. matchingbracket).
          */
         z-index: 3;
     }
-    
+
     .CodeMirror-lines {
         padding: @code-padding 0;
     }
@@ -102,6 +100,9 @@
         /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
         padding-top: 0px;
         padding-bottom: 0px;
+    }
+    &.CodeMirror-focused .CodeMirror-selected {
+        background: @selection-color-focused;
     }
 }
 
@@ -125,15 +126,15 @@
     .CodeMirror pre.CodeMirror-cursor {
         visibility: hidden;
     }
-    .CodeMirror .CodeMirror-focused pre.CodeMirror-cursor {
+    .CodeMirror.CodeMirror-focused pre.CodeMirror-cursor {
         visibility: visible;
     }
     
-    .CodeMirror div.CodeMirror-selected {
-        background: #d9d9d9;
+    .CodeMirror.cm-s-default .CodeMirror-selected {
+        background: @selection-color-unfocused;
     }
-    .CodeMirror .CodeMirror-focused div.CodeMirror-selected {
-        background: #d2dcf8;
+    .CodeMirror.cm-s-default.CodeMirror-focused .CodeMirror-selected {
+        background: @selection-color-focused;
     }
     .CodeMirror .CodeMirror-gutters {
         background: transparent;

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -123,10 +123,10 @@
         background-color: @background-color-1;
     }
 
-    .CodeMirror pre.CodeMirror-cursor {
+    .CodeMirror .CodeMirror-cursor {
         visibility: hidden;
     }
-    .CodeMirror.CodeMirror-focused pre.CodeMirror-cursor {
+    .CodeMirror.CodeMirror-focused .CodeMirror-cursor {
         visibility: visible;
     }
     

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -97,6 +97,10 @@
 @inline-color-2: #8a8a8a;
 @inline-color-3: @bc-black;
 
+/* Selection colors */
+@selection-color-focused: #d2dcf8;
+@selection-color-unfocused: #d9d9d9;
+
 /* Code font formatting
  *
  * NOTE (JRB): At this time, the font-family must be set in .code-font (not in one of the platform-specific versions).


### PR DESCRIPTION
Restores the original blue selection color in both main and inline editors. As part of this, factored out the selection colors into LESS variables.

While fixing this, I noticed and fixed a few other issues:
- Focused inline editor selections were no longer blue--this was because `.CodeMirror-focused` is on the wrapper (I think it used to be somewhere nested inside the wrapper).
- The cursor was visible in unfocused inline editors--this was because `.CodeMirror-cursor` is no longer a `pre`.
- Consolidated a couple of rules for `.CodeMirror-cursor` (one of which I had recently introduced without noticing the other rule).
