### PR TITLE
Correct fix for gutter padding issue in #3211

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -28,15 +28,6 @@
     background-color: @background-color-3;
 }
 
-// TODO: Temporary workaround at end of sprint 22 for #3211, which was introduced by
-// https://github.com/marijnh/CodeMirror/commit/4a745fe6680d104ff4c4347617a5964dcb01c46b
-// This just reverts the effect of that commit for now--it doesn't seem to fix an issue
-// we're currently experiencing.
-.CodeMirror-gutter {
-    margin-bottom: 0;
-    padding-bottom: 0;
-}
-
 .platform-mac .CodeMirror {
     .code-font-mac();
 }
@@ -112,7 +103,6 @@
     .CodeMirror-gutters {
         background-color: @background-color-3;
         border-right: none;
-        padding: @code-padding 0;
         min-width: 2.5em;
     }
     .CodeMirror-linenumber {


### PR DESCRIPTION
The original fix in #3212 (overriding a style change made in CodeMirror) was a temporary measure until we figured out the real problem. It turns out that the issue is that we were setting vertical `padding` on both `.CodeMirror-lines` and `.CodeMirror-gutters` (since we want a little space at the top of the code area). I think the gutter padding used to be necessary in v2 because the line numbers were actually separate, but now that the line numbers are laid out as part of the lines themselves, it seems like we're only supposed to have it on `.CodeMirror-lines`. (I'm confirming this with Marijn, but it seems correct just looking at how the DOM is structured now.)

(Also, it was probably wrong for this padding to be on `.CodeMirror-gutters` to begin with--it was probably on `.CodeMirror-gutter` in v2, but it was in a block of styles that ended up needing to be on `.CodeMirror-gutters` instead, so it just got moved along with them.)

The line numbers still seem to line up properly, and the original bug no longer reproduces for me with this change.
