### PR TITLE
JSCodeHinting - Find requirejs modules even when project root doesn't match requirejs root

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
      */
     function splitPath(path) {
         var index   = path.lastIndexOf("/"),
-            dir     = path.substring(0, index),
+            dir     = (index === -1) ? "" : path.substring(0, index),
             file    = path.substring(index + 1, path.length);
         
         return {dir: dir, file: file };


### PR DESCRIPTION
Find requirejs modules even when project root doesn't match the requirejs root.

Looks for any files that end with the name of the module we're looking for.  Does not do any tie breaking yet, but this gets the requirejs support working when you open the 'brackets' dir for instance, instead of the 'brackets/src' dir.

This partially fixes https://github.com/adobe-research/brackets/issues/32 - still can't configure requirejs roots, but now we find a lot more requirejs modules if the source root wasn't the directory opened.
