### PR TITLE
Don't install system extensions

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -140,7 +140,7 @@ define(function (require, exports, module) {
                     
                     nodeConnection.domains.extensionManager.install(path, destinationDirectory, {
                         disabledDirectory: disabledDirectory,
-                        systemDirectory: systemDirectory,
+                        systemExtensionDirectory: systemDirectory,
                         apiVersion: brackets.metadata.apiVersion,
                         nameHint: nameHint
                     })

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -134,10 +134,13 @@ define(function (require, exports, module) {
         _nodeConnectionDeferred
             .done(function (nodeConnection) {
                 if (nodeConnection.connected()) {
-                    var destinationDirectory = ExtensionLoader.getUserExtensionPath();
-                    var disabledDirectory = destinationDirectory.replace(/\/user$/, "/disabled");
+                    var destinationDirectory    = ExtensionLoader.getUserExtensionPath(),
+                        disabledDirectory       = destinationDirectory.replace(/\/user$/, "/disabled"),
+                        systemDirectory         = FileUtils.getNativeBracketsDirectoryPath() + "/extensions/default/";
+                    
                     nodeConnection.domains.extensionManager.install(path, destinationDirectory, {
                         disabledDirectory: disabledDirectory,
+                        systemDirectory: systemDirectory,
                         apiVersion: brackets.metadata.apiVersion,
                         nameHint: nameHint
                     })

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -174,7 +174,7 @@ function _removeAndInstall(packagePath, installDirectory, validationResult, call
  * @param {function} callback (err, result)
  */
 function _cmdInstall(packagePath, destinationDirectory, options, callback) {
-    if (!options || !options.disabledDirectory || !options.apiVersion) {
+    if (!options || !options.disabledDirectory || !options.apiVersion || !options.systemDirectory) {
         callback(new Error(Errors.MISSING_REQUIRED_OPTIONS), null);
         return;
     }
@@ -197,7 +197,8 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback) {
             extensionName = path.basename(packagePath, ".zip");
         }
         validationResult.name = extensionName;
-        var installDirectory = path.join(destinationDirectory, extensionName);
+        var installDirectory = path.join(destinationDirectory, extensionName),
+            systemInstallDirectory = path.join(options.systemDirectory, extensionName);
         
         if (validationResult.metadata && validationResult.metadata.engines &&
                 validationResult.metadata.engines.brackets) {
@@ -213,7 +214,7 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback) {
         
         // If the extension is already there, at this point we will not overwrite
         // a running extension. Instead, we unzip into the disabled directory.
-        if (fs.existsSync(installDirectory)) {
+        if (fs.existsSync(installDirectory) || fs.existsSync(systemInstallDirectory)) {
             validationResult.disabledReason  = Errors.ALREADY_INSTALLED;
             installDirectory = path.join(options.disabledDirectory, extensionName);
             _removeAndInstall(packagePath, installDirectory, validationResult, callback);
@@ -386,7 +387,7 @@ function init(domainManager) {
             description: "absolute filesystem path where this extension should be installed"
         }, {
             name: "options",
-            type: "{disabledDirectory: !string, apiVersion: !string, nameHint: ?string}",
+            type: "{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, systemDirectory: !string}",
             description: "installation options: disabledDirectory should be set so that extensions can be installed disabled."
         }],
         [{

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -170,11 +170,12 @@ function _removeAndInstall(packagePath, installDirectory, validationResult, call
  * 
  * @param {string} Absolute path to the package zip file
  * @param {string} the destination directory
- * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string}} additional settings to control the installation
+ * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, 
+ *      systemExtensionDirectory: !string}} additional settings to control the installation
  * @param {function} callback (err, result)
  */
 function _cmdInstall(packagePath, destinationDirectory, options, callback) {
-    if (!options || !options.disabledDirectory || !options.apiVersion || !options.systemDirectory) {
+    if (!options || !options.disabledDirectory || !options.apiVersion || !options.systemExtensionDirectory) {
         callback(new Error(Errors.MISSING_REQUIRED_OPTIONS), null);
         return;
     }
@@ -198,7 +199,7 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback) {
         }
         validationResult.name = extensionName;
         var installDirectory = path.join(destinationDirectory, extensionName),
-            systemInstallDirectory = path.join(options.systemDirectory, extensionName);
+            systemInstallDirectory = path.join(options.systemExtensionDirectory, extensionName);
         
         if (validationResult.metadata && validationResult.metadata.engines &&
                 validationResult.metadata.engines.brackets) {
@@ -387,7 +388,7 @@ function init(domainManager) {
             description: "absolute filesystem path where this extension should be installed"
         }, {
             name: "options",
-            type: "{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, systemDirectory: !string}",
+            type: "{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, systemExtensionDirectory: !string}",
             description: "installation options: disabledDirectory should be set so that extensions can be installed disabled."
         }],
         [{


### PR DESCRIPTION
The extension manager currently refuses to install extensions that are already installed the user's extension directory, but will happily install extensions that already exist in the system default extension directory. This can cause problems with extensions like Edge Web Fonts that are freely distributed online, but which are installed by default in Edge Code. This pull request adds an additional required option, `systemDirectory`, to the `install` command in the `ExtensionManagerDomain` that is used to avoid conflicts in the same way as the `destinationDirectory` parameter.
