### PR TITLE
Fix regressions (from Sprint 23) in the display of literals and keywords in code hints.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
         KEYWORDS        = annotateKeywords(KEYWORD_TOKENS);
     
     var LITERAL_NAMES   = [
-        "true", "false", "null", "undefined"
+        "true", "false", "null"
     ],
         LITERAL_TOKENS  = LITERAL_NAMES.map(function (t) {
             return makeToken(t, []);

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -337,6 +337,15 @@ define(function (require, exports, module) {
                 if (searchResult) {
                     searchResult.value = hint.value;
                     searchResult.guess = hint.guess;
+
+                    if (hint.keyword !== undefined) {
+                        searchResult.keyword = hint.keyword;
+                    }
+
+                    if (hint.literal !== undefined) {
+                        searchResult.literal = hint.literal;
+                    }
+
                     if (hint.depth !== undefined) {
                         searchResult.depth = hint.depth;
                     }

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -107,6 +107,10 @@ define(function (require, exports, module) {
                 if (token.keyword) {
                     $hintObj.addClass("keyword-hint");
                 }
+
+                if (token.literal) {
+                    $hintObj.addClass("literal-hint");
+                }
              
                 // highlight the matched portion of each hint
                 if (token.stringRanges) {


### PR DESCRIPTION
1. keywords should be monospace.
2. literals should be dark grey.
3. 'undefined' was listed twice so remove it from brackets and use the one from Tern.
