### PR TITLE
Syntax for line:col jumps in QuickOpen search queries

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -213,20 +213,21 @@ define(function (require, exports, module) {
      * is followed by a colon. Callers should explicitly test result with isNaN()
      * 
      * @param {string} query string to extract line number from
-     * @returns {number} line number. Returns NaN to indicate no line number was found
+     * @returns {{query: string, currentFile: boolean, line: number, ch: number}} A cursorPos object with
+     *      the extracted line and column numbers, and two additional fields; query with the original position 
+     *      string and currentFile indicating if the cursor position should be applied to the current file
      */
-    function extractLineNumber(query) {
-        // only match : at beginning of query for now
-        // TODO: match any location of : when QuickOpen._handleItemFocus() is modified to
-        // dynamic open files
-        if (query.indexOf(":") !== 0) {
-            return NaN;
-        }
-
-        var result = NaN;
-        var regInfo = query.match(/(!?:)(\d+)/); // colon followed by a digit
-        if (regInfo) {
-            result = regInfo[2] - 1;
+    function extractCursorPos(query) {
+        var regInfo = query.match(/:(\d+)?(,(\d+)?)?/),
+            result;
+        
+        if (regInfo && query.length > 1) {
+            result = {
+                query: regInfo[0],
+                currentFile: query.indexOf(":") === 0,
+                line: regInfo[1] - 1 || 0,
+                ch: regInfo[3] - 1 || 0
+            };
         }
 
         return result;
@@ -273,29 +274,26 @@ define(function (require, exports, module) {
             selectedDOMItem = $(".smart_autocomplete_container > li:first-child").get(0);
         }
         
-        var selectedItem = domItemToSearchResult(selectedDOMItem);
+        var selectedItem    = domItemToSearchResult(selectedDOMItem),
+            query           = this.$searchField.val(),
+            cursorPos       = extractCursorPos(query);
 
         // Delegate to current plugin
         if (currentPlugin) {
             currentPlugin.itemSelect(selectedItem);
         } else {
-
-            // extract line number, if any
-            var query = this.$searchField.val(),
-                gotoLine = extractLineNumber(query);
-
             // Navigate to file and line number
             var fullPath = selectedItem && selectedItem.fullPath;
             if (fullPath) {
                 CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath})
                     .done(function () {
-                        if (!isNaN(gotoLine)) {
+                        if (cursorPos) {
                             var editor = EditorManager.getCurrentFullEditor();
-                            editor.setCursorPos(gotoLine, 0, true);
+                            editor.setCursorPos(cursorPos.line, cursorPos.ch, true);
                         }
                     });
-            } else if (!isNaN(gotoLine)) {
-                EditorManager.getCurrentFullEditor().setCursorPos(gotoLine, 0, true);
+            } else if (cursorPos) {
+                EditorManager.getCurrentFullEditor().setCursorPos(cursorPos.line, cursorPos.ch, true);
             }
         }
 
@@ -378,11 +376,11 @@ define(function (require, exports, module) {
             return true;
         }
         
-        var lineNum = extractLineNumber(query),
+        var cursorPos = extractCursorPos(query),
             editor = EditorManager.getCurrentFullEditor();
         
         // We could just use 0 and lineCount() here, but in future we might want this logic to work for inline editors as well.
-        return (!isNaN(lineNum) && editor && lineNum >= editor.getFirstVisibleLine() && lineNum <= editor.getLastVisibleLine());
+        return (cursorPos && editor && cursorPos.line >= editor.getFirstVisibleLine() && cursorPos.line <= editor.getLastVisibleLine());
     };
     
     /**
@@ -482,6 +480,11 @@ define(function (require, exports, module) {
             return asyncResult.promise();
         }
         
+        var cursorPos = extractCursorPos(query);
+        if (cursorPos && !cursorPos.currentFile && cursorPos.query !== "") {
+            query = query.replace(cursorPos.query, "");
+        }
+
         // First pass: filter based on search string; convert to SearchResults containing extra info
         // for sorting & display
         var filteredList = $.map(fileList, function (fileInfo) {
@@ -521,10 +524,10 @@ define(function (require, exports, module) {
         this._updateDialogLabel(query);
         
         // "Go to line" mode is special-cased
-        var gotoLine = extractLineNumber(query);
-        if (!isNaN(gotoLine)) {
-            var from = {line: gotoLine, ch: 0};
-            var to = {line: gotoLine, ch: 99999};
+        var cursorPos = extractCursorPos(query);
+        if (cursorPos && cursorPos.currentFile) {
+            var from = {line: cursorPos.line, ch: cursorPos.ch};
+            var to = {line: cursorPos.line, ch: 99999};
             
             EditorManager.getCurrentFullEditor().setSelection(from, to, true);
         }

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -89,10 +89,7 @@ define(function (require, exports, module) {
             SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keyup", getSearchField()[0]);
         }
 
-        // TODO: fix me!
-        // This test is currently turned off due to failures on Windows 7
-        // See https://github.com/adobe/brackets/issues/2696
-        it("can open a file and jump to a line, centering that line on the screen", function () {
+        it("can open a file and jump to a cursor position, centering that line on the screen", function () {
             var err = false;
             
             SpecRunnerUtils.loadProjectInTestWindow(testPath);
@@ -127,11 +124,11 @@ define(function (require, exports, module) {
                 // of the scoring in the StringMatch algorithm.
                 expect(DocumentManager.getCurrentDocument().file.name).toEqual("lotsOfLines.html");
                 executeCommand(Commands.NAVIGATE_GOTO_LINE);
-                enterSearchText(":50");
+                enterSearchText(":50,20");
             });
             
             waitsFor(function () {
-                return getSearchField().val() === ":50";
+                return getSearchField().val() === ":50,20";
             }, "goto line entry timeout", 1000);
             
             var eventLooped = false;
@@ -149,8 +146,8 @@ define(function (require, exports, module) {
                 var scrollPos = editor.getScrollPos();
                 
                 // The user enters a 1-based number, but the reported position
-                // is 0 based, so we check for 49.
-                expect(editor).toHaveCursorPosition(49, 0);
+                // is 0 based, so we check for 49,19.
+                expect(editor).toHaveCursorPosition(49, 19);
                 
                 // We expect the result to be scrolled roughly to the middle of the window.
                 expect(scrollPos.y).toBeGreaterThan(400);


### PR DESCRIPTION
Implements jumps to line and column in quickopen queries as described in https://trello.com/card/quick-open-support-a-mix-of-file-names-lines-and-columns/4f90a6d98f77505d7940ce88/744
