### PR TITLE
Break words that are too long for dialog

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -396,6 +396,7 @@
 
 .dialog-filename {
     font-weight: @font-weight-semibold;
+    word-wrap: break-word;
 }
 
 /* Any Dialog text in this style is automatically turned into a link that opens in the browser. Use data-href for the link's target. */


### PR DESCRIPTION
Pull request #3446 improves the case in #2447 by providing a natural breaking point at all path separators, but doesn't fix all cases. I added `word-wrap: break-word;` so it also breaks words that do have enough natural breaking points to fit in dialog. 
