### PR TITLE
Fix #3466: Crash happened when make some operation with decimal number in the Tab Size/Spaces field.

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -98,12 +98,12 @@ define(function (require, exports, module) {
         
         // restore focus to the editor
         EditorManager.focusEditor();
-
+        
         if (!value || isNaN(value)) {
             return;
         }
         
-        value = Math.max(Math.min(value, 10), 1);
+        value = Math.max(Math.min(Math.floor(value), 10), 1);
         if (Editor.getUseTabChar()) {
             Editor.setTabSize(value);
         } else {


### PR DESCRIPTION
Fix for issue #3466 by not letting the unit be a float value, by making it an integer before saving it.
