### PR TITLE
Minor Live Development stylesheet/unit test bugs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,8 @@ module.exports = function (grunt) {
                     'src/thirdparty/CodeMirror2/lib/util/dialog.js',
                     'src/thirdparty/CodeMirror2/lib/util/searchcursor.js',
                     'src/thirdparty/mustache/mustache.js',
-                    'src/thirdparty/path-utils/path-utils.min'
+                    'src/thirdparty/path-utils/path-utils.min',
+                    'src/thirdparty/less-1.3.0.min.js'
                 ],
                 helpers : [
                     'test/spec/PhantomHelper.js'

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global brackets, define, $, less, window, XMLHttpRequest */
+/*global brackets, define, $, less, window */
 
 /**
  * main integrates LiveDevelopment into Brackets
@@ -47,7 +47,8 @@ define(function main(require, exports, module) {
         PreferencesManager  = require("preferences/PreferencesManager"),
         Dialogs             = require("widgets/Dialogs"),
         UrlParams           = require("utils/UrlParams").UrlParams,
-        Strings             = require("strings");
+        Strings             = require("strings"),
+        ExtensionUtils      = require("utils/ExtensionUtils");
 
     var PREFERENCES_CLIENT_ID = PreferencesManager.getClientId(module.id);
     var prefs;
@@ -78,17 +79,13 @@ define(function main(require, exports, module) {
 
     /** Load Live Development LESS Style */
     function _loadStyles() {
-        var request = new XMLHttpRequest();
-        request.open("GET", "LiveDevelopment/main.less", true);
-        request.onload = function onLoad(event) {
-            var parser = new less.Parser();
-            parser.parse(request.responseText, function onParse(err, tree) {
-                console.assert(!err, err);
-                $("<style>" + tree.toCSS() + "</style>")
-                    .appendTo(window.document.head);
-            });
-        };
-        request.send(null);
+        var lessText    = require("text!LiveDevelopment/main.less"),
+            parser      = new less.Parser();
+        
+        parser.parse(lessText, function onParse(err, tree) {
+            console.assert(!err, err);
+            ExtensionUtils.addEmbeddedStyleSheet(tree.toCSS());
+        });
     }
 
     /**

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -41,6 +41,7 @@
   <script src="../src/thirdparty/CodeMirror2/addon/edit/closetag.js"></script>
   <script src="../src/thirdparty/mustache/mustache.js"></script>
   <script src="../src/thirdparty/path-utils/path-utils.js"></script>
+  <script src="../src/thirdparty/less-1.3.0.min.js"></script>
   <script src="thirdparty/bootstrap2/js/bootstrap.min.js"></script>
     
   <!-- All other scripts are loaded through require. -->  


### PR DESCRIPTION
This fixes three related Live Development stylesheet bugs: 
1. Stylesheets were loaded asynchronously on initialization. This is a minor issue, but initialization should probably not complete until Live Development is actually initialized. (Things like this tend to cause problems with testing.)
2. The XHR that loaded the .less file was failing due to path problems in the unit tests.
3. The LESS parser was not loaded in the unit test window, so even if the .less files were properly loaded, they would fail to parse. 

This pull request uses require.js instead of an XHR to load the .less file properly, and also adds the less parser to SpecRunner.html so that it is available during unit tests.
