### PR TITLE
Clean up tern web workers whenever we re-init the tern server, or close ...

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/MessageIds.js
+++ b/src/extensions/default/JavaScriptCodeHints/MessageIds.js
@@ -35,7 +35,8 @@ define(function (require, exports, module) {
         TERN_GET_FILE_MSG           = "GetFile",
         TERN_CALLED_FUNC_TYPE_MSG   = "FunctionType",
         TERN_PRIME_PUMP_MSG         = "PrimePump",
-        TERN_GET_GUESSES_MSG        = "GetGuesses";
+        TERN_GET_GUESSES_MSG        = "GetGuesses",
+        TERN_WORKER_READY           = "WorkerReady";
 
     exports.TERN_ADD_FILES_MSG          = TERN_ADD_FILES_MSG;
     exports.TERN_JUMPTODEF_MSG          = TERN_JUMPTODEF_MSG;

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -977,11 +977,20 @@ define(function (require, exports, module) {
      * we know we will need to re-init it in any new project that is opened.  
      */
     function handleProjectClose() {
-        if (_ternWorker) {
+        function terminateWorker() {
             _ternWorker.terminate();
             _ternWorker = null;
-            ternPromise = null;
             resolvedFiles = {};
+        }
+        
+        if (_ternWorker) {
+            if (addFilesPromise) {
+                // If we're in the middle of added files, don't terminate 
+                // until we're done or we might get NPEs
+                addFilesPromise.done(terminateWorker).fail(terminateWorker);
+            } else {
+                terminateWorker();
+            }
         }
     }
 

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -62,32 +62,11 @@ define(function (require, exports, module) {
         // temporarily exclude less*min.js because it is causing instability in tern.
         excludedFilesRegEx  = /require\.js$|jquery[\w.\-]*\.js$|less[\w.\-]*\.min\.js$/,
         isDocumentDirty     = false,
-        _ternWorker         = (function () {
-            var path = ExtensionUtils.getModulePath(module, "tern-worker.js");
-            return new Worker(path);
-        }());
+        _ternWorker         = null;
 
     var MAX_TEXT_LENGTH     = 1000000, // about 1MB
         MAX_FILES_IN_DIR    = 100,
         MAX_FILES_IN_PROJECT = 100;
-
-    /**
-     * Create a new tern server.
-     */
-    function initTernServer(dir, files) {
-        numResolvedFiles = 0;
-        numAddedFiles = 0;
-        stopAddingFiles = false;
-        numInitialFiles = files.length;
-
-        _ternWorker.postMessage({
-            type        : MessageIds.TERN_INIT_MSG,
-            dir         : dir,
-            files       : files,
-            env         : ternEnvironment
-        });
-        rootTernDir = dir + "/";
-    }
 
     /**
      *  Add new files to tern, keeping any previous files.
@@ -107,9 +86,11 @@ define(function (require, exports, module) {
             }
 
             numAddedFiles += files.length;
-            _ternWorker.postMessage({
-                type        : MessageIds.TERN_ADD_FILES_MSG,
-                files       : files
+            ternPromise.done(function (worker) {
+                worker.postMessage({
+                    type        : MessageIds.TERN_ADD_FILES_MSG,
+                    files       : files
+                });
             });
 
         } else {
@@ -800,6 +781,63 @@ define(function (require, exports, module) {
         }
     }
 
+    function initTernWorker() {
+        if (_ternWorker) {
+            _ternWorker.terminate();
+        }
+        var workerDeferred = $.Deferred();
+        ternPromise = workerDeferred.promise();
+        var path = ExtensionUtils.getModulePath(module, "tern-worker.js");
+        _ternWorker = new Worker(path);
+
+        _ternWorker.addEventListener("message", function (e) {
+            var response = e.data,
+                type = response.type;
+    
+            if (type === MessageIds.TERN_COMPLETIONS_MSG ||
+                    type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
+                // handle any completions the worker calculated
+                handleTernCompletions(response);
+            } else if (type === MessageIds.TERN_GET_FILE_MSG) {
+                // handle a request for the contents of a file
+                handleTernGetFile(response);
+            } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
+                handleJumptoDef(response);
+            } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
+                handlePrimePumpCompletion(response);
+            } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
+                handleGetGuesses(response);
+            } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
+                handleUpdateFile(response);
+            } else if (type === MessageIds.TERN_WORKER_READY) {
+                workerDeferred.resolveWith(null, [_ternWorker]);
+            } else {
+                console.log("Worker: " + (response.log || response));
+            }
+        });
+        
+    }
+    /**
+     * Create a new tern server.
+     */
+    function initTernServer(dir, files) {
+        initTernWorker();
+        numResolvedFiles = 0;
+        numAddedFiles = 0;
+        stopAddingFiles = false;
+        numInitialFiles = files.length;
+
+        ternPromise.done(function (worker) {
+            worker.postMessage({
+                type        : MessageIds.TERN_INIT_MSG,
+                dir         : dir,
+                files       : files,
+                env         : ternEnvironment
+            });
+        });
+        rootTernDir = dir + "/";
+    }
+
     /**
      *  We can skip tern initialization if we are opening a file that has
      *  already been added to tern.
@@ -829,17 +867,13 @@ define(function (require, exports, module) {
             file        = split.file,
             pr;
 
-        var ternDeferred     = $.Deferred(),
-            addFilesDeferred = $.Deferred();
+        var addFilesDeferred = $.Deferred();
 
-        ternPromise = ternDeferred.promise();
         addFilesPromise = addFilesDeferred.promise();
         pr = ProjectManager.getProjectRoot() ? ProjectManager.getProjectRoot().fullPath : null;
 
         // avoid re-initializing tern if possible.
         if (canSkipTernInitialization(path)) {
-            // skipping initializing tern
-            ternDeferred.resolveWith(null, [_ternWorker]);
 
             // update the previous document in tern to prevent stale files.
             if (isDocumentDirty && previousDocument) {
@@ -863,7 +897,6 @@ define(function (require, exports, module) {
         projectRoot = pr;
         getFilesInDirectory(dir, function (files) {
             initTernServer(dir, files);
-            ternDeferred.resolveWith(null, [_ternWorker]);
 
             if (shouldPrimePump) {
                 var hintsPromise = primePump(path, document.getText());
@@ -930,29 +963,14 @@ define(function (require, exports, module) {
         isDocumentDirty = true;
     }
 
-    _ternWorker.addEventListener("message", function (e) {
-        var response = e.data,
-            type = response.type;
-
-        if (type === MessageIds.TERN_COMPLETIONS_MSG ||
-                type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
-            // handle any completions the worker calculated
-            handleTernCompletions(response);
-        } else if (type === MessageIds.TERN_GET_FILE_MSG) {
-            // handle a request for the contents of a file
-            handleTernGetFile(response);
-        } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
-            handleJumptoDef(response);
-        } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
-            handlePrimePumpCompletion(response);
-        } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
-            handleGetGuesses(response);
-        } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
-            handleUpdateFile(response);
-        } else {
-            console.log("Worker: " + (response.log || response));
+    function handleProjectClose() {
+        if (_ternWorker) {
+            _ternWorker.terminate();
+            _ternWorker = null;
+            ternPromise = null;
+            resolvedFiles = {};
         }
-    });
+    }
 
     exports.getBuiltins = getBuiltins;
     exports.getResolvedPath = getResolvedPath;
@@ -962,4 +980,5 @@ define(function (require, exports, module) {
     exports.handleFileChange = handleFileChange;
     exports.requestHints = requestHints;
     exports.requestJumptoDef = requestJumptoDef;
+    exports.handleProjectClose = handleProjectClose;
 });

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -781,6 +781,13 @@ define(function (require, exports, module) {
         }
     }
 
+    /**
+     * Init the web worker that does all the code hinting work.
+     *
+     * If a worker already exists, then this will terminate that worker and
+     * start a new worker - this helps alleviate leaks that may be ocurring in 
+     * the code that the worker runs.  
+     */
     function initTernWorker() {
         if (_ternWorker) {
             _ternWorker.terminate();
@@ -963,6 +970,12 @@ define(function (require, exports, module) {
         isDocumentDirty = true;
     }
 
+    /**
+     * Do some cleanup when a project is closed.
+     *
+     * We can clean up the web worker we use to calculate hints now, since
+     * we know we will need to re-init it in any new project that is opened.  
+     */
     function handleProjectClose() {
         if (_ternWorker) {
             _ternWorker.terminate();

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         StringUtils     = brackets.getModule("utils/StringUtils"),
         StringMatch     = brackets.getModule("utils/StringMatch"),
         LanguageManager = brackets.getModule("language/LanguageManager"),
+        ProjectManager  = brackets.getModule("project/ProjectManager"),
         HintUtils       = require("HintUtils"),
         ScopeManager    = require("ScopeManager"),
         Session         = require("Session"),
@@ -620,6 +621,10 @@ define(function (require, exports, module) {
         $(EditorManager)
             .on(HintUtils.eventName("activeEditorChange"),
                 handleActiveEditorChange);
+        
+        $(ProjectManager).on("beforeProjectClose", function () {
+            ScopeManager.handleProjectClose();
+        });
         
         // immediately install the current editor
         installEditorListeners(EditorManager.getActiveEditor());

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -36,339 +36,341 @@ importScripts("thirdparty/requirejs/require.js");
         var ternRequire = require.config({baseUrl: "./thirdparty"});
         ternRequire(["tern/lib/tern", "tern/plugin/requirejs", "tern/plugin/doc_comment"], function (tern, requirejs, docComment) {
             Tern = tern;
-        });
-    });
 
-    var ternServer  = null;
-
-    // Save the tern callbacks for when we get the contents of the file
-    var fileCallBacks = {};
-    
-    /**
-     * Provide the contents of the requested file to tern
-     * @param {string} name - the name of the file
-     * @param {Function} next - the function to call with the text of the file
-     *  once it has been read in.
-     */
-    function getFile(name, next) {
-        // save the callback
-        fileCallBacks[name] = next;
+            var ternServer  = null;
         
-        // post a message back to the main thread to get the file contents 
-        self.postMessage({
-            type: MessageIds.TERN_GET_FILE_MSG,
-            file: name
-        });
-    }
-
-    /**
-     * Handle a response from the main thread providing the contents of a file
-     * @param {string} file - the name of the file
-     * @param {string} text - the contents of the file
-     */
-    function handleGetFile(file, text) {
-        var next = fileCallBacks[file];
-        if (next) {
-            next(null, text);
-        }
-        delete fileCallBacks[file];
-    }
-    
-    /**
-     * Create a new tern server.
-     *
-     * @param {Object} env - an Object with the environment, as read in from
-     *  the json files in thirdparty/tern/defs
-     * @param {string} dir - the current directory
-     * @param {Array.<string>} files - a list of filenames tern should be aware of
-     */
-    function initTernServer(env, dir, files) {
-        var ternOptions = {
-            defs: env,
-            async: true,
-            getFile: getFile,
-            plugins: {requirejs: {}, doc_comment: true}
-        };
-        ternServer = new Tern.Server(ternOptions);
+            // Save the tern callbacks for when we get the contents of the file
+            var fileCallBacks = {};
+            
+            /**
+             * Provide the contents of the requested file to tern
+             * @param {string} name - the name of the file
+             * @param {Function} next - the function to call with the text of the file
+             *  once it has been read in.
+             */
+            function getFile(name, next) {
+                // save the callback
+                fileCallBacks[name] = next;
+                
+                // post a message back to the main thread to get the file contents 
+                self.postMessage({
+                    type: MessageIds.TERN_GET_FILE_MSG,
+                    file: name
+                });
+            }
         
-        files.forEach(function (file) {
-            ternServer.addFile(file);
-        });
-        
-    }
-
-    /**
-     * Build an object that can be used as a request to tern
-     * @param {string} dir - the current directory
-     * @param {string} file - the filename the request is in
-     * @param {string} query - the type of request being made
-     * @param {number} offset - the offset in the file the request is at
-     * @param {string} text - the text of the file
-     */
-    function buildRequest(dir, file, query, offset, text) {
-        query = {type: query};
-        query.start = offset;
-        query.end = offset;
-        query.file = file;
-        query.filter = false;
-        query.sort = false;
-        query.depths = true;
-        query.guess = true;
-        query.origins = true;
-        query.expandWordForward = false;
-
-        var request = {query: query, files: [], offset: offset};
-        request.files.push({type: "full", name: file, text: text});
-
-        return request;
-    }
-
-    /**
-     * Send a log message back from the worker to the main thread
-     * 
-     * @param {string} msg - the log message
-     */
-    function _log(msg) {
-        self.postMessage({log: msg });
-    }
-    
-    /**
-     * Get definition location
-     * @param {string} dir      - the directory
-     * @param {string} file     - the file name
-     * @param {number} offset   - the offset into the file for cursor
-     * @param {string} text     - the text of the file
-     */
-    function getJumptoDef(dir, file, offset, text) {
-        
-        var request = buildRequest(dir, file, "definition", offset, text);
-        request.query.lineCharPositions = true;
-        // request.query.typeOnly = true;       // FIXME: tern doesn't work exactly right yet.
-        ternServer.request(request, function (error, data) {
-            if (error) {
-                _log("Error returned from Tern 'definition' request: " + error);
-                self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG});
-                return;
+            /**
+             * Handle a response from the main thread providing the contents of a file
+             * @param {string} file - the name of the file
+             * @param {string} text - the contents of the file
+             */
+            function handleGetFile(file, text) {
+                var next = fileCallBacks[file];
+                if (next) {
+                    next(null, text);
+                }
+                delete fileCallBacks[file];
             }
             
-            // Post a message back to the main thread with the definition
-            self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG,
-                              file: file,
-                              resultFile: data.file,
-                              offset: offset,
-                              start: data.start,
-                              end: data.end
-                             });
-        });
-    }
-
-    /**
-     * Get all the known properties for guessing.
-     *
-     * @param {string} dir      - the directory
-     * @param {string} file     - the file name
-     * @param {number} offset   - the offset into the file where we want completions for
-     * @param {string} text     - the text of the file
-     * @param {string} type     - the type of the message to reply with.
-     */
-    function getTernProperties(dir, file, offset, text, type) {
-
-        var request = buildRequest(dir, file, "properties", undefined, text),
-            i;
-        //_log("tern properties: request " + request.type + dir + " " + file);
-        ternServer.request(request, function (error, data) {
-            var properties = [];
-            if (error) {
-                _log("Error returned from Tern 'properties' request: " + error);
-            } else {
-                //_log("tern properties: completions = " + data.completions.length);
-                for (i = 0; i < data.completions.length; ++i) {
-                    var property = data.completions[i];
-                    properties.push({value: property, guess: true});
-                }
-            }
-
-            // Post a message back to the main thread with the completions
-            self.postMessage({type: type,
-                              dir: dir,
-                              file: file,
-                              offset: offset,
-                              properties: properties
+            /**
+             * Create a new tern server.
+             *
+             * @param {Object} env - an Object with the environment, as read in from
+             *  the json files in thirdparty/tern/defs
+             * @param {string} dir - the current directory
+             * @param {Array.<string>} files - a list of filenames tern should be aware of
+             */
+            function initTernServer(env, dir, files) {
+                var ternOptions = {
+                    defs: env,
+                    async: true,
+                    getFile: getFile,
+                    plugins: {requirejs: {}, doc_comment: true}
+                };
+                ternServer = new Tern.Server(ternOptions);
+                
+                files.forEach(function (file) {
+                    ternServer.addFile(file);
                 });
-        });
-    }
-        
-    /**
-     * Get the completions for the given offset
-     * @param {string} dir      - the directory
-     * @param {string} file     - the file name
-     * @param {number} offset   - the offset into the file where we want completions for
-     * @param {string} text     - the text of the file
-     * @param {boolean} isProperty - true if getting a property hint,
-     * otherwise getting an identifier hint.
-     */
-    function getTernHints(dir, file, offset, text, isProperty) {
-        
-        var request = buildRequest(dir, file, "completions", offset, text),
-            i;
-
-        //_log("request " + dir + " " + file + " " + offset /*+ " " + text */);
-        ternServer.request(request, function (error, data) {
-            var completions = [];
-            if (error) {
-                _log("Error returned from Tern 'completions' request: " + error);
-            } else {
-                //_log("found " + data.completions.length + " for " + file + "@" + offset);
-                for (i = 0; i < data.completions.length; ++i) {
-                    var completion = data.completions[i];
-                    completions.push({value: completion.name, type: completion.type, depth: completion.depth,
-                        guess: completion.guess, origin: completion.origin});
-                }
+                
             }
-
-            if (completions.length > 0 || !isProperty) {
-                // Post a message back to the main thread with the completions
-                self.postMessage({type: MessageIds.TERN_COMPLETIONS_MSG,
-                    dir: dir,
-                    file: file,
-                    offset: offset,
-                    completions: completions
+        
+            /**
+             * Build an object that can be used as a request to tern
+             * @param {string} dir - the current directory
+             * @param {string} file - the filename the request is in
+             * @param {string} query - the type of request being made
+             * @param {number} offset - the offset in the file the request is at
+             * @param {string} text - the text of the file
+             */
+            function buildRequest(dir, file, query, offset, text) {
+                query = {type: query};
+                query.start = offset;
+                query.end = offset;
+                query.file = file;
+                query.filter = false;
+                query.sort = false;
+                query.depths = true;
+                query.guess = true;
+                query.origins = true;
+                query.expandWordForward = false;
+        
+                var request = {query: query, files: [], offset: offset};
+                request.files.push({type: "full", name: file, text: text});
+        
+                return request;
+            }
+        
+            /**
+             * Send a log message back from the worker to the main thread
+             * 
+             * @param {string} msg - the log message
+             */
+            function _log(msg) {
+                self.postMessage({log: msg });
+            }
+            
+            /**
+             * Get definition location
+             * @param {string} dir      - the directory
+             * @param {string} file     - the file name
+             * @param {number} offset   - the offset into the file for cursor
+             * @param {string} text     - the text of the file
+             */
+            function getJumptoDef(dir, file, offset, text) {
+                
+                var request = buildRequest(dir, file, "definition", offset, text);
+                request.query.lineCharPositions = true;
+                // request.query.typeOnly = true;       // FIXME: tern doesn't work exactly right yet.
+                ternServer.request(request, function (error, data) {
+                    if (error) {
+                        _log("Error returned from Tern 'definition' request: " + error);
+                        self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG});
+                        return;
+                    }
+                    
+                    // Post a message back to the main thread with the definition
+                    self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG,
+                                      file: file,
+                                      resultFile: data.file,
+                                      offset: offset,
+                                      start: data.start,
+                                      end: data.end
+                                     });
+                });
+            }
+        
+            /**
+             * Get all the known properties for guessing.
+             *
+             * @param {string} dir      - the directory
+             * @param {string} file     - the file name
+             * @param {number} offset   - the offset into the file where we want completions for
+             * @param {string} text     - the text of the file
+             * @param {string} type     - the type of the message to reply with.
+             */
+            function getTernProperties(dir, file, offset, text, type) {
+        
+                var request = buildRequest(dir, file, "properties", undefined, text),
+                    i;
+                //_log("tern properties: request " + request.type + dir + " " + file);
+                ternServer.request(request, function (error, data) {
+                    var properties = [];
+                    if (error) {
+                        _log("Error returned from Tern 'properties' request: " + error);
+                    } else {
+                        //_log("tern properties: completions = " + data.completions.length);
+                        for (i = 0; i < data.completions.length; ++i) {
+                            var property = data.completions[i];
+                            properties.push({value: property, guess: true});
+                        }
+                    }
+        
+                    // Post a message back to the main thread with the completions
+                    self.postMessage({type: type,
+                                      dir: dir,
+                                      file: file,
+                                      offset: offset,
+                                      properties: properties
+                        });
+                });
+            }
+                
+            /**
+             * Get the completions for the given offset
+             * @param {string} dir      - the directory
+             * @param {string} file     - the file name
+             * @param {number} offset   - the offset into the file where we want completions for
+             * @param {string} text     - the text of the file
+             * @param {boolean} isProperty - true if getting a property hint,
+             * otherwise getting an identifier hint.
+             */
+            function getTernHints(dir, file, offset, text, isProperty) {
+                
+                var request = buildRequest(dir, file, "completions", offset, text),
+                    i;
+        
+                //_log("request " + dir + " " + file + " " + offset /*+ " " + text */);
+                ternServer.request(request, function (error, data) {
+                    var completions = [];
+                    if (error) {
+                        _log("Error returned from Tern 'completions' request: " + error);
+                    } else {
+                        //_log("found " + data.completions.length + " for " + file + "@" + offset);
+                        for (i = 0; i < data.completions.length; ++i) {
+                            var completion = data.completions[i];
+                            completions.push({value: completion.name, type: completion.type, depth: completion.depth,
+                                guess: completion.guess, origin: completion.origin});
+                        }
+                    }
+        
+                    if (completions.length > 0 || !isProperty) {
+                        // Post a message back to the main thread with the completions
+                        self.postMessage({type: MessageIds.TERN_COMPLETIONS_MSG,
+                            dir: dir,
+                            file: file,
+                            offset: offset,
+                            completions: completions
+                            });
+                    } else {
+                        // if there are no completions, then get all the properties
+                        getTernProperties(dir, file, offset, text, MessageIds.TERN_COMPLETIONS_MSG);
+                    }
+                });
+            }
+        
+            /**
+             * Get the function type for the given offset
+             * @param {string} dir      - the directory
+             * @param {string} file     - the file name
+             * @param {number} offset   - the offset into the file where we want completions for
+             * @param {string} text     - the text of the file
+             */
+            function handleFunctionType(dir, file, pos, offset, text) {
+                
+                var request = buildRequest(dir, file, "type", pos, text);
+                    
+                request.preferFunction = true;
+                
+                //_log("request " + dir + " " + file + " " + offset /*+ " " + text */);
+                ternServer.request(request, function (error, data) {
+                    var fnType = "";
+                    if (error) {
+                        _log("Error returned from Tern 'type' request: " + error);
+                    } else {
+                        fnType = data.type;
+                    }
+        
+                    // Post a message back to the main thread with the completions
+                    self.postMessage({type: MessageIds.TERN_CALLED_FUNC_TYPE_MSG,
+                                      dir: dir,
+                                      file: file,
+                                      offset: offset,
+                                      fnType: fnType
+                                     });
+                });
+            }
+        
+            /**
+             *  Add an array of files to tern.
+             *
+             * @param {Array.<string>} files - each string in the array is the full
+             * path of a file.
+             */
+            function handleAddFiles(files) {
+                files.forEach(function (file) {
+                    ternServer.addFile(file);
+                });
+            }
+        
+            /**
+             *  Update the context of a file in tern.
+             *
+             * @param {string} path - full path of file.
+             * @param {string} text - content of the file.
+             */
+            function handleUpdateFile(path, text) {
+        
+                ternServer.addFile(path, text);
+        
+                self.postMessage({type: MessageIds.TERN_UPDATE_FILE_MSG,
+                    path: path
                     });
-            } else {
-                // if there are no completions, then get all the properties
-                getTernProperties(dir, file, offset, text, MessageIds.TERN_COMPLETIONS_MSG);
-            }
-        });
-    }
-
-    /**
-     * Get the function type for the given offset
-     * @param {string} dir      - the directory
-     * @param {string} file     - the file name
-     * @param {number} offset   - the offset into the file where we want completions for
-     * @param {string} text     - the text of the file
-     */
-    function handleFunctionType(dir, file, pos, offset, text) {
         
-        var request = buildRequest(dir, file, "type", pos, text);
-            
-        request.preferFunction = true;
-        
-        //_log("request " + dir + " " + file + " " + offset /*+ " " + text */);
-        ternServer.request(request, function (error, data) {
-            var fnType = "";
-            if (error) {
-                _log("Error returned from Tern 'type' request: " + error);
-            } else {
-                fnType = data.type;
+                // reset to get the best hints with the updated file.
+                ternServer.reset();
             }
-
-            // Post a message back to the main thread with the completions
-            self.postMessage({type: MessageIds.TERN_CALLED_FUNC_TYPE_MSG,
-                              dir: dir,
-                              file: file,
-                              offset: offset,
-                              fnType: fnType
-                             });
-        });
-    }
-
-    /**
-     *  Add an array of files to tern.
-     *
-     * @param {Array.<string>} files - each string in the array is the full
-     * path of a file.
-     */
-    function handleAddFiles(files) {
-        files.forEach(function (file) {
-            ternServer.addFile(file);
-        });
-    }
-
-    /**
-     *  Update the context of a file in tern.
-     *
-     * @param {string} path - full path of file.
-     * @param {string} text - content of the file.
-     */
-    function handleUpdateFile(path, text) {
-
-        ternServer.addFile(path, text);
-
-        self.postMessage({type: MessageIds.TERN_UPDATE_FILE_MSG,
-            path: path
-            });
-
-        // reset to get the best hints with the updated file.
-        ternServer.reset();
-    }
-
-    /**
-     *  Make a completions request to tern to force tern to resolve files
-     *  and create a fast first lookup for the user.
-     * @param {string} path     - the path of the file
-     * @param {string} text     - the text of the file
-     */
-    function handlePrimePump(path, text) {
-        var request = buildRequest("", path, "completions", 0, text);
-
-        ternServer.request(request, function (error, data) {
-            // Post a message back to the main thread
-            self.postMessage({type: MessageIds.TERN_PRIME_PUMP_MSG,
-                path: path
+        
+            /**
+             *  Make a completions request to tern to force tern to resolve files
+             *  and create a fast first lookup for the user.
+             * @param {string} path     - the path of the file
+             * @param {string} text     - the text of the file
+             */
+            function handlePrimePump(path, text) {
+                var request = buildRequest("", path, "completions", 0, text);
+        
+                ternServer.request(request, function (error, data) {
+                    // Post a message back to the main thread
+                    self.postMessage({type: MessageIds.TERN_PRIME_PUMP_MSG,
+                        path: path
+                        });
                 });
-        });
-    }
-    
-    self.addEventListener("message", function (e) {
-        var dir, file, text, offset,
-            request = e.data,
-            type = request.type;
-
-        if (type === MessageIds.TERN_INIT_MSG) {
+            }
             
-            dir         = request.dir;
-            var env     = request.env,
-                files   = request.files;
-            initTernServer(env, dir, files);
-        } else if (type === MessageIds.TERN_COMPLETIONS_MSG) {
-            dir = request.dir;
-            file = request.file;
-            text    = request.text;
-            offset  = request.offset;
-            getTernHints(dir, file, offset, text, request.isProperty);
-        } else if (type === MessageIds.TERN_GET_FILE_MSG) {
-            file = request.file;
-            text = request.text;
-            handleGetFile(file, text);
-        } else if (type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
-            dir     = request.dir;
-            file    = request.file;
-            text    = request.text;
-            offset  = request.offset;
-            var pos = request.pos;
-            handleFunctionType(dir, file, pos, offset, text);
-        } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
-            file    = request.file;
-            dir     = request.dir;
-            text    = request.text;
-            offset  = request.offset;
-            getJumptoDef(dir, file, offset, text);
-        } else if (type === MessageIds.TERN_ADD_FILES_MSG) {
-            handleAddFiles(request.files);
-        } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
-            handlePrimePump(request.path, request.text);
-        } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
-            dir     = request.dir;
-            file    = request.file;
-            text    = request.text;
-            offset  = request.offset;
-            getTernProperties(dir, file, offset, text, MessageIds.TERN_GET_GUESSES_MSG);
-        } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
-            handleUpdateFile(request.path, request.text);
-        } else {
-            _log("Unknown message: " + JSON.stringify(request));
-        }
+            self.addEventListener("message", function (e) {
+                var dir, file, text, offset,
+                    request = e.data,
+                    type = request.type;
+                
+                if (type === MessageIds.TERN_INIT_MSG) {
+                    
+                    dir         = request.dir;
+                    var env     = request.env,
+                        files   = request.files;
+                    initTernServer(env, dir, files);
+                } else if (type === MessageIds.TERN_COMPLETIONS_MSG) {
+                    dir = request.dir;
+                    file = request.file;
+                    text    = request.text;
+                    offset  = request.offset;
+                    getTernHints(dir, file, offset, text, request.isProperty);
+                } else if (type === MessageIds.TERN_GET_FILE_MSG) {
+                    file = request.file;
+                    text = request.text;
+                    handleGetFile(file, text);
+                } else if (type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
+                    dir     = request.dir;
+                    file    = request.file;
+                    text    = request.text;
+                    offset  = request.offset;
+                    var pos = request.pos;
+                    handleFunctionType(dir, file, pos, offset, text);
+                } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
+                    file    = request.file;
+                    dir     = request.dir;
+                    text    = request.text;
+                    offset  = request.offset;
+                    getJumptoDef(dir, file, offset, text);
+                } else if (type === MessageIds.TERN_ADD_FILES_MSG) {
+                    handleAddFiles(request.files);
+                } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
+                    handlePrimePump(request.path, request.text);
+                } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
+                    dir     = request.dir;
+                    file    = request.file;
+                    text    = request.text;
+                    offset  = request.offset;
+                    getTernProperties(dir, file, offset, text, MessageIds.TERN_GET_GUESSES_MSG);
+                } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
+                    handleUpdateFile(request.path, request.text);
+                } else {
+                    _log("Unknown message: " + JSON.stringify(request));
+                }
+            });
+            // tell the main thread we're ready to start processing messages
+            self.postMessage({type: MessageIds.TERN_WORKER_READY});
+        });
     });
 
 }());


### PR DESCRIPTION
...a project.

If we don't call terminate on the worker, it appears that the worker, and all the memory it's using will never get collected.  So when we were switching projects, we were leaving behind orphaned workers, resulting in a large memory leak.

To enable re-initing the web worker I had to change around the logic - now the worker sends a message when it is done being init'ed and the main thread waits for that message before it starts sending messages to the workers.
