### PR TITLE
Fix #3478: Persistent highlight is taller than transient highlight

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -58,7 +58,15 @@ define(function (require, exports, module) {
      * @type {int}
      */
     var MAX_FONT_SIZE = 72;
-
+    
+    /**
+     * @const
+     * @private
+     * The proportion between the font-size and the line-height in pixels
+     * @type {float}
+     */
+    var LINE_HEIGHT = 1.25;
+    
     /**
      * @private
      * @type {PreferenceStorage}
@@ -147,28 +155,19 @@ define(function (require, exports, module) {
         // Guaranteed to work by the validation above.
         var fsUnits = fsStyle.substring(fsStyle.length - 2, fsStyle.length);
         var lhUnits = lhStyle.substring(lhStyle.length - 2, lhStyle.length);
-
-        var fsOld = parseFloat(fsStyle.substring(0, fsStyle.length - 2));
-        var lhOld = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
-
-        var fsDelta = (fsUnits === "px") ? adjustment : (0.1 * adjustment);
-        var lhDelta = (lhUnits === "px") ? adjustment : (0.1 * adjustment);
-
-        var fsNew = fsOld + fsDelta;
-        var lhNew = lhOld + lhDelta;
+        var delta   = (fsUnits === "px") ? 1 : 0.1;
         
-        var fsStr = fsNew + fsUnits;
-        var lhStr = lhNew + lhUnits;
-
-        // Don't let the font size get too small.
-        if ((fsUnits === "px" && fsNew < MIN_FONT_SIZE) ||
-                (fsUnits === "em" && fsNew < (MIN_FONT_SIZE * 0.1))) {
-            return false;
-        }
+        var fsOld   = parseFloat(fsStyle.substring(0, fsStyle.length - 2));
+        var lhOld   = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
         
-        // Don't let the font size get too large.
-        if ((fsUnits === "px" && fsNew > MAX_FONT_SIZE) ||
-                (fsUnits === "em" && fsNew > (MAX_FONT_SIZE * 0.1))) {
+        var fsNew   = fsOld + (delta * adjustment);
+        var lhNew   = (fsUnits === lhUnits) ? fsNew * LINE_HEIGHT : lhOld;
+        
+        var fsStr   = fsNew + fsUnits;
+        var lhStr   = lhNew + lhUnits;
+
+        // Don't let the font size get too small or too large.
+        if (fsNew < MIN_FONT_SIZE * delta || fsNew > MAX_FONT_SIZE * delta) {
             return false;
         }
         

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -166,7 +166,8 @@ define(function (require, exports, module) {
         var fsStr   = fsNew + fsUnits;
         var lhStr   = lhNew + lhUnits;
 
-        // Don't let the font size get too small or too large.
+        // Don't let the font size get too small or too large. The minimum font size is 1px or 0.1em
+        // and the maximum font size is 72px or 7.2em depending on the unit used
         if (fsNew < MIN_FONT_SIZE * delta || fsNew > MAX_FONT_SIZE * delta) {
             return false;
         }

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
     /**
      * @const
      * @private
-     * The proportion between the font-size and the line-height in pixels
+     * The ratio of line-height to font-size when they use the same units
      * @type {float}
      */
     var LINE_HEIGHT = 1.25;


### PR DESCRIPTION
The problem in #3478 was that when the font-size increased the font-size line-height ratio was lost. They line height should always be 1.25 times higher than the font-size so that the text would fit inside the line.

I applied the solution to the font adjustment instead of the styles, to make it possible to keep using pixels for both font size and line height. If we can change the line-height to ems, an easier solution would be to just remove all the line-height adjustments in the command function.
