### PR TITLE
Reveal hidden cursor on lint

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
         Menus                   = brackets.getModule("command/Menus"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
+        Editor                  = brackets.getModule("editor/Editor").Editor,
         LanguageManager         = brackets.getModule("language/LanguageManager"),
         PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
         PerfUtils               = brackets.getModule("utils/PerfUtils"),
@@ -55,7 +56,7 @@ define(function (require, exports, module) {
     var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
     
     var INDICATOR_ID = "JSLintStatus",
-        defaultPrefs = { enabled: true };
+        defaultPrefs = { enabled: true, wordWrap: true };
     
     
     /** @const {string} JSLint commands ID */
@@ -100,7 +101,34 @@ define(function (require, exports, module) {
      * a gold star when no errors are found.
      */
     function run() {
-        var currentDoc = DocumentManager.getCurrentDocument();
+        var currentDoc = DocumentManager.getCurrentDocument(),
+            editor = EditorManager.getCurrentFullEditor();
+            
+        // Disable word wrap for line counting
+        var wordWrap = _prefs.getValue('wordWrap');
+        editor._codeMirror.setOption('lineWrapping', false);
+
+        // Gather info to determine whether to scroll after editor resizes
+        var scrollInfo = editor._codeMirror.getScrollInfo();
+        var currScroll = scrollInfo.top,
+            height = scrollInfo.clientHeight,
+            textHeight = editor.getTextHeight(),
+            currLine = editor.getCursorPos().line,
+            mustShow = false;
+
+        var lastLine = Math.floor((currScroll + height) / textHeight) - 2;
+        var threshold = lastLine - Math.ceil(185 / textHeight);
+
+        // Reset word wrap to initial
+        editor._codeMirror.setOption('lineWrapping', wordWrap);
+
+        // Detrmine whether panel would block text at cursor
+        // If so, set variable to determine action after
+        // editor is resized
+        if (currLine >= threshold && currLine <= lastLine) {
+            mustShow = true;
+        }
+
         
         var perfTimerDOM,
             perfTimerLint;
@@ -148,7 +176,6 @@ define(function (require, exports, module) {
                         var line      = lineTd.text();
                         var character = lineTd.data("character");
         
-                        var editor = EditorManager.getCurrentFullEditor();
                         editor.setCursorPos(line - 1, character - 1, true);
                         EditorManager.focusEditor();
                     });
@@ -187,6 +214,11 @@ define(function (require, exports, module) {
         }
         
         EditorManager.resizeEditor();
+
+        // Scroll cursor back into view only if cursor
+        if (mustShow) {
+            edistor._codeMirror.scrollIntoView();
+        }
     }
     
     /**


### PR DESCRIPTION
Reveal potentially hidden cursor when linter panel opens. Does not
include cases where the cursor is not visible in the editor. References
issue #3003.
