### PR TITLE
Extract the current attribute value up to a space or >.

### DIFF
--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -649,7 +649,7 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos({ line: 5, ch: 10 }); // Set cursor between = and the space
                 selectHint(HTMLCodeHints.attrHintProvider, "rtl");
                 expect(testDocument.getLine(5)).toBe("  <h1 dir=\"rtl\" ltr id='foo'>Heading</h1>");
-                expectCursorAt({ line: 5, ch: 15 });            // cursor after the inserted value
+                expectCursorAt({ line: 5, ch: 15 });          // cursor after the inserted value
             });
 
             it("should insert a quoted attribute value before an existing id attribute", function () {
@@ -658,7 +658,7 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos({ line: 5, ch: 10 }); // Set cursor between = and the space
                 selectHint(HTMLCodeHints.attrHintProvider, "rtl");
                 expect(testDocument.getLine(5)).toBe("  <h1 dir=\"rtl\" id='foo'>Heading</h1>");
-                expectCursorAt({ line: 5, ch: 15 });            // cursor after the inserted value
+                expectCursorAt({ line: 5, ch: 15 });          // cursor after the inserted value
             });
 
             it("should insert a quoted attribute value right before the closing > of the tag", function () {
@@ -667,7 +667,17 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos({ line: 7, ch: 9 }); // Set cursor between = and >
                 selectHint(HTMLCodeHints.attrHintProvider, "rtl");
                 expect(testDocument.getLine(7)).toBe("  <p dir=\"rtl\"></p>");
-                expectCursorAt({ line: 7, ch: 14 });            // cursor after the inserted value
+                expectCursorAt({ line: 7, ch: 14 });         // cursor after the inserted value
+            });
+
+            it("should insert a quoted attribute value without overwriting the closing > of the tag", function () {
+                // Insert an attribute value right before > on line 7 with an opening double quote that 
+                // creates an inbalanced string up to the first attribute value in the next tag.
+                testDocument.replaceRange("<a dir=\"><span class=\"foo\"></span></a>", { line: 7, ch: 2 }, { line: 7, ch: 9 });
+                testEditor.setCursorPos({ line: 7, ch: 10 }); // Set cursor between dir=" and >
+                selectHint(HTMLCodeHints.attrHintProvider, "rtl");
+                expect(testDocument.getLine(7)).toBe("  <a dir=\"rtl\"><span class=\"foo\"></span></a>");
+                expectCursorAt({ line: 7, ch: 14 });          // cursor after the inserted value
             });
         });
         

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -72,8 +72,10 @@ define(function (require, exports, module) {
         }
         
         if (foundEqualSign) {
-            var spaceIndex = attrValue.indexOf(" ");
-            attrValue = attrValue.substring(0, (spaceIndex > offset) ? spaceIndex : offset);
+            var spaceIndex = attrValue.indexOf(" "),
+                bracketIndex = attrValue.indexOf(">"),
+                upToIndex = (spaceIndex !== -1 && spaceIndex < bracketIndex) ? spaceIndex : bracketIndex;
+            attrValue = attrValue.substring(0, (upToIndex > offset) ? upToIndex : offset);
         } else if (offset > 0 && (startChar === "'" || startChar === '"')) {
             //The att value is getting edit in progress. There is possible extra
             //stuff in this token state since the quote isn't closed, so we assume


### PR DESCRIPTION
This prevents us from getting the content of next tag in the current attribute value and thus fixes issue #3229.
