### PR TITLE
Re-instrument HTML after document changed

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -69,7 +69,6 @@ define(function LiveDevelopment(require, exports, module) {
         DocumentManager      = require("document/DocumentManager"),
         EditorManager        = require("editor/EditorManager"),
         FileUtils            = require("file/FileUtils"),
-        HTMLInstrumentation  = require("language/HTMLInstrumentation"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         NativeFileError      = require("file/NativeFileError"),
         NativeApp            = require("utils/NativeApp"),

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -73,6 +73,21 @@ define(function (require, exports, module) {
      * @return {Array} Array of tag info, or null if no tags were found
      */
     function scanDocument(doc) {
+        if (!_cachedValues.hasOwnProperty(doc.file.fullPath)) {
+            $(doc).on("change.htmlInstrumentation", function (document) {
+                // Clear cached values on doc change
+                _cachedValues[doc.file.fullPath] = null;
+            });
+            
+            $(doc).one("deleted", function (document) {
+                delete _cachedValues[doc.file.fullPath];
+                document.off(".htmlInstrumentation");
+            });
+            
+            // Assign to cache, but don't set a value yet
+            _cachedValues[doc.file.fullPath] = null;
+        }
+        
         if (_cachedValues[doc.file.fullPath]) {
             var cachedValue = _cachedValues[doc.file.fullPath];
             

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -92,8 +92,6 @@ define(function (require, exports, module) {
                 _cachedValues[doc.file.fullPath] = null;
             });
             
-            $(doc).one("deleted.htmlInstrumentation", _removeDocFromCache);
-            
             // Assign to cache, but don't set a value yet
             _cachedValues[doc.file.fullPath] = null;
         }

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -42,7 +42,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var DOMHelpers = require("LiveDevelopment/Agents/DOMHelpers");
+    var DocumentManager = require("document/DocumentManager"),
+        DOMHelpers      = require("LiveDevelopment/Agents/DOMHelpers");
     
     // Hash of scanned documents. Key is the full path of the doc. Value is an object
     // with two properties: timestamp and tags. Timestamp is the document timestamp,
@@ -67,6 +68,16 @@ define(function (require, exports, module) {
         return false;
     }
     
+    /** 
+     * Remove a document from the cache
+     */
+    function _removeDocFromCache(evt, document) {
+        if (_cachedValues.hasOwnProperty(document.file.fullPath)) {
+            delete _cachedValues[document.file.fullPath];
+            $(document).off(".htmlInstrumentation");
+        }
+    }
+    
     /**
      * Scan a document to prepare for HTMLInstrumentation
      * @param {Document} doc The doc to scan. 
@@ -74,15 +85,14 @@ define(function (require, exports, module) {
      */
     function scanDocument(doc) {
         if (!_cachedValues.hasOwnProperty(doc.file.fullPath)) {
-            $(doc).on("change.htmlInstrumentation", function (document) {
-                // Clear cached values on doc change
+            $(doc).on("change.htmlInstrumentation", function () {
+                // Clear cached values on doc change, but keep the entry
+                // in the _cachedValues hash. Keeping the entry means
+                // the event handlers (like this one) won't be added again.
                 _cachedValues[doc.file.fullPath] = null;
             });
             
-            $(doc).one("deleted", function (document) {
-                delete _cachedValues[doc.file.fullPath];
-                document.off(".htmlInstrumentation");
-            });
+            $(doc).one("deleted.htmlInstrumentation", _removeDocFromCache);
             
             // Assign to cache, but don't set a value yet
             _cachedValues[doc.file.fullPath] = null;
@@ -305,6 +315,8 @@ define(function (require, exports, module) {
         
         return -1;
     }
+    
+    $(DocumentManager).on("beforeDocumentDelete", _removeDocFromCache);
     
     exports.scanDocument = scanDocument;
     exports.generateInstrumentedHTML = generateInstrumentedHTML;

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -504,7 +504,6 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    spyOn(editor.document, "getText").andCallThrough();
                     instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
                 });

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -495,5 +495,41 @@ define(function (require, exports, module) {
                 });
             });
         });
+        
+        describe("HTML Instrumentation in dirty files", function () {
+                
+            beforeEach(function () {
+                init(this, WellFormedFileEntry);
+                runs(function () {
+                    editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
+                    expect(editor).toBeTruthy();
+
+                    spyOn(editor.document, "getText").andCallThrough();
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    elementCount = getIdToTagMap(instrumentedHTML, elementIds);
+                });
+            });
+    
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
+                instrumentedHTML = "";
+                elementCount = 0;
+                elementIds = {};
+            });
+            
+            it("should re-instrument after document is dirtied", function () {
+                runs(function () {
+                    var pos = {line: 15, ch: 0};
+                    editor.document.replaceRange("<div>New Content</div>", pos);
+                    
+                    var newInstrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document),
+                        newElementIds = {},
+                        newElementCount = getIdToTagMap(newInstrumentedHTML, newElementIds);
+                    
+                    expect(newElementCount).toBe(elementCount + 1);
+                });
+            });
+        });
     });
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
      */
     function createMockActiveDocument(options) {
         var language    = options.language || LanguageManager.getLanguage("javascript"),
-            filename    = options.filename || "_unitTestDummyFile_." + language._fileExtensions[0],
+            filename    = options.filename || "_unitTestDummyFile_" + Date.now() + "." + language._fileExtensions[0],
             content     = options.content || "";
         
         // Use unique filename to avoid collissions in open documents list


### PR DESCRIPTION
Fix for #3652

Adds a document `change` listener to scanned documents. The cached values are cleared when the document changes.

Adds unit test to verify functionality.
