### PR TITLE
Disable two unit tests that are failing intermittently due to CM bug

### DIFF
--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -584,6 +584,7 @@ define(function (require, exports, module) {
                                       "*/\n" +
                                       "}";
             
+            /*  TODO (#2887): disabled due to https://github.com/marijnh/CodeMirror/issues/1255
             it("should block uncomment, cursor in whitespace within block comment", function () {
                 myDocument.setText(BLOCK_CONTAINING_WS);
 
@@ -615,6 +616,7 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual(expectedText);
                 expectSelection({start: {line: 2, ch: 0}, end: {line: 2, ch: 4}});
             });
+            */
             
             // Selections mixing whitespace and existing block comments
             


### PR DESCRIPTION
#2887 tracks re-enabling these tests
