### PR TITLE
Fix timing of agent loading in live development

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -102,13 +102,13 @@ define(function CSSAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page).on("loadEventFired.CSSAgent", _onLoadEventFired);
+        Inspector.on("actualPageLoad.CSSAgent", _onLoadEventFired);
         return _load.promise();
     }
 
     /** Clean up */
     function unload() {
-        $(Inspector.Page).off(".CSSAgent");
+        Inspector.off(".CSSAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -298,9 +298,10 @@ define(function DOMAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
+        Inspector
+            .on("actualPageLoad.DOMAgent", _onLoadEventFired);
         $(Inspector.Page)
-            .on("frameNavigated.DOMAgent", _onFrameNavigated)
-            .on("loadEventFired.DOMAgent", _onLoadEventFired);
+            .on("frameNavigated.DOMAgent", _onFrameNavigated);
         $(Inspector.DOM)
             .on("documentUpdated.DOMAgent", _onDocumentUpdated)
             .on("setChildNodes.DOMAgent", _onSetChildNodes)
@@ -313,6 +314,7 @@ define(function DOMAgent(require, exports, module) {
 
     /** Clean up */
     function unload() {
+        Inspector.off(".DOMAgent");
         $(Inspector.Page).off(".DOMAgent");
         $(Inspector.DOM).off(".DOMAgent");
     }

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -108,7 +108,7 @@ define(function RemoteAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page).on("loadEventFired.RemoteAgent", _onLoadEventFired);
+        Inspector.on("actualPageLoad.RemoteAgent", _onLoadEventFired);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
         _load.done(function () {
             _intervalId = window.setInterval(function () {
@@ -120,6 +120,7 @@ define(function RemoteAgent(require, exports, module) {
 
     /** Clean up */
     function unload() {
+        Inspector.off(".RemoteAgent");
         $(Inspector.Page).off(".RemoteAgent");
         $(Inspector.DOM).off(".RemoteAgent");
         if (_intervalId) {

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -226,6 +226,14 @@ define(function Inspector(require, exports, module) {
     function off(name, handler) {
         $exports.off(name, handler);
     }
+    
+    /** 
+     * Notify agents that the correct page (corresponding to the current document in Brackets) has
+     * been loaded in the browser.
+     */
+    function triggerActualPageLoad() {
+        $exports.triggerHandler("actualPageLoad");
+    }
 
     /** Disconnect from the remote debugger WebSocket */
     function disconnect() {
@@ -322,5 +330,6 @@ define(function Inspector(require, exports, module) {
     exports.connect = connect;
     exports.connectToURL = connectToURL;
     exports.connected = connected;
+    exports.triggerActualPageLoad = triggerActualPageLoad;
     exports.init = init;
 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, brackets, window */
+/*global define, $, brackets, window, PathUtils */
 
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument
@@ -74,6 +74,7 @@ define(function LiveDevelopment(require, exports, module) {
         ProjectManager      = require("project/ProjectManager"),
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils");
+        
 
     // Inspector
     var Inspector       = require("LiveDevelopment/Inspector/Inspector");
@@ -426,10 +427,25 @@ define(function LiveDevelopment(require, exports, module) {
         // Sample list taken from https://chromiumcodereview.appspot.com/10947037/patch/12001/13004
         // However, the link refers to the Chrome Extension API, it may not apply 100% to the Inspector API
     }
+    
+    /** Triggered by Page.loadEventFired */
+    function _onLoadEventFired(event, res) {
+        // Determine what page was actually opened in the browser, so we know it's
+        // the page that corresponds to the current document, rather than something
+        // spurious like the interstitial loading page.
+        Inspector.Runtime.evaluate("window.location.href", function (res) {
+            var doc = _getCurrentDocument(), // this calculates doc.url as a side-effect
+                url = PathUtils.parseUrl(res.result.value).hrefNoSearch;
+            if (doc.url === url) {
+                Inspector.triggerActualPageLoad();
+            }
+        });
+    }
 
     /** Triggered by Inspector.connect */
     function _onConnect(event) {
         $(Inspector.Inspector).on("detached", _onDetached);
+        $(Inspector.Page).on("loadEventFired", _onLoadEventFired);
         
         // Load agents
         _setStatus(STATUS_LOADING_AGENTS);
@@ -448,6 +464,7 @@ define(function LiveDevelopment(require, exports, module) {
     /** Triggered by Inspector.disconnect */
     function _onDisconnect(event) {
         $(Inspector.Inspector).off("detached", _onDetached);
+        $(Inspector.Page).off("loadEventFired", _onLoadEventFired);
         unloadAgents();
         _closeDocument();
         _setStatus(STATUS_INACTIVE);


### PR DESCRIPTION
For #2858, make live development agents handle the loading of the real page corresponding to the current document (not the interstitial page).

@peterflynn 
