### PR TITLE
More extension manager bug fixes

### DIFF
--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -156,6 +156,8 @@ define(function (require, exports, module) {
                 var $target = $(e.target);
                 if ($target.hasClass("undo-remove")) {
                     self.model.markForRemoval($target.attr("data-extension-id"), false);
+                } else if ($target.hasClass("remove")) {
+                    self.model.markForRemoval($target.attr("data-extension-id"), true);
                 } else {
                     // Open any other link in the external browser.
                     NativeApp.openURLInDefaultBrowser($target.attr("href"));

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -18,12 +18,7 @@
                 {{^requiresNewer}}{{Strings.EXTENSION_INCOMPATIBLE_OLDER}}{{/requiresNewer}}
             </div>
         {{/isCompatible}}
-        {{#failedToStart}}
-            <p class="error"><em>{{Strings.EXTENSION_FAILED_TO_START}}</em></p>
-        {{/failedToStart}}
-        {{#metadata.description}}
-            {{metadata.description}}
-        {{/metadata.description}}
+        {{metadata.description}}
         {{^metadata.description}}
             <p class="muted"><em>{{Strings.EXTENSION_NO_DESCRIPTION}}</em></p>
         {{/metadata.description}}
@@ -47,13 +42,20 @@
             </button>
         {{/showInstallButton}}
         {{#isInstalled}}
+            {{^failedToStart}}
+                {{^isMarkedForRemoval}}
+                    <button class="btn btn-mini remove" data-extension-id="{{metadata.name}}" {{^allowRemove}}disabled title="{{Strings.CANT_REMOVE_DEV}}"{{/allowRemove}}>
+                        {{Strings.REMOVE}}
+                    </button>
+                {{/isMarkedForRemoval}}
+            {{/failedToStart}}
+            {{#failedToStart}}
+                {{^isMarkedForRemoval}}
+                    {{Strings.EXTENSION_ERROR}} (<a class="remove" data-extension-id="{{metadata.name}}">{{Strings.REMOVE}}</a>)
+                {{/isMarkedForRemoval}}
+            {{/failedToStart}}
             {{#isMarkedForRemoval}}
                 {{Strings.MARKED_FOR_REMOVAL}} (<a class="undo-remove" data-extension-id="{{metadata.name}}">{{Strings.UNDO_REMOVE}}</a>)
-            {{/isMarkedForRemoval}}
-            {{^isMarkedForRemoval}}
-                <button class="btn btn-mini remove" data-extension-id="{{metadata.name}}" {{^allowRemove}}disabled title="{{Strings.CANT_REMOVE_DEV}}"{{/allowRemove}}>
-                    {{Strings.REMOVE}}
-                </button>
             {{/isMarkedForRemoval}}
         {{/isInstalled}}
     </td>

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -27,6 +27,9 @@
         {{^metadata.description}}
             <p class="muted"><em>{{Strings.EXTENSION_NO_DESCRIPTION}}</em></p>
         {{/metadata.description}}
+        {{#metadata.homepage}}
+            <p><a href="{{metadata.homepage}}">{{Strings.EXTENSION_MORE_INFO}}</a></p>
+        {{/metadata.homepage}}
         {{#metadata.keywords.length}}
             <br/>
             <span class="ext-keywords">{{Strings.EXTENSION_KEYWORDS}}:

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -333,7 +333,7 @@ define({
     "EXTENSION_INCOMPATIBLE_OLDER"         : "This extension currently only works with older versions of {APP_NAME}.",
     "EXTENSION_NO_DESCRIPTION"             : "No description",
     "EXTENSION_MORE_INFO"                  : "More info...",
-    "EXTENSION_FAILED_TO_START"            : "This extension did not start up successfully and should be removed.",
+    "EXTENSION_ERROR"                      : "Extension error",
     "EXTENSION_KEYWORDS"                   : "Keywords",
     "EXTENSION_INSTALLED"                  : "Installed",
     "EXTENSION_SEARCH_PLACEHOLDER"         : "Search",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -332,6 +332,7 @@ define({
     "EXTENSION_INCOMPATIBLE_NEWER"         : "This extension requires a newer version of {APP_NAME}.",
     "EXTENSION_INCOMPATIBLE_OLDER"         : "This extension currently only works with older versions of {APP_NAME}.",
     "EXTENSION_NO_DESCRIPTION"             : "No description",
+    "EXTENSION_MORE_INFO"                  : "More info...",
     "EXTENSION_FAILED_TO_START"            : "This extension did not start up successfully and should be removed.",
     "EXTENSION_KEYWORDS"                   : "Keywords",
     "EXTENSION_INSTALLED"                  : "Installed",

--- a/test/spec/ExtensionManager-test-files/mockRegistry.json
+++ b/test/spec/ExtensionManager-test-files/mockRegistry.json
@@ -29,6 +29,7 @@
         "name": "Really Great Guy"
       },
       "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis quam purus, convallis ut fringilla nec, iaculis ac felis. Cras ac commodo dui. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In nibh eros, venenatis sed consectetur ut, rutrum ac dolor. Ut scelerisque egestas odio, sed dignissim ligula lobortis ac.",
+      "homepage": "https://fakesite.com/long-desc-extension.html",
       "keywords": [
         "awesome",
         "socool"

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -804,14 +804,21 @@ define(function (require, exports, module) {
                     });
                 });
                 
-                it("should show extensions that failed to load and allow them to be removed", function () {
+                it("should show extensions that failed to load with a 'remove' link", function () {
                     mockLoadExtensions(["user/mock-extension-3"], true);
                     setupViewWithMockData(ExtensionManagerViewModel.SOURCE_INSTALLED);
                     runs(function () {
                         expect(view).toHaveText("mock-extension-3");
-                        var $button = $("button.remove[data-extension-id=mock-extension-3]", view.$el);
-                        expect($button.length).toBe(1);
-                        expect($button.attr("disabled")).toBeFalsy();
+                        var $removeLink = $("a.remove[data-extension-id=mock-extension-3]", view.$el);
+                        expect($removeLink.length).toBe(1);
+                        expect($removeLink.attr("disabled")).toBeFalsy();
+                        
+                        $removeLink.click();
+                        expect(view.model.isMarkedForRemoval("mock-extension-3")).toBe(true);
+                        var $undoLink = $("a.undo-remove[data-extension-id=mock-extension-3]", view.$el);
+                        expect($undoLink.length).toBe(1);
+                        $removeLink = $("a.remove[data-extension-id=mock-extension-3]", view.$el);
+                        expect($removeLink.length).toBe(0);
                     });
                 });
                 

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -551,6 +551,13 @@ define(function (require, exports, module) {
                             return "Expected view" + notText + " to contain text " + expected;
                         };
                         return SpecRunnerUtils.findDOMText(this.actual.$el, expected);
+                    },
+                    toHaveLink: function (expected) {
+                        var notText = this.isNot ? " not" : "";
+                        this.message = function () {
+                            return "Expected view" + notText + " to contain link " + expected;
+                        };
+                        return SpecRunnerUtils.findDOMText(this.actual.$el, expected, true);
                     }
                 });
                 spyOn(InstallExtensionDialog, "installUsingDialog").andCallFake(function (url) {
@@ -585,6 +592,9 @@ define(function (require, exports, module) {
                                         expect(view).toHaveText(value);
                                     }
                                 });
+                            if (item.metadata.homepage) {
+                                expect(view).toHaveLink(item.metadata.homepage);
+                            }
                             
                             // Array-valued fields
                             [item.metadata.keywords, item.metadata.categories].forEach(function (arr) {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -865,9 +865,10 @@ define(function (require, exports, module) {
      * @param {jQueryObject|Node} root The root element to search from. Can be either a jQuery object
      *     or a raw DOM node.
      * @param {string} content The content to find.
+     * @param {boolean} asLink If true, find the content in the href of an <a> tag, otherwise find it in text nodes.
      * @return true if content was found
      */
-    function findDOMText(root, content) {
+    function findDOMText(root, content, asLink) {
         // Unfortunately, we can't just use jQuery's :contains() selector, because it appears that
         // you can't escape quotes in it.
         var i;
@@ -876,12 +877,15 @@ define(function (require, exports, module) {
         }
         if (!root) {
             return false;
-        } else if (root.nodeType === 3) { // text node
+        } else if (!asLink && root.nodeType === 3) { // text node
             return root.textContent.indexOf(content) !== -1;
         } else {
+            if (asLink && root.nodeType === 1 && root.tagName.toLowerCase() === "a" && root.getAttribute("href") === content) {
+                return true;
+            }
             var children = root.childNodes;
             for (i = 0; i < children.length; i++) {
-                if (findDOMText(children[i], content)) {
+                if (findDOMText(children[i], content, asLink)) {
                     return true;
                 }
             }


### PR DESCRIPTION
For #3873, adds a "More Info..." link if there is a homepage in the extension metadata. You can test this out with https://github.com/njx/select-parent.

For #3865, moves the "extension error" message to the "remove" button column.
