### PR TITLE
Issue #3131 - Making JSLint errors copyable

### DIFF
--- a/src/extensions/default/JSLint/htmlContent/bottom-panel.html
+++ b/src/extensions/default/JSLint/htmlContent/bottom-panel.html
@@ -1,4 +1,4 @@
-<div id="jslint-results" class="bottom-panel vert-resizable top-resizer no-focus">
+<div id="jslint-results" class="bottom-panel vert-resizable top-resizer">
     <div class="toolbar simple-toolbar-layout">
         <div class="title">{{JSLINT_ERRORS}}</div>
     </div>

--- a/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
+++ b/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
@@ -16,12 +16,7 @@
     
     /* Enable text selection */
     cursor: auto;
-    -webkit-user-select: text;
-    -khtml-user-select: text;
-    -moz-user-select: text;
-    -ms-user-select: text;
-    -o-user-select: text;
-    user-select: text;
+    .user-select(text);
     
     &:focus {
         outline: none;

--- a/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
+++ b/src/extensions/default/WebPlatformDocs/WebPlatformDocs.less
@@ -16,7 +16,12 @@
     
     /* Enable text selection */
     cursor: auto;
-    .user-select(text);
+    -webkit-user-select: text;
+    -khtml-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    -o-user-select: text;
+    user-select: text;
     
     &:focus {
         outline: none;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -48,12 +48,7 @@ html, body {
     overflow: hidden;
     
     /* Turn off selection for UI elements */
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
-    user-select: none;
+    .user-select(none);
     
     /* And make sure we get a pointer cursor even over text */
     cursor: default;
@@ -838,4 +833,9 @@ li.smart_autocomplete_highlight {
         background: url("images/spinner2x.png") 50% no-repeat;
         background-size: 100%;
     }
+}
+
+/* Turn on text selection for JSLint error messages */
+#jslint-results {
+    .user-select(text);
 }

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -118,3 +118,13 @@
     -o-transform-origin: @horizontal @vertical;
     transform-origin: @horizontal @vertical;
 }
+
+/* Change the settings for user-select and its counterparts, defaulting to none. */
+.user-select(@type: none) {
+    -webkit-user-select: @type;
+    -khtml-user-select: @type;
+    -moz-user-select: @type;
+    -ms-user-select: @type;
+    -o-user-select: @type;
+    user-select: @type;
+}

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -128,3 +128,4 @@
     -o-user-select: @type;
     user-select: @type;
 }
+

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -441,12 +441,7 @@
             
             // Enable text selection
             cursor: auto;
-            -webkit-user-select: text;
-            -khtml-user-select: text;
-            -moz-user-select: text;
-            -ms-user-select: text;
-            -o-user-select: text;
-            user-select: text;
+            .user-select(text);
         }
     }
 }
@@ -563,12 +558,7 @@
         
         // Enable text selection
         cursor: auto;
-        -webkit-user-select: text;
-        -khtml-user-select: text;
-        -moz-user-select: text;
-        -ms-user-select: text;
-        -o-user-select: text;
-        user-select: text;
+        .user-select(text);
     }
 }
 


### PR DESCRIPTION
I made the JSLint errors copyable and make a LESS mix-in along the way, cleaning up some other code as well that used the -user-select CSS.
