### PR TITLE
Issue #3679 - File extension now dimmed if created via File > New

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1125,9 +1125,14 @@ define(function (require, exports, module) {
                     if (isFolder) {
                         _projectTree.jstree("sort", data.rslt.obj.parent());
                     }
-
+                    
                     _projectTree.jstree("select_node", data.rslt.obj, true);
-
+                    
+                    //If the new item is a file, generate the file display entry.
+                    if (!isFolder) {
+                        _projectTree.jstree("set_text", data.rslt.obj, ViewUtils.getFileEntryDisplay(entry));
+                    }
+                   
                     // Notify listeners that the project model has changed
                     $(exports).triggerHandler("projectFilesChange");
                     

--- a/src/utils/CollectionUtils.js
+++ b/src/utils/CollectionUtils.js
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
      * @return {boolean} True if the object contains the property
      */
     function hasProperty(object, property) {
-        return Object.prototype.hasOwnProperty.apply(object, [property]);
+        return Object.prototype.hasOwnProperty.call(object, property);
     }
     
     // Define public API


### PR DESCRIPTION
Looks like the createNewItem() method never used "set_text" on successCallback of creating a new file item.
