### PR TITLE
Close hints when the cursor moves to a new hinting context

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -505,7 +505,7 @@ define(function (require, exports, module) {
     /**
      *  Test if a hint popup is open.
      *
-     * @returns {Boolean} - true if the hints are open, false otherwise.
+     * @returns {boolean} - true if the hints are open, false otherwise.
      */
     function isOpen() {
         return (hintList && hintList.isOpen());

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -503,6 +503,15 @@ define(function (require, exports, module) {
     }
 
     /**
+     *  Test if a hint popup is open.
+     *
+     * @returns {Boolean} - true if the hints are open, false otherwise.
+     */
+    function isOpen() {
+        return (hintList && hintList.isOpen());
+    }
+
+    /**
      * Expose CodeHintList for unit testing
      */
     function _getCodeHintList() {
@@ -511,6 +520,7 @@ define(function (require, exports, module) {
     exports._getCodeHintList        = _getCodeHintList;
     
     // Define public API
+    exports.isOpen                  = isOpen;
     exports.handleKeyEvent          = handleKeyEvent;
     exports.handleChange            = handleChange;
     exports.registerHintProvider    = registerHintProvider;

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -107,7 +107,24 @@ define(function (require, exports, module) {
             return cm.getTokenAt(this.getCursor());
         }
     };
-    
+
+    /**
+     * Get the token after the one at the given cursor position
+     *
+     * @param {{line: number, ch: number}} cursor - cursor position before
+     *      which a token should be retrieved
+     * @return {Object} - the CodeMirror token after the one at the given
+     *      cursor position
+     */
+    Session.prototype.getNextTokenOnLine = function (cursor) {
+        cursor = this.getNextCursorOnLine(cursor);
+        if (cursor) {
+            return this.getToken(cursor);
+        }
+
+        return null;
+    };
+
     /**
      * Get the next cursor position on the line, or null if there isn't one.
      * 
@@ -115,9 +132,8 @@ define(function (require, exports, module) {
      *      immediately following the current cursor position, or null if
      *      none exists.
      */
-    Session.prototype.getNextCursorOnLine = function () {
-        var cursor  = this.getCursor(),
-            doc     = this.editor.document,
+    Session.prototype.getNextCursorOnLine = function (cursor) {
+        var doc     = this.editor.document,
             line    = doc.getLine(cursor.line);
 
         if (cursor.ch < line.length) {

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
     var JUMPTO_DEFINITION = "navigate.jumptoDefinition";
 
     var session      = null,  // object that encapsulates the current session state
-        cachedCursor = null, // last cursor of the current hinting session
+        cachedCursor = null,  // last cursor of the current hinting session
         cachedHints  = null,  // sorted hints for the current hinting session
         cachedType   = null,  // describes the lookup type and the object context
         cachedToken  = null,  // the token used in the current hinting session
@@ -196,7 +196,7 @@ define(function (require, exports, module) {
      *  Have conditions have changed enough to justify closing the hints popup?
      *
      * @param {Session} session - the active hinting session
-     * @return {Boolean} - true if the hints popup should be closed.
+     * @return {boolean} - true if the hints popup should be closed.
      */
     JSHints.prototype.shouldCloseHints = function (session) {
 
@@ -217,12 +217,6 @@ define(function (require, exports, module) {
         if (lastToken && lastToken.className === null) {
             lastToken = session.getNextTokenOnLine(cachedCursor);
         }
-
-//        if (token)
-//            console.log("token: " + token.className + " " + token.string);
-//
-//        if (lastToken)
-//            console.log("last : " + lastToken.className + " " + lastToken.string);
 
         // Both of the tokens should never be null (happens when token is off
         // the end of the line), so one is null then close the hints.
@@ -352,8 +346,7 @@ define(function (require, exports, module) {
             delimiter;
 
         if (token && token.string === ".") {
-            var nextCursor  = session.getNextCursorOnLine(cursor),
-                nextToken   = nextCursor ? session.getToken(nextCursor) : null;
+            var nextToken  = session.getNextTokenOnLine(cursor);
 
             if (nextToken && // don't replace delimiters, etc.
                     HintUtils.maybeIdentifier(nextToken.string) &&

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -199,6 +199,7 @@ define(function (require, exports, module) {
      * @return {Boolean} - true if the hints popup should be closed.
      */
     JSHints.prototype.shouldCloseHints = function (session) {
+
         // close if the token className has changed then close the hints.
         var cursor = session.getCursor(),
             token = session.getToken(cursor),
@@ -226,12 +227,18 @@ define(function (require, exports, module) {
         // Both of the tokens should never be null (happens when token is off
         // the end of the line), so one is null then close the hints.
         if (!lastToken || !token ||
-                token.className !== lastToken.className ||
-                token.string !== lastToken.string) {
+                token.className !== lastToken.className) {
             return true;
         }
 
-        return false;
+        // Test if one token string is a prefix of the other.
+        // If one is a prefix of the other then consider it the
+        // same token and don't close the hints.
+        if (token.string.length >= lastToken.string.length) {
+            return token.string.indexOf(lastToken.string) !== 0;
+        } else {
+            return lastToken.string.indexOf(token.string) !== 0;
+        }
     };
 
     /**

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -149,13 +149,14 @@ define(function (require, exports, module) {
             runs(function () { callback(hintList); });
         }
         /*
-         * Test if hints are close or not closed at a given position.
+         * Test if hints should be closed or not closed at a given position.
          *
          * @param {Object} provider - a CodeHintProvider object
          * @param {Object + jQuery.Deferred} hintObj - a hint response object,
          *      possibly deferred
-         * @param {line, ch} - new position to move to after hints are received.
-         * @param {Boolean} expectedValue - true if hints should close,
+         * @param {line: number, ch: number} newPos - new position to move to
+         * after hints are received.
+         * @param {boolean} expectedValue - true if hints should close,
          * false otherwise.
          */
         function expectCloseHints(provider, hintObj, newPos, expectedValue) {

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -148,6 +148,22 @@ define(function (require, exports, module) {
 
             runs(function () { callback(hintList); });
         }
+        /*
+         * Test if hints are close or not closed at a given position.
+         *
+         * @param {Object} provider - a CodeHintProvider object
+         * @param {Object + jQuery.Deferred} hintObj - a hint response object,
+         *      possibly deferred
+         * @param {line, ch} - new position to move to after hints are received.
+         * @param {Boolean} expectedValue - true if hints should close,
+         * false otherwise.
+         */
+        function expectCloseHints(provider, hintObj, newPos, expectedValue) {
+            _waitForHints(hintObj, function (hintList) {
+                testEditor.setCursorPos(newPos);
+                expect(provider.shouldCloseHints(JSCodeHints.getSession())).toBe(expectedValue);
+            });
+        }
 
         /*
          * Expect a given list of hints to be absent from a given hint
@@ -443,7 +459,56 @@ define(function (require, exports, module) {
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsAbsent(hintObj, ["case", "function", "var"]);
             });
-            
+
+            it("should close hints when move over '.' ", function () {
+                testEditor.setCursorPos({ line: 17, ch: 11 });
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 10 }, true);
+            });
+
+            it("should close hints only when move off the end of a property ", function () {
+                testEditor.setCursorPos({ line: 17, ch: 11 });
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 12 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 13 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 14 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 15 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 16 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 17 }, true);
+            });
+
+            it("should close hints only when move off the beginning of an identifier ", function () {
+                testEditor.setCursorPos({ line: 17, ch: 10 });
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 9 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 8 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 17, ch: 7 }, true);
+            });
+
+            it("should close hints only when move off the beginning of a keyword ", function () {
+                testEditor.setCursorPos({ line: 24, ch: 7 });
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                hintsPresent(hintObj, ["var"]);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 24, ch: 6 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 24, ch: 5 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 24, ch: 4 }, false);
+                expectCloseHints(JSCodeHints.jsHintProvider, hintObj,
+                    { line: 24, ch: 3 }, true);
+            });
+
             it("should NOT list implicit hints on left-brace", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 expectNoHints(JSCodeHints.jsHintProvider, "{");


### PR DESCRIPTION
This should fix many issues when using the left and right arrow keys with the code hints displayed.

The code hints will be closed when the cursor moves to a new context. The hints will remaining up if you are still on the same identifier or property.
