### PR TITLE
Fix Live Dev unit tests due to HTMLDocument refactoring

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -54,10 +54,10 @@ define(function HTMLDocumentModule(require, exports, module) {
      * @param Document the source document from Brackets
      */
     var HTMLDocument = function HTMLDocument(doc, editor) {
+        this.doc = doc;
         if (!editor) {
             return;
         }
-        this.doc = doc;
         this.editor = editor;
 
         this.onCursorActivity = this.onCursorActivity.bind(this);
@@ -99,6 +99,9 @@ define(function HTMLDocumentModule(require, exports, module) {
 
     /** Triggered on cursor activity by the editor */
     HTMLDocument.prototype.onCursorActivity = function onCursorActivity(event, editor) {
+        if (!this.editor) {
+            return;
+        }
         var codeMirror = this.editor._codeMirror;
         if (LiveDevelopment.config.experimental && Inspector.config.highlight) {
             var location = codeMirror.indexFromPos(codeMirror.getCursor());
@@ -109,6 +112,9 @@ define(function HTMLDocumentModule(require, exports, module) {
 
     /** Triggered on change by the editor */
     HTMLDocument.prototype.onChange = function onChange(event, editor, change) {
+        if (!this.editor) {
+            return;
+        }
         var codeMirror = this.editor._codeMirror;
         while (change) {
             var from = codeMirror.indexFromPos(change.from);
@@ -121,7 +127,7 @@ define(function HTMLDocumentModule(require, exports, module) {
 
     /** Triggered by the HighlightAgent to highlight a node in the editor */
     HTMLDocument.prototype.onHighlight = function onHighlight(event, node) {
-        if (!node || !node.location) {
+        if (!node || !node.location || !this.editor) {
             if (this._highlight) {
                 this._highlight.clear();
                 delete this._highlight;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -316,7 +316,11 @@ define(function LiveDevelopment(require, exports, module) {
                     stylesheetDeferred.resolve();
                 })
                 .done(function (doc) {
-                    if (!_liveDocument || (doc !== _liveDocument.doc)) {
+                    // CSSAgent includes containing HTMLDocument in list returned
+                    // from getStyleSheetURLS() (which could be useful for collecting
+                    // embedded style sheets) but we need to filter doc out here.
+                    if ((_classForDocument(doc) === CSSDocument) &&
+                            (!_liveDocument || (doc !== _liveDocument.doc))) {
                         _setDocInfo(doc);
                         var liveDoc = _createDocument(doc);
                         if (liveDoc) {


### PR DESCRIPTION
This was introduced with my recent refactoring of HTMLDocument. Not sure why this only broke on Mac. Until that change, HTMLDocument was only ever created when experimental code was on, and that code hasn't been exercised very much.

Not sure why, but CSSAgent includes containing HTMLDocument in list returned from getStyleSheetURLs(). This could be useful for collecting embedded style sheets, but we do not want to add HTMLDocument to _relatedDocuments list, so filter it out.

Actual crash was coming from HTMLDocument being created with undefined editor. I fixed that particular code path, but also added bullet-proffing to HTMLDocument in case that ever happens in some other code path.
