### PR TITLE
Fix bug #3239 (Dragging a file onto Brackets to open it is broken on Win)

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
             lineWrapping: _wordWrap,
             styleActiveLine: _styleActiveLine,
             matchBrackets: true,
-            dragDrop: true,
+            dragDrop: false,
             extraKeys: codeMirrorKeyMap,
             autoCloseBrackets: _closeBrackets,
             autoCloseTags: {


### PR DESCRIPTION
Fix bug #3239 (Dragging a file onto Brackets to open it is broken on Win if you drag onto the editor area)

Revert 8f35d64's change enabling CodeMirror dragDrop. This problem is the reason we had dragDrop disabled, and that unfortunately wasn't remembered when pull #3097 was getting merged.
