### PR TITLE
Fix LanguageManager unit test

### DIFF
--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
                     "id": "html",
                     "name": "HTML",
                     "mode": ["htmlmixed", "text/x-brackets-html"],
-                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit"],
+                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp"],
                     "blockComment": {prefix: "<!--", suffix: "-->"}
                 };
                 


### PR DESCRIPTION
This was broken by https://github.com/adobe/brackets/pull/3921.
