### PR TITLE
[OPEN] Vendor prefixes in less stylesheets update.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -109,7 +109,7 @@ a, img {
 }
 
 #titlebar, .modal-bar {
-    .box-shadow(0 1px 1px 0 fadeout(@bc-black, 90%));
+    box-shadow: 0 1px 1px 0 fadeout(@bc-black, 90%);
     
     // Make sure the bottom box-shadow goes above the editor (position: relative needed to start a new stacking group)
     position: relative;
@@ -124,7 +124,6 @@ a, img {
     position: relative;
     background-color: @background-color-3;
     border-top: 1px solid darken(@background-color-3, @bc-color-step-size / 2);
-    box-sizing: border-box;
     color: @bc-grey;
     font-family: @fontstack-sans-serif;
     font-size: 0.9em;
@@ -133,6 +132,7 @@ a, img {
     height: 20px;
     overflow: hidden;
     padding: 3px 20px 3px 10px;
+    .sane-box-model;
 }
     
 #status-info {
@@ -205,7 +205,6 @@ a, img {
     position: relative;
     left: -1px;
     top: -2px;
-    -webkit-border-radius: 2px;
     border-radius: 2px;
     box-shadow: inset 0 1px 0 rgba(0,0,0,0.1);
 }
@@ -263,7 +262,7 @@ a, img {
         padding-top: @base-padding / 2;
         padding-bottom: @base-padding / 2;
         z-index: @z-index-brackets-results-panel;
-        .box-shadow(0 -1px 3px 0 fadeout(@bc-black, 70%));
+        box-shadow: 0 -1px 3px 0 fadeout(@bc-black, 70%);
         .title {
             font-size: @label-font-size;
             font-weight: bold;

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -57,7 +57,6 @@
 
 /* Helpful for percentage-sizing items that have border/padding */
 .sane-box-model {
-    -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -113,7 +113,7 @@
     right: 0;
     width: @main-toolbar-width;
     height: 100%;
-    box-sizing: border-box;
+    .sane-box-model;
     
     background: @main-toolbar-background-color;
     padding: 5px 0px;
@@ -227,8 +227,8 @@
                 
         background-color: @bc-white;
         border: 1px solid #c8c8c8;
-        .border-radius(0 0 3px 3px);
-        .box-shadow(0 6px 18px 0 rgba(0, 0, 0, .2));
+        border-radius: 0 0 3px 3px;
+        box-shadow: 0 6px 18px 0 rgba(0, 0, 0, .2);
         
         // Menu items
         li {
@@ -243,7 +243,7 @@
                 color: @bc-black;
                 text-shadow: none;
                 white-space: nowrap;
-                .box-shadow(none);
+                box-shadow: none;
 
                 &:hover, &.highlight {
                     color: @bc-black;
@@ -302,7 +302,7 @@
 
 .codehint-menu {
     .dropdown-menu {
-        .box-shadow(none);
+        box-shadow: none;
         max-height: 160px;
         overflow-y: auto;
 

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -26,12 +26,12 @@
 /* (these are based on jsTree's default theme .css file, so they are not very LESS-like) */
 
 .jstree-brackets li, 
-.jstree-brackets ins { background-image:url("images/jsTreeSprites.svg"); background-repeat:no-repeat; background-color:transparent; }
-.jstree-brackets li { background-position:-90px 0; background-repeat:repeat-y; }
-.jstree-brackets li.jstree-last { background:transparent; }
-.jstree-brackets .jstree-open > ins { background-position:-72px 0; }
-.jstree-brackets .jstree-closed > ins { background-position:-54px 0; }
-.jstree-brackets .jstree-leaf > ins { background-position:-36px 0; }
+.jstree-brackets ins { background-image: url("images/jsTreeSprites.svg"); background-repeat: no-repeat; background-color: transparent; }
+.jstree-brackets li { background-position: -90px 0; background-repeat: repeat-y; }
+.jstree-brackets li.jstree-last { background: transparent; }
+.jstree-brackets .jstree-open > ins { background-position: -72px 0; }
+.jstree-brackets .jstree-closed > ins { background-position: -54px 0; }
+.jstree-brackets .jstree-leaf > ins { background-position: -36px 0; }
 
 @jstree-icon-backindent: 12px;
 
@@ -86,8 +86,8 @@ ins.jstree-icon {
     left: -@jstree-icon-backindent !important;
 }
 
-.jstree-brackets a .jstree-icon { background-position:-56px -19px; }
-.jstree-brackets a.jstree-loading .jstree-icon { background:url("images/throbber.gif") center center no-repeat !important; }
+.jstree-brackets a .jstree-icon { background-position: -56px -19px; }
+.jstree-brackets a.jstree-loading .jstree-icon { background: url("images/throbber.gif") center center no-repeat !important; }
 
 .jstree-brackets li > a {
     padding-top: 3px;
@@ -100,30 +100,30 @@ ins.jstree-icon {
 
 // These styles control the expand/collapse arrow icons. Most other styles in this file with background-position are unused.
 .jstree-brackets .jstree-no-dots li, 
-.jstree-brackets .jstree-no-dots .jstree-leaf > ins { background:transparent; }
-.jstree-brackets .jstree-no-dots .jstree-open > ins { background-position:-18px 0; }
-.jstree-brackets .jstree-no-dots .jstree-closed > ins { background-position:0 0; }
+.jstree-brackets .jstree-no-dots .jstree-leaf > ins { background: transparent; }
+.jstree-brackets .jstree-no-dots .jstree-open > ins { background-position: -18px 0; }
+.jstree-brackets .jstree-no-dots .jstree-closed > ins { background-position: 0 0; }
 
-.jstree-brackets .jstree-no-icons a .jstree-icon { display:none; }
+.jstree-brackets .jstree-no-icons a .jstree-icon { display: none; }
 
-.jstree-brackets .jstree-search { font-style:italic; }
+.jstree-brackets .jstree-search { font-style: italic; }
 
-.jstree-brackets .jstree-no-icons .jstree-checkbox { display:inline-block; }
-.jstree-brackets .jstree-no-checkboxes .jstree-checkbox { display:none !important; }
-.jstree-brackets .jstree-checked > a > .jstree-checkbox { background-position:-38px -19px; }
-.jstree-brackets .jstree-unchecked > a > .jstree-checkbox { background-position:-2px -19px; }
-.jstree-brackets .jstree-undetermined > a > .jstree-checkbox { background-position:-20px -19px; }
-.jstree-brackets .jstree-checked > a > .jstree-checkbox:hover { background-position:-38px -37px; }
-.jstree-brackets .jstree-unchecked > a > .jstree-checkbox:hover { background-position:-2px -37px; }
-.jstree-brackets .jstree-undetermined > a > .jstree-checkbox:hover { background-position:-20px -37px; }
+.jstree-brackets .jstree-no-icons .jstree-checkbox { display: inline-block; }
+.jstree-brackets .jstree-no-checkboxes .jstree-checkbox { display: none !important; }
+.jstree-brackets .jstree-checked > a > .jstree-checkbox { background-position: -38px -19px; }
+.jstree-brackets .jstree-unchecked > a > .jstree-checkbox { background-position: -2px -19px; }
+.jstree-brackets .jstree-undetermined > a > .jstree-checkbox { background-position: -20px -19px; }
+.jstree-brackets .jstree-checked > a > .jstree-checkbox:hover { background-position: -38px -37px; }
+.jstree-brackets .jstree-unchecked > a > .jstree-checkbox:hover { background-position: -2px -37px; }
+.jstree-brackets .jstree-undetermined > a > .jstree-checkbox:hover { background-position: -20px -37px; }
 
 #vakata-dragged.jstree-brackets ins { background:transparent !important; }
-#vakata-dragged.jstree-brackets .jstree-ok { background:url("images/jsTreeSprites.svg") -2px -53px no-repeat !important; }
-#vakata-dragged.jstree-brackets .jstree-invalid { background:url("images/jsTreeSprites.svg") -18px -53px no-repeat !important; }
-#jstree-marker.jstree-brackets { background:url("images/jsTreeSprites.svg") -41px -57px no-repeat !important; text-indent:-100px; }
+#vakata-dragged.jstree-brackets .jstree-ok { background: url("images/jsTreeSprites.svg") -2px -53px no-repeat !important; }
+#vakata-dragged.jstree-brackets .jstree-invalid { background: url("images/jsTreeSprites.svg") -18px -53px no-repeat !important; }
+#jstree-marker.jstree-brackets { background: url("images/jsTreeSprites.svg") -41px -57px no-repeat !important; text-indent: -100px; }
 
-.jstree-brackets a.jstree-search { color:aqua; }
-.jstree-brackets .jstree-locked a { color:silver; cursor:default; }
+.jstree-brackets a.jstree-search { color: aqua; }
+.jstree-brackets .jstree-locked a { color: silver; cursor: default; }
 
 .jstree-brackets .jstree-rename-input {
     border: 1px solid silver;
@@ -136,12 +136,12 @@ ins.jstree-icon {
 }
 
 #vakata-contextmenu.jstree-brackets-context, 
-#vakata-contextmenu.jstree-brackets-context li ul { background:#f0f0f0; border:1px solid #979797; -moz-box-shadow: 1px 1px 2px #999; -webkit-box-shadow: 1px 1px 2px #999; box-shadow: 1px 1px 2px #999; }
+#vakata-contextmenu.jstree-brackets-context li ul { background: #f0f0f0; border: 1px solid #979797; box-shadow: 1px 1px 2px #999; }
 #vakata-contextmenu.jstree-brackets-context li { }
 #vakata-contextmenu.jstree-brackets-context a { color:black; }
 #vakata-contextmenu.jstree-brackets-context a:hover, 
-#vakata-contextmenu.jstree-brackets-context .vakata-hover > a { padding:0 5px; background:#e8eff7; border:1px solid #aecff7; color:black; -moz-border-radius:2px; -webkit-border-radius:2px; border-radius:2px; }
+#vakata-contextmenu.jstree-brackets-context .vakata-hover > a { padding: 0 5px; background: #e8eff7; border: 1px solid #aecff7; color: black; border-radius: 2px; }
 #vakata-contextmenu.jstree-brackets-context li.jstree-contextmenu-disabled a, 
-#vakata-contextmenu.jstree-brackets-context li.jstree-contextmenu-disabled a:hover { color:silver; background:transparent; border:0; padding:1px 4px; }
-#vakata-contextmenu.jstree-brackets-context li.vakata-separator { background:white; border-top:1px solid #e0e0e0; margin:0; }
-#vakata-contextmenu.jstree-brackets-context li ul { margin-left:-4px; }
+#vakata-contextmenu.jstree-brackets-context li.jstree-contextmenu-disabled a:hover { color: silver; background: transparent; border: 0; padding: 1px 4px; }
+#vakata-contextmenu.jstree-brackets-context li.vakata-separator { background: white; border-top: 1px solid #e0e0e0; margin: 0; }
+#vakata-contextmenu.jstree-brackets-context li ul { margin-left: -4px; }


### PR DESCRIPTION
I removed the old unused prefixes of border-radius and box-shadow and updated the styles to use the box-sizing mixin since -moz- is still required.
