### PR TITLE
Update native menu unit tests to pass command ID for separator

### DIFF
--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -945,7 +945,7 @@ define(function (require, exports, module) {
                     brackets.app.addMenu("Section Test", "menuitem-sectiontest", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 10", "Menu-test.command10", "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 11", "Menu-test.command11", "", "", "", "", function (err) {});
-                    brackets.app.addMenuItem(SECTION_MENU, "---", "", "", "", "", "", function (err) {});
+                    brackets.app.addMenuItem(SECTION_MENU, "---", String(Date.now()), "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 12", "Menu-test.command12", "", "", "", "", function (err) {});
                     brackets.app.addMenuItem(SECTION_MENU, "Command 13", "Menu-test.command13", "", "", "", "", function (err) {});
                 });


### PR DESCRIPTION
This should be merged after adobe/brackets-shell#201

Update the native menu unit tests so we always pass a unique command ID for the separator item in the test menu. This allows the tests to be run repeatedly without error.
