### PR TITLE
Implements word wrap for function signatures

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -214,6 +214,11 @@ define(function (require, exports, module) {
                 }
             });
             
+            // single item lists may be styled differently (function signatures are an example)
+            if (this.hints.length === 1) {
+                $ul.find("li a").addClass("single");
+            }
+
             // attach to DOM
             $parent.append($ul);
             
@@ -222,10 +227,11 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Computes top left location for hint list so that the list is not clipped by the window
+     * Computes top left location for hint list so that the list is not clipped by the window.
+     * Also computes the largest available width.
      *
      * @private
-     * @return {{left: number, top: number}}
+     * @return {{left: number, top: number, width: number}}
      */
     CodeHintList.prototype._calcHintListLocation = function () {
         var cursor      = this.editor._codeMirror.cursorCoords(),
@@ -244,13 +250,17 @@ define(function (require, exports, module) {
         }
 
         posTop -= 30;   // shift top for hidden parent element
-
-        var rightOverhang = posLeft + $menuWindow.width() - $window.width();
+        
+        var menuWidth = $menuWindow.width();
+        var availableWidth = menuWidth;
+        var rightOverhang = posLeft + menuWidth - $window.width();
         if (rightOverhang > 0) {
             posLeft = Math.max(0, posLeft - rightOverhang);
+        } else {
+            availableWidth = rightOverhang * -1 + menuWidth;
         }
 
-        return {left: posLeft, top: posTop};
+        return {left: posLeft, top: posTop, width: availableWidth};
     };
     
     /**
@@ -371,7 +381,7 @@ define(function (require, exports, module) {
             var hintPos = this._calcHintListLocation();
             
             this.$hintMenu.addClass("open")
-                .css({"left": hintPos.left, "top": hintPos.top});
+                .css({"left": hintPos.left, "top": hintPos.top, "width": hintPos.width + "px"});
             this.opened = true;
             
             PopUpManager.addPopUp(this.$hintMenu, this.handleClose, true);
@@ -390,7 +400,8 @@ define(function (require, exports, module) {
         // Update the CodeHintList location
         if (this.hints.length) {
             var hintPos = this._calcHintListLocation();
-            this.$hintMenu.css({"left": hintPos.left, "top": hintPos.top});
+            this.$hintMenu.css({"left": hintPos.left, "top": hintPos.top,
+                                "width": hintPos.width + "px"});
         }
     };
 

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -148,6 +148,7 @@ define(function (require, exports, module) {
             _addHint;
 
         this.hints = hintObj.hints;
+        this.hints.handleWideResults = hintObj.handleWideResults;
 
         // if there is no match, assume name is already a formatted jQuery
         // object; otherwise, use match to format name for display.
@@ -214,11 +215,11 @@ define(function (require, exports, module) {
                 }
             });
             
-            // single item lists may be styled differently (function signatures are an example)
-            if (this.hints.length === 1) {
-                $ul.find("li a").addClass("single");
+            // Lists with wide results require different formatting
+            if (this.hints.handleWideResults) {
+                $ul.find("li a").addClass("wide-result");
             }
-
+            
             // attach to DOM
             $parent.append($ul);
             
@@ -256,7 +257,7 @@ define(function (require, exports, module) {
         var rightOverhang = posLeft + menuWidth - $window.width();
         if (rightOverhang > 0) {
             posLeft = Math.max(0, posLeft - rightOverhang);
-        } else {
+        } else if (this.hints.handleWideResults) {
             availableWidth = rightOverhang * -1 + menuWidth;
         }
 

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -258,7 +258,8 @@ define(function (require, exports, module) {
         if (rightOverhang > 0) {
             posLeft = Math.max(0, posLeft - rightOverhang);
         } else if (this.hints.handleWideResults) {
-            availableWidth = rightOverhang * -1 + menuWidth;
+            // Right overhang is negative
+            availableWidth = menuWidth + Math.abs(rightOverhang);
         }
 
         return {left: posLeft, top: posTop, width: availableWidth};

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -537,6 +537,8 @@ define(function (require, exports, module) {
             }
             hints[0] = {value: fnHint, positions: []};
         }
+        
+        hints.handleWideResults = true;
         return hints;
     };
 

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -162,11 +162,12 @@ define(function (require, exports, module) {
         } else {
             formattedHints = [];
         }
-
+        
         return {
             hints: formattedHints,
             match: null, // the CodeHintManager should not format the results
-            selectInitial: true
+            selectInitial: true,
+            handleWideResults: hints.handleWideResults
         };
     }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -241,7 +241,7 @@
                 white-space: nowrap;
                 .box-shadow(none);
                 
-                &.single {
+                &.wide-result {
                     white-space: normal;
                 }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -240,6 +240,10 @@
                 text-shadow: none;
                 white-space: nowrap;
                 .box-shadow(none);
+                
+                &.single {
+                    white-space: normal;
+                }
 
                 &:hover, &.highlight {
                     color: @bc-black;


### PR DESCRIPTION
Fix for #3610 by implementing word wrap for function signatures (or any other long single item hint list).

I spoke with @njx about his thoughts on this and he suggested that we use JavaScript to figure out appropriate width and positioning for the code hint box. The CodeHintList was already computing the left and top of the code hint list box, so I added the width in there.

When the box is to the extreme right, it is still pretty small. We could have moved it farther left in those cases, but I think it would be too far away from the actual code hint site if we do that.

Right now, the box is constrained by a `max-width` CSS property (currently 400px). I didn't change that setting, because I think it's more pleasant to wrap at 400px than to make the box wider still. I'm open to other opinions on it.
