### PR TITLE
Fix Issue #3632

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -456,7 +456,12 @@ define(function (require, exports, module) {
                 cursor = sessionType.functionCallPos,
                 token = cursor ? this.getToken(cursor) : undefined,
                 varName;
-            if (token) {
+            if (token &&
+                    // only change the 'fn' when the token looks like a function
+                    // name, and isn't some other kind of expression
+                    (token.type === "variable" ||
+                     token.type === "variable-2" ||
+                     token.type === "property")) {
                 varName = token.string;
                 if (varName) {
                     fnHint = varName + fnHint.substr(2);


### PR DESCRIPTION
Only replace the 'fn' in the function type hint if the token that was called looks like an identifier/property.  If it is an expression resulting in a function call, then just display 'fn' since we don't have a way to determine a 'name' for the called function.
