### PR TITLE
Show number of search results in Find bar while typing

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -96,6 +96,7 @@ define({
     
     // Find, Replace, Find in Files
     "SEARCH_REGEXP_INFO"                : "Use /re/ syntax for regexp search",
+    "FIND_RESULT_COUNT"                 : "{0} results",
     "WITH"                              : "With",
     "BUTTON_YES"                        : "Yes",
     "BUTTON_NO"                         : "No",

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -183,6 +183,9 @@ define(function (require, exports, module) {
                     // Search field is empty - no results
                     $("#find-counter").text("");
                     cm.setCursor(searchStartPos);
+                    if (modalBar) {
+                        getDialogTextField().removeClass("no-results");
+                    }
                     return;
                 }
                 

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -176,12 +176,12 @@ define(function (require, exports, module) {
             isFindFirst = true;
             cm.operation(function () {
                 if (state.query) {
-                    // Search field is empty - no results
-                    $("#find-counter").text("");
                     clearHighlights(getSearchState(cm));
                 }
                 state.query = parseQuery(query);
                 if (!state.query) {
+                    // Search field is empty - no results
+                    $("#find-counter").text("");
                     cm.setCursor(searchStartPos);
                     return;
                 }

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
     var CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
+        StringUtils         = require("utils/StringUtils"),
         Editor              = require("editor/Editor"),
         EditorManager       = require("editor/EditorManager"),
         ModalBar            = require("widgets/ModalBar").ModalBar;
@@ -148,8 +149,8 @@ define(function (require, exports, module) {
     }
     
     var queryDialog = Strings.CMD_FIND +
-            ': <input type="text" style="width: 10em"/> <div class="message"><span style="color: #888">(' +
-            Strings.SEARCH_REGEXP_INFO  + ')</span></div><div class="error"></div>';
+            ": <input type='text' style='width: 10em'/> <div class='message'><span id='find-counter'></span> " +
+            "<span style='color: #888'>(" + Strings.SEARCH_REGEXP_INFO  + ")</span></div><div class='error'></div>";
 
     /**
      * If no search pending, opens the search dialog. If search is already open, moves to
@@ -175,6 +176,8 @@ define(function (require, exports, module) {
             isFindFirst = true;
             cm.operation(function () {
                 if (state.query) {
+                    // Search field is empty - no results
+                    $("#find-counter").text("");
                     clearHighlights(getSearchState(cm));
                 }
                 state.query = parseQuery(query);
@@ -190,9 +193,11 @@ define(function (require, exports, module) {
                     $(cm.getWrapperElement()).addClass("find-highlighting");
                     
                     // FUTURE: if last query was prefix of this one, could optimize by filtering existing result set
+                    var resultCount = 0;
                     var cursor = getSearchCursor(cm, state.query);
                     while (cursor.findNext()) {
                         state.marked.push(cm.markText(cursor.from(), cursor.to(), { className: "CodeMirror-searching" }));
+                        resultCount++;
 
                         //Remove this section when https://github.com/marijnh/CodeMirror/issues/1155 will be fixed
                         if (cursor.pos.match && cursor.pos.match[0] === "") {
@@ -202,6 +207,9 @@ define(function (require, exports, module) {
                             cursor = getSearchCursor(cm, state.query, {line: cursor.to().line + 1, ch: 0});
                         }
                     }
+                    $("#find-counter").text(StringUtils.format(Strings.FIND_RESULT_COUNT, resultCount));
+                } else {
+                    $("#find-counter").text("");
                 }
                 
                 state.posFrom = state.posTo = searchStartPos;
@@ -232,6 +240,7 @@ define(function (require, exports, module) {
             }
         });
         $(modalBar).on("closeOk closeCancel closeBlur", function (e, query) {
+            // Clear highlights but leave search state in place so Find Next/Previous work after closing
             clearHighlights(state);
             
             // As soon as focus goes back to the editor, restore normal selection color

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -793,7 +793,9 @@ a, img {
     // brackets_codemirror_override.less (see the note about #324).
     background: rgb(255, 108, 0);
 }
-
+#find-counter {
+    font-weight: bold;
+}
 
 
 /* Quick Open search bar & dropdown */


### PR DESCRIPTION
This adds a simple search result counter to the Find bar.  It does _not_ track which result the highlight is currently on (e.g. "3 of 7").  The counter is hidden when the search field is blank.
