### PR TITLE
Dismiss code hints before running a command

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -148,6 +148,15 @@
             "platform": "mac"
         }
     ],
+    "edit.showCodeHints":  [
+        {
+            "key": "Ctrl-Space"
+        },
+        {
+            "key": "Ctrl-Space",
+            "platform": "mac"
+        }
+    ],
     "view.hideSidebar":  [
         "Ctrl-Shift-H"
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -153,7 +153,7 @@
             "key": "Ctrl-Space"
         },
         {
-            "key": "Ctrl- ",
+            "key": "Ctrl-Space",
             "platform": "mac"
         }
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -153,7 +153,7 @@
             "key": "Ctrl-Space"
         },
         {
-            "key": "Ctrl-Space",
+            "key": "Ctrl- ",
             "platform": "mac"
         }
     ],

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -28,15 +28,14 @@
  /**
   * Manages global application commands that can be called from menu items, key bindings, or subparts
   * of the application.
- *
- * This module dispatches these event(s):
- *    - commandRegistered  -- when a new command is registered
+  *
+  * This module dispatches these event(s):
+  *    - commandRegistered  -- when a new command is registered
+  *    - beforeExecuteCommand -- before dispatching a command
   */
 define(function (require, exports, module) {
     "use strict";
     
-    var Commands = require("command/Commands");
-
     /**
      * Map of all registered global commands
      * @type Object.<commandID: string, Command>
@@ -234,14 +233,15 @@ define(function (require, exports, module) {
      * @return {$.Promise} a jQuery promise that will be resolved when the command completes.
      */
     function execute(id) {
-        var command = _commands[id],
-            closeHintsCommand = _commands[Commands.CLOSE_CODE_HINTS];
-
-        if (id !== Commands.SHOW_CODE_HINTS && closeHintsCommand) {
-            closeHintsCommand.execute.call(closeHintsCommand);
-        }
+        var command = _commands[id];
         
         if (command) {
+            try {
+                $(exports).triggerHandler("beforeExecuteCommand");
+            } catch (err) {
+                console.error(err);
+            }
+            
             return command.execute.apply(command, Array.prototype.slice.call(arguments, 1));
         } else {
             return (new $.Deferred()).reject().promise();

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -35,6 +35,8 @@
 define(function (require, exports, module) {
     "use strict";
     
+    var Commands = require("command/Commands");
+
     /**
      * Map of all registered global commands
      * @type Object.<commandID: string, Command>
@@ -232,7 +234,13 @@ define(function (require, exports, module) {
      * @return {$.Promise} a jQuery promise that will be resolved when the command completes.
      */
     function execute(id) {
-        var command = _commands[id];
+        var command = _commands[id],
+            closeHintsCommand = _commands[Commands.CLOSE_CODE_HINTS];
+
+        if (id !== Commands.SHOW_CODE_HINTS && closeHintsCommand) {
+            closeHintsCommand.execute.call(closeHintsCommand);
+        }
+        
         if (command) {
             return command.execute.apply(command, Array.prototype.slice.call(arguments, 1));
         } else {

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -77,7 +77,6 @@ define(function (require, exports, module) {
     exports.EDIT_OPEN_LINE_BELOW        = "edit.openLineBelow";
     exports.TOGGLE_CLOSE_BRACKETS       = "edit.autoCloseBrackets";
     exports.SHOW_CODE_HINTS             = "edit.showCodeHints";
-    exports.CLOSE_CODE_HINTS            = "edit.closeCodeHints";
 
     // VIEW
     exports.VIEW_HIDE_SIDEBAR           = "view.hideSidebar";

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -76,6 +76,8 @@ define(function (require, exports, module) {
     exports.EDIT_OPEN_LINE_ABOVE        = "edit.openLineAbove";
     exports.EDIT_OPEN_LINE_BELOW        = "edit.openLineBelow";
     exports.TOGGLE_CLOSE_BRACKETS       = "edit.autoCloseBrackets";
+    exports.SHOW_CODE_HINTS             = "edit.showCodeHints";
+    exports.CLOSE_CODE_HINTS            = "edit.closeCodeHints";
 
     // VIEW
     exports.VIEW_HIDE_SIDEBAR           = "view.hideSidebar";

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -98,8 +98,9 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_LINE_COMMENT);
         menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.TOGGLE_CLOSE_BRACKETS);
         menu.addMenuItem(Commands.SHOW_CODE_HINTS);
+        menu.addMenuDivider();
+        menu.addMenuItem(Commands.TOGGLE_CLOSE_BRACKETS);
 
         /*
          * View menu

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -99,6 +99,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_BLOCK_COMMENT);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_CLOSE_BRACKETS);
+        menu.addMenuItem(Commands.SHOW_CODE_HINTS);
 
         /*
          * View menu

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -447,10 +447,7 @@ define(function (require, exports, module) {
     function handleKeyEvent(editor, event) {
         keyDownEditor = editor;
         if (event.type === "keydown") {
-            if (event.keyCode === 32 && event.ctrlKey) { // User pressed Ctrl+Space
-                event.preventDefault();
-                _startNewSession(editor);
-            } else if (_inSession(editor) && hintList.isOpen()) {
+            if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
                 hintList.handleKeyEvent(event);
             }
@@ -520,9 +517,9 @@ define(function (require, exports, module) {
         return hintList;
     }
 
+    $(CommandManager).on("beforeExecuteCommand", _endSession);
+
     CommandManager.register(Strings.CMD_SHOW_CODE_HINTS, Commands.SHOW_CODE_HINTS, _startNewSession);
-    // This is only for internal use. So we're not localizing the string and it's not exposed in any menu.
-    CommandManager.register("Close Code Hints", Commands.CLOSE_CODE_HINTS, _endSession);
 
     exports._getCodeHintList        = _getCodeHintList;
     

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -517,6 +517,10 @@ define(function (require, exports, module) {
         return hintList;
     }
 
+    // Dismiss code hints before executing any command since the command
+    // may make the current hinting session irrevalent after execution. 
+    // For example, when the user hits Ctrl+K to open Quick Doc, it is 
+    // pointless to keep the hint list since the user wants to view the Quick Doc.
     $(CommandManager).on("beforeExecuteCommand", _endSession);
 
     CommandManager.register(Strings.CMD_SHOW_CODE_HINTS, Commands.SHOW_CODE_HINTS, _startNewSession);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -236,6 +236,7 @@ define({
     "CMD_OPEN_LINE_ABOVE"                 : "Open Line Above",
     "CMD_OPEN_LINE_BELOW"                 : "Open Line Below",
     "CMD_TOGGLE_CLOSE_BRACKETS"           : "Auto Close Braces",
+    "CMD_SHOW_CODE_HINTS"                 : "Show Code Hints",
     
     // View menu commands
     "VIEW_MENU"                           : "View",


### PR DESCRIPTION
This is to fix issue #3426 by dismissing code hints with an event fired before the actual command is executed.
A new command is also added to invoke code hints from Edit menu.
