### PR TITLE
Remove line-height: inherit from .CodeMirror pre since this is now in the core CodeMirror CSS

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -20,13 +20,7 @@
 
 /* Brackets / CodeMirror Code Formatting */
 
-/*
- * TODO This can be removed next time we update CodeMirror2.
- * Marijn made this change to codemirror.css, but I need it now
- * in order to make font resizing work.
- */
 .CodeMirror pre {
-    line-height: inherit;
     padding: 0 @code-padding;
 }
 


### PR DESCRIPTION
Found this TODO while looking at `brackets_codemirror_override.less` and realized we can clean it up now. I tested increase/decrease font size and it still works.
