### PR TITLE
File/Folder delete improvements

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -87,6 +87,7 @@ define(function (require, exports, module) {
     var NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
         ProjectManager      = require("project/ProjectManager"),
         EditorManager       = require("editor/EditorManager"),
+        FileSyncManager     = require("project/FileSyncManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         FileUtils           = require("file/FileUtils"),
         CommandManager      = require("command/CommandManager"),
@@ -94,7 +95,8 @@ define(function (require, exports, module) {
         CollectionUtils     = require("utils/CollectionUtils"),
         PerfUtils           = require("utils/PerfUtils"),
         Commands            = require("command/Commands"),
-        LanguageManager     = require("language/LanguageManager");
+        LanguageManager     = require("language/LanguageManager"),
+        Strings             = require("strings");
     
     /**
      * @private
@@ -1223,13 +1225,9 @@ define(function (require, exports, module) {
     function notifyPathDeleted(path) {
         var i, docPath;
         
-        for (docPath in _openDocuments) {
-            if (FileUtils.isAffectedWhenRenaming(docPath, path)) {
-                // This will close the doc and remove from the working set
-                notifyFileDeleted(new NativeFileSystem.FileEntry(docPath), true);
-                delete _openDocuments[docPath];
-            }
-        }
+        /* FileSyncManager.syncOpenDocuments() does all the work of closing files
+           in the working set and notifying the user of any unsaved changes. */
+        FileSyncManager.syncOpenDocuments(Strings.FILE_DELETED_TITLE);
         
         // Send a "pathDeleted" event. This will trigger the views to update.
         $(exports).triggerHandler("pathDeleted", path);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -100,6 +100,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Do you want to save the changes you made in the document <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Do you want to save your changes to the following files?",
     "EXT_MODIFIED_TITLE"                : "External Changes",
+    "FILE_DELETED_TITLE"                : "File Deleted",
     "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> has been modified on disk, but also has unsaved changes in {APP_NAME}.<br /><br />Which version do you want to keep?",
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> has been deleted on disk, but has unsaved changes in {APP_NAME}.<br /><br />Do you want to keep your changes?",
     

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -237,11 +237,12 @@ define(function (require, exports, module) {
      * about each one. Processing is sequential: if the user chooses to reload a document, the next
      * prompt is not shown until after the reload has completed.
      *
+     * @param {string} title Title of the dialog.
      * @return {$.Promise} Resolved/rejected after all documents have been prompted and (if
      *      applicable) reloaded (and any resulting error UI has been dismissed). Rejected if any
      *      one reload failed.
      */
-    function presentConflicts() {
+    function presentConflicts(title) {
         
         var allConflicts = editConflicts.concat(deleteConflicts);
         
@@ -280,7 +281,7 @@ define(function (require, exports, module) {
                 );
             }
             
-            Dialogs.showModalDialog(dialogId, Strings.EXT_MODIFIED_TITLE, message)
+            Dialogs.showModalDialog(dialogId, title, message)
                 .done(function (id) {
                     if (id === Dialogs.DIALOG_BTN_DONTSAVE) {
                         if (toClose) {
@@ -326,8 +327,12 @@ define(function (require, exports, module) {
      * Brackets synced up with the copy on disk (either by loading or saving the file). For clean
      * files, we silently upate the editor automatically. For files with unsaved changes, we prompt
      * the user.
+     *
+     * @param {string} title Title to use for document. Default is "External Changes".
      */
-    function syncOpenDocuments() {
+    function syncOpenDocuments(title) {
+        
+        title = title || Strings.EXT_MODIFIED_TITLE;
         
         // We can become "re-entrant" if the user leaves & then returns to Brackets before we're
         // done -- easy if a prompt dialog is left open. Since the user may have left Brackets to
@@ -378,7 +383,7 @@ define(function (require, exports, module) {
                                 closeDeletedDocs();
                                 
                                 // 5) Prompt for dirty editors (conflicts)
-                                presentConflicts()
+                                presentConflicts(title)
                                     .always(function () {
                                         if (_restartPending) {
                                             // Restart the sync if needed

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -555,17 +555,6 @@ define(function (require, exports, module) {
         _rebuildWorkingSet(true);
     }
     
-    /**
-     * @private
-     * @param {string} path
-     */
-    function _handlePathDeleted(path) {
-        // Rebuild the working set if any file or folder was deleted.
-        // We could be smarter about this and only delete affected
-        // items.
-        _rebuildWorkingSet(false);
-    }
-    
     function refresh() {
         _redraw();
     }
@@ -603,10 +592,6 @@ define(function (require, exports, module) {
     
         $(DocumentManager).on("fileNameChange", function (event, oldName, newName) {
             _handleFileNameChanged(oldName, newName);
-        });
-        
-        $(DocumentManager).on("pathDeleted", function (event, path) {
-            _handlePathDeleted(path);
         });
         
         $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange);

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -519,9 +519,57 @@ define(function (require, exports, module) {
 
         }); // describe("unlink")
         
-        describe("mkdir", function () {
+        describe("makedir", function () {
+            var error, complete, isDirectory;
+            
             it("should make a new directory", function () {
-                // TODO: Write this test once we have a function to delete the directory
+                var newDirName = baseDir + "/new_dir";
+                
+                complete = false;
+                runs(function () {
+                    brackets.fs.makedir(newDirName, parseInt("777", 0), function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Verify directory was created
+                runs(function () {
+                    complete = false;
+                    brackets.fs.stat(newDirName, function (err, stat) {
+                        error = err;
+                        isDirectory = stat.isDirectory();
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(isDirectory).toBe(true);
+                });
+                
+                // Delete the directory
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(newDirName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
             });
         });
         
@@ -697,5 +745,125 @@ define(function (require, exports, module) {
             });
             // TODO: More testing of error cases? 
         });
+        
+        describe("moveToTrash", function () {
+            var error, complete, isDirectory;
+            
+            it("should move a file to the trash", function () {
+                var newFileName = baseDir + "/delete_me.txt";
+                
+                // Create a file
+                runs(function () {
+                    complete = false;
+                    brackets.fs.writeFile(newFileName, "", _FSEncodings.UTF8, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Move it to the trash
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(newFileName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Make sure it's gone
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(newFileName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                });
+            });
+            
+            it("should move a folder to the trash", function () {
+                var newDirName = baseDir + "/dir_to_delete";
+                
+                // Create a file
+                runs(function () {
+                    complete = false;
+                    brackets.fs.makedir(newDirName, parseInt("777", 8), function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Move it to the trash
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(newDirName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.NO_ERROR);
+                });
+                
+                // Make sure it's gone
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(newDirName, function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                });
+            });
+            
+            it("should return an error if the item doesn't exsit", function () {
+                
+                // Move it to the trash
+                runs(function () {
+                    complete = false;
+                    brackets.fs.moveToTrash(baseDir + "/doesnt_exist", function (err) {
+                        error = err;
+                        complete = true;
+                    });
+                });
+                
+                waitsFor(function () { return complete; });
+                
+                runs(function () {
+                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                });
+            });
+        }); // moveToTrash
     });
 });


### PR DESCRIPTION
When deleting a file with unsaved contents, the user is now prompted to keep the editor open or to close it and loose changes. This dialog appears if you delete a dirty file directly _or_ delete a folder containing a dirty file.

Adding this notification actually _simplified_ the code because we now rely on `FileSyncManager.syncOpenDocuments()` to take care of files that were deleted from disk. There is one small side affect: this call will also sync any other changes from disk into any open editors. This is an extreme edge case, and even if it _does_ occur, the behavior is technically correct. This is what the user would see anyway if Brackets was deactivated and reactivated.

This pull request also adds unit tests for the `fs.moveToTrash()` function. 
