### PR TITLE
Fix attribute hint issue #2804

### DIFF
--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -455,6 +455,29 @@ define(function (require, exports, module) {
                 verifyAttrHints(hintList);
             });
             
+            it("should list attribute value hints for an attribute that follows a valueless attribute", function () {  // (bug #2804)
+                testDocument.replaceRange("  <input checked accept='' >\n", { line: 9, ch: 0 });  // insert new line
+                
+                // cursor between quotes of accept attribute
+                testEditor.setCursorPos({ line: 9, ch: 25 });
+                var hintList = expectHints(HTMLCodeHints.attrHintProvider);
+                
+                verifyAttrHints(hintList, "application/msexcel");
+
+                // cursor between equal sign and opening quote of accept attribute
+                testEditor.setCursorPos({ line: 9, ch: 24 });
+                hintList = expectHints(HTMLCodeHints.attrHintProvider);
+                
+                verifyAttrHints(hintList, "application/msexcel");
+            });
+
+            it("should NOT list attribute value hints when the cursor is after the end quote of an attribute value", function () {
+                testDocument.replaceRange("  <input checked accept='' >\n", { line: 9, ch: 0 });  // insert new line
+                
+                // Set cursor after the closing quote of accept attribute
+                testEditor.setCursorPos({ line: 9, ch: 26 });
+                expectNoHints(HTMLCodeHints.attrHintProvider);
+            });
         });
         
         

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -199,7 +199,8 @@ define(function (require, exports, module) {
             hasEndQuote = attrInfo.hasEndQuote,
             strLength = ctx.token.string.length;
         
-        if (ctx.token.className === "string" && ctx.pos.ch === ctx.token.end && strLength > 1) {
+        if ((ctx.token.className === "string" || ctx.token.className === "error") &&
+                ctx.pos.ch === ctx.token.end && strLength > 1) {
             var firstChar = ctx.token.string[0],
                 lastChar = ctx.token.string[strLength - 1];
             
@@ -396,14 +397,17 @@ define(function (require, exports, module) {
                 return createTagInfo();
             }
             
-            if (!tokenType) {
-                tokenType = TAG_NAME;
-                offset--; //need to take off 1 for the leading "<"
+            // Make sure the cursor is not after an equal sign or a quote before we report the context as a tag.
+            if (ctx.token.string !== "=" && ctx.token.string.match(/^["']/) === null) {
+                if (!tokenType) {
+                    tokenType = TAG_NAME;
+                    offset--; //need to take off 1 for the leading "<"
+                }
+                
+                // We're actually in the tag, just return that as we have no relevant 
+                // info about what attr is selected
+                return createTagInfo(tokenType, offset, _extractTagName(ctx));
             }
-            
-            // We're actually in the tag, just return that as we have no relevant 
-            // info about what attr is selected
-            return createTagInfo(tokenType, offset, _extractTagName(ctx));
         }
         
         if (ctx.token.string === "=") {


### PR DESCRIPTION
This is for #2804. Add some code to catch the cases where the cursor is in an error token type but actually either inside an attribute value or after an empty attribute value.
Also add three more extension unit tests to verify the new code.
