### PR TITLE
[JS Code Hints] Fix Issue #3511

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -217,6 +217,28 @@ define(function (require, exports, module) {
     };
 
     /**
+     * @return {{line:number, ch:number}} - the line, col info for where the previous "."
+     *      in a property lookup occurred, or undefined if no previous "." was found.
+     */
+    Session.prototype.findPreviousDot = function () {
+        var cursor = this.getCursor(),
+            token = this.getToken(cursor);
+        
+        // If the cursor is right after the dot, then the current token will be "."
+        if (token && token.string === ".") {
+            return cursor;
+        } else {
+            // If something has been typed like 'foo.b' then we have to look back 2 tokens
+            // to get past the 'b' token
+            token = this._getPreviousToken(cursor);
+            if (token && token.string === ".") {
+                return cursor;
+            }
+        }
+        return undefined;
+    };
+    
+    /**
      * Get the type of the current session, i.e., whether it is a property
      * lookup and, if so, what the context of the lookup is.
      * 
@@ -278,19 +300,12 @@ define(function (require, exports, module) {
                     }
                 }
             }
-            if (token.string === ".") {
+            if (token.className === "property") {
+                propertyLookup = true;
+            }
+            if (this.findPreviousDot()) {
                 propertyLookup = true;
                 context = this.getContext(cursor);
-            } else {
-                if (token.className === "property") {
-                    propertyLookup = true;
-                }
-
-                token = this._getPreviousToken(cursor);
-                if (token && token.string === ".") {
-                    propertyLookup = true;
-                    context = this.getContext(cursor);
-                }
             }
             if (propertyLookup) { showFunctionType = false; }
         }

--- a/src/extensions/default/JavaScriptCodeHints/test/file1.js
+++ b/src/extensions/default/JavaScriptCodeHints/test/file1.js
@@ -43,3 +43,7 @@ require(["MyModule"], function (myModule) {
 
 funB();
 var x = A1;
+
+var arr = [];
+arr["my-key"] = 1;
+arr["for"] = 10;

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -665,6 +665,53 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should insert hint as [\"my-key\"] since 'my-key' is not a valid property name", function () {
+                var start = { line: 49, ch: 0 },
+                    middle = { line: 49, ch: 5 },
+                    end = { line: 49, ch: 13 };
+                
+                testDoc.replaceRange("arr.m", start, start);
+                testEditor.setCursorPos(middle);
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "my-key");
+                runs(function () {
+                    expect(testEditor.getCursorPos()).toEqual(end);
+                    expect(testDoc.getRange(start, end)).toEqual("arr[\"my-key\"]");
+                    expect(testDoc.getLine(end.line).length).toEqual(13);
+                });
+            });
+
+            it("should insert hint as [\"my-key\"] make sure this works if nothing is typed after the '.'", function () {
+                var start = { line: 49, ch: 0 },
+                    middle = { line: 49, ch: 4 },
+                    end = { line: 49, ch: 13 };
+                
+                testDoc.replaceRange("arr.", start, start);
+                testEditor.setCursorPos(middle);
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "my-key");
+                runs(function () {
+                    expect(testEditor.getCursorPos()).toEqual(end);
+                    expect(testDoc.getRange(start, end)).toEqual("arr[\"my-key\"]");
+                    expect(testDoc.getLine(end.line).length).toEqual(13);
+                });
+            });
+
+            it("should insert hint as '.for' since keywords can be used as property names", function () {
+                var start = { line: 49, ch: 0 },
+                    middle = { line: 49, ch: 5 },
+                    end = { line: 49, ch: 7 };
+                
+                testDoc.replaceRange("arr.f", start, start);
+                testEditor.setCursorPos(middle);
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                selectHint(JSCodeHints.jsHintProvider, hintObj, "for");
+                runs(function () {
+                    expect(testEditor.getCursorPos()).toEqual(end);
+                    expect(testDoc.getRange(start, end)).toEqual("arr.for");
+                    expect(testDoc.getLine(end.line).length).toEqual(7);
+                });
+            });
         });
 
     });


### PR DESCRIPTION
when inserting a hint which is not a valid property name, such as 'my-key', insert the hint as ["my-key"] instead of .my-key.

insertHint now runs the hint through the acorn tokenizer to see if it looks like a valid property name.  If it's invalid, it replaces the '.' with brackets.
Refactored some code in Session.getType() - pulled out a method to find the leading '.' in a property lookup, and use that method from the insertHint logic as well.
Added 3 new unittests to test this new behavior.
