### PR TITLE
Turn quickopen test on (in integration category)

### DIFF
--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -33,6 +33,8 @@ define(function (require, exports, module) {
         SpecRunnerUtils       = require("spec/SpecRunnerUtils");
     
     describe("QuickOpen", function () {
+        this.category = "integration";
+        
         var testPath = SpecRunnerUtils.getTestPath("/spec/QuickOpen-test-files");
         var brackets, test$, executeCommand, EditorManager, DocumentManager;
 
@@ -90,7 +92,7 @@ define(function (require, exports, module) {
         // TODO: fix me!
         // This test is currently turned off due to failures on Windows 7
         // See https://github.com/adobe/brackets/issues/2696
-        xit("can open a file and jump to a line, centering that line on the screen", function () {
+        it("can open a file and jump to a line, centering that line on the screen", function () {
             var err = false;
             
             SpecRunnerUtils.loadProjectInTestWindow(testPath);


### PR DESCRIPTION
@RaymondLim mentioned that the fix for #2951 may have fixed this test on Windows (bug #2696 ). I just tried this test on Windows 7 and it worked for me, but I've had trouble reproducing the failure in general. With this pull request, I re-enable the test (and move it to the integration category).
