### PR TITLE
Extension Installation fixes: synchronous directory creation and remove leftover files

### DIFF
--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -85,7 +85,9 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                     callbackCalled = true;
                     readStream.destroy();
                     fs.remove(installDirectory, function (err) {
-                        console.error("Error while removing directory after failed installation", installDirectory, err);
+                        if (err) {
+                            console.error("Error while removing directory after failed installation", installDirectory, err);
+                        }
                     });
                 }
             })
@@ -107,7 +109,9 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                                 callbackCalled = true;
                                 readStream.destroy();
                                 fs.remove(installDirectory, function (err) {
-                                    console.error("Error while removing directory after failed installation", installDirectory, err);
+                                    if (err) {
+                                        console.error("Error while removing directory after failed installation", installDirectory, err);
+                                    }
                                 });
                             }
                         });

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -84,6 +84,9 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                     callback(exc);
                     callbackCalled = true;
                     readStream.destroy();
+                    fs.remove(installDirectory, function (err) {
+                        console.error("Error while removing directory after failed installation", installDirectory, err);
+                    });
                 }
             })
             .on("entry", function (entry) {
@@ -91,23 +94,11 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                 if (prefixlength) {
                     installpath = installpath.substring(prefixlength + 1);
                 }
-                
                 if (entry.type === "Directory") {
                     if (installpath === "") {
                         return;
                     }
-                    extractStream.pause();
-                    fs.mkdirs(installDirectory + "/" + installpath, function (err) {
-                        if (err) {
-                            if (!callbackCalled) {
-                                callback(err);
-                                callbackCalled = true;
-                            }
-                            extractStream.close();
-                            return;
-                        }
-                        extractStream.resume();
-                    });
+                    fs.mkdirsSync(installDirectory + "/" + installpath);
                 } else {
                     entry.pipe(fs.createWriteStream(installDirectory + "/" + installpath))
                         .on("error", function (err) {
@@ -115,6 +106,9 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
                                 callback(err);
                                 callbackCalled = true;
                                 readStream.destroy();
+                                fs.remove(installDirectory, function (err) {
+                                    console.error("Error while removing directory after failed installation", installDirectory, err);
+                                });
                             }
                         });
                 }

--- a/src/extensibility/node/node_modules/unzip/node_modules/fstream/node_modules/graceful-fs/README.md
+++ b/src/extensibility/node/node_modules/unzip/node_modules/fstream/node_modules/graceful-fs/README.md
@@ -1,5 +1,33 @@
-Just like node's `fs` module, but it does an incremental back-off when
-EMFILE is encountered.
+# graceful-fs
 
-Useful in asynchronous situations where one needs to try to open lots
-and lots of files.
+graceful-fs functions as a drop-in replacement for the fs module,
+making various improvements.
+
+The improvements are meant to normalize behavior across different
+platforms and environments, and to make filesystem access more
+resilient to errors.
+
+## Improvements over fs module
+
+graceful-fs:
+
+* keeps track of how many file descriptors are open, and by default
+  limits this to 1024. Any further requests to open a file are put in a
+  queue until new slots become available. If 1024 turns out to be too
+  much, it decreases the limit further.
+* fixes `lchmod` for Node versions prior to 0.6.2.
+* implements `fs.lutimes` if possible. Otherwise it becomes a noop.
+* ignores `EINVAL` and `EPERM` errors in `chown`, `fchown` or
+  `lchown` if the user isn't root.
+* makes `lchmod` and `lchown` become noops, if not available.
+* retries reading a file if `read` results in EAGAIN error.
+
+On Windows, it retries renaming a file for up to one second if `EACCESS`
+or `EPERM` error occurs, likely because antivirus software has locked
+the directory.
+
+## Configuration
+
+The maximum number of open file descriptors that graceful-fs manages may
+be adjusted by setting `fs.MAX_OPEN` to a different number. The default
+is 1024.

--- a/src/extensibility/node/node_modules/unzip/node_modules/fstream/node_modules/graceful-fs/package.json
+++ b/src/extensibility/node/node_modules/unzip/node_modules/fstream/node_modules/graceful-fs/package.json
@@ -5,8 +5,8 @@
     "url": "http://blog.izs.me"
   },
   "name": "graceful-fs",
-  "description": "fs monkey-patching to avoid EMFILE and other problems",
-  "version": "1.2.0",
+  "description": "A drop-in replacement for fs, making various improvements.",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/node-graceful-fs.git"
@@ -23,14 +23,23 @@
   },
   "keywords": [
     "fs",
-    "EMFILE",
+    "module",
+    "reading",
+    "retry",
+    "retries",
+    "queue",
     "error",
+    "errors",
     "handling",
-    "monkeypatch"
+    "EMFILE",
+    "EAGAIN",
+    "EINVAL",
+    "EPERM",
+    "EACCESS"
   ],
   "license": "BSD",
-  "readme": "Just like node's `fs` module, but it does an incremental back-off when\nEMFILE is encountered.\n\nUseful in asynchronous situations where one needs to try to open lots\nand lots of files.\n",
+  "readme": "# graceful-fs\n\ngraceful-fs functions as a drop-in replacement for the fs module,\nmaking various improvements.\n\nThe improvements are meant to normalize behavior across different\nplatforms and environments, and to make filesystem access more\nresilient to errors.\n\n## Improvements over fs module\n\ngraceful-fs:\n\n* keeps track of how many file descriptors are open, and by default\n  limits this to 1024. Any further requests to open a file are put in a\n  queue until new slots become available. If 1024 turns out to be too\n  much, it decreases the limit further.\n* fixes `lchmod` for Node versions prior to 0.6.2.\n* implements `fs.lutimes` if possible. Otherwise it becomes a noop.\n* ignores `EINVAL` and `EPERM` errors in `chown`, `fchown` or\n  `lchown` if the user isn't root.\n* makes `lchmod` and `lchown` become noops, if not available.\n* retries reading a file if `read` results in EAGAIN error.\n\nOn Windows, it retries renaming a file for up to one second if `EACCESS`\nor `EPERM` error occurs, likely because antivirus software has locked\nthe directory.\n\n## Configuration\n\nThe maximum number of open file descriptors that graceful-fs manages may\nbe adjusted by setting `fs.MAX_OPEN` to a different number. The default\nis 1024.\n",
   "readmeFilename": "README.md",
-  "_id": "graceful-fs@1.2.0",
+  "_id": "graceful-fs@1.2.1",
   "_from": "graceful-fs@~1.2.0"
 }


### PR DESCRIPTION
Fixes for #3734 and #3735 by using sync directory creation and removing leftover files from failed installations.

(Also includes a harmless update to the latest version of graceful-fs which has an updated readme)
