### PR TITLE
Destroy modalBar after last occurence is replaced

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -325,6 +325,8 @@ define(function (require, exports, module) {
                             match = cursor.findNext();
                             if (!match ||
                                     (start && cursor.from().line === start.line && cursor.from().ch === start.ch)) {
+                                // No more matches, so destroy modalBar
+                                modalBar = null;
                                 return;
                             }
                         }


### PR DESCRIPTION
This is for issue #3748.

Note: the FindReplace.js code was copied directly from CodeMirror, so after we determine the fix, we should push a fix to CodeMirror.
