### PR TITLE
Locale descriptions in switching language modal.

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
         KeyBindingManager  = brackets.getModule("command/KeyBindingManager"),
         Menus              = brackets.getModule("command/Menus"),
         Strings            = brackets.getModule("strings"),
+        StringUtils        = brackets.getModule("utils/StringUtils"),
         PerfUtils          = brackets.getModule("utils/PerfUtils"),
         ProjectManager     = brackets.getModule("project/ProjectManager"),
         NativeApp          = brackets.getModule("utils/NativeApp"),
@@ -226,12 +227,22 @@ define(function (require, exports, module) {
                         .val(val)
                         .appendTo($select);
                 }
+                
+                // returns the localized label for the given locale
+                // or the locale, if nothing found
+                function getLocalizedLabel(locale) {
+                    
+                    var key = "LOCALE_" + locale.toUpperCase().replace("-", "_"),
+                        i18n = Strings[key];
+                    
+                    return i18n === undefined ? locale : StringUtils.format(Strings.LOCALE_LABEL, locale, i18n);
+                }
 
                 // add system default
                 addLocale(Strings.LANGUAGE_SYSTEM_DEFAULT, null);
                 
                 // add english
-                addLocale("en", "en");
+                addLocale(getLocalizedLabel("en"), "en");
                 
                 // inspect all children of dirEntry
                 entries.forEach(function (entry) {
@@ -246,7 +257,7 @@ define(function (require, exports, module) {
                                 label += match[2].toUpperCase();
                             }
                             
-                            addLocale(label, language);
+                            addLocale(getLocalizedLabel(label), language);
                         }
                     }
                 });

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -35,7 +35,6 @@ define(function (require, exports, module) {
         KeyBindingManager  = brackets.getModule("command/KeyBindingManager"),
         Menus              = brackets.getModule("command/Menus"),
         Strings            = brackets.getModule("strings"),
-        StringUtils        = brackets.getModule("utils/StringUtils"),
         PerfUtils          = brackets.getModule("utils/PerfUtils"),
         ProjectManager     = brackets.getModule("project/ProjectManager"),
         NativeApp          = brackets.getModule("utils/NativeApp"),
@@ -235,7 +234,7 @@ define(function (require, exports, module) {
                     var key = "LOCALE_" + locale.toUpperCase().replace("-", "_"),
                         i18n = Strings[key];
                     
-                    return i18n === undefined ? locale : StringUtils.format(Strings.LOCALE_LABEL, locale, i18n);
+                    return i18n === undefined ? locale : i18n;
                 }
 
                 // add system default

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -27,25 +27,6 @@
 define({
     
     /**
-     * Locales
-     */
-    "LOCALE_DE"                         : "Deutsch",
-    "LOCALE_EN"                         : "Englisch",
-    "LOCALE_FR"                         : "Französisch",
-    "LOCALE_CS"                         : "Tschechisch",
-    "LOCALE_ES"                         : "Spanisch",
-    "LOCALE_IT"                         : "Italienisch",
-    "LOCALE_JA"                         : "Japanisch",
-    "LOCALE_NB"                         : "Norwegisch",
-    "LOCALE_PL"                         : "Polnisch",
-    "LOCALE_PT_BR"                      : "Portugiesisch, Brasilien",
-    "LOCALE_PT_PT"                      : "Portugiesisch",
-    "LOCALE_RU"                         : "Russisch",
-    "LOCALE_SV"                         : "Schwedisch",
-    "LOCALE_TR"                         : "Türkisch",
-    "LOCALE_ZH_CN"                      : "Chinesisch, vereinfacht",
-    
-    /**
      * Errors
      */
 
@@ -155,6 +136,25 @@ define({
     "LANGUAGE_SUBMIT"                   : "{APP_NAME} neu starten",
     "LANGUAGE_CANCEL"                   : "Abbrechen",
     "LANGUAGE_SYSTEM_DEFAULT"           : "Systemstandard",
+    
+    /**
+     * Locales
+     */
+    "LOCALE_DE"                         : "Deutsch",
+    "LOCALE_EN"                         : "Englisch",
+    "LOCALE_FR"                         : "Französisch",
+    "LOCALE_CS"                         : "Tschechisch",
+    "LOCALE_ES"                         : "Spanisch",
+    "LOCALE_IT"                         : "Italienisch",
+    "LOCALE_JA"                         : "Japanisch",
+    "LOCALE_NB"                         : "Norwegisch",
+    "LOCALE_PL"                         : "Polnisch",
+    "LOCALE_PT_BR"                      : "Portugiesisch, Brasilien",
+    "LOCALE_PT_PT"                      : "Portugiesisch",
+    "LOCALE_RU"                         : "Russisch",
+    "LOCALE_SV"                         : "Schwedisch",
+    "LOCALE_TR"                         : "Türkisch",
+    "LOCALE_ZH_CN"                      : "Chinesisch, vereinfacht",
 
     /**
      * ProjectManager

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -25,6 +25,26 @@
 /*global define */
 
 define({
+    
+    /**
+     * Locales
+     */
+    "LOCALE_DE"                         : "Deutsch",
+    "LOCALE_EN"                         : "Englisch",
+    "LOCALE_FR"                         : "Französisch",
+    "LOCALE_CS"                         : "Tschechisch",
+    "LOCALE_ES"                         : "Spanisch",
+    "LOCALE_IT"                         : "Italienisch",
+    "LOCALE_JA"                         : "Japanisch",
+    "LOCALE_NB"                         : "Norwegisch",
+    "LOCALE_PL"                         : "Polnisch",
+    "LOCALE_PT_BR"                      : "Portugiesisch, Brasilien",
+    "LOCALE_PT_PT"                      : "Portugiesisch",
+    "LOCALE_RU"                         : "Russisch",
+    "LOCALE_SV"                         : "Schwedisch",
+    "LOCALE_TR"                         : "Türkisch",
+    "LOCALE_ZH_CN"                      : "Chinesisch, vereinfacht",
+    
     /**
      * Errors
      */

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -25,6 +25,12 @@
 /*global define */
 
 define({
+    
+    /**
+     * Locales
+     */
+    "LOCALE_LABEL"                      : "{0} ({1})",
+    
     /**
      * Errors
      */

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -27,11 +27,6 @@
 define({
     
     /**
-     * Locales
-     */
-    "LOCALE_LABEL"                      : "{0} ({1})",
-    
-    /**
      * Errors
      */
 
@@ -137,6 +132,25 @@ define({
     "LANGUAGE_SUBMIT"                   : "Reload {APP_NAME}",
     "LANGUAGE_CANCEL"                   : "Cancel",
     "LANGUAGE_SYSTEM_DEFAULT"           : "System Default",
+    
+    /**
+     * Locales
+     */
+    "LOCALE_CS"                         : "Czech",
+    "LOCALE_DE"                         : "German",
+    "LOCALE_EN"                         : "English",
+    "LOCALE_ES"                         : "Spanish",
+    "LOCALE_FR"                         : "French",
+    "LOCALE_IT"                         : "Italian",
+    "LOCALE_JA"                         : "Japanese",
+    "LOCALE_NB"                         : "Norwegian",
+    "LOCALE_PL"                         : "Polish",
+    "LOCALE_PT_BR"                      : "Portuguese, Brazil",
+    "LOCALE_PT_PT"                      : "Portuguese",
+    "LOCALE_RU"                         : "Russian",
+    "LOCALE_SV"                         : "Swedish",
+    "LOCALE_TR"                         : "Turkish ",
+    "LOCALE_ZH_CN"                      : "Chinese, simplified",
 
     /**
      * ProjectManager

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -149,7 +149,7 @@ define({
     "LOCALE_PT_PT"                      : "Portuguese",
     "LOCALE_RU"                         : "Russian",
     "LOCALE_SV"                         : "Swedish",
-    "LOCALE_TR"                         : "Turkish ",
+    "LOCALE_TR"                         : "Turkish",
     "LOCALE_ZH_CN"                      : "Chinese, simplified",
 
     /**


### PR DESCRIPTION
Here i take up the pull request https://github.com/adobe/brackets/pull/3677.

I added english i18n for the locales and i moved them in the strings.js to the modal strings.

additional infos:
issue https://github.com/adobe/brackets/issues/1461
card https://trello.com/c/Pjw3vGt2

I also removed the locale label string, because a short descriptions "feels" a lot more usable than a locale in ( ). So now there will be plain "English" instead of "en". And because of the fallback there wont be a plain locale in the modal anymore.
