### PR TITLE
force inline CodeMirror to redraw when added

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -158,7 +158,13 @@ define(function (require, exports, module) {
         InlineTextEditor.prototype.parentClass.onAdded.apply(this, arguments);
         
         this.editors.forEach(function (editor) {
-            editor.refresh();
+            // HACK: We use height:auto on inline CodeMirror instances to prop
+            // the line widget height. However, using auto confuses CodeMirror
+            // during the intial render, resulting in a viewport too small and
+            // skipping rendering until the highlightWorker kicks in.
+            // As a workaround, scrolling will force CodeMirror to recompute
+            // the viewport and redraw the full contents of hte inline editor
+            editor._codeMirror.scrollTo(0, 0);
         });
 
         // Update display of inline editors when the hostEditor signals a redraw

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
             // during the intial render, resulting in a viewport too small and
             // skipping rendering until the highlightWorker kicks in.
             // As a workaround, scrolling will force CodeMirror to recompute
-            // the viewport and redraw the full contents of hte inline editor
+            // the viewport and redraw the full contents of the inline editor
             editor._codeMirror.scrollTo(0, 0);
         });
 

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
         this.editors.forEach(function (editor) {
             // HACK: We use height:auto on inline CodeMirror instances to prop
             // the line widget height. However, using auto confuses CodeMirror
-            // during the intial render, resulting in a viewport too small and
+            // during the initial render, resulting in a viewport too small and
             // skipping rendering until the highlightWorker kicks in.
             // As a workaround, scrolling will force CodeMirror to recompute
             // the viewport and redraw the full contents of the inline editor


### PR DESCRIPTION
Fix for #2754

@njx A workaround due to our `height:auto` change
