### PR TITLE
Show correct current document in the working set after opening Brackets with sidebar closed.

### DIFF
--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -112,6 +112,7 @@ define(function (require, exports, module) {
         });
         
         $sidebar.on("panelExpanded", function (evt, width) {
+            WorkingSetView.refresh();
             $sidebar.find(".sidebar-selection").width(width);
             $sidebar.find(".scroller-shadow").css("display", "block");
             $sidebar.find(".sidebar-selection-triangle").css("left", width);

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -555,6 +555,10 @@ define(function (require, exports, module) {
         _rebuildWorkingSet();
     }
     
+    function refresh() {
+        _redraw();
+    }
+    
     function create(element) {
         // Init DOM element
         $openFilesContainer = element;
@@ -603,4 +607,5 @@ define(function (require, exports, module) {
     }
     
     exports.create = create;
+    exports.refresh = refresh;
 });

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -606,6 +606,6 @@ define(function (require, exports, module) {
         _redraw();
     }
     
-    exports.create = create;
+    exports.create  = create;
     exports.refresh = refresh;
 });


### PR DESCRIPTION
Fix to make the sidebar correctly highlight the current document upon Brackets launch, after closing Brackets with the sidebar closed.

Issue #3637
