### PR TITLE
Reveal cursor on panel open

### DIFF
--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -108,14 +108,10 @@ define(function (require, exports, module) {
             if (_currentEditor) {
 
                 // Gather info to determine whether to scroll after editor resizes
-                var scrollInfo = _currentEditor._codeMirror.getScrollInfo(),
-                    currScroll = scrollInfo.top,
-                    height     = scrollInfo.clientHeight,
+                var height     = _currentEditor._codeMirror.getScrollInfo().clientHeight,
                     textHeight = _currentEditor.getTextHeight(),
                     cursorTop  = _currentEditor._codeMirror.cursorCoords().top,
-                    allHeight  = 0;
-
-                var bottom = cursorTop - $("#editor-holder").offset().top + textHeight - height;
+                    bottom     = cursorTop - $("#editor-holder").offset().top + textHeight - height;
 
                 // Determine whether panel would block text at cursor
                 // If so, scroll the editor to expose the cursor above

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -99,6 +99,32 @@ define(function (require, exports, module) {
         $panel.on("panelCollapsed panelExpanded panelResizeUpdate", function () {
             triggerEditorResize();
         });
+
+        $panel.on("panelExpanded", function () {
+            var _currentEditor = EditorManager.getCurrentFullEditor();
+
+            // Make sure that we're not switching files
+            // and still on an active editor
+            if (_currentEditor) {
+
+                // Gather info to determine whether to scroll after editor resizes
+                var scrollInfo = _currentEditor._codeMirror.getScrollInfo(),
+                    currScroll = scrollInfo.top,
+                    height     = scrollInfo.clientHeight,
+                    textHeight = _currentEditor.getTextHeight(),
+                    cursorTop  = _currentEditor._codeMirror.cursorCoords().top,
+                    allHeight  = 0;
+
+                var bottom = cursorTop - $("#editor-holder").offset().top + textHeight - height;
+
+                // Determine whether panel would block text at cursor
+                // If so, scroll the editor to expose the cursor above
+                // the panel
+                if (bottom <= $panel.height() && bottom >= 5) {
+                    _currentEditor._codeMirror.scrollIntoView();
+                }
+            }
+        });
     }
     
     


### PR DESCRIPTION
For issue #3371:
Added code to `PanelManagement` to reveal cursor that would otherwise be hidden by the panel with it opens.
