### PR TITLE
Make HTML and CSS code completion not to overwrite the neighboring text.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -483,6 +483,18 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Test whether the provider has an exclusion that is still the same as text after the cursor.
+     *
+     * @param {string} exclusion - Text not to be overwritten when the provider inserts the selected hint.
+     * @param {string} textAfterCursor - Text that is immediately after the cursor position.
+     * @return {boolean} true if the exclusion is not null and is exactly the same as textAfterCursor,
+     * false otherwise.
+     */
+    function hasValidExclusion(exclusion, textAfterCursor) {
+        return (exclusion && exclusion === textAfterCursor);
+    }
+    
+    /**
      *  Test if a hint popup is open.
      *
      * @returns {boolean} - true if the hints are open, false otherwise.
@@ -504,4 +516,5 @@ define(function (require, exports, module) {
     exports.handleKeyEvent          = handleKeyEvent;
     exports.handleChange            = handleChange;
     exports.registerHintProvider    = registerHintProvider;
+    exports.hasValidExclusion       = hasValidExclusion;
 });

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -35,18 +35,6 @@ define(function (require, exports, module) {
         properties          = JSON.parse(CSSProperties);
     
     /**
-     * Check whether the exclusion is still the same as text after the cursor.
-     *
-     * @param {string} exclusion - Text not to be overwritten when inserting hint.
-     * @param {string} textAfterCursor - Text that is immediately after the cursor position.
-     * @return {boolean} true if the exclusion is not null and is exactly the same as textAfterCursor,
-     * false otherwise.
-     */
-    function _hasValidExclusion(exclusion, textAfterCursor) {
-        return (exclusion && exclusion === textAfterCursor);
-    }
-    
-    /**
      * @constructor
      */
     function CssPropHints() {
@@ -55,6 +43,28 @@ define(function (require, exports, module) {
         this.exclusion = null;
     }
 
+    /**
+     * Check whether the exclusion is still the same as text after the cursor. 
+     * If not, reset it to null.
+     *
+     * @param {boolean} propNameOnly
+     * true to indicate that we update the exclusion only if the cursor is inside property name context.
+     * Otherwise, we also update exclusion for property value context.
+     */
+    CssPropHints.prototype.updateExclusion = function (propNameOnly) {
+        var textAfterCursor;
+        if (this.exclusion && this.info) {
+            if (this.info.context === CSSUtils.PROP_NAME) {
+                textAfterCursor = this.info.name.substr(this.info.offset);
+            } else if (!propNameOnly && this.info.context === CSSUtils.PROP_VALUE) {
+                textAfterCursor = this.info.value.substr(this.info.offset);
+            }
+            if (!CodeHintManager.hasValidExclusion(this.exclusion, textAfterCursor)) {
+                this.exclusion = null;
+            }
+        }
+    };
+    
     /**
      * Determines whether CSS propertyname or -name hints are available in the current editor
      * context.
@@ -84,18 +94,7 @@ define(function (require, exports, module) {
         }
         
         if (implicitChar) {
-            // If we have an exclusion from previous session, clear it now.
-            if (this.exclusion) {
-                if (this.info.context === CSSUtils.PROP_NAME) {
-                    textAfterCursor = this.info.name.substr(this.info.offset);
-                } else {
-                    textAfterCursor = this.info.value.substr(this.info.offset);
-                }
-                if (!_hasValidExclusion(this.exclusion, textAfterCursor)) {
-                    this.exclusion = null;
-                }
-            }
-            
+            this.updateExclusion(false);
             if (this.info.context === CSSUtils.PROP_NAME) {
                 // Check if implicitChar is the first character typed before an existing property name.
                 if (!this.exclusion && this.info.offset === 1 && implicitChar === this.info.name[0]) {
@@ -108,11 +107,8 @@ define(function (require, exports, module) {
         } else if (this.info.context === CSSUtils.PROP_NAME) {
             if (this.info.offset === 0) {
                 this.exclusion = this.info.name;
-            } else if (this.exclusion) {
-                textAfterCursor = this.info.name.substr(this.info.offset);
-                if (!_hasValidExclusion(this.exclusion, textAfterCursor)) {
-                    this.exclusion = null;
-                }
+            } else {
+                this.updateExclusion(true);
             }
         }
         
@@ -153,12 +149,7 @@ define(function (require, exports, module) {
         }
         
         // Clear the exclusion if the user moves the cursor with left/right arrow key.
-        if (this.exclusion && context === CSSUtils.PROP_NAME) {
-            var textAfterCursor = needle.substr(this.info.offset);
-            if (!_hasValidExclusion(this.exclusion, textAfterCursor)) {
-                this.exclusion = null;
-            }
-        }
+        this.updateExclusion(true);
 
         if (context === CSSUtils.PROP_VALUE) {
             if (!properties[needle]) {
@@ -229,7 +220,7 @@ define(function (require, exports, module) {
         if (this.info.context === CSSUtils.PROP_NAME) {
             keepHints = true;
             var textAfterCursor = this.info.name.substr(this.info.offset);
-            if (this.info.name.length === 0 || _hasValidExclusion(this.exclusion, textAfterCursor)) {
+            if (this.info.name.length === 0 || CodeHintManager.hasValidExclusion(this.exclusion, textAfterCursor)) {
                 // It's a new insertion, so append a colon and set keepHints
                 // to show property value hints.
                 hint += ":";

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -526,11 +526,11 @@ define(function (require, exports, module) {
                 expectCursorAt({ line: 9, ch: 16 });            // cursor at end of attr name
             });
             
-            it("should overwrite attribute but not change value, cursor at start", function () {  // (bug #1312)
+            it("should insert a new attribute before the existing one that starts at cursor", function () {  // (bug #1312)
                 testEditor.setCursorPos({ line: 5, ch: 6 });    // cursor between space and start of existing attribute name ("id")
                 selectHint(HTMLCodeHints.attrHintProvider, "class");
-                expect(testDocument.getLine(5)).toBe("  <h1 class='foo'>Heading</h1>");
-                expectCursorAt({ line: 5, ch: 11 });            // cursor at end of attr name
+                expect(testDocument.getLine(5)).toBe("  <h1 class=\"\"id='foo'>Heading</h1>");
+                expectCursorAt({ line: 5, ch: 13 });            // cursor between two double-quotes
             });
             it("should change nothing when cursor at end", function () {  // (bug #1314)
                 testEditor.setCursorPos({ line: 5, ch: 8 });    // cursor between end of existing attribute name ("id") and =
@@ -539,21 +539,21 @@ define(function (require, exports, module) {
                 expectCursorAt({ line: 5, ch: 8 });            // cursor stays at end of attr name
             });
             
-            it("should overwrite attribute with valueless attribute, but still not change value", function () {
+            it("should insert a valueless attribute before the existing attribute that starts at cursor", function () {
                 testDocument.replaceRange("  <input id='foo'>\n", { line: 9, ch: 0 });  // insert new line
                 
-                testEditor.setCursorPos({ line: 9, ch: 9 });    // cursor after trailing space
+                testEditor.setCursorPos({ line: 9, ch: 9 });    // cursor after between "i" and "d"
                 selectHint(HTMLCodeHints.attrHintProvider, "checked");
-                expect(testDocument.getLine(9)).toBe("  <input checked='foo'>");
+                expect(testDocument.getLine(9)).toBe("  <input checkedid='foo'>");
                 expectCursorAt({ line: 9, ch: 16 });            // cursor between end of attr name and =
             });
             
-            it("should overwrite valueless attribute with normal attribute, adding value", function () {
+            it("should insert a new atribute with an empty value before the existing valueless attribute", function () {
                 testDocument.replaceRange("  <input checked>\n", { line: 9, ch: 0 });  // insert new line
                 
                 testEditor.setCursorPos({ line: 9, ch: 9 });    // cursor after trailing space
                 selectHint(HTMLCodeHints.attrHintProvider, "class");
-                expect(testDocument.getLine(9)).toBe("  <input class=\"\">");
+                expect(testDocument.getLine(9)).toBe("  <input class=\"\"checked>");
                 expectCursorAt({ line: 9, ch: 16 });            // cursor between the two "s
             });
  


### PR DESCRIPTION
This fixes issue #3005 for HTML and CSS code completion. 

Changes for HTML code completion are
- Never replace the existing tag or attribute name or just plain text if code hint is invoked at the very beginning of an existing tag or attribute name or just plain text.
- Replace an existing tag, or attribute name/value if it is invoked when the cursor is inside (or at the end of)  an existing tag or attribute name/value.
- Always replace an existing attribute value even if it is invoked from the very beginning of the attribute value. (ie. after the `=` or `"` or `'`) However, if it is triggered by typing everything from tag name until the `=`, then any word after the `=` is not replaced. For example, if the user types `<a dir=` before `myEmail@address.com` and select an attribute value from the hint list, `myEmail@address.com` will not be replaced.

Changes for CSS code completion are
- Never replace an existing property name when invoking the CSS hints from the very beginning of an existing one with Ctrl+Space.
- Never replace an existing property name when invoking the CSS  hints by typing a letter before an existing property name. (eg. typing `m` in front of `display: none;`)
- Always replace an existing property value regardless of invoking it from any cursor position. (ie. no change for property value hinting)
