### PR TITLE
Scroll position fixes

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -730,8 +730,10 @@ define(function (require, exports, module) {
         // of the editor height).
         if (screenCursorPosition < editorHeight * CENTERING_MARGIN ||
                 screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)) {
-            this.setScrollPos(null, documentCursorPosition -
-                                editorHeight / 2 + statusBarHeight);
+
+            var pos = documentCursorPosition - editorHeight / 2 + statusBarHeight;
+            pos = Math.max(pos, 0);
+            this.setScrollPos(null, pos);
         }
     };
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -712,7 +712,7 @@ define(function (require, exports, module) {
      *
      * This does not alter the horizontal scroll position.
      */
-    Editor.prototype.centerOnCursor = function () {
+    Editor.prototype.centerOnCursor = function (isFindFirst) {
         var $scrollerElement = $(this.getScrollerElement());
         var editorHeight = $scrollerElement.height();
         
@@ -728,7 +728,10 @@ define(function (require, exports, module) {
         // not being within CENTERING_MARGIN of the top or bottom
         // of the editor (where CENTERING_MARGIN is a percentage
         // of the editor height).
-        if (screenCursorPosition < editorHeight * CENTERING_MARGIN ||
+        // For finding the first item (i.e. find while typing), do
+        // not center if hit is in first half of screen because this
+        // appears to be an unnecesary scroll.
+        if ((!isFindFirst && screenCursorPosition < editorHeight * CENTERING_MARGIN) ||
                 screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)) {
 
             var pos = documentCursorPosition - editorHeight / 2 + statusBarHeight;
@@ -798,10 +801,10 @@ define(function (require, exports, module) {
      * @param {!{line:number, ch:number}} end
      * @param {boolean} center true to center the viewport
      */
-    Editor.prototype.setSelection = function (start, end, center) {
+    Editor.prototype.setSelection = function (start, end, center, isFindFirst) {
         this._codeMirror.setSelection(start, end);
         if (center) {
-            this.centerOnCursor();
+            this.centerOnCursor(isFindFirst);
         }
     };
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -732,7 +732,8 @@ define(function (require, exports, module) {
                 screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)) {
 
             var pos = documentCursorPosition - editorHeight / 2 + statusBarHeight;
-            pos = Math.max(pos, 0);
+            var info = this._codeMirror.getScrollInfo();
+            pos = Math.min(Math.max(pos, 0), (info.height - info.clientHeight));
             this.setScrollPos(null, pos);
         }
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -87,7 +87,11 @@ define(function (require, exports, module) {
     
     /** @type {boolean}  Global setting: Indent unit (i.e. number of spaces when indenting) */
     var _indentUnit = _prefs.getValue("indentUnit");
-    
+
+    /** @type {number}  Constant: ignore upper boundary when centering text */
+    var BOUNDARY_CHECK_NORMAL   = 0,
+        BOUNDARY_IGNORE_TOP     = 1;
+
     /**
      * @private
      * Handle Tab key press.
@@ -246,7 +250,18 @@ define(function (require, exports, module) {
 
         return result.promise();
     }
-    
+
+    /**
+     * Helper functions to check options.
+     * @param {number} options BOUNDARY_CHECK_NORMAL or BOUNDARY_IGNORE_TOP
+     */
+    function _checkTopBoundary(options) {
+        return (options !== BOUNDARY_IGNORE_TOP);
+    }
+    function _checkBottomBoundary(options) {
+        return true;
+    }
+
     /**
      * List of all current (non-destroy()ed) Editor instances. Needed when changing global preferences
      * that affect all editors, e.g. tabbing or color scheme settings.
@@ -711,8 +726,10 @@ define(function (require, exports, module) {
      * entirely outside the viewport.
      *
      * This does not alter the horizontal scroll position.
+     *
+     * @param {number} centerOptions Option value, or 0 for no options.
      */
-    Editor.prototype.centerOnCursor = function (isFindFirst) {
+    Editor.prototype.centerOnCursor = function (centerOptions) {
         var $scrollerElement = $(this.getScrollerElement());
         var editorHeight = $scrollerElement.height();
         
@@ -731,8 +748,8 @@ define(function (require, exports, module) {
         // For finding the first item (i.e. find while typing), do
         // not center if hit is in first half of screen because this
         // appears to be an unnecesary scroll.
-        if ((!isFindFirst && screenCursorPosition < editorHeight * CENTERING_MARGIN) ||
-                screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)) {
+        if ((_checkTopBoundary(centerOptions) && (screenCursorPosition < editorHeight * CENTERING_MARGIN)) ||
+                (_checkBottomBoundary(centerOptions) && (screenCursorPosition > editorHeight * (1 - CENTERING_MARGIN)))) {
 
             var pos = documentCursorPosition - editorHeight / 2 + statusBarHeight;
             var info = this._codeMirror.getScrollInfo();
@@ -800,11 +817,12 @@ define(function (require, exports, module) {
      * @param {!{line:number, ch:number}} start
      * @param {!{line:number, ch:number}} end
      * @param {boolean} center true to center the viewport
+     * @param {number} centerOptions Option value, or 0 for no options.
      */
-    Editor.prototype.setSelection = function (start, end, center, isFindFirst) {
+    Editor.prototype.setSelection = function (start, end, center, centerOptions) {
         this._codeMirror.setSelection(start, end);
         if (center) {
-            this.centerOnCursor(isFindFirst);
+            this.centerOnCursor(centerOptions);
         }
     };
 
@@ -1310,5 +1328,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SELECT_ALL,     Commands.EDIT_SELECT_ALL, _handleSelectAll);
 
     // Define public API
-    exports.Editor = Editor;
+    exports.Editor                  = Editor;
+    exports.BOUNDARY_CHECK_NORMAL   = BOUNDARY_CHECK_NORMAL;
+    exports.BOUNDARY_IGNORE_TOP     = BOUNDARY_IGNORE_TOP;
 });

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
     var CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
+        Editor              = require("editor/Editor"),
         EditorManager       = require("editor/EditorManager"),
         ModalBar            = require("widgets/ModalBar").ModalBar;
     
@@ -85,6 +86,7 @@ define(function (require, exports, module) {
         cm.operation(function () {
             var state = getSearchState(cm);
             var cursor = getSearchCursor(cm, state.query, rev ? state.posFrom : state.posTo);
+
             if (!cursor.find(rev)) {
                 // If no result found before hitting edge of file, try wrapping around
                 cursor = getSearchCursor(cm, state.query, rev ? {line: cm.lineCount() - 1} : {line: 0, ch: 0});
@@ -96,7 +98,9 @@ define(function (require, exports, module) {
                     return;
                 }
             }
-            editor.setSelection(cursor.from(), cursor.to(), true, isFindFirst);
+
+            var centerOptions = (isFindFirst) ? Editor.BOUNDARY_IGNORE_TOP : Editor.BOUNDARY_CHECK_NORMAL;
+            editor.setSelection(cursor.from(), cursor.to(), true, centerOptions);
             state.posFrom = cursor.from();
             state.posTo = cursor.to();
             state.findNextCalled = true;
@@ -280,7 +284,7 @@ define(function (require, exports, module) {
                                 return;
                             }
                         }
-                        editor.setSelection(cursor.from(), cursor.to(), true);
+                        editor.setSelection(cursor.from(), cursor.to(), true, Editor.BOUNDARY_CHECK_NORMAL);
                         createModalBar(doReplaceConfirm, true);
                         modalBar.getRoot().on("click", function (e) {
                             modalBar.close();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
         EditorManager       = require("editor/EditorManager"),
         ModalBar            = require("widgets/ModalBar").ModalBar;
     
-    var modalBar;
+    var modalBar,
+        isFindFirst = false;
     
     function SearchState() {
         this.posFrom = this.posTo = this.query = null;
@@ -95,7 +96,7 @@ define(function (require, exports, module) {
                     return;
                 }
             }
-            editor.setSelection(cursor.from(), cursor.to(), true);
+            editor.setSelection(cursor.from(), cursor.to(), true, isFindFirst);
             state.posFrom = cursor.from();
             state.posTo = cursor.to();
             state.findNextCalled = true;
@@ -161,6 +162,7 @@ define(function (require, exports, module) {
         // Called each time the search query changes while being typed. Jumps to the first matching
         // result, starting from the original cursor position
         function findFirst(query) {
+            isFindFirst = true;
             cm.operation(function () {
                 if (!query) {
                     return;
@@ -187,6 +189,7 @@ define(function (require, exports, module) {
                     getDialogTextField().toggleClass("no-results", !foundAny);
                 }
             });
+            isFindFirst = false;
         }
         
         if (modalBar) {


### PR DESCRIPTION
This is for issue #2774.

I added range checking on setScrollPos(). This fixes the worst part of the problem which is part of the screen being blank. This happens with _both_ forward and backward Find, so both upper and lower range is checked.

This also fixes the unnecessary scroll when "b" is typed. I added code so that the "center on search" code does not change scroll position during findFirst (i.e. search while typing) when hit is in first half of page because the Find dialog appears to overlap page, so the appears to be a reverse scroll.
