### PR TITLE
Fixes #2608 (Quick Open shows red on first use)

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -391,7 +391,7 @@ define(function (require, exports, module) {
      */
     QuickNavigateDialog.prototype._handleResultsReady = function (e, results) {
         // Give visual clue when there are no results
-        var isNoResults = (results.length === 0 && fileList && !this._isValidLineNumberQuery(this.$searchField.val()));
+        var isNoResults = (results.length === 0 && (fileList || currentPlugin) && !this._isValidLineNumberQuery(this.$searchField.val()));
         this.$searchField.toggleClass("no-results", isNoResults);
     };
     
@@ -473,8 +473,6 @@ define(function (require, exports, module) {
                 // keeps listening to it anyway. So the last Promise to resolve "wins" the UI update even if it's for
                 // a stale query. Guard from that by checking that filter text hasn't changed while we were waiting:
                 if (!queryIsStale(query)) {
-                    // New data, so we'll clear the matcher's caches
-                    matcher.reset();
                     // We're still the current query. Synchronously re-run the search call and resolve with its results
                     asyncResult.resolve(searchFileList(query, matcher));
                 } else {

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -473,6 +473,8 @@ define(function (require, exports, module) {
                 // keeps listening to it anyway. So the last Promise to resolve "wins" the UI update even if it's for
                 // a stale query. Guard from that by checking that filter text hasn't changed while we were waiting:
                 if (!queryIsStale(query)) {
+                    // New data, so we'll clear the matcher's caches
+                    matcher.reset();
                     // We're still the current query. Synchronously re-run the search call and resolve with its results
                     asyncResult.resolve(searchFileList(query, matcher));
                 } else {
@@ -790,7 +792,8 @@ define(function (require, exports, module) {
             .done(function (files) {
                 fileList = files;
                 fileListPromise = null;
-            });
+                this._filenameMatcher.reset();
+            }.bind(this));
     };
 
     function getCurrentEditorSelectedText() {

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -391,7 +391,7 @@ define(function (require, exports, module) {
      */
     QuickNavigateDialog.prototype._handleResultsReady = function (e, results) {
         // Give visual clue when there are no results
-        var isNoResults = (results.length === 0 && !this._isValidLineNumberQuery(this.$searchField.val()));
+        var isNoResults = (results.length === 0 && fileList && !this._isValidLineNumberQuery(this.$searchField.val()));
         this.$searchField.toggleClass("no-results", isNoResults);
     };
     
@@ -786,7 +786,6 @@ define(function (require, exports, module) {
         
         // Start fetching the file list, which will be needed the first time the user enters an un-prefixed query. If FileIndexManager's
         // caches are out of date, this list might take some time to asynchronously build. See searchFileList() for how this is handled.
-        fileList = null;
         fileListPromise = FileIndexManager.getFileInfoList("all")
             .done(function (files) {
                 fileList = files;
@@ -833,8 +832,11 @@ define(function (require, exports, module) {
             beginSearch("@", getCurrentEditorSelectedText());
         }
     }
-
-
+    
+    // Listen for a change of project to invalidate our file list
+    $(ProjectManager).on("projectOpen", function () {
+        fileList = null;
+    });
 
     // TODO: allow QuickOpenJS to register it's own commands and key bindings
     CommandManager.register(Strings.CMD_QUICK_OPEN,         Commands.NAVIGATE_QUICK_OPEN,       doFileSearch);

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -390,9 +390,10 @@ define(function (require, exports, module) {
      * list items are re-rendered. Both happen synchronously just after we return. Called even when results is empty.
      */
     QuickNavigateDialog.prototype._handleResultsReady = function (e, results) {
-        // Give visual clue when there are no results
+        // Give visual clue when there are no results (unless we're in "Go To Line" mode, where there
+        // are never results, or we're in file search mode and waiting for the index to get rebuilt)
         var isNoResults = (results.length === 0 && (fileList || currentPlugin) && !this._isValidLineNumberQuery(this.$searchField.val()));
-        this.$searchField.toggleClass("no-results", isNoResults);
+        this.$searchField.toggleClass("no-results", Boolean(isNoResults));
     };
     
     /**

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -761,11 +761,7 @@ define(function (require, exports, module) {
      * (This object's caches are all stored in "_" prefixed properties.)
      */
     function StringMatcher() {
-        // We keep track of the last query to know when we need to invalidate.
-        this._lastQuery = null;
-        
-        this._specialsCache = {};
-        this._noMatchCache = {};
+        this.reset();
     }
     
     /**
@@ -781,6 +777,17 @@ define(function (require, exports, module) {
      * @type {Object.<string, boolean>}
      */
     StringMatcher.prototype._noMatchCache = null;
+    
+    /**
+     * Clears the caches. Use this in the event that the caches may be invalid.
+     */
+    StringMatcher.prototype.reset = function () {
+        // We keep track of the last query to know when we need to invalidate.
+        this._lastQuery = null;
+        
+        this._specialsCache = {};
+        this._noMatchCache = {};
+    };
     
     /**
      * Performs a single match using the stringMatch function. See stringMatch for full documentation.

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -594,20 +594,20 @@ define(function (require, exports, module) {
         });
         
         describe("StringMatcher", function () {
+            this.addMatchers({
+                toBeInCache: function (matcher, cacheName) {
+                    var value = matcher[cacheName][this.actual];
+                    var notText = this.isNot ? " not" : "";
+                    
+                    this.message = function () {
+                        return "Expected " + cacheName + " to" + notText + " contain key " + this.actual;
+                    };
+                    
+                    return value !== undefined;
+                }
+            });
+            
             it("should manage its caches properly", function () {
-                this.addMatchers({
-                    toBeInCache: function (matcher, cacheName) {
-                        var value = matcher[cacheName][this.actual];
-                        var notText = this.isNot ? " not" : "";
-                        
-                        this.message = function () {
-                            return "Expected " + cacheName + " to" + notText + " contain key " + this.actual;
-                        };
-                        
-                        return value !== undefined;
-                    }
-                });
-                
                 var matcher = new StringMatch.StringMatcher();
                 expect(matcher._noMatchCache).toEqual({});
                 expect(matcher._specialsCache).toEqual({});
@@ -641,6 +641,16 @@ define(function (require, exports, module) {
                 // Array.prototype has length
                 var lengthResult = matcher.match("length", "l");
                 expect(lengthResult).toBeTruthy();
+            });
+            
+            it("can reset the caches", function () {
+                var matcher = new StringMatch.StringMatcher();
+                matcher.match("foo", "spec/live");
+                expect("foo").toBeInCache(matcher, "_specialsCache");
+                expect("foo").toBeInCache(matcher, "_noMatchCache");
+                matcher.reset();
+                expect("foo").not.toBeInCache(matcher, "_specialsCache");
+                expect("foo").not.toBeInCache(matcher, "_noMatchCache");
             });
         });
     });

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -594,17 +594,19 @@ define(function (require, exports, module) {
         });
         
         describe("StringMatcher", function () {
-            this.addMatchers({
-                toBeInCache: function (matcher, cacheName) {
-                    var value = matcher[cacheName][this.actual];
-                    var notText = this.isNot ? " not" : "";
-                    
-                    this.message = function () {
-                        return "Expected " + cacheName + " to" + notText + " contain key " + this.actual;
-                    };
-                    
-                    return value !== undefined;
-                }
+            beforeEach(function () {
+                this.addMatchers({
+                    toBeInCache: function (matcher, cacheName) {
+                        var value = matcher[cacheName][this.actual];
+                        var notText = this.isNot ? " not" : "";
+                        
+                        this.message = function () {
+                            return "Expected " + cacheName + " to" + notText + " contain key " + this.actual;
+                        };
+                        
+                        return value !== undefined;
+                    }
+                });
             });
             
             it("should manage its caches properly", function () {


### PR DESCRIPTION
Fixes #2608 (Quick Open shows red on first use) and also makes Quick Open more responsive on large projects by not immediately invalidating the cached file list.

Just eliminating the "red on first use" is a one line change:

``` javascript
        var isNoResults = (results.length === 0 && fileList && !this._isValidLineNumberQuery(this.$searchField.val()));
```

But I was also keen to make Quick Open more useful for Brackets again by updating the file list in the background, providing possibly mildly stale results in the meantime.

Ideally, we'd have a spinner while the loading is happening, but I have other things on my plate right now and didn't want to try to build a spinner into the modal bar right now.
