### PR TITLE
Use Language instead of file extension to choose live dev document type

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -103,7 +103,7 @@ define(function HTMLDocumentModule(require, exports, module) {
             return;
         }
         var codeMirror = this.editor._codeMirror;
-        if (LiveDevelopment.config.experimental && Inspector.config.highlight) {
+        if (Inspector.config.highlight) {
             var location = codeMirror.indexFromPos(codeMirror.getCursor());
             var node = DOMAgent.allNodesAtLocation(location).pop();
             HighlightAgent.node(node);

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -221,10 +221,10 @@ define(function LiveDevelopment(require, exports, module) {
      * @param {Document} document
      */
     function _classForDocument(doc) {
-        switch (doc.extension) {
+        switch (doc.getLanguage().getId()) {
         case "css":
             return CSSDocument;
-        case "js":
+        case "javascript":
             return exports.config.experimental ? JSDocument : null;
         }
 

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -592,9 +592,8 @@ define(function (require, exports, module) {
         }
         
         this.file = file;
-        this.refreshText(rawText, initialTimestamp);
-        
         this._updateLanguage();
+        this.refreshText(rawText, initialTimestamp);
         
         // This is a good point to clean up any old dangling Documents
         _gcDocuments();


### PR DESCRIPTION
Fixes #3307

Also, update `Document` language before reading file content.
