### PR TITLE
Fix live preview refresh issues

### DIFF
--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -74,7 +74,8 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        return Inspector.Console.enable().done(function () {
+        // FIXME Windows only: Somtimes enable() isn't acknowledged
+        return Inspector.retry(Inspector.Console.enable).done(function () {
             $(Inspector.Console)
                 .on("messageAdded.ConsoleAgent", _onMessageAdded)
                 .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -74,13 +74,13 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
+        $(Inspector.Console)
+            .on("messageAdded.ConsoleAgent", _onMessageAdded)
+            .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
+            .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
+
         // FIXME Windows only: Somtimes enable() isn't acknowledged
-        return Inspector.retry(Inspector.Console.enable).done(function () {
-            $(Inspector.Console)
-                .on("messageAdded.ConsoleAgent", _onMessageAdded)
-                .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
-                .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
-        });
+        return Inspector.retry(Inspector.Console.enable);
     }
 
     /** Clean up */

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -99,7 +99,7 @@ define(function HighlightAgent(require, exports, module) {
      * @param {string} rule selector
      */
     function rule(name) {
-        if (_highlight.ref === name) {
+        if (_highlight && (_highlight.ref === name)) {
             return;
         }
         hide();

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -65,10 +65,10 @@ define(function NetworkAgent(require, exports, module) {
     function load() {
         _urlRequested = {};
 
+        $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
+
         // FIXME Windows only: Somtimes enable() isn't acknowledged
-        return Inspector.retry(Inspector.Network.enable).always(function () {
-            $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
-        });
+        return Inspector.retry(Inspector.Network.enable);
     }
 
     /** Unload the agent */

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -64,7 +64,9 @@ define(function NetworkAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _urlRequested = {};
-        return Inspector.Network.enable().done(function () {
+
+        // FIXME Windows only: Somtimes enable() isn't acknowledged
+        return Inspector.retry(Inspector.Network.enable).always(function () {
             $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
         });
     }

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -45,21 +45,6 @@ define(function RemoteAgent(require, exports, module) {
     var _objectId; // the object id of the remote object
     var _intervalId; // interval used to send keepAlive events
 
-    // WebInspector Event: Page.loadEventFired
-    function _onLoadEventFired(event, res) {
-        // res = {timestamp}
-        var command = "window._LD=" + RemoteFunctions + "(" + LiveDevelopment.config.experimental + ")";
-
-        Inspector.Runtime.evaluate(command, function onEvaluate(response) {
-            if (response.error || response.wasThrown) {
-                _load.reject(null, response.error);
-            } else {
-                _objectId = response.result.objectId;
-                _load.resolve();
-            }
-        });
-    }
-
     // WebInspector Event: DOM.attributeModified
     function _onAttributeModified(event, res) {
         // res = {nodeId, name, value}
@@ -105,16 +90,52 @@ define(function RemoteAgent(require, exports, module) {
         });
     }
 
+    function _stopKeepAliveInterval() {
+        if (_intervalId) {
+            window.clearInterval(_intervalId);
+        }
+    }
+
+    function _startKeepAliveInterval() {
+        _stopKeepAliveInterval();
+
+        _intervalId = window.setInterval(function () {
+            call("keepAlive");
+        }, 1000);
+    }
+
+    /**
+     * @private
+     * Cancel the keepAlive interval if the page reloads
+     */
+    function _onFrameStartedLoading(event, res) {
+        _stopKeepAliveInterval();
+    }
+
+    // WebInspector Event: Page.loadEventFired
+    function _onLoadEventFired(event, res) {
+        // res = {timestamp}
+        var command = "window._LD=" + RemoteFunctions + "(" + LiveDevelopment.config.experimental + ")";
+
+        Inspector.Runtime.evaluate(command, function onEvaluate(response) {
+            if (response.error || response.wasThrown) {
+                _load.reject(null, response.error);
+            } else {
+                _objectId = response.result.objectId;
+                _load.resolve();
+
+                _startKeepAliveInterval();
+            }
+        });
+    }
+
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
         $(Inspector.Page).on("loadEventFired.RemoteAgent", _onLoadEventFired);
+        $(Inspector.Page).on("frameStartedLoading.RemoteAgent", _onFrameStartedLoading);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
-        _load.done(function () {
-            _intervalId = window.setInterval(function () {
-                call("keepAlive");
-            }, 1000);
-        });
+
         return _load.promise();
     }
 
@@ -122,9 +143,7 @@ define(function RemoteAgent(require, exports, module) {
     function unload() {
         $(Inspector.Page).off(".RemoteAgent");
         $(Inspector.DOM).off(".RemoteAgent");
-        if (_intervalId) {
-            window.clearInterval(_intervalId);
-        }
+        _stopKeepAliveInterval();
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -93,6 +93,7 @@ define(function RemoteAgent(require, exports, module) {
     function _stopKeepAliveInterval() {
         if (_intervalId) {
             window.clearInterval(_intervalId);
+            _intervalId = null;
         }
     }
 

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -333,6 +333,33 @@ define(function Inspector(require, exports, module) {
         return _socket !== undefined && _socket.readyState === WebSocket.OPEN;
     }
 
+    function retry(fn, interval, retryCount) {
+        var deferred = new $.Deferred();
+
+        interval = interval || 100;
+        retryCount = retryCount || 5;
+
+        function _doRetry() {
+            // FIXME Windows only: Somtimes methods (e.g. Console.enable()) aren't acknowledged
+            Async.withTimeout(fn.call(), interval).done(function () {
+                deferred.resolve();
+            }).fail(function () {
+                retryCount--;
+
+                if (retryCount <= 0) {
+                    deferred.reject();
+                    return;
+                }
+
+                _doRetry();
+            });
+        }
+
+        _doRetry();
+
+        return deferred.promise();
+    }
+
     /** Initialize the Inspector
      * Read the Inspector.json configuration and define the command objects
      * -> Inspector.domain.command()
@@ -362,5 +389,6 @@ define(function Inspector(require, exports, module) {
     exports.connect = connect;
     exports.connectToURL = connectToURL;
     exports.connected = connected;
+    exports.retry = retry;
     exports.init = init;
 });

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -289,7 +289,7 @@ define(function Inspector(require, exports, module) {
             _socket.onopen = _onConnect;
             _socket.onclose = _onDisconnect;
             _socket.onerror = _onError;
-        })
+        });
     }
 
     /** Connect to the remote debugger of the page that is at the given URL

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -307,6 +307,11 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         if (_serverProvider) {
+            // Stop listening for requests
+            if (_serverProvider && _serverProvider.setRequestFilterPaths) {
+                _serverProvider.setRequestFilterPaths([]);
+            }
+
             // Remove any "request" listeners that were added previously
             $(_serverProvider).off(".livedev");
         }

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -228,10 +228,7 @@ define(function (require, exports, module) {
         return _nodeConnectionDeferred;
     }
     
-    AppInit.appReady(function () {
-        // Register as a Live Development server provider
-        LiveDevServerManager.registerProvider(_staticServerProvider, 5);
-        
+    function init() {
         // Start up the node connection, which is held in the
         // _nodeConnectionDeferred module variable. (Use 
         // _nodeConnectionDeferred.done() to access it.
@@ -260,6 +257,10 @@ define(function (require, exports, module) {
                     });
 
                     clearTimeout(connectionTimeout);
+
+                    // Register as a Live Development server provider
+                    LiveDevServerManager.registerProvider(_staticServerProvider, 5);
+
                     _nodeConnectionDeferred.resolveWith(null, [_nodeConnection]);
                 },
                 function () { // Failed to connect
@@ -272,7 +273,11 @@ define(function (require, exports, module) {
         if (brackets.test) {
             brackets.test.extensions.StaticServer = module.exports;
         }
-    });
+
+        return _nodeConnectionDeferred.promise();
+    }
+
+    exports.init = init;
 
     // For unit tests only
     exports._getStaticServerProvider = _getStaticServerProvider;

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -190,11 +190,12 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var deferred = $.Deferred();
-                    Inspector.Runtime.evaluate("window.open('', '_self').close()", function (response) {
-                        Inspector.disconnect();
-                        deferred.resolve();
+                    Inspector.Runtime.evaluate("window.open('', '_self').close()").done(function () {
+                        Inspector.disconnect().done(function () {
+                            deferred.resolve();
+                        });
                     });
-                    waitsForDone(deferred.promise(), "Inspector.Runtime.evaluate");
+                    waitsForDone(deferred.promise(), "Inspector.Runtime.evaluate", 5000);
                 });
                 
                 runs(function () {
@@ -327,7 +328,7 @@ define(function (require, exports, module) {
                 //start live dev
                 var liveDoc;
                 runs(function () {
-                    LiveDevelopment.open();
+                    waitsForDone(LiveDevelopment.open(), "LiveDevelopment.open()", 5000);
                 });
                 waitsFor(function () {
                     liveDoc = LiveDevelopment.getLiveDocForPath(testPath + "/simple1.css");
@@ -392,7 +393,7 @@ define(function (require, exports, module) {
                 // start live dev
                 var liveDoc, liveHtmlDoc;
                 runs(function () {
-                    waitsForDone(LiveDevelopment.open(), "LiveDevelopment.open()", 2000);
+                    waitsForDone(LiveDevelopment.open(), "LiveDevelopment.open()", 5000);
                 });
                 
                 waitsFor(function () {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -189,18 +189,11 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    var deferred = $.Deferred();
-                    Inspector.Runtime.evaluate("window.open('', '_self').close()").done(function () {
-                        Inspector.disconnect().done(function () {
-                            deferred.resolve();
-                        });
-                    });
-                    waitsForDone(deferred.promise(), "Inspector.Runtime.evaluate", 5000);
+                    var promise = Inspector.Runtime.evaluate("window.open('', '_self').close()");
+                    waitsForDone(promise, "Inspector.Runtime.evaluate", 5000);
                 });
                 
-                runs(function () {
-                    expect(Inspector.connected()).toBeFalsy();
-                });
+                waitsFor(function () { return !Inspector.connected(); }, 10000);
             });
         });
 

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -326,17 +326,17 @@ define(function (require, exports, module) {
                 });
                 
                 //start live dev
-                var liveDoc;
                 runs(function () {
-                    waitsForDone(LiveDevelopment.open(), "LiveDevelopment.open()", 5000);
+                    LiveDevelopment.open();
                 });
+                // Wait for the file and its stylesheets to fully load (and be communicated back).
                 waitsFor(function () {
-                    liveDoc = LiveDevelopment.getLiveDocForPath(testPath + "/simple1.css");
-                    return !!liveDoc;
-                }, "Waiting for LiveDevelopment document", 10000);
+                    return (LiveDevelopment.status === LiveDevelopment.STATUS_ACTIVE);
+                }, "Waiting for browser to become active", 10000);
                 
-                var doneSyncing = false;
+                var liveDoc, doneSyncing = false;
                 runs(function () {
+                    liveDoc = LiveDevelopment.getLiveDocForPath(testPath + "/simple1.css");
                     liveDoc.getSourceFromBrowser().done(function (text) {
                         browserText = text;
                     }).always(function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -276,6 +276,7 @@ define(function (require, exports, module) {
             function isBracketsDoneLoading() {
                 return _testWindow.brackets && _testWindow.brackets.test && _testWindow.brackets.test.doneLoading;
             },
+            "brackets.test.doneLoading",
             10000
         );
 


### PR DESCRIPTION
#3761 I found 2 issues here:
- When hitting refresh rapidly, the inspector API was returning an error `Inspected frame has gone`. This was due to our `keepAlive` `RemoteAgent` function call trying to call to a page(frame?) that no longer exists. I've updated `RemoteAgent` to stop the `keepAlive` timer when a new page loads.
- After getting in the above error state where the inspector web socket is still open, there were async issues calling `Inspector.connect()` where the inspector may get a disconnect event in the middle of the connection process. This caused an error dialog to appear `Unable to load live development page`. I've changed `connect()` to wait for a new `disconnect()` promise to complete.
#3792 After switching the current live document, remove all HTTP request filters.
