### PR TITLE
Fix code hint provider selection

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
                 this.handleClose();
             }
         } else {
-            this.hints.forEach(function (item, index) {
+            $.each(this.hints, function (index, item) {
                 if (index > self.maxResults) {
                     return false;
                 }

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
         var mode = editor.getModeForSelection(),
             enabledProviders = _getProvidersForMode(mode);
         
-        enabledProviders.forEach(function (item, index) {
+        $.each(enabledProviders, function (index, item) {
             if (item.provider.hasHints(editor, lastChar)) {
                 sessionProvider = item.provider;
                 return false;


### PR DESCRIPTION
Commit 5878608 replaced a number of instances of `$.each` with `Array.forEach`. But those functions are not interchangeable: only the former supports early break-out. Both the CodeHintManager and the CodeHintList relied on this feature. In particular, that commit broke:

1) CodeHintManager provider selection, by always choosing the last provider instead of stopping at the first, highest-priority provider

2) the CodeHintList, by adding all the available hints instead of of just the first `maxResults` hints.

The first issue also breaks Edge Web Fonts in particular.

This pull reverts just those two changes. I haven't checked all the other replacements from that commit to see if there are other related problems. (Want to have a look, @TomMalbran?)
