### PR TITLE
Fix Find highlighting bugs

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -245,6 +245,12 @@ define(function (require, exports, module) {
 
         // Prepopulate the search field with the current selection, if any.
         if (initialQuery !== undefined) {
+            // Eliminate newlines since we don't generally support searching across line boundaries (#2960)
+            var newline = initialQuery.indexOf("\n");
+            if (newline !== -1) {
+                initialQuery = initialQuery.substr(0, newline);
+            }
+            
             $input
                 .attr("value", initialQuery)
                 .get(0).select();

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -785,9 +785,12 @@ a, img {
     // Highlight color, overlaid on top of the .find-highlighting color
     background-color: rgba(244, 237, 98, 0.7);
 }
-.CodeMirror.find-highlighting div.CodeMirror-selected {
+.CodeMirror.find-highlighting div.CodeMirror-selected,
+.CodeMirror .CodeMirror.find-highlighting div.CodeMirror-selected {
     // Selection color while highlighting shown - ALWAYS has the .CodeMirror-searching color
-    // blended atop it
+    // blended atop it.
+    // Note: the 2nd selector reflecting CM nesting is needed to override the similar rules in
+    // brackets_codemirror_override.less (see the note about #324).
     background: rgb(255, 108, 0);
 }
 


### PR DESCRIPTION
- Fix bug #2910 (Find doesn't show orange highlight in inline editors) -- Add a selector to match the specificity of the inline-editor-specific selection color rules in brackets_codemirror_override.less
- Fix bug #2960 (Find shows wrong orange in placed if opened with selection
  containing newlines) -- Strip newlines from prepopulated Find text
