### PR TITLE
Use integer line-height to avoid rounding differences

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
      * The ratio of line-height to font-size when they use the same units
      * @type {float}
      */
-    var LINE_HEIGHT = 1.3;
+    var LINE_HEIGHT = 1.25;
     
     /**
      * @private
@@ -175,8 +175,8 @@ define(function (require, exports, module) {
         if (fsUnits === lhUnits) {
             lhNew = fsNew * LINE_HEIGHT;
             if (lhUnits === "px") {
-                // Use integer px value to avoid subsequent round-off differences
-                lhNew = Math.round(lhNew);
+                // Use integer px value to avoid rounding differences
+                lhNew = Math.ceil(lhNew);
             }
         }
         

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
         var lhOld   = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
         
         var fsNew   = fsOld + (delta * adjustment);
-        var lhNew   = (fsUnits === lhUnits) ? fsNew * LINE_HEIGHT : lhOld;
+        var lhNew   = (fsUnits === lhUnits) ? Math.round(fsNew * LINE_HEIGHT) : lhOld;
         
         var fsStr   = fsNew + fsUnits;
         var lhStr   = lhNew + lhUnits;

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -171,7 +171,14 @@ define(function (require, exports, module) {
         var lhOld   = parseFloat(lhStyle.substring(0, lhStyle.length - 2));
         
         var fsNew   = fsOld + (delta * adjustment);
-        var lhNew   = (fsUnits === lhUnits) ? Math.round(fsNew * LINE_HEIGHT) : lhOld;
+        var lhNew   = lhOld;
+        if (fsUnits === lhUnits) {
+            lhNew = fsNew * LINE_HEIGHT;
+            if (lhUnits === "px") {
+                // Use integer px value to avoid subsequent round-off differences
+                lhNew = Math.round(lhNew);
+            }
+        }
         
         var fsStr   = fsNew + fsUnits;
         var lhStr   = lhNew + lhUnits;

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -121,11 +121,11 @@ define(function (require, exports, module) {
             });
             
             it("should keep the same font size when opening another document", function () {
-                var promise, expectedSize, editor;
+                var promise, originalSize, editor;
                 
                 runs(function () {
                     editor       = EditorManager.getCurrentFullEditor();
-                    expectedSize = editor.getTextHeight() + 1;
+                    originalSize = editor.getTextHeight();
                     
                     promise = CommandManager.execute(Commands.VIEW_INCREASE_FONT_SIZE);
                     waitsForDone(promise, "Increase font size");
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     editor = EditorManager.getCurrentFullEditor();
-                    expect(editor.getTextHeight()).toBe(expectedSize);
+                    expect(editor.getTextHeight()).toBeGreaterThan(originalSize);
                 });
                 
                 // This must be in the last spec in the suite.


### PR DESCRIPTION
Yet another attempt at #3478.

@iwehrman Can you try this branch to see if it fixes the issue for you?
