### PR TITLE
Fix #3602 (Can't close Quick Docs via Esc after click in left-hand content)

### DIFF
--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
@@ -1,4 +1,4 @@
-<div class="css-prop-defn">
+<div class="css-prop-defn" tabIndex="0"> <!-- tabIndex needed: otherwise click focuses CodeMirror scroller and Esc won't work -->
     <div class="css-prop-summary">
         <h1>{{propName}}</h1>
         <div>{{{summary}}}</div>
@@ -7,7 +7,7 @@
         <div class="divider"></div>
     </div>
     <div class="css-prop-values quiet-scrollbars">
-        <div class="scroller" tabIndex="0"> <!-- tabIndex needed: otherwise click focuses CodeMirror scroller -->
+        <div class="scroller" tabIndex="0"> <!-- tabIndex needed: otherwise can't be focused on open or via click -->
             <dl>
                 {{#propValues}}
                 <dt>{{value}}</dt>

--- a/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
+++ b/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
@@ -19,6 +19,10 @@
     -o-user-select: text;
     user-select: text;
     
+    &:focus {
+        outline: none;
+    }
+    
     font-family: SourceSansPro;
     font-size: 14px;
     


### PR DESCRIPTION
Fix bug #3602 -- Make non-scrolling parts of content focusable so focus stays in widget (where we listen for Esc) rather than bubbling up to some random part of CM that no one's listening to.

This was one of the dangling issues we never got an answer on in pull #3496, but @adrocknaphobia mentioned today it felt like a bug and I'm inclined to agree.
