### PR TITLE
Added syntax highlighting for *.tpl / *.twig files

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -14,7 +14,7 @@
     "html": {
         "name": "HTML",
         "mode": ["htmlmixed", "text/x-brackets-html"],
-        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht"],
+        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig"],
         "blockComment": ["<!--", "-->"]
     },
     


### PR DESCRIPTION
*.tpl / *.twig files are Smarty / Twig templates and should be treated as HTML files.
