### PR TITLE
Fix #3253: Active line highlight doesn't disappear in unfocused editor

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -554,11 +554,7 @@ a, img {
         /* remove CodeMirror default height: 300px */
         height: auto;
     }
-    
-    .CodeMirror-activeline-background {
-        background: darken(@activeline-bgcolor, @bc-color-step-size / 2) !important; 
-    }
-    
+        
     .inline-editor-header {
         padding: 10px 10px 0px 10px;
         

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -47,7 +47,7 @@
 
 @code-padding: 15px;
 
-.CodeMirror-activeline-background {
+.CodeMirror-focused .CodeMirror-activeline-background {
     background: @activeline-bgcolor !important; 
 }
 
@@ -176,6 +176,13 @@
     
     .CodeMirror .CodeMirror-vscrollbar, .CodeMirror .CodeMirror-hscrollbar {
         cursor: default;
+    }
+    
+    .CodeMirror-focused .CodeMirror-activeline-background {
+        background: darken(@activeline-bgcolor, @bc-color-step-size / 2) !important; 
+    }
+    &.CodeMirror-focused .CodeMirror .CodeMirror-activeline-background {
+        background: transparent !important; 
     }
 }
 


### PR DESCRIPTION
I applied @RaymondLim idea a bit different to fix #3253 in LESS.
