### PR TITLE
Center on selection in two more 'jump to' features

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
         $filenameInfo.click(function () {
             CommandManager.execute(Commands.FILE_OPEN, { fullPath: doc.file.fullPath })
                 .done(function () {
-                    EditorManager.getCurrentFullEditor().setCursorPos(startLine);
+                    EditorManager.getCurrentFullEditor().setCursorPos(startLine, 0, true);
                 });
         });
 

--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -152,7 +152,7 @@ define(function (require, exports, module) {
                             $selectedRow = $row;
                             
                             var editor = EditorManager.getCurrentFullEditor();
-                            editor.setCursorPos(item.line - 1, item.character - 1);
+                            editor.setCursorPos(item.line - 1, item.character - 1, true);
                             EditorManager.focusEditor();
                         };
                         $row.click(clickCallback);


### PR DESCRIPTION
Center on selection in two more 'jump to' features:
- clicking JSLint results
- clicking inline editor header to jump to full file
