### PR TITLE
String in case we want to add a "More" link in Extension Manager

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -348,6 +348,7 @@ define({
     "EXTENSION_KEYWORDS"                   : "Keywords",
     "EXTENSION_INSTALLED"                  : "Installed",
     "EXTENSION_SEARCH_PLACEHOLDER"         : "Search",
+    "EXTENSION_MORE_INFO_LINK"             : "More",
     "EXTENSION_FREE_ON_GITHUB"             : "Looking for cool new community developed features? Check out all the free Brackets extensions on GitHub.",
     
     // extensions/default/JSLint


### PR DESCRIPTION
i.e. a link to get to the extension's home page.

I also considered "More info" or "Read more" or "Learn more"... don't have super strong feelings about any of those options.

Fwiw, Firefox's extension listing uses "More" and Chrome's uses "Visit homepage."
