### PR TITLE
Simplify key handlings in code hint manager.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -464,14 +464,7 @@ define(function (require, exports, module) {
             // Last inserted character, used later by handleChange
             lastChar = String.fromCharCode(event.charCode);
         } else if (event.type === "keyup" && _inSession(editor)) {
-            if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
-                    event.keyCode === KeyEvent.DOM_VK_RIGHT ||
-                    event.keyCode === KeyEvent.DOM_VK_BACK_SPACE) {
-                // Update the list after a simple navigation.
-                // We do this in "keyup" because we want the cursor position to be updated before
-                // we redraw the list.
-                _updateHintList();
-            }
+            _updateHintList();
         }
     }
     

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -453,28 +453,24 @@ define(function (require, exports, module) {
             } else if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
                 hintList.handleKeyEvent(event);
-            } else if (!(event.ctrlKey || event.altKey || event.metaKey) &&
-                        (event.keyCode === KeyEvent.DOM_VK_ENTER ||
-                         event.keyCode === KeyEvent.DOM_VK_RETURN ||
-                         event.keyCode === KeyEvent.DOM_VK_TAB)) {
+            }
+            if (!(event.ctrlKey || event.altKey || event.metaKey) &&
+                    (event.keyCode === KeyEvent.DOM_VK_ENTER ||
+                     event.keyCode === KeyEvent.DOM_VK_RETURN ||
+                     event.keyCode === KeyEvent.DOM_VK_TAB)) {
                 lastChar = String.fromCharCode(event.keyCode);
             }
         } else if (event.type === "keypress") {
             // Last inserted character, used later by handleChange
             lastChar = String.fromCharCode(event.charCode);
-        } else if (event.type === "keyup") {
-            if (_inSession(editor)) {
-                if ((event.keyCode !== 32 && event.ctrlKey) || event.altKey || event.metaKey) {
-                    // End the session if the user presses any key with a modifier (other than Ctrl+Space).
-                    _endSession();
-                } else if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
-                           event.keyCode === KeyEvent.DOM_VK_RIGHT ||
-                           event.keyCode === KeyEvent.DOM_VK_BACK_SPACE) {
-                    // Update the list after a simple navigation.
-                    // We do this in "keyup" because we want the cursor position to be updated before
-                    // we redraw the list.
-                    _updateHintList();
-                }
+        } else if (event.type === "keyup" && _inSession(editor)) {
+            if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
+                    event.keyCode === KeyEvent.DOM_VK_RIGHT ||
+                    event.keyCode === KeyEvent.DOM_VK_BACK_SPACE) {
+                // Update the list after a simple navigation.
+                // We do this in "keyup" because we want the cursor position to be updated before
+                // we redraw the list.
+                _updateHintList();
             }
         }
     }


### PR DESCRIPTION
Set lastChar for "enter" and "tab" keys regardless of whether we're in a hinting session or not. This fixes issue #2691.

Remove code that dismisses code hints on pressing some keys with modifier keys. So we no longer dismiss code hints when a shortcut is pressed. We will have to fix the issue of code hints dismissal with another solution, but definitely not with key handling. This change fixes issue #2539.
