### PR TITLE
Improve Live Dev test reliability

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -788,6 +788,9 @@ define(function LiveDevelopment(require, exports, module) {
         _serverProvider = serverProvider;
     }
 
+    // Initialize exports.status
+    _setStatus(STATUS_INACTIVE);
+
     // For unit testing
     exports._pathToUrl          = _pathToUrl;
     exports._urlToPath          = _urlToPath;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -557,15 +557,9 @@ define(function LiveDevelopment(require, exports, module) {
                 if (!browserStarted && exports.status !== STATUS_ERROR) {
                     url = launcherUrl + "?" + encodeURIComponent(url);
 
-                    // If err === FileError.ERR_NOT_FOUND, it means a remote debugger connection
-                    // is available, but the requested URL is not loaded in the browser. In that
-                    // case we want to launch the live browser (to open the url in a new tab)
-                    // without using the --remote-debugging-port flag. This works around issues
-                    // on Windows where Chrome can't be opened more than once with the
-                    // --remote-debugging-port flag set.
                     NativeApp.openLiveBrowser(
                         url,
-                        err !== NativeFileError.ERR_NOT_FOUND
+                        true        // enable remote debugging
                     )
                         .done(function () {
                             browserStarted = true;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -776,14 +776,14 @@ define(function LiveDevelopment(require, exports, module) {
         // Register user defined server provider
         var userServerProvider = new UserServerProvider();
         LiveDevServerManager.registerProvider(userServerProvider, 99);
+
+        // Initialize exports.status
+        _setStatus(STATUS_INACTIVE);
     }
 
     function _setServerProvider(serverProvider) {
         _serverProvider = serverProvider;
     }
-
-    // Initialize exports.status
-    _setStatus(STATUS_INACTIVE);
 
     // For unit testing
     exports._pathToUrl          = _pathToUrl;

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -68,14 +68,14 @@ define(function (require, exports, module) {
         var localText,
             browserText;
         
-        //verify we aren't currently connected
+        //verify live dev isn't currently active
         expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
         
         runs(function () {
             waitsForDone(SpecRunnerUtils.openProjectFiles([htmlFile]), "SpecRunnerUtils.openProjectFiles");
         });
         
-        //start the connection
+        //start live dev
         runs(function () {
             LiveDevelopment.open();
         });
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
             expect(fixSpaces(browserText)).toBe(fixSpaces(localText));
             
             var doc = DocumentManager.getOpenDocumentForPath(testPath + "/" + htmlFile);
-            //expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
+            expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
         });
     }
 
@@ -157,7 +157,7 @@ define(function (require, exports, module) {
             });
             
             it("should establish a browser connection for an opened html file", function () {
-                //verify we aren't currently connected
+                //verify live dev isn't currently active
                 expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 //open a file
@@ -165,7 +165,7 @@ define(function (require, exports, module) {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles");
                 });
                 
-                //start the connection
+                //start live dev
                 runs(function () {
                     LiveDevelopment.open();
                 });
@@ -177,15 +177,15 @@ define(function (require, exports, module) {
                     expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_ACTIVE);
                     
                     var doc = DocumentManager.getOpenDocumentForPath(testPath + "/simple1.html");
-                    //expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
+                    expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
                 });
                 
-                // Let things settle down before trying to close the connection.
+                // Let things settle down before trying to stop live dev.
                 waits(1000);
             });
             
             it("should should not start a browser connection for an opened css file", function () {
-                //verify we aren't currently connected
+                //verify live dev isn't currently active
                 expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 //open a file
@@ -193,12 +193,12 @@ define(function (require, exports, module) {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]), "SpecRunnerUtils.openProjectFiles");
                 });
                 
-                //start the connection
+                //start live dev
                 runs(function () {
                     LiveDevelopment.open();
                 });
                 
-                //we just need to wait an arbitrary time since we can't check for the connection to be true
+                //need to wait an arbitrary time since we can't check for live dev to be active
                 waits(1000);
  
                 runs(function () {
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
                 var localText,
                     browserText;
                 
-                //verify we aren't currently connected
+                //verify live dev isn't currently active
                 expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 var cssOpened = false;
@@ -245,7 +245,7 @@ define(function (require, exports, module) {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css", "simple1.html"]), "SpecRunnerUtils.openProjectFiles");
                 });
                 
-                //start the connection
+                //start live dev
                 var liveDoc;
                 runs(function () {
                     LiveDevelopment.open();
@@ -278,7 +278,7 @@ define(function (require, exports, module) {
                     browserHtmlText,
                     htmlDoc;
                 
-                // verify we aren't currently connected
+                //verify live dev isn't currently active
                 expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 var cssOpened = false;
@@ -302,7 +302,7 @@ define(function (require, exports, module) {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles");
                 });
                 
-                // Modify some text in test file before starting live connection
+                // Modify some text in test file before starting live dev
                 runs(function () {
                     htmlDoc =  DocumentManager.getCurrentDocument();
                     origHtmlText = htmlDoc.getText();
@@ -310,7 +310,7 @@ define(function (require, exports, module) {
                     htmlDoc.setText(updatedHtmlText);
                 });
                                 
-                // start the connection
+                // start live dev
                 var liveDoc, liveHtmlDoc;
                 runs(function () {
                     waitsForDone(LiveDevelopment.open(), "LiveDevelopment.open()", 2000);

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -80,10 +80,11 @@ define(function (require, exports, module) {
         runs(function () {
             LiveDevelopment.open();
         });
-        waitsFor(function () { return Inspector.connected(); }, "Waiting for browser", 10000);
         
         // Wait for the file and its stylesheets to fully load (and be communicated back).
-        waits(1000);
+        waitsFor(function () {
+            return (LiveDevelopment.status === LiveDevelopment.STATUS_ACTIVE);
+        }, "Waiting for browser to become active", 10000);
         
         runs(function () {
             waitsForDone(SpecRunnerUtils.openProjectFiles([cssFile]), "SpecRunnerUtils.openProjectFiles");

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -39,7 +39,6 @@ define(function (require, exports, module) {
         LiveDevelopment,
         LiveDevServerManager,
         DOMAgent,
-        Inspector,
         DocumentManager,
         ProjectManager;
     
@@ -70,7 +69,7 @@ define(function (require, exports, module) {
             browserText;
         
         //verify we aren't currently connected
-        expect(Inspector.connected()).toBeFalsy();
+        expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
         
         runs(function () {
             waitsForDone(SpecRunnerUtils.openProjectFiles([htmlFile]), "SpecRunnerUtils.openProjectFiles");
@@ -134,7 +133,6 @@ define(function (require, exports, module) {
                         LiveDevelopment      = testWindow.brackets.test.LiveDevelopment;
                         LiveDevServerManager = testWindow.brackets.test.LiveDevServerManager;
                         DOMAgent             = testWindow.brackets.test.DOMAgent;
-                        Inspector            = testWindow.brackets.test.Inspector;
                         DocumentManager      = testWindow.brackets.test.DocumentManager;
                         CommandManager       = testWindow.brackets.test.CommandManager;
                         Commands             = testWindow.brackets.test.Commands;
@@ -151,14 +149,16 @@ define(function (require, exports, module) {
                     LiveDevelopment.close();
                 });
 
-                waitsFor(function () { return !Inspector.connected(); }, "Waiting to close inspector", 10000);
+                waitsFor(function () {
+                    return (LiveDevelopment.status === LiveDevelopment.STATUS_INACTIVE);
+                }, "Waiting for browser to become inactive", 10000);
 
                 SpecRunnerUtils.closeTestWindow();
             });
             
             it("should establish a browser connection for an opened html file", function () {
                 //verify we aren't currently connected
-                expect(Inspector.connected()).toBeFalsy();
+                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 //open a file
                 runs(function () {
@@ -169,10 +169,12 @@ define(function (require, exports, module) {
                 runs(function () {
                     LiveDevelopment.open();
                 });
-                waitsFor(function () { return Inspector.connected(); }, "Waiting for browser", 10000);
+                waitsFor(function () {
+                    return (LiveDevelopment.status === LiveDevelopment.STATUS_ACTIVE);
+                }, "Waiting for browser to become active", 10000);
  
                 runs(function () {
-                    expect(Inspector.connected()).toBeTruthy();
+                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_ACTIVE);
                     
                     var doc = DocumentManager.getOpenDocumentForPath(testPath + "/simple1.html");
                     //expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeTruthy();
@@ -184,7 +186,7 @@ define(function (require, exports, module) {
             
             it("should should not start a browser connection for an opened css file", function () {
                 //verify we aren't currently connected
-                expect(Inspector.connected()).toBeFalsy();
+                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 //open a file
                 runs(function () {
@@ -200,7 +202,7 @@ define(function (require, exports, module) {
                 waits(1000);
  
                 runs(function () {
-                    expect(Inspector.connected()).toBeFalsy();
+                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
 
                     var doc = DocumentManager.getOpenDocumentForPath(testPath + "/simple1.css");
                     expect(isOpenInBrowser(doc, LiveDevelopment.agents)).toBeFalsy();
@@ -220,7 +222,7 @@ define(function (require, exports, module) {
                     browserText;
                 
                 //verify we aren't currently connected
-                expect(Inspector.connected()).toBeFalsy();
+                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 var cssOpened = false;
                 runs(function () {
@@ -277,7 +279,7 @@ define(function (require, exports, module) {
                     htmlDoc;
                 
                 // verify we aren't currently connected
-                expect(Inspector.connected()).toBeFalsy();
+                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
                 
                 var cssOpened = false;
                 runs(function () {


### PR DESCRIPTION
LiveDevelopment status getting set to STATUS_ACTIVE happens after the Inspector becomes connected, so this is a better event to wait for. This removes the need to blindly wait an extra second just to be safe.

Also, this will detect the case that LiveDevelopment stays in the "Initializing..." state.

@gruehle Signed up to code review
