### PR TITLE
Fix JSCodeHint tests so they pass when running all tests.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
      * @param {function(Array.<string>)} successCallback - callback with
      * array of file path names.
      */
-    function getFilesInDirectory(dir, successCallback) {
+    function getFilesInDirectory(dir, successCallback, errorCallback) {
         var files = []; // file names without paths.
 
         /**
@@ -250,8 +250,7 @@ define(function (require, exports, module) {
         function fileCallback(path) {
             files.push(path);
         }
-
-        forEachFileInDirectory(dir, doneCallback, fileCallback);
+        forEachFileInDirectory(dir, doneCallback, fileCallback, null, errorCallback);
     }
 
     /**
@@ -781,6 +780,8 @@ define(function (require, exports, module) {
                 addFilesDeferred.resolveWith(null, [_ternWorker]);
             }
 
+        }, function () {
+            addFilesDeferred.resolveWith(null);
         });
     }
 


### PR DESCRIPTION
One of the promises the code hinter was waiting for internally was never being resolved because the directory it was looking for didn't exist.  Now resolve the promise even when the director doesn't exist so we don't just hang.
