### PR TITLE
Fix chrome launching problems

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -557,15 +557,9 @@ define(function LiveDevelopment(require, exports, module) {
                 if (!browserStarted && exports.status !== STATUS_ERROR) {
                     url = launcherUrl + "?" + encodeURIComponent(url);
 
-                    // If err === FileError.ERR_NOT_FOUND, it means a remote debugger connection
-                    // is available, but the requested URL is not loaded in the browser. In that
-                    // case we want to launch the live browser (to open the url in a new tab)
-                    // without using the --remote-debugging-port flag. This works around issues
-                    // on Windows where Chrome can't be opened more than once with the
-                    // --remote-debugging-port flag set.
                     NativeApp.openLiveBrowser(
                         url,
-                        true
+                        true        // enable remote debugging
                     )
                         .done(function () {
                             browserStarted = true;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -565,7 +565,7 @@ define(function LiveDevelopment(require, exports, module) {
                     // --remote-debugging-port flag set.
                     NativeApp.openLiveBrowser(
                         url,
-                        err !== NativeFileError.ERR_NOT_FOUND
+                        true
                     )
                         .done(function () {
                             browserStarted = true;


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/2370

This changes Brackets to always set enableRemoteDebugging to true. This only seems to effect Windows, but it's changed for both Mac and Windows, so both should be tested.

There is an associated randy/starting-live-dev branch on brackets-shell.

@gruehle - there is a remaining issue that @DennisKehrig had on WinXP where he reported that his default browser was forced to be Chrome. I was prompted to change default browser on Win7, so I asked him to double-check that this is a real issue.
