### PR TITLE
Change SpecRunner to run more than one suite, fix issues in tests

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -99,7 +99,21 @@ define(function LiveDevelopment(require, exports, module) {
         "edit"      : require("LiveDevelopment/Agents/EditAgent")
     };
 
-    var launcherUrl = window.location.href.replace(/\/(src\/index.html|test\/SpecRunner.html).*/, "") + "/src/LiveDevelopment/launch.html";
+    // construct path to launch.html
+    // window location is can be one of the following:
+    // Installed:                /path/to/Brackets.app/Contents/www/index.html
+    // Installed, dev:           /path/to/Brackets.app/Contents/dev/src/index.html
+    // Installed, dev, test:     /path/to/Brackets.app/Contents/dev/test/SpecRunner.html
+    // Arbitrary git repo:       /path/to/brackets/src/index.html
+    // Arbitrary git repo, test: /path/to/brackets/test/SpecRunner.html
+    var launcherUrl = window.location.pathname;
+
+    // special case for test/SpecRunner.html since we can't tell how requirejs
+    // baseUrl is configured dynamically
+    launcherUrl = launcherUrl.replace("/test/SpecRunner.html", "/src/index.html");
+
+    launcherUrl = launcherUrl.substr(0, launcherUrl.lastIndexOf("/")) + "/LiveDevelopment/launch.html";
+    launcherUrl = window.location.origin + launcherUrl;
 
     // Some agents are still experimental, so we don't enable them all by default
     // However, extensions can enable them by calling enableAgent().

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -99,7 +99,7 @@ define(function LiveDevelopment(require, exports, module) {
         "edit"      : require("LiveDevelopment/Agents/EditAgent")
     };
 
-    var launcherUrl = window.location.href.replace(/\/index.html.*/, "") + "/LiveDevelopment/launch.html";
+    var launcherUrl = window.location.href.replace(/\/(src\/index.html|test\/SpecRunner.html).*/, "") + "/src/LiveDevelopment/launch.html";
 
     // Some agents are still experimental, so we don't enable them all by default
     // However, extensions can enable them by calling enableAgent().
@@ -556,9 +556,6 @@ define(function LiveDevelopment(require, exports, module) {
         // helper function that actually does the launch once we are sure we have
         // a doc and the server for that doc is up and running.
         function doLaunchAfterServerReady() {
-            var targetUrl = doc.root.url;
-            var interstitialUrl = launcherUrl + "?" + encodeURIComponent(targetUrl);
-
             _setStatus(STATUS_CONNECTING);
             
             if (_serverProvider) {
@@ -579,7 +576,7 @@ define(function LiveDevelopment(require, exports, module) {
                 });
             }
 
-            Inspector.connectToURL(interstitialUrl).done(result.resolve).fail(function onConnectFail(err) {
+            Inspector.connectToURL(launcherUrl).done(result.resolve).fail(function onConnectFail(err) {
                 if (err === "CANCEL") {
                     result.reject(err);
                     return;
@@ -617,7 +614,7 @@ define(function LiveDevelopment(require, exports, module) {
 
                 if (!browserStarted && exports.status !== STATUS_ERROR) {
                     NativeApp.openLiveBrowser(
-                        interstitialUrl,
+                        launcherUrl,
                         true        // enable remote debugging
                     )
                         .done(function () {
@@ -650,7 +647,7 @@ define(function LiveDevelopment(require, exports, module) {
                     
                 if (exports.status !== STATUS_ERROR) {
                     window.setTimeout(function retryConnect() {
-                        Inspector.connectToURL(interstitialUrl).done(result.resolve).fail(onConnectFail);
+                        Inspector.connectToURL(launcherUrl).done(result.resolve).fail(onConnectFail);
                     }, 500);
                 }
             });

--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -946,6 +946,11 @@ define(function (require, exports, module) {
      * @param {function(DOMError)=} errorCallback Callback function for error operations
      */
     NativeFileSystem.DirectoryReader.prototype.readEntries = function (successCallback, errorCallback) {
+        if (!this._directory.fullPath) {
+            errorCallback(new NativeFileError(NativeFileError.PATH_EXISTS_ERR));
+            return;
+        }
+        
         var rootPath = this._directory.fullPath,
             filesystem = this.filesystem,
             timeout = NativeFileSystem.ASYNC_TIMEOUT,

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -37,10 +37,11 @@ module.exports = function (grunt) {
             opts            = { cwd: process.cwd() },
             cmd             = common.resolve(grunt.option("shell") || grunt.config("shell." + platform)),
             spec            = grunt.option("spec") || "all",
+            suite           = grunt.option("suite") || "all",
             results         = grunt.option("results") || process.cwd() + "/results.json",
             resultsPath     = common.resolve(results),
             specRunnerPath  = common.resolve("test/SpecRunner.html"),
-            args            = " --startup-path=\"" + specRunnerPath + "?suite=all&spec=" + encodeURIComponent(spec) + "&resultsPath=" + encodeURIComponent(resultsPath) + "\"";
+            args            = " --startup-path=\"" + specRunnerPath + "?suite=" + encodeURIComponent(suite) + "&spec=" + encodeURIComponent(spec) + "&resultsPath=" + encodeURIComponent(resultsPath) + "\"";
 
         if (platform === "win") {
             cmd += args;

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -64,10 +64,10 @@
           <div class="nav-collapse">
             <ul class="nav">
               <li><a id="all" href="?suite=all">All</a></li>
-              <li><a id="UnitTestSuite" href="?suite=UnitTestSuite">Unit</a></li>
-              <li><a id="IntegrationTestSuite" href="?suite=IntegrationTestSuite">Integration</a></li>
-              <li><a id="PerformanceTestSuite" href="?suite=PerformanceTestSuite">Performance</a></li>
-              <li><a id="ExtensionTestSuite" href="?suite=ExtensionTestSuite">Extensions</a></li>
+              <li><a id="unit" href="?suite=unit">Unit</a></li>
+              <li><a id="integration" href="?suite=integration">Integration</a></li>
+              <li><a id="performance" href="?suite=performance">Performance</a></li>
+              <li><a id="extension" href="?suite=extension">Extensions</a></li>
               <li><a id="reload" href="#">Reload</a></li>
               <li><a id="show-dev-tools" href="#">Show Developer Tools</a></li>
             </ul>

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
     require("test/UnitTestSuite");
     require("test/PerformanceTestSuite");
     
-    var selectedSuite,
+    var selectedSuites,
         params = new UrlParams(),
         reporter,
         _nodeConnectionDeferred = new $.Deferred(),
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
 
     params.parse();
     
-    function _loadExtensionTests(suite) {
+    function _loadExtensionTests() {
         // augment jasmine to identify extension unit tests
         var addSuite = jasmine.Runner.prototype.addSuite;
         jasmine.Runner.prototype.addSuite = function (suite) {
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
             paths = ["default"];
         
         // load dev and user extensions only when running the extension test suite
-        if (suite === "ExtensionTestSuite") {
+        if (selectedSuites.indexOf("extension")) {
             paths.push("dev");
             paths.push(ExtensionLoader.getUserExtensionPath());
         }
@@ -127,7 +127,9 @@ define(function (require, exports, module) {
             window.location.reload(true);
         });
         
-        $("#" + selectedSuite).closest("li").toggleClass("active", true);
+        if (selectedSuites.length === 1) {
+            $("#" + (selectedSuites[0])).closest("li").toggleClass("active", true);
+        }
         
         AppInit._dispatchReady(AppInit.APP_READY);
         
@@ -200,22 +202,10 @@ define(function (require, exports, module) {
                 );
         });
 
-        selectedSuite = params.get("suite") || localStorage.getItem("SpecRunner.suite") || "UnitTestSuite";
+        selectedSuites = (params.get("suite") || localStorage.getItem("SpecRunner.suite") || "unit").split(",");
         
         // Create a top-level filter to show/hide performance and extensions tests
-        var runAll = (selectedSuite === "all"),
-            isPerfSuite = (selectedSuite === "PerformanceTestSuite"),
-            isExtSuite = (selectedSuite === "ExtensionTestSuite"),
-            isIntegrationSuite = (selectedSuite === "IntegrationTestSuite"),
-            category;
-            
-        if (isPerfSuite) {
-            category = "performance";
-        } else if (isIntegrationSuite) {
-            category = "integration";
-        } else if (isExtSuite) {
-            category = "extension";
-        }
+        var runAll = (selectedSuites.indexOf("all") >= 0);
         
         var topLevelFilter = function (spec) {
             // special case "all" suite to run unit, perf, extension, and integration tests
@@ -223,40 +213,25 @@ define(function (require, exports, module) {
                 return true;
             }
 
-            var currentSuite = spec.suite;
-            
-            // unit test suites have no category
-            if (!isPerfSuite && !isExtSuite && !isIntegrationSuite) {
-                if (spec.category !== undefined) {
-                    // if an individualy spec has a category, filter it out
-                    return false;
-                }
-                
+            var currentSuite = spec.suite,
+                category = spec.category;
+
+            if (!category) {
+                // find the category from the closest suite
                 while (currentSuite) {
-                    if (currentSuite.category !== undefined) {
-                        // any suite in the hierarchy may specify a category
-                        return false;
+                    if (currentSuite.category) {
+                        category = currentSuite.category;
+                        break;
                     }
-                    
+
                     currentSuite = currentSuite.parentSuite;
                 }
-                
-                return true;
             }
             
-            if (spec.category === category) {
-                return true;
-            }
-            
-            while (currentSuite) {
-                if (currentSuite.category === category) {
-                    return true;
-                }
-                
-                currentSuite = currentSuite.parentSuite;
-            }
-            
-            return false;
+            // if unit tests are selected, make sure there is no category in the heirarchy
+            // if not a unit test, make sure the category is selected
+            return (selectedSuites.indexOf("unit") >= 0 && category === undefined) ||
+                (selectedSuites.indexOf(category) >= 0);
         };
         
         /*
@@ -266,9 +241,9 @@ define(function (require, exports, module) {
          */
         
         // configure spawned test windows to load extensions
-        SpecRunnerUtils.setLoadExtensionsInTestWindow(isExtSuite);
+        SpecRunnerUtils.setLoadExtensionsInTestWindow(selectedSuites.indexOf("extension") >= 0);
         
-        _loadExtensionTests(selectedSuite).done(function () {
+        _loadExtensionTests(selectedSuites).done(function () {
             var jasmineEnv = jasmine.getEnv();
             
             // Initiailize unit test preferences for each spec
@@ -302,7 +277,7 @@ define(function (require, exports, module) {
             reporterView = new BootstrapReporterView(document, reporter);
             
             // remember the suite for the next unit test window launch
-            localStorage.setItem("SpecRunner.suite", selectedSuite);
+            localStorage.setItem("SpecRunner.suite", selectedSuites);
             
             $(window.document).ready(_documentReadyHandler);
         });

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -157,7 +157,7 @@ define(function (require, exports, module) {
                 });
                    
                 runs(function () {
-                    waitsForDone(Inspector.connectToURL(url), "Inspector.connectToURL", 5000);
+                    waitsForDone(Inspector.connectToURL(url), "Inspector.connectToURL", 10000);
                 });
                 
                 runs(function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -156,7 +156,8 @@ define(function (require, exports, module) {
         
         // Prevent adding doc to working set
         docToShim._handleEditorChange = function (event, editor, changeList) {
-            this.isDirty = true;
+            var wasDirty = this.isDirty;
+            this.isDirty = !editor._codeMirror.isClean();
                     
             // TODO: This needs to be kept in sync with Document._handleEditorChange(). In the
             // future, we should fix things so that we either don't need mock documents or that this

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -156,7 +156,6 @@ define(function (require, exports, module) {
         
         // Prevent adding doc to working set
         docToShim._handleEditorChange = function (event, editor, changeList) {
-            var wasDirty = this.isDirty;
             this.isDirty = !editor._codeMirror.isClean();
                     
             // TODO: This needs to be kept in sync with Document._handleEditorChange(). In the


### PR DESCRIPTION
After this change, instead of running "all", the Jenkins machines will run `grunt test-integration --suite="unit,extension"` only.

I made some attempts to fix issues in the integration suite, but I wasn't able to fix all issues, particularly intermittent NodeConnection and LiveDevelopment issues that seem to only reproduce on the build machines.

A short summary:
- fixes NativeFileSystem where calling `readEntries` on an empty path would read the entire disk
- fixes LiveDevelopment launcherUrl when run from SpecRunner.html
- Sync up SpecRunnerUtils mock document implementation with the latest from DocumentManager

There also appears to be a memory leak when running unit tests that I did not have time to pin down. I'd like to get at least these changes in ASAP in order to get Jenkins running again.
