### PR TITLE
Fix extension installation unit tests to not rely on hardcoded string

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -87,19 +87,8 @@ define(function (require, exports, module) {
                 if (nodeConnection.connected()) {
                     nodeConnection.domains.extensionManager.validate(path)
                         .done(function (result) {
-                            
-                            // Convert the errors into properly localized strings
-                            var i,
-                                errors = result.errors;
-                            
-                            for (i = 0; i < errors.length; i++) {
-                                var formatArguments = errors[i];
-                                formatArguments[0] = Strings[formatArguments[0]];
-                                errors[i] = StringUtils.format.apply(window, formatArguments);
-                            }
-                            
                             d.resolve({
-                                errors: errors,
+                                errors: result.errors,
                                 metadata: result.metadata
                             });
                         })

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -88,8 +88,8 @@ define(function (require, exports, module) {
             
             runs(function () {
                 expect(packageData.errors.length).toEqual(2);
-                expect(packageData.errors[0].indexOf(missingNameVersion)).not.toEqual(-1);
-                expect(packageData.errors[1].indexOf(missingNameVersion)).not.toEqual(-1);
+                expect(packageData.errors[0][0]).toEqual("MISSING_PACKAGE_NAME");
+                expect(packageData.errors[1][0]).toEqual("MISSING_PACKAGE_VERSION");
             });
         });
         

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -88,8 +88,8 @@ define(function (require, exports, module) {
             
             runs(function () {
                 expect(packageData.errors.length).toEqual(2);
-                expect(packageData.errors[0]).toEqual("Missing package name in " + missingNameVersion + ".");
-                expect(packageData.errors[1]).toEqual("Missing package version in " + missingNameVersion + ".");
+                expect(packageData.errors[0].indexOf(missingNameVersion)).not.toEqual(-1);
+                expect(packageData.errors[1].indexOf(missingNameVersion)).not.toEqual(-1);
             });
         });
         


### PR DESCRIPTION
We shouldn't rely on the actual UI string since that means the unit test would fail in other languages.
