### PR TITLE
revert removal of jshint boss flag, see #2957

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true, boss: true */
 /*global define, $, brackets, window */
 
 /**

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -186,12 +186,12 @@ define(function (require, exports, module) {
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);
             });
             
-            it("should allow a generic key binding to be replaced", function () {
+            it("should not allow a generic key binding to be replaced with another generic binding", function () {
                 KeyBindingManager.addBinding("test.foo", "Ctrl-A");
                 KeyBindingManager.addBinding("test.bar", "Ctrl-A");
                 
                 var expected = keyMap([
-                    keyBinding("Ctrl-A", "test.bar")
+                    keyBinding("Ctrl-A", "test.foo")
                 ]);
                 
                 expect(KeyBindingManager.getKeymap()).toEqual(expected);


### PR DESCRIPTION
@WebsiteDeveloper accidentally removed a jshint flag that we need to keep due to #2957

Also, fixes broken unit test due to new behavior from #3032.
