### PR TITLE
Vertically centering opened file status icon and label

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -400,7 +400,7 @@ a, img {
         
         display: block;
         height: 16px;
-        line-height: 16px;
+        line-height: 15px;
         margin-left: 18px;
         padding: 3px (@sidebar-triangle-size * 2) 3px 0;
         
@@ -511,7 +511,7 @@ a, img {
 
 
 .file-status-icon {
-    margin: 3px 0 0 8px;
+    margin: 2px 0 0 8px;
     .bracket-sprite;
     display: inline-block;
     position: absolute;


### PR DESCRIPTION
There's an optical illusion that makes the opened file status icon and label look like they're not vertically centered. I've nudged them up 1px even though the original value is correct. Let me know what you think.

It's more noticeable when the filename is in all caps.
