### PR TITLE
Fix #2961 (Documents may leak due to listeners left on FileEntry)

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -263,7 +263,7 @@ define(function (require, exports, module) {
         return (isFolder && path.indexOf(oldName) === 0) || (!isFolder && path === oldName);
     }
     
-	/**
+    /**
      * Update a file entry path after a file/folder name change.
      * @param {FileEntry} entry The FileEntry or DirectoryEntry to update
      * @param {string} oldName The full path of the old name

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -287,8 +287,6 @@ define(function (require, exports, module) {
                 }
             }
             
-            $(entry).triggerHandler("rename", [oldFullPath, fullPath]);
-            
             return true;
         }
         

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -34,7 +34,8 @@
     "xml": {
         "name": "XML",
         "mode": "xml",
-        "fileExtensions": ["svg", "xml", "wxs", "wxl"]
+        "fileExtensions": ["svg", "xml", "wxs", "wxl"],
+        "blockComment": ["<!--", "-->"]
     },
     
     "php": {


### PR DESCRIPTION
Fix bug #2961 (Documents may leak due to listeners left on FileEntry) -- Simplify by just directly pinging refcounted documents from DocumentManager.notifyPathNameChanged(). FileUtils no longer triggers a "rename" event on FileEntry objects and we no longer have a per-Document listener.

Also, enable block comments in XML files.
