### PR TITLE
Fix expandWordForward should be false.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -115,7 +115,7 @@ importScripts("thirdparty/requirejs/require.js");
         query.depths = true;
         query.guess = true;
         query.origins = true;
-        query.expandWordForward = true;
+        query.expandWordForward = false;
 
         var request = {query: query, files: [], offset: offset};
         request.files.push({type: "full", name: file, text: text});


### PR DESCRIPTION
Setting expandWordForward to false prevents Tern from including text to the right of the cursor as part of the word to hint for.
