### PR TITLE
Use "Meiryo UI" as Japanese UI font when it is available.

### DIFF
--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -81,4 +81,4 @@
 
 /* Font Stacks */
 
-@fontstack-sans-serif: 'SourceSansPro', Helvetica, Arial, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+@fontstack-sans-serif: 'SourceSansPro', Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;


### PR DESCRIPTION
This is for issue #2371.
