### PR TITLE
Style textarea like input

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -622,7 +622,7 @@
 }
 
 /* Input */
-input {
+input, textarea {
     background-color: #fff;
     border: 1px solid #9c9e9e;
     .border-radius(3px);


### PR DESCRIPTION
Recent UI updates changed the way input form controls are styled, but didn't make corresponding changes to textareas. This pull request additionally applies these changes to textareas.

Addresses adobe/brackets-edge-web-fonts#112.
