### PR TITLE
Don't execute menu commands if we're at a breakpoint

### DIFF
--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -53,7 +53,17 @@ define(function (require, exports, module) {
             // which we have to return true (issue #3152).
             return (eventName === Commands.FILE_CLOSE_WINDOW);
         }
-        var promise = CommandManager.execute(eventName);
+        var promise, e = new Error(), stackDepth = e.stack.split("\n").length;
+        
+        // This function should *only* be called as a top-level function. If the current
+        // stack depth is > 2, it is most likely because we are at a breakpoint. 
+        if (stackDepth < 3) {
+            promise = CommandManager.execute(eventName);
+        } else {
+            console.error("Skipping command " + eventName + " because it looks like you are " +
+                          "at a breakpoint. If you are NOT at a breakpoint, please " +
+                          "file a bug and mention this comment. Stack depth = " + stackDepth + ".");
+        }
         return (promise && promise.state() === "rejected") ? false : true;
     }
 


### PR DESCRIPTION
This pull request contains a horrible, horrible hack. I am ashamed to have written this code. There must be a better way to do this, but I haven't been able to find it. Please think twice (or more) before merging this request... 

Here is the scenario: you're hacking away on Brackets and need to hunt down a bug in the Brackets code. You open the Dev Tools, browse through the scripts, and set a breakpoint. Your breakpoint is hit. Life is good. While still at the breakpoint, you go back to Brackets and select a menu item (or press a menu shortcut). The command is executed. WTF? I thought I was at a breakpoint!?!? Well, guess what, you _were_ at a breakpoint, and the menu command was executed anyway. As you can imagine, this could lead to Very Bad Things.

On to the hack... I could not find a reliable way to determine if Brackets was being debugged, and at a breakpoint. The only possible solution I could think of is to look at the stack at the time `ShellAPI.executeCommand()` is called. Under normal circumstances, this is the _only_ call on the call stack. If you are at a breakpoint, I noticed that all of the code up to the breakpoint is _also_ included on the stack. Read the code to see the hack. 

Excuse me while I hide my head in shame.
