### PR TITLE
Adding support for multiple lineComment prefixes

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
      * @param {!Editor} editor
      * @param {!string} prefix, e.g. "<!--"
      * @param {!string} suffix, e.g. "-->"
-     * @param {?Array.<string>} linePrefixes, e.g. ["//"]
+     * @param {!Array.<string>} linePrefixes, e.g. ["//"]
      */
     function blockCommentPrefixSuffix(editor, prefix, suffix, linePrefixes) {
         
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
             endCtx         = TokenUtils.getInitialContext(editor._codeMirror, {line: sel.end.line, ch: sel.end.ch}),
             prefixExp      = new RegExp("^" + StringUtils.regexEscape(prefix), "g"),
             suffixExp      = new RegExp(StringUtils.regexEscape(suffix) + "$", "g"),
-            lineExp        = linePrefixes && linePrefixes.length ? _createLineExpressions(linePrefixes) : null,
+            lineExp        = _createLineExpressions(linePrefixes),
             prefixPos      = null,
             suffixPos      = null,
             canComment     = false,
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
         }
         
         // Check if we should just do a line uncomment (if all lines in the selection are commented).
-        if (lineExp && (_matchExpressions(ctx.token.string, lineExp) || _matchExpressions(endCtx.token.string, lineExp))) {
+        if (lineExp.length && (_matchExpressions(ctx.token.string, lineExp) || _matchExpressions(endCtx.token.string, lineExp))) {
             var startCtxIndex = editor.indexFromPos({line: ctx.pos.line, ch: ctx.token.start});
             var endCtxIndex   = editor.indexFromPos({line: endCtx.pos.line, ch: endCtx.token.start + endCtx.token.string.length});
             
@@ -493,11 +493,11 @@ define(function (require, exports, module) {
         result        = result && _findNextBlockComment(ctx, selEnd, prefixExp);
         
         if (className === "comment" || result || isLineSelection) {
-            blockCommentPrefixSuffix(editor, prefix, suffix);
+            blockCommentPrefixSuffix(editor, prefix, suffix, []);
         } else {
             // Set the new selection and comment it
             editor.setSelection(selStart, selEnd);
-            blockCommentPrefixSuffix(editor, prefix, suffix);
+            blockCommentPrefixSuffix(editor, prefix, suffix, []);
             
             // Restore the old selection taking into account the prefix change
             if (isMultipleLine) {
@@ -525,8 +525,8 @@ define(function (require, exports, module) {
         var language = editor.getLanguageForSelection();
         
         if (language.hasBlockCommentSyntax()) {
-            // getLineCommentPrefix returns null if no line comment syntax is defined
-            blockCommentPrefixSuffix(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix(), language.getLineCommentPrefix());
+            // getLineCommentPrefixes always return an array, and will be empty if no line comment syntax is defined
+            blockCommentPrefixSuffix(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix(), language.getLineCommentPrefixes());
         }
     }
     
@@ -543,7 +543,7 @@ define(function (require, exports, module) {
         var language = editor.getLanguageForSelection();
         
         if (language.hasLineCommentSyntax()) {
-            lineCommentPrefix(editor, language.getLineCommentPrefix());
+            lineCommentPrefix(editor, language.getLineCommentPrefixes());
         } else if (language.hasBlockCommentSyntax()) {
             lineCommentPrefixSuffix(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix());
         }

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -49,22 +49,22 @@ define(function (require, exports, module) {
     /**
      * @private
      * Creates regular expressions for multiple line comment prefixes
-     * @param {Array.<string>} prefixes - the line comment prefixes
+     * @param {!Array.<string>} prefixes - the line comment prefixes
      * @return {Array.<RegExp>}
      */
     function _createLineExpressions(prefixes) {
-        var lineExps = [];
+        var lineExp = [];
         prefixes.forEach(function (prefix) {
-            lineExps.push(new RegExp("^\\s*" + StringUtils.regexEscape(prefix)));
+            lineExp.push(new RegExp("^\\s*" + StringUtils.regexEscape(prefix)));
         });
-        return lineExps;
+        return lineExp;
     }
     
     /**
      * @private
      * Returns true if any regular expression matches the given string
-     * @param {string} string - where to look
-     * @param {Array.<RegExp>} expressions - what to look
+     * @param {!string} string - where to look
+     * @param {!Array.<RegExp>} expressions - what to look
      * @return {boolean}
      */
     function _matchExpressions(string, expressions) {
@@ -75,10 +75,12 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Returns the line comment prefix that best matches
-     * @param {string} string - where to look
-     * @param {Array.<RegExp>} expressions - the line comment regular expressions
-     * @param {Array.<string>} prefixes - the line comment prefixes
+     * Returns the line comment prefix that best matches the string. Since there might be line comment prefixes
+     * that are prefixes of other line comment prefixes, it searches throught all and returns the longest line
+     * comment prefix that matches the string.
+     * @param {!string} string - where to look
+     * @param {!Array.<RegExp>} expressions - the line comment regular expressions
+     * @param {!Array.<string>} prefixes - the line comment prefixes
      * @return {string}
      */
     function _getLinePrefix(string, expressions, prefixes) {
@@ -108,7 +110,6 @@ define(function (require, exports, module) {
         for (i = startLine; i <= endLine; i++) {
             line = editor.document.getLine(i);
             // A line is commented out if it starts with 0-N whitespace chars, then a line comment prefix
-            console.log(_matchExpressions(line, lineExp));
             if (line.match(/\S/) && !_matchExpressions(line, lineExp)) {
                 containsUncommented = true;
                 break;
@@ -168,7 +169,7 @@ define(function (require, exports, module) {
                 }
             
             } else {
-                // Uncomment - remove first every prefix on each line (if any)
+                // Uncomment - remove the prefix on each line (if any)
                 for (i = startLine; i <= endLine; i++) {
                     line   = doc.getLine(i);
                     prefix = _getLinePrefix(line, lineExp, prefixes);
@@ -176,7 +177,6 @@ define(function (require, exports, module) {
                     if (prefix) {
                         commentI = line.indexOf(prefix);
                         doc.replaceRange("", {line: i, ch: commentI}, {line: i, ch: commentI + prefix.length});
-                        break;
                     }
                 }
             }
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
             endCtx         = TokenUtils.getInitialContext(editor._codeMirror, {line: sel.end.line, ch: sel.end.ch}),
             prefixExp      = new RegExp("^" + StringUtils.regexEscape(prefix), "g"),
             suffixExp      = new RegExp(StringUtils.regexEscape(suffix) + "$", "g"),
-            lineExp        = linePrefixes ? _createLineExpressions(linePrefixes) : null,
+            lineExp        = linePrefixes && linePrefixes.length ? _createLineExpressions(linePrefixes) : null,
             prefixPos      = null,
             suffixPos      = null,
             canComment     = false,

--- a/src/extensions/default/LESSSupport/main.js
+++ b/src/extensions/default/LESSSupport/main.js
@@ -35,6 +35,6 @@ define(function (require, exports, module) {
         mode: "less",
         fileExtensions: ["less"],
         blockComment: ["/*", "*/"],
-        lineComment: "//"
+        lineComment: ["//"]
     });
 });

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -458,7 +458,7 @@ define(function (require, exports, module) {
      * @return {Array.<string>} The prefixes
      */
     Language.prototype.getLineCommentPrefix = function () {
-        return this._lineCommentSyntax.length && this._lineCommentSyntax;
+        return this._lineCommentSyntax;
     };
 
     /**

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -285,11 +285,11 @@ define(function (require, exports, module) {
     /** @type {Array.<string>} File names for extensionless files that use this language */
     Language.prototype._fileNames = null;
     
-    /** @type {Object.<string,Language>} Which language to use for what CodeMirror mode */
-    Language.prototype._modeToLanguageMap = null;
-    
     /** @type {Array.<string>} Line comment syntax */
     Language.prototype._lineCommentSyntax = null;
+    
+    /** @type {Object.<string,Language>} Which language to use for what CodeMirror mode */
+    Language.prototype._modeToLanguageMap = null;
     
     /** @type {{ prefix: string, suffix: string }} Block comment syntax */
     Language.prototype._blockCommentSyntax = null;
@@ -450,14 +450,14 @@ define(function (require, exports, module) {
      * @return {boolean} Whether line comments are supported
      */
     Language.prototype.hasLineCommentSyntax = function () {
-        return Boolean(this._lineCommentSyntax.length);
+        return this._lineCommentSyntax.length > 0;
     };
     
     /**
      * Returns an array of prefixes to use for line comments.
      * @return {Array.<string>} The prefixes
      */
-    Language.prototype.getLineCommentPrefix = function () {
+    Language.prototype.getLineCommentPrefixes = function () {
         return this._lineCommentSyntax;
     };
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -454,7 +454,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Returns the prefix to use for line comments.
+     * Returns an array of prefixes to use for line comments.
      * @return {Array.<string>} The prefixes
      */
     Language.prototype.getLineCommentPrefix = function () {
@@ -462,12 +462,12 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Sets the prefix to use for line comments in this language.
+     * Sets the prefixes to use for line comments in this language.
      * @param {!string|Array.<string>} prefix Prefix string or and array of prefix strings
      *   to use for line comments (i.e. "//" or ["//", "#"])
      */
     Language.prototype.setLineCommentSyntax = function (prefix) {
-        var prefixes = !Array.isArray(prefix) ? [prefix] : prefix;
+        var prefixes = Array.isArray(prefix) ? prefix : [prefix];
         var i;
         
         if (prefixes.length) {
@@ -478,6 +478,8 @@ define(function (require, exports, module) {
                 this._lineCommentSyntax.push(prefixes[i]);
             }
             this._wasModified();
+        } else {
+            console.error("The prefix array should not be empty");
         }
     };
     

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -39,7 +39,7 @@
  *         mode: "haskell",
  *         fileExtensions: ["hs"],
  *         blockComment: ["{-", "-}"],
- *         lineComment: "--"
+ *         lineComment: ["--"]
  *     });
  *
  * To use that language and it's related mode, wait for the returned promise to be resolved:
@@ -49,7 +49,7 @@
  *
  * You can also refine an existing language. Currently you can only set the comment styles:
  *     var language = LanguageManager.getLanguage("haskell");
- *     language.setLineComment("--");
+ *     language.setLineComment(["--"]);
  *     language.setBlockComment("{-", "-}");
  *
  * Some CodeMirror modes define variations of themselves. They are called MIME modes.
@@ -234,6 +234,7 @@ define(function (require, exports, module) {
         
         this._fileExtensions    = [];
         this._modeToLanguageMap = {};
+        this._lineCommentSyntax = [];
     }
     
     
@@ -249,7 +250,7 @@ define(function (require, exports, module) {
     /** @type {Array.<string>} File extensions that use this language */
     Language.prototype._fileExtensions = null;
     
-    /** @type {{ prefix: string }} Line comment syntax */
+    /** @type {Array.<string>} Line comment syntax */
     Language.prototype._lineCommentSyntax = null;
     
     /** @type {Object.<string,Language>} Which language to use for what CodeMirror mode */
@@ -384,25 +385,28 @@ define(function (require, exports, module) {
      * @return {boolean} Whether line comments are supported
      */
     Language.prototype.hasLineCommentSyntax = function () {
-        return Boolean(this._lineCommentSyntax);
+        return Boolean(this._lineCommentSyntax.length);
     };
     
     /**
      * Returns the prefix to use for line comments.
-     * @return {string} The prefix
+     * @return {Array.<string>} The prefixes
      */
     Language.prototype.getLineCommentPrefix = function () {
-        return this._lineCommentSyntax && this._lineCommentSyntax.prefix;
+        return this._lineCommentSyntax.length && this._lineCommentSyntax;
     };
 
     /**
      * Sets the prefix to use for line comments in this language.
-     * @param {!string} prefix Prefix string to use for block comments (i.e. "//")
+     * @param {!Array.<string>} prefixes Prefixes strings to use for line comments (i.e. ["//"])
      */
-    Language.prototype.setLineCommentSyntax = function (prefix) {
-        _validateNonEmptyString(prefix, "prefix");
-        
-        this._lineCommentSyntax = { prefix: prefix };
+    Language.prototype.setLineCommentSyntax = function (prefixes) {
+        var self = this;
+        prefixes.forEach(function (prefix) {
+            _validateNonEmptyString(prefix, "prefix");
+            
+            self._lineCommentSyntax.push(prefix);
+        });
     };
     
     /**
@@ -488,7 +492,7 @@ define(function (require, exports, module) {
      * @param {!string}               definition.name           Human-readable name of the language, as it's commonly referred to (i.e. "C++")
      * @param {Array.<string>}        definition.fileExtensions List of file extensions used by this language (i.e. ["php", "php3"])
      * @param {Array.<string>}        definition.blockComment   Array with two entries defining the block comment prefix and suffix (i.e. ["<!--", "-->"])
-     * @param {string}                definition.lineComment    Line comment prefix (i.e. "//")
+     * @param {Array.<string>}        definition.lineComment    Array of multiple line comment prefixes (i.e. ["//"] or ["//", "#"])
      * @param {string|Array.<string>} definition.mode           CodeMirror mode (i.e. "htmlmixed"), optionally with a MIME mode defined by that mode ["clike", "text/x-c++src"]
      *                                                          Unless the mode is located in thirdparty/CodeMirror2/mode/<name>/<name>.js, you need to first load it yourself.
      *

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -401,12 +401,12 @@ define(function (require, exports, module) {
      * @param {!Array.<string>} prefixes Prefixes strings to use for line comments (i.e. ["//"])
      */
     Language.prototype.setLineCommentSyntax = function (prefixes) {
-        var self = this;
-        prefixes.forEach(function (prefix) {
-            _validateNonEmptyString(prefix, "prefix");
+        var self = this, i;
+        for (i = 0; i < prefixes.length; i++) {
+            _validateNonEmptyString(prefixes[i], "prefix");
             
-            self._lineCommentSyntax.push(prefix);
-        });
+            self._lineCommentSyntax.push(prefixes[i]);
+        }
     };
     
     /**

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -93,7 +93,8 @@
     "clojure": {
         "name": "Clojure",
         "mode": "clojure",
-        "fileExtensions": ["clj"]
+        "fileExtensions": ["clj"],
+        "lineComment": [";", ";;"]
     },
 
     "perl": {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -23,13 +23,14 @@
         "mode": "javascript",
         "fileExtensions": ["js", "jsx"],
         "blockComment": ["/*", "*/"],
-        "lineComment": "//"
+        "lineComment": ["//"]
     },
     
     "json": {
         "name": "JSON",
         "mode": ["javascript", "application/json"],
-        "fileExtensions": ["json"]
+        "fileExtensions": ["json"],
+        "lineComment": ["//"]
     },
     
     "xml": {
@@ -50,7 +51,7 @@
         "mode": ["clike", "text/x-csrc"],
         "fileExtensions": ["c", "h", "i"],
         "blockComment": ["/*", "*/"],
-        "lineComment": "//"
+        "lineComment": ["//"]
     },
     
     "cpp": {
@@ -58,7 +59,7 @@
         "mode": ["clike", "text/x-c++src"],
         "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii"],
         "blockComment": ["/*", "*/"],
-        "lineComment": "//"
+        "lineComment": ["//"]
     },
     
     "csharp": {
@@ -66,14 +67,14 @@
         "mode": ["clike", "text/x-csharp"],
         "fileExtensions": ["cs"],
         "blockComment": ["/*", "*/"],
-        "lineComment": "//"
+        "lineComment": ["//"]
     },
     
     "clike": {
         "name": "clike",
         "mode": "clike",
         "blockComment": ["/*", "*/"],
-        "lineComment": "//"
+        "lineComment": ["//", "#"]
     },
     
     "java": {

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -39,6 +39,8 @@ define(function (require, exports, module) {
         
         beforeEach(function () {
             waitsForDone(LanguageManager.ready, "LanguageManager ready", 10000);
+            
+            spyOn(console, "error");
         });
         
         function defineLanguage(definition) {
@@ -284,6 +286,9 @@ define(function (require, exports, module) {
                 }, "The language should be resolved", 50);
                 
                 runs(function () {
+                    language.setLineCommentSyntax([]);
+                    expect(console.error).toHaveBeenCalledWith("The prefix array should not be empty");
+                    
                     expect(function () { language.setLineCommentSyntax([""]);      }).toThrow(new Error("prefix must not be empty"));
                     expect(function () { language.setLineCommentSyntax(["#", ""]); }).toThrow(new Error("prefix must not be empty"));
                     

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
             if (expected.lineComment) {
                 var lineComment = Array.isArray(expected.lineComment) ? expected.lineComment : [expected.lineComment];
                 expect(actual.hasLineCommentSyntax()).toBe(true);
-                expect(actual.getLineCommentPrefix().toString()).toBe(lineComment.toString());
+                expect(actual.getLineCommentPrefixes().toString()).toBe(lineComment.toString());
             } else {
                 expect(actual.hasLineCommentSyntax()).toBe(false);
             }

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -48,10 +48,6 @@ define(function (require, exports, module) {
                 def.blockComment = [def.blockComment.prefix, def.blockComment.suffix];
             }
             
-            if (def.lineComment) {
-                def.lineComment = def.lineComment.prefix;
-            }
-            
             return LanguageManager.defineLanguage(definition.id, def);
         }
         
@@ -76,7 +72,7 @@ define(function (require, exports, module) {
             
             if (expected.lineComment) {
                 expect(actual.hasLineCommentSyntax()).toBe(true);
-                expect(actual.getLineCommentPrefix()).toBe(expected.lineComment.prefix);
+                expect(actual.getLineCommentPrefix()).toEqual(expected.lineComment);
             } else {
                 expect(actual.hasLineCommentSyntax()).toBe(false);
             }
@@ -234,19 +230,17 @@ define(function (require, exports, module) {
                 }, "The language should be resolved", 50);
                 
                 runs(function () {
-                    expect(function () { language.setLineCommentSyntax("");           }).toThrow(new Error("prefix must not be empty"));
+                    expect(function () { language.setLineCommentSyntax([""]);         }).toThrow(new Error("prefix must not be empty"));
                     expect(function () { language.setBlockCommentSyntax("<!---", ""); }).toThrow(new Error("suffix must not be empty"));
                     expect(function () { language.setBlockCommentSyntax("", "--->");  }).toThrow(new Error("prefix must not be empty"));
                     
-                    def.lineComment = {
-                        prefix: "//"
-                    };
+                    def.lineComment = ["//"];
                     def.blockComment = {
                         prefix: "<!---",
                         suffix: "--->"
                     };
                     
-                    language.setLineCommentSyntax(def.lineComment.prefix);
+                    language.setLineCommentSyntax(def.lineComment);
                     language.setBlockCommentSyntax(def.blockComment.prefix, def.blockComment.suffix);
                     
                     validateLanguage(def, language);
@@ -381,7 +375,7 @@ define(function (require, exports, module) {
                         name: "Shell",
                         mode: "shell",
                         fileExtensions: ["sh"],
-                        lineComment: "#"
+                        lineComment: ["#"]
                     }).done(function (language) {
                         shellLanguage = language;
                     });


### PR DESCRIPTION
There are a few languages like PHP that support 2 types of line comment ("//" and "#").

To address this, I made lineComment be an array for every language and saved also as an array in Language. It will also return an array when asking for a linePrefix.

`lineCommentPrefix` can work with multiple line prefixes and uncomment any line comment prefix defined in the array if it is found at the start of the line as before, but it will always comment using the first line comment prefix.

`blockCommentPrefixSuffix` can also work multiple line prefixes and uncomment any line comment prefix defined in the array. This also fixes a bug where in PHP if there was a comment using `#` and you would Toggle Block Comment inside that line comment it could uncomment any block comment found before that line.
