### PR TITLE
Set src/nls/zh-cn/strings.js to binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+src/nls/zh-cn/strings.js binary


### PR DESCRIPTION
I am not entirely sure this is the right way to do it.

Whenever I run `git checkout master` under Windows, and then `git checkout <some branch>`, git thinks I have changed `src/nls/zh-cn/strings.js`. By setting it to binary via `.gitattributes`, I no longer have this problem.
