### PR TITLE
Add check for broken symlinks to hacking scripts (#2895)

### DIFF
--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -15,7 +15,7 @@ if [ ! -d "${1}" ]; then
   exit;
 fi
 
-if [ -d "${1}/Contents/dev" ]; then
+if [[ -d "${1}/Contents/dev" || -n $(find -L "${1}/Contents/dev" -type l) ]]; then
   rm "${1}/Contents/dev"
   echo "$1 has been restored to the installed configuration."
 fi

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -26,7 +26,7 @@ fi;
 root_dir=${full_path%/*/*}
 
 # Remove existing "dev" symlink, if present
-if [ -d "${1}/Contents/dev" ]; then
+if [[ -d "${1}/Contents/dev" || -n $(find -L "${1}/Contents/dev" -type l) ]]; then
   rm "${1}/Contents/dev"
 fi
 


### PR DESCRIPTION
This is a possible fix for #2895.

It adds an additional check for broken symlinks to the current condition.
