### PR TITLE
Turn off newline creation when autoclosing tags

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -347,7 +347,8 @@ define(function (require, exports, module) {
             lineNumbers: true,
             matchBrackets: true,
             dragDrop: false,    // work around issue #1123
-            extraKeys: codeMirrorKeyMap
+            extraKeys: codeMirrorKeyMap,
+            closeTagIndent: []
         });
         
         // Can't get CodeMirror's focused state without searching for


### PR DESCRIPTION
Fixes #2547.

This is a CM v2-compatible version of the fix @jasonsanjose made in 5c32c30 to turn off newline creation when autoclosing an HTML tag. The name "closeTagIndent" is a bit of a misnomer--as far as I can tell, it's supposed to be a list of tags for which newlines are inserted (which also causes the close tag to be indented).
