### PR TITLE
Install jasmine-node as needed by the jasmine-node task.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - 0.8
 before_script:
   - npm install -g grunt-cli
+  - npm install -g jasmine-node


### PR DESCRIPTION
It looks like there was a spurious travis failure the other day and on IRC, I had a report of grunt failing at the jasmine-node task. It looks like you need jasmine-node installed globally for the grunt task to work. It's probably the case that we've just lucked out with other travis-hosted projects having already installed jasmine-node.

With this change, we ensure that jasmine-node is installed globally in travis (as we do with grunt-cli).
