### PR TITLE
Fix typo in category id

### DIFF
--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -66,7 +66,7 @@
               <li><a id="UnitTestSuite" href="?suite=UnitTestSuite">Unit</a></li>
               <li><a id="IntegrationTestSuite" href="?suite=IntegrationTestSuite">Integration</a></li>
               <li><a id="PerformanceTestSuite" href="?suite=PerformanceTestSuite">Performance</a></li>
-              <li><a id="ExtensionSuite" href="?suite=ExtensionTestSuite">Extensions</a></li>
+              <li><a id="ExtensionTestSuite" href="?suite=ExtensionTestSuite">Extensions</a></li>
               <li><a id="reload" href="#">Reload</a></li>
               <li><a id="show-dev-tools" href="#">Show Developer Tools</a></li>
             </ul>


### PR DESCRIPTION
In master, if you click the "Extensions" tab, the button is not highlighted. This fixes that.
