### PR TITLE
Make LD unit test retry connection a few times before failing

### DIFF
--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -150,7 +150,9 @@ define(function (require, exports, module) {
             
             it("should return a ready socket on Inspector.connect and close the socket on Inspector.disconnect", function () {
                 var id  = Math.floor(Math.random() * 100000),
-                    url = LiveDevelopment.launcherUrl + "?id=" + id;
+                    url = LiveDevelopment.launcherUrl + "?id=" + id,
+                    connected = false,
+                    failed = false;
                 
                 runs(function () {
                     waitsForDone(
@@ -161,10 +163,28 @@ define(function (require, exports, module) {
                 });
                    
                 runs(function () {
-                    waitsForDone(Inspector.connectToURL(url), "Inspector.connectToURL", 10000);
+                    var retries = 0;
+                    function tryConnect() {
+                        if (retries < 10) {
+                            retries++;
+                            Inspector.connectToURL(url)
+                                .done(function () {
+                                    connected = true;
+                                })
+                                .fail(function () {
+                                    window.setTimeout(tryConnect, 500);
+                                });
+                        } else {
+                            failed = true;
+                        }
+                    }
+                    tryConnect();
                 });
                 
+                waitsFor(function () { return connected || failed; }, 10000);
+                
                 runs(function () {
+                    expect(failed).toBe(false);
                     expect(Inspector.connected()).toBeTruthy();
                 });
                 


### PR DESCRIPTION
Fixes #3386.

This unit test was often failing if the browser was closed before the test was run. I think the issue is that even though the test was waiting for `NativeApp.openLiveBrowser()` to complete, that didn't guarantee that Chrome was fully started up and ready to accept connections, so trying to connect immediately (just once) might fail. In this patch, we do what the real LiveDevelopment code was, which is to retry connecting a few times (with a short wait period between each) before giving up.
