### PR TITLE
prime pump to improve first hint performance

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -53,7 +53,6 @@ define(function (require, exports, module) {
         cachedToken  = null,  // the token used in the current hinting session
         matcher      = null;  // string matcher for hints
 
-
     /**
      *  Get the value of current session.
      *  Used for unit testing.
@@ -392,14 +391,17 @@ define(function (require, exports, module) {
          * information, and reject any pending deferred requests.
          * 
          * @param {Editor} editor - editor context to be initialized.
+         * @param {boolean} primePump - true if the pump should be primed.
          */
-        function initializeSession(editor) {
+        function initializeSession(editor, primePump) {
             ScopeManager.handleEditorChange(editor.document);
             session = new Session(editor);
             cachedHints = null;
 
             // prime pump for hints so the first user request is fast
-            ScopeManager.requestHints(session, session.editor.document, 0);
+            if (primePump) {
+                ScopeManager.requestHints(session, session.editor.document, 0);
+            }
         }
 
         /*
@@ -415,7 +417,7 @@ define(function (require, exports, module) {
             cachedType = null;
 
             if (editor && editor.getLanguageForSelection().getId() === HintUtils.LANGUAGE_ID) {
-                initializeSession(editor);
+                initializeSession(editor, true);
                 $(editor)
                     .on(HintUtils.eventName("change"), function () {
                         ScopeManager.handleFileChange(editor.document);

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -397,6 +397,9 @@ define(function (require, exports, module) {
             ScopeManager.handleEditorChange(editor.document);
             session = new Session(editor);
             cachedHints = null;
+
+            // prime pump for hints so the first user request is fast
+            ScopeManager.requestHints(session, session.editor.document, 0);
         }
 
         /*

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
                 // create Editor instance (containing a CodeMirror instance)
                 runs(function () {
                     testEditor = createMockEditor(testDoc);
-                    JSCodeHints.initializeSession(testEditor);
+                    JSCodeHints.initializeSession(testEditor, false);
                 });
             });
             


### PR DESCRIPTION
This does not fix the long delay for the first hint but rather performs the first hint after the document has been loaded so by the time the user is ready to ask for a hint the response will be fast.
