### PR TITLE
Restore call to _updateLineRange on inline editor change

### DIFF
--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -272,7 +272,6 @@ define(function (require, exports, module) {
     /**
      * Updates start line display.
      * @param {Editor} editor
-     * @return {boolean} Returns true when the widget height requires an update
      */
     InlineTextEditor.prototype._updateLineRange = function (editor) {
         var oldStartLine    = this._startLine,
@@ -286,8 +285,6 @@ define(function (require, exports, module) {
         if (oldStartLine !== this._startLine) {
             this.$lineNumber.text(this._startLine + 1);
         }
-
-        return (this._lineCount !== oldLineCount);
     };
 
     /**

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -256,6 +256,7 @@ define(function (require, exports, module) {
         $(inlineInfo.editor).on("change.InlineTextEditor", function (event, editor) {
             if (self.hostEditor.isFullyVisible()) {
                 self.sizeInlineWidgetToContents(true);
+                self._updateLineRange(editor);
             }
         });
         


### PR DESCRIPTION
For #2919.

@jasonsanjose - could you review this? It looks like the call to `_updateLineRange()` got removed as part of https://github.com/adobe/brackets/pull/2516 way back when. I'm guessing that was just an oversight and the only desired change there was to remove the call to `refresh()`, but wanted to double-check with you.
