### PR TITLE
Reduce width of the Project Settings text input to make room for the Jap...

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -435,7 +435,7 @@
     input.url {
         display: inline;
         margin: 10px;
-        width: 400px;
+        width: 350px;
     }
 }
 


### PR DESCRIPTION
This change reduces the width of the text input on the Project Settings dialog to make room for the label when translated to Japanese, as described in #3089. But it doesn't reduce the width too much, so there's still room for the translated default text within the input. 

The aforementioned issue shows the problem before this change. With this change, the dialog looks like this: 

In Japanese: ![Japanese](http://f.cl.ly/items/2G051K3H0k2Z3c3h2v2J/Screen%20Shot%202013-04-04%20at%2011.16.08%20AM.png)

In English: ![English](http://f.cl.ly/items/0B1w3N1i2b2z3E0Q3p3Z/Screen%20Shot%202013-04-04%20at%2011.16.46%20AM.png)

CC @ybayer
