### PR TITLE
Load default JSLint enabled status from a config file

### DIFF
--- a/src/extensions/default/JSLint/config.json
+++ b/src/extensions/default/JSLint/config.json
@@ -1,0 +1,3 @@
+{
+    "enabled_by_default": true
+}

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -52,10 +52,13 @@ define(function (require, exports, module) {
         JSLintTemplate          = require("text!htmlContent/bottom-panel.html"),
         ResultsTemplate         = require("text!htmlContent/results-table.html");
     
-    var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
+    var KeyboardPrefs = JSON.parse(require("text!keyboard.json")),
+        JSLintOptions = JSON.parse(require("text!config.json"));
     
     var INDICATOR_ID = "JSLintStatus",
-        defaultPrefs = { enabled: true };
+        defaultPrefs = {
+            enabled: JSLintOptions.enabled_by_default
+        };
     
     
     /** @const {string} JSLint commands ID */


### PR DESCRIPTION
This pull requests adds to the JSLint extension directory a `config.json` file that contains a single boolean property, `enabled_by_default`, which determines whether JSLint should be enabled in the absence of an `enabled` preference. 

This generalization allows Edge Code to disable JSLint by default. 
