### PR TITLE
Output JUnit XML from automated test runs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1683,6 +1683,25 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
 OTHER DEALINGS IN THE SOFTWARE.
 
+Larry Myers
+Copyright (c) 2010 Larry Myers
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 Niels Provos 
 Copyright (c) 2000-2007 Niels Provos <provos@citi.umich.edu>
 All rights reserved.

--- a/NOTICE
+++ b/NOTICE
@@ -1683,25 +1683,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
 OTHER DEALINGS IN THE SOFTWARE.
 
-Larry Myers
-Copyright (c) 2010 Larry Myers
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
 Niels Provos 
 Copyright (c) 2000-2007 Niels Provos <provos@citi.umich.edu>
 All rights reserved.

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
             cmd             = common.resolve(grunt.option("shell") || grunt.config("shell." + platform)),
             spec            = grunt.option("spec") || "all",
             suite           = grunt.option("suite") || "all",
-            results         = grunt.option("results") || process.cwd() + "/results.json",
+            results         = grunt.option("results") || process.cwd() + "/results.xml",
             resultsPath     = common.resolve(results),
             specRunnerPath  = common.resolve("test/SpecRunner.html"),
             args            = " --startup-path=\"" + specRunnerPath + "?suite=" + encodeURIComponent(suite) + "&spec=" + encodeURIComponent(spec) + "&resultsPath=" + encodeURIComponent(resultsPath) + "\"";

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -56,7 +56,6 @@ define(function (require, exports, module) {
     // Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
     
-    
     // TODO (#2155): These are used by extensions via brackets.getModule(), so tests that run those
     // extensions need these to be required up front. We need a better solution for this eventually.
     require("utils/ExtensionUtils");
@@ -64,12 +63,18 @@ define(function (require, exports, module) {
     // Load both top-level suites. Filtering is applied at the top-level as a filter to BootstrapReporter.
     require("test/UnitTestSuite");
     require("test/PerformanceTestSuite");
+
+    // Load JUnitXMLReporter
+    require("test/thirdparty/jasmine-reporters/jasmine.junit_reporter");
     
     var selectedSuites,
-        params = new UrlParams(),
+        params                  = new UrlParams(),
         reporter,
         _nodeConnectionDeferred = new $.Deferred(),
-        reporterView;
+        reporterView,
+        _writeResults           = new $.Deferred(),
+        _writeResultsPromise    = _writeResults.promise(),
+        resultsPath;
     
     /**
      * @const
@@ -79,7 +84,9 @@ define(function (require, exports, module) {
      */
     var NODE_CONNECTION_TIMEOUT = 30000; // 30 seconds - TODO: share with StaticServer?
 
+    // parse URL parameters
     params.parse();
+    resultsPath = params.get("resultsPath");
     
     function _loadExtensionTests() {
         // augment jasmine to identify extension unit tests
@@ -139,33 +146,69 @@ define(function (require, exports, module) {
     /**
      * Listener for UnitTestReporter "runnerEnd" event. Attached only if
      * "resultsPath" URL parameter exists. Does not overwrite existing file.
-     * Writes UnitTestReporter spec results as formatted JSON.
+     * 
      * @param {!$.Event} event
      * @param {!UnitTestReporter} reporter
      */
     function _runnerEndHandler(event, reporter) {
-        var resultsPath = params.get("resultsPath"),
-            json = reporter.toJSON(),
-            deferred = new $.Deferred();
-        
+        if (resultsPath.substr(-5) === ".json") {
+            writeResults(resultsPath, reporter.toJSON());
+        }
+
+        _writeResults.always(function () { window.close(); });
+    }
+
+    function writeResults(path, text) {
         // check if the file already exists
-        brackets.fs.stat(resultsPath, function (err, stat) {
+        brackets.fs.stat(path, function (err, stat) {
             if (err === brackets.fs.ERR_NOT_FOUND) {
-                // file not found, write the new file with JSON content
-                brackets.fs.writeFile(resultsPath, json, NativeFileSystem._FSEncodings.UTF8, function (err) {
+                // file not found, write the new file with xml content
+                brackets.fs.writeFile(path, text, NativeFileSystem._FSEncodings.UTF8, function (err) {
                     if (err) {
-                        deferred.reject();
+                        _writeResults.reject();
                     } else {
-                        deferred.resolve();
+                        _writeResults.resolve();
                     }
                 });
             } else {
                 // file exists, do not overwrite
-                deferred.reject();
+                _writeResults.reject();
             }
         });
+    }
+
+    /**
+     * Patch JUnitXMLReporter to use brackets.fs and to consolidate all results
+     * into a single file.
+     */
+    function _patchJUnitReporter() {
+        jasmine.JUnitXmlReporter.prototype.reportRunnerResults = function(runner) {
+            var suites = runner.suites(),
+                output = '<?xml version="1.0" encoding="UTF-8" ?>';
+
+            output += "\n<testsuites>";
+
+            for (var i = 0; i < suites.length; i++) {
+                var suite = suites[i];
+                // if we are consolidating, only write out top-level suites
+                if (suite.parentSuite) {
+                    continue;
+                }
+                else  {
+                    output += this.getNestedOutput(suite);
+                }
+            }
+
+            output += "\n</testsuites>";
+            writeResults(resultsPath, output);
+
+            // When all done, make it known on JUnitXmlReporter
+            jasmine.JUnitXmlReporter.finished_at = (new Date()).getTime();
+        },
         
-        deferred.always(function () { window.close(); });
+        jasmine.JUnitXmlReporter.prototype.writeFile = function (path, filename, text) {
+            // do nothing
+        }
     }
     
     function init() {
@@ -263,9 +306,17 @@ define(function (require, exports, module) {
             // spec and performance data.
             reporter = new UnitTestReporter(jasmineEnv, topLevelFilter, params.get("spec"));
             
-            // Optionally emit JSON for automated runs
-            if (params.get("resultsPath")) {
+            // Optionally emit JUnit XML file for automated runs
+            if (resultsPath) {
+                if (resultsPath.substr(-4) === ".xml") {
+                    _patchJUnitReporter();
+                    jasmineEnv.addReporter(new jasmine.JUnitXmlReporter(null, true, false));
+                }
+
+                // Close the window
                 $(reporter).on("runnerEnd", _runnerEndHandler);
+            } else {
+                _writeResults.resolve();
             }
             
             jasmineEnv.addReporter(reporter);

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -170,7 +170,7 @@ define(function (require, exports, module) {
      * @param {!UnitTestReporter} reporter
      */
     function _runnerEndHandler(event, reporter) {
-        if (resultsPath.substr(-5) === ".json") {
+        if (resultsPath && resultsPath.substr(-5) === ".json") {
             writeResults(resultsPath, reporter.toJSON());
         }
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -204,11 +204,11 @@ define(function (require, exports, module) {
 
             // When all done, make it known on JUnitXmlReporter
             jasmine.JUnitXmlReporter.finished_at = (new Date()).getTime();
-        },
+        };
         
         jasmine.JUnitXmlReporter.prototype.writeFile = function (path, filename, text) {
             // do nothing
-        }
+        };
     }
     
     function init() {

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -142,21 +142,6 @@ define(function (require, exports, module) {
         
         jasmine.getEnv().execute();
     }
-    
-    /**
-     * Listener for UnitTestReporter "runnerEnd" event. Attached only if
-     * "resultsPath" URL parameter exists. Does not overwrite existing file.
-     * 
-     * @param {!$.Event} event
-     * @param {!UnitTestReporter} reporter
-     */
-    function _runnerEndHandler(event, reporter) {
-        if (resultsPath.substr(-5) === ".json") {
-            writeResults(resultsPath, reporter.toJSON());
-        }
-
-        _writeResults.always(function () { window.close(); });
-    }
 
     function writeResults(path, text) {
         // check if the file already exists
@@ -176,25 +161,37 @@ define(function (require, exports, module) {
             }
         });
     }
+    
+    /**
+     * Listener for UnitTestReporter "runnerEnd" event. Attached only if
+     * "resultsPath" URL parameter exists. Does not overwrite existing file.
+     * 
+     * @param {!$.Event} event
+     * @param {!UnitTestReporter} reporter
+     */
+    function _runnerEndHandler(event, reporter) {
+        if (resultsPath.substr(-5) === ".json") {
+            writeResults(resultsPath, reporter.toJSON());
+        }
+
+        _writeResults.always(function () { window.close(); });
+    }
 
     /**
      * Patch JUnitXMLReporter to use brackets.fs and to consolidate all results
      * into a single file.
      */
     function _patchJUnitReporter() {
-        jasmine.JUnitXmlReporter.prototype.reportRunnerResults = function(runner) {
+        jasmine.JUnitXmlReporter.prototype.reportRunnerResults = function (runner) {
             var suites = runner.suites(),
-                output = '<?xml version="1.0" encoding="UTF-8" ?>';
+                output = '<?xml version="1.0" encoding="UTF-8" ?>',
+                i;
 
             output += "\n<testsuites>";
 
-            for (var i = 0; i < suites.length; i++) {
+            for (i = 0; i < suites.length; i++) {
                 var suite = suites[i];
-                // if we are consolidating, only write out top-level suites
-                if (suite.parentSuite) {
-                    continue;
-                }
-                else  {
+                if (!suite.parentSuite) {
                     output += this.getNestedOutput(suite);
                 }
             }

--- a/test/thirdparty/jasmine-reporters/LICENSE
+++ b/test/thirdparty/jasmine-reporters/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010 Larry Myers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/test/thirdparty/jasmine-reporters/README.markdown
+++ b/test/thirdparty/jasmine-reporters/README.markdown
@@ -1,0 +1,55 @@
+# Jasmine Reporters
+
+Jasmine Reporters is a collection of javascript jasmine.Reporter classes that can be used with
+the [JasmineBDD testing framework](http://pivotal.github.com/jasmine/).
+
+Included reporters:
+
+* ConsoleReporter - Report test results to the browser console.
+* JUnitXmlReporter - Report test results to a file (using Rhino or PyPhantomJS) in JUnit XML Report format.
+* TapReporter - Test Anything Protocol, report tests results to console.
+* TeamcityReporter - Basic reporter that outputs spec results to for the Teamcity build system.
+
+
+## Usage
+
+Examples are included in the test directory that show how to use the reporters,
+as well a basic runner scripts for Rhino + envjs, and a basic runner for 
+[PhantomJS](https://github.com/ariya/phantomjs) (using PyPhantomJS and the
+saveToFile plugin). Either of these methods could be used in a Continuous
+Integration project for running headless tests and generating JUnit XML output.
+
+### Rhino + EnvJS
+
+Everything needed to run the tests in Rhino + EnvJS is included in this
+repository inside the `ext` directory, specifically Rhino 1.7r2 and envjs 1.2
+for Rhino.
+
+### PhantomJS, PyPhantomJS
+
+PhantomJS is included as a submodule inside the `ext` directory. The included
+example runner makes use of PyPhantomJS to execute the headless tests and
+save XML output to the filesystem.
+
+While PhantomJS and PyPhantomJS both run on MacOS / Linux / Windows, there are
+specific dependencies for each platform. Specifics on installing these are not
+included here, but is left as an exercise for the reader. The [PhantomJS](https://github.com/ariya/phantomjs)
+project contains links to various documentation, including installation notes.
+
+Here is how I got it working in MacOSX 10.6 (YMMV):
+
+* ensure you are using Python 2.6+
+* install Xcode (this gives you make, et al)
+* install qt (this gives you qmake, et al)
+  * this may be easiest via [homebrew](https://github.com/mxcl/homebrew)
+  * `brew install qt`
+* install the python sip module
+  * `pip install sip # this will fail to fully install sip, keep going`
+  * `cd build/sip`
+  * `python configure.py`
+  * `make && sudo make install`
+* install the python pyqt module
+  * `pip install pyqt # this will fail to fully install pyqt, keep going`
+  * `cd build/pyqt`
+  * `python configure.py`
+  * `make && sudo make install`

--- a/test/thirdparty/jasmine-reporters/jasmine.junit_reporter.js
+++ b/test/thirdparty/jasmine-reporters/jasmine.junit_reporter.js
@@ -1,0 +1,223 @@
+(function() {
+
+    if (typeof jasmine == 'undefined') {
+        throw new Error("jasmine library does not exist in global namespace!");
+    }
+
+    function elapsed(startTime, endTime) {
+        return (endTime - startTime)/1000;
+    }
+
+    function ISODateString(d) {
+        function pad(n) { return n < 10 ? '0'+n : n; }
+
+        return d.getFullYear() + '-' +
+            pad(d.getMonth()+1) + '-' +
+            pad(d.getDate()) + 'T' +
+            pad(d.getHours()) + ':' +
+            pad(d.getMinutes()) + ':' +
+            pad(d.getSeconds());
+    }
+
+    function trim(str) {
+        return str.replace(/^\s+/, "" ).replace(/\s+$/, "" );
+    }
+
+    function escapeInvalidXmlChars(str) {
+        return str.replace(/\&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/\>/g, "&gt;")
+            .replace(/\"/g, "&quot;")
+            .replace(/\'/g, "&apos;");
+    }
+
+    /**
+     * Generates JUnit XML for the given spec run.
+     * Allows the test results to be used in java based CI
+     * systems like CruiseControl and Hudson.
+     *
+     * @param {string} savePath where to save the files
+     * @param {boolean} consolidate whether to save nested describes within the
+     *                  same file as their parent; default: true
+     * @param {boolean} useDotNotation whether to separate suite names with
+     *                  dots rather than spaces (ie "Class.init" not
+     *                  "Class init"); default: true
+     */
+    var JUnitXmlReporter = function(savePath, consolidate, useDotNotation) {
+        this.savePath = savePath || '';
+        this.consolidate = consolidate === jasmine.undefined ? true : consolidate;
+        this.useDotNotation = useDotNotation === jasmine.undefined ? true : useDotNotation;
+    };
+    JUnitXmlReporter.finished_at = null; // will be updated after all files have been written
+
+    JUnitXmlReporter.prototype = {
+        reportSpecStarting: function(spec) {
+            spec.startTime = new Date();
+
+            if (!spec.suite.startTime) {
+                spec.suite.startTime = spec.startTime;
+            }
+        },
+
+        reportSpecResults: function(spec) {
+            var results = spec.results();
+            spec.didFail = !results.passed();
+            spec.duration = elapsed(spec.startTime, new Date());
+            spec.output = '<testcase classname="' + this.getFullName(spec.suite) +
+                '" name="' + escapeInvalidXmlChars(spec.description) + '" time="' + spec.duration + '">';
+
+            var failure = "";
+            var failures = 0;
+            var resultItems = results.getItems();
+            for (var i = 0; i < resultItems.length; i++) {
+                var result = resultItems[i];
+
+                if (result.type == 'expect' && result.passed && !result.passed()) {
+                    failures += 1;
+                    failure += '<failure type="' + result.type + '" message="' + trim(escapeInvalidXmlChars(result.message)) + '">';
+                    failure += escapeInvalidXmlChars(result.trace.stack || result.message);
+                    failure += "</failure>";
+                }
+            }
+            if (failure) {
+                spec.output += failure;
+            }
+            spec.output += "</testcase>";
+        },
+
+        reportSuiteResults: function(suite) {
+            var results = suite.results();
+            var specs = suite.specs();
+            var specOutput = "";
+            // for JUnit results, let's only include directly failed tests (not nested suites')
+            var failedCount = 0;
+
+            suite.status = results.passed() ? 'Passed.' : 'Failed.';
+            if (results.totalCount === 0) { // todo: change this to check results.skipped
+                suite.status = 'Skipped.';
+            }
+
+            // if a suite has no (active?) specs, reportSpecStarting is never called
+            // and thus the suite has no startTime -- account for that here
+            suite.startTime = suite.startTime || new Date();
+            suite.duration = elapsed(suite.startTime, new Date());
+
+            for (var i = 0; i < specs.length; i++) {
+                failedCount += specs[i].didFail ? 1 : 0;
+                specOutput += "\n  " + specs[i].output;
+            }
+            suite.output = '\n<testsuite name="' + this.getFullName(suite) +
+                '" errors="0" tests="' + specs.length + '" failures="' + failedCount +
+                '" time="' + suite.duration + '" timestamp="' + ISODateString(suite.startTime) + '">';
+            suite.output += specOutput;
+            suite.output += "\n</testsuite>";
+        },
+
+        reportRunnerResults: function(runner) {
+            var suites = runner.suites();
+            for (var i = 0; i < suites.length; i++) {
+                var suite = suites[i];
+                var fileName = 'TEST-' + this.getFullName(suite, true) + '.xml';
+                var output = '<?xml version="1.0" encoding="UTF-8" ?>';
+                // if we are consolidating, only write out top-level suites
+                if (this.consolidate && suite.parentSuite) {
+                    continue;
+                }
+                else if (this.consolidate) {
+                    output += "\n<testsuites>";
+                    output += this.getNestedOutput(suite);
+                    output += "\n</testsuites>";
+                    this.writeFile(this.savePath, fileName, output);
+                }
+                else {
+                    output += suite.output;
+                    this.writeFile(this.savePath, fileName, output);
+                }
+            }
+            // When all done, make it known on JUnitXmlReporter
+            JUnitXmlReporter.finished_at = (new Date()).getTime();
+        },
+
+        getNestedOutput: function(suite) {
+            var output = suite.output;
+            for (var i = 0; i < suite.suites().length; i++) {
+                output += this.getNestedOutput(suite.suites()[i]);
+            }
+            return output;
+        },
+
+        writeFile: function(path, filename, text) {
+            function getQualifiedFilename(separator) {
+                if (path && path.substr(-1) !== separator && filename.substr(0) !== separator) {
+                    path += separator;
+                }
+                return path + filename;
+            }
+
+            // Rhino
+            try {
+                // turn filename into a qualified path
+                if (path) {
+                    filename = getQualifiedFilename(java.lang.System.getProperty("file.separator"));
+                    // create parent dir and ancestors if necessary
+                    var file = java.io.File(filename);
+                    var parentDir = file.getParentFile();
+                    if (!parentDir.exists()) {
+                        parentDir.mkdirs();
+                    }
+                }
+                // finally write the file
+                var out = new java.io.BufferedWriter(new java.io.FileWriter(filename));
+                out.write(text);
+                out.close();
+                return;
+            } catch (e) {}
+            // PhantomJS, via a method injected by phantomjs-testrunner.js
+            try {
+                // turn filename into a qualified path
+                filename = getQualifiedFilename(window.fs_path_separator);
+                __phantom_writeFile(filename, text);
+                return;
+            } catch (f) {}
+            // Node.js
+            try {
+                var fs = require("fs");
+                var nodejs_path = require("path");
+                var fd = fs.openSync(nodejs_path.join(path, filename), "w");
+                fs.writeSync(fd, text, 0);
+                fs.closeSync(fd);
+                return;
+            } catch (g) {}
+        },
+
+        getFullName: function(suite, isFilename) {
+            var fullName;
+            if (this.useDotNotation) {
+                fullName = suite.description;
+                for (var parentSuite = suite.parentSuite; parentSuite; parentSuite = parentSuite.parentSuite) {
+                    fullName = parentSuite.description + '.' + fullName;
+                }
+            }
+            else {
+                fullName = suite.getFullName();
+            }
+
+            // Either remove or escape invalid XML characters
+            if (isFilename) {
+                return fullName.replace(/[^\w]/g, "");
+            }
+            return escapeInvalidXmlChars(fullName);
+        },
+
+        log: function(str) {
+            var console = jasmine.getGlobal().console;
+
+            if (console && console.log) {
+                console.log(str);
+            }
+        }
+    };
+
+    // export public
+    jasmine.JUnitXmlReporter = JUnitXmlReporter;
+})();


### PR DESCRIPTION
Add a new default option to write JUnit XML formatted results. JSON or XML selection is based out output file extension.

This change helps support a temporary fix for #3343. My plan for Jenkins is to create separate jobs for unit, extension and integration suites and store those results in Jenkins as XML.
