### PR TITLE
Make mousewheel/trackpad scrolling in Quick Docs less painful

### DIFF
--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -109,9 +109,16 @@ define(function (require, exports, module) {
         var scrollingUp = (event.originalEvent.wheelDeltaY > 0),
             scroller = event.currentTarget;
         
-        // The "bubbling" here is native behavior, not true DOM bubbling: if the docs scroller is at its
-        // limit, then the next closest parent gets scrolled instead. So we need to preventDefault() *only*
-        // in those cases (don't want to block normal scrolling of the docs themselves).
+        // If content has no scrollbar, let host editor scroll normally
+        if (scroller.clientHeight >= scroller.scrollHeight) {
+            return;
+        }
+        
+        // We need to block the event from both the host CodeMirror code (by stopping bubbling) and the
+        // browser's native behavior (by preventing default). We preventDefault() *only* when the docs
+        // scroller is at its limit (when an ancestor would get scrolled instead); otherwise we'd block
+        // normal scrolling of the docs themselves.
+        event.stopPropagation();
         if (scrollingUp && scroller.scrollTop === 0) {
             event.preventDefault();
         } else if (!scrollingUp && scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight) {

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -81,8 +81,10 @@ define(function (require, exports, module) {
         
         this._sizeEditorToContent   = this._sizeEditorToContent.bind(this);
         this._handleLinkClick       = this._handleLinkClick.bind(this);
+        this._handleWheelScroll     = this._handleWheelScroll.bind(this);
         
         this.$wrapperDiv.on("click", "a", this._handleLinkClick);
+        this.$wrapperDiv.find(".scroller").on("mousewheel", this._handleWheelScroll);
     }
     
     InlineDocsViewer.prototype = Object.create(InlineWidget.prototype);
@@ -98,6 +100,22 @@ define(function (require, exports, module) {
         var url = $(event.target).attr("href");
         if (url) {
             NativeApp.openURLInDefaultBrowser(url);
+        }
+    };
+    
+    
+    /** Don't allow scrollwheel/trackpad to bubble up to host editor - makes scrolling docs painful */
+    InlineDocsViewer.prototype._handleWheelScroll = function (event) {
+        var scrollingUp = (event.originalEvent.wheelDeltaY > 0),
+            scroller = event.currentTarget;
+        
+        // The "bubbling" here is native behavior, not true DOM bubbling: if the docs scroller is at its
+        // limit, then the next closest parent gets scrolled instead. So we need to preventDefault() *only*
+        // in those cases (don't want to block normal scrolling of the docs themselves).
+        if (scrollingUp && scroller.scrollTop === 0) {
+            event.preventDefault();
+        } else if (!scrollingUp && scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight) {
+            event.preventDefault();
         }
     };
     


### PR DESCRIPTION
When cursor is over Quick Docs details area, never let mousewheel/trackpad scroll the host editor.  (If the docs scroller is already maxed out, do nothing at all).

In theory we could do something fancier... e.g. remember when the last host editor scroll event event occurred, as a heuristic to detect whether you're trying to scroll the docs specifically vs. just passing over the docs while scrolling the host editor.  But I think what's implemented here is "good enough" for now.
