### PR TITLE
Replace .isResolved & .isRejected with .state

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -340,7 +340,7 @@ define(function (require, exports, module) {
         if (sessionEditor) {
             if (sessionEditor === editor &&
                     (hintList.isOpen() ||
-                     (deferredHints && !deferredHints.isResolved() && !deferredHints.isRejected()))) {
+                     (deferredHints && deferredHints.state() === "pending"))) {
                 return true;
             } else {
                 // the editor has changed

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -263,7 +263,7 @@ define(function (require, exports, module) {
      */
     function cancelDownload(downloadId) {
         // TODO: if we're still waiting on the NodeConnection, how do we cancel?
-        console.assert(_nodeConnectionDeferred.isResolved());
+        console.assert(_nodeConnectionDeferred.state() === "resolved");
         _nodeConnectionDeferred.done(function (connection) {
             connection.domains.extensionManager.abortDownload(downloadId);
         });

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -287,7 +287,7 @@ define(function (require, exports, module) {
                     self.cachedHints.queryDir   = queryDir;
                     self.cachedHints.docDir     = docDir;
                     
-                    if (!self.cachedHints.deferred.isRejected()) {
+                    if (self.cachedHints.deferred.state() !== "rejected") {
                         var currentDeferred = self.cachedHints.deferred;
                         // Since we've cached the results, the next call to _getUrlList should be synchronous.
                         // If it isn't, we've got a problem and should reject both the current deferred
@@ -296,13 +296,11 @@ define(function (require, exports, module) {
                         if (syncResults instanceof Array) {
                             currentDeferred.resolveWith(self, [syncResults]);
                         } else {
-                            if (currentDeferred && !currentDeferred.isResolved() && !currentDeferred.isRejected()) {
+                            if (currentDeferred && currentDeferred.state() === "pending") {
                                 currentDeferred.reject();
                             }
                             
-                            if (self.cachedHints.deferred &&
-                                    !self.cachedHints.deferred.isResolved() &&
-                                    !self.cachedHints.deferred.isRejected()) {
+                            if (self.cachedHints.deferred && self.cachedHints.deferred.state() === "pending") {
                                 self.cachedHints.deferred.reject();
                                 self.cachedHints.deferred = null;
                             }

--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
         setDeferredTimeout(deferred, CONNECTION_TIMEOUT);
         
         brackets.app.getNodeState(function (err, nodePort) {
-            if (!err && nodePort && !deferred.isRejected()) {
+            if (!err && nodePort && deferred.state() !== "rejected") {
                 port = nodePort;
                 ws = new WebSocket("ws://localhost:" + port);
                 

--- a/test/perf/OpenFile-perf-files/brackets-concat.js
+++ b/test/perf/OpenFile-perf-files/brackets-concat.js
@@ -20365,7 +20365,7 @@ define('LiveDevelopment/Inspector/Inspector',['require','exports','module'],func
         _connectDeferred = deferred;
         var promise = getAvailableSockets();
         promise.done(function onGetAvailableSockets(response) {
-            if (deferred.isRejected()) {
+            if (deferred.state() === "rejected") {
                 return;
             }
             var i, page;
@@ -58619,7 +58619,7 @@ define('LiveDevelopment/Inspector/Inspector',['require','exports','module'],func
         _connectDeferred = deferred;
         var promise = getAvailableSockets();
         promise.done(function onGetAvailableSockets(response) {
-            if (deferred.isRejected()) {
+            if (deferred.state() === "rejected") {
                 return;
             }
             var i, page;

--- a/test/perf/OpenFile-perf-files/brackets-concat.js
+++ b/test/perf/OpenFile-perf-files/brackets-concat.js
@@ -20365,7 +20365,7 @@ define('LiveDevelopment/Inspector/Inspector',['require','exports','module'],func
         _connectDeferred = deferred;
         var promise = getAvailableSockets();
         promise.done(function onGetAvailableSockets(response) {
-            if (deferred.state() === "rejected") {
+            if (deferred.isRejected()) {
                 return;
             }
             var i, page;
@@ -58619,7 +58619,7 @@ define('LiveDevelopment/Inspector/Inspector',['require','exports','module'],func
         _connectDeferred = deferred;
         var promise = getAvailableSockets();
         promise.done(function onGetAvailableSockets(response) {
-            if (deferred.state() === "rejected") {
+            if (deferred.isRejected()) {
                 return;
             }
             var i, page;

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
                     language = lang;
                 });
                 
-                expect(promise.isResolved()).toBeTruthy();
+                expect(promise.state() === "resolved").toBeTruthy();
                 
                 validateLanguage(def, language);
             });

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return connectDeferred &&
-                        connectDeferred.isResolved() &&
+                        connectDeferred.state() === "resolved" &&
                         connection.connected();
                 },
                 "The NodeConnection should connect",
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
             });
             waitsFor(
                 function () {
-                    return loadDeferred && loadDeferred.isResolved();
+                    return loadDeferred && loadDeferred.state() === "resolved";
                 },
                 "The load should complete",
                 CONNECTION_TIMEOUT
@@ -127,15 +127,13 @@ define(function (require, exports, module) {
                 );
                 waitsFor(
                     function () {
-                        return loadDeferred &&
-                            (loadDeferred.isRejected() ||
-                                loadDeferred.isResolved());
+                        return loadDeferred && loadDeferred.state() !== "pending";
                     },
                     CONNECTION_TIMEOUT
                 );
                 runs(
                     function () {
-                        expect(loadDeferred.isRejected()).toBe(true);
+                        expect(loadDeferred.state() === "rejected").toBe(true);
                         expect(connection.connected()).toBe(true);
                         expect(connection._port).toBe(port);
                     }
@@ -157,7 +155,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return commandDeferred &&
-                        commandDeferred.isResolved() &&
+                        commandDeferred.state() === "resolved" &&
                         result;
                 },
                 CONNECTION_TIMEOUT
@@ -182,7 +180,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return commandDeferred &&
-                        commandDeferred.isResolved() &&
+                        commandDeferred.state() === "resolved" &&
                         result;
                 },
                 CONNECTION_TIMEOUT
@@ -230,7 +228,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return commandDeferred &&
-                        commandDeferred.isRejected() &&
+                        commandDeferred.state() === "rejected" &&
                         result;
                 },
                 CONNECTION_TIMEOUT
@@ -249,7 +247,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return commandDeferred &&
-                        commandDeferred.isResolved() &&
+                        commandDeferred.state() === "resolved" &&
                         result;
                 },
                 CONNECTION_TIMEOUT
@@ -276,7 +274,7 @@ define(function (require, exports, module) {
             waitsFor(
                 function () {
                     return commandDeferred &&
-                        commandDeferred.isResolved() &&
+                        commandDeferred.state() === "resolved" &&
                         result;
                 },
                 CONNECTION_TIMEOUT


### PR DESCRIPTION
This is a step towards the eventually upgrade to jQuery 2.0 (#3123).

Both `.isResolved` & `.isRejected` were deprecated in jQuery 1.7 and removed in 1.8 (http://api.jquery.com/deferred.isResolved/).
