### PR TITLE
Automatically share code font

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -26,7 +26,9 @@
 
 .CodeMirror-scroll {
     background-color: @background-color-3;
+}
 
+.CodeMirror {
     .code-font();
 }
 

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -26,6 +26,8 @@
 
 .CodeMirror-scroll {
     background-color: @background-color-3;
+
+    .code-font();
 }
 
 .platform-mac .CodeMirror {

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -128,11 +128,9 @@
 }
 
 .code-font-win() {
-    .code-font();
 }
 
 .code-font-mac() {
-    .code-font();
     /* Use the Medium weight on the Mac to counterbalance the grayscale antialiasing. */
     font-family: 'SourceCodePro-Medium', "ＭＳ ゴシック", "MS Gothic", monospace;
 }


### PR DESCRIPTION
This change moves code font to a shared selector so that it's automatically shared for any new platforms (such as Linux). This eliminates the need for each platform to add the following set of rules:

```
.platform-linux .CodeMirror-scroll {
    .code-font-linux();
}
.code-font-linux() {
    .code-font();
}
```

This is similar to change I made in @pritambaral branch: https://github.com/pritambaral/brackets/pull/1
