### PR TITLE
Fix bug #3502 (clicking some links in Quick Docs doesn't work)

### DIFF
--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
             .on("click", "a", function (e) {
                 e.stopImmediatePropagation();
                 e.preventDefault();
-                NativeApp.openURLInDefaultBrowser($(e.target).attr("href"));
+                NativeApp.openURLInDefaultBrowser($(e.currentTarget).attr("href"));
             })
             // Handle install button clicks
             .on("click", "button.install", function (e) {

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
     /** Clicking any link should open it in browser, not in Brackets shell */
     InlineDocsViewer.prototype._handleLinkClick = function (event) {
         event.preventDefault();
-        var url = $(event.target).attr("href");
+        var url = $(event.currentTarget).attr("href");
         if (url) {
             NativeApp.openURLInDefaultBrowser(url);
         }

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -209,7 +209,7 @@ define(function (require, exports, module) {
         $updateList.html(Mustache.render(UpdateListTemplate, templateVars));
         
         $dlg.on("click", "a", function (e) {
-            var url = $(e.target).attr("data-url");
+            var url = $(e.currentTarget).attr("data-url");
             
             if (url) {
                 // Make sure the URL has a domain that we know about

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -149,8 +149,8 @@ define(function (require, exports, module) {
 
         $(".clickable-link", $dlg).on("click", function _handleLink(e) {
             // Links use data-href (not href) attribute so Brackets itself doesn't redirect
-            if (e.target.dataset && e.target.dataset.href) {
-                NativeApp.openURLInDefaultBrowser(e.target.dataset.href);
+            if (e.currentTarget.dataset && e.currentTarget.dataset.href) {
+                NativeApp.openURLInDefaultBrowser(e.currentTarget.dataset.href);
             }
         });
 


### PR DESCRIPTION
Fix bug #3502 -- don't use `event.target` since that might point to a child of the link tag, e.g. in this case a `<b>`.

Also fix same bug in the other places we have similar logic, although so far they haven't hit this problem.
