### PR TITLE
reenable jasmine phantom tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,8 +136,7 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config']);
 
     // task: test
-    //grunt.registerTask('test', ['jshint', 'jasmine']);
-    grunt.registerTask('test', ['jshint']);
+    grunt.registerTask('test', ['jshint', 'jasmine']);
 
     // task: set-sprint
     // Update sprint number in package.json and rewrite src/config.json

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         "branch": "",
         "SHA": ""
     },
+    "engines": {
+        "node": "~0.10.1"
+    },
     "devDependencies": {
         "grunt": "~0.4.0",
         "grunt-cli": "~0.1.0",

--- a/src/config.json
+++ b/src/config.json
@@ -27,6 +27,9 @@
         "branch": "",
         "SHA": ""
     },
+    "engines": {
+        "node": "~0.10.1"
+    },
     "devDependencies": {
         "grunt": "~0.4.0",
         "grunt-cli": "~0.1.0",


### PR DESCRIPTION
I've added a requirement for node 0.10.1 in our package.json.

@gruehle After some research and trying a few different things, it looks like we can use node 0.10.1 with the latest phantomjs dependency on mac and win. It appears the issues were isolated to newer 0.8.x builds https://github.com/Obvious/phantomjs/issues/38.
