### PR TITLE
Don't claim to have hints if the current context is not property name or property value.

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -42,16 +42,16 @@ define(function (require, exports, module) {
 
         this.info = CSSUtils.getInfoAtPos(editor, cursor);
         
-        if (implicitChar === null) {
-            if (this.info.context === CSSUtils.PROP_NAME || this.info.context === CSSUtils.PROP_VALUE) {
-                return true;
-            }
-        } else {
+        if (this.info.context !== CSSUtils.PROP_NAME && this.info.context !== CSSUtils.PROP_VALUE) {
+            return false;
+        }
+        
+        if (implicitChar) {
             return (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) ||
                    (this.secondaryTriggerKeys.indexOf(implicitChar) !== -1);
         }
         
-        return false;
+        return true;
     };
        
     /**

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
             expect(selection.start).toEqual(pos);
         }
         
-        describe("CSS attributes in general (selection of correct attribute based on input)", function () {
+        describe("CSS properties in general (selection of correct property based on input)", function () {
    
             beforeEach(function () {
                 // create Editor instance (containing a CodeMirror instance)
@@ -148,6 +148,10 @@ define(function (require, exports, module) {
             it("should NOT list prop-name hints if previous property is not closed properly", function () {
                 testEditor.setCursorPos({ line: 16, ch: 6 });   // cursor directly after color
                 expectNoHints(CSSCodeHints.cssPropHintProvider);
+            });
+            it("should NOT list prop-name hints in media type declaration", function () {
+                testEditor.setCursorPos({ line: 0, ch: 1 });
+                expect(CSSCodeHints.cssPropHintProvider.hasHints(testEditor, 'm')).toBe(false);
             });
         });
 


### PR DESCRIPTION
This fixes issue #2716.
