### PR TITLE
Fix About Dialog Contributors (Issue 3012 from Pull 2934)

### DIFF
--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
             });
         }).fail(function () {
             $dlg.find(".about-spinner").css("display", "none");
-            $contributors.html(Mustache.render("{{ABOUT_TEXT_LINE6}}", Strings));
+            $contributors.html(Mustache.render("<p class='dialog-message'>{{ABOUT_TEXT_LINE6}}</p>", Strings));
         });
     }
 

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -73,13 +73,15 @@ define(function (require, exports, module) {
         }, Strings);
         
         Dialogs.showModalDialogUsingTemplate(Mustache.render(AboutDialogTemplate, templateVars));
+        
+        // Get containers
+        var $dlg = $(".about-dialog.instance");
+        var $contributors = $dlg.find(".about-contributors");
             
         // Get all the project contributors and add them to the dialog
         $.getJSON(brackets.config.contributors_url).done(function (contributorsInfo) {
             
             // Populate the contributors data
-            var $dlg = $(".about-dialog.instance");
-            var $contributors = $dlg.find(".about-contributors");
             var totalContributors = contributorsInfo.length;
             var contributorsCount = 0;
             
@@ -111,9 +113,6 @@ define(function (require, exports, module) {
                 }
             });
         }).fail(function () {
-            var $dlg = $(".about-dialog.instance");
-            var $contributors = $dlg.find(".about-contributors");
-
             $dlg.find(".about-spinner").css("display", "none");
             $contributors.html("Lots of people (but we're having trouble loading that data right now).");
         });

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
             });
         }).fail(function () {
             $dlg.find(".about-spinner").css("display", "none");
-            $contributors.html("Lots of people (but we're having trouble loading that data right now).");
+            $contributors.html(Mustache.render("{{ABOUT_TEXT_LINE6}}", Strings));
         });
     }
 

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -45,17 +45,6 @@ define(function (require, exports, module) {
     var buildInfo;
     
 	
-    /**
-     * @private
-     * Gets a data structure that has the information for all the contributors of Brackets.
-     * The information is fetched from brackets.config.contributors_url using the github API.
-     * @return {$.Promise} jQuery Promise object that is resolved or rejected after the information is fetched.
-     */
-    function _getContributorsInformation() {
-        return $.getJSON(brackets.config.contributors_url);
-    }
-    
-    
     function _handleCheckForUpdates() {
         UpdateNotification.checkForUpdate(true);
     }
@@ -86,7 +75,7 @@ define(function (require, exports, module) {
         Dialogs.showModalDialogUsingTemplate(Mustache.render(AboutDialogTemplate, templateVars));
             
         // Get all the project contributors and add them to the dialog
-        _getContributorsInformation().done(function (contributorsInfo) {
+        $.getJSON(brackets.config.contributors_url).done(function (contributorsInfo) {
             
             // Populate the contributors data
             var $dlg = $(".about-dialog.instance");

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -52,16 +52,7 @@ define(function (require, exports, module) {
      * @return {$.Promise} jQuery Promise object that is resolved or rejected after the information is fetched.
      */
     function _getContributorsInformation() {
-        var result = new $.Deferred();
-        
-        $.getJSON(brackets.config.contributors_url)
-            .done(function (data) {
-                result.resolve(data);
-            }).fail(function () {
-                result.reject();
-            });
-        
-        return result.promise();
+        return $.getJSON(brackets.config.contributors_url);
     }
     
     
@@ -130,6 +121,12 @@ define(function (require, exports, module) {
                     }
                 }
             });
+        }).fail(function () {
+            var $dlg = $(".about-dialog.instance");
+            var $contributors = $dlg.find(".about-contributors");
+
+            $dlg.find(".about-spinner").css("display", "none");
+            $contributors.html("Lots of people (but we're having trouble loading that data right now).");
         });
     }
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -280,6 +280,7 @@ define({
     "ABOUT_TEXT_LINE3"                     : "Notices, terms and conditions pertaining to third party software are located at <a class=\"clickable-link\" data-href=\"http://www.adobe.com/go/thirdparty/\">http://www.adobe.com/go/thirdparty/</a> and incorporated by reference herein.",
     "ABOUT_TEXT_LINE4"                     : "Documentation and source at <a class=\"clickable-link\" data-href=\"https://github.com/adobe/brackets/\">https://github.com/adobe/brackets/</a>",
     "ABOUT_TEXT_LINE5"                     : "Made with \u2764 and JavaScript by:",
+    "ABOUT_TEXT_LINE6"                     : "Lots of people (but we're having trouble loading that data right now).",
     "UPDATE_NOTIFICATION_TOOLTIP"          : "There's a new build of {APP_NAME} available! Click here for details.",
     "UPDATE_AVAILABLE_TITLE"               : "Update Available",
     "UPDATE_MESSAGE"                       : "Hey, there's a new build of {APP_NAME} available. Here are some of the new features:",


### PR DESCRIPTION
This is a fix for #3012 in response to #2934 reworking the _getContributorsInformation function to return the $.getJSON call directly, as well as add a "graceful" fail message as suggested by @njx.

Hoping this could get merged into spring 21 rather than being pushed to 22.
