### PR TITLE
Update assumptions on platform-specific font loading

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -712,6 +712,9 @@ a, img {
     .code-font();
 }
 
+.platform-mac .dummy-text {
+    .code-font-mac();
+}
 
 /* Find in Files results panel - temporary UI, to be replaced with a richer search feature later */
 

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -103,16 +103,11 @@
 
 /* Code font formatting
  *
- * NOTE (JRB): At this time, the font-family must be set in .code-font (not in one of the platform-specific versions).
- * This is because, in order to get the web font to load early enough, we have a div called "dummy-text" that
+ * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that
  * is styled with .code-font().
  *
- * The platform-specific selector gets added to the body tag at document ready time, so it may not happen soon
- * enough to get the web font loaded. So, we can't rely on this selector to load web fonts in a platform-specific way
- *
- * An alternative (if we wanted platform-specific fonts) would be to have a dummy text div for EVERY web font, and
- * then style those dummy text divs directly in brackets_fonts.less. However, this would result in us downloading
- * all fonts for every platform. This probably isn't a huge performance problem, but isn't necessary at this time.
+ * The platform-specific selector gets added to the body tag *before* document ready time.
+ * We rely on this behavior to load platform-specific web fonts early.
  */
 .code-font() {
     color: @content-color;


### PR DESCRIPTION
Change usage of `dummy-text` to adapt based on platform. It appears that the last time we addressed web font loading issues we didn't apply platform class names until after `document.ready`. This is no longer the case (see brackets.js `_beforeHTMLReady()`)

Fixes text measurement issue on mac where cached lines result in wrong cursor positioning after a mouse click. See #2768
