### PR TITLE
Safer version of file deleting

### DIFF
--- a/src/file/NativeFileSystem.js
+++ b/src/file/NativeFileSystem.js
@@ -370,7 +370,14 @@ define(function (require, exports, module) {
      * @param {function(DOMError)=} errorCallback Callback function for error operations
      */
     NativeFileSystem.Entry.prototype.remove = function (successCallback, errorCallback) {
-        var deleteFunc = brackets.fs.moveToTrash || brackets.fs.unlink;
+        var deleteFunc = brackets.fs.moveToTrash; // Future: Could fallback to unlink 
+        
+        if (!deleteFunc) {
+            // Running in a shell that doesn't support moveToTrash. Return an error.
+            errorCallback(brackets.fs.ERR_UNKNOWN);
+            return;
+        }
+        
         deleteFunc(this.fullPath, function (err) {
             if (err === brackets.fs.NO_ERROR) {
                 successCallback();


### PR DESCRIPTION
Always use the `fs.moveToTrash` function to delete files. Previously `unlink` was used if `moveToTrash` didn't exist.

This way, if you are running in the Sprint 24 shell, trying to delete a file will just throw an error rather than permanently deleting the file.

The old behavior, combined with #3924, could lead to data loss. 
