### PR TITLE
Remove Bootstrap-default orange background from code elements

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -786,3 +786,9 @@ table {
         background-color: @tc-highlight; // TopCoat palette
     }
 }
+
+/* Type */
+
+code {
+  background-color: transparent;
+}


### PR DESCRIPTION
Bootstrap colors the background of `<code>` elements light orange by default. Kinda weird: 
![orange](http://f.cl.ly/items/201m0U15151b2f0c273t/Screen%20Shot%202013-05-21%20at%202.08.37%20PM.png)

This pull restores the `background-color` property to good ol' `transparent`: 
![not orange](http://f.cl.ly/items/0O1Q3l2c1t0V1e3i2O1C/Screen%20Shot%202013-05-21%20at%201.58.58%20PM.png)

This has been blessed by @larz0.
