### PR TITLE
More highlight drawing fixes

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -235,9 +235,11 @@ function RemoteFunctions(experimental) {
             var stylesToSet = {
                 "left": _screenOffset(element, "offsetLeft") + "px",
                 "top": _screenOffset(element, "offsetTop") + "px",
-                "width": (elementBounds.width - 2) + "px",
-                "height": (elementBounds.height - 2) + "px",
+                "width": elementBounds.width + "px",
+                "height": elementBounds.height + "px",
                 "z-index": 2000000,
+                "margin": 0,
+                "padding": 0,
                 "position": "absolute",
                 "pointer-events": "none",
                 "border-top-left-radius": styles.borderTopLeftRadius,


### PR DESCRIPTION
This fixes a couple more highlight drawing problems uncovered in issue #3326 
1. The highlight box was too small. The last checkin changed to `box-size: border-box`, but the width and height calculations were adjusting for the border. Those adjustments are removed.
2. Set `padding: 0` and `margin: 0`. This way if the app has a `div` selector with paddings and/or margins set, the highlight doesn't pick them up.
