### PR TITLE
Fix file extension color when selected in project tree

### DIFF
--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -61,7 +61,7 @@
         font-size: 13px;
         cursor: default;
         
-        &.jstree-clicked {
+        &.jstree-clicked, &.jstree-clicked .extension {
             color: @project-panel-text-1;
         }
     }


### PR DESCRIPTION
Color (white) on file name extension was missing on the selected node of the project tree.
