### PR TITLE
Only support live preview for known subset of HTML document extensions.

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -67,7 +67,11 @@ define(function CSSAgent(require, exports, module) {
      * @param {string} url
      */
     function styleForURL(url) {
-        return _urlToStyle[_canonicalize(url)];
+        if (_urlToStyle) {
+            return _urlToStyle[_canonicalize(url)];
+        }
+        
+        return null;
     }
 
     /** Get a list of all loaded stylesheet files by URL */

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -923,7 +923,7 @@ define(function LiveDevelopment(require, exports, module) {
             return false;
         }
 
-        return true;
+        return _isHtmlFileExt(localPath);
     };
 
     /**


### PR DESCRIPTION
Safe fix for #3403.

A better fix would be to remove the side-affecting code in `CSSDocument` that sets up `CSSAgent`, but that fix would be far more invasive. This doesn't quite get us back to Sprint 22 behavior where we would infer an index.html from a CSS file in the same directory, but it at least shows a warning that a file must be a HTML file (or a server HTML file) in order for live preview to work.

The original bug #2033 to correctly determine the default file became a user story https://trello.com/c/gbBtpARq.
