### PR TITLE
Add/expose isVisibile, show, and hide methods for SidebarView object

### DIFF
--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -75,10 +75,32 @@ define(function (require, exports, module) {
     /**
      * Toggle sidebar visibility.
      */
-    function toggleSidebar(width) {
+    function toggle() {
         Resizer.toggle($sidebar);
     }
 
+    /**
+     * Show the sidebar.
+     */
+    function show() {
+        Resizer.show($sidebar);
+    }
+    
+    /**
+     * Hide the sidebar.
+     */
+    function hide() {
+        Resizer.hide($sidebar);
+    }
+    
+    /**
+     * Returns the visibility state of the sidebar.
+     * @return {boolean} true if element is visible, false if it is not visible
+     */
+    function visible() {
+        return Resizer.visible($sidebar);
+    }
+    
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         $sidebar                = $("#sidebar");
@@ -128,8 +150,11 @@ define(function (require, exports, module) {
     });
     
     $(ProjectManager).on("projectOpen", _updateProjectTitle);
-    CommandManager.register(Strings.CMD_HIDE_SIDEBAR,       Commands.VIEW_HIDE_SIDEBAR,     toggleSidebar);
+    CommandManager.register(Strings.CMD_HIDE_SIDEBAR, Commands.VIEW_HIDE_SIDEBAR, toggle);
     
     // Define public API
-    exports.toggleSidebar = toggleSidebar;
+    exports.toggle  = toggle;
+    exports.show    = show;
+    exports.hide    = hide;
+    exports.visible = visible;
 });

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -436,11 +436,11 @@ define(function (require, exports, module) {
         });
     });
     
-    exports.makeResizable        = makeResizable;
-    exports.toggle               = toggle;
-    exports.show                 = show;
-    exports.hide                 = hide;
-    exports.visible              = visible;
+    exports.makeResizable   = makeResizable;
+    exports.toggle          = toggle;
+    exports.show            = show;
+    exports.hide            = hide;
+    exports.visible         = visible;
     
     //Resizer Constants
     exports.DIRECTION_VERTICAL   = DIRECTION_VERTICAL;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -107,6 +107,15 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Returns the visibility state of a resizable element.
+     * @param {DOMNode} element Html element to toggle
+     * @return {boolean} true if element is visible, false if it is not visible
+     */
+    function visible(element) {
+        return $(element).is(":visible");
+    }
+    
+    /**
      * Adds resizing capabilities to a given html element.
      *
      * Resizing can be configured in two directions:
@@ -431,6 +440,7 @@ define(function (require, exports, module) {
     exports.toggle               = toggle;
     exports.show                 = show;
     exports.hide                 = hide;
+    exports.visible              = visible;
     
     //Resizer Constants
     exports.DIRECTION_VERTICAL   = DIRECTION_VERTICAL;


### PR DESCRIPTION
For Issue #1187 

Added public API functions for SidebarView object: show(), hide(), and visible().

Changed public API function: toggleSidebar() to toggle().

Did a find in files for current Brackets codebase and all currently listed Brackets extensions.  toggleSidebar() is not used anywhere except for locally in SidebarView.js.

Ran unit tests without any problems.  I'm not sure that SidebarView has any unit tests right now.  If you want me to research and possibly create unit tests I can.  Otherwise, this fix is complete and ready for review.
