### PR TITLE
Fix over-repaint issue when typing

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -102,11 +102,16 @@
     
     .CodeMirror-gutters {
         background-color: @background-color-3;
-        border-color: @background-color-3; /* maintain line gutter border-right to avoid repaint performance issues */
+        
+        /*
+        Maintain line gutter border-right to avoid repaint performance issues
+        See https://github.com/marijnh/CodeMirror/issues/1514
+        */
+        border-color: @background-color-3;
     }
     .CodeMirror-linenumber {
         color: @accent-comment;
-        min-width: 30px;
+        min-width: 2.5em;
         /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
         padding: 0 3px 0 10px;  /* left padding for project panel selection triangle */
     }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -106,7 +106,7 @@
     }
     .CodeMirror-linenumber {
         color: @accent-comment;
-        /*min-width: 30px*/
+        min-width: 30px;
         /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
         padding: 0 3px 0 10px;  /* left padding for project panel selection triangle */
     }
@@ -155,7 +155,7 @@
     }
     
     .CodeMirror-scroll {
-        /*outline: none;*/
+        outline: none;
     }
     
     .CodeMirror-sizer {

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -102,11 +102,11 @@
     
     .CodeMirror-gutters {
         background-color: @background-color-3;
-        border-right: none;
+        border-color: @background-color-3; /* maintain line gutter border-right to avoid repaint performance issues */
     }
     .CodeMirror-linenumber {
         color: @accent-comment;
-        min-width: 2.5em;
+        /*min-width: 30px*/
         /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
         padding: 0 3px 0 10px;  /* left padding for project panel selection triangle */
     }
@@ -155,7 +155,7 @@
     }
     
     .CodeMirror-scroll {
-        outline: none;
+        /*outline: none;*/
     }
     
     .CodeMirror-sizer {


### PR DESCRIPTION
Somehow, removing the default 1px `border-right` from `CodeMirror-gutters` placeholder caused the repaint issue (where the entire window repaints for each keystroke). As a fix, I've changed the border color to match the gutter background.

The problem does reproduce in a boilerplate CodeMirror demo. I'll file a bug.
