### PR TITLE
Fail gracefully when rendering the project list

### DIFF
--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -943,7 +943,8 @@ define(function (require, exports, module) {
     /**
      * Read the next block of entries from this directory
      * @param {function(Array.<Entry>)} successCallback Callback function for successful operations
-     * @param {function(DOMError)=} errorCallback Callback function for error operations
+     * @param {function(DOMError, ?Array.<Entry>)=} errorCallback Callback function for error operations,
+     *      which may include an array of entries that could be read without error
      */
     NativeFileSystem.DirectoryReader.prototype.readEntries = function (successCallback, errorCallback) {
         var rootPath = this._directory.fullPath,
@@ -991,28 +992,31 @@ define(function (require, exports, module) {
                                 }
                                 deferred.resolve();
                             } else {
+                                entries[index] = null;  // failed to stat this file, so don't include it
                                 lastError = new NativeFileError(NativeFileSystem._fsErrorToDOMErrorName(statErr));
                                 deferred.reject(lastError);
                             }
                         });
                         
                         return deferred.promise();
-                    }, true);
+                    }, false);
     
                     // We want the error callback to get called after some timeout (in case some deferreds don't return).
                     // So, we need to wrap masterPromise in another deferred that has this timeout functionality    
                     var timeoutWrapper = Async.withTimeout(masterPromise, timeout);
+                    
+                    // The entries array may have null values if stat returned things that were
+                    // neither a file nor a dir. So, we need to clean those out.
+                    var cleanedEntries = [];
     
                     // Add the callbacks to this top-level Promise, which wraps all the individual deferred objects
-                    timeoutWrapper.done(function () { // success
-                        // The entries array may have null values if stat returned things that were
-                        // neither a file nor a dir. So, we need to clean those out.
-                        var cleanedEntries = [], i;
-                        for (i = 0; i < entries.length; i++) {
-                            if (entries[i]) {
-                                cleanedEntries.push(entries[i]);
+                    timeoutWrapper.always(function () { // always clean the successful entries 
+                        entries.forEach(function (entry) {
+                            if (entry) {
+                                cleanedEntries.push(entry);
                             }
-                        }
+                        });
+                    }).done(function () { // success
                         successCallback(cleanedEntries);
                     }).fail(function (err) { // error
                         if (err === Async.ERROR_TIMEOUT) {
@@ -1024,7 +1028,7 @@ define(function (require, exports, module) {
                         }
                         
                         if (errorCallback) {
-                            errorCallback(err);
+                            errorCallback(err, cleanedEntries);
                         }
                     });
     

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -623,6 +623,39 @@ define(function (require, exports, module) {
      */
     function _treeDataProvider(treeNode, jsTreeCallback) {
         var dirEntry, isProjectRoot = false;
+        
+        function processEntries(entries) {
+            var subtreeJSON = _convertEntriesToJSON(entries),
+                wasNodeOpen = false,
+                emptyDirectory = (subtreeJSON.length === 0);
+            
+            if (emptyDirectory) {
+                if (!isProjectRoot) {
+                    wasNodeOpen = treeNode.hasClass("jstree-open");
+                } else {
+                    // project root is a special case, add a placeholder
+                    subtreeJSON.push({});
+                }
+            }
+            
+            jsTreeCallback(subtreeJSON);
+            
+            if (!isProjectRoot && emptyDirectory) {
+                // If the directory is empty, force it to appear as an open or closed node.
+                // This is a workaround for issue #149 where jstree would show this node as a leaf.
+                var classToAdd = (wasNodeOpen) ? "jstree-closed" : "jstree-open";
+                
+                treeNode.removeClass("jstree-leaf jstree-closed jstree-open")
+                        .addClass(classToAdd);
+                
+                // This is a workaround for a part of issue #2085, where the file creation process
+                // depends on the open_node.jstree event being triggered, which doesn't happen on 
+                // empty folders
+                if (!wasNodeOpen) {
+                    treeNode.trigger("open_node.jstree");
+                }
+            }
+        }
 
         if (treeNode === -1) {
             // Special case: root of tree
@@ -635,46 +668,20 @@ define(function (require, exports, module) {
 
         // Fetch dirEntry's contents
         dirEntry.createReader().readEntries(
-            function (entries) {
-                var subtreeJSON = _convertEntriesToJSON(entries),
-                    wasNodeOpen = false,
-                    emptyDirectory = (subtreeJSON.length === 0);
-                
-                if (emptyDirectory) {
-                    if (!isProjectRoot) {
-                        wasNodeOpen = treeNode.hasClass("jstree-open");
-                    } else {
-                        // project root is a special case, add a placeholder
-                        subtreeJSON.push({});
-                    }
+            processEntries,
+            function (error, entries) {
+                if (entries) {
+                    // some but not all entries failed to load, so render what we can
+                    processEntries(entries);
+                } else {
+                    Dialogs.showModalDialog(
+                        Dialogs.DIALOG_ID_ERROR,
+                        Strings.ERROR_LOADING_PROJECT,
+                        StringUtils.format(Strings.READ_DIRECTORY_ENTRIES_ERROR,
+                            StringUtils.htmlEscape(dirEntry.fullPath),
+                            error.name)
+                    );
                 }
-                
-                jsTreeCallback(subtreeJSON);
-                
-                if (!isProjectRoot && emptyDirectory) {
-                    // If the directory is empty, force it to appear as an open or closed node.
-                    // This is a workaround for issue #149 where jstree would show this node as a leaf.
-                    var classToAdd = (wasNodeOpen) ? "jstree-closed" : "jstree-open";
-                    
-                    treeNode.removeClass("jstree-leaf jstree-closed jstree-open")
-                            .addClass(classToAdd);
-                    
-                    // This is a workaround for a part of issue #2085, where the file creation process
-                    // depends on the open_node.jstree event being triggered, which doesn't happen on 
-                    // empty folders
-                    if (!wasNodeOpen) {
-                        treeNode.trigger("open_node.jstree");
-                    }
-                }
-            },
-            function (error) {
-                Dialogs.showModalDialog(
-                    Dialogs.DIALOG_ID_ERROR,
-                    Strings.ERROR_LOADING_PROJECT,
-                    StringUtils.format(Strings.READ_DIRECTORY_ENTRIES_ERROR,
-                        StringUtils.htmlEscape(dirEntry.fullPath),
-                        error.name)
-                );
             }
         );
 


### PR DESCRIPTION
Partially addresses #2943 by failing more gracefully from filesystem errors when rendering the project list.

This pull request has two parts: 
1. Relax `NativeFileSystem.readEntries` so that even when some files can't be statted, the list of files that could be statted can still be used by clients. This is accomplished by adding the incomplete list of statted files as an additional, optional argument to the errBack. 
2. Update `ProjectManager._treeDataProvider` to use this additional argument, if possible, when rendering the project list.

See #2943 for more discussion. 
