### PR TITLE
Fix dropdown closing

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -87,14 +87,18 @@
     .CodeMirror-lines {
         padding: @code-padding 0;
         
-        /* This is necessary for issue #2780. It seems that because the cursor is in front of the code, it can
-         * interfere with the mouseup when the user clicks on the code and the cursor moves underneath the mouse
-         * position.
+        /* This is necessary for issue #2780. The logic for closing dropdowns depends on "click" events. Now
+         * that each line has a separate div element, there is a good chance that mouseDown and mouseUp events
+         * occur on different elements, which means a click event will not be sent. By disabling pointer events here,
+         * we are guaranteed that the mouse event will be captured by our parent div, and click events will 
+         * be dispatched.
          */
         pointer-events: none;
     }
     
     .CodeMirror-linewidget {
+        /* Re-enable pointer events for line widget. Pointer events are disabled for "CodeMirror-lines", which is the
+         * parent of line widgets, so they need to be explicitly re-enabled here in order for selection to work. */
         pointer-events: auto;
     }
     

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -82,6 +82,10 @@
          * (e.g. matchingbracket).
          */
         z-index: 3;
+    }
+
+    .CodeMirror-lines {
+        padding: @code-padding 0;
         
         /* This is necessary for issue #2780. It seems that because the cursor is in front of the code, it can
          * interfere with the mouseup when the user clicks on the code and the cursor moves underneath the mouse
@@ -89,10 +93,11 @@
          */
         pointer-events: none;
     }
-
-    .CodeMirror-lines {
-        padding: @code-padding 0;
+    
+    .CodeMirror-linewidget {
+        pointer-events: auto;
     }
+    
     .CodeMirror-gutters {
         background-color: @background-color-3;
         border-right: none;
@@ -153,6 +158,10 @@
     
     .CodeMirror .CodeMirror-vscrollbar, .CodeMirror .CodeMirror-hscrollbar {
         cursor: default;
+    }
+    
+    .CodeMirror-lines {
+        pointer-events: none;
     }
 }
 

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -159,10 +159,6 @@
     .CodeMirror .CodeMirror-vscrollbar, .CodeMirror .CodeMirror-hscrollbar {
         cursor: default;
     }
-    
-    .CodeMirror-lines {
-        pointer-events: none;
-    }
 }
 
 /*

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -160,6 +160,10 @@
         outline: none;
     }
     
+    .CodeMirror-sizer {
+        cursor: text;
+    }
+    
     .CodeMirror .CodeMirror-vscrollbar, .CodeMirror .CodeMirror-hscrollbar {
         cursor: default;
     }


### PR DESCRIPTION
Fixes #2780 

This is an updated version of #2808. Instead of just setting `pointer-events: none` on the cursor, set it on the entire `CodeMirror-lines` element. This is the same thing that was done in the v2 branch.

There is one complication--inline editors are now children of the `CodeMirror-lines` div, so `pointer-events` need to be reset to `auto` for the inline editor div.
