### PR TITLE
Added search box to ExtensionManager dialog.

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -26,7 +26,7 @@
 /*unittests: ExtensionManager*/
 
 /**
- * The ExtensionManager fetches/caches/filters the extension registry and provides
+ * The ExtensionManager fetches/caches the extension registry and provides
  * information about the status of installed extensions. ExtensionManager raises the 
  * following events:
  *     statusChange - indicates that the status of an extension has changed. Second 
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
     
     var FileUtils        = require("file/FileUtils"),
         NativeFileSystem = require("file/NativeFileSystem").NativeFileSystem,
-        ExtensionLoader  = require("utils/ExtensionLoader");
+        ExtensionLoader  = require("utils/ExtensionLoader"),
+        StringUtils      = require("utils/StringUtils");
     
     // semver isn't a proper AMD module, so it will just load into the global namespace.
     require("extensibility/node/node_modules/semver/semver");
@@ -68,7 +69,7 @@ define(function (require, exports, module) {
      *     status: the current status, one of the status constants above
      */
     var _extensions = {};
-    
+
     /**
      * @private
      * Clears out our existing data. For unit testing only.
@@ -194,6 +195,17 @@ define(function (require, exports, module) {
         return result;
     }
     
+    /**
+     * Given an extension id and version number, returns the URL for downloading that extension from
+     * the repository. Does not guarantee that the extension exists at that URL.
+     * @param {string} id The extension's name from the metadata.
+     * @param {string} version The version to download.
+     * @return {string} The URL to download the extension from.
+     */
+    function getExtensionURL(id, version) {
+        return StringUtils.format(brackets.config.extension_url, id, version);
+    }
+    
     // Listen to extension load events
     $(ExtensionLoader).on("load", _handleExtensionLoad);
 
@@ -201,6 +213,7 @@ define(function (require, exports, module) {
     exports.getRegistry = getRegistry;
     exports.getStatus = getStatus;
     exports.getCompatibilityInfo = getCompatibilityInfo;
+    exports.getExtensionURL = getExtensionURL;
     
     exports.NOT_INSTALLED = NOT_INSTALLED;
     exports.ENABLED = ENABLED;

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -44,13 +44,25 @@ define(function (require, exports, module) {
             Mustache.render(dialogTemplate, Strings)
         );
         
-        var view = new ExtensionManagerView();
-        view.$el.appendTo($(".extension-manager-dialog .modal-body"));
+        // Create the view.
+        var $dlg = $(".extension-manager-dialog"),
+            view = new ExtensionManagerView();
+        view.$el.appendTo($(".modal-body", $dlg));
+        
+        // Filter the view's model when the user types in the search field.
+        $dlg.on("input", ".search", function (e) {
+            view.model.filter($(this).val());
+        }).on("click", ".search-clear", function (e) {
+            $(".search", $dlg).val("");
+            view.model.filter("");
+        });
         
         $(".extension-manager-dialog .install-from-url")
             .click(function () {
                 CommandManager.execute(Commands.FILE_INSTALL_EXTENSION);
             });
+        
+        $dlg.find(".search").focus();
     }
     
     CommandManager.register(Strings.CMD_EXTENSION_MANAGER, Commands.FILE_EXTENSION_MANAGER, _showDialog);

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -32,9 +32,133 @@ define(function (require, exports, module) {
         NativeApp              = require("utils/NativeApp"),
         ExtensionManager       = require("extensibility/ExtensionManager"),
         InstallExtensionDialog = require("extensibility/InstallExtensionDialog"),
-        StringUtils            = require("utils/StringUtils"),
         registry_utils         = require("extensibility/registry_utils"),
         itemTemplate           = require("text!htmlContent/extension-manager-view-item.html");
+    
+    /**
+     * @private
+     * @type {Array}
+     * A list of fields to search when trying to search for a query string in an object. Each field is 
+     * represented as an array of keys to recurse downward through the object. We store this here to avoid 
+     * doing it for each search call.
+     */
+    var _searchFields = [["metadata", "name"], ["metadata", "title"], ["metadata", "description"],
+                         ["metadata", "author", "name"], ["metadata", "keywords"], ["owner"]];
+    /**
+     * @constructor
+     * The model for the ExtensionManagerView. Keeps track of the extensions that are currently visible
+     * and manages sorting/filtering them.
+     * Events:
+     *     filterChange - triggered whenever the filtered set changes (including on initialize).
+     */
+    function Model() {
+    }
+    
+    /**
+     * @type {Object}
+     * The current registry as fetched by ExtensionManager.
+     */
+    Model.prototype.registry = null;
+    
+    /**
+     * @type {Array.<Object>}
+     * The list of IDs of items matching the current query and sorted with the current sort.
+     */
+    Model.prototype.filterSet = null;
+    
+    /**
+     * @type {Object}
+     * The list of all ids from the registry, sorted with the current sort.
+     */
+    Model.prototype._sortedFullSet = null;
+    
+    /**
+     * @private
+     * @type {string}
+     * The last query we filtered by. Used to optimize future searches.
+     */
+    Model.prototype._lastQuery = null;
+    
+    /**
+     * Initializes the model, fetching the main extension registry.
+     * @return {$.Promise} a promise that's resolved with the registry JSON data
+     * or rejected if the server can't be reached.
+     */
+    Model.prototype.initialize = function () {
+        var self = this;
+        return ExtensionManager.getRegistry(true)
+            .done(function (registry) {
+                self.registry = registry;
+                
+                // Sort the registry by last published date and store the sorted list of IDs.
+                self._sortedFullSet = registry_utils.sortRegistry(registry).map(function (entry) {
+                    return entry.metadata.name;
+                });
+                
+                // Initial filtered list is the same as the sorted list.
+                self.filterSet = self._sortedFullSet.slice(0);
+                $(self).triggerHandler("filterChange");
+            });
+    };
+    
+    /**
+     * @private
+     * Searches for the given query in the current registry list and updates the filter set,
+     * dispatching a filterChange event.
+     * @param {string} query The string to search for.
+     */
+    Model.prototype.filter = function (query) {
+        var self = this, initialList, newFilterSet = [];
+        if (this._lastQuery && query.indexOf(this._lastQuery) === 0) {
+            // This is the old query with some new letters added, so we know we can just
+            // search in the current filter set.
+            initialList = this.filterSet;
+        } else {
+            // This is a new query, so start with the full list.
+            initialList = this._sortedFullSet;
+        }
+        
+        query = query.toLowerCase();
+        initialList.forEach(function (id) {
+            var entry = self.registry[id];
+            if (entry && self._entryMatchesQuery(entry, query)) {
+                newFilterSet.push(id);
+            }
+        });
+        
+        this._lastQuery = query;
+        this.filterSet = newFilterSet;
+        $(this).trigger("filterChange");
+    };
+    
+    /**
+     * @private
+     * Tests if the given entry matches the query. See `filterRegistry()` for criteria.
+     * @param {Object} entry The registry entry to test.
+     * @param {string} query The query to match against.
+     * @return {boolean} Whether the query matches.
+     */
+    Model.prototype._entryMatchesQuery = function (entry, query) {
+        return _searchFields.some(function (fieldSpec) {
+            var i, cur = entry;
+            for (i = 0; i < fieldSpec.length; i++) {
+                // Recurse downward through the specified fields to the leaf value.
+                cur = cur[fieldSpec[i]];
+                if (!cur) {
+                    return false;
+                }
+            }
+            // If the leaf value is an array (like keywords), search each item, otherwise
+            // just search in the string.
+            if (Array.isArray(cur)) {
+                return cur.some(function (keyword) {
+                    return keyword.toLowerCase().indexOf(query) !== -1;
+                });
+            } else if (cur.toLowerCase().indexOf(query) !== -1) {
+                return true;
+            }
+        });
+    };
     
     /**
      * @constructor
@@ -44,45 +168,17 @@ define(function (require, exports, module) {
      */
     function ExtensionManagerView() {
         var self = this;
+        this.model = new Model();
         this._itemTemplate = Mustache.compile(itemTemplate);
         this.$el = $("<div class='extension-list'/>");
-        
-        // Listen for extension status changes.
-        $(ExtensionManager).on("statusChange", function (e, id, status) {
-            // Re-render the registry item.
-            // FUTURE: later on, some of these views might be for installed extensions that aren't 
-            // in the registry, e.g. legacy extensions or local dev extensions.
-            ExtensionManager.getRegistry().done(function (registry) {
-                if (registry[id]) {
-                    var $oldItem = self._itemViews[id],
-                        $newItem = self._renderItem(registry[id]);
-                    if ($oldItem) {
-                        $oldItem.replaceWith($newItem);
-                        self._itemViews[id] = $newItem;
-                    }
-                }
-            });
-        });
-        
-        // UI event handlers
-        $(this.$el)
-            // Intercept clicks on external links to open in the native browser.
-            .on("click", "a", function (e) {
-                e.stopImmediatePropagation();
-                e.preventDefault();
-                NativeApp.openURLInDefaultBrowser($(e.target).attr("href"));
-            })
-            // Handle install button clicks
-            .on("click", "button.install", function (e) {
-                self._installUsingDialog($(this).attr("data-extension-id"));
-            });
+        this._$table = $("<table class='table'/>").appendTo(this.$el);
         
         // Show the busy spinner and access the registry.
         var $spinner = $("<div class='spinner large spin'/>")
             .appendTo(this.$el);
-        ExtensionManager.getRegistry(true).done(function (registry) {
-            // Display the registry view.
-            self._render(registry_utils.sortRegistry(registry));
+        this.model.initialize().done(function (registry) {
+            self._setupEventHandlers();
+            self._render();
         }).fail(function () {
             $("<div class='alert-message error load-error'/>")
                 .text(Strings.EXTENSION_MANAGER_ERROR_LOAD)
@@ -99,6 +195,19 @@ define(function (require, exports, module) {
     ExtensionManagerView.prototype.$el = null;
     
     /**
+     * @type {Model}
+     * The view's model. Handles sorting and filtering of items in the view.
+     */
+    ExtensionManagerView.prototype.model = null;
+    
+    /**
+     * @private
+     * @type {jQueryObject}
+     * The root of the table inside the view.
+     */
+    ExtensionManagerView.prototype._$table = null;
+    
+    /**
      * @private
      * @type {function} The compiled template we use for rendering items in the registry list.
      */
@@ -111,6 +220,55 @@ define(function (require, exports, module) {
      */
     ExtensionManagerView.prototype._itemViews = {};
     
+    /**
+     * @private
+     * Attaches our event handlers. We wait to do this until we've fully fetched the registry.
+     */
+    ExtensionManagerView.prototype._setupEventHandlers = function () {
+        var self = this;
+        
+        // Listen for model filter changes.
+        $(this.model).on("filterChange", function () {
+            self._render();
+        });
+        
+        // Listen for extension status changes.
+        $(ExtensionManager).on("statusChange", function (e, id, status) {
+            // Re-render the registry item.
+            // FUTURE: later on, some of these views might be for installed extensions that aren't 
+            // in the registry, e.g. legacy extensions or local dev extensions.
+            var registry = self.model.registry;
+            if (registry[id]) {
+                var $oldItem = self._itemViews[id],
+                    $newItem = self._renderItem(registry[id]);
+                if ($oldItem) {
+                    $oldItem.replaceWith($newItem);
+                    self._itemViews[id] = $newItem;
+                }
+            }
+        });
+        
+        // UI event handlers
+        $(this.$el)
+            // Intercept clicks on external links to open in the native browser.
+            .on("click", "a", function (e) {
+                e.stopImmediatePropagation();
+                e.preventDefault();
+                NativeApp.openURLInDefaultBrowser($(e.target).attr("href"));
+            })
+            // Handle install button clicks
+            .on("click", "button.install", function (e) {
+                // "this" is correct here (it's the button)
+                self._installUsingDialog($(this).attr("data-extension-id"));
+            });
+    };
+    
+    /**
+     * @private
+     * Renders the view for a single registry entry.
+     * @param {Object} entry The registry entry to render.
+     * @return {jQueryObject} The rendered node as a jQuery object.
+     */
     ExtensionManagerView.prototype._renderItem = function (entry) {
         // Create a Mustache context object containing the entry data and our helper functions.
         var context = $.extend({}, entry),
@@ -137,21 +295,20 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Display the given registry data.
-     * @param {Array} registry The sorted list of registry entries to show.
+     * Renders the registry entries in the model's current filter list.
      */
-    ExtensionManagerView.prototype._render = function (registry) {
-        // TODO: localize strings in template
+    ExtensionManagerView.prototype._render = function () {
         var self = this,
-            $table = $("<table class='table'/>"),
             $item;
-        this._itemViews = {};
-        registry.forEach(function (entry) {
-            var $item = self._renderItem(entry);
-            self._itemViews[entry.metadata.name] = $item;
-            $item.appendTo($table);
+        this._$table.empty();
+        this.model.filterSet.forEach(function (id) {
+            var $item = self._itemViews[id];
+            if (!$item) {
+                $item = self._renderItem(self.model.registry[id]);
+                self._itemViews[id] = $item;
+            }
+            $item.appendTo(self._$table);
         });
-        $table.appendTo(this.$el);
         $(this).triggerHandler("render");
     };
     
@@ -161,15 +318,15 @@ define(function (require, exports, module) {
      * @param {string} id ID of the extension to install.
      */
     ExtensionManagerView.prototype._installUsingDialog = function (id) {
-        var self = this;
-        ExtensionManager.getRegistry().done(function (registry) {
-            var entry = registry[id];
-            if (entry) {
-                var url = StringUtils.format(brackets.config.extension_url, id, entry.metadata.version);
-                InstallExtensionDialog.installUsingDialog(url);
-            }
-        });
+        var entry = this.model.registry[id];
+        if (entry) {
+            var url = ExtensionManager.getExtensionURL(id, entry.metadata.version);
+            InstallExtensionDialog.installUsingDialog(url);
+        }
     };
     
     exports.ExtensionManagerView = ExtensionManagerView;
+    
+    // For unit test only
+    exports.Model = Model;
 });

--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -1,5 +1,7 @@
 <div class="extension-manager-dialog modal">
     <div class="modal-header">
+        <button class="search-clear"></button>
+        <input class="search" type="text" placeholder="Search">
         <h1 class="dialog-title">{{EXTENSION_MANAGER_TITLE}}</h1>
     </div>
     <div class="modal-body"></div>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -466,6 +466,24 @@
     margin-top: -325px;
     margin-left: -350px;
     
+    .modal-header {
+        width: 700px;
+        
+        .search {
+            float: right;
+            margin-top: 8px;
+        }
+        .search-clear {
+            position: relative;
+            display: block;
+            float: right;
+            margin: 15px 15px 0 -20px;
+            background: url("images/close_btn.svg") no-repeat;
+            width: 15px;
+            height: 16px;
+            z-index: 1;
+        }
+    }
     .modal-body {
         width: 700px;
         height: 500px;

--- a/test/spec/ExtensionManager-test-files/mockRegistryForSearch.json
+++ b/test/spec/ExtensionManager-test-files/mockRegistryForSearch.json
@@ -1,0 +1,116 @@
+{
+  "find-uniq1-in-name": {
+    "metadata": {
+      "name": "find-uniq1-in-name",
+      "title": "Find item 1",
+      "description": "Find item 1 description with uniqIn1And5",
+      "version": "1.0.1",
+      "author": {
+        "name": "Find item 1 author"
+      },
+      "engines": {
+        "brackets": ">0.20.0"
+      }
+    },
+    "owner": "github:someuser",
+    "versions": [
+      {
+        "version": "1.0.1",
+        "published": "2013-04-10T18:21:27.058Z",
+        "brackets": ">0.20.0"
+      }
+    ]
+  },
+  "item-2": {
+    "metadata": {
+      "name": "item-2",
+      "author": {
+        "name": "Find UNIQ2 in author name"
+      },
+      "description": "Find item 2",
+      "version": "1.0.0"
+    },
+    "owner": "github:anotheruser",
+    "versions": [
+      {
+        "version": "1.0.0",
+        "published": "2013-04-10T18:26:20.553Z"
+      }
+    ]
+  },
+  "item-3": {
+    "metadata": {
+      "name": "item-3",
+      "author": {
+        "name": "Author of item 3"
+      },
+      "description": "Find Uniq3 in description",
+      "version": "1.0.0"
+    },
+    "owner": "github:someuser",
+    "versions": [
+      {
+        "version": "1.0.0",
+        "published": "2013-04-10T13:26:20.553Z"
+      }
+    ]
+  },
+  "item-4": {
+    "metadata": {
+      "name": "item-4",
+      "author": {
+        "name": "Author of item 4"
+      },
+      "title": "Find uniq4 in title",
+      "description": "Find item 4",
+      "version": "1.0.0"
+    },
+    "owner": "github:anotheruser",
+    "versions": [
+      {
+        "version": "1.0.0",
+        "published": "2013-04-10T15:26:20.553Z"
+      }
+    ]
+  },
+  "item-5": {
+    "metadata": {
+      "name": "item-5",
+      "author": {
+        "name": "Author of item 5 uniqin1and5-2"
+      },
+      "title": "Find item 5",
+      "description": "Find item 5 description",
+      "version": "1.0.0"
+    },
+    "owner": "github:uniq5",
+    "versions": [
+      {
+        "version": "1.0.0",
+        "published": "2013-04-16T18:26:20.553Z"
+      }
+    ]
+  },
+  "item-6": {
+    "metadata": {
+      "name": "item-6",
+      "author": {
+        "name": "Author of item 6"
+      },
+      "title": "Find item 6",
+      "description": "Find item 6 description",
+      "version": "1.0.0",
+      "keywords": [
+        "a keyword",
+        "uniq6"
+      ]
+    },
+    "owner": "github:someuser",
+    "versions": [
+      {
+        "version": "1.0.0",
+        "published": "2013-04-15T18:26:20.553Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds filter-as-you-type functionality to the Extension Manager.

Some notes:
- Note that the view now has its own model (separate from Extension Manager) that manages the sorting and filtering of items within the view--this really seemed view-specific, not appropriate to go into the central Extension Manager code. The model still relies on the Extension Manager to do the actual fetching of the registry from the server.
- I didn't break the view model out as a separate file since it's really specific to the view--no one else should need to know much about it. Of course, I already broke that rule since the dialog knows about it :), but I think of the dialog as just a thin shell around the view. I'm happy to break the model out into a separate file if it's appropriate.
- I also didn't add unit tests for the dialog since the filtering functionality is tested on the model.
- This just does a full linear search on each keystroke. I added a task to the Trello card to stress-test this with a reasonable number of extensions. If it turns out to be slow, we can back it down to do the search on Enter instead.
- This doesn't highlight the found search string in each item. I wasn't clear on whether this was part of the criteria--need to check with @adrocknaphobia.
- The search box is actually in the outer dialog, not the view itself, just because it seemed to make more sense there in the current design. Once we get the final XD design, it's easy to move it wherever it needs to be, since it just calls a filter function on the view's model.
