### PR TITLE
[JS Code Hints] Fix crash when hinting with angular.js.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -57,8 +57,8 @@ define(function (require, exports, module) {
         numResolvedFiles    = 0,
         numAddedFiles       = 0,
         stopAddingFiles     = false,
-        excludedFilesString = "require\\.js$|jquery-[\\d]\\.[\\d]\\.js$|\\.min\\.js$",
-        excludedFilesRegEx  = new RegExp(excludedFilesString),
+        // exclude require and jquery since we have special knowledge of those
+        excludedFilesRegEx  = /require\.js$|jquery-[\d]\.[\d]\.js$/,
         _ternWorker         = (function () {
             var path = ExtensionUtils.getModulePath(module, "tern-worker.js");
             return new Worker(path);


### PR DESCRIPTION
Updated to a version of tern that fixes the bug.
Take out the excludes of minified libraries, as they all work now that the bug is fixed.
Stil exclude require and jquery files since we have json defs files for those that have better type information.
Fixes Issue #3827

All code hinting tests pass
Also tested all the different frameworks in todomvc, and they all work now.
