### PR TITLE
Fix Issue #2877: Debug menu shortcuts are enabled even when Debug menu is hidden

### DIFF
--- a/src/debug/DebugCommandHandlers.js
+++ b/src/debug/DebugCommandHandlers.js
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
     
     // Show Developer Tools (optionally enabled)
     CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS,      Commands.DEBUG_SHOW_DEVELOPER_TOOLS,   handleShowDeveloperTools)
-        .setEnabled(!!brackets.app.showDeveloperTools);
+        .setEnabled(!!brackets.app.showDeveloperTools && brackets.config.show_debug_menu);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW, Commands.DEBUG_NEW_BRACKETS_WINDOW,    _handleNewBracketsWindow);
     
     // Start with the "Run Tests" item disabled. It will be enabled later if the test file can be found.

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -850,7 +850,8 @@ define(function (require, exports, module) {
         CommandManager.register(Strings.CMD_QUIT,           Commands.FILE_QUIT, handleFileQuit);
     }
 
-    CommandManager.register(Strings.CMD_REFRESH_WINDOW,     Commands.DEBUG_REFRESH_WINDOW, handleFileReload);
+    CommandManager.register(Strings.CMD_REFRESH_WINDOW,     Commands.DEBUG_REFRESH_WINDOW, handleFileReload)
+        .setEnabled(brackets.config.show_debug_menu);
     CommandManager.register(Strings.CMD_ABORT_QUIT,         Commands.APP_ABORT_QUIT, _handleAbortQuit);
     
     CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);


### PR DESCRIPTION
This fixes adobe/brackets#2877 by disabling the "Refresh Brackets" and "Show Developer Tools" commands after they are created using the brackets.config.show_debug_menu value.
