### PR TITLE
Fix #3440: Working set does not re-sort when automatic sort is turned on

### DIFF
--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -144,6 +144,7 @@ define(function (require, exports, module) {
     function _enableAutomatic() {
         _setAutomatic(true);
         _addListeners();
+        _currentSort.callAutomaticFn();
     }
     
     /**


### PR DESCRIPTION
This fixes the issue #3440 by sorting the working set after the Automatic Sort is enabled using the current sort method.
