### PR TITLE
Add placeholder menu when running native menu unit tests.

### DIFF
--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -38,12 +38,12 @@ define(function (require, exports, module) {
 
     describe("Native Menus", function () {
 
-        var TEST_MENU_TITLE = "TEST",
-            TEST_MENU_ID = "test",
-            TEST_MENU_ITEM = "Item 1",
-            TEST_MENU_ITEM_ID = "item1";
-
-        var PLACEHOLDER_MENU_ID = "placeholder";
+        var PLACEHOLDER_MENU_ID     = "placeholder",
+            PLACEHOLDER_MENU_TITLE  = "MENU",
+            TEST_MENU_TITLE         = "TEST",
+            TEST_MENU_ID            = "test",
+            TEST_MENU_ITEM          = "Item 1",
+            TEST_MENU_ITEM_ID       = "item1";
         
         it("should have a brackets.app namespace", function () {
             var complete = false,
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
             
             // Add an empty native menu so the menu bar doesn't keep flashing
             runs(function () {
-                brackets.app.addMenu("MENU", PLACEHOLDER_MENU_ID, "", "", function (err) {
+                brackets.app.addMenu(PLACEHOLDER_MENU_TITLE, PLACEHOLDER_MENU_ID, "", "", function (err) {
                     complete = true;
                     error = err;
                 });
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
             });
 		
             it("should return an error if invalid parameters are passed", function () {
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
@@ -195,7 +195,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -214,7 +214,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
                         error = err;
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
 
                 runs(function () {
                     expect(error).toBe(0);
@@ -249,7 +249,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -263,7 +263,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -284,7 +284,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -320,7 +320,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
 
                 runs(function () {
                     complete = false;
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
             });
 
             it("should add new menu before reference menu", function () {
@@ -344,7 +344,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -358,7 +358,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -379,7 +379,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -399,7 +399,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -415,7 +415,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
 
                 runs(function () {
                     complete = false;
@@ -424,7 +424,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
             });
 
             it("should add new menu at end of list when reference menu doesn't exist", function () {
@@ -437,7 +437,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -456,7 +456,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -472,7 +472,7 @@ define(function (require, exports, module) {
                         // Ignore error
                     });
                 });
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
             });
 
         }); // describe("addMenu (with reference)")
@@ -524,7 +524,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -540,7 +540,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -551,7 +551,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
             });
          
             it("should return an error if invalid parameters are passed", function () {
@@ -564,7 +564,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
@@ -603,7 +603,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -644,7 +644,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -663,7 +663,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -681,7 +681,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -707,7 +707,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -726,7 +726,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -744,7 +744,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -771,7 +771,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -790,7 +790,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -808,7 +808,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -834,7 +834,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -853,7 +853,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -871,7 +871,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -897,7 +897,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -916,7 +916,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -934,7 +934,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -977,7 +977,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     complete = false;
@@ -990,7 +990,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1007,7 +1007,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     complete = false;
@@ -1020,7 +1020,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1037,7 +1037,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     complete = false;
@@ -1050,7 +1050,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1067,7 +1067,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     complete = false;
@@ -1080,7 +1080,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1112,7 +1112,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1126,7 +1126,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1144,7 +1144,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
@@ -1162,7 +1162,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -1191,7 +1191,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1213,7 +1213,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1231,7 +1231,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, "calling removeMenuItem", 1000);
+                waitsFor(function () { return complete; }, "calling removeMenuItem");
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1246,7 +1246,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, "calling getMenuTitle", 1000);
+                waitsFor(function () { return complete; }, "calling getMenuTitle");
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -1263,7 +1263,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, "calling removeMenuItem", 1000);
+                waitsFor(function () { return complete; }, "calling removeMenuItem");
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
@@ -1280,7 +1280,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, "calling removeMenuItem", 1000);
+                waitsFor(function () { return complete; }, "calling removeMenuItem");
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
@@ -1309,7 +1309,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1332,7 +1332,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1352,7 +1352,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1368,7 +1368,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1384,7 +1384,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1405,7 +1405,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1421,7 +1421,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1437,7 +1437,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1455,7 +1455,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
@@ -1482,7 +1482,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1507,7 +1507,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1528,7 +1528,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1544,7 +1544,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1560,7 +1560,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1582,7 +1582,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1598,7 +1598,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1614,7 +1614,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(0);
@@ -1632,7 +1632,7 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return complete; });
                 
                 runs(function () {
                     expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);

--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -42,11 +42,28 @@ define(function (require, exports, module) {
             TEST_MENU_ID = "test",
             TEST_MENU_ITEM = "Item 1",
             TEST_MENU_ITEM_ID = "item1";
+
+        var PLACEHOLDER_MENU_ID = "placeholder";
         
         it("should have a brackets.app namespace", function () {
+            var complete = false,
+                error = 0;
+            
             expect(brackets.app).toBeTruthy();
+            
+            // Add an empty native menu so the menu bar doesn't keep flashing
+            runs(function () {
+                brackets.app.addMenu("MENU", PLACEHOLDER_MENU_ID, "", "", function (err) {
+                    complete = true;
+                    error = err;
+                });
+            });
+            
+            waitsFor(function () { return complete; });
+            
+            expect(error).toBe(0);
         });
-    
+
         describe("addMenu", function () {
         
             it("should add a menu", function () {
@@ -1623,5 +1640,20 @@ define(function (require, exports, module) {
             });
         });
         
+        it("should remove placeholder menu", function () {
+            var complete = false,
+                error = 0;
+            
+            runs(function () {
+                brackets.app.removeMenu(PLACEHOLDER_MENU_ID, function (err) {
+                    complete = true;
+                    error = err;
+                });
+            });
+            
+            waitsFor(function () { return complete; });
+            
+            expect(error).toBe(0);
+        });
     }); // describe("Native Menus")
 });


### PR DESCRIPTION
Fix for #2677

Add a placeholder menu at the beginning of the Native Menu unit tests and remove it at the end. 

This fixes the annoying flicker on Windows when running all of the tests. 
