### PR TITLE
Use Tern jump-to-definition search for quickeditt

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -95,6 +95,12 @@ define(function (require, exports, module) {
     var _inlineEditProviders = [];
     
     /**
+     * QuickEdit helper function.
+     * @type {function}
+     */
+    var _quickEditHelper = null;
+    
+    /**
      * Registered inline documentation widget providers. See {@link #registerInlineDocsProvider()}.
      * @type {Array.<function(...)>}
      */
@@ -214,7 +220,23 @@ define(function (require, exports, module) {
     function registerInlineEditProvider(provider) {
         _inlineEditProviders.push(provider);
     }
-    
+
+    /**
+     * Registers a helper for QuickEdit to provide a hook into Tern's jump-to-defintion.
+     * 
+     * @param {function}
+     */
+    function registerQuickEditHelper(helper) {
+        _quickEditHelper = helper;
+    }
+
+    /**
+     * Return QuickEdit helper.
+     */
+    function getQuickEditHelper() {
+        return _quickEditHelper;
+    }
+
     /**
      * Registers a new inline docs provider. When Quick Docs is invoked each registered provider is
      * asked if it wants to provide inline docs given the current editor and cursor location.
@@ -732,6 +754,8 @@ define(function (require, exports, module) {
     exports.getFocusedInlineWidget = getFocusedInlineWidget;
     exports.resizeEditor = resizeEditor;
     exports.registerInlineEditProvider = registerInlineEditProvider;
+    exports.registerQuickEditHelper = registerQuickEditHelper;
+    exports.getQuickEditHelper = getQuickEditHelper;
     exports.registerInlineDocsProvider = registerInlineDocsProvider;
     exports.getInlineEditors = getInlineEditors;
     exports.closeInlineWidget = closeInlineWidget;

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -95,12 +95,6 @@ define(function (require, exports, module) {
     var _inlineEditProviders = [];
     
     /**
-     * QuickEdit helper function.
-     * @type {function}
-     */
-    var _quickEditHelper = null;
-    
-    /**
      * Registered inline documentation widget providers. See {@link #registerInlineDocsProvider()}.
      * @type {Array.<function(...)>}
      */
@@ -219,22 +213,6 @@ define(function (require, exports, module) {
      */
     function registerInlineEditProvider(provider) {
         _inlineEditProviders.push(provider);
-    }
-
-    /**
-     * Registers a helper for QuickEdit to provide a hook into Tern's jump-to-defintion.
-     * 
-     * @param {function}
-     */
-    function registerQuickEditHelper(helper) {
-        _quickEditHelper = helper;
-    }
-
-    /**
-     * Return QuickEdit helper.
-     */
-    function getQuickEditHelper() {
-        return _quickEditHelper;
     }
 
     /**
@@ -754,8 +732,6 @@ define(function (require, exports, module) {
     exports.getFocusedInlineWidget = getFocusedInlineWidget;
     exports.resizeEditor = resizeEditor;
     exports.registerInlineEditProvider = registerInlineEditProvider;
-    exports.registerQuickEditHelper = registerQuickEditHelper;
-    exports.getQuickEditHelper = getQuickEditHelper;
     exports.registerInlineDocsProvider = registerInlineDocsProvider;
     exports.getInlineEditors = getInlineEditors;
     exports.closeInlineWidget = closeInlineWidget;

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -166,10 +166,9 @@ define(function (require, exports, module) {
         self.setSelectedIndex(0);
         
         if (this._ranges.length > 1) {      // attach to main container
-            this.$htmlContent.append(this.$relatedContainer).append(this.$editorsDiv);
-        } else {                            // no need to show ranges found if there's only one
-            this.$htmlContent.append(this.$editorsDiv);
+            this.$htmlContent.append(this.$relatedContainer);
         }
+        this.$htmlContent.append(this.$editorsDiv);
                 
         // Listen for clicks directly on us, so we can set focus back to the editor
         var clickHandler = this._onClick.bind(this);

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -126,13 +126,13 @@ define(function (require, exports, module) {
         this.$editorsDiv.on("mousewheel.MultiRangeInlineEditor", function (e) {
             e.stopPropagation();
         });
-        
+
         // Outer container for border-left and scrolling
         this.$relatedContainer = $(window.document.createElement("div")).addClass("related-container");
         
         // List "selection" highlight
         this.$selectedMarker = $(window.document.createElement("div")).appendTo(this.$relatedContainer).addClass("selection");
-        
+
         // Inner container
         this.$related = $(window.document.createElement("div")).appendTo(this.$relatedContainer).addClass("related");
         
@@ -165,8 +165,11 @@ define(function (require, exports, module) {
         // select the first range
         self.setSelectedIndex(0);
         
-        // attach to main container
-        this.$htmlContent.append(this.$relatedContainer).append(this.$editorsDiv);
+        if (this._ranges.length > 1) {      // attach to main container
+            this.$htmlContent.append(this.$relatedContainer).append(this.$editorsDiv);
+        } else {                            // no need to show ranges found if there's only one
+            this.$htmlContent.append(this.$editorsDiv);
+        }
                 
         // Listen for clicks directly on us, so we can set focus back to the editor
         var clickHandler = this._onClick.bind(this);

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -400,6 +400,14 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @param {string} file a relative path
+     * @return {string} returns the path we resolved when we tried to parse the file, or undefined
+     */
+    function getResolvedPath(file) {
+        return resolvedFiles[file];
+    }
+
+    /**
      * Get a Promise for the definition from TernJS, for the file & offset passed in.
      * @return {jQuery.Promise} - a promise that will resolve to definition when
      *      it is done
@@ -617,14 +625,6 @@ define(function (require, exports, module) {
                 $deferredHints.resolveWith(null, [fnType]);
             }
         }
-    }
-
-    /**
-     * @param {string} file a relative path
-     * @return {string} returns the path we resolved when we tried to parse the file, or undefined
-     */
-    function getResolvedPath(file) {
-        return resolvedFiles[file];
     }
 
     /**

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -449,9 +449,8 @@ define(function (require, exports, module) {
         
         var $deferredJump = getPendingRequest(file, offset, HintUtils.TERN_JUMPTODEF_MSG);
         
-//        pendingTernRequests[file] = null;
-        
         if ($deferredJump) {
+            response.fullPath = getResolvedPath(response.resultFile);
             $deferredJump.resolveWith(null, [response]);
         }
     }

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -587,7 +587,7 @@ define(function (require, exports, module) {
         CommandManager.register(Strings.CMD_JUMPTO_DEFINITION, JUMPTO_DEFINITION, handleJumpToDefinition);
         
         // Register quickEditHelper.
-        EditorManager.registerQuickEditHelper(quickEditHelper);
+        brackets._jsCodeHintsHelper = quickEditHelper;
   
         // Add the menu item
         var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -559,11 +559,11 @@ define(function (require, exports, module) {
                             if (resolvedPath) {
                                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: resolvedPath})
                                     .done(function () {
-                                        session.editor.setSelection(jumpResp.start, jumpResp.end, true);
+                                        session.editor.setSelection(jumpResp.start, jumpResp.start);
                                     });
                             }
                         } else {
-                            session.editor.setSelection(jumpResp.start, jumpResp.end, true);
+                            session.editor.setSelection(jumpResp.start, jumpResp.start);
                         }
                     }
 
@@ -573,9 +573,22 @@ define(function (require, exports, module) {
             }
         }
 
+        /*
+         * Helper for QuickEdit jump-to-definition request.
+         */
+        function quickEditHelper() {
+            var offset     = session.getOffset(),
+                response   = ScopeManager.requestJumptoDef(session, session.editor.document, offset);
+
+            return response;
+        }
+
         // Register command handler
         CommandManager.register(Strings.CMD_JUMPTO_DEFINITION, JUMPTO_DEFINITION, handleJumpToDefinition);
         
+        // Register quickEditHelper.
+        EditorManager.registerQuickEditHelper(quickEditHelper);
+  
         // Add the menu item
         var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
         if (menu) {

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -559,11 +559,11 @@ define(function (require, exports, module) {
                             if (resolvedPath) {
                                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: resolvedPath})
                                     .done(function () {
-                                        session.editor.setSelection(jumpResp.start, jumpResp.start);
+                                        session.editor.setSelection(jumpResp.start, jumpResp.end, true);
                                     });
                             }
                         } else {
-                            session.editor.setSelection(jumpResp.start, jumpResp.start);
+                            session.editor.setSelection(jumpResp.start, jumpResp.end, true);
                         }
                     }
 

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -143,6 +143,7 @@ importScripts("thirdparty/requirejs/require.js");
         
         var request = buildRequest(dir, file, "definition", offset, text);
         request.query.lineCharPositions = true;
+        // request.query.typeOnly = true;       // FIXME: tern doesn't work exactly right yet.
         ternServer.request(request, function (error, data) {
             if (error) {
                 _log("Error returned from Tern 'definition' request: " + error);

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
      */
     function _createInlineEditor(hostEditor, functionName) {
         // Use Tern jump-to-definition helper, if it's available, to find InlineEditor target.
-        var helper = EditorManager.getQuickEditHelper();
+        var helper = brackets._jsCodeHintsHelper;
         if (helper === null) {
             return null;
         }

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -135,27 +135,22 @@ define(function (require, exports, module) {
 
                     } else {        // no result from Tern.  Fall back to _findInProject().
 
-                        if (!functionName) {
-                            result.reject();
-                        } else {
-
-                            _findInProject(functionName).done(function (functions) {
-                                if (functions && functions.length > 0) {
-                                    var jsInlineEditor = new MultiRangeInlineEditor(functions);
-                                    jsInlineEditor.load(hostEditor);
-                                    
-                                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-                                    result.resolve(jsInlineEditor);
-                                } else {
-                                    // No matching functions were found
-                                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-                                    result.reject();
-                                }
-                            }).fail(function () {
-                                PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                        _findInProject(functionName).done(function (functions) {
+                            if (functions && functions.length > 0) {
+                                var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                                jsInlineEditor.load(hostEditor);
+                                
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.resolve(jsInlineEditor);
+                            } else {
+                                // No matching functions were found
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
                                 result.reject();
-                            });
-                        }
+                            }
+                        }).fail(function () {
+                            PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                            result.reject();
+                        });
                     }
 
                 }).fail(function () {
@@ -213,7 +208,6 @@ define(function (require, exports, module) {
         // Always use the selection start for determining the function name. The pos
         // parameter is usually the selection end.        
         var functionName = _getFunctionName(hostEditor, sel.start);
-
         if (!functionName) {
             return null;
         }

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
     var MultiRangeInlineEditor  = brackets.getModule("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
         FileIndexManager        = brackets.getModule("project/FileIndexManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
+        DocumentManager         = brackets.getModule("document/DocumentManager"),
         JSUtils                 = brackets.getModule("language/JSUtils"),
         PerfUtils               = brackets.getModule("utils/PerfUtils");
     
@@ -105,24 +106,89 @@ define(function (require, exports, module) {
     function _createInlineEditor(hostEditor, functionName) {
         var result = new $.Deferred();
         PerfUtils.markStart(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-        
-        _findInProject(functionName).done(function (functions) {
-            if (functions && functions.length > 0) {
-                var jsInlineEditor = new MultiRangeInlineEditor(functions);
-                jsInlineEditor.load(hostEditor);
-                
-                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-                result.resolve(jsInlineEditor);
-            } else {
-                // No matching functions were found
-                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-                result.reject();
+
+        // Use Tern jump-to-definition helper, if it's available, to find InlineEditor target.
+        var helper = EditorManager.getQuickEditHelper();
+        if (helper !== null) {
+            var response = helper();
+            if (response.hasOwnProperty("promise")) {
+                response.promise.done(function (jumpResp) {
+                    var resolvedPath = jumpResp.fullPath;
+                    if (resolvedPath) {
+
+                        // Tern doesn't always return entire function extent.
+                        // Use QuickEdit search now that we know which file to look at.
+                        var fileInfos = [];
+                        fileInfos.push({name: jumpResp.resultFile, fullPath: resolvedPath});
+                        JSUtils.findMatchingFunctions(functionName, fileInfos)
+                            .done(function (functions) {
+                                var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                                jsInlineEditor.load(hostEditor);
+                                
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.resolve(jsInlineEditor);
+                            })
+                            .fail(function () {
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.reject();
+                            });
+
+                    } else {        // no result from Tern.  Fall back to _findInProject().
+
+                        if (!functionName) {
+                            result.reject();
+                        } else {
+
+                            _findInProject(functionName).done(function (functions) {
+                                if (functions && functions.length > 0) {
+                                    var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                                    jsInlineEditor.load(hostEditor);
+                                    
+                                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                    result.resolve(jsInlineEditor);
+                                } else {
+                                    // No matching functions were found
+                                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                    result.reject();
+                                }
+                            }).fail(function () {
+                                PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.reject();
+                            });
+                        }
+                    }
+
+                }).fail(function () {
+                    PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                    result.reject();
+                });
+
             }
-        }).fail(function () {
-            PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-            result.reject();
-        });
-        
+
+        } else {
+
+            if (!functionName) {
+                return null;
+            }
+
+            _findInProject(functionName).done(function (functions) {
+                if (functions && functions.length > 0) {
+                    var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                    jsInlineEditor.load(hostEditor);
+                    
+                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                    result.resolve(jsInlineEditor);
+                } else {
+                    // No matching functions were found
+                    PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                    result.reject();
+                }
+            }).fail(function () {
+                PerfUtils.finalizeMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                result.reject();
+            });
+        }
+
         return result.promise();
     }
     
@@ -147,14 +213,11 @@ define(function (require, exports, module) {
         if (sel.start.line !== sel.end.line) {
             return null;
         }
-        
+
         // Always use the selection start for determining the function name. The pos
         // parameter is usually the selection end.        
         var functionName = _getFunctionName(hostEditor, sel.start);
-        if (!functionName) {
-            return null;
-        }
-        
+
         return _createInlineEditor(hostEditor, functionName);
     }
 

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -125,11 +125,17 @@ define(function (require, exports, module) {
                     fileInfos.push({name: jumpResp.resultFile, fullPath: resolvedPath});
                     JSUtils.findMatchingFunctions(functionName, fileInfos)
                         .done(function (functions) {
-                            var jsInlineEditor = new MultiRangeInlineEditor(functions);
-                            jsInlineEditor.load(hostEditor);
-                            
-                            PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
-                            result.resolve(jsInlineEditor);
+                            if (functions && functions.length > 0) {
+                                var jsInlineEditor = new MultiRangeInlineEditor(functions);
+                                jsInlineEditor.load(hostEditor);
+                                
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.resolve(jsInlineEditor);
+                            } else {
+                                // No matching functions were found
+                                PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);
+                                result.reject();
+                            }
                         })
                         .fail(function () {
                             PerfUtils.addMeasurement(PerfUtils.JAVASCRIPT_INLINE_CREATE);

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -167,10 +167,6 @@ define(function (require, exports, module) {
 
         } else {
 
-            if (!functionName) {
-                return null;
-            }
-
             _findInProject(functionName).done(function (functions) {
                 if (functions && functions.length > 0) {
                     var jsInlineEditor = new MultiRangeInlineEditor(functions);
@@ -217,6 +213,10 @@ define(function (require, exports, module) {
         // Always use the selection start for determining the function name. The pos
         // parameter is usually the selection end.        
         var functionName = _getFunctionName(hostEditor, sel.start);
+
+        if (!functionName) {
+            return null;
+        }
 
         return _createInlineEditor(hostEditor, functionName);
     }


### PR DESCRIPTION
Current changes:
- Use tern's jump-to-definition search for QuickEdit.
- Change jump-to-definition to just select function name and place cursor at the end of the name to match what other editors do.

Future plans:
- support finding var definitions in QuickEdit.
- don't fall back to old QuickEdit search when tern knows a symbol is a builtin.
- get tern to provide whole function extent, including function body and JSDoc style comments, if possible.

Note that the futures depend on improvements in tern.
