### PR TITLE
Fix unit tests for increment/decrement font size

### DIFF
--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -84,9 +84,16 @@ define(function (require, exports, module) {
         describe("Adjust the Font Size", function () {
             it("should increase the font size in both editor and inline editor", function () {
                 runs(function () {
-                    var editors      = getEditors();
-                    var expectedSize = editors.editor.getTextHeight() + 2;
+                    var editors = getEditors();
                     
+                    // Editor.getTextHeight() returns line-height which has already been
+                    // rounded off, which means we can't be exact here, so increment text
+                    // size by a number near a whole number (3 * 1.3 = 3.9 ~= 4).
+                    var expectedSize = editors.editor.getTextHeight() + 4;
+                    
+                    // Incrementing adds 1px to font-size and 1.3px to line-height.
+                    // Note this only works when font-size and line-height are specified in px.
+                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     
@@ -97,9 +104,16 @@ define(function (require, exports, module) {
             
             it("should decrease the font size in both editor and inline editor", function () {
                 runs(function () {
-                    var editors      = getEditors();
-                    var expectedSize = editors.editor.getTextHeight() - 2;
+                    var editors = getEditors();
                     
+                    // Editor.getTextHeight() returns line-height which has already been
+                    // rounded off, which means we can't be exact here, so decrement text
+                    // size by a number near a whole number (3 * 1.3 = 3.9 ~= 4).
+                    var expectedSize = editors.editor.getTextHeight() - 4;
+                    
+                    // Decrementing subtracts 1px from font-size and 1.3px from line-height.
+                    // Note this only works when font-size and line-height are specified in px.
+                    CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
                     

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -84,41 +84,25 @@ define(function (require, exports, module) {
         describe("Adjust the Font Size", function () {
             it("should increase the font size in both editor and inline editor", function () {
                 runs(function () {
-                    var editors = getEditors();
+                    var editors      = getEditors(),
+                        originalSize = editors.editor.getTextHeight();
                     
-                    // Editor.getTextHeight() returns line-height which has already been
-                    // rounded off, which means we can't be exact here, so increment text
-                    // size by a number near a whole number (3 * 1.3 = 3.9 ~= 4).
-                    var expectedSize = editors.editor.getTextHeight() + 4;
-                    
-                    // Incrementing adds 1px to font-size and 1.3px to line-height.
-                    // Note this only works when font-size and line-height are specified in px.
-                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
-                    CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     
-                    expect(editors.editor.getTextHeight()).toBe(expectedSize);
-                    expect(editors.inline.getTextHeight()).toBe(expectedSize);
+                    expect(editors.editor.getTextHeight()).toBeGreaterThan(originalSize);
+                    expect(editors.inline.getTextHeight()).toBeGreaterThan(originalSize);
                 });
             });
             
             it("should decrease the font size in both editor and inline editor", function () {
                 runs(function () {
-                    var editors = getEditors();
+                    var editors      = getEditors(),
+                        originalSize = editors.editor.getTextHeight();
                     
-                    // Editor.getTextHeight() returns line-height which has already been
-                    // rounded off, which means we can't be exact here, so decrement text
-                    // size by a number near a whole number (3 * 1.3 = 3.9 ~= 4).
-                    var expectedSize = editors.editor.getTextHeight() - 4;
-                    
-                    // Decrementing subtracts 1px from font-size and 1.3px from line-height.
-                    // Note this only works when font-size and line-height are specified in px.
-                    CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
-                    CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
                     CommandManager.execute(Commands.VIEW_DECREASE_FONT_SIZE);
                     
-                    expect(editors.editor.getTextHeight()).toBe(expectedSize);
-                    expect(editors.inline.getTextHeight()).toBe(expectedSize);
+                    expect(editors.editor.getTextHeight()).toBeLessThan(originalSize);
+                    expect(editors.inline.getTextHeight()).toBeLessThan(originalSize);
                 });
             });
             


### PR DESCRIPTION
This is for #3794. A recent change to try fix #3478 exposed the inaccuracy of these tests. Specifically, changing the ratio of line-height to font-size from 1.25 to 1.3 broke these tests. Note that #3478 is still not fixed.

Making these tests perfectly accurate would require either some new function(s) in Editor, or to largely duplicate the code in ViewCommandHandlers._adjustFontSize(). If that's desired, then these tests should be disabled for now.

Otherwise, I found a possibly reasonable way to fix these unit tests. I also added comments to the tests to explain their shortcomings.
