### PR TITLE
Set background of inline widget to transparent

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -132,6 +132,10 @@
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {
+    .CodeMirror {
+        background: transparent;
+    }
+    
     .CodeMirror span.CodeMirror-matchingbracket {
         /* Ensure visibility against gray inline editor background */
         background-color: @background-color-1;


### PR DESCRIPTION
I just noticed that the background of inline editors got messed up after this morning's CM upstream merge. This is because CM now declares an explicit white background color for the editor (it used to be transparent). This just sets the inline editor to explicitly have a transparent background.
