### PR TITLE
Use start (not end) of selection to determine soft tab spaces

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -154,7 +154,7 @@ define(function (require, exports, module) {
                 CodeMirror.commands.insertTab(instance);
             } else {
                 var i, ins = "", numSpaces = instance.getOption("indentUnit");
-                numSpaces -= to.ch % numSpaces;
+                numSpaces -= from.ch % numSpaces;
                 for (i = 0; i < numSpaces; i++) {
                     ins += " ";
                 }


### PR DESCRIPTION
This is for #3723. FYI @jeffslofish .

The original fix exposed a bug in the code. It was using end of selection (instead of start) to determine the number of spaces to insert. The bug wasn't noticed because it never inserted when there was a selection (always indented). 
