### PR TITLE
Dispatch languageAdded event from LanguageManager

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -1208,6 +1208,16 @@ define(function (require, exports, module) {
         // Send a "fileNameChanged" event. This will trigger the views to update.
         $(exports).triggerHandler("fileNameChange", [oldName, newName]);
     }
+    
+    /**
+     * @private
+     * Update document
+     */
+    function _handleLanguageAdded(event, language) {
+        CollectionUtils.forEach(_openDocuments, function (doc, key) {
+            doc._updateLanguage();
+        });
+    }
 
     // Define public API
     exports.Document                    = Document;
@@ -1239,6 +1249,10 @@ define(function (require, exports, module) {
     PerfUtils.createPerfMeasurement("DOCUMENT_MANAGER_GET_DOCUMENT_FOR_PATH", "DocumentManager.getDocumentForPath()");
 
     // Handle project change events
-    $(ProjectManager).on("projectOpen", _projectOpen);
-    $(ProjectManager).on("beforeProjectClose beforeAppClose", _savePreferences);
+    var $ProjectManager = $(ProjectManager);
+    $ProjectManager.on("projectOpen", _projectOpen);
+    $ProjectManager.on("beforeProjectClose beforeAppClose", _savePreferences);
+    
+    // Handle Language change events
+    $(LanguageManager).on("languageAdded", _handleLanguageAdded);
 });

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -370,6 +370,11 @@ define(function (require, exports, module) {
                 console.warn("Cannot register file extension \"" + extension + "\" for " + this.name + ", it already belongs to " + language.name);
             } else {
                 _fileExtensionToLanguageMap[extension] = this;
+                
+                // TODO (issue #2966) Allow extensions to add new file extensions to existing languages
+                // Notify on the Language and on LanguageManager?
+                // $(this).triggerHandler("fileExtensionAdded", [extension]);
+                // $(exports).triggerHandler("fileExtensionAdded", [extension, this]);
             }
         }
     };
@@ -464,6 +469,16 @@ define(function (require, exports, module) {
         this._modeToLanguageMap[mode] = language;
     };
     
+    /**
+     * @private
+     * Notify listeners when a language is added
+     * @param {!Language} language The new language
+     */
+    function _triggerLanguageAdded(language) {
+        // finally, store language to _language map
+        _languages[language.getId()] = language;
+        $(exports).triggerHandler("languageAdded", [language]);
+    }
     
     /**
      * Defines a language.
@@ -514,9 +529,9 @@ define(function (require, exports, module) {
                 
             // globally associate mode to language
             _setLanguageForMode(language.getMode(), language);
-        
-            // finally, store lanuage to _language map
-            _languages[id] = language;
+            
+            // fire an event to notify DocumentManager of the new language
+            _triggerLanguageAdded(language);
             
             result.resolve(language);
         }).fail(function (error) {

--- a/src/utils/CollectionUtils.js
+++ b/src/utils/CollectionUtils.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * Iterates over all the properties in an object or elements in an array. Differs from
      * $.each in that it iterates over array-like objects like regular objects.
      * @param {*} object The object or array to iterate over.
-     * @param {function(index, value)} callback The function that will be executed on every object.
+     * @param {function(value, index)} callback The function that will be executed on every object.
      */
     function forEach(object, callback) {
         var keys = Object.keys(object),

--- a/src/utils/CollectionUtils.js
+++ b/src/utils/CollectionUtils.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * Iterates over all the properties in an object or elements in an array. Differs from
      * $.each in that it iterates over array-like objects like regular objects.
      * @param {*} object The object or array to iterate over.
-     * @param {function(value, index)} callback The function that will be executed on every object.
+     * @param {function(value, key)} callback The function that will be executed on every object.
      */
     function forEach(object, callback) {
         var keys = Object.keys(object),

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -142,21 +142,17 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Returns a Document suitable for use with an Editor in isolation: i.e., a Document that will
-     * never be set as the currentDocument or added to the working set.
+     * Returns a Document suitable for use with an Editor in isolation, but
+     * maintained active for global updates like name and language changes.
      */
-    function createMockDocument(initialContent, languageId) {
-        var language = LanguageManager.getLanguage(languageId) || LanguageManager.getLanguage("javascript");
+    function createMockActiveDocument(options) {
+        var language    = options.language || LanguageManager.getLanguage("javascript"),
+            filename    = options.filename || "_unitTestDummyFile_." + language._fileExtensions[0],
+            content     = options.content || "";
         
         // Use unique filename to avoid collissions in open documents list
-        var dummyFile = new NativeFileSystem.FileEntry("_unitTestDummyFile_." + language._fileExtensions[0]);
-        
-        var docToShim = new DocumentManager.Document(dummyFile, new Date(), initialContent);
-        
-        // Prevent adding doc to global 'open docs' list; prevents leaks or collisions if a test
-        // fails to clean up properly (if test fails, or due to an apparent bug with afterEach())
-        docToShim.addRef = function () {};
-        docToShim.releaseRef = function () {};
+        var dummyFile = new NativeFileSystem.FileEntry(filename);
+        var docToShim = new DocumentManager.Document(dummyFile, new Date(), content);
         
         // Prevent adding doc to working set
         docToShim._handleEditorChange = function (event, editor, changeList) {
@@ -170,6 +166,24 @@ define(function (require, exports, module) {
         docToShim.notifySaved = function () {
             throw new Error("Cannot notifySaved() a unit-test dummy Document");
         };
+        
+        return docToShim;
+    }
+    
+    /**
+     * Returns a Document suitable for use with an Editor in isolation: i.e., a Document that will
+     * never be set as the currentDocument or added to the working set.
+     */
+    function createMockDocument(initialContent, languageId) {
+        var language    = LanguageManager.getLanguage(languageId) || LanguageManager.getLanguage("javascript"),
+            options     = { language: language, content: initialContent },
+            docToShim   = createMockActiveDocument(options);
+        
+        // Prevent adding doc to global 'open docs' list; prevents leaks or collisions if a test
+        // fails to clean up properly (if test fails, or due to an apparent bug with afterEach())
+        docToShim.addRef = function () {};
+        docToShim.releaseRef = function () {};
+        
         return docToShim;
     }
     
@@ -838,6 +852,7 @@ define(function (require, exports, module) {
     exports.getBracketsSourceRoot           = getBracketsSourceRoot;
     exports.makeAbsolute                    = makeAbsolute;
     exports.createMockDocument              = createMockDocument;
+    exports.createMockActiveDocument        = createMockActiveDocument;
     exports.createMockEditor                = createMockEditor;
     exports.createTestWindowAndRun          = createTestWindowAndRun;
     exports.closeTestWindow                 = closeTestWindow;


### PR DESCRIPTION
Fires new `languageAdded` event when a language has finished loading. Update all open documents for matching language. Update unit tests.

Fix for #2962 for the extension loading use case
