### PR TITLE
Improved panel management - prevent resizing panels larger than available space

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -380,8 +380,6 @@ define(function (require, exports, module) {
      */
     function _onEditorAreaResize(event, editorAreaHt, refreshFlag) {
         
-        _editorHolder.height(editorAreaHt);    // affects size of "not-editor" placeholder as well
-        
         if (_currentEditor) {
             var curRoot = _currentEditor.getRootElement(),
                 curWidth = $(curRoot).width();

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -355,23 +355,23 @@ define(function (require, exports, module) {
      */
     var REFRESH_SKIP = "skip";
 
-    /** 
-     * Update the editor area's size: invokes PanelManager to compute the correct size and call us back with it.
-     * Anyone who changes the size/visibility of editor area siblings without going through PanelManager/Resizer
-     * *must* manually call resizeEditor().
+    /**
+     * Must be called whenever the size/visibility of editor area siblings is changed without going through
+     * PanelManager or Resizer. Resizable panels created via PanelManager do not require this manual call.
      */
     function resizeEditor() {
         if (!_editorHolder) {
             return;  // still too early during init
         }
+        // PanelManager computes the correct editor-holder size & calls us back with it, via _onEditorAreaResize()
         PanelManager._notifyLayoutChange();
     }
     
     /**
-     * Update the current CodeMirror's editor's size. Must be called any time the contents of the editor area
+     * Update the current CodeMirror editor's size. Must be called any time the contents of the editor area
      * are swapped or any time the editor-holder area has changed height. EditorManager calls us in the swap
      * case. PanelManager calls us in the most common height-change cases (panel and/or window resize), but
-     * some other cases are handled by external code calling resizeEditor() (e.g. ModalBar hide/show.
+     * some other cases are handled by external code calling resizeEditor() (e.g. ModalBar hide/show).
      * 
      * @param {number} editorAreaHt
      * @param {string=} refreshFlag For internal use. Set to "force" to ensure the editor will refresh, 

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Commands                = brackets.getModule("command/Commands"),
+        PanelManager            = brackets.getModule("view/PanelManager"),
         CommandManager          = brackets.getModule("command/CommandManager"),
         Menus                   = brackets.getModule("command/Menus"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
@@ -156,7 +157,7 @@ define(function (require, exports, module) {
                         EditorManager.focusEditor();
                     });
                 
-                $lintResults.show();
+                Resizer.show($lintResults);
                 if (JSLINT.errors.length === 1) {
                     StatusBar.updateIndicator(INDICATOR_ID, true, "jslint-errors", Strings.JSLINT_ERROR_INFORMATION);
                 } else {
@@ -175,7 +176,7 @@ define(function (require, exports, module) {
                 setGotoEnabled(true);
             
             } else {
-                $lintResults.hide();
+                Resizer.hide($lintResults);
                 StatusBar.updateIndicator(INDICATOR_ID, true, "jslint-valid", Strings.JSLINT_NO_ERRORS);
                 setGotoEnabled(false);
             }
@@ -184,12 +185,10 @@ define(function (require, exports, module) {
 
         } else {
             // JSLint is disabled or does not apply to the current file, hide the results
-            $lintResults.hide();
+            Resizer.hide($lintResults);
             StatusBar.updateIndicator(INDICATOR_ID, true, "jslint-disabled", Strings.JSLINT_DISABLED);
             setGotoEnabled(false);
         }
-        
-        EditorManager.resizeEditor();
     }
     
     /**
@@ -263,20 +262,15 @@ define(function (require, exports, module) {
         ExtensionUtils.loadStyleSheet(module, "jslint.css");
         
         var jsLintHtml = Mustache.render(JSLintTemplate, Strings);
-        $(jsLintHtml).insertBefore("#status-bar");
+        var resultsPanel = PanelManager.createBottomPanel("jslint.results", $(jsLintHtml), 100);
+        $lintResults = $("#jslint-results");
         
         var goldStarHtml = Mustache.render("<div id=\"gold-star\" title=\"{{JSLINT_NO_ERRORS}}\">&#9733;</div>", Strings);
         $(goldStarHtml).insertBefore("#status-file");
-        
-        $lintResults = $("#jslint-results");
         
         StatusBar.addIndicator(INDICATOR_ID, $("#gold-star"));
         
         // Called on HTML ready to trigger the initial UI state
         setEnabled(_prefs.getValue("enabled"));
-        
-        // AppInit.htmlReady() has already executed before extensions are loaded
-        // so, for now, we need to call this ourself
-        Resizer.makeResizable($lintResults.get(0), "vert", "top", 100);
     });
 });

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -49,26 +49,15 @@ define(function (require, exports, module) {
             DocumentManager.setCurrentDocument(doc);
         });
     });
+    
     /**
-     * Returns an Editor suitable for use in isolation, given a Document. (Unlike
-     * SpecRunnerUtils.createMockEditor(), which is given text and creates the Document
-     * for you).
+     * Returns an Editor suitable for use in isolation, given a Document.
      *
      * @param {Document} doc - the document to be contained by the new Editor
      * @return {Editor} - the mock editor object
      */
     function createMockEditor(doc) {
-        // Initialize EditorManager
-        var $editorHolder = $("<div id='mock-editor-holder'/>");
-        EditorManager.setEditorHolder($editorHolder);
-        $("body").append($editorHolder);
-        
-        // create Editor instance
-        var editor = new Editor(doc, true, $editorHolder.get(0));
-
-        EditorManager._notifyActiveEditorChanged(editor);
-        
-        return editor;
+        return SpecRunnerUtils.createMockEditorForDocument(doc);
     }
 
     describe("JavaScript Code Hinting", function () {

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -62,7 +62,7 @@
             Note: all children must be in a vertical stack with heights explicitly set in a fixed
                 unit such as px (not percent/em/auto). If you change the height later, you must
                 call EditorManager.resizeEditor() each time. Otherwise editor-holder's height will
-                not get set correctly.
+                not get set correctly. Use PanelManager to have this managed for you automatically.
          -->
         <div class="content">
             <!-- Horizontal titlebar containing menus & filename when inBrowser -->
@@ -83,14 +83,7 @@
                 </div>
             </div>
             
-            <div id="search-results" class="bottom-panel vert-resizable top-resizer no-focus">
-                <div class="toolbar simple-toolbar-layout">
-                    <div class="title">{{SEARCH_RESULTS}}</div>
-                    <div class="title" id="search-result-summary"></div>
-                    <a href="#" class="close">&times;</a>
-                </div>
-                <div class="table-container resizable-content"></div>
-            </div>
+            <!-- Bottom panels and status bar are programmatically created here -->
             
         </div>
 

--- a/src/htmlContent/search-results.html
+++ b/src/htmlContent/search-results.html
@@ -1,0 +1,8 @@
+<div id="search-results" class="bottom-panel vert-resizable top-resizer no-focus">
+    <div class="toolbar simple-toolbar-layout">
+        <div class="title">{{SEARCH_RESULTS}}</div>
+        <div class="title" id="search-result-summary"></div>
+        <a href="#" class="close">&times;</a>
+    </div>
+    <div class="table-container resizable-content"></div>
+</div>

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, PathUtils, window */
+/*global define, $, PathUtils, window, Mustache */
 
 /*
  * Adds a "find in files" command to allow the user to find all occurances of a string in all files in
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var Async               = require("utils/Async"),
+        Resizer             = require("utils/Resizer"),
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         Strings             = require("strings"),
@@ -50,12 +51,15 @@ define(function (require, exports, module) {
         ProjectManager      = require("project/ProjectManager"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
+        PanelManager        = require("view/PanelManager"),
         FileIndexManager    = require("project/FileIndexManager"),
         FileUtils           = require("file/FileUtils"),
         KeyEvent            = require("utils/KeyEvent"),
         AppInit             = require("utils/AppInit"),
         StatusBar           = require("widgets/StatusBar"),
         ModalBar            = require("widgets/ModalBar").ModalBar;
+    
+    var searchResultsTemplate = require("text!htmlContent/search-results.html");
 
     var searchResults = [];
     
@@ -64,8 +68,8 @@ define(function (require, exports, module) {
         currentQuery = "",
         currentScope;
     
-    // Div holding the search results. Initialized in htmlReady().
-    var $searchResultsDiv;
+    // Bottom panel holding the search results. Initialized in htmlReady().
+    var searchResultsPanel;
     
     function _getQueryRegExp(query) {
         // Clear any pending RegEx error message
@@ -193,9 +197,8 @@ define(function (require, exports, module) {
     };
     
     function _hideSearchResults() {
-        if ($searchResultsDiv.is(":visible")) {
-            $searchResultsDiv.hide();
-            EditorManager.resizeEditor();
+        if (searchResultsPanel.isVisible()) {
+            searchResultsPanel.hide();
         }
     }
 
@@ -340,12 +343,10 @@ define(function (require, exports, module) {
                     _hideSearchResults();
                 });
             
-            $searchResultsDiv.show();
+            searchResultsPanel.show();
         } else {
             _hideSearchResults();
         }
-        
-        EditorManager.resizeEditor();
     }
     
     /**
@@ -444,11 +445,12 @@ define(function (require, exports, module) {
     
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
-        $searchResultsDiv  = $("#search-results");
+        var panelHtml = Mustache.render(searchResultsTemplate, Strings);
+        searchResultsPanel = PanelManager.createBottomPanel("search-results", $(panelHtml));
     });
 
     function _fileNameChangeHandler(event, oldName, newName) {
-        if ($searchResultsDiv.is(":visible")) {
+        if (searchResultsPanel.isVisible()) {
             // Update the search results
             searchResults.forEach(function (item) {
                 item.fullPath = item.fullPath.replace(oldName, newName);
@@ -458,7 +460,7 @@ define(function (require, exports, module) {
     }
   
     function _pathDeletedHandler(event, path) {
-        if ($searchResultsDiv.is(":visible")) {
+        if (searchResultsPanel.isVisible()) {
             // Update the search results
             searchResults.forEach(function (item, idx) {
                 if (FileUtils.isAffectedWhenRenaming(item.fullPath, path)) {

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -446,7 +446,7 @@ define(function (require, exports, module) {
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         var panelHtml = Mustache.render(searchResultsTemplate, Strings);
-        searchResultsPanel = PanelManager.createBottomPanel("search-results", $(panelHtml));
+        searchResultsPanel = PanelManager.createBottomPanel("find-in-files.results", $(panelHtml));
     });
 
     function _fileNameChangeHandler(event, oldName, newName) {

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -138,7 +138,8 @@ define(function (require, exports, module) {
      * @param {!string} direction Direction of the resize action: one of the DIRECTION_* constants.
      * @param {!string} position Which side of the element can be dragged: one of the POSITION_* constants
      *                          (TOP/BOTTOM for vertical resizing or LEFT/RIGHT for horizontal).
-     * @param {?number} minSize Minimum size (width or height) of the element. Defaults to 0.
+     * @param {?number} minSize Minimum size (width or height) of the element's outer dimensions, including
+     *                          border & padding. Defaults to 0.
      * @param {?boolean} collapsible Indicates the panel is collapsible on double click on the
      *                          resizer. Defaults to false.
      * @param {?string} forceLeft CSS selector indicating element whose 'left' should be locked to the
@@ -167,7 +168,10 @@ define(function (require, exports, module) {
         
         $element.prepend($resizer);
         
+        // Important so min/max sizes behave predictably
+        $element.css("box-sizing", "border-box");
         
+        // Detect legacy cases where panels in the editor area are created without using PanelManager APIs
         if ($parent[0] && $parent.is(".content") && !createdByPanelManager) {
             console.warn("Deprecated: resizable panels should be created via PanelManager.createBottomPanel(). Using Resizer directly will stop working in the future. \nElement:", element);
             $(exports).triggerHandler("deprecatedPanelAdded", [$element]);

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -25,7 +25,7 @@
 /*global define, window, $, brackets */
 
 /**
- * Manages panels surrounding the editor area.
+ * Manages layout of panels surrounding the editor area, and size of the editor area (but not its contents).
  * 
  * Updates panel sizes when the window is resized. Maintains the max resizing limits for panels, based on
  * currently available window size.
@@ -89,14 +89,16 @@ define(function (require, exports, module) {
     
     
     /**
-     * Calculates a new size for editor-holder and dispatches a change event. Does not actually update
-     * editor-holder's size (EditorManager does that in response to our event).
+     * Calculates a new size for editor-holder and resizes it accordingly, then and dispatches the "editorAreaResize"
+     * event. (The editors within are resized by EditorManager, in response to that event).
      * 
      * @param {string=} refreshHint  One of "skip", "force", or undefined. See EditorManager docs.
      */
     function triggerEditorResize(refreshHint) {
         // Find how much space is left for the editor
         var editorAreaHeight = calcEditorHeight();
+        
+        $editorHolder.height(editorAreaHeight);  // affects size of "not-editor" placeholder as well
         
         // Resize editor to fill the space
         $(exports).trigger("editorAreaResize", [editorAreaHeight, refreshHint]);
@@ -210,6 +212,12 @@ define(function (require, exports, module) {
         }
     });
     
+    // Unit test only: allow passing in mock DOM notes, e.g. for use with SpecRunnerUtils.createMockEditor()
+    function _setMockDOM($mockWindowContent, $mockEditorHolder) {
+        $windowContent = $mockWindowContent;
+        $editorHolder = $mockEditorHolder;
+    }
+    
     // If someone adds a panel in the .content stack the old way, make sure we still listen for resize/show/hide
     // (Resizer emits a deprecation warning for us - no need to log anything here)
     $(Resizer).on("deprecatedPanelAdded", function (event, $panel) {
@@ -224,4 +232,5 @@ define(function (require, exports, module) {
     // Define public API
     exports.createBottomPanel    = createBottomPanel;
     exports._notifyLayoutChange  = _notifyLayoutChange;
+    exports._setMockDOM          = _setMockDOM;
 });

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, window, $, brackets */
+
+/**
+ * Manages panels surrounding the editor area.
+ * 
+ * Updates panel sizes when the window is resized. Maintains the max resizing limits for panels, based on
+ * currently available window size. Persists & restores panel sizes across sessions.
+ * 
+ * Events:
+ *    - editorAreaResize -- When editor-holder's size changes for any reason (including panel show/hide
+ *              panel resize, or the window resize).
+ *              The 2nd arg is the new editor-holder height.
+ *              The 3rd arg is a refreshHint flag for internal EditorManager use.
+ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    var AppInit                 = require("utils/AppInit"),
+        EditorManager           = require("editor/EditorManager"),
+        Resizer                 = require("utils/Resizer");
+    
+    
+    /** @type {jQueryObject} The ".content" vertical stack (editor + all header/footer panels) */
+    var $windowContent;
+    
+    /** @type {jQueryObject} The "#editor-holder": has only one visible child, the current CodeMirror
+        instance (or the no-editor placeholder) */
+    var $editorHolder;
+    
+    
+    /**
+     * Calculates the available height for the full-size Editor (or the no-editor placeholder),
+     * accounting for the current size of all visible panels, toolbar, & status bar.
+     * @return {number}
+     */
+    function _calcEditorHeight() {
+        var availableHt = $windowContent.height();
+        
+        $editorHolder.siblings().each(function (i, elem) {
+            var $elem = $(elem);
+            if ($elem.css("display") !== "none") {
+                availableHt -= $elem.outerHeight();
+            }
+        });
+        
+        // Clip value to 0 (it could be negative if a panel wants more space than we have)
+        return Math.max(availableHt, 0);
+    }
+    
+    
+    /**
+     * Calculates a new size for editor-holder and dispatches a change event. Does not actually update
+     * editor-holder's size (EditorManager does that in response to our event).
+     * 
+     * @param {string=} refreshHint  One of "skip", "force", or undefined. See EditorManager docs.
+     */
+    function triggerEditorResize(refreshHint) {
+        var editorAreaHeight = _calcEditorHeight();
+        
+        // TODO: update panel max heights
+        
+        $(exports).trigger("editorAreaResize", [editorAreaHeight, refreshHint]);
+    }
+    
+    
+    /** Trigger editor area resize whenever the window is resized */
+    function handleWindowResize() {
+        // Immediately adjust editor's height, but skip the refresh since CodeMirror will call refresh()
+        // itself when it sees the window resize event
+        triggerEditorResize("skip");
+    }
+    
+    /** Trigger editor area resize whenever the given panel is shown/hidden/resized */
+    function listenToResize($panel) {
+        $panel.on("panelCollapsed panelExpanded panelResizeUpdate", function () {
+            triggerEditorResize();
+        });
+    }
+    
+    
+    /**
+     * Represents a panel below the editor area (a child of ".content").
+     * 
+     * @param {!jQueryObject} $panel  The entire panel, including any chrome, already in the DOM.
+     * @param {number=} minSize  Minimum height of panel in px; default is 0
+     */
+    function Panel($panel, minSize) {
+        this.$panel = $panel;
+        
+        Resizer.makeResizable($panel[0], Resizer.DIRECTION_VERTICAL, Resizer.POSITION_TOP, minSize, false, undefined, true);
+        listenToResize($panel);
+    }
+    
+    /** @type {jQueryObject} */
+    Panel.prototype.$panel = null;
+    
+    Panel.prototype.isVisible = function () {
+        return this.$panel.is(":visible");
+    };
+    
+    Panel.prototype.show = function () {
+        Resizer.show(this.$panel[0]);
+    };
+    Panel.prototype.hide = function () {
+        Resizer.hide(this.$panel[0]);
+    };
+    
+    Panel.prototype.setVisible = function (visible) {
+        if (visible) {
+            Resizer.show(this.$panel[0]);
+        } else {
+            Resizer.hide(this.$panel[0]);
+        }
+    };
+    
+    
+    /**
+     * Creates a new panel beneath the editor area and above the status bar footer. Panel is initially invisible.
+     * 
+     * @param {!string} id  Unique id for this panel. Use package-style naming, e.g. "myextension.feature.panelname"
+     * @param {!jQueryObject} $panel  DOM content to use as the panel. Need not be in the document yet.
+     * @param {number=} minSize  Minimum height of panel in px; default is 0
+     * @return {!Panel}
+     */
+    function createBottomPanel(id, $panel, minSize) {   // TODO: allow retrieval by id...
+        $panel.insertBefore("#status-bar");
+        $panel.hide();
+        return new Panel($panel, minSize);
+    }
+    
+    
+    /**
+     * Force PanelManager to recalculate the editor-holder size and trigger an event, in cases that our normal panel
+     * and window listeners wouldn't detect.
+     * 
+     * For internal use only: most code should call EditorManager.resizeEditor() for this purpose.
+     */
+    function _notifyLayoutChange(refreshHint) {
+        triggerEditorResize(refreshHint);
+    }
+    
+    
+    // Attach to key parts of the overall UI, once created
+    AppInit.htmlReady(function () {
+        $windowContent = $(".content");
+        $editorHolder = $("#editor-holder");
+        
+        // Sidebar is a special case: a side panel rather than a bottom panel. It could still affect the
+        // editor-holder's height if changing .content's width causes the inBrowser titlebar to wrap/unwrap.
+        if (brackets.inBrowser) {
+            listenToResize($("#sidebar"));
+        }
+    });
+    
+    // If someone adds a panel in the .content stack the old way, make sure we still listen for resize/show/hide
+    // (Resizer emits a deprecation warning for us - no need to log anything here)
+    $(Resizer).on("deprecatedPanelAdded", function (event, $panel) {
+        listenToResize($panel);
+    });
+    
+    // Add this as a capture handler so we're guaranteed to run it before the editor does its own
+    // refresh on resize.
+    window.addEventListener("resize", handleWindowResize, true);
+    
+    
+    // Define public API
+    exports.createBottomPanel    = createBottomPanel;
+    exports._notifyLayoutChange  = _notifyLayoutChange;
+});

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -40,7 +40,6 @@ define(function (require, exports, module) {
     "use strict";
     
     var AppInit                 = require("utils/AppInit"),
-        EditorManager           = require("editor/EditorManager"),
         Resizer                 = require("utils/Resizer");
     
     
@@ -190,10 +189,8 @@ define(function (require, exports, module) {
     
     
     /**
-     * Force PanelManager to recalculate the editor-holder size and trigger an event, in cases that our normal panel
-     * and window listeners wouldn't detect.
-     * 
-     * For internal use only: most code should call EditorManager.resizeEditor() for this purpose.
+     * Used by EditorManager to notify us of layout changes our normal panel/window listeners wouldn't detect.
+     * For internal use only: most code should call EditorManager.resizeEditor().
      */
     function _notifyLayoutChange(refreshHint) {
         triggerEditorResize(refreshHint);

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $, brackets, window, document, Mustache */
 

--- a/test/spec/EditorManager-test.js
+++ b/test/spec/EditorManager-test.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     'use strict';
     
     var EditorManager   = require("editor/EditorManager"),
+        PanelManager    = require("view/PanelManager"),
         SpecRunnerUtils = require("spec/SpecRunnerUtils");
 
     describe("EditorManager", function () {
@@ -37,19 +38,24 @@ define(function (require, exports, module) {
             var testEditor, testDoc, $root, $fakeContentDiv;
             
             beforeEach(function () {
-                var mock = SpecRunnerUtils.createMockEditor("");
-                testEditor = mock.editor;
-                testDoc = mock.doc;
-                $root = $(testEditor.getRootElement());
-                
                 // Normally the editor holder would be created inside a "content" div, which is
                 // used in the available height calculation. We create a fake content div just to
-                // hold the height, and move the editor holder into it.
+                // hold the height, and we'll place the editor holder in it.
                 $fakeContentDiv = $("<div class='content'/>")
                     .css("height", "200px")
                     .appendTo(document.body);
+                
+                // createMockEditor() creates the mock-editor-holder, and links EditorManager/PanelManager
+                // to it (and links PanelManager to our content div)
+                var mock = SpecRunnerUtils.createMockEditor("");
+                
+                // move newly created mock-editor-holder into the content div we created above
                 $("#mock-editor-holder")
                     .appendTo($fakeContentDiv);
+                
+                testEditor = mock.editor;
+                testDoc = mock.doc;
+                $root = $(testEditor.getRootElement());
                 
                 testDoc._masterEditor = testEditor;
                 EditorManager._doShow(testDoc);
@@ -72,7 +78,7 @@ define(function (require, exports, module) {
                 EditorManager.resizeEditor(); // cache the width
                                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_FORCE);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_FORCE);
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -83,7 +89,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_FORCE);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_FORCE);
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -94,7 +100,7 @@ define(function (require, exports, module) {
                 $root.height(300); // change the height (to be different from content div)
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_FORCE);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_FORCE);
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -106,7 +112,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_FORCE);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_FORCE);
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -117,7 +123,7 @@ define(function (require, exports, module) {
                 EditorManager.resizeEditor(); // cache the width
                                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_SKIP);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_SKIP);
                 expect(testEditor.refreshAll).not.toHaveBeenCalled();
             });
 
@@ -128,7 +134,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_SKIP);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_SKIP);
                 expect(testEditor.refreshAll).not.toHaveBeenCalled();
             });
 
@@ -139,7 +145,7 @@ define(function (require, exports, module) {
                 $root.height(300); // change the height (to be different from content div)
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_SKIP);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_SKIP);
                 expect(testEditor.refreshAll).not.toHaveBeenCalled();
             });
 
@@ -151,7 +157,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor(EditorManager.REFRESH_SKIP);
+                PanelManager._notifyLayoutChange(EditorManager.REFRESH_SKIP);
                 expect(testEditor.refreshAll).not.toHaveBeenCalled();
             });
             
@@ -162,7 +168,7 @@ define(function (require, exports, module) {
                 EditorManager.resizeEditor(); // cache the width
                                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor();
+                PanelManager._notifyLayoutChange();
                 expect(testEditor.refreshAll).not.toHaveBeenCalled();
             });
 
@@ -173,7 +179,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor();
+                PanelManager._notifyLayoutChange();
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -184,7 +190,7 @@ define(function (require, exports, module) {
                 $root.height(300); // change the height (to be different from content div)
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor();
+                PanelManager._notifyLayoutChange();
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
 
@@ -196,7 +202,7 @@ define(function (require, exports, module) {
                 $root.width(300); // change the width
                 
                 spyOn(testEditor, "refreshAll");
-                EditorManager.resizeEditor();
+                PanelManager._notifyLayoutChange();
                 expect(testEditor.refreshAll).toHaveBeenCalled();
             });
         });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -205,26 +205,34 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Returns a Document and Editor suitable for use with an Editor in
-     * isolation: i.e., a Document that will never be set as the
-     * currentDocument or added to the working set.
-     * @return {!{doc:{Document}, editor:{Editor}}}
+     * Returns an Editor tied to the given Document, but suitable for use in isolation
+     * (without being placed inside the surrounding Brackets UI).
+     * @return {!Editor}
      */
-    function createMockEditor(initialContent, languageId, visibleRange) {
+    function createMockEditorForDocument(doc, visibleRange) {
         // Initialize EditorManager/PanelManager and position the editor-holder offscreen
         // (".content" may not exist, but that's ok for headless tests where editor height doesn't matter)
         var $editorHolder = createMockElement().attr("id", "mock-editor-holder");
         PanelManager._setMockDOM($(".content"), $editorHolder);
         EditorManager.setEditorHolder($editorHolder);
         
-        // create dummy Document for the Editor
-        var doc = createMockDocument(initialContent, languageId);
-        
         // create Editor instance
         var editor = new Editor(doc, true, $editorHolder.get(0), visibleRange);
         EditorManager._notifyActiveEditorChanged(editor);
         
-        return { doc: doc, editor: editor };
+        return editor;
+    }
+    
+    /**
+     * Returns a Document and Editor suitable for use in isolation: i.e., the Document
+     * will never be set as the currentDocument or added to the working set and the
+     * Editor does not live inside a full-blown Brackets UI layout.
+     * @return {!{doc:!Document, editor:!Editor}}
+     */
+    function createMockEditor(initialContent, languageId, visibleRange) {
+        // create dummy Document, then Editor tied to it
+        var doc = createMockDocument(initialContent, languageId);
+        return { doc: doc, editor: createMockEditorForDocument(doc, visibleRange) };
     }
     
     /**
@@ -944,6 +952,7 @@ define(function (require, exports, module) {
     exports.createMockDocument              = createMockDocument;
     exports.createMockActiveDocument        = createMockActiveDocument;
     exports.createMockElement               = createMockElement;
+    exports.createMockEditorForDocument     = createMockEditorForDocument;
     exports.createMockEditor                = createMockEditor;
     exports.createTestWindowAndRun          = createTestWindowAndRun;
     exports.closeTestWindow                 = closeTestWindow;

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
         DocumentManager     = require("document/DocumentManager"),
         Editor              = require("editor/Editor").Editor,
         EditorManager       = require("editor/EditorManager"),
+        PanelManager        = require("view/PanelManager"),
         ExtensionLoader     = require("utils/ExtensionLoader"),
         UrlParams           = require("utils/UrlParams").UrlParams,
         LanguageManager     = require("language/LanguageManager");
@@ -210,8 +211,10 @@ define(function (require, exports, module) {
      * @return {!{doc:{Document}, editor:{Editor}}}
      */
     function createMockEditor(initialContent, languageId, visibleRange) {
-        // Initialize EditorManager and position the editor-holder offscreen
+        // Initialize EditorManager/PanelManager and position the editor-holder offscreen
+        // (".content" may not exist, but that's ok for headless tests where editor height doesn't matter)
         var $editorHolder = createMockElement().attr("id", "mock-editor-holder");
+        PanelManager._setMockDOM($(".content"), $editorHolder);
         EditorManager.setEditorHolder($editorHolder);
         
         // create dummy Document for the Editor


### PR DESCRIPTION
Fixes another part #2015 by maintaining panel max resize limits based on currently available slack space (i.e. space used by the editor area).  This fixes [part 1](https://github.com/adobe/brackets/issues/2015#issuecomment-10528269) of the 4-part list of issues there -- when dragging a panel to fill the whole UI, you can't overshoot and send the status bar (or other panels) sliding off the bottom of the window.  And it gives us a clean foundation to build the remaining fixes on.

This also enables a cleaner fix to #3371 -- see pull #3931 which is based on this branch.

Here's what's changed:
- PanelManager provides APIs to create panels below the editor area. JSLint
  and Find in Files now use these APIs.  (Find in Files panel UI is now moved out of main-view.html into a template).
- Move editor-holder ht calculations from EditorManager to PanelManager
- EditorManager listens to PanelManager for resize notifications. PanelManager
  listens for window resize (moved from EditorManager) and for Resizer events
  on all bottom panels. The old EditorManager.resizeEditor() API is still used
  for edge cases such as status & search bar show/hide, extensions that add
  fixed top panels, and extensions that don't use Resizer APIs to hide/show
  panels.
- Since PanelManager is listening, Resizer no longer pings EditorManager
  directly about show/hide/resize.  (This would let us use Resizer as a generic splitter widget in other parts of the UI if needed).
- Resizer emits events to notify PanelManager about any panels it may have missed (legacy extensions that add panels via
  Resizer instead of PanelManager).
- Add max-size support to Resizer.  Change Resizer min/max limits to operate in terms of panel outer height.
- PanelManager updates all bottom panels' max sizes when anything is resized/shown/hidden.
