### PR TITLE
fix hinting on non-ascii characters

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -27,20 +27,13 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var acorn                       = require("thirdparty/acorn/acorn");
+
     var LANGUAGE_ID                 = "javascript",
         HTML_LANGUAGE_ID            = "html",
         SUPPORTED_LANGUAGES         = [LANGUAGE_ID, HTML_LANGUAGE_ID],
         SINGLE_QUOTE                = "'",
-        DOUBLE_QUOTE                = "\"",
-        TERN_ADD_FILES_MSG          = "AddFiles",
-        TERN_UPDATE_FILE_MSG        = "UpdateFile",
-        TERN_INIT_MSG               = "Init",
-        TERN_JUMPTODEF_MSG          = "JumptoDef",
-        TERN_COMPLETIONS_MSG        = "Completions",
-        TERN_GET_FILE_MSG           = "GetFile",
-        TERN_CALLED_FUNC_TYPE_MSG   = "FunctionType",
-        TERN_PRIME_PUMP_MSG         = "PrimePump",
-        TERN_GET_GUESSES_MSG        = "GetGuesses";
+        DOUBLE_QUOTE                = "\"";
 
     /**
      * Create a hint token with name value that occurs at the given list of
@@ -62,12 +55,22 @@ define(function (require, exports, module) {
 
     /**
      * Is the string key perhaps a valid JavaScript identifier?
-     * 
-     * @param {string} key - the string to test
+     *
+     * @param {string} key - string to test.
      * @return {boolean} - could key be a valid identifier?
      */
     function maybeIdentifier(key) {
-        return (/[0-9a-z_\$]/i).test(key);
+        var result = false,
+            i;
+
+        for (i = 0; i < key.length; i++) {
+            result = acorn.isIdentifierChar(key.charCodeAt(i));
+            if (!result) {
+                break;
+            }
+        }
+
+        return result;
     }
 
     /**
@@ -175,6 +178,7 @@ define(function (require, exports, module) {
     function isSupportedLanguage(languageId) {
         return SUPPORTED_LANGUAGES.indexOf(languageId) !== -1;
     }
+
     var KEYWORD_NAMES   = [
         "break", "case", "catch", "continue", "debugger", "default", "delete",
         "do", "else", "finally", "for", "function", "if", "in", "instanceof",
@@ -207,14 +211,5 @@ define(function (require, exports, module) {
     exports.LANGUAGE_ID                 = LANGUAGE_ID;
     exports.SINGLE_QUOTE                = SINGLE_QUOTE;
     exports.DOUBLE_QUOTE                = DOUBLE_QUOTE;
-    exports.TERN_ADD_FILES_MSG          = TERN_ADD_FILES_MSG;
-    exports.TERN_JUMPTODEF_MSG          = TERN_JUMPTODEF_MSG;
-    exports.TERN_COMPLETIONS_MSG        = TERN_COMPLETIONS_MSG;
-    exports.TERN_INIT_MSG               = TERN_INIT_MSG;
-    exports.TERN_GET_FILE_MSG           = TERN_GET_FILE_MSG;
-    exports.TERN_CALLED_FUNC_TYPE_MSG   = TERN_CALLED_FUNC_TYPE_MSG;
-    exports.TERN_PRIME_PUMP_MSG         = TERN_PRIME_PUMP_MSG;
-    exports.TERN_GET_GUESSES_MSG        = TERN_GET_GUESSES_MSG;
-    exports.TERN_UPDATE_FILE_MSG        = TERN_UPDATE_FILE_MSG;
     exports.SUPPORTED_LANGUAGES         = SUPPORTED_LANGUAGES;
 });

--- a/src/extensions/default/JavaScriptCodeHints/MessageIds.js
+++ b/src/extensions/default/JavaScriptCodeHints/MessageIds.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
+/*global define */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var TERN_ADD_FILES_MSG          = "AddFiles",
+        TERN_UPDATE_FILE_MSG        = "UpdateFile",
+        TERN_INIT_MSG               = "Init",
+        TERN_JUMPTODEF_MSG          = "JumptoDef",
+        TERN_COMPLETIONS_MSG        = "Completions",
+        TERN_GET_FILE_MSG           = "GetFile",
+        TERN_CALLED_FUNC_TYPE_MSG   = "FunctionType",
+        TERN_PRIME_PUMP_MSG         = "PrimePump",
+        TERN_GET_GUESSES_MSG        = "GetGuesses";
+
+    exports.TERN_ADD_FILES_MSG          = TERN_ADD_FILES_MSG;
+    exports.TERN_JUMPTODEF_MSG          = TERN_JUMPTODEF_MSG;
+    exports.TERN_COMPLETIONS_MSG        = TERN_COMPLETIONS_MSG;
+    exports.TERN_INIT_MSG               = TERN_INIT_MSG;
+    exports.TERN_GET_FILE_MSG           = TERN_GET_FILE_MSG;
+    exports.TERN_CALLED_FUNC_TYPE_MSG   = TERN_CALLED_FUNC_TYPE_MSG;
+    exports.TERN_PRIME_PUMP_MSG         = TERN_PRIME_PUMP_MSG;
+    exports.TERN_GET_GUESSES_MSG        = TERN_GET_GUESSES_MSG;
+    exports.TERN_UPDATE_FILE_MSG        = TERN_UPDATE_FILE_MSG;
+});
+
+

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -42,7 +42,8 @@ define(function (require, exports, module) {
         ExtensionUtils      = brackets.getModule("utils/ExtensionUtils"),
         FileUtils           = brackets.getModule("file/FileUtils"),
         FileIndexManager    = brackets.getModule("project/FileIndexManager"),
-        HintUtils           = require("HintUtils");
+        HintUtils           = require("HintUtils"),
+        MessageIds          = require("MessageIds");
     
     var ternEnvironment     = [],
         pendingTernRequests = {},
@@ -80,7 +81,7 @@ define(function (require, exports, module) {
         numInitialFiles = files.length;
 
         _ternWorker.postMessage({
-            type        : HintUtils.TERN_INIT_MSG,
+            type        : MessageIds.TERN_INIT_MSG,
             dir         : dir,
             files       : files,
             env         : ternEnvironment
@@ -107,7 +108,7 @@ define(function (require, exports, module) {
 
             numAddedFiles += files.length;
             _ternWorker.postMessage({
-                type        : HintUtils.TERN_ADD_FILES_MSG,
+                type        : MessageIds.TERN_ADD_FILES_MSG,
                 files       : files
             });
 
@@ -410,14 +411,14 @@ define(function (require, exports, module) {
      */
     function getJumptoDef(dir, file, offset, text) {
         postMessage({
-            type: HintUtils.TERN_JUMPTODEF_MSG,
+            type: MessageIds.TERN_JUMPTODEF_MSG,
             dir: dir,
             file: file,
             offset: offset,
             text: text
         });
 
-        return addPendingRequest(file, offset, HintUtils.TERN_JUMPTODEF_MSG);
+        return addPendingRequest(file, offset, MessageIds.TERN_JUMPTODEF_MSG);
     }
 
     /**
@@ -451,7 +452,7 @@ define(function (require, exports, module) {
         var file = response.file,
             offset = response.offset;
         
-        var $deferredJump = getPendingRequest(file, offset, HintUtils.TERN_JUMPTODEF_MSG);
+        var $deferredJump = getPendingRequest(file, offset, MessageIds.TERN_JUMPTODEF_MSG);
         
 //        pendingTernRequests[file] = null;
         
@@ -473,7 +474,7 @@ define(function (require, exports, module) {
      */
     function getTernHints(dir, file, offset, text, isProperty) {
         postMessage({
-            type: HintUtils.TERN_COMPLETIONS_MSG,
+            type: MessageIds.TERN_COMPLETIONS_MSG,
             dir: dir,
             file: file,
             offset: offset,
@@ -481,7 +482,7 @@ define(function (require, exports, module) {
             isProperty: isProperty
         });
         
-        return addPendingRequest(file, offset, HintUtils.TERN_COMPLETIONS_MSG);
+        return addPendingRequest(file, offset, MessageIds.TERN_COMPLETIONS_MSG);
     }
 
     /**
@@ -497,7 +498,7 @@ define(function (require, exports, module) {
      */
     function getTernFunctionType(dir, file, pos, offset, text) {
         postMessage({
-            type: HintUtils.TERN_CALLED_FUNC_TYPE_MSG,
+            type: MessageIds.TERN_CALLED_FUNC_TYPE_MSG,
             dir: dir,
             file: file,
             pos: pos,
@@ -505,7 +506,7 @@ define(function (require, exports, module) {
             text: text
         });
 
-        return addPendingRequest(file, offset, HintUtils.TERN_CALLED_FUNC_TYPE_MSG);
+        return addPendingRequest(file, offset, MessageIds.TERN_CALLED_FUNC_TYPE_MSG);
     }
     
     
@@ -580,14 +581,14 @@ define(function (require, exports, module) {
             $deferred = $.Deferred();
 
         postMessage({
-            type: HintUtils.TERN_GET_GUESSES_MSG,
+            type: MessageIds.TERN_GET_GUESSES_MSG,
             dir: "",
             file: path,
             offset: offset,
             text: text
         });
 
-        var promise = addPendingRequest(path, offset, HintUtils.TERN_GET_GUESSES_MSG);
+        var promise = addPendingRequest(path, offset, MessageIds.TERN_GET_GUESSES_MSG);
         promise.done(function (guesses) {
             session.setGuesses(guesses);
             $deferred.resolve();
@@ -642,7 +643,7 @@ define(function (require, exports, module) {
 
         function replyWith(name, txt) {
             _postMessageByPass({
-                type: HintUtils.TERN_GET_FILE_MSG,
+                type: MessageIds.TERN_GET_FILE_MSG,
                 file: name,
                 text: txt
             });
@@ -722,12 +723,12 @@ define(function (require, exports, module) {
      */
     function primePump(path, text) {
         _postMessageByPass({
-            type        : HintUtils.TERN_PRIME_PUMP_MSG,
+            type        : MessageIds.TERN_PRIME_PUMP_MSG,
             path        : path,
             text        : text
         });
 
-        return addPendingRequest(path, 0, HintUtils.TERN_PRIME_PUMP_MSG);
+        return addPendingRequest(path, 0, MessageIds.TERN_PRIME_PUMP_MSG);
     }
 
     /**
@@ -776,12 +777,12 @@ define(function (require, exports, module) {
         var path  = document.file.fullPath;
 
         _postMessageByPass({
-            type       : HintUtils.TERN_UPDATE_FILE_MSG,
+            type       : MessageIds.TERN_UPDATE_FILE_MSG,
             path       : path,
             text       : document.getText()
         });
 
-        return addPendingRequest(path, 0, HintUtils.TERN_UPDATE_FILE_MSG);
+        return addPendingRequest(path, 0, MessageIds.TERN_UPDATE_FILE_MSG);
     }
 
     /**
@@ -933,20 +934,20 @@ define(function (require, exports, module) {
         var response = e.data,
             type = response.type;
 
-        if (type === HintUtils.TERN_COMPLETIONS_MSG ||
-                type === HintUtils.TERN_CALLED_FUNC_TYPE_MSG) {
+        if (type === MessageIds.TERN_COMPLETIONS_MSG ||
+                type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
             // handle any completions the worker calculated
             handleTernCompletions(response);
-        } else if (type === HintUtils.TERN_GET_FILE_MSG) {
+        } else if (type === MessageIds.TERN_GET_FILE_MSG) {
             // handle a request for the contents of a file
             handleTernGetFile(response);
-        } else if (type === HintUtils.TERN_JUMPTODEF_MSG) {
+        } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
             handleJumptoDef(response);
-        } else if (type === HintUtils.TERN_PRIME_PUMP_MSG) {
+        } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
             handlePrimePumpCompletion(response);
-        } else if (type === HintUtils.TERN_GET_GUESSES_MSG) {
+        } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
             handleGetGuesses(response);
-        } else if (type === HintUtils.TERN_UPDATE_FILE_MSG) {
+        } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
             handleUpdateFile(response);
         } else {
             console.log("Worker: " + (response.log || response));

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -203,16 +203,23 @@ define(function (require, exports, module) {
     Session.prototype.getQuery = function () {
         var cursor  = this.getCursor(),
             token   = this.getToken(cursor),
-            query   = "";
-        
+            query   = "",
+            start   = cursor.ch,
+            end     = start;
+
         if (token) {
-            // If the token string is not an identifier, then the query string
-            // is empty.
-            if (HintUtils.maybeIdentifier(token.string)) {
-                query = token.string.substring(0, token.string.length - (token.end - cursor.ch));
-                query = query.trim();
+            var line = this.getLine(cursor.line);
+            while (start > 0) {
+                if (HintUtils.maybeIdentifier(line[start - 1])) {
+                    start--;
+                } else {
+                    break;
+                }
             }
+
+            query = line.substring(start, end);
         }
+
         return query;
     };
 

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -29,10 +29,10 @@ importScripts("thirdparty/requirejs/require.js");
 (function () {
     "use strict";
     
-    var HintUtils;
+    var MessageIds;
     var Tern;
-    require(["./HintUtils"], function (hintUtils) {
-        HintUtils = hintUtils;
+    require(["./MessageIds"], function (messageIds) {
+        MessageIds = messageIds;
         var ternRequire = require.config({baseUrl: "./thirdparty"});
         ternRequire(["tern/lib/tern", "tern/plugin/requirejs", "tern/plugin/doc_comment"], function (tern, requirejs, docComment) {
             Tern = tern;
@@ -56,7 +56,7 @@ importScripts("thirdparty/requirejs/require.js");
         
         // post a message back to the main thread to get the file contents 
         self.postMessage({
-            type: HintUtils.TERN_GET_FILE_MSG,
+            type: MessageIds.TERN_GET_FILE_MSG,
             file: name
         });
     }
@@ -146,12 +146,12 @@ importScripts("thirdparty/requirejs/require.js");
         ternServer.request(request, function (error, data) {
             if (error) {
                 _log("Error returned from Tern 'definition' request: " + error);
-                self.postMessage({type: HintUtils.TERN_JUMPTODEF_MSG});
+                self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG});
                 return;
             }
             
             // Post a message back to the main thread with the definition
-            self.postMessage({type: HintUtils.TERN_JUMPTODEF_MSG,
+            self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG,
                               file: file,
                               resultFile: data.file,
                               offset: offset,
@@ -227,7 +227,7 @@ importScripts("thirdparty/requirejs/require.js");
 
             if (completions.length > 0 || !isProperty) {
                 // Post a message back to the main thread with the completions
-                self.postMessage({type: HintUtils.TERN_COMPLETIONS_MSG,
+                self.postMessage({type: MessageIds.TERN_COMPLETIONS_MSG,
                     dir: dir,
                     file: file,
                     offset: offset,
@@ -235,7 +235,7 @@ importScripts("thirdparty/requirejs/require.js");
                     });
             } else {
                 // if there are no completions, then get all the properties
-                getTernProperties(dir, file, offset, text, HintUtils.TERN_COMPLETIONS_MSG);
+                getTernProperties(dir, file, offset, text, MessageIds.TERN_COMPLETIONS_MSG);
             }
         });
     }
@@ -263,7 +263,7 @@ importScripts("thirdparty/requirejs/require.js");
             }
 
             // Post a message back to the main thread with the completions
-            self.postMessage({type: HintUtils.TERN_CALLED_FUNC_TYPE_MSG,
+            self.postMessage({type: MessageIds.TERN_CALLED_FUNC_TYPE_MSG,
                               dir: dir,
                               file: file,
                               offset: offset,
@@ -294,7 +294,7 @@ importScripts("thirdparty/requirejs/require.js");
 
         ternServer.addFile(path, text);
 
-        self.postMessage({type: HintUtils.TERN_UPDATE_FILE_MSG,
+        self.postMessage({type: MessageIds.TERN_UPDATE_FILE_MSG,
             path: path
             });
 
@@ -313,7 +313,7 @@ importScripts("thirdparty/requirejs/require.js");
 
         ternServer.request(request, function (error, data) {
             // Post a message back to the main thread
-            self.postMessage({type: HintUtils.TERN_PRIME_PUMP_MSG,
+            self.postMessage({type: MessageIds.TERN_PRIME_PUMP_MSG,
                 path: path
                 });
         });
@@ -324,46 +324,46 @@ importScripts("thirdparty/requirejs/require.js");
             request = e.data,
             type = request.type;
 
-        if (type === HintUtils.TERN_INIT_MSG) {
+        if (type === MessageIds.TERN_INIT_MSG) {
             
             dir         = request.dir;
             var env     = request.env,
                 files   = request.files;
             initTernServer(env, dir, files);
-        } else if (type === HintUtils.TERN_COMPLETIONS_MSG) {
+        } else if (type === MessageIds.TERN_COMPLETIONS_MSG) {
             dir = request.dir;
             file = request.file;
             text    = request.text;
             offset  = request.offset;
             getTernHints(dir, file, offset, text, request.isProperty);
-        } else if (type === HintUtils.TERN_GET_FILE_MSG) {
+        } else if (type === MessageIds.TERN_GET_FILE_MSG) {
             file = request.file;
             text = request.text;
             handleGetFile(file, text);
-        } else if (type === HintUtils.TERN_CALLED_FUNC_TYPE_MSG) {
+        } else if (type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
             dir     = request.dir;
             file    = request.file;
             text    = request.text;
             offset  = request.offset;
             var pos = request.pos;
             handleFunctionType(dir, file, pos, offset, text);
-        } else if (type === HintUtils.TERN_JUMPTODEF_MSG) {
+        } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
             file    = request.file;
             dir     = request.dir;
             text    = request.text;
             offset  = request.offset;
             getJumptoDef(dir, file, offset, text);
-        } else if (type === HintUtils.TERN_ADD_FILES_MSG) {
+        } else if (type === MessageIds.TERN_ADD_FILES_MSG) {
             handleAddFiles(request.files);
-        } else if (type === HintUtils.TERN_PRIME_PUMP_MSG) {
+        } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
             handlePrimePump(request.path, request.text);
-        } else if (type === HintUtils.TERN_GET_GUESSES_MSG) {
+        } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
             dir     = request.dir;
             file    = request.file;
             text    = request.text;
             offset  = request.offset;
-            getTernProperties(dir, file, offset, text, HintUtils.TERN_GET_GUESSES_MSG);
-        } else if (type === HintUtils.TERN_UPDATE_FILE_MSG) {
+            getTernProperties(dir, file, offset, text, MessageIds.TERN_GET_GUESSES_MSG);
+        } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
             handleUpdateFile(request.path, request.text);
         } else {
             _log("Unknown message: " + JSON.stringify(request));

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file1.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file1.js
@@ -148,4 +148,9 @@ var _A1 = A1;
 var s = "", // string type
     help;   // unknown type
 
-
+function testNonAscii() {
+    "use strict";
+    var hope;  // unknown type
+    hope["frenchçProp"] = "";
+    
+}

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -1084,6 +1084,16 @@ define(function (require, exports, module) {
                 hintsPresentOrdered(hintObj, ["shift", "shiftKey"]);
             });
 
+            it("should handle valid non-ascii characters in a property name", function () {
+                var start = { line: 153, ch: 0 },
+                    end   = { line: 153, ch: 13 };
+
+                testDoc.replaceRange("hope.frenchçP", start, start);
+                testEditor.setCursorPos(end);
+                var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                // check we have a properties that start with "shift"
+                hintsPresentOrdered(hintObj, ["frenchçProp"]);
+            });
         });
         
         describe("JavaScript Code Hinting in a HTML file", function () {


### PR DESCRIPTION
HintUtils requires acorn in order to use isIdentifierChar().
Refactor Tern messages ids out from HintUtils into MessageId to remove the tern-worker's dependency on HintUtils.
