### PR TITLE
Fix #3100: New lines always create white spaces

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
         TokenUtils         = require("utils/TokenUtils"),
         ViewUtils          = require("utils/ViewUtils");
     
-    var defaultPrefs = { useTabChar: false, tabSize: 4, indentUnit: 4, closeBrackets: false,
+    var defaultPrefs = { useTabChar: false, tabSize: 4, spaceUnits: 4, closeBrackets: false,
                          showLineNumbers: true, styleActiveLine: true, wordWrap: true };
     
     /** Editor preferences */
@@ -86,8 +86,8 @@ define(function (require, exports, module) {
     /** @type {number}  Global setting: Tab size */
     var _tabSize = _prefs.getValue("tabSize");
     
-    /** @type {number}  Global setting: Indent unit (i.e. number of spaces when indenting) */
-    var _indentUnit = _prefs.getValue("indentUnit");
+    /** @type {number}  Global setting: Space units (i.e. number of spaces when indenting) */
+    var _spaceUnits = _prefs.getValue("spaceUnits");
     
     /** @type {boolean}  Global setting: Auto closes (, {, [, " and ' */
     var _closeBrackets = _prefs.getValue("closeBrackets");
@@ -154,7 +154,7 @@ define(function (require, exports, module) {
             if (instance.getOption("indentWithTabs")) {
                 CodeMirror.commands.insertTab(instance);
             } else {
-                var i, ins = "", numSpaces = _indentUnit;
+                var i, ins = "", numSpaces = instance.getOption("indentUnit");
                 numSpaces -= to.ch % numSpaces;
                 for (i = 0; i < numSpaces; i++) {
                     ins += " ";
@@ -175,12 +175,13 @@ define(function (require, exports, module) {
     function _handleSoftTabNavigation(instance, direction, functionName) {
         var handled = false;
         if (!instance.getOption("indentWithTabs")) {
-            var cursor = instance.getCursor(),
-                jump = cursor.ch % _indentUnit,
-                line = instance.getLine(cursor.line);
+            var indentUnit = instance.getOption("indentUnit"),
+                cursor     = instance.getCursor(),
+                jump       = cursor.ch % indentUnit,
+                line       = instance.getLine(cursor.line);
 
             if (direction === 1) {
-                jump = _indentUnit - jump;
+                jump = indentUnit - jump;
 
                 if (cursor.ch + jump > line.length) { // Jump would go beyond current line
                     return false;
@@ -199,7 +200,7 @@ define(function (require, exports, module) {
                 // If we are on the tab boundary, jump by the full amount, 
                 // but not beyond the start of the line.
                 if (jump === 0) {
-                    jump = _indentUnit;
+                    jump = indentUnit;
                 }
 
                 // Search backwards to the first non-space character
@@ -354,7 +355,7 @@ define(function (require, exports, module) {
             electricChars: false,   // we use our own impl of this to avoid CodeMirror bugs; see _checkElectricChars()
             indentWithTabs: _useTabChar,
             tabSize: _tabSize,
-            indentUnit: _indentUnit,
+            indentUnit: _useTabChar ? _tabSize : _spaceUnits,
             lineNumbers: _showLineNumbers,
             lineWrapping: _wordWrap,
             styleActiveLine: _styleActiveLine,
@@ -1312,6 +1313,17 @@ define(function (require, exports, module) {
     // Global settings that affect all Editor instances (both currently open Editors as well as those created
     // in the future)
 
+    /**
+     * @private
+     * Updates Editor option with the given value. Affects all Editors.
+     * @param {boolean | number} value
+     * @param {string} cmOption - CodeMirror option string
+     */
+    function _setEditorOption(value, cmOption) {
+        _instances.forEach(function (editor) {
+            editor._codeMirror.setOption(cmOption, value);
+        });
+    }
     
     /**
      * @private
@@ -1321,10 +1333,7 @@ define(function (require, exports, module) {
      * @param {string} prefName - preference name string
      */
     function _setEditorOptionAndPref(value, cmOption, prefName) {
-        _instances.forEach(function (editor) {
-            editor._codeMirror.setOption(cmOption, value);
-        });
-        
+        _setEditorOption(value, cmOption);
         _prefs.setValue(prefName, (typeof value === "boolean") ? Boolean(value) : value);
     }
 		
@@ -1335,6 +1344,7 @@ define(function (require, exports, module) {
     Editor.setUseTabChar = function (value) {
         _useTabChar = value;
         _setEditorOptionAndPref(value, "indentWithTabs", "useTabChar");
+        _setEditorOption(_useTabChar ? _tabSize : _spaceUnits, "indentUnit");
     };
     
     /** @type {boolean} Gets whether all Editors use tab characters (vs. spaces) when inserting new text */
@@ -1349,6 +1359,7 @@ define(function (require, exports, module) {
     Editor.setTabSize = function (value) {
         _tabSize = value;
         _setEditorOptionAndPref(value, "tabSize", "tabSize");
+        _setEditorOption(value, "indentUnit");
     };
     
     /** @type {number} Get indent unit  */
@@ -1360,14 +1371,14 @@ define(function (require, exports, module) {
      * Sets indentation width. Affects all Editors.
      * @param {number} value
      */
-    Editor.setIndentUnit = function (value) {
-        _indentUnit = value;
-        _setEditorOptionAndPref(value, "indentUnit", "indentUnit");
+    Editor.setSpaceUnits = function (value) {
+        _spaceUnits = value;
+        _setEditorOptionAndPref(value, "indentUnit", "spaceUnits");
     };
     
     /** @type {number} Get indentation width */
-    Editor.getIndentUnit = function () {
-        return _indentUnit;
+    Editor.getSpaceUnits = function () {
+        return _spaceUnits;
     };
     
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1334,7 +1334,7 @@ define(function (require, exports, module) {
      */
     function _setEditorOptionAndPref(value, cmOption, prefName) {
         _setEditorOption(value, cmOption);
-        _prefs.setValue(prefName, (typeof value === "boolean") ? Boolean(value) : value);
+        _prefs.setValue(prefName, value);
     }
 		
     /**
@@ -1351,7 +1351,7 @@ define(function (require, exports, module) {
     Editor.getUseTabChar = function () {
         return _useTabChar;
     };
-
+    
     /**
      * Sets tab character width. Affects all Editors.
      * @param {number} value
@@ -1366,7 +1366,7 @@ define(function (require, exports, module) {
     Editor.getTabSize = function () {
         return _tabSize;
     };
-
+    
     /**
      * Sets indentation width. Affects all Editors.
      * @param {number} value

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
     }
 
     function _getIndentSize() {
-        return Editor.getUseTabChar() ? Editor.getTabSize() : Editor.getIndentUnit();
+        return Editor.getUseTabChar() ? Editor.getTabSize() : Editor.getSpaceUnits();
     }
     
     function _updateIndentSize() {
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
         if (Editor.getUseTabChar()) {
             Editor.setTabSize(Math.max(Math.min(value, 10), 1));
         } else {
-            Editor.setIndentUnit(Math.max(Math.min(value, 10), 1));
+            Editor.setSpaceUnits(Math.max(Math.min(value, 10), 1));
         }
 
         // update indicator

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -103,10 +103,11 @@ define(function (require, exports, module) {
             return;
         }
         
+        value = Math.max(Math.min(value, 10), 1);
         if (Editor.getUseTabChar()) {
-            Editor.setTabSize(Math.max(Math.min(value, 10), 1));
+            Editor.setTabSize(value);
         } else {
-            Editor.setSpaceUnits(Math.max(Math.min(value, 10), 1));
+            Editor.setSpaceUnits(value);
         }
 
         // update indicator


### PR DESCRIPTION
This is a possible fix for #3100. The idea is that now changing Spaces and Tabs both also change the indent unit option of all the open editors, since Indent Unit is used for both and not just for Spaces.
