### PR TITLE
Fix phantomjs dependency issues with (1) mac and (2) node 0.10.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,8 +136,7 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config']);
 
     // task: test
-    //grunt.registerTask('test', ['jshint', 'jasmine']);
-    grunt.registerTask('test', ['jshint']);
+    grunt.registerTask('test', ['jshint', 'jasmine']);
 
     // task: set-sprint
     // Update sprint number in package.json and rewrite src/config.json

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
         "SHA": ""
     },
     "devDependencies": {
-        "grunt": "~0.4.0",
-        "grunt-cli": "~0.1.0",
-        "grunt-contrib-jshint": "~0.2.0",
-        "grunt-contrib-watch": "~0.2.0",
-        "grunt-contrib-jasmine": "~0.4.0",
-        "grunt-template-jasmine-requirejs": "~0.1.0",
-        "q": "~0.9.0"
+        "phantomjs": "1.8.1-1",
+        "grunt-lib-phantomjs": "0.2.0",
+        "grunt": "0.4.1",
+        "grunt-cli": "0.1.6",
+        "grunt-contrib-jshint": "0.2.0",
+        "grunt-contrib-watch": "0.2.0",
+        "grunt-contrib-jasmine": "0.4.1",
+        "grunt-template-jasmine-requirejs": "0.1.0",
+        "q": "0.9.2"
     },
     "scripts": {
         "postinstall": "grunt install",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "q": "0.9.2"
     },
     "scripts": {
+        "preinstall": "npm install unzip@0.1.6-alpha",
         "postinstall": "grunt install",
         "test": "grunt test"
     }

--- a/src/config.json
+++ b/src/config.json
@@ -28,13 +28,15 @@
         "SHA": ""
     },
     "devDependencies": {
-        "grunt": "~0.4.0",
-        "grunt-cli": "~0.1.0",
-        "grunt-contrib-jshint": "~0.2.0",
-        "grunt-contrib-watch": "~0.2.0",
-        "grunt-contrib-jasmine": "~0.4.0",
-        "grunt-template-jasmine-requirejs": "~0.1.0",
-        "q": "~0.9.0"
+        "phantomjs": "1.8.1-1",
+        "grunt-lib-phantomjs": "0.2.0",
+        "grunt": "0.4.1",
+        "grunt-cli": "0.1.6",
+        "grunt-contrib-jshint": "0.2.0",
+        "grunt-contrib-watch": "0.2.0",
+        "grunt-contrib-jasmine": "0.4.1",
+        "grunt-template-jasmine-requirejs": "0.1.0",
+        "q": "0.9.2"
     },
     "scripts": {
         "postinstall": "grunt install",

--- a/src/config.json
+++ b/src/config.json
@@ -39,6 +39,7 @@
         "q": "0.9.2"
     },
     "scripts": {
+        "preinstall": "npm install unzip@0.1.6-alpha",
         "postinstall": "grunt install",
         "test": "grunt test"
     }


### PR DESCRIPTION
phantomjs npm package installation issues
1. With phantomjs 1.8.2, the mac zip file format changed causing this issue https://github.com/Obvious/phantomjs/issues/15 and related issue https://github.com/gruntjs/grunt-lib-phantomjs/issues/17
2. With node 0.10.x phantomjs' npm package (https://github.com/Obvious/phantomjs) install fails due to an issue with unzipping, see https://github.com/Obvious/phantomjs/issues/34

Make sure to `rm -rf node_modules` in the brackets directory then run `npm install`. This is required in case there are leftover installations deeper in the dependency tree that will take precedent over our explicit version dependencies.
