### PR TITLE
Update to latest CM; fix up code hints to explicitly set cursor

### DIFF
--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -151,6 +151,7 @@ define(function (require, exports, module) {
             } else {
                 this.editor.document.replaceRange(completion, start);
             }
+            this.editor.setCursorPos(start.line, start.ch + completion.length);
         }
         
         return false;
@@ -602,6 +603,7 @@ define(function (require, exports, module) {
             } else {
                 this.editor.document.replaceRange(completion, start);
             }
+            this.editor.setCursorPos(start.line, start.ch + completion.length);
         }
 
         if (!this.closeOnSelect) {

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -367,6 +367,7 @@ define(function (require, exports, module) {
 
         // Replace the current token with the completion
         session.editor.document.replaceRange(completion, start, end);
+        session.editor.setCursorPos(start.line, start.ch + completion.length);
 
         // Return false to indicate that another hinting session is not needed
         return false;


### PR DESCRIPTION
The latest CM changed `replaceRange()` so that if the cursor is at the beginning of the replaced text and a range is being replaced (instead of inserted), the cursor now stays there instead of being pushed to the end. This fixes up HTML and JS code hints so that they retain the original behavior (of pushing the cursor to the end) by simply setting the cursor position afterwards.

@RaymondLim -- could you look at this one? (When this is merged, it should include the fix for #3201 as well.)
