### PR TITLE
Fix #3422: Can't find the string: LK4: NO_DISABLED_DIRECTORY

### DIFF
--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -325,7 +325,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "Doplněk není kompatibilní s touto verzi Brackets. Naleznete jej ve složce disabled extensions.",
     "MISSING_MAIN"                         : "Balíček neobsahuje soubor main.js.",
     "ALREADY_INSTALLED"                    : "Doplněk s tímto jménem je již nainstalován. Nový doplněk je nainstalován ve složce disabled extensions.",
-    "NO_DISABLED_DIRECTORY"                : "Nelze uložit doplněk do extensions/disabled protože složka neexistuje.",
     "DOWNLOAD_ID_IN_USE"                   : "Interní chyba: ID stahování se již používá.",
     "NO_SERVER_RESPONSE"                   : "Nelze se přípojit na server.",
     "BAD_HTTP_STATUS"                      : "Soubor nebyl nalezen (HTTP {0}).",

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -330,7 +330,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "Die Erweiterung ist nicht mit der aktuellen Version von Brackets kompatibel. Die Erweiterung wurde in den Ordner für die deaktivierten Erweiterungen installiert.",
     "MISSING_MAIN"                         : "Das Paket hat keine main.js-Datei.",
     "ALREADY_INSTALLED"                    : "Eine Erweiterung mit dem gleichen Namen wurde bereits installiert. Die neue Erweiterung wurde in den Ordner für deaktivierte Erweiterungen installiert.",
-    "NO_DISABLED_DIRECTORY"                : "Die Erweiterung konnte nicht gespeichert werden, weil der Ordner für deaktivierte Erweiterungen nicht existiert.",
     "DOWNLOAD_ID_IN_USE"                   : "Interner Fehler: Download-ID wird schon verwendet.",
     "NO_SERVER_RESPONSE"                   : "Verbindung konnte nicht hergestellt werden.",
     "BAD_HTTP_STATUS"                      : "Die Datei wurde auf dem Server nicht gefunden (HTTP {0}).",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -321,7 +321,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "La extensión no es compatible con esta versión de Brackets. Está en la carpeta de extensiones deshabilitadas.",
     "MISSING_MAIN"                         : "El paquete no contiene el archivo main.js.",
     "ALREADY_INSTALLED"                    : "Ya hay instalada una extensión con el mismo nombre. La nueva extensión está en la carpeta de extensiones deshabilitadas.",
-    "NO_DISABLED_DIRECTORY"                : "No se puede guardar la extensión en extensions/disabled porque la carpeta no existe.",
     "DOWNLOAD_ID_IN_USE"                   : "Error interno: el ID de descarga ya está siendo utilizado.",
     "NO_SERVER_RESPONSE"                   : "No se puede conectar con el servidor.",
     "BAD_HTTP_STATUS"                      : "Archivo no encontrado en el servidor (HTTP {0}).",

--- a/src/nls/pl/strings.js
+++ b/src/nls/pl/strings.js
@@ -324,7 +324,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "Rozszerzenie nie jest kompatybilne z tą wersją Brackets. Rozszerzenie zostanie zainstalowane w folderze rozszerzeń nieaktywnych.",
     "MISSING_MAIN"                         : "Pakiet nie zawiera pliku main.js.",
     "ALREADY_INSTALLED"                    : "Rozszerzenie z taką samą nazwą jest już zainstalowane. Nowe rozszerzenie zostanie zainstalowane w folderze rozszerzeń nieaktywnych.",
-    "NO_DISABLED_DIRECTORY"                : "Nie można zapisać rozszerzenia w extensions/disabled ponieważ folder ten nie istnieje.",
     "DOWNLOAD_ID_IN_USE"                   : "Błąd wewnętrzny: nazwa ściąganego pliku już istnieje.",
     "NO_SERVER_RESPONSE"                   : "Nie można połączyć z serwerem.",
     "BAD_HTTP_STATUS"                      : "Nie znaleziono pliku na serwerze (HTTP {0}).",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -328,7 +328,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "The extension isn't compatible with this version of {APP_NAME}. It's installed in your disabled extensions folder.",
     "MISSING_MAIN"                         : "The package has no main.js file.",
     "ALREADY_INSTALLED"                    : "An extension with the same name was already installed. The new extension is installed in your disabled extensions folder.",
-    "NO_DISABLED_DIRECTORY"                : "Cannot save extension to extensions/disabled because the folder does not exist.",
     "DOWNLOAD_ID_IN_USE"                   : "Internal error: download ID already in use.",
     "NO_SERVER_RESPONSE"                   : "Cannot connect to server.",
     "BAD_HTTP_STATUS"                      : "File not found on server (HTTP {0}).",

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -324,7 +324,6 @@ define({
     "API_NOT_COMPATIBLE"                   : "这个扩展包不兼容当前的版本,将安装至Disabled扩展文件夹中.",
     "MISSING_MAIN"                         : "扩展包遗失main.js文件.",
     "ALREADY_INSTALLED"                    : "该扩展已经存在,将安装至Disabled扩展文件夹中.",
-    "NO_DISABLED_DIRECTORY"                : "由于扩展文件夹不存在\"extensions/disabled\",所以无法保存扩展至扩展文件夹.",
     "DOWNLOAD_ID_IN_USE"                   : "内部错误:该下载ID已被使用.",
     "DOWNLOAD_TARGET_EXISTS"               : "临时下载文件已存在: {0}.",
     "NO_SERVER_RESPONSE"                   : "无法连接到服务器.",


### PR DESCRIPTION
For issue #3422.This just removes the unused NO_DISABLED_DIRECTORY string from all the languages except fr and ja.

I also tried to reproduce the steps, but installing an extension did not created the disabled folder. I think that the string might be used for the Extension Disable feature, if so, we can just close this request, and when that is implemented, the string could be used with a different text probably.
