### PR TITLE
Trigger scroll on project files container to reposition scroller shadows (#2255)

### DIFF
--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -66,6 +66,10 @@ define(function (require, exports, module) {
         
         $projectTitle.html(displayName);
         $projectTitle.attr("title", fullPath);
+        
+        // Trigger a scroll on the project files container to 
+        // reposition the scroller shadows and avoid issue #2255
+        $projectFilesContainer.trigger("scroll");
     }
     
     /**


### PR DESCRIPTION
This is a possible fix for #2255.

The problem was that the scroller shadow for the project files area was overlapping the title because it was not being repositioned once the title was first set.

Triggering a scroll event forces `_updateScrollerShadow` on `ViewUtils` to run again, positioning the shadow scroller in the right place.
