### PR TITLE
Fix exception when opening empty folder and file open

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -493,7 +493,7 @@ define(function (require, exports, module) {
                         // select the current document if it becomes visible when this folder is opened
                         var curDoc = DocumentManager.getCurrentDocument();
                         
-                        if (_hasFileSelectionFocus() && curDoc) {
+                        if (_hasFileSelectionFocus() && curDoc && data) {
                             var entry = data.rslt.obj.data("entry");
                             
                             if (curDoc.file.fullPath.indexOf(entry.fullPath) === 0) {


### PR DESCRIPTION
I hit this exception when testing extensions:
1. Open a file in editor
2. Open an empty folder in file tree

ProjectManager dereferences null 'data' object trying to determine if the open file is in the folder being opened for the purpose of highlighting it.
