### PR TITLE
Add support for complex file extensions like ".coffee.md" or ".html.erb"

### DIFF
--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -173,7 +173,7 @@ define(function (require, exports, module) {
     /**
      * Resolves a language ID to a Language object.
      * File names have a higher priority than file extensions. 
-     * @param {!string} id Identifier for this language, use only letters a-z and _ inbetween (i.e. "cpp", "foo_bar")
+     * @param {!string} id Identifier for this language, use only letters a-z or digits 0-9 and _ inbetween (i.e. "cpp", "foo_bar", "c99")
      * @return {Language} The language with the provided identifier or undefined
      */
     function getLanguage(id) {
@@ -320,7 +320,7 @@ define(function (require, exports, module) {
     
     /**
      * Sets the identifier for this language or prints an error to the console.
-     * @param {!string} id Identifier for this language, use only letters a-z and _ inbetween (i.e. "cpp", "foo_bar")
+     * @param {!string} id Identifier for this language, use only letters a-z or digits 0-9, and _ inbetween (i.e. "cpp", "foo_bar", "c99")
      * @return {boolean} Whether the ID was valid and set or not
      */
     Language.prototype._setId = function (id) {
@@ -641,7 +641,7 @@ define(function (require, exports, module) {
     /**
      * Defines a language.
      *
-     * @param {!string}               id                        Unique identifier for this language, use only letters a-z, numbers and _ inbetween (i.e. "cpp", "foo_bar")
+     * @param {!string}               id                        Unique identifier for this language, use only letters a-z or digits 0-9, and _ inbetween (i.e. "cpp", "foo_bar", "c99")
      * @param {!Object}               definition                An object describing the language
      * @param {!string}               definition.name           Human-readable name of the language, as it's commonly referred to (i.e. "C++")
      * @param {Array.<string>}        definition.fileExtensions List of file extensions used by this language (i.e. ["php", "php3"])

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -136,6 +136,21 @@ define(function (require, exports, module) {
                 expect(LanguageManager.getLanguageForPath("foo.doesNotExist")).toBe(unknown);
             });
             
+            it("should map complex file extensions to languages", function () {
+                var ruby    = LanguageManager.getLanguage("ruby"),
+                    html    = LanguageManager.getLanguage("html"),
+                    unknown = LanguageManager.getLanguage("unknown");
+                
+                expect(LanguageManager.getLanguageForPath("foo.html.erb")).toBe(unknown);
+                expect(LanguageManager.getLanguageForPath("foo.erb")).toBe(unknown);
+                
+                html.addFileExtension("html.erb");
+                ruby.addFileExtension("erb");
+                
+                expect(LanguageManager.getLanguageForPath("foo.html.erb")).toBe(html);
+                expect(LanguageManager.getLanguageForPath("foo.erb")).toBe(ruby);
+            });
+            
             it("should map file names to languages", function () {
                 var coffee  = LanguageManager.getLanguage("coffeescript"),
                     unknown = LanguageManager.getLanguage("unknown");


### PR DESCRIPTION
The entries in the fileNames field of a language definition can now also contain extensions since file names are checked before extensions are checked.

Supersedes #3122, #3172 and #3169 to reduce the chance for more merge conflicts.
