### PR TITLE
Update to latest CodeMirror upstream master

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -284,7 +284,9 @@ define(function (require, exports, module) {
      * @param {!boolean} makeMasterEditor  If true, this Editor will set itself as the (secret) "master"
      *          Editor for the Document. If false, this Editor will attach to the Document as a "slave"/
      *          secondary editor.
-     * @param {!string} mode  Syntax-highlighting language mode; "" means plain-text mode.
+     * @param {!(string|Object)} mode  Syntax-highlighting language mode; "" means plain-text mode.
+     *          May either be a string naming the mode, or an object containing a "name" property
+     *          naming the mode along with configuration options required by the mode. 
      *          See {@link EditorUtils#getModeFromFileExtension()}.
      * @param {!jQueryObject} container  Container to add the editor to.
      * @param {{startLine: number, endLine: number}=} range If specified, range of lines within the document
@@ -1191,7 +1193,9 @@ define(function (require, exports, module) {
      * an *approximation* of whether the mode is consistent across the whole range (a pattern like
      * A-B-A would return A as the mode, not null).
      *
-     * @return {?(Object|String)} Object or Name of syntax-highlighting mode; see {@link EditorUtils#getModeFromFileExtension()}.
+     * @return {?(Object|string)} Name of syntax-highlighting mode, or object containing a "name" property
+     *     naming the mode along with configuration options required by the mode. 
+     *     See {@link EditorUtils#getModeFromFileExtension()}.
      */
     Editor.prototype.getModeForSelection = function () {
         // Check for mixed mode info
@@ -1229,7 +1233,8 @@ define(function (require, exports, module) {
     /**
      * Sets the syntax-highlighting mode for the document.
      *
-     * @param {string} mode Name of syntax highlighting mode.
+     * @param {(string|Object)} mode Name of syntax highlighting mode, or object containing a "name"
+     *     property naming the mode along with configuration options required by the mode.
      */
     Editor.prototype.setModeForDocument = function (mode) {
         this._codeMirror.setOption("mode", mode);

--- a/src/editor/EditorUtils.js
+++ b/src/editor/EditorUtils.js
@@ -56,7 +56,9 @@ define(function (require, exports, module) {
      * @private
      * Given a file URL, determines the mode to use based
      * off the file's extension.
-     * @param {string} fileUrl  A cannonical file URL to extract the extension from
+     * @param {string} fileUrl  A canonical file URL to extract the extension from
+     * @return {(string|Object)} Name of syntax-highlighting mode, or object containing a "name" property
+     *     naming the mode along with configuration options required by the mode. 
      */
     function getModeFromFileExtension(fileUrl) {
         var ext = PathUtils.filenameExtension(fileUrl);
@@ -95,7 +97,11 @@ define(function (require, exports, module) {
         case "cfc":
         case "dhtml":
         case "xht":
-            return "htmlmixed";
+            return {
+                name: "htmlmixed",
+                scriptTypes: [{matches: /\/x-handlebars-template|\/x-mustache/i,
+                               mode: null}]
+            };
 
         case "svg":
         case "xml":

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -84,29 +84,40 @@ define(function (require, exports, module) {
         });
             
         describe("File extension to mode mapping", function () {
+            beforeEach(function () {
+                this.addMatchers({
+                    toSpecifyModeNamed: function (expected) {
+                        if (typeof this.actual === "string") {
+                            return this.actual === expected;
+                        } else {
+                            return this.actual.name === expected;
+                        }
+                    }
+                });
+            });
             
             it("should switch to the HTML mode for files ending in .html", function () {
                 // verify editor content
                 var mode = EditorUtils.getModeFromFileExtension("file:///only/testing/the/path.html");
-                expect(mode).toEqual("htmlmixed");
+                expect(mode).toSpecifyModeNamed("htmlmixed");
             });
             
             it("should switch modes even if the url has a query string", function () {
                 // verify editor content
                 var mode = EditorUtils.getModeFromFileExtension("http://only.org/testing/the/path.css?v=2");
-                expect(mode).toEqual("css");
+                expect(mode).toSpecifyModeNamed("css");
             });
             
             it("should accept just a file name too", function () {
                 // verify editor content
                 var mode = EditorUtils.getModeFromFileExtension("path.js");
-                expect(mode).toEqual("javascript");
+                expect(mode).toSpecifyModeNamed("javascript");
             });
 
             it("should default to plaintext for unknown file extensions", function () {
                 // verify editor content
                 var mode = EditorUtils.getModeFromFileExtension("test.foo");
-                expect(mode).toEqual("");
+                expect(mode).toSpecifyModeNamed("");
             });
         });
         

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -584,7 +584,6 @@ define(function (require, exports, module) {
                                       "*/\n" +
                                       "}";
             
-            /*  TODO (#2887): disabled due to https://github.com/marijnh/CodeMirror/issues/1255
             it("should block uncomment, cursor in whitespace within block comment", function () {
                 myDocument.setText(BLOCK_CONTAINING_WS);
 
@@ -616,7 +615,6 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual(expectedText);
                 expectSelection({start: {line: 2, ch: 0}, end: {line: 2, ch: 4}});
             });
-            */
             
             // Selections mixing whitespace and existing block comments
             


### PR DESCRIPTION
- Update SHA to our CodeMirror fork's master, which is now clean with upstream
  (brackets-sprint20 branch in the adobe/CodeMirror2 fork is no longer needed)
- Fix htmlmixed mode to specify parameters for handling mustache/handlebars
  templates, as required by latest CodeMirror
- Reinstate commented-out unit tests from #2887 since the underlying CM bug
  should now be fixed

@redmunds - assigning to you to review the htmlmixed update.
