### PR TITLE
Replace deprecated functions ($.fn.load, $.fn.error, jqXHR.success & jqXHR.error)

### DIFF
--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
         var $link = $("<link/>").attr(attributes);
         
         if (deferred) {
-            $link.load(deferred.resolve).error(deferred.reject);
+            $link.on('load', deferred.resolve).on('error', deferred.reject);
         }
         
         $link.appendTo("head");

--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -486,8 +486,8 @@ define(function (require, exports, module) {
         
         if (this.connected()) {
             $.getJSON("http://localhost:" + this._port + "/api")
-                .success(refreshInterfaceCallback)
-                .error(function () { deferred.reject(); });
+                .done(refreshInterfaceCallback)
+                .fail(function () { deferred.reject(); });
         } else {
             deferred.reject();
         }


### PR DESCRIPTION
As of jQuery 1.8, `$.fn.load` & `$.fn.error` have been deprecated, and cause an issue with the jQuery 2.0.0 upgrade. (http://api.jquery.com/error/)

Additionally, the `jqXHR.success` & `jqXHR.error` were deprecated in favor of the deferred `.done` & `.fail`. (http://api.jquery.com/jQuery.ajax/)
