### PR TITLE
[CRAZY] CSS font-family hints 

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -90,7 +90,7 @@
     "flex-wrap":                   {"values": ["nowrap", "wrap", "wrap-reverse"]},
     "float":                       {"values": ["left", "right", "none", "inherit"]},
     "font":                        {"values": []},
-    "font-family":                 {"values": []},
+    "font-family":                 {"values": ["cursive", "fantasy", "inherit", "monospace", "sans-serif", "serif"]},
     "font-feature-settings":       {"values": ["normal"]},
     "font-kerning":                {"values": ["auto", "none", "normal"]},
     "font-language-override":      {"values": ["normal"]},


### PR DESCRIPTION
This pull request makes three changes, the first of which is ostensibly innocuous while the latter two of which are probably crazy:
1. Add font-family values that are directly defined by the CSS specification to `CSSProperties.json` so that the CSS hinter can provide font-family hints. This is useful because EWF might not be installed, might have failed to load, etc.
2. Change the CodeHintManager API and implementation (:sunglasses:) so that CodeHintProviders can end the current session _and_ request that the CodeHintManager immediately attempt to begin a new one by querying all the registered providers for hints. This is a non-breaking API change: providers may now return `true` to signal this in addition to all of their previous options, `null`, a hint object, or a deferred hint object, for which the semantics have not changed.
3. Change the CSS hinter to request a session restart when it switches context from property names to property values. As a consequence, if you type `font-family:` then upon typing the `:` the provider returns `true`, hence requesting that the session be restarted. If a higher-priority provider is registered (like, e.g., EWF) then it can take over. Without this change, higher priority providers wouldn't get the opportunity to take over until the lower-priority provider ended the session because it either ran out of hints to provide (which is not the case here) or it inserted a hint (which also wouldn't happen here if the user typed out `font-family` in full).

Discuss! 
