### PR TITLE
Use getRemoteDebuggingPort() API to disable cache on reload

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -520,7 +520,8 @@ define(function (require, exports, module) {
             result.resolve();
         } else {
             var Inspector = require("LiveDevelopment/Inspector/Inspector");
-            Inspector.getAvailableSockets("127.0.0.1", "9234")
+            var port = brackets.app.getRemoteDebuggingPort ? brackets.app.getRemoteDebuggingPort() : 9234;
+            Inspector.getAvailableSockets("127.0.0.1", port)
                 .fail(result.reject)
                 .done(function (response) {
                     var page = response[0];


### PR DESCRIPTION
This should be merged after adobe/brackets-shell#212 

Use the new `getRemoteDebuggingPort()` call, if available.

Partial fix for #2918 (the rest is in adobe/brackets-shell#212)
