### PR TITLE
Highlight HTML element in browser

### DIFF
--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -107,6 +107,10 @@ define(function HighlightAgent(require, exports, module) {
         RemoteAgent.call("highlightRule", name);
     }
     
+    function domElement(id) {
+        rule("[data-brackets-id='" + id + "']");
+    }
+    
     /**
      * Redraw active highlights
      */
@@ -133,6 +137,7 @@ define(function HighlightAgent(require, exports, module) {
     exports.hide = hide;
     exports.node = node;
     exports.rule = rule;
+    exports.domElement = domElement;
     exports.redraw = redraw;
     exports.load = load;
     exports.unload = unload;

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -107,6 +107,10 @@ define(function HighlightAgent(require, exports, module) {
         RemoteAgent.call("highlightRule", name);
     }
     
+    /** Highlight all nodes with 'data-brackets-id' value
+     * that matches id.
+     * @param {string} value of the 'data-brackets-id' to match
+     */
     function domElement(id) {
         rule("[data-brackets-id='" + id + "']");
     }

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, window, document */
+/*global define, $, window, document, navigator */
 
 /**
  * RemoteFunctions define the functions to be executed in the browser. This

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -44,7 +44,8 @@
 define(function HTMLDocumentModule(require, exports, module) {
     "use strict";
 
-    var DOMAgent            = require("LiveDevelopment/Agents/DOMAgent"),
+    var DocumentManager     = require("document/DocumentManager"),
+        DOMAgent            = require("LiveDevelopment/Agents/DOMAgent"),
         HighlightAgent      = require("LiveDevelopment/Agents/HighlightAgent"),
         HTMLInstrumentation = require("language/HTMLInstrumentation"),
         Inspector           = require("LiveDevelopment/Inspector/Inspector"),
@@ -65,6 +66,9 @@ define(function HTMLDocumentModule(require, exports, module) {
         $(this.editor).on("cursorActivity", this.onCursorActivity);
         this.onCursorActivity();
 
+        this.onDocumentSaved = this.onDocumentSaved.bind(this);
+        $(DocumentManager).on("documentSaved", this.onDocumentSaved);
+        
         // Experimental code
         if (LiveDevelopment.config.experimental) {
 
@@ -84,6 +88,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         }
 
         $(this.editor).off("cursorActivity", this.onCursorActivity);
+        $(DocumentManager).off("documentSaved", this.onDocumentSaved);
 
         // Experimental code
         if (LiveDevelopment.config.experimental) {
@@ -156,6 +161,14 @@ define(function HTMLDocumentModule(require, exports, module) {
         this._highlight = codeMirror.markText(from, to, { className: "highlight" });
     };
 
+    /** Triggered when a document is saved */
+    HTMLDocument.prototype.onDocumentSaved = function onDocumentSaved(event, doc) {
+        if (doc === this.doc) {
+            HTMLInstrumentation.scanDocument(this.doc);
+            HTMLInstrumentation._markText(this.editor);
+        }
+    };
+    
     // Export the class
     module.exports = HTMLDocument;
 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -69,7 +69,7 @@ define(function LiveDevelopment(require, exports, module) {
         DocumentManager      = require("document/DocumentManager"),
         EditorManager        = require("editor/EditorManager"),
         FileUtils            = require("file/FileUtils"),
-        HTMLInstrumentaion   = require("language/HTMLInstrumentation"),
+        HTMLInstrumentation  = require("language/HTMLInstrumentation"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         NativeFileError      = require("file/NativeFileError"),
         NativeApp            = require("utils/NativeApp"),
@@ -564,7 +564,7 @@ define(function LiveDevelopment(require, exports, module) {
             if (_serverProvider) {
                 // Install a request filter for the current document. In the future,
                 // we need to install filters for *all* files that need to be instrumented.
-                HTMLInstrumentaion.scanDocument(doc);
+                HTMLInstrumentation.scanDocument(doc);
                 _serverProvider.setRequestFilterPaths(
                     ["/" + ProjectManager.makeProjectRelativeIfPossible(doc.file.fullPath)]
                 );
@@ -573,7 +573,7 @@ define(function LiveDevelopment(require, exports, module) {
                 //$(_serverProvider).off("request");
                 
                 $(_serverProvider).on("request", function (event, request) {
-                    var html = HTMLInstrumentaion.generateInstrumentedHTML(doc);
+                    var html = HTMLInstrumentation.generateInstrumentedHTML(doc);
                     
                     request.send({ body: html });
                 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -570,9 +570,9 @@ define(function LiveDevelopment(require, exports, module) {
                 );
                 
                 // Remove any "request" listeners that were added previously
-                //$(_serverProvider).off("request");
+                $(_serverProvider).off(".livedev");
                 
-                $(_serverProvider).on("request", function (event, request) {
+                $(_serverProvider).on("request.livedev", function (event, request) {
                     var html = HTMLInstrumentation.generateInstrumentedHTML(doc);
                     
                     request.send({ body: html });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -69,6 +69,7 @@ define(function LiveDevelopment(require, exports, module) {
         DocumentManager      = require("document/DocumentManager"),
         EditorManager        = require("editor/EditorManager"),
         FileUtils            = require("file/FileUtils"),
+        HTMLInstrumentaion   = require("language/HTMLInstrumentation"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         NativeFileError      = require("file/NativeFileError"),
         NativeApp            = require("utils/NativeApp"),

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -911,16 +911,17 @@ define(function (require, exports, module) {
         }
         
         this._markClean();
-        $(exports).triggerHandler("documentSaved", this);
         
         // TODO: (issue #295) fetching timestamp async creates race conditions (albeit unlikely ones)
         var thisDoc = this;
         this.file.getMetadata(
             function (metadata) {
                 thisDoc.diskTimestamp = metadata.modificationTime;
+                $(exports).triggerHandler("documentSaved", thisDoc);
             },
             function (error) {
                 console.log("Error updating timestamp after saving file: " + thisDoc.file.fullPath);
+                $(exports).triggerHandler("documentSaved", thisDoc);
             }
         );
     };

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
         });
         
         // Patch up any unclosed tag lengths. For now, unclosed tags are
-        //extended to the beginning of the next tag, or the end of the
+        // extended to the beginning of the next tag, or the end of the
         // doc if this is the last tag, <html> or <body>. This is far from 
         // perfect, but is much simpler than implementing all of the html 
         // rules for omitted closing tags.

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -200,8 +200,10 @@ define(function (require, exports, module) {
      * @return none
      */
     function _markText(editor) {
+        var cache = _cachedValues[editor.document.file.fullPath];
+        
         var cm = editor._codeMirror,
-            tags = _cachedValues[editor.document.file.fullPath].tags;
+            tags = cache && cache.tags;
         
         if (!tags) {
             console.error("Couldn't find the tag information for " + editor.document.file.fullPath);
@@ -241,7 +243,7 @@ define(function (require, exports, module) {
      */
     function _getTagIDAtDocumentPos(editor, pos) {
         var i,
-            cm = editor.document._masterEditor._codeMirror,
+            cm = editor._codeMirror,
             marks = cm.findMarksAt(pos),
             match;
         

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, CodeMirror */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var DOMHelpers = require("LiveDevelopment/Agents/DOMHelpers");
+    
+    // Unique ID assigned to every tag.
+    var _tagID = 1;
+
+    /**
+     * @private
+     * Returns true if the specified tag is empty. This could be an empty HTML tag like 
+     * <meta> or <link>, or a closed tag like <div />
+     */
+    function _isEmptyTag(payload) {
+        if (payload.closed) {
+            return true;
+        }
+        
+        if (!payload.nodeName) {
+            return true;
+        }
+        
+        if (/(!doctype|area|base|basefont|br|col|frame|hr|img|input|isindex|link|meta|param|embed)/i
+                .test(payload.nodeName)) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Scan a document to prepare for HTMLInstrumentation
+     * @param {Document} doc The doc to scan. NOTE: The current implementation requires
+     *                       that this doc has a _masterEditor. This restriction may be
+     *                       lifted in the future.
+     * @return none
+     */
+    function scanDocument(doc) {
+        if (!doc._masterEditor) {
+            console.error("HTMLInstrumentation.scanDocument() only works with " +
+                          "documents that have a master editor.");
+            return;
+        }
+        
+        var cm = doc._masterEditor._codeMirror,
+            text = doc.getText();
+        
+        // Remove existing marks
+        var marks = cm.getAllMarks();
+        cm.operation(function () {
+            marks.forEach(function (mark) {
+                if (mark.hasOwnProperty("tagID")) {
+                    mark.clear();
+                }
+            });
+        });
+        
+        // Scan 
+        var tags = [];
+        var tagStack = [];
+        
+        DOMHelpers.eachNode(text, function (payload) {
+            if (payload.nodeType === 1 && payload.nodeName) {
+                // Empty tag
+                if (_isEmptyTag(payload)) {
+                    // Only push img and input. Ignore all other empty tags
+                    if (/(img|input)/i.test(payload.nodeName)) {
+                        tags.push({
+                            name:   payload.nodeName,
+                            id:     _tagID++,
+                            offset: payload.sourceOffset,
+                            length: payload.sourceLength
+                        });
+                    }
+                } else if (payload.closing) {
+                    // Closing tag
+                    var startTag = tagStack.pop(),
+                        lastTag = payload;
+                    
+                    while (startTag.nodeName !== payload.nodeName) {
+                        // Unclosed start tag
+                        tags.push({
+                            name:   startTag.nodeName,
+                            id:     _tagID++,
+                            offset: startTag.sourceOffset,
+                            length: lastTag.sourceLength + lastTag.sourceOffset - startTag.sourceOffset
+                        });
+                        lastTag = startTag;
+                        startTag = tagStack.pop();
+                    }
+                    
+                    tags.push({
+                        name:   startTag.nodeName,
+                        id:     _tagID++,
+                        offset: startTag.sourceOffset,
+                        length: payload.sourceLength + payload.sourceOffset - startTag.sourceOffset
+                    });
+                } else {
+                    // Opening tag
+                    tagStack.push(payload);
+                }
+            }
+        });
+        
+        // Sort by initial offset
+        tags.sort(function (a, b) {
+            if (a.offset < b.offset) {
+                return -1;
+            }
+            if (a.offset === b.offset) {
+                return 0;
+            }
+            return 1;
+        });
+                
+        // Mark
+        tags.forEach(function (tag) {
+            var startPos = cm.posFromIndex(tag.offset),
+                endPos = cm.posFromIndex(tag.offset + tag.length),
+                mark = cm.markText(startPos, endPos);
+            
+            mark.tagID = tag.id;
+        });
+    }
+    
+    /**
+     * Generate instrumented HTML for the specified document. 
+     * NOTE: The scanDocument() function MUST be called before generating instrumented HTML.
+     * @param {Document} doc The doc to scan. NOTE: The current implementation requires
+     *                       that this doc has a _masterEditor. This restriction may be
+     *                       lifted in the future.
+     * @return none
+     */
+    function generateInstrumentedHTML(doc) {
+        if (!doc._masterEditor) {
+            console.error("HTMLInstrumentation.generateInstrumentedHTML() " +
+                          "only works with documents that have a master editor.");
+            return;
+        }
+        
+        var cm = doc._masterEditor._codeMirror,
+            marks = cm.getAllMarks(),
+            gen = doc.getText();
+        
+        // Only look at markers that have "tagID"
+        marks = marks.filter(function (mark) {
+            return mark.hasOwnProperty("tagID");
+        });
+        
+        // Make sure markers are sorted by start pos
+        marks.sort(function (a, b) {
+            var posA = a.find().from,
+                posB = b.find().from;
+            
+            if (posA.line === posB.line && posA.ch === posB.ch) {
+                return 0;
+            }
+            
+            if (posA.line < posB.line || (posA.line === posB.line && posA.ch < posB.ch)) {
+                return -1;
+            }
+            
+            return 1;
+        });
+        
+        // Walk through the markers and insert the 'data-brackets-id' attribute at the
+        // end of the open tag
+        var mark, insertCount = 0;
+        for (mark = marks.shift(); mark; mark = marks.shift()) {
+            var attrText = " data-brackets-id='" + mark.tagID + "'";
+            var offset = cm.indexFromPos(mark.find().from);
+
+            // Find end of tag - NOTE: This does not work if an attribute value contains ">"
+            var insertIndex = gen.indexOf(">", offset + insertCount);
+            if (gen[insertIndex] === "/") {
+                insertIndex--;
+            }
+            gen = gen.substr(0, insertIndex) + attrText + gen.substr(insertIndex);
+            insertCount += attrText.length;
+        }
+        
+        return gen;
+    }
+    
+    
+    /**
+     * Get the instrumented tagID at the specified document position. Returns -1 if
+     * there are no instrumented tags at the location.
+     * NOTE: The scanDocument() function MUST be called first.
+     * @param {Document} doc The doc to scan. NOTE: The current implementation requires
+     *                       that this doc has a _masterEditor. This restriction may be
+     *                       lifted in the future.
+     * @return {number} tagID at the specified position, or -1 if there is no tag
+     */
+    function getTagIDAtDocumentPos(doc, pos) {
+        if (!doc._masterEditor) {
+            console.error("HTMLInstrumentation.getTagIDAtDocumentPos() only works with " +
+                          "documents that have a master editor.");
+            return -1;
+        }
+        
+        var i,
+            cm = doc._masterEditor._codeMirror,
+            marks = cm.findMarksAt(pos),
+            match;
+        
+        var _distance = function (mark) {
+            var markerLoc = mark.find();
+            if (markerLoc) {
+                var markPos = markerLoc.from;
+                return (cm.indexFromPos(pos) - cm.indexFromPos(markPos));
+            } else {
+                return Number.MAX_VALUE;
+            }
+        };
+        
+        for (i = 0; i < marks.length; i++) {
+            if (!match) {
+                match = marks[i];
+            } else {
+                if (_distance(marks[i]) < _distance(match)) {
+                    match = marks[i];
+                }
+            }
+        }
+        
+        if (match) {
+            return match.tagID;
+        }
+        
+        return -1;
+    }
+    
+    exports.scanDocument = scanDocument;
+    exports.generateInstrumentedHTML = generateInstrumentedHTML;
+    exports.getTagIDAtDocumentPos = getTagIDAtDocumentPos;
+});

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
     
     /**
      * Mark the text for the specified editor. Either the scanDocument() or 
-     * tbe generateInstrumentedHTML() function must be called before this function
+     * the generateInstrumentedHTML() function must be called before this function
      * is called.
      *
      * NOTE: This function is "private" for now (has a leading underscore), since

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -105,10 +105,10 @@ define(function (require, exports, module) {
                     }
                 } else if (payload.closing) {
                     // Closing tag
-                    var i = tagStack.length,
+                    var i,
                         startTag;
                     
-                    for (i = tagStack.length - 1; i; i--) {
+                    for (i = tagStack.length - 1; i >= 0; i--) {
                         if (tagStack[i].nodeName === payload.nodeName) {
                             startTag = tagStack[i];
                             tagStack.splice(i, 1);
@@ -158,15 +158,19 @@ define(function (require, exports, module) {
             return 1;
         });
         
-        // Patch up any unclosed tag lengths. For now unclosed tags are
-        // just extended to the beginning of the next tag (or the end of the
-        // doc if this is the last tag). This is far from perfect, but is much
-        // simpler than implementing all of the browser rules for omitted closing
-        // tags.
+        // Patch up any unclosed tag lengths. For now, unclosed tags are
+        //extended to the beginning of the next tag, or the end of the
+        // doc if this is the last tag, <html> or <body>. This is far from 
+        // perfect, but is much simpler than implementing all of the html 
+        // rules for omitted closing tags.
         tags.forEach(function (tag, index) {
             if (tag.length < 0) {
-                // Extend length to beginning of next tag
-                if (index < tags.length - 1) {
+                // Special case for <html> and <body> -- extend those to the 
+                // end of the text.
+                if (tag.name === "HTML" || tag.name === "BODY") {
+                    tag.length = text.length - tag.offset;
+                } else if (index < tags.length - 1) {
+                    // Extend length to beginning of next tag
                     tag.length = tags[index + 1].offset - tag.offset;
                 } else {
                     // Last tag of the doc. Extend to end of text

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -151,12 +151,15 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Generate instrumented HTML for the specified document. 
+     * Generate instrumented HTML for the specified document. Each tag has a "data-brackets-id"
+     * attribute with a unique ID for its value. For example, "<div>" becomes something like
+     * "<div data-brackets-id='45'>". The attribute value is just a number that is guaranteed
+     * to be unique. 
      * NOTE: The scanDocument() function MUST be called before generating instrumented HTML.
      * @param {Document} doc The doc to scan. NOTE: The current implementation requires
      *                       that this doc has a _masterEditor. This restriction may be
      *                       lifted in the future.
-     * @return none
+     * @return {string} instrumented html content
      */
     function generateInstrumentedHTML(doc) {
         if (!doc._masterEditor) {
@@ -199,7 +202,7 @@ define(function (require, exports, module) {
 
             // Find end of tag - NOTE: This does not work if an attribute value contains ">"
             var insertIndex = gen.indexOf(">", offset + insertCount);
-            if (gen[insertIndex] === "/") {
+            if (gen[insertIndex - 1] === "/") {
                 insertIndex--;
             }
             gen = gen.substr(0, insertIndex) + attrText + gen.substr(insertIndex);


### PR DESCRIPTION
This pull request extends the Live Highlight feature to highlight HTML elements. When an HTML file is opened and Live Preview is enabled, the element under the cursor is highlighted in the browser.

Highlighting remains accurate when editing the document, as long as the document remains in the foreground. If you switch to a different document and then back to the edited HTML doc, you will need to save changes to get correct highlighting. This will be fixed in a future user story.

There is a new `HTMLInstrumentation` module that handles the instrumentation of the HTML content. A `data-brackets-id` attribute is added to all tags, and the value of the attribute is guaranteed to be unique. 

There are functions for marking up a text editor (`HTMLInstrumentation._markText()`) and getting the data-brackets-id attribute value at the current cursor position (`HTMLInstrumentation._getTagIDAtDocumentPos()`). These functions are marked "private" for now (initial underscore), since they are likely to change when we add support for HTML Live Development in the next couple sprints.
