### PR TITLE
Fix live preview refresh issues (again)

### DIFF
--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -246,31 +246,54 @@ define(function Inspector(require, exports, module) {
         $exports.off(name, handler);
     }
 
-    /** Disconnect from the remote debugger WebSocket */
+    /**
+     * Disconnect from the remote debugger WebSocket
+     * @return {jQuery.Promise} Promise that is resolved immediately if not
+     *     currently connected or asynchronously when the socket is closed.
+     */
     function disconnect() {
-        if (_socket) {
-            if (_socket.readyState === 1) {
-                _socket.close();
-            } else {
+        var deferred = new $.Deferred(),
+            promise = deferred.promise();
+
+        if (_socket && (_socket.readyState === WebSocket.OPEN)) {
+            _socket.onclose = function () {
+                // trigger disconnect event
+                _onDisconnect();
+
+                deferred.resolve();
+            };
+
+            promise = Async.withTimeout(promise, 5000);
+
+            _socket.close();
+        } else {
+            if (_socket) {
                 delete _socket.onmessage;
                 delete _socket.onopen;
                 delete _socket.onclose;
                 delete _socket.onerror;
-            }
-            _socket = undefined;
-        }
-    }
 
-    /** Connect to the remote debugger WebSocket at the given URL
+                _socket = undefined;
+            }
+            
+            deferred.resolve();
+        }
+
+        return promise;
+    }
+    /**
+     * Connect to the remote debugger WebSocket at the given URL.
+     * Clients must listen for the `connect` event.
      * @param {string} WebSocket URL
      */
     function connect(socketURL) {
-        disconnect();
-        _socket = new WebSocket(socketURL);
-        _socket.onmessage = _onMessage;
-        _socket.onopen = _onConnect;
-        _socket.onclose = _onDisconnect;
-        _socket.onerror = _onError;
+        disconnect().done(function () {
+            _socket = new WebSocket(socketURL);
+            _socket.onmessage = _onMessage;
+            _socket.onopen = _onConnect;
+            _socket.onclose = _onDisconnect;
+            _socket.onerror = _onError;
+        });
     }
 
     /** Connect to the remote debugger of the page that is at the given URL

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -83,6 +83,8 @@
 define(function Inspector(require, exports, module) {
     "use strict";
 
+    var Async = require("utils/Async");
+
     // jQuery exports object for events
     var $exports = $(exports);
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -307,6 +307,11 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         if (_serverProvider) {
+            // Stop listening for requests
+            if (_serverProvider.setRequestFilterPaths) {
+                _serverProvider.setRequestFilterPaths([]);
+            }
+
             // Remove any "request" listeners that were added previously
             $(_serverProvider).off(".livedev");
         }


### PR DESCRIPTION
Replaces original pull #3852 
#3761 I found 2 issues here:
- When hitting refresh rapidly, the inspector API was returning an error `Inspected frame has gone`. This was due to our `keepAlive` `RemoteAgent` function call trying to call to a page(frame?) that no longer exists. I've updated `RemoteAgent` to stop the `keepAlive` timer when a new page loads.
- After getting in the above error state where the inspector web socket is still open, there were async issues calling `Inspector.connect()` where the inspector may get a disconnect event in the middle of the connection process. This caused an error dialog to appear `Unable to load live development page`. I've changed `connect()` to wait for a new `disconnect()` promise to complete.
#3792 After switching the current live document, remove all HTTP request filters.
