### PR TITLE
Quick Docs Keyboard Navigation

### DIFF
--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -108,6 +108,9 @@ define(function (require, exports, module) {
         // Set height initially, and again whenever width might have changed (word wrap)
         this._sizeEditorToContent();
         $(window).on("resize", this._sizeEditorToContent);
+
+        // Set focus
+        this.$wrapperDiv.find(".scroller")[0].focus();
     };
     
     InlineDocsViewer.prototype.onClosed = function () {

--- a/src/styles/quiet-scrollbars.css
+++ b/src/styles/quiet-scrollbars.css
@@ -49,14 +49,16 @@
 /* The data URIs for the thumb were generated from the Fireworks files in 
  * styles/vertical-thumb-fw-outline.png and styles/horiz-thumb-fw-outline.png.
  */
-.quiet-scrollbars :hover::-webkit-scrollbar-thumb:vertical {
+.quiet-scrollbars :hover::-webkit-scrollbar-thumb:vertical,
+.quiet-scrollbars :focus::-webkit-scrollbar-thumb:vertical {
     -webkit-border-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAUCAYAAABf2RdVAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABV0RVh0Q3JlYXRpb24gVGltZQA0LzIzLzEyckCqugAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNXG14zYAAACPSURBVCiR7ZIhDoNAEEXfkJCsxKBJimTPwA3mDHvqsXWrquqaIH5FKUk3XKAJT87789U3SQkYgZ5fNuABvDpgrLUOOefZzBYzW3LOc6112J/pgL6UMkZE+lZERCqlHO0m6WZmCydICuDencmWK/Tfoc3dn63YbxsAkpKkyd1XwD/eV0nT7jBJAO2Ej+kCvAFNxTqyZCNcEQAAAABJRU5ErkJggg==") 9 0;
     border-color: transparent;
     border-width: 9px 0;
     min-height: 20px;
 }
 
-.quiet-scrollbars :hover::-webkit-scrollbar-thumb:horizontal {
+.quiet-scrollbars :hover::-webkit-scrollbar-thumb:horizontal,
+.quiet-scrollbars :focus::-webkit-scrollbar-thumb:horizontal {
     -webkit-border-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAJCAYAAAAywQxIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAABV0RVh0Q3JlYXRpb24gVGltZQA0LzIzLzEyckCqugAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNXG14zYAAACLSURBVCiRrdIxCgIxEEbhfxYFOyuxCCLazjGmTu6YKyRV7hFLCzshlcXCQoqxMWCd5B3gqx6pKgAcAJwA7NFfBVB2P+zsnLvGGI89kois3vtijAGp6sU5d+vFWsy85ZyfpKp3IuIRrKWqj2UG9N8CoFprP6MQM28NLCGE1wgqImtK6Q2g0uxtGjitL9E6N1T9Wl8CAAAAAElFTkSuQmCC") 0 9;
     border-color: transparent;
     border-width: 0 9px;


### PR DESCRIPTION
This change sets focus to the scroller element in the Quick Docs inline editor so default keyboard navigation works and Ctrl-K also closes the inline editor. Also changed quiet-scrollbars to display on :focus (in addition to :hover).

Below are questions from @peterflynn (I copied from IRC) cc: @njx, @adrocknaphobia , @GarthDB 

1) Should it take focus away from the host editor automatically when opened?  Adam says yes and it's consistent with inline editors, so this might be already resolved
[redmunds] This was implemented.

2) Should there be some sort of indicator that it has focus?  Garth says no, but I'm not as sure (see next issue)
[redmunds] quiet-scrollbars now display on focus, but this only works for content tall enough to scroll.

3) What happens when you click inside the widget but outside the scrollable part of it?  Right now, focus goes to some weird part of the host editor's CM wrapper, where pressing the arrows actually scrolls the host editor but typing letters doesn't edit the host editor. Tthat seems bad, except that afaict you can't make the text there selectable without allowing it to take focus, so I'm not sure what the right answer is there. we could let it take focus, but then capture arrow keys & pipe them over to the scrollable part of the docs or something... but that seems hard to get right
[redmunds] Focus is not in a usable place, but nothing bad seems to happen. Easy to change focus with mouse. Only way to change focus with keyboard is using Ctrl-K (but have to hit it twice).

4) Is there a gesture to jump focus in & out of the inline widget?  we've talked about doing this for inline editors, but it seems even more useful here -- especially if it steals focus by default (because you'll often want to type in the code while looking at the docs, Esc to close isn't a good enough way to resolve this)

5) should scrolling with arrow keys momentarily make the quiet scrollbars visible?  that's how Lion scrollbars work, but currently our quiet scrollbars don't do that.  it could make scrolling with arrow keys feel confusing
[redmunds] quiet-scrollbars now display on focus
