### PR TITLE
Prevent prefix based conflicts when renaming

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1156,7 +1156,7 @@ define(function (require, exports, module) {
         var keysToDelete = [];
         for (path in _openDocuments) {
             if (_openDocuments.hasOwnProperty(path)) {
-                if (path.indexOf(oldName) === 0) {
+                if (FileUtils.isAffectedWhenRenaming(path, oldName, newName, isFolder)) {
                     // Copy value to new key
                     var newKey = path.replace(oldName, newName);
                     
@@ -1164,8 +1164,8 @@ define(function (require, exports, module) {
                     keysToDelete.push(path);
                     
                     // Update document file
-                    FileUtils.updateFileEntryPath(_openDocuments[newKey].file, oldName, newName);
-                        
+                    FileUtils.updateFileEntryPath(_openDocuments[newKey].file, oldName, newName, isFolder);
+                    
                     if (!isFolder) {
                         // If the path name is a file, there can only be one matched entry in the open document
                         // list, which we just updated. Break out of the for .. in loop. 
@@ -1181,7 +1181,7 @@ define(function (require, exports, module) {
         
         // Update working set
         for (i = 0; i < _workingSet.length; i++) {
-            FileUtils.updateFileEntryPath(_workingSet[i], oldName, newName);
+            FileUtils.updateFileEntryPath(_workingSet[i], oldName, newName, isFolder);
         }
         
         // Send a "fileNameChanged" event. This will trigger the views to update.

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1225,7 +1225,7 @@ define(function (require, exports, module) {
                 
                 for (i = 0; i < nodes.length; i++) {
                     var node = $(nodes[i]);
-                    FileUtils.updateFileEntryPath(node.data("entry"), oldName, newName);
+                    FileUtils.updateFileEntryPath(node.data("entry"), oldName, newName, isFolder);
                 }
                 
                 // Notify that one of the project files has changed

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1296,7 +1296,9 @@ define(function (require, exports, module) {
                     }
                     
                     var oldName = selected.data("entry").fullPath;
-                    var oldNameRegex = new RegExp(StringUtils.regexEscape(data.rslt.old_name) + "$");
+                    // Folder paths have to end with a slash. Use look-head (?=...) to only replace the folder's name, not the slash as well
+                    var oldNameEndPattern = isFolder ? "(?=\/$)" : "$";
+                    var oldNameRegex = new RegExp(StringUtils.regexEscape(data.rslt.old_name) + oldNameEndPattern);
                     var newName = oldName.replace(oldNameRegex, data.rslt.new_name);
                     
                     renameItem(oldName, newName, isFolder)


### PR DESCRIPTION
Renaming file "foo" should not affect file "foobar/baz" even though "foo" is a prefix of "foobar".

Best merged after #2912 since it can't really be tested without it. Though the commit is included here, too. Please let me know if I should create a pull request with just the last commit.
