### PR TITLE
Fix #3412: Cryptic error message when addMenuItem() is passed bad args

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -96,12 +96,12 @@ define(function (require, exports, module) {
      * specify the relative position of a newly created menu object
      * @enum {string}
      */
-    var BEFORE           = "before";
-    var AFTER            = "after";
-    var FIRST            = "first";
-    var LAST             = "last";
-    var FIRST_IN_SECTION = "firstInSection";
-    var LAST_IN_SECTION  = "lastInSection";
+    var BEFORE           = "before",
+        AFTER            = "after",
+        FIRST            = "first",
+        LAST             = "last",
+        FIRST_IN_SECTION = "firstInSection",
+        LAST_IN_SECTION  = "lastInSection";
 
     /**
      * Other constants
@@ -112,10 +112,10 @@ define(function (require, exports, module) {
      * Error Codes from Brackets Shell
      * @enum {number}
      */
-    var NO_ERROR           = 0;
-    var ERR_UNKNOWN        = 1;
-    var ERR_INVALID_PARAMS = 2;
-    var ERR_NOT_FOUND      = 3;
+    var NO_ERROR           = 0,
+        ERR_UNKNOWN        = 1,
+        ERR_INVALID_PARAMS = 2,
+        ERR_NOT_FOUND      = 3;
     
     /**
      * Maps menuID's to Menu objects
@@ -558,12 +558,16 @@ define(function (require, exports, module) {
             
             brackets.app.addMenuItem(this.id, name, commandID, bindingStr, displayStr, position, relativeID, function (err) {
                 switch (err) {
+                case NO_ERROR:
+                    break;
                 case ERR_INVALID_PARAMS:
                     console.error("addMenuItem(): Invalid Parameters when adding the command " + commandID);
                     break;
                 case ERR_NOT_FOUND:
                     console.error("_getRelativeMenuItem(): MenuItem with Command id " + relativeID + " not found in the Menu " + menuID);
                     break;
+                default:
+                    console.error("addMenuItem(); Unknown Error (" + err + ") when adding the command " + commandID);
                 }
             });
             menuItem.isNative = true;
@@ -816,6 +820,14 @@ define(function (require, exports, module) {
         if (!_isHTMLMenu(id)) {
             brackets.app.addMenu(name, id, position, relativeID, function (err) {
                 switch (err) {
+                case NO_ERROR:
+                    // Make sure name is up to date
+                    brackets.app.setMenuTitle(id, name, function (err) {
+                        if (err) {
+                            console.error("setMenuTitle() -- error: " + err);
+                        }
+                    });
+                    break;
                 case ERR_UNKNOWN:
                     console.error("addMenu(): Unknown Error when adding the menu " + id);
                     break;
@@ -825,14 +837,8 @@ define(function (require, exports, module) {
                 case ERR_NOT_FOUND:
                     console.error("addMenu(): Menu with command " + relativeID + " could not be found when adding the menu " + id);
                     break;
-                case NO_ERROR:
-                    // Make sure name is up to date
-                    brackets.app.setMenuTitle(id, name, function (err) {
-                        if (err) {
-                            console.error("setMenuTitle() -- error: " + err);
-                        }
-                    });
-                    break;
+                default:
+                    console.error("addMenu(): Unknown Error (" + err + ") when adding the menu " + id);
                 }
             });
             return menu;

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -91,23 +91,32 @@ define(function (require, exports, module) {
 
     
     /**
-      * Insertion position constants
-      * Used by addMenu(), addMenuItem(), and addSubMenu() to
-      * specify the relative position of a newly created menu object
-      * @enum {string}
-      */
-    var BEFORE =            "before";
-    var AFTER =             "after";
-    var FIRST =             "first";
-    var LAST =              "last";
-    var FIRST_IN_SECTION =  "firstInSection";
-    var LAST_IN_SECTION =   "lastInSection";
+     * Insertion position constants
+     * Used by addMenu(), addMenuItem(), and addSubMenu() to
+     * specify the relative position of a newly created menu object
+     * @enum {string}
+     */
+    var BEFORE           = "before";
+    var AFTER            = "after";
+    var FIRST            = "first";
+    var LAST             = "last";
+    var FIRST_IN_SECTION = "firstInSection";
+    var LAST_IN_SECTION  = "lastInSection";
 
     /**
-      * Other constants
-      */
+     * Other constants
+     */
     var DIVIDER = "---";
-
+    
+    /**
+     * Error Codes from Brackets Shell
+     * @enum {number}
+     */
+    var NO_ERROR           = 0;
+    var ERR_UNKNOWN        = 1;
+    var ERR_INVALID_PARAMS = 2;
+    var ERR_NOT_FOUND      = 3;
+    
     /**
      * Maps menuID's to Menu objects
      * @type {Object.<string, Menu>}
@@ -462,7 +471,8 @@ define(function (require, exports, module) {
      * @return {MenuItem} the newly created MenuItem
      */
     Menu.prototype.addMenuItem = function (command, keyBindings, position, relativeID) {
-        var id,
+        var menuID = this.id,
+            id,
             $menuItem,
             $link,
             menuItem,
@@ -547,8 +557,13 @@ define(function (require, exports, module) {
             }
             
             brackets.app.addMenuItem(this.id, name, commandID, bindingStr, displayStr, position, relativeID, function (err) {
-                if (err) {
-                    console.error("addMenuItem() -- error: " + err + " when adding command: " + commandID);
+                switch (err) {
+                case ERR_INVALID_PARAMS:
+                    console.error("addMenuItem(): Invalid Parameters when adding the command " + commandID);
+                    break;
+                case ERR_NOT_FOUND:
+                    console.error("_getRelativeMenuItem(): MenuItem with Command id " + relativeID + " not found in the Menu " + menuID);
+                    break;
                 }
             });
             menuItem.isNative = true;
@@ -800,15 +815,24 @@ define(function (require, exports, module) {
 
         if (!_isHTMLMenu(id)) {
             brackets.app.addMenu(name, id, position, relativeID, function (err) {
-                if (err) {
-                    console.error("addMenu() -- error: " + err + " when adding menu with ID: " + id);
-                } else {
+                switch (err) {
+                case ERR_UNKNOWN:
+                    console.error("addMenu(): Unknown Error when adding the menu " + id);
+                    break;
+                case ERR_INVALID_PARAMS:
+                    console.error("addMenu(): Invalid Parameters when adding the menu " + id);
+                    break;
+                case ERR_NOT_FOUND:
+                    console.error("addMenu(): Menu with command " + relativeID + " could not be found when adding the menu " + id);
+                    break;
+                case NO_ERROR:
                     // Make sure name is up to date
                     brackets.app.setMenuTitle(id, name, function (err) {
                         if (err) {
                             console.error("setMenuTitle() -- error: " + err);
                         }
                     });
+                    break;
                 }
             });
             return menu;


### PR DESCRIPTION
Fix for the issue #3412 by graving the resulting error code from the callback and providing a better error message for each code. I added a similar approach to `addMenu()` since it had a similar problem.

I searched through the Brackets Shell code to find which where the possible error codes for each function to provide a specific error message for each, but let me know if I missed one, since I mainly went through the Mac implementation since in the Win one was harder to find the error codes, and the list isn't complete in the JavaScript file.
