### PR TITLE
Fix running dev & user extension unit tests

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
             paths = ["default"];
         
         // load dev and user extensions only when running the extension test suite
-        if (selectedSuites.indexOf("extension")) {
+        if (selectedSuites.indexOf("extension") >= 0) {
             paths.push("dev");
             paths.push(ExtensionLoader.getUserExtensionPath());
         }


### PR DESCRIPTION
@jasonsanjose - I think this was a typo in pull #3334.  Only core (extensions/default) extensions show up in the spec runner UI otherwise.
