### PR TITLE
Bug fixes for extension manager

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -50,7 +50,8 @@ define(function (require, exports, module) {
     /**
      * Extension status constants.
      */
-    var ENABLED       = "enabled";
+    var ENABLED      = "enabled",
+        START_FAILED = "startFailed";
     
     /**
      * Extension location constants.
@@ -178,7 +179,7 @@ define(function (require, exports, module) {
                 metadata: metadata,
                 path: path,
                 locationType: locationType,
-                status: ENABLED
+                status: (e.type === "loadFailed" ? START_FAILED : ENABLED)
             };
             $(exports).triggerHandler("statusChange", [id]);
         }
@@ -265,8 +266,10 @@ define(function (require, exports, module) {
         return result.promise();
     }
     
-    // Listen to extension load events
-    $(ExtensionLoader).on("load", _handleExtensionLoad);
+    // Listen to extension load and loadFailed events
+    $(ExtensionLoader)
+        .on("load", _handleExtensionLoad)
+        .on("loadFailed", _handleExtensionLoad);
 
     // Public exports
     exports.downloadRegistry = downloadRegistry;
@@ -276,6 +279,7 @@ define(function (require, exports, module) {
     exports.extensions = extensions;
     
     exports.ENABLED = ENABLED;
+    exports.START_FAILED = START_FAILED;
     
     exports.LOCATION_DEFAULT = LOCATION_DEFAULT;
     exports.LOCATION_DEV = LOCATION_DEV;

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -201,6 +201,7 @@ define(function (require, exports, module) {
         // Calculate various bools, since Mustache doesn't let you use expressions and interprets
         // arrays as iteration contexts.
         context.isInstalled = !!entry.installInfo;
+        context.failedToStart = (entry.installInfo && entry.installInfo.status === ExtensionManager.START_FAILED);
         context.hasVersionInfo = !!info.versions;
                 
         var compatInfo = ExtensionManager.getCompatibilityInfo(info, brackets.metadata.apiVersion);

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -132,6 +132,7 @@ define(function (require, exports, module) {
         case STATE_INSTALLING:
             url = this.$url.val();
             this.$inputArea.hide();
+            this.$browseExtensionsButton.hide();
             this.$msg.text(StringUtils.format(Strings.INSTALLING_FROM, url))
                 .append("<span class='spinner spin'/>");
             this.$msgArea.show();

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -153,7 +153,9 @@ define(function (require, exports, module) {
                                 // This was a new extension and everything looked fine.
                                 // We load it into Brackets right away.
                                 ExtensionLoader.loadExtension(result.name, {
-                                    baseUrl: result.installedTo
+                                    // On Windows, it looks like Node converts Unix-y paths to backslashy paths.
+                                    // We need to convert them back.
+                                    baseUrl: FileUtils.convertWindowsPathToUnixPath(result.installedTo)
                                 }, "main").then(function () {
                                     d.resolve(result);
                                 }, function () {

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -205,6 +205,22 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Convert a Windows-native path to use Unix style slashes.
+     * On Windows, this converts "C:\foo\bar\baz.txt" to "C:/foo/bar/baz.txt".
+     * On Mac, this does nothing, since Mac paths are already in Unix syntax.
+     * (Note that this does not add an initial forward-slash. Internally, our
+     * APIs generally use the "C:/foo/bar/baz.txt" style for "native" paths.)
+     * @param {string} path A native-style path.
+     * @return {string} A Unix-style path.
+     */
+    function convertWindowsPathToUnixPath(path) {
+        if (brackets.platform === "win") {
+            path = path.replace(/\\/g, "/");
+        }
+        return path;
+    }
+    
+    /**
      * Canonicalizes a folder path to not include a trailing slash.
      * @param {string} path
      * @return {string}
@@ -346,6 +362,7 @@ define(function (require, exports, module) {
     exports.readAsText                     = readAsText;
     exports.writeText                      = writeText;
     exports.convertToNativePath            = convertToNativePath;
+    exports.convertWindowsPathToUnixPath   = convertWindowsPathToUnixPath;
     exports.getNativeBracketsDirectoryPath = getNativeBracketsDirectoryPath;
     exports.getNativeModuleDirectoryPath   = getNativeModuleDirectoryPath;
     exports.canonicalizeFolderPath         = canonicalizeFolderPath;

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -18,11 +18,14 @@
                 {{^requiresNewer}}{{Strings.EXTENSION_INCOMPATIBLE_OLDER}}{{/requiresNewer}}
             </div>
         {{/isCompatible}}
+        {{#failedToStart}}
+            <p class="error"><em>{{Strings.EXTENSION_FAILED_TO_START}}</em></p>
+        {{/failedToStart}}
         {{#metadata.description}}
             {{metadata.description}}
         {{/metadata.description}}
         {{^metadata.description}}
-            <span class="muted"><em>{{Strings.EXTENSION_NO_DESCRIPTION}}</em></span>
+            <p class="muted"><em>{{Strings.EXTENSION_NO_DESCRIPTION}}</em></p>
         {{/metadata.description}}
         {{#metadata.keywords.length}}
             <br/>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -331,6 +331,7 @@ define({
     "EXTENSION_INCOMPATIBLE_NEWER"         : "This extension requires a newer version of {APP_NAME}.",
     "EXTENSION_INCOMPATIBLE_OLDER"         : "This extension currently only works with older versions of {APP_NAME}.",
     "EXTENSION_NO_DESCRIPTION"             : "No description",
+    "EXTENSION_FAILED_TO_START"            : "This extension did not start up successfully and should be removed.",
     "EXTENSION_KEYWORDS"                   : "Keywords",
     "EXTENSION_INSTALLED"                  : "Installed",
     "EXTENSION_SEARCH_PLACEHOLDER"         : "Search",
@@ -349,7 +350,7 @@ define({
      * Unit names
      */
 
-    "UNIT_PIXELS"                          : "pixels",    
+    "UNIT_PIXELS"                          : "pixels",
     
     // extensions/default/DebugCommands
     "DEBUG_MENU"                                : "Debug",

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -518,6 +518,9 @@
         padding: 0;
         
         .extension-list {
+            td {
+                height: 2em;
+            }
             .ext-info {
                 padding-left: 15px;
                 width: 220px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -491,7 +491,8 @@
             background: #fff url("images/topcoat-search-20.svg") 3px 4px no-repeat;
             float: right;
             margin-top: 6px;
-            text-indent: 23px;
+            padding-left: 27px;
+            padding-right: 20px;
         }
         .search-clear {
             position: relative;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -534,6 +534,10 @@
             .muted {
                 color: #888;
             }
+            .error {
+                font-weight: @font-weight-semibold;
+                color: #ff5656;
+            }
             .ext-version,
             .ext-date,
             .ext-author {

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
     require("spec/ExtensionManager-test");
     require("spec/ExtensionUtils-test");
     require("spec/FileIndexManager-test");
+    require("spec/FileUtils-test");
     require("spec/FindReplace-test");
     require("spec/HTMLInstrumentation-test");
     require("spec/InlineEditorProviders-test");

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -143,9 +143,6 @@ define(function (require, exports, module) {
                 // mocked the loading part
                 expect(lastExtensionLoad.name).toEqual("basic-valid-extension");
                 var expectedPath = mockGetUserExtensionPath() + "/basic-valid-extension";
-                if (brackets.platform === "win") {
-                    expectedPath = expectedPath.replace(/\//g, "\\");
-                }
                 expect(lastExtensionLoad.config.baseUrl).toEqual(expectedPath);
                 expect(lastExtensionLoad.entryPoint).toEqual("main");
                 NativeFileSystem.resolveNativeFileSystemPath(extensionsRoot + "/user/basic-valid-extension/main.js",

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, window, $, jasmine, brackets */
+/*unittests: FileUtils*/
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var FileUtils = require("file/FileUtils");
+    
+    describe("FileUtils", function () {
+        describe("convertWindowsPathToUnixPath", function () {
+            var origPlatform;
+            
+            beforeEach(function () {
+                origPlatform = brackets.platform;
+            });
+            
+            afterEach(function () {
+                brackets.platform = origPlatform;
+            });
+            
+            it("should convert a Windows path to a Unix-style path when on Windows", function () {
+                brackets.platform = "win";
+                expect(FileUtils.convertWindowsPathToUnixPath("C:\\foo\\bar\\baz.txt")).toBe("C:/foo/bar/baz.txt");
+            });
+            
+            it("should not modify a native path when on Mac, even if it has backslashes", function () {
+                brackets.platform = "mac";
+                expect(FileUtils.convertWindowsPathToUnixPath("/some/back\\slash/path.txt")).toBe("/some/back\\slash/path.txt");
+            });
+        });
+    });
+});

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -180,12 +180,13 @@ define(function (require, exports, module) {
                 deferred.resolve();
             });
             
-            it("should hide the url field while installing", function () {
+            it("should hide the url field and 'browse extensions' button while installing", function () {
                 var deferred = new $.Deferred(),
                     installer = makeInstaller(null, deferred);
                 setUrl();
                 fields.$okButton.click();
                 expect(fields.$url.is(":visible")).toBeFalsy();
+                expect(fields.$browseExtensionsButton.is(":visible")).toBeFalsy();
                 deferred.resolve();
             });
     


### PR DESCRIPTION
To @dangoor. Fixes #3859, #3861, #3865, #3866, #3868.

Note that for #3868, I now force paths coming back from package installation to always use forward slashes. This seems to be consistent with how we deal with paths in the rest of Brackets, but it's a little hard to tell. I filed #3872 on that general problem.
