### PR TITLE
Fix #3950  Add Ctrl-Alt-O keyboard shortcut for Open Folder

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -5,6 +5,9 @@
     "file.open":  [
         "Ctrl-O"
     ],
+    "file.openFolder":  [
+        "Ctrl-Alt-O"
+    ],
     "file.close":  [
         "Ctrl-W"
     ],


### PR DESCRIPTION
Added Ctrl-Alt-O keyboard shortcut for Open Folder action to keyboard.json 
