### PR TITLE
Restore binding for frameNavigated event

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -779,7 +779,8 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         $(Inspector.Inspector).on("detached", _onDetached);
-        
+        $(Inspector.Page).on("frameNavigated.DOMAgent", _onFrameNavigated);
+		
         waitForInterstitialPageLoad()
             .fail(function () {
                 close();


### PR DESCRIPTION
This is for #2277 (again)

@iwehrman @gruehle I can't quite tell from the github history (which is kinda scary), but this event binding got stomped somewhere between sha f3419c1 and 5488286.
