### PR TITLE
Mode handling fix for cmv3

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -469,7 +469,7 @@ define(function (require, exports, module) {
         while (TokenUtils.moveNextToken(ctx)) {
             if (inStyleBlock) {
                 // Check for end of this <style> block
-                if (ctx.token.state.mode !== "css") {
+                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos) !== "css") {
                     // currentStyleBlock.end is already set to pos of the last CSS token by now
                     currentStyleBlock.text = editor.document.getRange(currentStyleBlock.start, currentStyleBlock.end);
                     inStyleBlock = false;
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
                 }
             } else {
                 // Check for start of a <style> block
-                if (ctx.token.state.mode === "css") {
+                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos) === "css") {
                     currentStyleBlock = {
                         start: { line: ctx.pos.line, ch: ctx.pos.ch }
                     };

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -460,16 +460,18 @@ define(function (require, exports, module) {
      */
     function findStyleBlocks(editor) {
         // Start scanning from beginning of file
-        var ctx = TokenUtils.getInitialContext(editor._codeMirror, {line: 0, ch: 0});
-        
-        var styleBlocks = [];
-        var currentStyleBlock = null;
-        var inStyleBlock = false;
+        var ctx = TokenUtils.getInitialContext(editor._codeMirror, {line: 0, ch: 0}),
+            styleBlocks = [],
+            currentStyleBlock = null,
+            inStyleBlock = false,
+            outerMode = editor._codeMirror.getMode(),
+            tokenModeName;
         
         while (TokenUtils.moveNextToken(ctx)) {
+            tokenModeName = CodeMirror.innerMode(outerMode, ctx.token.state).mode.name;
             if (inStyleBlock) {
                 // Check for end of this <style> block
-                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos).name !== "css") {
+                if (tokenModeName !== "css") {
                     // currentStyleBlock.end is already set to pos of the last CSS token by now
                     currentStyleBlock.text = editor.document.getRange(currentStyleBlock.start, currentStyleBlock.end);
                     inStyleBlock = false;
@@ -478,7 +480,7 @@ define(function (require, exports, module) {
                 }
             } else {
                 // Check for start of a <style> block
-                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos).name === "css") {
+                if (tokenModeName === "css") {
                     currentStyleBlock = {
                         start: { line: ctx.pos.line, ch: ctx.pos.ch }
                     };

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -469,7 +469,7 @@ define(function (require, exports, module) {
         while (TokenUtils.moveNextToken(ctx)) {
             if (inStyleBlock) {
                 // Check for end of this <style> block
-                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos) !== "css") {
+                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos).name !== "css") {
                     // currentStyleBlock.end is already set to pos of the last CSS token by now
                     currentStyleBlock.text = editor.document.getRange(currentStyleBlock.start, currentStyleBlock.end);
                     inStyleBlock = false;
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
                 }
             } else {
                 // Check for start of a <style> block
-                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos) === "css") {
+                if (TokenUtils.getModeAt(editor._codeMirror, ctx.pos).name === "css") {
                     currentStyleBlock = {
                         start: { line: ctx.pos.line, ch: ctx.pos.ch }
                     };


### PR DESCRIPTION
This is for: https://github.com/adobe/brackets/issues/3010

While fixing similar code in my Quick Markup extension, I noticed this code checking for mode that is no longer defined in CodeMirror V3. All unit, integration, and extension tests pass in master, so this case does not seem to have a test for it.

@RaymondLim I seem to remember that you added this code, but I can't remember the case that it fixes, so can you verify this change? Also, should we add a test for this case?
