### PR TITLE
Fixed: #3032 KeyBindingManager no longer warns / prevents binding collisions

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true, boss: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
 /*global define, $, brackets, window */
 
 /**
@@ -397,9 +397,14 @@ define(function (require, exports, module) {
         
         // skip if the key is already assigned
         if (existing) {
-            // do not re-assign a key binding
-            console.error("Cannot assign " + normalized + " to " + commandID + ". It is already assigned to " + _keyMap[normalized].commandID);
-            return null;
+            if (!existing.explicitPlatform && explicitPlatform) {
+                // remove the the generic binding to replace with this new platform-specific binding
+                removeBinding(normalized);
+            } else {
+                // do not re-assign a key binding
+                console.error("Cannot assign " + normalized + " to " + commandID + ". It is already assigned to " + _keyMap[normalized].commandID);
+                return null;
+            }
         }
         
         // delete existing bindings when

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -395,18 +395,11 @@ define(function (require, exports, module) {
             return null;
         }
         
-        // skip if the key is already assigned explicitly for this platform
+        // skip if the key is already assigned
         if (existing) {
-            if (!existing.explicitPlatform) {
-                // remove existing generic bindings, then re-map this binding
-                // to the new command
-                removeBinding(normalized);
-            } else {
-                // do not re-assign a platform-specific key binding
-                console.log("Cannot assign " + normalized + " to " + commandID +
-                            ". It is already assigned to " + _keyMap[normalized].commandID);
-                return null;
-            }
+            // do not re-assign a key binding
+            console.error("Cannot assign " + normalized + " to " + commandID + ". It is already assigned to " + _keyMap[normalized].commandID);
+            return null;
         }
         
         // delete existing bindings when


### PR DESCRIPTION
Fix for #3032
