### PR TITLE
Cleanup for comments from pull request #3439, switch to tern hinting

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -161,6 +161,23 @@ define(function (require, exports, module) {
     }
 
     /**
+     * determine if the cached hint information should be invalidated and re-calculated
+     *
+     * @param {Session} session - the active hinting session
+     * @return {boolean} - true if the hints should be recalculated
+     */
+    JSHints.prototype.needNewHints = function (session) {
+        var cursor  = session.getCursor(),
+            type    = session.getType();
+        
+        return !cachedHints ||
+                cachedLine !== cursor.line ||
+                type.property !== cachedType.property ||
+                type.context !== cachedType.context ||
+                type.showFunctionType !== cachedType.showFunctionType;
+    };
+    
+    /**
      * Determine whether hints are available for a given editor context
      * 
      * @param {Editor} editor - the current editor context
@@ -178,15 +195,7 @@ define(function (require, exports, module) {
                     type    = session.getType(),
                     query   = session.getQuery();
 
-                // Invalidate cached information if: 1) no scope exists; 2) the
-                // cursor has moved a line; 3) the scope is dirty; or 4) if the
-                // cursor has moved into a different scope. Cached information
-                // is also reset on editor change.
-                if (!cachedHints ||
-                        cachedLine !== cursor.line ||
-                        type.property !== cachedType.property ||
-                        type.context !== cachedType.context ||
-                        type.showFunctionType !== cachedType.showFunctionType) {
+                if (this.needNewHints(session)) {
                     //console.log("clear hints");
                     cachedLine = null;
                     cachedHints = null;
@@ -215,10 +224,7 @@ define(function (require, exports, module) {
 
             // Compute fresh hints if none exist, or if the session
             // type has changed since the last hint computation
-            if (!cachedHints ||
-                    type.property !== cachedType.property ||
-                    type.context !== cachedType.context ||
-                    type.showFunctionType !== cachedType.showFunctionType ||                                               query.length === 0) {
+            if (this.needNewHints(session)) {
                 var offset          = session.getOffset(),
                     scopeResponse   = ScopeManager.requestHints(session, session.editor.document, offset),
                     self            = this;
@@ -398,15 +404,11 @@ define(function (require, exports, module) {
                             if (resolvedPath) {
                                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: resolvedPath})
                                     .done(function () {
-                                        session.editor.setCursorPos(jumpResp.start);
-                                        session.editor.setSelection(jumpResp.start, jumpResp.end);
-                                        session.editor.centerOnCursor();
+                                        session.editor.setSelection(jumpResp.start, jumpResp.end, true);
                                     });
                             }
                         } else {
-                            session.editor.setCursorPos(jumpResp.start);
-                            session.editor.setSelection(jumpResp.start, jumpResp.end);
-                            session.editor.centerOnCursor();
+                            session.editor.setSelection(jumpResp.start, jumpResp.end, true);
                         }
                     }
 

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -46,6 +46,9 @@ importScripts("thirdparty/requirejs/require.js");
     
     /**
      * Provide the contents of the requested file to tern
+     * @param {string} name - the name of the file
+     * @param {Function} next - the function to call with the text of the file
+     *  once it has been read in.
      */
     function getFile(name, next) {
         // save the callback
@@ -73,6 +76,11 @@ importScripts("thirdparty/requirejs/require.js");
     
     /**
      * Create a new tern server.
+     *
+     * @param {Object} env - an Object with the environment, as read in from
+     *  the json files in thirdparty/tern/defs
+     * @param {string} dir - the current directory
+     * @param {Array.<string>} files - a list of filenames tern should be aware of
      */
     function initTernServer(env, dir, files) {
         var ternOptions = {
@@ -89,6 +97,14 @@ importScripts("thirdparty/requirejs/require.js");
         
     }
 
+    /**
+     * Build an object that can be used as a request to tern
+     * @param {string} dir - the current directory
+     * @param {string} file - the filename the request is in
+     * @param {string} query - the type of request being made
+     * @param {number} offset - the offset in the file the request is at
+     * @param {string} text - the text of the file
+     */
     function buildRequest(dir, file, query, offset, text) {
         query = {type: query};
         query.start = offset;

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -507,7 +507,7 @@ define(function (require, exports, module) {
 
                 testEditor.setCursorPos(start);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "A2"); // hint 2 is "A2"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "A2");
                 runs(function () {
                     //expect(testEditor.getCursorPos()).toEqual(end);
                     expect(testDoc.getRange(start, end)).toEqual("A2");
@@ -522,7 +522,7 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos(start);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["A1", "A2", "A3"]);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "A1"); // hint 1 is "A1"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "A1");
                 runs(function () {
                     //expect(testEditor.getCursorPos()).toEqual(end);
                     expect(testDoc.getRange(before, end)).toEqual("A1");
@@ -537,7 +537,7 @@ define(function (require, exports, module) {
                 testDoc.replaceRange("A1.", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA"); // hint 0 is "propA"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA");
                 
                 runs(function () {
                     expect(testEditor.getCursorPos()).toEqual(end);
@@ -554,7 +554,7 @@ define(function (require, exports, module) {
                 testDoc.replaceRange("A1.prop", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA"); // hint 0 is "propA"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA");
                 
                 runs(function () {
                     expect(testEditor.getCursorPos()).toEqual(end);
@@ -571,7 +571,7 @@ define(function (require, exports, module) {
                 testDoc.replaceRange("A1.pro", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA"); // hint 0 is "propA"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA");
                 runs(function () {
                     expect(testEditor.getCursorPos()).toEqual(end);
                     expect(testDoc.getRange(start, end)).toEqual("A1.propA");
@@ -587,7 +587,7 @@ define(function (require, exports, module) {
                 testDoc.replaceRange("A1.propB", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA"); // hint 0 is "propA"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA");
                 runs(function () {
                     expect(testEditor.getCursorPos()).toEqual(end);
                     expect(testDoc.getRange(start, end)).toEqual("A1.propA");
@@ -604,7 +604,7 @@ define(function (require, exports, module) {
                 testDoc.replaceRange("(A1.prop)", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
-                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA"); // hint 0 is "propA"
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "propA");
                 
                 runs(function () {
                     expect(testEditor.getCursorPos()).toEqual(end);


### PR DESCRIPTION
This is fixes for the minor issues discussed in https://github.com/adobe/brackets/pull/3439

Update jsdoc
use ExtensionUtils.getModulePath instead of manually slicing up path
use FileUtils.readAsText instead of DocumentManager when we only need the text on disk
Call CollectionUtils.hasProperty instead of Object.prototype.hasOwnProperty...
Add comment explaining logic around finding location of called function for function type hinting
remove unnecessary calls to setCursorPos
remove stale comments in unittests
pull out hint invalidation check into a function and remove check for query.length === 0, not necessary anymore
