### PR TITLE
move starting of static server to live dev start time and fix up some comments

### DIFF
--- a/src/LiveDevelopment/LiveDevServerManager.js
+++ b/src/LiveDevelopment/LiveDevServerManager.js
@@ -76,13 +76,12 @@
  * # LiveDevServerProvider.readyToServe()
  *
  * This method is called when Live Development is starting to check if the
- * provider that has been selected is ready to serve. The provider can
- * return a boolean or a jQuery promise. If a promise is returned, the Live
- * Development launch process waits until the promise resolves/rejects.
- * If "false" is returned, or the promise rejects, an error window is shown
+ * provider that has been selected is ready to serve. The provider returns a
+ * jQuery promise. The Live Development launch process waits until the promise
+ * resolves/rejects. If the promise rejects, an error window is shown
  * and Live Development does not start.
  *
- * return {boolean + jQuery.Promise}
+ * return {jQuery.Promise}
  *
  */
 

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -53,13 +53,6 @@ define(function (require, exports, module) {
     var _nodeConnectionDeferred = $.Deferred();
     
     var _baseUrl = "";
-    
-    /**
-     * @private
-     * @type{StaticServerProvider}
-     * Stores the singleton StaticServerProvider for use in unit testing.
-     */
-    var _staticServerProvider;
 
     /**
      * @constructor
@@ -109,7 +102,6 @@ define(function (require, exports, module) {
      * # LiveDevServerProvider.readyToServe()
      *
      * Gets the server details from the StaticServerDomain in node.
-     * Handles connecting to node and installing the domain if necessary.
      * The domain itself handles starting a server if necessary (when
      * the staticServer.getServer command is called).
      *
@@ -152,6 +144,13 @@ define(function (require, exports, module) {
 
     /**
      * @private
+     * @type{StaticServerProvider}
+     * Stores the singleton StaticServerProvider for use in unit testing.
+     */
+    var _staticServerProvider = new StaticServerProvider();
+    
+    /**
+     * @private
      * @return {StaticServerProvider} The singleton StaticServerProvider initialized
      * on app ready.
      */
@@ -161,7 +160,6 @@ define(function (require, exports, module) {
 
     AppInit.appReady(function () {
         // Register as a Live Development server provider
-        _staticServerProvider = new StaticServerProvider();
         LiveDevServerManager.registerProvider(_staticServerProvider, 5);
         
         // Start up the node connection, which is held in the


### PR DESCRIPTION
Addresses #2987 and #2988 by moving the starting of the static server to live dev start time. Also fixes up some comments that were out of sync with an API change.

Assinging to @redmunds 
cc @njx 
Should also really really fix #2981 (cc @gruehle )
