### PR TITLE
Disable JSLint for HTML files

### DIFF
--- a/src/language/JSLintUtils.js
+++ b/src/language/JSLintUtils.js
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
         var $lintResults = $("#jslint-results");
         var $goldStar = $("#gold-star");
         
-        if (getEnabled() && /^(\.js|\.htm|\.html)$/i.test(ext)) {
+        if (getEnabled() && /^\.js$/i.test(ext)) {
             perfTimerLint = PerfUtils.markStart("JSLint linting:\t" + (!currentDoc || currentDoc.file.fullPath));
             var text = currentDoc.getText();
             


### PR DESCRIPTION
JSLint should only be run on JS files.

Fixes #2930 by not running JSLint on HTML files.
