### PR TITLE
Code review fixes for extension download

### DIFF
--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -177,7 +177,6 @@ define(function (require, exports, module) {
             if (newState === STATE_INSTALLED) {
                 msg = Strings.INSTALL_SUCCEEDED;
             } else if (newState === STATE_INSTALL_FAILED) {
-                // TODO: nicer formatting, especially for validation errors where there might be > 1 error code
                 msg = Strings.INSTALL_FAILED + "\n" + this._errorMessage;
             } else {
                 msg = Strings.INSTALL_CANCELED;

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
                 .fail(function (err) {
                     // If the "failure" is actually a user-requested cancel, don't show an error UI
                     if (err === "CANCELED") {
-                        console.assert(self._state === STATE_CANCELING_INSTALL || self._enterState === STATE_CANCELING_HUNG);
+                        console.assert(self._state === STATE_CANCELING_INSTALL || self._state === STATE_CANCELING_HUNG);
                         self._enterState(STATE_INSTALL_CANCELED);
                     } else {
                         self._errorMessage = Package.formatError(err);

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -44,7 +44,13 @@ define(function (require, exports, module) {
         STATE_INSTALLING        = 3,
         STATE_INSTALLED         = 4,
         STATE_INSTALL_FAILED    = 5,
-        STATE_INSTALL_CANCELLED = 6;
+        STATE_CANCELING_INSTALL = 6,
+        STATE_CANCELING_HUNG    = 7,
+        STATE_INSTALL_CANCELED  = 8;
+    
+    /** Timeout before we allow user to leave STATE_INSTALL_CANCELING without waiting for a resolution */
+    var CANCEL_TIMEOUT = 10 * 1000;
+    
     
     /** 
      * @constructor
@@ -133,25 +139,40 @@ define(function (require, exports, module) {
                     self._enterState(STATE_INSTALLED);
                 })
                 .fail(function (err) {
-                    // Ignore expected case: the Promise is failed when we programmatically cancel
-                    // In all other cases, record the error and transition to error display UI
-                    if (!(err === "CANCELED" && self._state === STATE_INSTALL_CANCELLED)) {
+                    // If the "failure" is actually a user-requested cancel, don't show an error UI
+                    if (err === "CANCELED") {
+                        console.assert(self._state === STATE_CANCELING_INSTALL || self._enterState === STATE_CANCELING_HUNG);
+                        self._enterState(STATE_INSTALL_CANCELED);
+                    } else {
                         self._errorMessage = Package.formatError(err);
                         self._enterState(STATE_INSTALL_FAILED);
                     }
                 });
             break;
             
+        case STATE_CANCELING_INSTALL:
+            // This should call back the STATE_INSTALLING fail() handler above, unless it's too late to cancel
+            // in which case we'll still jump to STATE_INSTALLED after this
+            this.$cancelButton.attr("disabled", "disabled");
+            this.$msg.text(Strings.CANCELING_INSTALL);
+            this._installer.cancel();
+            window.setTimeout(function () {
+                if (self._state === STATE_CANCELING_INSTALL) {
+                    self._enterState(STATE_CANCELING_HUNG);
+                }
+            }, CANCEL_TIMEOUT);
+            break;
+            
+        case STATE_CANCELING_HUNG:
+            this.$msg.text(Strings.CANCELING_HUNG);
+            this.$okButton
+                .removeAttr("disabled")
+                .text(Strings.CLOSE);
+            break;
+            
         case STATE_INSTALLED:
         case STATE_INSTALL_FAILED:
-        case STATE_INSTALL_CANCELLED:
-            if (newState === STATE_INSTALL_CANCELLED) {
-                // TODO: do we need to wait for acknowledgement? That will require adding a new
-                // "waiting for cancelled" state.
-                var success = this._installer.cancel();
-                console.assert(success);
-            }
-                
+        case STATE_INSTALL_CANCELED:
             this.$spinner.removeClass("spin");
             if (newState === STATE_INSTALLED) {
                 msg = Strings.INSTALL_SUCCEEDED;
@@ -159,7 +180,7 @@ define(function (require, exports, module) {
                 // TODO: nicer formatting, especially for validation errors where there might be > 1 error code
                 msg = Strings.INSTALL_FAILED + "\n" + this._errorMessage;
             } else {
-                msg = Strings.INSTALL_CANCELLED;
+                msg = Strings.INSTALL_CANCELED;
             }
             this.$msg.text(msg);
             this.$okButton
@@ -189,7 +210,7 @@ define(function (require, exports, module) {
      */
     InstallExtensionDialog.prototype._handleCancel = function () {
         if (this._state === STATE_INSTALLING) {
-            this._enterState(STATE_INSTALL_CANCELLED);
+            this._enterState(STATE_CANCELING_INSTALL);
         } else {
             this._enterState(STATE_CLOSED);
         }
@@ -203,7 +224,8 @@ define(function (require, exports, module) {
     InstallExtensionDialog.prototype._handleOk = function () {
         if (this._state === STATE_INSTALLED ||
                 this._state === STATE_INSTALL_FAILED ||
-                this._state === STATE_INSTALL_CANCELLED) {
+                this._state === STATE_INSTALL_CANCELED ||
+                this._state === STATE_CANCELING_HUNG) {
             // In these end states, this is a "Close" button: just close the dialog and indicate
             // success.
             this._enterState(STATE_CLOSED);
@@ -312,12 +334,14 @@ define(function (require, exports, module) {
         this._dialogDeferred = new $.Deferred();
         return this._dialogDeferred.promise();
     };
-
-    function RealInstaller() { }
-    RealInstaller.prototype.install = function (url) {
+    
+    
+    /** Mediates between this module and the Package extension-installation utils. Mockable for unit-testing. */
+    function InstallerFacade() { }
+    InstallerFacade.prototype.install = function (url) {
         if (this.pendingInstall) {
             console.error("Extension installation already pending");
-            return { promise: new $.Deferred().reject("DOWNLOAD_ID_IN_USE").promise() };
+            return new $.Deferred().reject("DOWNLOAD_ID_IN_USE").promise();
         }
         this.pendingInstall = Package.installFromURL(url);
         
@@ -331,8 +355,8 @@ define(function (require, exports, module) {
         
         return promise;
     };
-    RealInstaller.prototype.cancel = function () {
-        return this.pendingInstall.cancel();
+    InstallerFacade.prototype.cancel = function () {
+        this.pendingInstall.cancel();
     };
     
     /**
@@ -342,7 +366,7 @@ define(function (require, exports, module) {
      *     has finished installing, or rejected if the dialog is cancelled.
      */
     function _showDialog(installer) {
-        var dlg = new InstallExtensionDialog(new RealInstaller());
+        var dlg = new InstallExtensionDialog(new InstallerFacade());
         return dlg.show();
     }
     

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -345,11 +345,10 @@ define(function (require, exports, module) {
         
         return {
             promise: d.promise(),
-            _downloadId: downloadId,
             cancel: function () {
                 if (state === STATE_DOWNLOADING) {
                     // This will trigger download()'s fail() handler with CANCELED as the err code
-                    cancelDownload(this._downloadId);
+                    cancelDownload(downloadId);
                 }
                 // Else it's too late to cancel; we'll continue on through the done() chain and emit
                 // a success result (calling done() handlers) if all else goes well.

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -65,6 +65,7 @@ define(function (require, exports, module) {
      */
     var _uniqueId = 0;
     
+
     /**
      * TODO: can this go away now that we never call it directly?
      * 
@@ -81,33 +82,34 @@ define(function (require, exports, module) {
      */
     function validate(path) {
         var d = new $.Deferred();
-        _nodeConnectionDeferred.done(function (nodeConnection) {
-            if (nodeConnection.connected()) {
-                nodeConnection.domains.extensionManager.validate(path)
-                    .done(function (result) {
-                        
-                        // Convert the errors into properly localized strings
-                        var i,
-                            errors = result.errors;
-                        
-                        for (i = 0; i < errors.length; i++) {
-                            var formatArguments = errors[i];
-                            formatArguments[0] = Strings[formatArguments[0]];
-                            errors[i] = StringUtils.format.apply(window, formatArguments);
-                        }
-                        
-                        d.resolve({
-                            errors: errors,
-                            metadata: result.metadata
+        _nodeConnectionDeferred
+            .done(function (nodeConnection) {
+                if (nodeConnection.connected()) {
+                    nodeConnection.domains.extensionManager.validate(path)
+                        .done(function (result) {
+                            
+                            // Convert the errors into properly localized strings
+                            var i,
+                                errors = result.errors;
+                            
+                            for (i = 0; i < errors.length; i++) {
+                                var formatArguments = errors[i];
+                                formatArguments[0] = Strings[formatArguments[0]];
+                                errors[i] = StringUtils.format.apply(window, formatArguments);
+                            }
+                            
+                            d.resolve({
+                                errors: errors,
+                                metadata: result.metadata
+                            });
+                        })
+                        .fail(function (error) {
+                            d.reject(error);
                         });
-                    })
-                    .fail(function (error) {
-                        d.reject(error);
-                    });
-            } else {
-                d.reject();
-            }
-        })
+                } else {
+                    d.reject();
+                }
+            })
             .fail(function (error) {
                 d.reject(error);
             });
@@ -131,44 +133,45 @@ define(function (require, exports, module) {
      * disabledReason is either null or the reason the extension was installed disabled.
      *
      * @param {string} Absolute path to the package zip file
-     * @return {promise} A promise that is resolved with information about the package
+     * @return {$.Promise} A promise that is resolved with information about the package
      *          (which may include errors, in which case the extension was disabled), or
      *          rejected with an error object.
      */
     function install(path) {
         var d = new $.Deferred();
-        _nodeConnectionDeferred.done(function (nodeConnection) {
-            if (nodeConnection.connected()) {
-                var destinationDirectory = ExtensionLoader.getUserExtensionPath();
-                var disabledDirectory = destinationDirectory.replace(/\/user$/, "/disabled");
-                nodeConnection.domains.extensionManager.install(path, destinationDirectory, {
-                    disabledDirectory: disabledDirectory,
-                    apiVersion: brackets.metadata.apiVersion
-                })
-                    .done(function (result) {
-                        // If there were errors or the extension is disabled, we don't
-                        // try to load it so we're ready to return
-                        if (result.errors.length > 0 || result.disabledReason) {
-                            d.resolve(result);
-                        } else {
-                            // This was a new extension and everything looked fine.
-                            // We load it into Brackets right away.
-                            ExtensionLoader.loadExtension(result.name, {
-                                baseUrl: result.installedTo
-                            }, "main").then(function () {
-                                d.resolve(result);
-                            }, function () {
-                                d.reject(Errors.ERROR_LOADING);
-                            });
-                        }
+        _nodeConnectionDeferred
+            .done(function (nodeConnection) {
+                if (nodeConnection.connected()) {
+                    var destinationDirectory = ExtensionLoader.getUserExtensionPath();
+                    var disabledDirectory = destinationDirectory.replace(/\/user$/, "/disabled");
+                    nodeConnection.domains.extensionManager.install(path, destinationDirectory, {
+                        disabledDirectory: disabledDirectory,
+                        apiVersion: brackets.metadata.apiVersion
                     })
-                    .fail(function (error) {
-                        d.reject(error);
-                    });
-            } else {
-                d.reject();
-            }
-        })
+                        .done(function (result) {
+                            // If there were errors or the extension is disabled, we don't
+                            // try to load it so we're ready to return
+                            if (result.errors.length > 0 || result.disabledReason) {
+                                d.resolve(result);
+                            } else {
+                                // This was a new extension and everything looked fine.
+                                // We load it into Brackets right away.
+                                ExtensionLoader.loadExtension(result.name, {
+                                    baseUrl: result.installedTo
+                                }, "main").then(function () {
+                                    d.resolve(result);
+                                }, function () {
+                                    d.reject(Errors.ERROR_LOADING);
+                                });
+                            }
+                        })
+                        .fail(function (error) {
+                            d.reject(error);
+                        });
+                } else {
+                    d.reject();
+                }
+            })
             .fail(function (error) {
                 d.reject(error);
             });
@@ -215,40 +218,46 @@ define(function (require, exports, module) {
      */
     function download(url, downloadId) {
         var d = new $.Deferred();
-        _nodeConnectionDeferred.done(function (connection) {
-            // Validate URL
-            // TODO: PathUtils fails to parse URLs that are missing the protocol part (e.g. starts immediately with "www...")
-            var parsed = PathUtils.parseUrl(url);
-            if (!parsed.hostname) {  // means PathUtils failed to parse at all
-                d.reject(Errors.MALFORMED_URL);
-                return d.promise();
-            }
-            if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-                d.reject(Errors.UNSUPPORTED_PROTOCOL);
-                return d.promise();
-            }
-            
-            var urlInfo = { url: url, parsed: parsed, filenameHint: parsed.filename };
-            githubURLFilter(urlInfo);
-            
-            // Decide download destination
-            var filename = urlInfo.filenameHint;
-            filename = filename.replace(/[^a-zA-Z0-9_\- \(\)\.]/g, "_"); // make sure it's a valid filename
-            if (!filename) {  // in case of URL ending in "/"
-                filename = "extension.zip";
-            }
-            
-            var tempDownloadFolder = brackets.app.getApplicationSupportDirectory() + "/extensions/";
-            var localPath = tempDownloadFolder + filename;
-            
-            // Download the bits (using Node since brackets-shell doesn't support binary file IO)
-            var r = connection.domains.extensionManager.downloadFile(downloadId, urlInfo.url, localPath);
-            r.done(function (result) {
-                d.resolve(localPath);
-            }).fail(function (err) {
-                d.reject(err);
-            });
-        })
+        _nodeConnectionDeferred
+            .done(function (connection) {
+                if (connection.connected()) {   // TODO: we do this check EVERYWHERE -- could it be wrapped up by NodeConnection for us?
+                    // Validate URL
+                    // TODO: PathUtils fails to parse URLs that are missing the protocol part (e.g. starts immediately with "www...")
+                    var parsed = PathUtils.parseUrl(url);
+                    if (!parsed.hostname) {  // means PathUtils failed to parse at all
+                        d.reject(Errors.MALFORMED_URL);
+                        return d.promise();
+                    }
+                    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+                        d.reject(Errors.UNSUPPORTED_PROTOCOL);
+                        return d.promise();
+                    }
+                    
+                    var urlInfo = { url: url, parsed: parsed, filenameHint: parsed.filename };
+                    githubURLFilter(urlInfo);
+                    
+                    // Decide download destination
+                    var filename = urlInfo.filenameHint;
+                    filename = filename.replace(/[^a-zA-Z0-9_\- \(\)\.]/g, "_"); // make sure it's a valid filename
+                    if (!filename) {  // in case of URL ending in "/"
+                        filename = "extension.zip";
+                    }
+                    
+                    var tempDownloadFolder = brackets.app.getApplicationSupportDirectory() + "/extensions/";    // TODO: use a different temp location?
+                    var localPath = tempDownloadFolder + filename;
+                    
+                    // Download the bits (using Node since brackets-shell doesn't support binary file IO)
+                    var r = connection.domains.extensionManager.downloadFile(downloadId, urlInfo.url, localPath);
+                    r.done(function (result) {
+                        d.resolve(localPath);
+                    }).fail(function (err) {
+                        d.reject(err);
+                    });
+                    
+                } else {
+                    d.reject();
+                }
+            })
             .fail(function (error) {
                 d.reject(error);
             });
@@ -260,16 +269,13 @@ define(function (require, exports, module) {
      * if the download has already finished.
      * 
      * @param {number} downloadId Identifier previously passed to download()
-     * @return {boolean}
      */
     function cancelDownload(downloadId) {
         // TODO: if we're still waiting on the NodeConnection, how do we cancel?
         console.assert(_nodeConnectionDeferred.isResolved());
-        var success;
         _nodeConnectionDeferred.done(function (connection) {
-            success = connection.domains.extensionManager.abortDownload(downloadId);
+            connection.domains.extensionManager.abortDownload(downloadId);
         });
-        return success;
     }
     
     
@@ -284,6 +290,10 @@ define(function (require, exports, module) {
      * TODO: if top level value is an array it's ambiguous (multiple error objects or one?)
      * 
      * Use formatError() to convert a single error object to a friendly, localized error message.
+     * 
+     * The returned cancel() function will *attempt* to cancel installation, but it is not guaranteed to
+     * succeed. If cancel() succeeds, the Promise is rejected with a CANCELED error code. If we're unable
+     * to cancel, the Promise is resolved or rejected normally, as if cancel() had never been called.
      * 
      * @return {{promise: $.Promise, cancel: function():boolean}}
      */
@@ -301,8 +311,6 @@ define(function (require, exports, module) {
             .done(function (localPath) {
                 state = STATE_INSTALLING;
                 
-                // TOOD: need to clean up ZIP from temp location
-                
                 install(localPath)
                     .done(function (result) {
                         if (result.errors && result.errors.length > 0) {
@@ -316,13 +324,13 @@ define(function (require, exports, module) {
                         } else {
                             // Success! Extension is now running in Brackets
                             state = STATE_SUCCEEDED;
-                            d.resolve(result);
+                            d.resolve(result.metadata);
                         }
                     })
                     .fail(function (err) {
                         // File IO errors, internal error in install()/validate(), or extension startup crashed
                         state = STATE_FAILED;
-                        d.reject(err);
+                        d.reject(err);  // TODO: needs to be err.message ?
                     })
                     .always(function () {
                         // Whether success or failure, we can delete the original downloaded ZIP file now
@@ -332,7 +340,7 @@ define(function (require, exports, module) {
                     });
             })
             .fail(function (err) {
-                // Download errors
+                // Download error (the Node-side download code cleans up any partial ZIP file)
                 state = STATE_FAILED;
                 d.reject(err);
             });
@@ -342,10 +350,11 @@ define(function (require, exports, module) {
             _downloadId: downloadId,
             cancel: function () {
                 if (state === STATE_DOWNLOADING) {
-                    return cancelDownload(this._downloadId);
-                } else {
-                    return false;
+                    // This will trigger download()'s fail() handler with CANCELED as the err code
+                    cancelDownload(this._downloadId);
                 }
+                // Else it's too late to cancel; we'll continue on through the done() chain and emit
+                // a success result (calling done() handlers) if all else goes well.
             }
         };
     }

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -37,7 +37,7 @@ var unzip   = require("unzip"),
 
 
 var Errors = {
-    NOT_FOUND_ERR: "NOT_FOUND_ERR",
+    NOT_FOUND_ERR: "NOT_FOUND_ERR",                 // {0} is path where ZIP file was expected
     INVALID_ZIP_FILE: "INVALID_ZIP_FILE",           // {0} is path to ZIP file
     INVALID_PACKAGE_JSON: "INVALID_PACKAGE_JSON",   // {0} is JSON parse error, {1} is path to ZIP file
     MISSING_PACKAGE_NAME: "MISSING_PACKAGE_NAME",   // {0} is path to ZIP file
@@ -49,9 +49,9 @@ var Errors = {
     NO_DISABLED_DIRECTORY: "NO_DISABLED_DIRECTORY",
     ALREADY_INSTALLED: "ALREADY_INSTALLED",
     DOWNLOAD_ID_IN_USE: "DOWNLOAD_ID_IN_USE",
-    DOWNLOAD_TARGET_EXISTS: "DOWNLOAD_TARGET_EXISTS",   // {0} is the download target file
     BAD_HTTP_STATUS: "BAD_HTTP_STATUS",             // {0} is the HTTP status code
     NO_SERVER_RESPONSE: "NO_SERVER_RESPONSE",
+    CANNOT_WRITE_TEMP: "CANNOT_WRITE_TEMP",
     CANCELED: "CANCELED"
 };
 
@@ -405,7 +405,6 @@ function _createTempFile() {
     }
     
     var localPath = pathPrefix + suffix;
-    console.log("Creating temp file " + localPath);
     var outStream = fs.createWriteStream(localPath);
     return { outStream: outStream, localPath: localPath };
 }
@@ -518,16 +517,15 @@ function init(domainManager) {
             type: "string",
             description: "absolute filesystem path of the extension package"
         }],
-        {
-            errors: {
-                type: "string|Array.<string>",
-                description: "download error, if any; first string is error code (one of Errors.*); subsequent strings are additional info"
-            },
-            metadata: {
-                type: "{name: string, version: string}",
-                description: "all package.json metadata (null if there's no package.json)"
-            }
-        }
+        [{
+            name: "errors",
+            type: "string|Array.<string>",
+            description: "download error, if any; first string is error code (one of Errors.*); subsequent strings are additional info"
+        }, {
+            name: "metadata",
+            type: "{name: string, version: string}",
+            description: "all package.json metadata (null if there's no package.json)"
+        }]
     );
     domainManager.registerCommand(
         "extensionManager",
@@ -548,28 +546,27 @@ function init(domainManager) {
             type: "{disabledDirectory: ?string, apiVersion: ?string, nameHint: ?string}",
             description: "installation options: disabledDirectory should be set so that extensions can be installed disabled."
         }],
-        {
-            errors: {
-                type: "string|Array.<string>",
-                description: "download error, if any; first string is error code (one of Errors.*); subsequent strings are additional info"
-            },
-            metadata: {
-                type: "{name: string, version: string}",
-                description: "all package.json metadata (null if there's no package.json)"
-            },
-            disabledReason: {
-                type: "string",
-                description: "reason this extension was installed disabled (one of Errors.*), none if it was enabled"
-            },
-            installedTo: {
-                type: "string",
-                description: "absolute path where the extension was installed to"
-            },
-            commonPrefix: {
-                type: "string",
-                description: "top level directory in the package zip which contains all of the files"
-            }
-        }
+        [{
+            name: "errors",
+            type: "string|Array.<string>",
+            description: "download error, if any; first string is error code (one of Errors.*); subsequent strings are additional info"
+        }, {
+            name: "metadata",
+            type: "{name: string, version: string}",
+            description: "all package.json metadata (null if there's no package.json)"
+        }, {
+            name: "disabledReason",
+            type: "string",
+            description: "reason this extension was installed disabled (one of Errors.*), none if it was enabled"
+        }, {
+            name: "installedTo",
+            type: "string",
+            description: "absolute path where the extension was installed to"
+        }, {
+            name: "commonPrefix",
+            type: "string",
+            description: "top level directory in the package zip which contains all of the files"
+        }]
     );
     domainManager.registerCommand(
         "extensionManager",
@@ -587,10 +584,8 @@ function init(domainManager) {
             description: "URL to download from"
         }],
         {
-            error: {
-                type: "string|Array.<string>",
-                description: "download error, if any; first string is error code (one of Errors.*); subsequent strings are additional info"
-            }
+            type: "string",
+            description: "Local path to the downloaded file"
         }
     );
     domainManager.registerCommand(
@@ -605,10 +600,8 @@ function init(domainManager) {
             description: "Unique identifier for this download 'session', previously pased to downloadFile"
         }],
         {
-            result: {
-                type: "boolean",
-                description: "True if the download was pending and able to be canceled; false otherwise"
-            }
+            type: "boolean",
+            description: "True if the download was pending and able to be canceled; false otherwise"
         }
     );
 }

--- a/src/extensibility/node/package.json
+++ b/src/extensibility/node/package.json
@@ -5,5 +5,6 @@
         "semver": ">1.1.0 <2.0.0",
         "fs-extra": "0.5.x",
         "async": "0.2.x"
+        "request": "2.16.x"
     }
 }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -311,7 +311,7 @@ define({
     "CANCELING_INSTALL"                    : "Canceling...",
     "CANCELING_HUNG"                       : "Canceling the install is taking a long time. An internal error may have occurred.",
     "INSTALL_CANCELED"                     : "Installation canceled.",
-    // These must match the error codes in ExtensionsDomain.Errors.* :
+    // These must match the error codes in ExtensionsDomain.Errors.* & Package.Errors.* :
     "INVALID_ZIP_FILE"                     : "{0} is not a valid zipped package.",
     "INVALID_PACKAGE_JSON"                 : "Package.json file is not valid (error was: {0}).",
     "MISSING_PACKAGE_NAME"                 : "Missing package name in {0}.",
@@ -323,9 +323,9 @@ define({
     "ALREADY_INSTALLED"                    : "The extension was installed into your disabled extensions directory because it was previously installed.",
     "NO_DISABLED_DIRECTORY"                : "Cannot save extension to extensions/disabled because the folder does not exist.",
     "DOWNLOAD_ID_IN_USE"                   : "Internal error: download ID already in use.",
-    "DOWNLOAD_TARGET_EXISTS"               : "Temp download file already exists: {0}.",
     "NO_SERVER_RESPONSE"                   : "Cannot connect to server.",
     "BAD_HTTP_STATUS"                      : "File not found on server (HTTP {0}).",
+    "CANNOT_WRITE_TEMP"                    : "Unable to save download to temp file.",
     "ERROR_LOADING"                        : "The extension encountered an error while starting up.",
     "MALFORMED_URL"                        : "Malformed URL.",
     "UNSUPPORTED_PROTOCOL"                 : "URL has an unsupported protocol.",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -308,7 +308,9 @@ define({
     "INSTALLING_FROM"                      : "Installing extension from {0}...",
     "INSTALL_SUCCEEDED"                    : "Installation successful!",
     "INSTALL_FAILED"                       : "Installation failed.",
-    "INSTALL_CANCELLED"                    : "Installation cancelled.",
+    "CANCELING_INSTALL"                    : "Canceling...",
+    "CANCELING_HUNG"                       : "Canceling the install is taking a long time. An internal error may have occurred.",
+    "INSTALL_CANCELED"                     : "Installation canceled.",
     // These must match the error codes in ExtensionsDomain.Errors.* :
     "INVALID_ZIP_FILE"                     : "{0} is not a valid zipped package.",
     "INVALID_PACKAGE_JSON"                 : "Package.json file is not valid (error was: {0}).",


### PR DESCRIPTION
Addresses comments from (already merged) pull #3158 -- fixing #3159.

The main changes are:
- (first commit) Change code to acknowledge that cancellation is async and might fail (where "fail" means the download+install succeeds or fails normally as if you hadn't clicked cancel at all)
- (second commit) Download files into the OS temp folder instead of the extensions/user parent folder

And there are a series of lesser fixes in each of those commits too.

I didn't write any unit tests for the new UI states -- haven't dug into the UI unit test code yet.  So we'll have to work out whether NJ or I is the better person to work on that tomorrow.

@njx for review
