### PR TITLE
Special handling of script tag for HTML instrumentation.

### DIFF
--- a/src/LiveDevelopment/Agents/DOMHelpers.js
+++ b/src/LiveDevelopment/Agents/DOMHelpers.js
@@ -198,6 +198,12 @@ define(function DOMHelpersModule(require, exports, module) {
             payload.nodeName = /^<([^>\s]+)/.exec(content)[1].toUpperCase();
             payload.attributes = _extractAttributes(content);
 
+            // Special handling for script tag since we've already collected
+            // everything up to the end tag.
+            if (payload.nodeName === "SCRIPT") {
+                payload.closing = true;
+            }
+            
             // closing node (/ at the beginning)
             if (payload.nodeName[0] === "/") {
                 payload.nodeName = payload.nodeName.substr(1);

--- a/src/LiveDevelopment/Agents/DOMHelpers.js
+++ b/src/LiveDevelopment/Agents/DOMHelpers.js
@@ -198,12 +198,6 @@ define(function DOMHelpersModule(require, exports, module) {
             payload.nodeName = /^<([^>\s]+)/.exec(content)[1].toUpperCase();
             payload.attributes = _extractAttributes(content);
 
-            // Special handling for script tag since we've already collected
-            // everything up to the end tag.
-            if (payload.nodeName === "SCRIPT") {
-                payload.closing = true;
-            }
-            
             // closing node (/ at the beginning)
             if (payload.nodeName[0] === "/") {
                 payload.nodeName = payload.nodeName.substr(1);

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -115,6 +115,13 @@ define(function (require, exports, module) {
                             length: payload.sourceLength
                         });
                     }
+                } else if (payload.nodeName === "SCRIPT") {
+                    tags.push({
+                        name:   payload.nodeName,
+                        tagID:  tagID++,
+                        offset: payload.sourceOffset,
+                        length: payload.sourceLength
+                    });
                 } else if (payload.closing) {
                     // Closing tag
                     var i,


### PR DESCRIPTION
script tags are collected with one step including the end tag. So we need to specially handle them in scanDocument function. This fixed issue #3327.
