### PR TITLE
Fix live browser id array leak

### DIFF
--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -54,7 +54,10 @@ define(function (require, exports, module) {
         
         brackets.app.openLiveBrowser(url, enableRemoteDebugging, function onRun(err, pid) {
             if (!err) {
-                liveBrowserOpenedPIDs.push(pid);
+                // Undefined ids never get removed from list, so don't push them on
+                if (pid !== undefined) {
+                    liveBrowserOpenedPIDs.push(pid);
+                }
                 result.resolve(pid);
             } else {
                 result.reject(_browserErrToFileError(err));


### PR DESCRIPTION
When researching adobe/brackets#3243, I noticed that undefined live browser ids are never used or removed from liveBrowserOpenedPIDs array, so I added a check to prevent adding them to array.
