### PR TITLE
Added unit tests for cancellation-waiting workflow in installer dialog.

### DIFF
--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -49,10 +49,6 @@ define(function (require, exports, module) {
         STATE_CANCELING_HUNG    = 7,
         STATE_INSTALL_CANCELED  = 8;
     
-    /** Timeout before we allow user to leave STATE_INSTALL_CANCELING without waiting for a resolution */
-    var CANCEL_TIMEOUT = 10 * 1000;
-    
-    
     /** 
      * @constructor
      * Creates a new extension installer dialog.
@@ -61,6 +57,10 @@ define(function (require, exports, module) {
     function InstallExtensionDialog(installer) {
         this._installer = installer;
         this._state = STATE_CLOSED;
+
+        // Timeout before we allow user to leave STATE_INSTALL_CANCELING without waiting for a resolution
+        // (per-instance so we can poke it for unit testing)
+        this._cancelTimeout = 10 * 1000;
     }
     
     /** @type {jQuery} The dialog root. */
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
                 if (self._state === STATE_CANCELING_INSTALL) {
                     self._enterState(STATE_CANCELING_HUNG);
                 }
-            }, CANCEL_TIMEOUT);
+            }, this._cancelTimeout);
             break;
             
         case STATE_CANCELING_HUNG:

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
     InstallExtensionDialog.prototype._handleCancel = function () {
         if (this._state === STATE_INSTALLING) {
             this._enterState(STATE_CANCELING_INSTALL);
-        } else {
+        } else if (this._state !== STATE_CANCELING_INSTALL) {
             this._enterState(STATE_CLOSED);
         }
     };

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -227,6 +227,38 @@ define(function (require, exports, module) {
                 expect(installer.cancel).toHaveBeenCalled();
                 deferred.resolve();
             });
+            
+            it("should disable the cancel button while cancellation is processed", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                expect(fields.$cancelButton.attr("disabled")).toBeTruthy();
+                deferred.reject("CANCELED");
+            });
+            
+            it("should ignore the Esc key while cancellation is processed", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keyup", fields.$dlg[0]);
+                expect(fields.$dlg.is(":visible")).toBeTruthy();
+                deferred.reject("CANCELED");
+            });
+    
+            it("should ignore the Enter key while cancellation is processed", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keyup", fields.$dlg[0]);
+                expect(fields.$dlg.is(":visible")).toBeTruthy();
+                deferred.reject("CANCELED");
+            });
     
             it("should re-enable the ok button and hide cancel button after install succeeds", function () {
                 var deferred = new $.Deferred(),
@@ -264,6 +296,17 @@ define(function (require, exports, module) {
                 expect(fields.$cancelButton.is(":visible")).toBeFalsy();
             });
             
+            it("should re-enable the ok button and hide cancel button after install finishes canceling", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                deferred.reject("CANCELED");
+                expect(fields.$okButton.attr("disabled")).toBeFalsy();
+                expect(fields.$cancelButton.is(":visible")).toBeFalsy();
+            });
+    
             it("should close the dialog if ok button clicked after install succeeds", function () {
                 var deferred = new $.Deferred(),
                     installer = makeInstaller(null, deferred);
@@ -371,6 +414,40 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keyup", fields.$dlg[0]);
                 expect(fields.$dlg.is(":visible")).toBeFalsy();
             });
+
+            it("should close the dialog if ok button clicked after install finishes canceling", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                deferred.reject("CANCELED");
+                fields.$okButton.click();
+                expect(fields.$dlg.is(":visible")).toBeFalsy();
+            });
+    
+            it("should close the dialog if Enter pressed after install finishes canceling", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(true);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                deferred.reject("CANCELED");
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", fields.$dlg[0]);
+                expect(fields.$dlg.is(":visible")).toBeFalsy();
+            });
+    
+            it("should close the dialog if Esc pressed after install finishes canceling", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(true);
+                setUrl();
+                fields.$okButton.click();
+                fields.$cancelButton.click();
+                deferred.reject("CANCELED");
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keyup", fields.$dlg[0]);
+                expect(fields.$dlg.is(":visible")).toBeFalsy();
+            });
+    
         });
     });
 });

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -510,6 +510,54 @@ define(function (require, exports, module) {
                     SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keyup", fields.$dlg[0]);
                     deferred.reject("CANCELED");
                 });
+            });
+
+            it("should keep close button enabled and not throw an exception if install succeeds after cancelation", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                runs(function () {
+                    setUrl();
+                    dialog._cancelTimeout = 50;
+                    fields.$okButton.click();
+                    fields.$cancelButton.click();
+                });
+                waits(100);
+                runs(function () {
+                    deferred.resolve();
+                    expect(fields.$okButton.attr("disabled")).toBeFalsy();
+                });
+            });
+
+            it("should keep close button enabled and not throw an exception if install fails after cancelation", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                runs(function () {
+                    setUrl();
+                    dialog._cancelTimeout = 50;
+                    fields.$okButton.click();
+                    fields.$cancelButton.click();
+                });
+                waits(100);
+                runs(function () {
+                    deferred.reject();
+                    expect(fields.$okButton.attr("disabled")).toBeFalsy();
+                });
+            });
+            
+            it("should keep close button enabled and not throw an exception if install cancelation completes after cancelation", function () {
+                var deferred = new $.Deferred(),
+                    installer = makeInstaller(null, deferred);
+                runs(function () {
+                    setUrl();
+                    dialog._cancelTimeout = 50;
+                    fields.$okButton.click();
+                    fields.$cancelButton.click();
+                });
+                waits(100);
+                runs(function () {
+                    deferred.reject("CANCELED");
+                    expect(fields.$okButton.attr("disabled")).toBeFalsy();
+                });
                 
                 // This must be in the last spec in the suite.
                 runs(function () {


### PR DESCRIPTION
Also fixed Esc to not cancel the dialog if we're waiting for cancellation.

@peterflynn -- assigning to you; @dangoor reviewed the original unit tests but since these are specifically related to the new workflow you added I think it makes sense for you to take a look. Feel free to hand off if you're overloaded.
