### PR TITLE
REVIEW ONLY: add 'Toggle CodeHints' command to debug menu

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -229,7 +229,8 @@ define(function (require, exports, module) {
         sessionEditor   = null,
         hintList        = null,
         deferredHints   = null,
-        keyDownEditor   = null;
+        keyDownEditor   = null,
+        enabled         = true;
 
     /**
      * Comparator to sort providers based on their priority
@@ -438,6 +439,9 @@ define(function (require, exports, module) {
      * @param {KeyboardEvent} event
      */
     function handleKeyEvent(editor, event) {
+        if (!enabled) {
+            return;
+        }
         keyDownEditor = editor;
         if (event.type === "keydown") {
             if (event.keyCode === 32 && event.ctrlKey) { // User pressed Ctrl+Space
@@ -482,7 +486,7 @@ define(function (require, exports, module) {
      * the lastChar.
      */
     function handleChange(editor) {
-        if (lastChar && editor === keyDownEditor) {
+        if (enabled && lastChar && editor === keyDownEditor) {
             keyDownEditor = null;
             if (_inSession(editor)) {
                 var charToRetest = lastChar;
@@ -519,6 +523,11 @@ define(function (require, exports, module) {
     }
     exports._getCodeHintList        = _getCodeHintList;
     
+    function _enable(enable) {
+        enabled = enable;
+    }
+    exports._enable                 = _enable;
+
     // Define public API
     exports.isOpen                  = isOpen;
     exports.handleKeyEvent          = handleKeyEvent;

--- a/src/extensions/default/CodeHintToggler/main.js
+++ b/src/extensions/default/CodeHintToggler/main.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, CodeMirror, brackets */
+
+define(function (require, exports, module) {
+    'use strict';
+    var AppInit         = brackets.getModule("utils/AppInit"),
+        CodeHintManager = brackets.getModule("editor/CodeHintManager"),
+        CommandManager  = brackets.getModule("command/CommandManager"),
+        Menus           = brackets.getModule("command/Menus");
+    
+    var TOGGLE_CODEHINTS_STRING      = "Toggle Code Hints",
+        TOGGLE_CODEHINTS_COMMAND_ID  = "menu.debug.codehints.toggle";
+
+    // TODO: persist across sessions?
+    var enabled = true;
+
+    function setEnabled(isEnabled) {
+        CodeHintManager._enable(isEnabled);
+        CommandManager.get(TOGGLE_CODEHINTS_COMMAND_ID).setChecked(isEnabled);
+    }
+
+    AppInit.appReady(function () {
+        CommandManager.register(TOGGLE_CODEHINTS_STRING, TOGGLE_CODEHINTS_COMMAND_ID, function () {
+            enabled = !enabled;
+            setEnabled(enabled);
+        });
+        
+        var debug_menu = Menus.getMenu("debug-menu");
+        if (debug_menu) {
+            debug_menu.addMenuItem(TOGGLE_CODEHINTS_COMMAND_ID);
+            setEnabled(enabled);
+        }
+    });
+});


### PR DESCRIPTION
This branch adds a "Toggle CodeHints" command to Debug menu. This allows you to turn off code hints for the sake of performance analysis of both with and without code hints.
