### PR TITLE
Fix #3326 - highlight drawing problems

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -224,7 +224,12 @@ function RemoteFunctions(experimental) {
             var elementBounds = element.getBoundingClientRect(),
                 highlight = window.document.createElement("div"),
                 styles = window.getComputedStyle(element);
-                
+            
+            // Don't highlight elements with 0 width & height
+            if (elementBounds.width === 0 && elementBounds.height === 0) {
+                return;
+            }
+            
             highlight.className = HIGHLIGHT_CLASSNAME;
             
             var stylesToSet = {
@@ -241,7 +246,8 @@ function RemoteFunctions(experimental) {
                 "border-bottom-right-radius": styles.borderBottomRightRadius,
                 "border-style": "solid",
                 "border-width": "1px",
-                "border-color": "rgb(94,167,255)"
+                "border-color": "rgb(94,167,255)",
+                "box-sizing": "border-box"
             };
             
             var animateStartValues = {


### PR DESCRIPTION
Fixes #3326 

This fixes two highlight drawing problems:
- Empty items should not be highlighted
- Highlight size is incorrect when element has padding or border
