### PR TITLE
Fix #2813 - Go to Definition can't find toString() methods

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
      * Computes top left location for hint list so that the list is not clipped by the window
      *
      * @private
-     * @return {Object.<left: number, top: number> }
+     * @return {{left: number, top: number}}
      */
     CodeHintList.prototype._calcHintListLocation = function () {
         var cursor = this.editor._codeMirror.cursorCoords(),

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -183,8 +183,7 @@ define(function (require, exports, module) {
 
     /**
      * Helper function for search(). Create a list of urls to existing files based on the query.
-     * @param {Object.<queryStr: string, ...} query -- a query object with a required property queryStr 
-     *     that will be used to filter out code hints
+     * @param {{queryStr: string}} query -- a query object, used to filter the code hints
      * @return {Array.<string>}
      */
     AttrHints.prototype._getUrlList = function (query) {
@@ -341,7 +340,7 @@ define(function (require, exports, module) {
     /**
      * Helper function that determins the possible value hints for a given html tag/attribute name pair
      * 
-     * @param {String} query
+     * @param {{queryStr: string}} query
      * The current query
      *
      * @param {String} tagName 

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -259,13 +259,11 @@ define(function (require, exports, module) {
         // Filter for documents that contain the named function
         var result              = new $.Deferred(),
             matchedDocuments    = [],
-            rangeResults        = [],
-            functionsInDocument;
+            rangeResults        = [];
         
         docEntries.forEach(function (docEntry) {
-            functionsInDocument = docEntry.functions[functionName];
-            
-            if (functionsInDocument) {
+            if (docEntry.functions.hasOwnProperty(functionName)) {
+                var functionsInDocument = docEntry.functions[functionName];
                 matchedDocuments.push({doc: docEntry.doc, fileInfo: docEntry.fileInfo, functions: functionsInDocument});
             }
         });
@@ -360,7 +358,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Return all functions that have the specified name.
+     * Return all functions that have the specified name, searching across all the given files.
      *
      * @param {!String} functionName The name to match.
      * @param {!Array.<FileIndexManager.FileInfo>} fileInfos The array of files to search.

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -58,7 +58,8 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Return an Array with names and offsets for all functions in the specified text
+     * Return an object mapping function name to offset info for all functions in the specified text.
+     * Offset info is an array, since multiple functions of the same name can exist.
      * @param {!string} text Document text
      * @return {Object.<string, Array.<{offsetStart: number, offsetEnd: number}>}
      */

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -762,14 +762,23 @@ define(function (require, exports, module) {
         // We keep track of the last query to know when we need to invalidate.
         this._lastQuery = null;
         
-        // The specials information does not change for a given string, so we can cache it
-        // easily.
         this._specialsCache = {};
-        
-        // If we find that a string doesn't match a query, we know that it won't match for
-        // any queries with the same prefix, so we cache those non-matches.
         this._noMatchCache = {};
     }
+    
+    /**
+     * Map from search-result string to the findSpecialCharacters() result for that string - easy to cache
+     * since this info doesn't change as the query changes.
+     * @type {Object.<string, {specials:Array.<number>, lastSegmentSpecialsIndex:number}>}
+     */
+    StringMatcher.prototype._specialsCache = null;
+    
+    /**
+     * Set of search-result strings that we know don't match the query _lastQuery - or any other query with
+     * that prefix.
+     * @type {Object.<string, boolean>}
+     */
+    StringMatcher.prototype._noMatchCache = null;
     
     /**
      * Performs a single match using the stringMatch function. See stringMatch for full documentation.
@@ -789,12 +798,12 @@ define(function (require, exports, module) {
         this._lastQuery = query;
         
         // Check for a known non-matching string.
-        if (this._noMatchCache[str]) {
+        if (this._noMatchCache.hasOwnProperty(str)) {
             return undefined;
         }
         
         // Load up the cached specials information (or build it if this is our first time through).
-        var special = this._specialsCache[str];
+        var special = this._specialsCache.hasOwnProperty(str) ? this._specialsCache[str] : undefined;
         if (special === undefined) {
             special = findSpecialCharacters(str);
             this._specialsCache[str] = special;

--- a/test/spec/JSUtils-test-files/simple.js
+++ b/test/spec/JSUtils-test-files/simple.js
@@ -121,9 +121,3 @@ function\u0009unicodeTabBefore () {
 
 function unicodeTabAfter\u0009() {
 }
-
-
-// test for issue #1390
-MyClass.prototype.length = function () {
-    return 1;
-}

--- a/test/spec/JSUtils-test-files/tricky.js
+++ b/test/spec/JSUtils-test-files/tricky.js
@@ -1,0 +1,9 @@
+// This function's name collides with an Object.prototype member
+function toString() {
+    return "";
+}
+
+// This function's name collides with an Array.prototype member
+function length() {
+    return 0;
+}

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
     };
 
     var simpleJsFileEntry   = new NativeFileSystem.FileEntry(testPath + "/simple.js");
+    var trickyJsFileEntry   = new NativeFileSystem.FileEntry(testPath + "/tricky.js");
     var invalidJsFileEntry  = new NativeFileSystem.FileEntry(testPath + "/invalid.js");
     var jQueryJsFileEntry   = new NativeFileSystem.FileEntry(testPath + "/jquery-1.7.js");
     var braceEndJsFileEntry = new NativeFileSystem.FileEntry(testPath + "/braceEnd.js");
@@ -248,6 +249,17 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "unicodeEscapedIdentifierPart\u02b8", [ {start: 115, end: 116} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabBefore", [ {start: 118, end: 119} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabAfter", [ {start: 121, end: 122} ]);
+                });
+            });
+            
+            it("should work when colliding with prototype properties", function () {
+                runs(function () {
+                    init(this, trickyJsFileEntry);
+                });
+                
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "toString", [ {start: 1, end: 3} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "length", [ {start: 6, end: 8} ]);
                 });
             });
             

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            it("should work when colliding with prototype properties", function () {
+            it("should work when colliding with prototype properties", function () { // #1390, #2813
                 runs(function () {
                     init(this, trickyJsFileEntry);
                 });
@@ -383,94 +383,98 @@ define(function (require, exports, module) {
         
     }); // describe("JSUtils")
     
-    describe("JS Parsing: ", function () {
+    
+    describe("JS Indexing: ", function () {
         
-        var lastJsCode,
-            match,
-            expectParseError;
+        var functions;  // populated by indexAndFind()
         
-        // Test helper function; tests that parsing plus a simple search won't crash.
-
-        var _match = function (jsCode, tagInfo) {
-            lastJsCode = jsCode;
-            try {
-                return JSUtils.findAllMatchingFunctionsInText(jsCode, tagInfo);
-            } catch (e) {
-                this.fail(e.message + ": " + jsCode);
-                return [];
-            }
-        };
-        
-        
-        // Test helper function: expects CSS parsing to fail at the given 0-based offset within the
-        // jsCode string, with the given error message.
-
-        var _expectParseError = function (jsCode, expectedCodeOffset, expectedErrorMessage) {
-            try {
-                JSUtils.findAllMatchingFunctionsInText(jsCode, null);
-                
-                // shouldn't get here since JSUtils.findAllMatchingFunctionsInText() is expected to throw
-                this.fail("Expected parse error: " + jsCode);
-                
-            } catch (error) {
-                expect(error.index).toBe(expectedCodeOffset);
-                expect(error.message).toBe(expectedErrorMessage);
-            }
-        };
-
-        // To call fail(), these helpers need access to the value of 'this' inside each it()
         beforeEach(function () {
-            match = _match.bind(this);
-            expectParseError = _expectParseError.bind(this);
+            SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
+                // Load module instances from brackets.test
+                var brackets        = testWindow.brackets;
+                DocumentManager     = brackets.test.DocumentManager;
+                FileIndexManager    = brackets.test.FileIndexManager;
+                FileViewController  = brackets.test.FileViewController;
+                JSUtils             = brackets.test.JSUtils;
+
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            });
         });
 
-        describe("Working with unsaved changes", function () {
-            var brackets;
-    
-            beforeEach(function () {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
-                    // Load module instances from brackets.test
-                    brackets            = testWindow.brackets;
-                    DocumentManager     = brackets.test.DocumentManager;
-                    FileIndexManager    = brackets.test.FileIndexManager;
-                    FileViewController  = brackets.test.FileViewController;
-                    JSUtils             = brackets.test.JSUtils;
+        afterEach(function () {
+            SpecRunnerUtils.closeTestWindow();
+        });
+        
+        function init(fileName) {
+            runs(function () {
+                waitsForDone(
+                    FileViewController.openAndSelectDocument(
+                        testPath + "/" + fileName,
+                        FileViewController.PROJECT_MANAGER
+                    ),
+                    "openAndSelectDocument"
+                );
+            });
+        }
+        
+        /**
+         * Builds a fileInfos index of the project, as required to call findMatchingFunctions(). Calls the
+         * specified 'invoker' function with fileInfos, and populates the 'functions' var once it's done.
+         * Does not need to be wrapped in a runs() block.
+         * @param {function(Array.<FileIndexManager.FileInfo>):$.Promise} invokeFind
+         */
+        function indexAndFind(invokeFind) {
+            runs(function () {
+                var result = new $.Deferred();
+                
+                FileIndexManager.getFileInfoList("all")
+                    .done(function (fileInfos) {
+                        invokeFind(fileInfos)
+                            .done(function (functionsResult) { functions = functionsResult; })
+                            .pipe(result.resolve, result.reject);
+                    });
+                
+                waitsForDone(result, "Index and invoke JSUtils.findMatchingFunctions()");
+            });
+        }
+        
 
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        describe("Index integrity", function () {
+            it("should handle colliding with prototype properties", function () { // #2813
+                // no init() needed - don't need any editors to be open
+                
+                indexAndFind(function (fileInfos) {
+                    return JSUtils.findMatchingFunctions("toString", fileInfos);
                 });
-            });
-
-            afterEach(function () {
-                SpecRunnerUtils.closeTestWindow();
-            });
-            
-            function fileChangedTest(buildCache) {
-                var doc,
-                    functions = null;
-
                 runs(function () {
-                    waitsForDone(
-                        FileViewController.openAndSelectDocument(
-                            testPath + "/edit.js",
-                            FileViewController.PROJECT_MANAGER
-                        ),
-                        "openAndSelectDocument"
-                    );
+                    expect(functions.length).toBe(1);
+                    expect(functions[0].lineStart).toBe(1);
+                    expect(functions[0].lineEnd).toBe(3);
                 });
+                
+                indexAndFind(function (fileInfos) {
+                    return JSUtils.findMatchingFunctions("length", fileInfos);
+                });
+                runs(function () {
+                    expect(functions.length).toBe(1);
+                    expect(functions[0].lineStart).toBe(6);
+                    expect(functions[0].lineEnd).toBe(8);
+                });
+            });
+        });
+        
+        
+        describe("Working with unsaved changes", function () {
+    
+            function fileChangedTest(buildCache) {
+                init("edit.js");
                 
                 // Populate JSUtils cache
                 if (buildCache) {
-                    runs(function () {
-                        FileIndexManager.getFileInfoList("all")
-                            .done(function (fileInfos) {
-                                // Look for "edit2" function
-                                JSUtils.findMatchingFunctions("edit2", fileInfos)
-                                    .done(function (result) { functions = result; });
-                            });
+                    // Look for "edit2" function
+                    indexAndFind(function (fileInfos) {
+                        return JSUtils.findMatchingFunctions("edit2", fileInfos);
                     });
-                    
-                    waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
-                    
                     runs(function () {
                         expect(functions.length).toBe(1);
                         expect(functions[0].lineStart).toBe(7);
@@ -478,25 +482,16 @@ define(function (require, exports, module) {
                     });
                 }
                 
+                // Add several blank lines at the beginning of the text
                 runs(function () {
                     var doc = DocumentManager.getCurrentDocument();
-                    
-                    // Add several blank lines at the beginning of the text
                     doc.setText("\n\n\n\n" + doc.getText());
-
-                    FileIndexManager.getFileInfoList("all")
-                        .done(function (fileInfos) {
-                            // JSUtils cache should update with new offsets
-                            functions = null;
-                            
-                            // Look for "edit2" function
-                            JSUtils.findMatchingFunctions("edit2", fileInfos)
-                                .done(function (result) { functions = result; });
-                        });
                 });
                 
-                waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
-                
+                // Look for function again, expecting line offsets to have changed
+                indexAndFind(function (fileInfos) {
+                    return JSUtils.findMatchingFunctions("edit2", fileInfos);
+                });
                 runs(function () {
                     expect(functions.length).toBe(1);
                     expect(functions[0].lineStart).toBe(11);
@@ -513,61 +508,29 @@ define(function (require, exports, module) {
             });
             
             function insertFunctionTest(buildCache) {
-                var functions = null;
-                
-                runs(function () {
-                    waitsForDone(
-                        FileViewController.openAndSelectDocument(
-                            testPath + "/edit.js",
-                            FileViewController.PROJECT_MANAGER
-                        ),
-                        "openAndSelectDocument"
-                    );
-                });
+                init("edit.js");
                 
                 // Populate JSUtils cache
                 if (buildCache) {
-                    runs(function () {
-                        // Look for the selector we're about to create--we shouldn't find it yet
-                        FileIndexManager.getFileInfoList("all")
-                            .done(function (fileInfos) {
-                                // Look for "TESTFUNCTION" function
-                                JSUtils.findMatchingFunctions("TESTFUNCTION", fileInfos)
-                                    .done(function (result) {
-                                        functions = result;
-                                    });
-                            });
+                    // Look for function that doesn't exist yet
+                    indexAndFind(function (fileInfos) {
+                        return JSUtils.findMatchingFunctions("TESTFUNCTION", fileInfos);
                     });
-                    
-                    waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
-                    
                     runs(function () {
                         expect(functions.length).toBe(0);
                     });
                 }
                 
+                // Add a new function to the file
                 runs(function () {
-                    // reset result functions array
-                    functions = null;
-                    
                     var doc = DocumentManager.getCurrentDocument();
-                    // Add a new function to the file
                     doc.setText(doc.getText() + "\n\nfunction TESTFUNCTION() {\n    return true;\n}\n");
-                    
-                    // Look for the selector we just created
-                    FileIndexManager.getFileInfoList("all")
-                        .done(function (fileInfos) {
-
-                            // Look for "TESTFUNCTION" function
-                            JSUtils.findMatchingFunctions("TESTFUNCTION", fileInfos)
-                                .done(function (result) {
-                                    functions = result;
-                                });
-                        });
                 });
                 
-                waitsFor(function () { return functions !== null; }, "JSUtils.findMatchingFunctions() timeout", 1000);
-                
+                // Look for the function we just created
+                indexAndFind(function (fileInfos) {
+                    return JSUtils.findMatchingFunctions("TESTFUNCTION", fileInfos);
+                });
                 runs(function () {
                     expect(functions.length).toBe(1);
                     expect(functions[0].lineStart).toBe(33);
@@ -583,5 +546,5 @@ define(function (require, exports, module) {
                 insertFunctionTest(true);
             });
         });
-    }); //describe("JS Parsing")
+    }); //describe("JS Indexing")
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
     
     /**
      * Utility for tests that wait on a Promise to complete. Placed in the global namespace so it can be used
-     * similarly to the standards Jasmine waitsFor(). Unlike waitsFor(), must be called from INSIDE
+     * similarly to the standard Jasmine waitsFor(). Unlike waitsFor(), must be called from INSIDE
      * the runs() that generates the promise.
      * @param {$.Promise} promise
      * @param {string} operationName  Name used for timeout error message

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -630,6 +630,18 @@ define(function (require, exports, module) {
                 expect("foo").toBeInCache(matcher, "_specialsCache");
                 expect("foo").not.toBeInCache(matcher, "_noMatchCache");
             });
+            
+            it("should handle collisions with built-in members", function () {
+                var matcher = new StringMatch.StringMatcher();
+                
+                // Object.prototype has toString
+                var toStringResult = matcher.match("toString", "t");
+                expect(toStringResult).toBeTruthy();
+                
+                // Array.prototype has length
+                var lengthResult = matcher.match("length", "l");
+                expect(lengthResult).toBeTruthy();
+            });
         });
     });
 });


### PR DESCRIPTION
Fix bug #2813 (Go to Definition can't find toString() methods) - Use hasOwnProperty() with StringMatcher caches instead of simple truthy checks that will see Object.prototype members too.  Includes unit test.

I did a quick skim for other instances of this bug (and added a few docs clarifications to this patch in the process).  Most other places I found where we use objects as string sets/maps are fine because it's either impossible for a key to collide with something from JS (e.g. the strings are absolute paths, or keyboard shortcuts) or the string is hardcoded by the developer and thus hitting this bug would be easy to spot & work around (e.g. the strings are command ids).

JSUtils._findAllFunctionsInText() narrowly avoids this bug via an Array.isArray() check, but it seemed fragile enough that I added a unit test for it too.

I didn't do an exhaustive search, though, so there might be other bugs like this lurking around.  I wish JS had real map/set constructs that weren't so bug-prone... :-/
