### PR TITLE
Fixing the adjust font restore scroll and adding unit tests

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -88,18 +88,16 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Sets the font size and restores the scroll position as best as possible
-     * @param {string} fsStr A string with the font size and the size unit
-     * @param {string} lhStr A string with the line height and a the size unit
+     * Sets the font size and restores the scroll position as best as possible.
+     * TODO: Remove the viewportTop hack and direclty use scrollPos.y once #3115 is fixed.
+     * @param {string} fontSizeStyle A string with the font size and the size unit
+     * @param {string} lineHeightStyle A string with the line height and a the size unit
      */
-    function _setSizeAndRestoreScroll(fsStr, lhStr) {
-        var editor     = EditorManager.getCurrentFullEditor(),
-            oldWidth   = editor._codeMirror.defaultCharWidth(),
-            oldHeight  = editor.getTextHeight();
-        
-        // Since the height isn't updated after the font-size is changed, we just consider the rendered lines
-        // to calculate the new scroll position
-        var scrollPos   = editor.getScrollPos(),
+    function _setSizeAndRestoreScroll(fontSizeStyle, lineHeightStyle) {
+        var editor      = EditorManager.getCurrentFullEditor(),
+            oldWidth    = editor._codeMirror.defaultCharWidth(),
+            oldHeight   = editor.getTextHeight(),
+            scrollPos   = editor.getScrollPos(),
             viewportTop = $(".CodeMirror-lines", editor.getRootElement()).parent().position().top,
             scrollTop   = scrollPos.y - viewportTop;
         
@@ -107,8 +105,8 @@ define(function (require, exports, module) {
         _removeDynamicFontSize();
         var style = $("<style type='text/css'></style>").attr("id", DYNAMIC_FONT_STYLE_ID);
         style.html(".CodeMirror {" +
-                   "font-size: "   + fsStr + " !important;" +
-                   "line-height: " + lhStr + " !important;}");
+                   "font-size: "   + fontSizeStyle   + " !important;" +
+                   "line-height: " + lineHeightStyle + " !important;}");
         $("head").append(style);
         
         editor.refreshAll();
@@ -121,7 +119,8 @@ define(function (require, exports, module) {
             scrollPosX  = scrollPos.x + Math.round(deltaX * (newWidth - oldWidth)),
             scrollPosY  = scrollPos.y + Math.round(deltaY * (newHeight - oldHeight));
         
-        // Scroll the document back to its original position, but not on the first load
+        // Scroll the document back to its original position, but not on the first load since the position
+        // was saved with the new height and already been restored.
         if (_fontSizePrefsLoaded) {
             editor.setScrollPos(scrollPosX, scrollPosY);
         }

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -84,24 +84,24 @@ define(function (require, exports, module) {
      */
     function _refreshAndRestoreScroll() {
         var editor     = EditorManager.getCurrentFullEditor(),
-            oldHeight  = editor.getTextHeight(),
-            oldWidth   = editor._codeMirror.defaultCharWidth();
+            oldWidth   = editor._codeMirror.defaultCharWidth(),
+            oldHeight  = editor.getTextHeight();
         
-        editor.refreshAll();
-        
-        // Since the height isnt updated after the font-size is changed, we just consider the rendered lines
-        // to calulate the new scroll position
+        // Since the height isn't updated after the font-size is changed, we just consider the rendered lines
+        // to calculate the new scroll position
         var scrollPos   = editor.getScrollPos(),
             viewportTop = $(".CodeMirror-lines", editor.getRootElement()).parent().position().top,
             scrollTop   = scrollPos.y - viewportTop;
         
-        // Calcualte the new scroll based on the old font sizes and scroll position
+        editor.refreshAll();
+        
+        // Calculate the new scroll based on the old font sizes and scroll position
         var newWidth    = editor._codeMirror.defaultCharWidth(),
             newHeight   = editor.getTextHeight(),
-            deltaX      = Math.round(scrollPos.x / oldWidth),
-            deltaY      = Math.round(scrollTop / oldHeight),
-            scrollPosX  = scrollPos.x + deltaX * (newWidth - oldWidth),
-            scrollPosY  = scrollPos.y + deltaY * (newHeight - oldHeight);
+            deltaX      = scrollPos.x / oldWidth,
+            deltaY      = scrollTop / oldHeight,
+            scrollPosX  = scrollPos.x + Math.round(deltaX * (newWidth - oldWidth)),
+            scrollPosY  = scrollPos.y + Math.round(deltaY * (newHeight - oldHeight));
         
         // Scroll the document back to its original position
         editor.setScrollPos(scrollPosX, scrollPosY);
@@ -110,9 +110,17 @@ define(function (require, exports, module) {
     /**
      * @private
      * Removes the styles used to update the font size and updates the editor if refresh is true
-     * @param {!boolean} refresh - true to refresh the current full editor
+     * @param {boolean} refresh True to refresh the current full editor
      */
     function _removeDynamicFontSize(refresh) {
+        // This makes CodeMirror calculate the font sizes before the styles are removed so that we can
+        // get the correct old font size before applying the refresh
+        if (refresh) {
+            var editor = EditorManager.getCurrentFullEditor();
+            editor._codeMirror.defaultCharWidth();
+            editor.getTextHeight();
+        }
+        
         $("#" + DYNAMIC_FONT_STYLE_ID).remove();
         if (refresh) {
             _refreshAndRestoreScroll();
@@ -122,7 +130,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Increases or decreases the editor's font size.
-     * @param {!number} adjustment - negative number to make the font smaller; positive number to make it bigger
+     * @param {number} adjustment Negative number to make the font smaller; positive number to make it bigger
      * @return {boolean} true if adjustment occurred, false if it did not occur 
      */
     function _adjustFontSize(adjustment) {
@@ -178,7 +186,7 @@ define(function (require, exports, module) {
         return true;
     }
     
-    /** Increses the font size by 1 */
+    /** Increases the font size by 1 */
     function _handleIncreaseFontSize() {
         if (_adjustFontSize(1)) {
             _prefs.setValue("fontSizeAdjustment", _prefs.getValue("fontSizeAdjustment") + 1);
@@ -233,10 +241,10 @@ define(function (require, exports, module) {
     /**
      * @private
      * Calculates the first and last visible lines of the focused editor
-     * @param {!number} textHeight
-     * @param {!number} scrollTop
-     * @param {!number} editorHeight
-     * @param {!number} viewportFrom
+     * @param {number} textHeight
+     * @param {number} scrollTop
+     * @param {number} editorHeight
+     * @param {number} viewportFrom
      * @return {{first: number, last: number}}
      */
     function _getLinesInView(textHeight, scrollTop, editorHeight, viewportFrom) {
@@ -254,7 +262,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Scroll the viewport one line up or down.
-     * @param {!number} -1 to scroll one line up; 1 to scroll one line down.
+     * @param {number} direction -1 to scroll one line up; 1 to scroll one line down.
      */
     function _scrollLine(direction) {
         var editor        = EditorManager.getCurrentFullEditor(),
@@ -345,7 +353,7 @@ define(function (require, exports, module) {
     KeyBindingManager.addBinding(Commands.VIEW_SCROLL_LINE_UP);
     KeyBindingManager.addBinding(Commands.VIEW_SCROLL_LINE_DOWN);
 
-    // Init PreferenceStorage
+    // Initialize the PreferenceStorage
     _prefs = PreferencesManager.getPreferenceStorage(module, _defaultPrefs);
 
     // Update UI when opening or closing a document

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -24,7 +24,7 @@
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
     
     require("spec/CodeHint-test");
     require("spec/CodeHintUtils-test");
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
     require("spec/QuickOpen-test");
     require("spec/StringMatch-test");
     require("spec/UpdateNotification-test");
+    require("spec/ViewCommandHandlers-test");
     require("spec/ViewUtils-test");
     require("spec/WorkingSetView-test");
 });

--- a/test/spec/ViewCommandHandlers-test-files/test.css
+++ b/test/spec/ViewCommandHandlers-test-files/test.css
@@ -1,0 +1,3 @@
+.testClass {
+  color: red;
+}

--- a/test/spec/ViewCommandHandlers-test-files/test.html
+++ b/test/spec/ViewCommandHandlers-test-files/test.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+<title>Simple Test</title>
+<link rel="stylesheet" href="test.css">
+</head>
+
+<body>
+<p class="testClass">Brackets is awesome!</p>
+</body>
+</html>

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
  *  
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone, document */
+/*global define, describe, beforeEach, it, runs, expect, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";
@@ -30,7 +30,6 @@ define(function (require, exports, module) {
     var CommandManager,      // loaded from brackets.test
         Commands,            // loaded from brackets.test
         EditorManager,       // loaded from brackets.test
-        DocumentManager,     // loaded from brackets.test
         FileViewController,
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
@@ -55,7 +54,6 @@ define(function (require, exports, module) {
                     CommandManager      = testWindow.brackets.test.CommandManager;
                     Commands            = testWindow.brackets.test.Commands;
                     EditorManager       = testWindow.brackets.test.EditorManager;
-                    DocumentManager     = testWindow.brackets.test.DocumentManager;
                     FileViewController  = testWindow.brackets.test.FileViewController;
                    
                     SpecRunnerUtils.loadProjectInTestWindow(testPath);

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone, document */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var CommandManager,      // loaded from brackets.test
+        Commands,            // loaded from brackets.test
+        EditorManager,       // loaded from brackets.test
+        DocumentManager,     // loaded from brackets.test
+        FileViewController,
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
+
+    describe("ViewCommandHandlers", function () {
+        this.category = "integration";
+        
+        var testPath = SpecRunnerUtils.getTestPath("/spec/ViewCommandHandlers-test-files"),
+            testWindow;
+        
+        var CSS_FILE  = testPath + "/test.css",
+            HTML_FILE = testPath + "/test.html";
+        
+        beforeEach(function () {
+            var promise;
+            
+            // Create a new window that will be shared by ALL tests in this spec.
+            if (!testWindow) {
+                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                    testWindow = w;
+    
+                    // Load module instances from brackets.test
+                    CommandManager      = testWindow.brackets.test.CommandManager;
+                    Commands            = testWindow.brackets.test.Commands;
+                    EditorManager       = testWindow.brackets.test.EditorManager;
+                    DocumentManager     = testWindow.brackets.test.DocumentManager;
+                    FileViewController  = testWindow.brackets.test.FileViewController;
+                   
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                });
+                
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: HTML_FILE});
+                    waitsForDone(promise, "Open into working set");
+                });
+                
+                runs(function () {
+                    // Open inline editor onto test.css's ".testClass" rule
+                    promise = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), {line: 8, ch: 11});
+                    waitsForDone(promise, "Open inline editor");
+                });
+            }
+        });
+        
+        function getEditors() {
+            var editor = EditorManager.getCurrentFullEditor();
+            return {
+                editor: editor,
+                inline: editor.getInlineWidgets()[0].editors[0]
+            };
+        }
+        
+        
+        describe("Adjust the Font Size", function () {
+            it("should increase the font size in both editor and inline editor", function () {
+                runs(function () {
+                    var editors      = getEditors();
+                    var expectedSize = editors.editor.getTextHeight() + 2;
+                    
+                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
+                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
+                    
+                    expect(editors.editor.getTextHeight()).toBe(expectedSize);
+                    expect(editors.inline.getTextHeight()).toBe(expectedSize);
+                });
+            });
+            
+            it("should decrease the font size in both editor and inline editor", function () {
+                runs(function () {
+                    var editors      = getEditors();
+                    var expectedSize = editors.editor.getTextHeight() - 2;
+                    
+                    CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
+                    CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
+                    
+                    expect(editors.editor.getTextHeight()).toBe(expectedSize);
+                    expect(editors.inline.getTextHeight()).toBe(expectedSize);
+                });
+            });
+            
+            it("should restore the font size in both editor and inline editor", function () {
+                runs(function () {
+                    var editors      = getEditors();
+                    var expectedSize = editors.editor.getTextHeight();
+                    
+                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
+                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
+                    CommandManager.execute(Commands.VIEW_RESTORE_FONT_SIZE);
+                    
+                    expect(editors.editor.getTextHeight()).toBe(expectedSize);
+                    expect(editors.inline.getTextHeight()).toBe(expectedSize);
+                });
+            });
+            
+            it("should keep the same font size when opening another document", function () {
+                var promise, expectedSize, editor;
+                
+                runs(function () {
+                    editor       = EditorManager.getCurrentFullEditor();
+                    expectedSize = editor.getTextHeight() + 1;
+                    
+                    promise = CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
+                    waitsForDone(promise, "Increase font size");
+                });
+                
+                runs(function () {
+                    // Open another document and bring it to the front
+                    waitsForDone(FileViewController.openAndSelectDocument(CSS_FILE, FileViewController.PROJECT_MANAGER),
+                                 "FILE_OPEN on file timeout", 1000);
+                });
+                
+                runs(function () {
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor.getTextHeight()).toBe(expectedSize);
+                });
+                
+                // This must be in the last spec in the suite.
+                runs(function () {
+                    this.after(function () {
+                        SpecRunnerUtils.closeTestWindow();
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
As requested I made a new request from #3250 with only the fixes made to the restore scroll and the unit tests. This time the restore scroll works perfect, and I made the unit tests use just one window for all the tests.
