### PR TITLE
Fix live development connection in Chrome 27 beta

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -53,13 +53,15 @@ define(function CSSAgent(require, exports, module) {
     function _onLoadEventFired(event, res) {
         // res = {timestamp}
         _urlToStyle = {};
-        Inspector.CSS.getAllStyleSheets(function onGetAllStyleSheets(res) {
-            var i, header;
-            for (i in res.headers) {
-                header = res.headers[i];
-                _urlToStyle[_canonicalize(header.sourceURL)] = header;
-            }
-            _load.resolve();
+        Inspector.CSS.enable().done(function () {
+            Inspector.CSS.getAllStyleSheets(function onGetAllStyleSheets(res) {
+                var i, header;
+                for (i in res.headers) {
+                    header = res.headers[i];
+                    _urlToStyle[_canonicalize(header.sourceURL)] = header;
+                }
+                _load.resolve();
+            });
         });
     }
 

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -74,11 +74,12 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        Inspector.Console.enable();
-        $(Inspector.Console)
-            .on("messageAdded.ConsoleAgent", _onMessageAdded)
-            .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
-            .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
+        return Inspector.Console.enable().done(function () {
+            $(Inspector.Console)
+                .on("messageAdded.ConsoleAgent", _onMessageAdded)
+                .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
+                .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
+        });
     }
 
     /** Clean up */

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -312,7 +312,6 @@ define(function DOMAgent(require, exports, module) {
             .on("childNodeCountUpdated.DOMAgent", _onChildNodeCountUpdated)
             .on("childNodeInserted.DOMAgent", _onChildNodeInserted)
             .on("childNodeRemoved.DOMAgent", _onChildNodeRemoved);
-        Inspector.Page.enable();
         return _load.promise();
     }
 

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -64,8 +64,9 @@ define(function NetworkAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _urlRequested = {};
-        Inspector.Network.enable();
-        $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
+        return Inspector.Network.enable().done(function () {
+            $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
+        });
     }
 
     /** Unload the agent */

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*jslint vars: true, plusplus: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $, window, document, navigator */
 
 /**

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -122,15 +122,23 @@ define(function ScriptAgent(require, exports, module) {
         _urlToScript = {};
         _idToScript = {};
         _load = new $.Deferred();
-        Inspector.Debugger.enable();
-        Inspector.Debugger.setPauseOnExceptions("uncaught");
+
+        var enableResult = new $.Deferred();
+
+        Inspector.Debugger.enable().done(function () {
+            Inspector.Debugger.setPauseOnExceptions("uncaught").done(function () {
+                enableResult.resolve();
+            });
+        });
+
         $(DOMAgent).on("getDocument.ScriptAgent", _onGetDocument);
         $(Inspector.Debugger)
             .on("scriptParsed.ScriptAgent", _onScriptParsed)
             .on("scriptFailedToParse.ScriptAgent", _onScriptFailedToParse)
             .on("paused.ScriptAgent", _onPaused);
         $(Inspector.DOM).on("childNodeInserted.ScriptAgent", _onChildNodeInserted);
-        return _load;
+
+        return $.when(_load.promise(), enableResult.promise());
     }
 
     /** Clean up */

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -122,7 +122,7 @@ define(function Inspector(require, exports, module) {
         }
 
         console.assert(_socket, "You must connect to the WebSocket before sending messages.");
-        var id, callback, args, i, params = {}, deferred, promise;
+        var id, callback, args, i, params = {}, promise;
 
         // extract the parameters, the callback function, and the message id
         args = Array.prototype.slice.call(arguments, 2);

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -122,16 +122,22 @@ define(function Inspector(require, exports, module) {
         }
 
         console.assert(_socket, "You must connect to the WebSocket before sending messages.");
-        var id, callback, args, i, params = {};
+        var id, callback, args, i, params = {}, deferred, promise;
 
         // extract the parameters, the callback function, and the message id
         args = Array.prototype.slice.call(arguments, 2);
         if (typeof args[args.length - 1] === "function") {
-            id = _messageId++;
-            _messageCallbacks[id] = args.pop();
+            callback = args.pop();
         } else {
-            id = 0;
+            var deferred = new $.Deferred();
+            promise = deferred.promise();
+            callback = function (result) {
+                deferred.resolve(result);
+            };
         }
+
+        id = _messageId++;
+        _messageCallbacks[id] = callback;
 
         // verify the parameters against the method signature
         // this also constructs the params object of type {name -> value}
@@ -141,6 +147,8 @@ define(function Inspector(require, exports, module) {
             }
         }
         _socket.send(JSON.stringify({ method: method, id: id, params: params }));
+
+        return promise;
     }
 
     /** WebSocket did close */
@@ -182,6 +190,7 @@ define(function Inspector(require, exports, module) {
         } else if (response.result) {
             if (_messageCallbacks[response.id]) {
                 _messageCallbacks[response.id](response.result);
+                delete _messageCallbacks[response.id];
             }
         } else {
             var domainAndMethod = response.method.split(".");
@@ -215,7 +224,9 @@ define(function Inspector(require, exports, module) {
         request.onerror = function onError() {
             def.reject(request.response);
         };
+
         request.send(null);
+
         return def.promise();
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -890,11 +890,11 @@ define(function LiveDevelopment(require, exports, module) {
     function _onDocumentSaved(event, doc) {
         if (doc && Inspector.connected() && _classForDocument(doc) !== CSSDocument &&
                 agents.network && agents.network.wasURLRequested(doc.url)) {
+            // Unload and reload agents before reloading the page
+            reconnect();
+
             // Reload HTML page
             Inspector.Page.reload();
-
-            // Reload unsaved changes
-            reconnect();
         }
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -331,7 +331,7 @@ define(function LiveDevelopment(require, exports, module) {
         _liveDocument = _createDocument(doc, editor);
         
         // Enable instrumentation
-        if (_liveDocument.setInstrumentationEnabled) {
+        if (_liveDocument && _liveDocument.setInstrumentationEnabled) {
             var enableInstrumentation = false;
             
             if (_serverProvider && _serverProvider.setRequestFilterPaths) {


### PR DESCRIPTION
Fix for #3402 
- Change Inspector domain methods to return a promise if no explicit callback parameter is defined
- Force `Page` domain to load prior to loading other agents (some agents wait for Page `loadEventFired` event...yes the name is from the department of redundancy department)
- Wait for domain `enable` calls to complete before agent loading continues
- Misc event handler cleanup

@njx can you retest on mac w/ chrome 27? I've tested mac Chrome 26 and win Chrome 27.
