### PR TITLE
Always check for a property name from next cursor position if current token is not one of them

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -357,7 +357,8 @@ define(function (require, exports, module) {
         }
 
         if (_isInPropName(ctx)) {
-            if (ctx.token.string.length > 0 && !ctx.token.string.match(/\S/)) {
+            if (ctx.token.string.length > 0 &&
+                    (ctx.token.string === "{" || !ctx.token.string.match(/\S/))) {
                 var testPos = {ch: ctx.pos.ch + 1, line: ctx.pos.line},
                     testToken = editor._codeMirror.getTokenAt(testPos);
                 

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -357,8 +357,9 @@ define(function (require, exports, module) {
         }
 
         if (_isInPropName(ctx)) {
-            if (ctx.token.string.length > 0 &&
-                    (ctx.token.string === "{" || !ctx.token.string.match(/\S/))) {
+            if (ctx.token.className === "property" || ctx.token.className === "property error" || ctx.token.className === "tag") {
+                propName = ctx.token.string;
+            } else {
                 var testPos = {ch: ctx.pos.ch + 1, line: ctx.pos.line},
                     testToken = editor._codeMirror.getTokenAt(testPos);
                 
@@ -366,8 +367,6 @@ define(function (require, exports, module) {
                     propName = testToken.string;
                     offset = 0;
                 }
-            } else if (ctx.token.className === "property" || ctx.token.className === "property error" || ctx.token.className === "tag") {
-                propName = ctx.token.string;
             }
             
             // If we're in property name context but not in an existing property name, 


### PR DESCRIPTION
This fixes issue #3448. Second commit fixes other cases -- after `;` and at the beginning of the line with no indendation.
