### PR TITLE
Replace range directly in CodeMirror instance insted of using the document.

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -189,7 +189,11 @@ define(function (require, exports, module) {
             end.ch = start.ch;
         }
         
-        this.editor.document.replaceRange(hint, start, end);
+        // HACK (tracking adobe/brackets#1688): We talk to the private CodeMirror instance
+        // directly to replace the range instead of using the Document, as we should. The
+        // reason is due to a flaw in our current document synchronization architecture when
+        // inline editors are open.
+        this.editor._codeMirror.replaceRange(hint, start, end);
         
         if (adjustCursor) {
             this.editor.setCursorPos(newCursor);


### PR DESCRIPTION
This fixes issue #2775.
