### PR TITLE
fixes #3163 (file handle is leaked on invalid zip files)

### DIFF
--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -108,7 +108,9 @@ function _cmdValidate(path, callback) {
         var errors = [];
         var commonPrefix = null;
         
-        fs.createReadStream(path)
+        var readStream = fs.createReadStream(path);
+        
+        readStream
             .pipe(unzip.Parse())
             .on("error", function (exception) {
                 // General error to report for problems reading the file
@@ -117,6 +119,7 @@ function _cmdValidate(path, callback) {
                     errors: errors
                 });
                 callbackCalled = true;
+                readStream.destroy();
             })
             .on("entry", function (entry) {
                 // look for the metadata
@@ -241,6 +244,7 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                 if (!callbackCalled) {
                     callback(exc);
                     callbackCalled = true;
+                    readStream.destroy();
                 }
             })
             .on("entry", function (entry) {
@@ -276,7 +280,7 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                 }
                 
             })
-            .on("close", function () {
+            .on("end", function () {
                 if (!callbackCalled) {
                     callback(null, validationResult);
                     callbackCalled = true;

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -163,6 +163,7 @@ function _cmdValidate(path, callback) {
                             // errors we can get here.
                             callback(exception, null);
                             callbackCalled = true;
+                            readStream.destroy();
                         })
                         .on("end", function () {
                             // attempt to parse the metadata
@@ -275,6 +276,7 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                             if (!callbackCalled) {
                                 callback(err);
                                 callbackCalled = true;
+                                readStream.destroy();
                             }
                         });
                 }

--- a/src/extensibility/node/spec/Installation.spec.js
+++ b/src/extensibility/node/spec/Installation.spec.js
@@ -50,6 +50,7 @@ var basicValidExtension  = path.join(testFilesDirectory, "basic-valid-extension.
     missingMain          = path.join(testFilesDirectory, "missing-main.zip"),
     oneLevelDown         = path.join(testFilesDirectory, "one-level-extension-master.zip"),
     incompatibleVersion  = path.join(testFilesDirectory, "incompatible-version.zip"),
+    invalidZip           = path.join(testFilesDirectory, "invalid-zip-file.zip"),
     missingPackageJSON   = path.join(testFilesDirectory, "missing-package-json.zip");
 
 describe("Package Installation", function () {
@@ -237,6 +238,16 @@ describe("Package Installation", function () {
                 path.join(extensionDirectory, "package.json")
             ];
             checkPaths(pathsToCheck, done);
+        });
+    });
+    
+    it("should not have trouble with invalid zip files", function (done) {
+        ExtensionsDomain._cmdInstall(invalidZip, installDirectory, {
+            disabledDirectory: disabledDirectory
+        }, function (err, result) {
+            expect(err).toBeNull();
+            expect(result.errors.length).toEqual(1);
+            done();
         });
     });
 });


### PR DESCRIPTION
Fixed #3163 by destroying the readstream when there's a parse error.
