### PR TITLE
Bash language support

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -155,5 +155,12 @@
         "name": "Haxe",
         "mode": "haxe",
         "fileExtensions": ["hx"]
+    },
+    
+    "bash": {
+        "name": "Bash",
+        "mode": ["shell", "text/x-sh"],
+        "fileExtensions": ["sh"],
+        "lineComment": ["#"]
     }
 }


### PR DESCRIPTION
This adds an entry to the languages.json file for Bash language support, by way of the CodeMirror "shell" mode. (That mode seems mainly for Bash, even though it's called "shell".) It looks great!

![Bash](http://f.cl.ly/items/1s1d083I0q2v1Y0H2q0C/Screen%20Shot%202013-04-04%20at%203.13.28%20PM.png)
