### PR TITLE
Update the hint list after the HOME or END keys are pressed.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -467,7 +467,9 @@ define(function (require, exports, module) {
                 _endSession();
             } else if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
                        event.keyCode === KeyEvent.DOM_VK_RIGHT ||
-                       event.keyCode === KeyEvent.DOM_VK_BACK_SPACE) {
+                       event.keyCode === KeyEvent.DOM_VK_BACK_SPACE ||
+                       event.keyCode === KeyEvent.DOM_VK_HOME ||
+                       event.keyCode === KeyEvent.DOM_VK_END) {
                 // Update the list after a simple navigation.
                 // We do this in "keyup" because we want the cursor position to be updated before
                 // we redraw the list.


### PR DESCRIPTION
This allows the js code hinter to dismiss the hints if the context has changed.
