### PR TITLE
Updates to bigger documentation pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-### Filing a bug?
+# The Basics
+
+### Filing a bug
 
 Check the [Troubleshooting Page](https://github.com/adobe/brackets/wiki/Troubleshooting) for common
 issues with installing & launching Brackets, using Live Preview, etc.
@@ -11,21 +13,23 @@ Disable all extensions to verify the issue is a core Brackets bug.
 **For feature requests** please first check our [feature backlog](http://bit.ly/BracketsBacklog) to
 see if it's already there. You can upvote features you'd like to see.
 
-### Submitting a pull request?
+### Submitting a pull request
 
 **Before you start coding**, post to the [brackets-dev Google group](http://groups.google.com/group/brackets-dev)
 or the [#brackets IRC channel on freenode](http://webchat.freenode.net/?channels=brackets) about what
 you're thinking of working on, so you can get early feedback. We don't want you to do tons of work
-and then have to rewrite half of it.
+and then have to rewrite half of it!
 
 For more on what's expected in a good pull request, see [Contributing Code](#contributing-code) below.
 
 
-# Contributing to Brackets
+# Ways to Contribute
 
 There are many ways you can contribute to the Brackets project:
 
 * **Fix a bug** or **implement a new feature** - read on below.
+* **[Write a Brackets extension](https://github.com/adobe/brackets/wiki/How-to-write-extensions)** and
+  tell us about it!
 * **Test Brackets** and [report bugs](https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue)
   you find. For sample testing steps, see
   [Brackets smoke tests](https://github.com/adobe/brackets/wiki/Brackets-Smoke-Tests),
@@ -37,10 +41,8 @@ There are many ways you can contribute to the Brackets project:
 * **Write documentation** and help keep it up to date
   (the [How to Use Brackets](https://github.com/adobe/brackets/wiki/How-to-Use-Brackets) intro page
   is one example).
-* Try out various [Brackets extensions](https://github.com/adobe/brackets/wiki/Brackets-Extensions)
+* **Try out some [Brackets extensions](https://github.com/adobe/brackets/wiki/Brackets-Extensions)**
   and give feedback to their authors.
-* [Write your own extension](https://github.com/adobe/brackets/wiki/How-to-write-extensions) and
-  tell us about it!
 
 
 ## Where Do I Start?
@@ -52,12 +54,12 @@ Here are some ideas:
 
 * [Starter bugs](https://github.com/adobe/brackets/issues?labels=starter+bug&state=open) can
   provide a good intro to the Brackets code.
+* [Extension ideas](https://github.com/adobe/brackets/issues?labels=Extension+Idea&state=closed)
+  are feature requests that we think would be best implemented as an add-on; it's up to the
+  Brackets community to write them!
 * [Starter features](http://bit.ly/BracketsBacklog) are a bit larger in scope. Be sure to discuss
   these in the newsgroup before starting. _(To see starter features, click Filter Cards on the
   right and then click the green "Starter Feature" label)._
-* [Extension ideas](https://github.com/adobe/brackets/issues?labels=Extension+Idea&state=open)
-  are feature requests that we think would be best implemented as an add-on; it's up to the
-  Brackets community to write them!
 
 Once you're ready to start coding, see the next section, [Contributing Code](#contributing-code).
 
@@ -70,6 +72,8 @@ before you've learned to code!
 
 ## Contributing Code
 
+To get started editing the Brackets code, read [How to Hack on Brackets](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets).
+
 Before submitting any pull request, please make sure to:
 
 1. Discuss any major changes or questions beforehand in the [brackets-dev newsgroup](http://groups.google.com/group/brackets-dev).
@@ -81,7 +85,7 @@ Before submitting any pull request, please make sure to:
    (we cannot merge before this).
 
 High quality code and a top-notch user experience are very important in Brackets, and we carefully
-review pull requests keep it that way. The better you follow the guidelines above, the more likely
+review pull requests to keep it that way. The better you follow the guidelines above, the more likely
 we are to accept your pull request - and the faster the code review will go.
 
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,58 +1,113 @@
-###Curious to start contributing to Brackets?
+### Filing a bug?
+
+Check the [Troubleshooting Page](https://github.com/adobe/brackets/wiki/Troubleshooting) for common
+issues with installing & launching Brackets, using Live Preview, etc.
+
+**For bugs** be sure to search existing issues first. Include steps to consistently reproduce the
+problem, actual vs. expected results, and your OS and Brackets version number.
+Disable all extensions to verify the issue is a core Brackets bug.
+[Read more guidelines for filing good bugs...](https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue)
+
+**For feature requests** please first check our [feature backlog](http://bit.ly/BracketsBacklog) to
+see if it's already there. You can upvote features you'd like to see.
+
+### Submitting a pull request?
+
+**Before you start coding**, post to the [brackets-dev Google group](http://groups.google.com/group/brackets-dev)
+or the [#brackets IRC channel on freenode](http://webchat.freenode.net/?channels=brackets) about what
+you're thinking of working on, so you can get early feedback. We don't want you to do tons of work
+and then have to rewrite half of it.
+
+For more on what's expected in a good pull request, see [Contributing Code](#contributing-code) below.
 
 
-With this file we want to provide some general guidance how to contribute to Brackets - your [feedback](https://groups.google.com/forum/?fromgroups=#!topic/brackets-dev/yEsaied7Fq8) is very welcome.
+# Contributing to Brackets
 
-Issues starting Brackets the first time? Please review the [Troubleshooting Page](https://github.com/adobe/brackets/wiki/Troubleshooting).         
+There are many ways you can contribute to the Brackets project:
 
-## Starter Bugs
+* **Fix a bug** or **implement a new feature** - read on below.
+* **Test Brackets** and [report bugs](https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue)
+  you find. For sample testing steps, see
+  [Brackets smoke tests](https://github.com/adobe/brackets/wiki/Brackets-Smoke-Tests),
+  [smoke tests with a local server](https://github.com/adobe/brackets/wiki/Brackets-Server-Smoke-Tests), and
+  [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests).
+* **Write unit tests** for Brackets.
+* **Translate** Brackets into other languages (and help keep those translations up to date) - see
+  [localization README](https://github.com/adobe/brackets/blob/master/src/nls/README.md).
+* **Write documentation** and help keep it up to date
+  (the [How to Use Brackets](https://github.com/adobe/brackets/wiki/How-to-Use-Brackets) intro page
+  is one example).
+* Try out various [Brackets extensions](https://github.com/adobe/brackets/wiki/Brackets-Extensions)
+  and give feedback to their authors.
+* [Write your own extension](https://github.com/adobe/brackets/wiki/How-to-write-extensions) and
+  tell us about it!
 
-If you need some inspiration for a **starter bug**, we have some for you either as [GitHub Issue](https://github.com/adobe/brackets/issues?labels=starter+bug&page=1&state=open) or on the [Trello Board](https://trello.com/board/brackets/4f90a6d98f77505d7940ce88) (there, choose on the right hand sidebar "Filter Cards" and then click on "Starter Feature").
 
-## Getting Started
+## Where Do I Start?
 
-**Before you start coding**, post to the [brackets-dev Google group](http://groups.google.com/group/brackets-dev) or the [#brackets IRC channel on freenode](http://freenode.net) about what you're thinking of working on, so you can get early feedback. 
-If you wouldn't chat about your idea that's cool too, but we may have to reject your pull request. This also provides you with an opportunity to find out what others including the core team are working on.      
+To start editing the Brackets code, read **[How to Hack on Brackets](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets)**.
+To create your first Brackets extension, check out **[How to Write Extensions](https://github.com/adobe/brackets/wiki/How-to-write-extensions)**.
+
+Here are some ideas:
+
+* [Starter bugs](https://github.com/adobe/brackets/issues?labels=starter+bug&state=open) can
+  provide a good intro to the Brackets code.
+* [Starter features](http://bit.ly/BracketsBacklog) are a bit larger in scope. Be sure to discuss
+  these in the newsgroup before starting. _(To see starter features, click Filter Cards on the
+  right and then click the green "Starter Feature" label)._
+* [Extension ideas](https://github.com/adobe/brackets/issues?labels=Extension+Idea&state=open)
+  are feature requests that we think would be best implemented as an add-on; it's up to the
+  Brackets community to write them!
+
+Once you're ready to start coding, see the next section, [Contributing Code](#contributing-code).
+
+**I'm new to JavaScript. How can I contribute to Brackets?** Brackets is a lot more complicated
+than the average website that uses JS. Better to start on some JS tutorials (like [Codecademy's](http://www.codecademy.com/tracks/javascript)
+or [MDN's](https://developer.mozilla.org/en-US/docs/JavaScript/Getting_Started)) and contribute
+in some of the other ways listed above. Testing is a great way to start thinking like a programmer
+before you've learned to code!
 
 
-Brackets is developed using Agile development methodologies, features are tracked as user stories on the [public Brackets backlog](http://bit.ly/BracketsBacklog). You may _vote_ on existing stories or find stories to work on with others.
-
-1. Please sign the [Brackets Contributor License Agreement](http://dev.brackets.io/brackets-contributor-license-agreement.html). You must agree to and submit this before you can contribute to Brackets.
-
-1. Please collaborate with others in providing and receiving guidance; the Brackets team made it a priority 
-to look at pull requests daily, however depending on the feature priority, the complexity of a contribution, 
-and available bandwidth we may not be able to work on it right away.
-
-
-## Making Changes
-If you use Brackets to edit Brackets, you can quickly reload the app itself by choosing Debug > Reload Brackets from the in-app menu.
-When coding, make sure to follow our [coding conventions](https://github.com/adobe/brackets/wiki/Brackets%20Coding%20Conventions).
-
+## Contributing Code
 
 Before submitting any pull request, please make sure to:
 
-1. read the following wiki page on GitHub: https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets.
-1. merge from adobe/brackets master
-1. re-test your code after the merge
-1. run the unit tests with Debug > Run Tests -- everything should pass
-1. if your change is nontrivial or might have affected the UI, run through the [Brackets smoke tests](Brackets-Smoke-Tests) and possibly the [Brackets server smoke tests](Brackets-Server-Smoke-Tests).
-1. review the [Pull Request Checklist](https://github.com/adobe/brackets/wiki/Pull-Request-Checklist) for additional guidance.
+1. Discuss any major changes or questions beforehand in the [brackets-dev newsgroup](http://groups.google.com/group/brackets-dev).
+2. Consider whether your change would be better as an optional extension. Brackets is lightweight
+   and tightly focused - but highly extensible.
+3. Follow the [Pull Request Checklist](https://github.com/adobe/brackets/wiki/Pull-Request-Checklist)
+   to ensure a good-quality pull request.
+4. Sign the [Brackets Contributor License Agreement](http://dev.brackets.io/brackets-contributor-license-agreement.html)
+   (we cannot merge before this).
+
+High quality code and a top-notch user experience are very important in Brackets, and we carefully
+review pull requests keep it that way. The better you follow the guidelines above, the more likely
+we are to accept your pull request - and the faster the code review will go.
+
  
-## Reviewing Code, Committing
+## The Code Review Process
 
-In general code reviews can be performed by anyone who knows his/her limits, is familiar with the feature area and the architecture, 
-where the code, being reviewed, is added or altered.
-To submit changes one needs commit rights - those are limited to ensure sustainable high quality. Committers are tasked with taking 
-a leading role in the project by making code contributions, assisting others with their contributions in the form 
-of reviewing and merging pull requests, and providing feedback and suggestions on the direction of the project.
+Brackets committers are responsible for reviewing all pull requests, providing feedback, and
+ultimately merging good code into `master`. The review process ensures all code is high quality,
+maintainable, and well documented.
 
-Please refer to the [Committer Policy](https://github.com/adobe/brackets/wiki/Brackets-Committer-Policy) for more information.
-If you want to perform reviews, but don't have commit rights yet, we encourage you to do so. Please add a note that you start reviewing.
-After you have finished your review ping us at IRC or leave a comment that your review has been completed. A committer will submit the pull request based on 
-priority. If a pull request already shows an assignee, please check with him/her first.
+Once you've opened a pull request, a committer will generally respond to it within a week with an
+initial set of comments (you don't need to ping anyone to find a reviewer). Some pull requests
+raise larger questions about UI design, product scope or architecture. Those are tagged to indicate
+that review will take longer:
 
-##Additional Resources
+* \[PM\] - needs high-level input from product management
+* \[XD\] - needs UI design / visual design discussion
+* \[ARCH\] - needs architectural discussion
 
-* [the Brackets github issue tracker](https://github.com/adobe/brackets/issues)
-* [Brackets wiki](https://github.com/adobe/brackets/wiki/Resources)
-* [Contribute Page](http://brackets.io/contribute/)
+The best way to avoid this sort of holdup is to discuss your changes on the newsgroup first!
+
+Once your pull request is merged, it will appear in the next release of Brackets - generally within
+two weeks.
+
+**Interested in becoming a committer?** See the [Committer Policy](https://github.com/adobe/brackets/wiki/Brackets-Committer-Policy)
+for details. Committers are expected to take a leading role in the project by making significant
+code contributions, reviewing pull requests, and providing feedback and suggestions on the
+direction of the project.
+
+Even if you're not a committer, you're still welcome to give feedback on any pull request!

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ How to run Brackets
 
 **Brackets isn't ready for general use yet.** It's still missing a lot of basic
 editor features. That said, what's there is reasonably stable&mdash;the
-Brackets team uses Brackets to develop Brackets full time. So if you're
-adventurous, try it out!
+Brackets team uses Brackets to develop Brackets full time. So feel free to
+give it a spin and let us know what's missing!
 
 Although Brackets is built in HTML/CSS/JS, it currently runs as a desktop 
 application in a thin native shell, so that it can access your local files.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ You can see some
 [screenshots of Brackets](https://github.com/adobe/brackets/wiki/Brackets-Screenshots)
 on the wiki and [intro videos](http://www.youtube.com/user/CodeBrackets) on the Brackets YouTube channel.
 
-Brackets is early in development, so many of the features you would
+Brackets is fairly early in development, so some of the features you would
 expect in a code editor are missing, and some existing features might be
 incomplete or not as useful as you'd want. But if you like the direction
-it's going, the [CONTRIBUTING.md](https://github.com/adobe/brackets/blob/master/CONTRIBUTING.md) 
-file contains some useful links to help you get started. Please contribute!    
+it's going, _there are lots of ways you can help._ See [CONTRIBUTING.md](https://github.com/adobe/brackets/blob/master/CONTRIBUTING.md)
+for more info. Please contribute!
 
 The text editor inside Brackets is based on 
 [CodeMirror](http://github.com/marijnh/CodeMirror)&mdash;thanks to Marijn for
@@ -36,10 +36,10 @@ for info on how we're using CodeMirror.
 How to run Brackets
 -------------------
 
-**Brackets isn't ready for general use yet.** It's still early in
-development, is missing a lot of basic editor features, and *probably*
-has bugs. That said, we've actually been using Brackets to develop Brackets
-for awhile now, so what's there is reasonably stable.
+**Brackets isn't ready for general use yet.** It's still missing a lot of basic
+editor features. That said, what's there is reasonably stable&mdash;the
+Brackets team uses Brackets to develop Brackets full time. So if you're
+adventurous, try it out!
 
 Although Brackets is built in HTML/CSS/JS, it currently runs as a desktop 
 application in a thin native shell, so that it can access your local files.
@@ -58,7 +58,7 @@ directly via git, see [How to Hack on Brackets](https://github.com/adobe/bracket
 for instructions on how to get everything. 
 
 By default, Brackets opens a folder containing some simple "Getting Started" content.
-You can choose a different folder to edit from *File > Open Folder*. (Might we
+You can choose a different folder to edit using *File > Open Folder*. (Might we
 suggest editing the Brackets source code and submitting some pull requests?)
 
 Most of Brackets should be pretty self-explanatory, but for information on how
@@ -71,34 +71,39 @@ for a list of new features and known issues in each build.
 
 I found a bug/missing feature!
 ------------------------------
-     
-Issues starting Brackets the first time? Please review [Troubleshooting](https://github.com/adobe/brackets/wiki/Troubleshooting).         
-       
-Brackets bugs are tracked in [the Brackets github issue tracker](https://github.com/adobe/brackets/issues). 
-When filing a new bug, please remember to include:
 
-* Brackets version/sprint number (or commit SHA if you're pulling directly from the repo)
-* Platform/OS version
-* Steps to reproduce problem with actual and expected results
-* Link to test files (you can create a gist on [gist.github.com](https://gist.github.com/) 
-  if that's convenient)       
-       
-More details on how to file an issue can be found [here](https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue).     
-For feature requests, go ahead and file them in the issue tracker; they'll be converted
-to user stories on the [public Brackets backlog*](http://bit.ly/BracketsBacklog).
+Issues starting Brackets the first time? Please review [Troubleshooting](https://github.com/adobe/brackets/wiki/Troubleshooting).
 
-\* Please excuse the mess in the "Icebox (To Be Reviewed)" list. We're still importing data from our internal system.
+**For bugs** be sure to [search existing issues](https://github.com/adobe/brackets/issues) first.
+Include steps to consistently reproduce the problem, actual vs. expected results, and your OS and
+Brackets version number. Disable all extensions to verify the issue is a core Brackets bug.
+[Read more guidelines for filing good bugs...](https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue)
+
+**For feature requests** please first check our [feature backlog](http://bit.ly/BracketsBacklog) to
+see if it's already there; you can upvote it if so. If not, feel free to file it as an issue; we'll
+move it to the feature backlog for you.
 
 I want to help!
 ---------------
 
-Awesome! Please read [How to Hack on Brackets](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets).
+Awesome! Please read the [Guide to Contributing](https://github.com/adobe/brackets/blob/master/CONTRIBUTING.md)
+and learn [How to Hack on Brackets](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets).
 
 I want to keep track of how Brackets is doing!
 ----------------------------------------------
 
-Not sure you needed the exclamation point there, but I like your enthusiasm.
+Not sure you needed the exclamation point there, but we like your enthusiasm.
+
+**What's Brackets working on next?**
+
+* In our [feature backlog](http://bit.ly/BracketsBacklog), the columns labeled "Sprint N"
+  are features already in progress and should ship within 2 weeks. Features at the top of
+  the "Product Backlog" list will come next.
+* Watch our [GitHub activity stream](https://github.com/adobe/brackets/pulse).
+
+**Contact info:**
 
 * **Twitter:** [@brackets](http://twitter.com/#!/brackets)
+* **Blog:** http://blog.brackets.io/
 * **IRC:** [#brackets on freenode](http://webchat.freenode.net/?channels=brackets)
 * **Developers mailing list:** http://groups.google.com/group/brackets-dev

--- a/samples/root/Getting Started/index.html
+++ b/samples/root/Getting Started/index.html
@@ -115,7 +115,7 @@
             For those of us who haven't yet memorized the color equivalents for HEX or RGB values, Brackets makes
             it quick and easy to see exactly what color is being used. In either CSS or HTML, simply hover over any
             color value or gradient and Brackets will display a preview of that color/gradient automatically. The
-            same goes for images simply hover over the image link in the Brackets editor and it will display a
+            same goes for images: simply hover over the image link in the Brackets editor and it will display a
             thumbnail preview of that image.
         </p>
         
@@ -123,8 +123,8 @@
             To try out Quick View for yourself, place your cursor on the <!-- <body> --> tag at the top of this
             document and press <kbd>Cmd/Ctrl + E</kbd> to open a CSS quick editor. Now simply hover over any of the
             color values within the CSS. You can also see it in action on gradients by opening a CSS quick editor
-            on the HTML tag at the top of this page and hovering over any of the background image values. To test
-            out the image preview, place your cursor over the screenshot image included earlier in this document.
+            on the <!-- <html> --> tag and hovering over any of the background image values. To try out the image
+            preview, place your cursor over the screenshot image included earlier in this document.
         </samp>
         
         <!--

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -62,10 +62,11 @@
  *     });
  * You can combine file names and extensions, or not define them at all.
  *
- * You can also refine an existing language. Currently you can only set the comment styles:
+ * You can also refine an existing language:
  *     var language = LanguageManager.getLanguage("haskell");
  *     language.setLineCommentSyntax(["--"]);
  *     language.setBlockCommentSyntax("{-", "-}");
+ *     language.addFileExtension("lhs");
  *
  * Some CodeMirror modes define variations of themselves. They are called MIME modes.
  * To find existing MIME modes, search for "CodeMirror.defineMIME" in thirdparty/CodeMirror2/mode

--- a/src/nls/README.md
+++ b/src/nls/README.md
@@ -9,65 +9,70 @@
 2. Add an entry for your translation to the `module.exports` object in `nls/strings.js`.
    (Eventually, we should remove this requirement and just scan the folder for available languages.)
 3. Copy the root `strings.js` file into your subfolder and start translating!
+4. Use the [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests) to
+   see strings in context.
 
-Strings not specified in a given locale will fall back to the language for that locale, if any,
-and strings not specified in either the locale or its language will fall back to the `root`
-string entry.
+Strings not specified in a given locale will fall back to the general language (without hyphen)
+first, and then will fall back to the English string from `nls/root/strings.js`.
 
-Localization is provided via the require.js i18n plugin. See the [require i18n docs][1]
-for more info.
+Localization is provided via the [require.js i18n plugin](http://requirejs.org/docs/api.html#i18n).
 
-## How to translate the Getting Started project
+### Translating the Getting Started project
 
 When first installed, Brackets will open a Getting Started project that serves
 as an introduction to Brackets features. This project can be translated by 
 providing a ``urls.js`` file that points to a localized directory under the
-``samples`` folder at the root of the Brackets repository. See the French (fr)
-localization (src/nls/fr/urls.js) for an example.
+``samples`` folder at the root of the Brackets repository. See the French
+localization (`src/nls/fr/urls.js`) for an example.
 
-[1]: http://requirejs.org/docs/api.html#i18n
 
-# How to make changes to existing translations
+# How to modify existing translations
 
-## Adobe contributed translations
+### Adobe-maintained translations
 
-As of sprint 21, Adobe provides translations for the following languages:
+Adobe provides translations for the following languages:
 
 * French (fr)
 * Japanese (ja)
 
-For all Adobe translations, Adobe asks that you do not submit pull requests
-that directly modify these files. Instead, there are 2 ways to contribute
-changes:
+These translations cannot be modified through our normal pull request
+process. Please contribute changes one of these ways:
 
 1. File an issue in our GitHub repository
    https://github.com/adobe/brackets/issues
-2. Submit a proposal at the Adobe® Translation Center (ATC),
-   http://translate.adobe.com (http://bit.ly/TranslateBrackets direct link to
-   Brackets)
+2. Submit a proposal at the Adobe® Translation Center (ATC), [under the Brackets
+   product](http://bit.ly/TranslateBrackets). At ATC, proposals can be voted on
+   by peers and are eventually accepted by moderators.
 
-At ATC, proposals can be voted on by peers and are eventually accepted by
-moderators.
+### Community-maintained translations
 
-## Community contributed translations
+The following languages have been contributed by the Brackets community:
 
-As of sprint 21, the following languages have been contributed by the Brackets
-community:
-
+* Czech (cs)
 * German (de)
 * Spanish (es)
 * Italian (it)
 * Norwegian Bokmål (nb)
+* Polish (pl)
 * Brazilian Portuguese (pt-br)
 * Portuguese (pt-pt)
-* Turkish (tr)
 * Russian (ru)
 * Swedish (sv)
+* Turkish (tr)
+* Simlified Chinese (zh-cn)
 
 These translations _can be directly modified_ through our normal pull request
 process.
 
-In the future, Adobe may support these languages officially and import these
-original translations into the Adobe Localization Framework. Once in ALF,
-changes to translations must follow the Adobe contributed translation
-guidelines above.
+In the future, Adobe may begin maintaining some of these languages too, at which
+point the process will switch to the one above. But until then, please _do not
+use_ http://translate.adobe.com for these languages.
+
+
+# Translation limitations
+
+Some strings cannot be localized yet:
+
+* [Keyboard shortcuts](https://trello.com/c/4k2yalBd)
+* [Some native menus on Mac](https://trello.com/c/0IsE7q02) (hardcoded support only for English, French, Japanese)
+* Windows installer UI (hardcoded support only for English, Japanese - with some limitations)


### PR DESCRIPTION
- _CONTRIBUTING.md_: big revamp. Broaden scope; put bug & pull request info at top (since it's linked the 'New Issue' & 'Create pull request' pages); clean up wording; remove some info that's redundant with other pages & link to them instead
- _README.md_: soften "it's early" messaging a tad; emphasize CONTRIBUTING.md more; revamp bug-filing section; add small "What's Brackets working on next?" section
- _nls/README.md_: tighten wording; update list of languages
- _Getting Started_: fix typos
- _LanguageManager_: fix incorrect statement about extensibility

@njx hoping you might have time to review this.  CC @adrocknaphobia @pthiess @gruehle in case you guys have feedback too.
