### PR TITLE
Make quick edit perf tests not fail

### DIFF
--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -339,9 +339,13 @@ define(function (require, exports, module) {
                 });
                 
                 var runCreateInlineEditor = function () {
+                    var editor = EditorManager.getCurrentFullEditor();
+                    // Set the cursor in the middle of a call to "extend" so the JS helper function works correctly.
+                    editor.setCursorPos(271, 20);
                     waitsForDone(
-                        JavaScriptQuickEdit._createInlineEditor(EditorManager.getCurrentFullEditor(), "extend"),
-                        "createInlineEditor"
+                        JavaScriptQuickEdit._createInlineEditor(editor, "extend"),
+                        "createInlineEditor",
+                        5000
                     );
                 };
                 


### PR DESCRIPTION
This makes it so the JS Quick Edit perf test runs, although the results are a big regression from previous sprints. The case we're testing is one where Tern doesn't find anything, and for some reason it seems to take Tern a long time to figure that out on each run.
