### PR TITLE
Fix Issue #2875: CSS code hints overwrite 1 char too many on current line

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -178,7 +178,6 @@ define(function (require, exports, module) {
                                   ch: cursor.ch + (hint.length - this.info.name.length) };
                 } else {
                     hint += ":";
-                    end.ch++;       // Add one for the colon that we're appending.
                 }
             }
         } else if (!this.info.isNewItem && this.info.index !== -1) {


### PR DESCRIPTION
In the case where the CSS code hint replaces a text and adds a ":" at the end, it shouldn't expand the length of the replaced text to make space for the additional character.
