### PR TITLE
Specify edit origin for color editor widgets in order to batch undos

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -820,10 +820,17 @@ define(function (require, exports, module) {
      * @param {!string} text  Text to insert or replace the range with
      * @param {!{line:number, ch:number}} start  Start of range, inclusive (if 'to' specified) or insertion point (if not)
      * @param {?{line:number, ch:number}} end  End of range, exclusive; optional
+     * @param {?string} origin  Optional string used to batch consecutive edits for undo.
+     *     If origin starts with "+", then consecutive edits with the same origin will be batched for undo if 
+     *     they are close enough together in time.
+     *     If origin starts with "*", then all consecutive edit with the same origin will be batched for
+     *     undo.
+     *     (Note that this is a higher level of batching than batchOperation(), which already batches all
+     *     edits within it for undo. Origin batching works across operations.)
      */
-    Document.prototype.replaceRange = function (text, start, end) {
+    Document.prototype.replaceRange = function (text, start, end, origin) {
         this._ensureMasterEditor();
-        this._masterEditor._codeMirror.replaceRange(text, start, end);
+        this._masterEditor._codeMirror.replaceRange(text, start, end, origin);
         // _handleEditorChange() triggers "change" event
     };
     

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -825,6 +825,7 @@ define(function (require, exports, module) {
      *     they are close enough together in time.
      *     If origin starts with "*", then all consecutive edit with the same origin will be batched for
      *     undo.
+     *     Edits with origins starting with other characters will not be batched.
      *     (Note that this is a higher level of batching than batchOperation(), which already batches all
      *     edits within it for undo. Origin batching works across operations.)
      */

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -491,7 +491,7 @@ define(function (require, exports, module) {
                     }
                     cm.setValue(newText);
                 } else {
-                    cm.replaceRange(newText, change.from, change.to);
+                    cm.replaceRange(newText, change.from, change.to, change.origin);
                 }
                 
             }

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     /** @const @type {number} */
     var MAX_USED_COLORS = 7;
     
-    /** Unique ID used to identify edits from this inline widget for undo batching. */
+    /** @type {number} Global var used to provide a unique ID for each color editor instance's _origin field. */
     var lastOriginId = 1;
     
     /**
@@ -92,6 +92,9 @@ define(function (require, exports, module) {
     
     /** @type {boolean} True while we're syncing a code editor change into the color picker */
     InlineColorEditor.prototype._isHostChange = null;
+    
+    /** @type {number} ID used to identify edits coming from this inline widget for undo batching */
+    InlineColorEditor.prototype._origin = null;
     
     
     /**

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -34,6 +34,8 @@ define(function (require, exports, module) {
     /** @const @type {number} */
     var MAX_USED_COLORS = 7;
     
+    /** Unique ID used to identify edits from this inline widget for undo batching. */
+    var lastOriginId = 1;
     
     /**
      * Inline widget containing a ColorEditor control
@@ -47,6 +49,7 @@ define(function (require, exports, module) {
         this._endBookmark = endBookmark;
         this._isOwnChange = false;
         this._isHostChange = false;
+        this._origin = "*InlineColorEditor_" + (lastOriginId++);
 
         this._handleColorChange = this._handleColorChange.bind(this);
         this._handleHostDocumentChange = this._handleHostDocumentChange.bind(this);
@@ -151,7 +154,7 @@ define(function (require, exports, module) {
             if (!this._isHostChange) {
                 // Replace old color in code with the picker's color, and select it
                 this._isOwnChange = true;
-                this.hostEditor.document.replaceRange(colorString, range.start, range.end);
+                this.hostEditor.document.replaceRange(colorString, range.start, range.end, this._origin);
                 this._isOwnChange = false;
                 this.hostEditor.setSelection(range.start, {
                     line: range.start.line,

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -281,6 +281,18 @@ define(function (require, exports, module) {
                 
             });
             
+            describe("edit batching", function () {
+                it("should combine multiple edits within the same inline editor into a single undo in the host editor", function () {
+                    makeColorEditor({line: 1, ch: 18});
+                    runs(function () {
+                        inline.colorEditor.setColorFromString("#010101");
+                        inline.colorEditor.setColorFromString("#123456");
+                        inline.colorEditor.setColorFromString("#bdafe0");
+                        testDocument._masterEditor._codeMirror.undo();
+                        expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#abcdef");
+                    });
+                });
+            });
         });
         
         describe("Inline editor - HTML", function () {


### PR DESCRIPTION
Fixes #2721. @peterflynn -- could you look at this one?

This takes advantage of the newly-exposed "origin" parameter to `replaceRange()` in CodeMirror. For each color editor, we create a unique origin string. This makes it so that all consecutive edits from a given color editor are batched into a single undo. This is slightly different from our v2 behavior, where the edits would only be batched if they were close together in time. We could implement that heuristic instead, but batching all edits from a given editor together seems to make sense as well, and is more predictable. (Of course, if there are intervening edits elsewhere in the document, they will interrupt the undo batching, as you would expect.)

Note that the change to `Editor._applyChanges()` isn't actually necessary for this bug fix and probably won't have any effect in the codebase today, but it seems to make sense semantically (i.e., if undos are batched in the underlying document, they should be batched in the synchronized editor, and vice versa). That issue should go away anyway when we switch to CM's own doc/view separation implementation.
