### PR TITLE
Rename classic "Go to Definition" to be more distinct from "Jump to Definition"

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -423,7 +423,7 @@ define(function (require, exports, module) {
         // Add the menu item
         var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
         if (menu) {
-            menu.addMenuItem(JUMPTO_DEFINITION, KeyboardPrefs.jumptoDefinition, Menus.BEFORE, Commands.NAVIGATE_GOTO_DEFINITION);
+            menu.addMenuItem(JUMPTO_DEFINITION, KeyboardPrefs.jumptoDefinition, Menus.AFTER, Commands.NAVIGATE_GOTO_DEFINITION);
         }
         
         ExtensionUtils.loadStyleSheet(module, "styles/brackets-js-hints.css");

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -232,7 +232,7 @@ define({
     "NAVIGATE_MENU"                       : "Navigate",
     "CMD_QUICK_OPEN"                      : "Quick Open",
     "CMD_GOTO_LINE"                       : "Go to Line",
-    "CMD_GOTO_DEFINITION"                 : "Go to Definition",
+    "CMD_GOTO_DEFINITION"                 : "Quick Find Definition",
     "CMD_JUMPTO_DEFINITION"               : "Jump to Definition",
     "CMD_JSLINT_FIRST_ERROR"              : "Go to First JSLint Error",
     "CMD_TOGGLE_QUICK_EDIT"               : "Quick Edit",


### PR DESCRIPTION
Rename classic "Go to Definition" to be more distinct from the new Tern-driven "Jump to Definition". Reorder menu so the ones that use QuickOpen search bar are all contiguous, while keeping the two "Definition" ones also contiguous.

In consultation with NJ & Adam.
