### PR TITLE
fixes #2820: code hints not properly selectable

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -464,7 +464,17 @@ define(function (require, exports, module) {
             // Last inserted character, used later by handleChange
             lastChar = String.fromCharCode(event.charCode);
         } else if (event.type === "keyup" && _inSession(editor)) {
-            _updateHintList();
+            if ((event.keyCode !== 32 && event.ctrlKey) || event.altKey || event.metaKey) {
+                // End the session if the user presses any key with a modifier (other than Ctrl+Space).
+                _endSession();
+            } else if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
+                       event.keyCode === KeyEvent.DOM_VK_RIGHT ||
+                       event.keyCode === KeyEvent.DOM_VK_BACK_SPACE) {
+                // Update the list after a simple navigation.
+                // We do this in "keyup" because we want the cursor position to be updated before
+                // we redraw the list.
+                _updateHintList();
+            }
         }
     }
     


### PR DESCRIPTION
This basically reverts the second part of the change introduced for
hints were being displayed, and this was causing trouble with the selection
(the previous behavior was that _updateHintList was called only for
left, right and backspace on keyup).

I also noticed that this fixed a behavior problem I was seeing in HTML code hints (I couldn't use the arrows to navigate properly in the list)
