### PR TITLE
Set selection in Move Line Up after operation is finished

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -591,8 +591,8 @@ define(function (require, exports, module) {
                     // the line we inserted below.
                     originalSel.start.line--;
                     originalSel.end.line--;
-                    editor.setSelection(originalSel.start, originalSel.end);
                 });
+                editor.setSelection(originalSel.start, originalSel.end);
             }
             break;
         case DIRECTION_DOWN:

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -99,6 +99,7 @@ define(function (require, exports, module) {
         var containsUncommented = _containsUncommented(editor, startLine, endLine);
         var i;
         var line;
+        var updateSelection = false;
         
         // Make the edit
         doc.batchOperation(function () {
@@ -111,8 +112,7 @@ define(function (require, exports, module) {
                 
                 // Make sure selection includes "//" that was added at start of range
                 if (sel.start.ch === 0 && hasSelection) {
-                    // use *current* selection end, which has been updated for our text insertions
-                    editor.setSelection({line: startLine, ch: 0}, editor.getSelection().end);
+                    updateSelection = true;
                 }
                 
             } else {
@@ -127,6 +127,12 @@ define(function (require, exports, module) {
             }
         });
         
+        // Update the selection after the document batch so it's not blown away on resynchronization
+        // if this editor is not the master editor.
+        if (updateSelection) {
+            // use *current* selection end, which has been updated for our text insertions
+            editor.setSelection({line: startLine, ch: 0}, editor.getSelection().end);
+        }
     }
     
     
@@ -217,7 +223,8 @@ define(function (require, exports, module) {
             suffixPos      = null,
             canComment     = false,
             invalidComment = false,
-            lineUncomment  = false;
+            lineUncomment  = false,
+            newSelection;
         
         var result, text, line;
         
@@ -339,13 +346,13 @@ define(function (require, exports, module) {
                     
                     // Correct the selection.
                     if (completeLineSel) {
-                        editor.setSelection({line: sel.start.line + 1, ch: 0}, {line: sel.end.line + 1, ch: 0});
+                       newSelection = {start: {line: sel.start.line + 1, ch: 0}, end: {line: sel.end.line + 1, ch: 0}};
                     } else {
                         var newSelStart = {line: sel.start.line, ch: sel.start.ch + prefix.length};
                         if (sel.start.line === sel.end.line) {
-                            editor.setSelection(newSelStart, {line: sel.end.line, ch: sel.end.ch + prefix.length});
+                            newSelection = {start: newSelStart, end: {line: sel.end.line, ch: sel.end.ch + prefix.length}};
                         } else {
-                            editor.setSelection(newSelStart, {line: sel.end.line, ch: sel.end.ch});
+                            newSelection = {start: newSelStart, end: {line: sel.end.line, ch: sel.end.ch}};
                         }
                     }
                 
@@ -379,6 +386,12 @@ define(function (require, exports, module) {
                     }
                 }
             });
+            
+            // Update the selection after the document batch so it's not blown away on resynchronization
+            // if this editor is not the master editor.
+            if (newSelection) {
+                editor.setSelection(newSelection.start, newSelection.end);
+            }
         }
     }
     
@@ -592,10 +605,9 @@ define(function (require, exports, module) {
                     originalSel.start.line--;
                     originalSel.end.line--;
                 });
-                // This selection change needs to be outside the batch above, since that batch is
-                // on the underlying document, not this editor. Putting it inside the batch would
-                // cause the selection to be blown away when the document's changes are synchronized
-                // back to this editor on operation end.
+    
+                // Update the selection after the document batch so it's not blown away on resynchronization
+                // if this editor is not the master editor.
                 editor.setSelection(originalSel.start, originalSel.end);
             }
             break;

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -592,6 +592,10 @@ define(function (require, exports, module) {
                     originalSel.start.line--;
                     originalSel.end.line--;
                 });
+                // This selection change needs to be outside the batch above, since that batch is
+                // on the underlying document, not this editor. Putting it inside the batch would
+                // cause the selection to be blown away when the document's changes are synchronized
+                // back to this editor on operation end.
                 editor.setSelection(originalSel.start, originalSel.end);
             }
             break;


### PR DESCRIPTION
Fixes #1343.

I believe the issue is that the actual edit is happening in the underlying "document" (which is actually the full editor), but the selection is being set in the inline editor (which is a different editor). So the selection is getting set in the inline editor, but then the change is synchronized back from the document when the operation ends, which modifies the selection we just set. The inline editor selection change really shouldn't be inside the document's batch.

So the fix is just to move the selection change (in the inline editor) outside of the operation.
