### PR TITLE
Cleaner fix for #2761 (Project tree selection incorrect after opening file by means other than sidebar)

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -306,7 +306,6 @@ define(function (require, exports, module) {
                                     .done(function (doc) {
                                         // Opened document is now the current main editor
                                         EditorManager.getCurrentFullEditor().setSelection(match.start, match.end, true);
-                                        ProjectManager.showInTree(doc.file);
                                     });
                             });
                             resultsDisplayed++;


### PR DESCRIPTION
Cleaner fix for #2761 -- Clear selection in project tree if current document not exposed in tree anywhere.

Backs out pull #2869, which made the behavior of Find in Files inconsistent with other means of opening files and didn't fix other cases of the bug.

Adds unit tests for several of these edge cases.
