### PR TITLE
Use getRemoteDebuggingPort() API to disable cache on reload

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -293,7 +293,8 @@ define(function (require, exports, module) {
             result.resolve();
         } else {
             var Inspector = brackets.getModule("LiveDevelopment/Inspector/Inspector");
-            Inspector.getAvailableSockets("127.0.0.1", "9234")
+            var port = brackets.app.getRemoteDebuggingPort ? brackets.app.getRemoteDebuggingPort() : 9234;
+            Inspector.getAvailableSockets("127.0.0.1", port)
                 .fail(result.reject)
                 .done(function (response) {
                     var page = response[0];


### PR DESCRIPTION
@jasonsanjose 

This pull request supersedes #2964 

Use the new `getRemoteDebuggingPort()` call, if available.

Partial fix for #2918 (the rest is in adobe/brackets-shell#212)
