### PR TITLE
LanguageManager documentation fixes

### DIFF
--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -39,7 +39,7 @@
  *         mode: "haskell",
  *         fileExtensions: ["hs"],
  *         blockComment: ["{-", "-}"],
- *         lineComment: "--"
+ *         lineComment: ["--"]
  *     });
  *
  * To use that language and its related mode, wait for the returned promise to be resolved:
@@ -64,8 +64,8 @@
  *
  * You can also refine an existing language. Currently you can only set the comment styles:
  *     var language = LanguageManager.getLanguage("haskell");
- *     language.setLineComment("--");
- *     language.setBlockComment("{-", "-}");
+ *     language.setLineCommentSyntax(["--"]);
+ *     language.setBlockCommentSyntax("{-", "-}");
  *
  * Some CodeMirror modes define variations of themselves. They are called MIME modes.
  * To find existing MIME modes, search for "CodeMirror.defineMIME" in thirdparty/CodeMirror2/mode
@@ -522,7 +522,7 @@ define(function (require, exports, module) {
 
     /**
      * Sets the prefixes to use for line comments in this language or prints an error to the console.
-     * @param {!string|Array.<string>} prefix Prefix string or and array of prefix strings
+     * @param {!string|Array.<string>} prefix Prefix string or an array of prefix strings
      *   to use for line comments (i.e. "//" or ["//", "#"])
      * @return {boolean} Whether the syntax was valid and set or not
      */


### PR DESCRIPTION
Most importantly, the samples still called setLineComment instead of setLineCommentSyntax
