### PR TITLE
Make literal's in hints use monospace font,

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
+++ b/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
@@ -45,6 +45,7 @@
 
 .brackets-js-hints.literal-hint {
     color: #444; /* dark grey */
+    font-family: monospace;
 }
 
 .brackets-js-hints.keyword-hint {


### PR DESCRIPTION
so they look more like keyword hints.

Fixes issue #3768
