### PR TITLE
Adding language, extensions and comments supports

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -20,7 +20,7 @@
     "javascript": {
         "name": "JavaScript",
         "mode": "javascript",
-        "fileExtensions": ["js"],
+        "fileExtensions": ["js", "jsx"],
         "blockComment": ["/*", "*/"],
         "lineComment": "//"
     },
@@ -46,7 +46,9 @@
     "cpp": {
         "name": "C++",
         "mode": ["clike", "text/x-c++src"],
-        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "c", "h", "i"]
+        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "c", "h", "i"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
     },
     
     "csharp": {
@@ -54,7 +56,14 @@
         "mode": ["clike", "text/x-csharp"],
         "fileExtensions": ["cs"]
     },
-
+    
+    "clike": {
+        "name": "C",
+        "mode": "clike",
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
+    },
+    
     "java": {
         "name": "Java",
         "mode": ["clike", "text/x-java"],
@@ -125,5 +134,11 @@
         "name": "YAML",
         "mode": "yaml",
         "fileExtensions": ["yaml", "yml"]
+    },
+    
+    "hx": {
+        "name": "Haxe",
+        "mode": "haxe",
+        "fileExtensions": ["hx"]
     }
 }

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -43,10 +43,18 @@
         "fileExtensions": ["php", "php3", "php4", "php5", "phtm", "phtml", "ctp"]
     },
     
+    "c": {
+        "name": "C",
+        "mode": ["clike", "text/x-csrc"],
+        "fileExtensions": ["c", "h", "i"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
+    },
+    
     "cpp": {
         "name": "C++",
         "mode": ["clike", "text/x-c++src"],
-        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "c", "h", "i"],
+        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii"],
         "blockComment": ["/*", "*/"],
         "lineComment": "//"
     },
@@ -54,11 +62,13 @@
     "csharp": {
         "name": "C#",
         "mode": ["clike", "text/x-csharp"],
-        "fileExtensions": ["cs"]
+        "fileExtensions": ["cs"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
     },
     
     "clike": {
-        "name": "C",
+        "name": "clike",
         "mode": "clike",
         "blockComment": ["/*", "*/"],
         "lineComment": "//"


### PR DESCRIPTION
This requests adds:
- Line and Block comments for PHP and C++.
- New .jsx file extension for JavaScript.
- Re-added the Haxe mode.

To add comments for PHP I had to add a new clike mode, since the inner most mode of PHP is clike and needed that to be registered as a mode. I would like it for a better way to add them, but didn't found it.
