### PR TITLE
Fix for #3773: Show Indexing Max Files Exceeded Error Dialog once

### DIFF
--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -58,6 +58,12 @@ define(function (require, exports, module) {
      */
     var _indexListDirty = true;
 
+    /**
+     * Store whether the index manager has exceeded the limit so the warning dialog only
+     * appears once.
+     */
+    var _maxFileDialogDisplayed = false;
+
     /** class FileIndex
      *
      * A FileIndex contains an array of fileInfos that meet the criteria specified by
@@ -218,7 +224,12 @@ define(function (require, exports, module) {
                         if (state.fileCount > 10000) {
                             if (!state.maxFilesHit) {
                                 state.maxFilesHit = true;
-                                _showMaxFilesDialog();
+                                if (_maxFileDialogDisplayed === false) {
+                                    _showMaxFilesDialog();
+                                    _maxFileDialogDisplayed = true;
+                                } else {
+                                    console.log("Maximum files index limit exceeded " + state.fileCount);
+                                }
                             }
                             return;
                         }
@@ -231,7 +242,6 @@ define(function (require, exports, module) {
                             _scanDirectoryRecurse(entry);
                         }
                     });
-
                     _finishDirScan(dirEntry);
                 },
                 // error callback

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -61,6 +61,7 @@ define(function (require, exports, module) {
     /**
      * Store whether the index manager has exceeded the limit so the warning dialog only
      * appears once.
+     * @type {boolean}
      */
     var _maxFileDialogDisplayed = false;
 
@@ -224,11 +225,12 @@ define(function (require, exports, module) {
                         if (state.fileCount > 10000) {
                             if (!state.maxFilesHit) {
                                 state.maxFilesHit = true;
-                                if (_maxFileDialogDisplayed === false) {
+                                if (!_maxFileDialogDisplayed) {
                                     _showMaxFilesDialog();
                                     _maxFileDialogDisplayed = true;
                                 } else {
-                                    console.log("Maximum files index limit exceeded " + state.fileCount);
+                                    console.warn("The maximum number of files have been indexed. Actions " +
+                                                 "that lookup files in the index may function incorrectly.");
                                 }
                             }
                             return;
@@ -407,11 +409,20 @@ define(function (require, exports, module) {
             return PathUtils.filenameExtension(filename) === ".css";
         }
     );
-    
-    $(ProjectManager).on("projectOpen projectFilesChange", function (event, projectRoot) {
+
+    /**
+     * When a new project is opened set the flag for index exceeding maximum
+     * warning back to false. 
+     */
+    $(ProjectManager).on("projectOpen", function (event, projectRoot) {
+        _maxFileDialogDisplayed = false;
         markDirty();
     });
     
+    $(ProjectManager).on("projectFilesChange", function (event, projectRoot) {
+        markDirty();
+    });
+
     PerfUtils.createPerfMeasurement("FILE_INDEX_MANAGER_SYNC", "syncFileIndex");
 
     exports.markDirty = markDirty;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -576,7 +576,7 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        if ([".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db"].indexOf(entry.name) > -1) {
+        if ([".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db", ".hg"].indexOf(entry.name) > -1) {
             return false;
         }
         var extension = entry.name.split('.').pop();


### PR DESCRIPTION
fixes issue #3773.  minor fix to only show dialog "Error Indexing Files" "The maximum number of files have been indexed. Actions that look up files in the index may function incorrectly."   The problem is if your current project has > 10k files you see this error every time you save an edit and dirty the cache.  The fix is to show to error the first infraction and  use console.log subsequent times.
