### PR TITLE
set matchGoodness to lowest number for prefix matches

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -334,6 +334,25 @@ define(function (require, exports, module) {
         }
 
         /**
+         *  Test if the searchResult contains a prefix only match.
+         *
+         * @param searchResult - the search result to test
+         * @returns {boolean} - true if the only match is a prefix match,
+         * false otherwise.
+         */
+        function isPrefixMatch(searchResult) {
+            var prefixOnly = false;
+
+            searchResult.stringRanges.every(function (range, i) {
+                prefixOnly = (i === 0) ? range.matched : !range.matched;
+
+                return prefixOnly;
+            });
+
+            return prefixOnly;
+        }
+
+        /**
          *  Filter an array hints using a given query and matcher.
          *  The hints are returned in the format of the matcher.
          *  The matcher returns the value in the "label" property,
@@ -367,6 +386,11 @@ define(function (require, exports, module) {
                         searchResult.builtin = 1;
                     } else {
                         searchResult.builtin = 0;
+                    }
+
+                    // make all prefix matches have the same value
+                    if (isPrefixMatch(searchResult)) {
+                        searchResult.matchGoodness = -Number.MAX_VALUE;
                     }
                 }
 


### PR DESCRIPTION
Fix for issue #3534 (https://github.com/adobe/brackets/issues/3534). The matchGoodness score for hints that match the prefix of a hint have a different value based on the length of the hint. For code hints, the length of the hint should not matter so this fix sets them to be all the same. When all the prefix matches have the same matchGoodness score, the secondary sorts for scope depth and builtin vs. not-builtin can kick in.
