### PR TITLE
Cleanup for Adding the CodeMirror built-in Auto Close Brackets addon

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -71,13 +71,13 @@ define(function (require, exports, module) {
     exports.EDIT_BLOCK_COMMENT          = "edit.blockComment";
     exports.EDIT_LINE_UP                = "edit.lineUp";
     exports.EDIT_LINE_DOWN              = "edit.lineDown";
+    exports.TOGGLE_CLOSE_BRACKETS       = "edit.autoCloseBrackets";
 
     // VIEW
     exports.VIEW_HIDE_SIDEBAR           = "view.hideSidebar";
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";
     exports.VIEW_DECREASE_FONT_SIZE     = "view.decreaseFontSize";
     exports.VIEW_RESTORE_FONT_SIZE      = "view.restoreFontSize";
-    exports.TOGGLE_CLOSE_BRACKETS       = "view.autoCloseBrackets";
     exports.TOGGLE_JSLINT               = "debug.jslint";
     exports.SORT_WORKINGSET_BY_ADDED    = "view.sortWorkingSetByAdded";
     exports.SORT_WORKINGSET_BY_NAME     = "view.sortWorkingSetByName";

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -202,6 +202,7 @@ define({
     "CMD_BLOCK_COMMENT"                   : "Toggle Block Comment",
     "CMD_LINE_UP"                         : "Move Line Up",
     "CMD_LINE_DOWN"                       : "Move Line Down",
+    "CMD_TOGGLE_CLOSE_BRACKETS"           : "Enable Close Brackets",
     
     // View menu commands
     "VIEW_MENU"                           : "View",
@@ -210,7 +211,6 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Increase Font Size",
     "CMD_DECREASE_FONT_SIZE"              : "Decrease Font Size",
     "CMD_RESTORE_FONT_SIZE"               : "Restore Font Size",
-    "CMD_TOGGLE_CLOSE_BRACKETS"           : "Enable Close Brackets",
     "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sort by Added",
     "CMD_SORT_WORKINGSET_BY_NAME"         : "Sort by Name",
     "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sort by Type",


### PR DESCRIPTION
Cleaning #3040. After moving the Menu Item from the view menu to the edit menu I forgot to move the command and string too. This addresses that, but since the export names haven't changed, it should just be a simple code move.

@redmunds want to do a fast review?
