### PR TITLE
Avoid adding duplicates to the list of welcome projects, and ...

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -695,9 +695,12 @@ define(function (require, exports, module) {
      * or the one for the current build.
      */
     function isWelcomeProjectPath(path) {
+        var canonPath = FileUtils.canonicalizeFolderPath(path);
+        if (canonPath === _getWelcomeProjectPath()) {
+            return true;
+        }
         var welcomeProjects = _prefs.getValue("welcomeProjects") || [];
-        welcomeProjects.push(_getWelcomeProjectPath());
-        return welcomeProjects.indexOf(FileUtils.canonicalizeFolderPath(path)) !== -1;
+        return welcomeProjects.indexOf(canonPath) !== -1;
     }
     
     /**
@@ -755,6 +758,7 @@ define(function (require, exports, module) {
                     var rootEntry = fs.root;
                     var projectRootChanged = (!_projectRoot || !rootEntry) ||
                         _projectRoot.fullPath !== rootEntry.fullPath;
+                    var i;
 
                     // Success!
                     var perfTimerName = PerfUtils.markStart("Load Project: " + rootPath),
@@ -1328,9 +1332,26 @@ define(function (require, exports, module) {
 
     // Init PreferenceStorage
     var defaults = {
-        projectPath:      _getWelcomeProjectPath()  /* initialize to brackets source */
+        projectPath:      _getWelcomeProjectPath()  /* initialize to welcome project */
     };
     _prefs = PreferencesManager.getPreferenceStorage(PREFERENCES_CLIENT_ID, defaults);
+        
+    if (!_prefs.getValue("welcomeProjectsFixed")) {
+        // One-time cleanup of duplicates in the welcome projects list--there used to be a bug where
+        // we would add lots of duplicate entries here.
+        var welcomeProjects = _prefs.getValue("welcomeProjects");
+        if (welcomeProjects) {
+            var newWelcomeProjects = [];
+            var i;
+            for (i = 0; i < welcomeProjects.length; i++) {
+                if (newWelcomeProjects.indexOf(welcomeProjects[i]) === -1) {
+                    newWelcomeProjects.push(welcomeProjects[i]);
+                }
+            }
+            _prefs.setValue("welcomeProjects", newWelcomeProjects);
+            _prefs.setValue("welcomeProjectsFixed", true);
+        }
+    }
 
     // Event Handlers
     $(FileViewController).on("documentSelectionFocusChange", _documentSelectionFocusChange);


### PR DESCRIPTION
...clean up existing duplicates

Fixes #2809.

In the part of the code where we were explicitly writing out a new set of welcome folders, we were properly detecting duplicates. But there was another bit of code in `isWelcomeProjectPath()` that was accessing the welcome folder array and pushing the current welcome path onto it temporarily, just for the purposes of including it in the list so that the `indexOf()` on the next line would also check it. This seemed safe (although not really all that smart anyway) since we didn't call `setValue()` again. However, it turns out that array/object values returned from the `PreferenceStorage` are actually live objects cached in the preference structure, so if you modify them, the new values will eventually get saved out even without an explicit `setValue()`. Not sure if this is a bug or a feature.

In any case, the fix is simple (don't push the extra value on, just check it separately). I also added a one-time check to clean up existing duplicates due to the original bug--seems important since people might have tons of garbage in their prefs file.
