### PR TITLE
Use window.document.title

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -47,7 +47,8 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         PerfUtils           = require("utils/PerfUtils"),
-        KeyEvent            = require("utils/KeyEvent");
+        KeyEvent            = require("utils/KeyEvent"),
+        StringUtils         = require("utils/StringUtils");
     
     /**
      * Handlers for commands related to document handling (opening, saving, etc.)
@@ -61,6 +62,8 @@ define(function (require, exports, module) {
     var _$titleWrapper = null;
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
+    /** @type {string} String template for window title. Use emdash on mac only. */
+    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} - {1}" : "{0} \u2014 {1}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;
@@ -101,7 +104,7 @@ define(function (require, exports, module) {
 
         // build shell/browser window title, e.g. "• file.html — Brackets"
         if (currentDoc) {
-            windowTitle = currentDoc.file.name + " \u2014 " + windowTitle;
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath, windowTitle);
             windowTitle = (currentDoc.isDirty) ? "• " + windowTitle : windowTitle;
         }
 

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -47,8 +47,7 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         PerfUtils           = require("utils/PerfUtils"),
-        KeyEvent            = require("utils/KeyEvent"),
-        StringUtils         = require("utils/StringUtils");
+        KeyEvent            = require("utils/KeyEvent");
     
     /**
      * Handlers for commands related to document handling (opening, saving, etc.)

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -53,16 +53,93 @@ define(function (require, exports, module) {
      * Handlers for commands related to document handling (opening, saving, etc.)
      */
     
-    function updateDocumentTitle() {
+    /** @type {jQueryObject} Container for label shown above editor; must be an inline element */
+    var _$title = null;
+    /** @type {jQueryObject} Container for dirty dot; must be an inline element */
+    var _$dirtydot = null;
+    /** @type {jQueryObject} Container for _$title; need not be an inline element */
+    var _$titleWrapper = null;
+    /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
+    var _currentTitlePath = null;
+    
+    /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
+    var _$titleContainerToolbar = null;
+    /** @type {Number} Last known height of _$titleContainerToolbar */
+    var _lastToolbarHeight = null;
+    
+    function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument(),
-            title = brackets.config.app_title;
+            windowTitle = brackets.config.app_title;
+
+        if (brackets.inBrowser) {
+            if (currentDoc) {
+                _$title.text(_currentTitlePath);
+                _$title.attr("title", currentDoc.file.fullPath);
+                // dirty dot is always in DOM so layout doesn't change, and visibility is toggled
+                _$dirtydot.css("visibility", (currentDoc.isDirty) ? "visible" : "hidden");
+            } else {
+                _$title.text("");
+                _$title.attr("title", "");
+                _$dirtydot.css("visibility", "hidden");
+            }
         
+            // Set _$titleWrapper to a fixed width just large enough to accomodate _$title. This seems equivalent to what
+            // the browser would do automatically, but the CSS trick we use for layout requires _$titleWrapper to have a
+            // fixed width set on it (see the "#main-toolbar.toolbar" CSS rule for details).
+            _$titleWrapper.css("width", "");
+            var newWidth = _$title.width();
+            _$titleWrapper.css("width", newWidth);
+            
+            // Changing the width of the title may cause the toolbar layout to change height, which needs to resize the
+            // editor beneath it (toolbar changing height due to window resize is already caught by EditorManager).
+            var newToolbarHeight = _$titleContainerToolbar.height();
+            if (_lastToolbarHeight !== newToolbarHeight) {
+                _lastToolbarHeight = newToolbarHeight;
+                EditorManager.resizeEditor();
+            }
+        }
+
+        // build shell/browser window title, e.g. "• file.html — Brackets"
         if (currentDoc) {
-            title = currentDoc.file.name + " \u2014 " + title;
-            title = (currentDoc.isDirty) ? "• " + title : title;
+            windowTitle = currentDoc.file.name + " \u2014 " + windowTitle;
+            windowTitle = (currentDoc.isDirty) ? "• " + windowTitle : windowTitle;
+        }
+
+        // update shell/browser window title
+        window.document.title = windowTitle;
+    }
+    
+    function updateDocumentTitle() {
+        var newDocument = DocumentManager.getCurrentDocument();
+
+        // TODO: This timer is causing a "Recursive tests with the same name are not supporte"
+        // exception. This code should be removed (if not needed), or updated with a unique
+        // timer name (if needed).
+        // var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
+        
+        if (newDocument) {
+            var fullPath = newDocument.file.fullPath;
+    
+            // In the main toolbar, show the project-relative path (if the file is inside the current project)
+            // or the full absolute path (if it's not in the project).
+            _currentTitlePath = ProjectManager.makeProjectRelativeIfPossible(fullPath);
+            
+        } else {
+            _currentTitlePath = null;
         }
         
-        window.document.title = title;
+        // Update title text & "dirty dot" display
+        updateTitle();
+
+        // PerfUtils.addMeasurement(perfTimerName);
+    }
+    
+    function handleDirtyChange(event, changedDoc) {
+        var currentDoc = DocumentManager.getCurrentDocument();
+        
+        if (currentDoc && changedDoc.file.fullPath === currentDoc.file.fullPath) {
+            updateTitle();
+        }
     }
 
     /**
@@ -658,7 +735,7 @@ define(function (require, exports, module) {
                 }
             });
     }
-	
+    
     /**
      * @private
      * Implementation for abortQuit callback to reset quit sequence settings
@@ -757,6 +834,15 @@ define(function (require, exports, module) {
     function handleShowInTree() {
         ProjectManager.showInTree(DocumentManager.getCurrentDocument().file);
     }
+    
+    // Init DOM elements
+    AppInit.htmlReady(function () {
+        var $titleContainerToolbar = $("#main-toolbar");
+        _$titleContainerToolbar = $titleContainerToolbar;
+        _$titleWrapper = $(".title-wrapper", _$titleContainerToolbar);
+        _$title = $(".title", _$titleWrapper);
+        _$dirtydot = $(".dirty-dot", _$titleWrapper);
+    });
 
     // Register global commands
     CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
@@ -786,7 +872,8 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
     
-    // Listen for changes that require updating the window title
-    $(DocumentManager).on("dirtyFlagChange currentDocumentChange fileNameChange", updateDocumentTitle);
+    // Listen for changes that require updating the editor titlebar
+    $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
+    $(DocumentManager).on("currentDocumentChange fileNameChange", updateDocumentTitle);
 
 });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.$("#main-toolbar .title").text()).toBe("");
+                    expect(testWindow.document.title).toBe(brackets.config.app_title);
                 });
             });
 
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.$("#main-toolbar .title").text()).toBe("");
+                    expect(testWindow.document.title).toBe(brackets.config.app_title);
                 });
             });
         });
@@ -232,6 +232,7 @@ define(function (require, exports, module) {
             it("should report clean immediately after opening a file", function () {
                 runs(function () {
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
+                    expect(testWindow.document.title).toBe("test.js — " + brackets.config.app_title);
                 });
             });
             
@@ -244,6 +245,7 @@ define(function (require, exports, module) {
                     
                     // verify Document dirty status
                     expect(doc.isDirty).toBe(true);
+                    expect(testWindow.document.title).toBe("• test.js — " + brackets.config.app_title);
                 });
             });
 

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -222,6 +222,8 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 var promise;
+                
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 runs(function () {
                     promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: testPath + "/test.js"});
@@ -232,7 +234,9 @@ define(function (require, exports, module) {
             it("should report clean immediately after opening a file", function () {
                 runs(function () {
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
-                    expect(testWindow.document.title).toBe("test.js — " + brackets.config.app_title);
+                    
+                    var expectedTitle = (brackets.platform === "mac" ? ("test.js — " + brackets.config.app_title) : ("test.js - " + brackets.config.app_title));
+                    expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });
             
@@ -245,7 +249,8 @@ define(function (require, exports, module) {
                     
                     // verify Document dirty status
                     expect(doc.isDirty).toBe(true);
-                    expect(testWindow.document.title).toBe("• test.js — " + brackets.config.app_title);
+                    var expectedTitle = (brackets.platform === "mac" ? ("• test.js — " + brackets.config.app_title) : ("• test.js - " + brackets.config.app_title));
+                    expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });
 


### PR DESCRIPTION
Removes all DOM updating code for the `title-wrapper`. Leaves HTML and styles intact until the new toolbar is implemented. main-view.html and brackets_patterns_override.less should be updated once the new toolbar design is implemented.
