### PR TITLE
Increase the boost for prefix matches.

### DIFF
--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -119,9 +119,9 @@ define(function (require, exports, module) {
     var SPECIAL_POINTS = 35;
     var MATCH_POINTS = 10;
     var LAST_SEGMENT_BOOST = 1;
-    var BEGINNING_OF_NAME_POINTS = 25;
+    var BEGINNING_OF_NAME_POINTS = 10;
     var DEDUCTION_FOR_LENGTH = 0.2;
-    var CONSECUTIVE_MATCHES_POINTS = 10;
+    var CONSECUTIVE_MATCHES_POINTS = 7;
     var NOT_STARTING_ON_SPECIAL_PENALTY = 25;
     
     // Used in match lists to designate matches of "special" characters (see
@@ -565,13 +565,21 @@ define(function (require, exports, module) {
                 // Continue boosting for each additional match at the beginning
                 // of the name
                 if (c - numConsecutive === lastSegmentStart) {
+                    if (DEBUG_SCORES) {
+                        scoreDebug.beginning += BEGINNING_OF_NAME_POINTS;
+                    }
                     newPoints += BEGINNING_OF_NAME_POINTS;
                 }
-
+                
+                numConsecutive++;
+                
                 // Consecutive matches that started on a special are a
                 // good indicator of intent, so we award an added bonus there.
                 if (currentRangeStartedOnSpecial) {
-                    numConsecutive++;
+                    newPoints += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
+                    if (DEBUG_SCORES) {
+                        scoreDebug.consecutive += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
+                    }
                 }
                 
                 if (DEBUG_SCORES) {

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -562,6 +562,12 @@ define(function (require, exports, module) {
             // handles the initial value of lastMatchIndex which is used for
             // constructing ranges but we don't yet have a true match.
             if (score > 0 && lastMatchIndex + 1 === c) {
+                // Continue boosting for each additional match at the beginning
+                // of the name
+                if (c - numConsecutive === lastSegmentStart) {
+                    newPoints += BEGINNING_OF_NAME_POINTS;
+                }
+
                 // Consecutive matches that started on a special are a
                 // good indicator of intent, so we award an added bonus there.
                 if (currentRangeStartedOnSpecial) {

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -573,19 +573,18 @@ define(function (require, exports, module) {
                 
                 numConsecutive++;
                 
+                var boost = CONSECUTIVE_MATCHES_POINTS * numConsecutive;
+                
                 // Consecutive matches that started on a special are a
                 // good indicator of intent, so we award an added bonus there.
                 if (currentRangeStartedOnSpecial) {
-                    newPoints += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
-                    if (DEBUG_SCORES) {
-                        scoreDebug.consecutive += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
-                    }
+                    boost = boost * 2;
                 }
                 
                 if (DEBUG_SCORES) {
-                    scoreDebug.consecutive += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
+                    scoreDebug.consecutive += boost;
                 }
-                newPoints += CONSECUTIVE_MATCHES_POINTS * numConsecutive;
+                newPoints += boost;
             } else {
                 numConsecutive = 1;
             }

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -545,8 +545,25 @@ define(function (require, exports, module) {
             
             it("should find the right jsu", function () {
                 expect(goodRelativeOrdering("jsu", [
-                    "src/language/JSLintUtils.js",
-                    "src/language/JSUtil.js"
+                    "src/language/JSUtil.js",
+                    "src/language/JSLintUtils.js"
+                ])).toBe(true);
+            });
+            
+            it("should prefer prefix matches", function () {
+                expect(goodRelativeOrdering("asc", [
+                    "ASC.js",
+                    "ActionScriptCompiler.js"
+                ])).toBe(true);
+                expect(goodRelativeOrdering("st", [
+                    "str",
+                    "String",
+                    "stringMatch",
+                    "StringMatcher",
+                    "screenTop",
+                    "scrollTo",
+                    "setTimeout",
+                    "switch"
                 ])).toBe(true);
             });
         });

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -550,6 +550,13 @@ define(function (require, exports, module) {
                 ])).toBe(true);
             });
             
+            it("should find the right trange", function () {
+                expect(goodRelativeOrdering("trange", [
+                    "src/document/TextRange.js",
+                    "src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/demos/slider/range.html"
+                ])).toBe(true);
+            });
+            
             it("should prefer prefix matches", function () {
                 expect(goodRelativeOrdering("asc", [
                     "ASC.js",


### PR DESCRIPTION
This is a fix for #3411 and is going to be useful for code hinting.

I'll note that this also improves an older test case where "jsu" matches JSLintUtils.js before "JSUtils.js".
