### PR TITLE
Fix exception when _noMatchCache contains the 'hasOwnProperty' property

### DIFF
--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -807,7 +807,7 @@ define(function (require, exports, module) {
         this._lastQuery = query;
         
         // Check for a known non-matching string.
-        if (this._noMatchCache.hasOwnProperty(str)) {
+        if (Object.prototype.hasOwnProperty.call(this._noMatchCache, str)) {
             return undefined;
         }
         

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -807,7 +807,7 @@ define(function (require, exports, module) {
         this._lastQuery = query;
         
         // Check for a known non-matching string.
-        if (Object.prototype.hasOwnProperty.call(this._noMatchCache, str)) {
+        if (CollectionUtils.hasProperty(this._noMatchCache, str)) {
             return undefined;
         }
         


### PR DESCRIPTION
When _noMatchCache sets "hasOwnProperty" as a property it overwrites the  "hasOwnProperty" function. An exception will be thrown on the next call to _noMatchCache.hasOwnProperty().
