### PR TITLE
Remove welcomeProjectManager cleanup code

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
             lineWrapping: _wordWrap,
             styleActiveLine: _styleActiveLine,
             matchBrackets: true,
-            dragDrop: true,
+            dragDrop: false,
             extraKeys: codeMirrorKeyMap,
             autoCloseBrackets: _closeBrackets,
             autoCloseTags: {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1346,23 +1346,6 @@ define(function (require, exports, module) {
     _prefs = PreferencesManager.getPreferenceStorage(module, defaults);
     //TODO: Remove preferences migration code
     PreferencesManager.handleClientIdChange(_prefs, "com.adobe.brackets.ProjectManager");
-    
-    if (!_prefs.getValue("welcomeProjectsFixed")) {
-        // One-time cleanup of duplicates in the welcome projects list--there used to be a bug where
-        // we would add lots of duplicate entries here.
-        var welcomeProjects = _prefs.getValue("welcomeProjects");
-        if (welcomeProjects) {
-            var newWelcomeProjects = [];
-            var i;
-            for (i = 0; i < welcomeProjects.length; i++) {
-                if (newWelcomeProjects.indexOf(welcomeProjects[i]) === -1) {
-                    newWelcomeProjects.push(welcomeProjects[i]);
-                }
-            }
-            _prefs.setValue("welcomeProjects", newWelcomeProjects);
-            _prefs.setValue("welcomeProjectsFixed", true);
-        }
-    }
 
     // Event Handlers
     $(FileViewController).on("documentSelectionFocusChange", _documentSelectionFocusChange);


### PR DESCRIPTION
Refers to issue https://github.com/adobe/brackets/issues/2823
- Passes all unit tests
- Passes ProjectManager integration test

Searched through all occurrences of "welcomeProjectsFixed" and found only the two local values.
