### PR TITLE
Fixed: #3382 Too long file path breaks dialog filename

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -367,6 +367,7 @@
 
 .dialog-filename {
     font-weight: @font-weight-semibold;
+	word-wrap: break-word;	
 }
 
 /* Any Dialog text in this style is automatically turned into a link that opens in the browser. Use data-href for the link's target. */


### PR DESCRIPTION
Possible fix for #3382.
