### PR TITLE
If live dev page leaves site, then terminate live dev

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -732,8 +732,10 @@ define(function LiveDevelopment(require, exports, module) {
         // Test that url is within site
         baseUrlRegExp = new RegExp("^" + StringUtils.regexEscape(baseUrl), "i");
         if (!url.match(baseUrlRegExp)) {
-            // No longer in site, so terminate live dev
-            _closeDocument();
+            // No longer in site, so terminate live dev, but don't close browser window
+            Inspector.disconnect();
+            _setStatus(STATUS_INACTIVE);
+            _serverProvider = null;
         }
     }
 


### PR DESCRIPTION
This is a fix for #2277.

Note that this bug says that element highlighting should stop when another url is entered, but it seems like we should allow other urls as long as user stays within site. Once site is left, then highlighting is stopped.

Also, it only says that highlighting should stop, but it seems like everything should stop, so the live dev connection is killed.

This feels kind of quick & dirty, so I am curious what I'm missing here. If this is a good enough starting point, then I'll add an integration test. 
