### PR TITLE
[OPEN] Code cleanup for FindInFiles.js

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -63,6 +63,9 @@ define(function (require, exports, module) {
         currentQuery = "",
         currentScope;
     
+    // Div holding the search results. Initialized in htmlReady().
+    var $searchResultsDiv;
+    
     function _getQueryRegExp(query) {
         // Clear any pending RegEx error message
         $(".modal-bar .message").css("display", "inline-block");
@@ -187,7 +190,13 @@ define(function (require, exports, module) {
         
         return this.result.promise();
     };
-
+    
+    function _hideSearchResults() {
+        if ($searchResultsDiv.is(":visible")) {
+            $searchResultsDiv.hide();
+            EditorManager.resizeEditor();
+        }
+    }
 
     function _getSearchMatches(contents, queryExpr) {
         // Quick exit if not found
@@ -231,8 +240,6 @@ define(function (require, exports, module) {
     }
         
     function _showSearchResults(searchResults, query, scope) {
-        var $searchResultsDiv = $("#search-results");
-        
         if (searchResults && searchResults.length) {
             var $resultTable = $("<table class='zebra-striped condensed-table' />")
                                 .append("<tbody>");
@@ -329,13 +336,12 @@ define(function (require, exports, module) {
             
             $("#search-results .close")
                 .one("click", function () {
-                    $searchResultsDiv.hide();
-                    EditorManager.resizeEditor();
+                    _hideSearchResults();
                 });
             
             $searchResultsDiv.show();
         } else {
-            $searchResultsDiv.hide();
+            _hideSearchResults();
         }
         
         EditorManager.resizeEditor();
@@ -441,15 +447,13 @@ define(function (require, exports, module) {
         doFindInFiles(selectedEntry);
     }
     
-    
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
-        var $searchResults  = $("#search-results"),
-            $searchContent  = $("#search-results .table-container");
+        $searchResultsDiv  = $("#search-results");
     });
 
     function _fileNameChangeHandler(event, oldName, newName) {
-        if ($("#search-results").is(":visible")) {
+        if ($searchResultsDiv.is(":visible")) {
             // Update the search results
             searchResults.forEach(function (item) {
                 item.fullPath = item.fullPath.replace(oldName, newName);
@@ -458,17 +462,8 @@ define(function (require, exports, module) {
         }
     }
     
-    function _beforeProjectCloseHandler(event, projectRoot) {
-        var $searchResultsDiv = $("#search-results");
-        if ($searchResultsDiv.is(":visible")) {
-            // Hide the search results
-            $searchResultsDiv.hide();
-            EditorManager.resizeEditor();
-        }
-    }
-    
     $(DocumentManager).on("fileNameChange", _fileNameChangeHandler);
-    $(ProjectManager).on("beforeProjectClose", _beforeProjectCloseHandler);
+    $(ProjectManager).on("beforeProjectClose", _hideSearchResults);
     
     CommandManager.register(Strings.CMD_FIND_IN_FILES,   Commands.EDIT_FIND_IN_FILES,   doFindInFiles);
     CommandManager.register(Strings.CMD_FIND_IN_SUBTREE, Commands.EDIT_FIND_IN_SUBTREE, doFindInSubtree);


### PR DESCRIPTION
There are no functional changes (although I _was_ tempted to make some...).

Clean-ups include:
- Add a module level var named `$searchResultsDiv` that is now used in several places throughout the code.
- Refactor the code that hides results into a new `_hideSearchResults()` function, and call this function when needed.
- Update the `htmlReady` callback to initialize `$searchResultsDiv` instead of initializing a couple local vars that were never used.
