### PR TITLE
Change live development unit test assumptions after HTML highlight changes

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -44,9 +44,6 @@ define(function (require, exports, module) {
 
     var DOMHelpers = require("LiveDevelopment/Agents/DOMHelpers");
     
-    // Unique ID assigned to every tag.
-    var _tagID = 1;
-    
     // Hash of scanned documents. Key is the full path of the doc. Value is an object
     // with two properties: timestamp and tags. Timestamp is the document timestamp,
     // tags is an array of tag info with start, length, and tagID properties.
@@ -84,7 +81,8 @@ define(function (require, exports, module) {
             }
         }
         
-        var text = doc.getText();
+        var text = doc.getText(),
+            tagID = 1;
         
         // Scan 
         var tags = [];
@@ -112,7 +110,7 @@ define(function (require, exports, module) {
                     if (/(img|input)/i.test(payload.nodeName)) {
                         tags.push({
                             name:   payload.nodeName,
-                            tagID:  _tagID++,
+                            tagID:  tagID++,
                             offset: payload.sourceOffset,
                             length: payload.sourceLength
                         });
@@ -133,7 +131,7 @@ define(function (require, exports, module) {
                     if (startTag) {
                         tags.push({
                             name:   startTag.nodeName,
-                            tagID:  _tagID++,
+                            tagID:  tagID++,
                             offset: startTag.sourceOffset,
                             length: payload.sourceLength + payload.sourceOffset - startTag.sourceOffset
                         });
@@ -153,7 +151,7 @@ define(function (require, exports, module) {
             // Push the unclosed tag with the "unclosed" length. 
             tags.push({
                 name:   tag.nodeName,
-                tagID:  _tagID++,
+                tagID:  tagID++,
                 offset: tag.sourceOffset,
                 length: tag.unclosedLength || tag.sourceLength
             });

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -377,11 +377,11 @@ define(function (require, exports, module) {
                 }, "LiveDevelopment STATUS_OUT_OF_SYNC and DOMAgent.root", 10000);
                 
                 // Grab the node that we've just modified in Brackets.
-                // Verify that we get the original text and not modified text.
+                // Verify that we get the modified text in memory and not the original text on disk.
                 var originalNode;
                 runs(function () {
-                    originalNode = DOMAgent.nodeAtLocation(230);
-                    expect(originalNode.value).toBe("Brackets is awesome!");
+                    originalNode = DOMAgent.nodeAtLocation(325);
+                    expect(originalNode.value).toBe("Live Preview in Brackets is awesome!");
                 });
                 
                 // wait for LiveDevelopment to unload and reload agents after saving
@@ -406,12 +406,11 @@ define(function (require, exports, module) {
                 }, "LiveDevelopment re-load and re-activate", 10000);
                 
                 // Grab the node that we've modified in Brackets. 
-                // This time we should have modified text since the file has been saved in Brackets.
                 var updatedNode, doneSyncing = false;
                 runs(function () {
                     testWindow.$(LiveDevelopment).off("statusChange", statusChangeHandler);
                     
-                    updatedNode = DOMAgent.nodeAtLocation(230);
+                    updatedNode = DOMAgent.nodeAtLocation(325);
                     liveDoc = LiveDevelopment.getLiveDocForPath(testPath + "/simple1.css");
                     
                     liveDoc.getSourceFromBrowser().done(function (text) {
@@ -424,7 +423,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(fixSpaces(browserCssText)).toBe(fixSpaces(localCssText));
                     
-                    // Verify that we have modified text
+                    // Verify that we still have modified text
                     expect(updatedNode.value).toBe("Live Preview in Brackets is awesome!");
                 });
                     


### PR DESCRIPTION
Live Development HTML documents may now contain in-memory changes for the initial load. Updated unit tests to account for this and new offsets from HTMLInstrumentation. Also changed HTMLInstrumentation to reset the unique tag ID for each requested document.
