### PR TITLE
Close Live Development when switching projects

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -855,10 +855,9 @@ define(function LiveDevelopment(require, exports, module) {
 
         if (Inspector.connected()) {
             hideHighlight();
-
             if (agents.network && agents.network.wasURLRequested(doc.url)) {
                 _openDocument(doc, EditorManager.getCurrentFullEditor());
-
+                
                 promise = _getRelatedDocuments();
             } else {
                 if (exports.config.experimental || _isHtmlFileExt(doc.extension)) {

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -843,24 +843,6 @@ define(function LiveDevelopment(require, exports, module) {
             .done(onInterstitialPageLoad);
     }
 
-    // ServerProvider is not automatically updated when switching projects
-    function serverProviderMatchesProject(docFullPath) {
-
-        // null server provider uses file:// url, so it's ok
-        if (!_serverProvider || !_serverProvider.root) {
-            return true;
-        }
-
-        // Server provider root should be the path to the document.
-        // Note that this can cause a false positive for nested projects,
-        // but this is caught with subsequent check for server url
-        if (docFullPath.indexOf(_serverProvider.root) !== 0) {
-            return false;
-        }
-
-        return true;
-    }
-
     /** Triggered by a document change from the DocumentManager */
     function _onDocumentChange() {
         var doc = _getCurrentDocument(),
@@ -874,11 +856,10 @@ define(function LiveDevelopment(require, exports, module) {
         if (Inspector.connected()) {
             hideHighlight();
 
-            if (serverProviderMatchesProject(doc.file.fullPath) &&
-                    agents.network && agents.network.wasURLRequested(doc.url)) {
+            if (agents.network && agents.network.wasURLRequested(doc.url)) {
                 _openDocument(doc, EditorManager.getCurrentFullEditor());
-                promise = _getRelatedDocuments();
 
+                promise = _getRelatedDocuments();
             } else {
                 if (exports.config.experimental || _isHtmlFileExt(doc.extension)) {
                     promise = close().done(open);
@@ -964,7 +945,6 @@ define(function LiveDevelopment(require, exports, module) {
      * @return {jQuery.Promise} Promise that is already resolved
      */
     UserServerProvider.prototype.readyToServe = function () {
-        this.root = ProjectManager.getProjectRoot().fullPath;
         return $.Deferred().resolve().promise();
     };
 
@@ -977,6 +957,7 @@ define(function LiveDevelopment(require, exports, module) {
         $(DocumentManager).on("currentDocumentChange", _onDocumentChange)
             .on("documentSaved", _onDocumentSaved)
             .on("dirtyFlagChange", _onDirtyFlagChange);
+        $(ProjectManager).on("beforeProjectClose beforeAppClose", close);
 
         // Register user defined server provider
         var userServerProvider = new UserServerProvider();


### PR DESCRIPTION
Old Title: Verify server provider matches project when switching documents

This is for #3410.

The server provider is not automatically updated when switching projects <del>, so we need to detect that case</del>. Keeping Live Dev open across projects seems a bit weird anyway, so it's easiest to just close it.
