### PR TITLE
Add Toggle Comment support for several more languages

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -79,13 +79,16 @@
     "java": {
         "name": "Java",
         "mode": ["clike", "text/x-java"],
-        "fileExtensions": ["java"]
+        "fileExtensions": ["java"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
     },
 
     "coffeescript": {
         "name": "CoffeeScript",
         "mode": "coffeescript",
-        "fileExtensions": ["coffee"]
+        "fileExtensions": ["coffee"],
+        "lineComment": "#"
     },
 
     "clojure": {
@@ -97,31 +100,38 @@
     "perl": {
         "name": "Perl",
         "mode": "perl",
-        "fileExtensions": ["pl", "pm"]
+        "fileExtensions": ["pl", "pm"],
+        "lineComment": "#"
     },
     
     "ruby": {
         "name": "Ruby",
         "mode": "ruby",
-        "fileExtensions": ["rb"]
+        "fileExtensions": ["rb"],
+        "lineComment": "#"
     },
     
     "python": {
         "name": "Python",
         "mode": "python",
-        "fileExtensions": ["py", "pyw"]
+        "fileExtensions": ["py", "pyw"],
+        "lineComment": "#"
     },
     
     "sass": {
         "name": "SASS",
         "mode": "sass",
-        "fileExtensions": ["sass", "scss"]
+        "fileExtensions": ["sass", "scss"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
     },
 
     "lua": {
         "name": "Lua",
         "mode": "lua",
-        "fileExtensions": ["lua"]
+        "fileExtensions": ["lua"],
+        "blockComment": ["--[[", "]]"],
+        "lineComment": "--"
     },
 
     "sql": {
@@ -139,18 +149,22 @@
     "markdown": {
         "name": "Markdown",
         "mode": "markdown",
-        "fileExtensions": ["md", "markdown"]
+        "fileExtensions": ["md", "markdown"],
+        "blockComment": ["<!--", "-->"]
     },
     
     "yaml": {
         "name": "YAML",
         "mode": "yaml",
-        "fileExtensions": ["yaml", "yml"]
+        "fileExtensions": ["yaml", "yml"],
+        "lineComment": "#"
     },
     
     "hx": {
         "name": "Haxe",
         "mode": "haxe",
-        "fileExtensions": ["hx"]
-    }
+        "fileExtensions": ["hx"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": "//"
+   }
 }


### PR DESCRIPTION
Toggle Line and/or Block Comment support for: Java, CoffeeScript, Perl, Ruby, Python, SASS, Lua, Markdown, YAML, Haxe.  All these languages were included in core already.

I hit a few snags while working on this:
- CoffeeScript supports block comments via `###`, but Toggle Block Comment behaves badly (I think because the open/close delimiters are identical).  So I've only included lineComment for now.  Filed #3057 on this.
- I wasn't clear on whether Ruby officially supports block comments.  I've seen mention of `=begin` and `=end` but couldn't find any real-world code that uses this (and I'm not clear what the "rules" are -- e.g. do those delimiters have to be alone on a line?).  So I only included lineComment for now.
- Clojure supposedly supports line comments, but people seem to use `;` and `;;` equally.  We'd probably want uncomment to fully strip either flavor, which we don't support yet.  But Clojure being functional, _toggling_ line comments also seems very rare -- toggling block comments might be useful, except it seems Clojure doesn't offer block comments.  So I've left Clojure out for now.
