### PR TITLE
Always explicitly set height on inline editors

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1051,7 +1051,9 @@ define(function (require, exports, module) {
             changed = (oldHeight !== height),
             isAttached = inlineWidget.info !== undefined;
 
-        if (changed) {
+        // Make sure we set an explicit height on the widget, so children can use things like
+        // min-height if they want.
+        if (changed || !node.style.height) {
             $(node).height(height);
 
             if (isAttached) {


### PR DESCRIPTION
@jasonsanjose 
Fixes #2755.

Depending on timing, `Editor.setInlineWidgetHeight()` would sometimes not set an explicit height on the widget node, because `$(node).height()` would return the same value as the requested height. This meant that the `min-height: 100%` set on the `relatedContainer` wouldn't work, because percentage min-heights don't work with implicit parent heights, only explicit heights, for some reason.

This seems like it ought to be okay since we were sometimes setting an explicit height on the widget node before--we were just doing so inconsistently. But this height-setting stuff seems complex enough that it might break some cases.
