### PR TITLE
[js code hints] Kill and restart the codehint worker thread every 30 hint requests.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/MessageIds.js
+++ b/src/extensions/default/JavaScriptCodeHints/MessageIds.js
@@ -47,6 +47,7 @@ define(function (require, exports, module) {
     exports.TERN_PRIME_PUMP_MSG         = TERN_PRIME_PUMP_MSG;
     exports.TERN_GET_GUESSES_MSG        = TERN_GET_GUESSES_MSG;
     exports.TERN_UPDATE_FILE_MSG        = TERN_UPDATE_FILE_MSG;
+    exports.TERN_WORKER_READY           = TERN_WORKER_READY;
 });
 
 

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -29,7 +29,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, Worker */
+/*global define, brackets, $, Worker, setTimeout */
 
 define(function (require, exports, module) {
     "use strict";
@@ -49,56 +49,19 @@ define(function (require, exports, module) {
         pendingTernRequests = {},
         builtinFiles       = ["ecma5.json", "browser.json", "jquery.json"],
         builtinLibraryNames = [],
-        rootTernDir         = null,
-        projectRoot         = null,
-        ternPromise         = null,
-        addFilesPromise     = null,
-        resolvedFiles       = {},       // file -> resolved file
-        numInitialFiles     = 0,
-        numResolvedFiles    = 0,
-        numAddedFiles       = 0,
-        stopAddingFiles     = false,
         // exclude require and jquery since we have special knowledge of those
         // temporarily exclude less*min.js because it is causing instability in tern.
         excludedFilesRegEx  = /require\.js$|jquery[\w.\-]*\.js$|less[\w.\-]*\.min\.js$/,
         isDocumentDirty     = false,
-        _ternWorker         = null;
+        _hintCount          = 0,
+        _lastPrimePump      = false,
+        currentWorker       = null;
 
     var MAX_TEXT_LENGTH     = 1000000, // about 1MB
         MAX_FILES_IN_DIR    = 100,
-        MAX_FILES_IN_PROJECT = 100;
-
-    /**
-     *  Add new files to tern, keeping any previous files.
-     *  The tern server must be initialized before making
-     *  this call.
-     *
-     * @param {Array.<string>} files - array of file to add to tern.
-     * @return {boolean} - true if more files may be added, false if maximum has been reached.
-     */
-    function addFilesToTern(files) {
-        // limit the number of files added to tern.
-        if (numResolvedFiles + numAddedFiles < MAX_FILES_IN_PROJECT) {
-            var available = MAX_FILES_IN_PROJECT - numResolvedFiles - numAddedFiles;
-
-            if (available < files.length) {
-                files = files.slice(0, available);
-            }
-
-            numAddedFiles += files.length;
-            ternPromise.done(function (worker) {
-                worker.postMessage({
-                    type        : MessageIds.TERN_ADD_FILES_MSG,
-                    files       : files
-                });
-            });
-
-        } else {
-            stopAddingFiles = true;
-        }
-
-        return stopAddingFiles;
-    }
+        MAX_FILES_IN_PROJECT = 100,
+        // how often to reset the tern server
+        MAX_HINTS           = 30;
 
     /**
      *  An array of library names that contain JavaScript builtins definitions.
@@ -139,19 +102,7 @@ define(function (require, exports, module) {
      * the message will not be posted until initialization is complete
      */
     function postMessage(msg) {
-        addFilesPromise.done(function (ternWorker) {
-            ternWorker.postMessage(msg);
-        });
-    }
-
-    /**
-     * Send a message to the tern worker - this is only for messages that
-     * need to be sent before and while the addFilesPromise is being resolved.
-     */
-    function _postMessageByPass(msg) {
-        ternPromise.done(function (ternWorker) {
-            ternWorker.postMessage(msg);
-        });
+        currentWorker.postMessage(msg);
     }
 
     /**
@@ -245,96 +196,6 @@ define(function (require, exports, module) {
     }
 
     /**
-     *  Add the files in the directory and subdirectories of a given directory
-     *  to tern.
-     *
-     * @param {string} dir - the root directory to add.
-     * @param {function ()} doneCallback - called when all files have been
-     * added to tern.
-     */
-    function addAllFilesAndSubdirectories(dir, doneCallback) {
-
-        var numDirectoriesLeft = 1;        // number of directories to process
-
-        /**
-         *  Add the files in the directory and subdirectories of a given directory
-         *  to tern, excluding the rootTernDir).
-         *
-         * @param {string} dir - the root directory to add.
-         * @param {function()} successCallback - callback when
-         * done processing files.
-         */
-        function addAllFilesRecursively(dir, successCallback) {
-
-            var files = [],
-                dirs = [];
-
-            function doneCallback() {
-                numDirectoriesLeft--;
-
-                if (!stopAddingFiles && files.length > 0 &&
-                        (dir + "/") !== rootTernDir) {
-                    addFilesToTern(files);
-                }
-
-                if (!stopAddingFiles) {
-                    dirs.forEach(function (path) {
-                        var dir = HintUtils.splitPath(path).dir;
-                        if (!stopAddingFiles) {
-                            numDirectoriesLeft++;
-                            addAllFilesRecursively(dir, successCallback);
-                        }
-                    });
-                }
-
-                if (numDirectoriesLeft === 0) {
-                    successCallback();
-                }
-            }
-
-            /**
-             *  Add files to global list.
-             *
-             * @param path - full path of file.
-             */
-            function fileCallback(path) {
-                if (!excludedFilesRegEx.test(path)) {
-                    files.push(path);
-                }
-            }
-
-            /**
-             *  For each directory, add all the files in its subdirectory.
-             *
-             * @param path
-             */
-            function directoryCallback(path) {
-                if (path !== rootTernDir) {
-                    dirs.push(path);
-                }
-            }
-
-            dir = FileUtils.canonicalizeFolderPath(dir);
-            forEachFileInDirectory(dir, doneCallback, fileCallback, directoryCallback);
-        }
-
-        addAllFilesRecursively(dir, function () {
-            doneCallback();
-        });
-    }
-
-    /**
-     *  Determine whether the current set of files are using modules to pull in
-     *  additional files.
-     *
-     * @returns {boolean} - true if more files than the current directory have
-     * been read in.
-     */
-    function usingModules() {
-        return numInitialFiles !== numResolvedFiles;
-    }
-
-    /**
      * Add a pending request waiting for the tern-worker to complete.
      *
      * @param {string} file - the name of the file
@@ -389,7 +250,7 @@ define(function (require, exports, module) {
      * @return {string} returns the path we resolved when we tried to parse the file, or undefined
      */
     function getResolvedPath(file) {
-        return resolvedFiles[file];
+        return currentWorker.getResolvedPath(file);
     }
 
     /**
@@ -496,62 +357,6 @@ define(function (require, exports, module) {
         return addPendingRequest(file, offset, MessageIds.TERN_CALLED_FUNC_TYPE_MSG);
     }
     
-    
-    /**
-     * Request hints from Tern.
-     *
-     * Note that successive calls to getScope may return the same objects, so
-     * clients that wish to modify those objects (e.g., by annotating them based
-     * on some temporary context) should copy them first. See, e.g.,
-     * Session.getHints().
-     * 
-     * @param {Session} session - the active hinting session
-     * @param {Document} document - the document for which scope info is 
-     *      desired
-     * @return {jQuery.Promise} - The promise will not complete until the tern
-     *      hints have completed.
-     */
-    function requestHints(session, document) {
-        var path    = document.file.fullPath,
-            split   = HintUtils.splitPath(path),
-            dir     = split.dir,
-            file    = split.file;
-        
-        var $deferredHints = $.Deferred(),
-            hintPromise,
-            fnTypePromise,
-            text = session.getJavascriptText(),
-            offset = session.getOffset();
-
-        var sessionType = session.getType();
-        hintPromise = getTernHints(dir, path, offset, text, sessionType.property);
-
-        if (sessionType.showFunctionType) {
-            // Show function sig
-            fnTypePromise = getTernFunctionType(dir, path, sessionType.functionCallPos, offset, text);
-        } else {
-            var $fnTypeDeferred = $.Deferred();
-            fnTypePromise = $fnTypeDeferred.promise();
-            $fnTypeDeferred.resolveWith(null);
-        }
-
-        $.when(hintPromise, fnTypePromise).done(
-            function (completions, fnType) {
-                if (completions.completions) {
-                    session.setTernHints(completions.completions);
-                    session.setGuesses(null);
-                } else {
-                    session.setTernHints([]);
-                    session.setGuesses(completions.properties);
-                }
-
-                session.setFnType(fnType);
-                $deferredHints.resolveWith(null);
-            }
-        );
-        return {promise: $deferredHints.promise()};
-    }
-
     /**
      * Get a Promise for all of the known properties from TernJS, for the directory and file.
      * The properties will be used as guesses in tern.
@@ -613,121 +418,6 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Handle a request from the worker for text of a file
-     *
-     * @param {{file:string}} request - the request from the worker.  Should be an Object containing the name
-     *      of the file tern wants the contents of 
-     */
-    function handleTernGetFile(request) {
-
-        function replyWith(name, txt) {
-            _postMessageByPass({
-                type: MessageIds.TERN_GET_FILE_MSG,
-                file: name,
-                text: txt
-            });
-        }
-
-        var name = request.file;
-
-        /**
-         * Helper function to get the text of a given document and send it to tern.
-         * If we successfully get the document from the DocumentManager then the text of 
-         * the document will be sent to the tern worker.
-         * The Promise for getDocumentForPath is returned so that custom fail functions can be
-         * used.
-         *
-         * @param {string} filePath - the path of the file to get the text of
-         * @return {jQuery.Promise} - the Promise returned from DocumentMangaer.getDocumentForPath 
-         */
-        function getDocText(filePath) {
-            return DocumentManager.getDocumentForPath(filePath).done(function (document) {
-                resolvedFiles[name] = filePath;
-                numResolvedFiles++;
-                replyWith(name, document.getText());
-            });
-        }
-        
-        /**
-         * Helper function to find any files in the project that end with the
-         * name we are looking for.  This is so we can find requirejs modules 
-         * when the baseUrl is unknown, or when the project root is not the same
-         * as the script root (e.g. if you open the 'brackets' dir instead of 'brackets/src' dir).
-         */
-        function findNameInProject() {
-            // check for any files in project that end with the right path.
-            var fileName = HintUtils.splitPath(name).file;
-            FileIndexManager.getFilenameMatches("all", fileName)
-                .done(function (files) {
-                    var file;
-                    files = files.filter(function (file) {
-                        var pos = file.fullPath.length - name.length;
-                        return pos === file.fullPath.lastIndexOf(name);
-                    });
-                    
-                    if (files.length === 1) {
-                        file = files[0];
-                    }
-                    if (file) {
-                        getDocText(file.fullPath).fail(function () {
-                            replyWith(name, "");
-                        });
-                    } else {
-                        replyWith(name, "");
-                    }
-                    
-                })
-                .fail(function () {
-                    replyWith(name, "");
-                });
-        }
-
-        getDocText(name).fail(function () {
-            getDocText(rootTernDir + name).fail(function () {
-                // check relative to project root
-                getDocText(projectRoot + name)
-                    // last look for any files that end with the right path
-                    // in the project
-                    .fail(findNameInProject);
-            });
-        });
-    }
-
-    /**
-     *  Prime the pump for a fast first lookup.
-     *
-     * @param {string} path - full path of file
-     * @param {string} text - text of file
-     * @return {jQuery.Promise} - the promise for the request
-     */
-    function primePump(path, text) {
-        _postMessageByPass({
-            type        : MessageIds.TERN_PRIME_PUMP_MSG,
-            path        : path,
-            text        : text
-        });
-
-        return addPendingRequest(path, 0, MessageIds.TERN_PRIME_PUMP_MSG);
-    }
-
-    /**
-     * Handle the response from the tern web worker when
-     * it responds to the prime pump message.
-     *
-     * @param {{path:string, type: string}} response - the response from the worker
-     */
-    function handlePrimePumpCompletion(response) {
-
-        var path = response.path,
-            type = response.type,
-            $deferredHints = getPendingRequest(path, 0, type);
-
-        if ($deferredHints) {
-            $deferredHints.resolve();
-        }
-    }
-
-    /**
      * Handle the response from the tern web worker when
      * it responds to the get guesses message.
      *
@@ -744,24 +434,6 @@ define(function (require, exports, module) {
         if ($deferredHints) {
             $deferredHints.resolveWith(null, [response.properties]);
         }
-    }
-
-    /**
-     *  Update tern with the new contents of a given file.
-     *
-     * @param {Document} document - the document to update
-     * @return {jQuery.Promise} - the promise for the request
-     */
-    function updateTernFile(document) {
-        var path  = document.file.fullPath;
-
-        _postMessageByPass({
-            type       : MessageIds.TERN_UPDATE_FILE_MSG,
-            path       : path,
-            text       : document.getText()
-        });
-
-        return addPendingRequest(path, 0, MessageIds.TERN_UPDATE_FILE_MSG);
     }
 
     /**
@@ -782,184 +454,615 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Init the web worker that does all the code hinting work.
+     * Encapsulate all the logic to talk to the worker thread.  This will create
+     * a new instance of a TernWorker, which the rest of the hinting code can use to talk
+     * to the worker, without worrying about initialization, priming the pump, etc.
      *
-     * If a worker already exists, then this will terminate that worker and
-     * start a new worker - this helps alleviate leaks that may be ocurring in 
-     * the code that the worker runs.  
      */
-    function initTernWorker() {
-        if (_ternWorker) {
-            _ternWorker.terminate();
-        }
-        var workerDeferred = $.Deferred();
-        ternPromise = workerDeferred.promise();
-        var path = ExtensionUtils.getModulePath(module, "tern-worker.js");
-        _ternWorker = new Worker(path);
+    function TernWorker() {
+        var ternPromise         = null,
+            addFilesPromise     = null,
+            rootTernDir         = null,
+            projectRoot         = null,
+            stopAddingFiles     = false,
+            resolvedFiles       = {},       // file -> resolved file
+            numInitialFiles     = 0,
+            numResolvedFiles    = 0,
+            numAddedFiles       = 0,
+            _ternWorker         = null;
 
-        _ternWorker.addEventListener("message", function (e) {
-            var response = e.data,
-                type = response.type;
-    
-            if (type === MessageIds.TERN_COMPLETIONS_MSG ||
-                    type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
-                // handle any completions the worker calculated
-                handleTernCompletions(response);
-            } else if (type === MessageIds.TERN_GET_FILE_MSG) {
-                // handle a request for the contents of a file
-                handleTernGetFile(response);
-            } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
-                handleJumptoDef(response);
-            } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
-                handlePrimePumpCompletion(response);
-            } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
-                handleGetGuesses(response);
-            } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
-                handleUpdateFile(response);
-            } else if (type === MessageIds.TERN_WORKER_READY) {
-                workerDeferred.resolveWith(null, [_ternWorker]);
-            } else {
-                console.log("Worker: " + (response.log || response));
-            }
-        });
+        /**
+         * @param {string} file a relative path
+         * @return {string} returns the path we resolved when we tried to parse the file, or undefined
+         */
+        function getResolvedPath(file) {
+            return resolvedFiles[file];
+        }
         
-    }
-    /**
-     * Create a new tern server.
-     */
-    function initTernServer(dir, files) {
-        initTernWorker();
-        numResolvedFiles = 0;
-        numAddedFiles = 0;
-        stopAddingFiles = false;
-        numInitialFiles = files.length;
-
-        ternPromise.done(function (worker) {
-            worker.postMessage({
-                type        : MessageIds.TERN_INIT_MSG,
-                dir         : dir,
-                files       : files,
-                env         : ternEnvironment
+        /**
+         *  Determine whether the current set of files are using modules to pull in
+         *  additional files.
+         *
+         * @returns {boolean} - true if more files than the current directory have
+         * been read in.
+         */
+        function usingModules() {
+            return numInitialFiles !== numResolvedFiles;
+        }
+        
+        /**
+         * Send a message to the tern worker - if the worker is being initialized,
+         * the message will not be posted until initialization is complete
+         */
+        function postMessage(msg) {
+            addFilesPromise.done(function (ternWorker) {
+                ternWorker.postMessage(msg);
             });
-        });
-        rootTernDir = dir + "/";
-    }
-
-    /**
-     *  We can skip tern initialization if we are opening a file that has
-     *  already been added to tern.
-     *
-     * @param {string} newFile - full path of new file being opened in the editor.
-     * @returns {boolean} - true if tern initialization should be skipped,
-     * false otherwise.
-     */
-    function canSkipTernInitialization(newFile) {
-        return resolvedFiles[newFile] !== undefined;
-    }
-
-
-    /**
-     *  Do the work to initialize a code hinting session.
-     *
-     * @param {Session} session - the active hinting session
-     * @param {Document} document - the document the editor has changed to
-     * @param {Document} previousDocument - the document the editor has changed from
-     * @param {boolean} shouldPrimePump - true if the pump should be primed.
-     */
-    function doEditorChange(session, document, previousDocument, shouldPrimePump) {
-        var path        = document.file.fullPath,
-            split       = HintUtils.splitPath(path),
-            dir         = split.dir,
-            files       = [],
-            file        = split.file,
-            pr;
-
-        var addFilesDeferred = $.Deferred();
-
-        addFilesPromise = addFilesDeferred.promise();
-        pr = ProjectManager.getProjectRoot() ? ProjectManager.getProjectRoot().fullPath : null;
-
-        // avoid re-initializing tern if possible.
-        if (canSkipTernInitialization(path)) {
-
-            // update the previous document in tern to prevent stale files.
-            if (isDocumentDirty && previousDocument) {
-                var updateFilePromise = updateTernFile(previousDocument);
-                updateFilePromise.done(function () {
-                    primePump(path, document.getText());
-                    addFilesDeferred.resolveWith(null, [_ternWorker]);
-                });
-            } else {
-                addFilesDeferred.resolveWith(null, [_ternWorker]);
-            }
-
-            isDocumentDirty = false;
-            return;
         }
 
-        isDocumentDirty = false;
-        pendingTernRequests = [];
-        resolvedFiles = {};
+        /**
+         * Send a message to the tern worker - this is only for messages that
+         * need to be sent before and while the addFilesPromise is being resolved.
+         */
+        function _postMessageByPass(msg) {
+            ternPromise.done(function (ternWorker) {
+                ternWorker.postMessage(msg);
+            });
+        }
 
-        projectRoot = pr;
-        getFilesInDirectory(dir, function (files) {
-            initTernServer(dir, files);
-
-            if (shouldPrimePump) {
-                var hintsPromise = primePump(path, document.getText());
-                hintsPromise.done(function () {
-                    if (!usingModules()) {
-                        // Read the subdirectories of the new file's directory.
-                        // Read them first in case there are too many files to
-                        // read in the project.
-                        addAllFilesAndSubdirectories(dir, function () {
-                            // If the file is in the project root, then read
-                            // all the files under the project root.
-                            var currentDir = (dir + "/");
-                            if (projectRoot && currentDir !== projectRoot &&
-                                    currentDir.indexOf(projectRoot) === 0) {
-                                addAllFilesAndSubdirectories(projectRoot, function () {
-                                    // prime the pump again but this time don't wait
-                                    // for completion.
-                                    primePump(path, document.getText());
-
-                                    addFilesDeferred.resolveWith(null, [_ternWorker]);
-                                });
-                            } else {
-                                addFilesDeferred.resolveWith(null, [_ternWorker]);
+        /**
+         *  Update tern with the new contents of a given file.
+         *
+         * @param {Document} document - the document to update
+         * @return {jQuery.Promise} - the promise for the request
+         */
+        function updateTernFile(document) {
+            var path  = document.file.fullPath;
+    
+            _postMessageByPass({
+                type       : MessageIds.TERN_UPDATE_FILE_MSG,
+                path       : path,
+                text       : document.getText()
+            });
+    
+            return addPendingRequest(path, 0, MessageIds.TERN_UPDATE_FILE_MSG);
+        }
+        
+        /**
+         * Handle a request from the worker for text of a file
+         *
+         * @param {{file:string}} request - the request from the worker.  Should be an Object containing the name
+         *      of the file tern wants the contents of 
+         */
+        function handleTernGetFile(request) {
+    
+            function replyWith(name, txt) {
+                _postMessageByPass({
+                    type: MessageIds.TERN_GET_FILE_MSG,
+                    file: name,
+                    text: txt
+                });
+            }
+    
+            var name = request.file;
+    
+            /**
+             * Helper function to get the text of a given document and send it to tern.
+             * If we successfully get the document from the DocumentManager then the text of 
+             * the document will be sent to the tern worker.
+             * The Promise for getDocumentForPath is returned so that custom fail functions can be
+             * used.
+             *
+             * @param {string} filePath - the path of the file to get the text of
+             * @return {jQuery.Promise} - the Promise returned from DocumentMangaer.getDocumentForPath 
+             */
+            function getDocText(filePath) {
+                return DocumentManager.getDocumentForPath(filePath).done(function (document) {
+                    resolvedFiles[name] = filePath;
+                    numResolvedFiles++;
+                    replyWith(name, document.getText());
+                });
+            }
+            
+            /**
+             * Helper function to find any files in the project that end with the
+             * name we are looking for.  This is so we can find requirejs modules 
+             * when the baseUrl is unknown, or when the project root is not the same
+             * as the script root (e.g. if you open the 'brackets' dir instead of 'brackets/src' dir).
+             */
+            function findNameInProject() {
+                // check for any files in project that end with the right path.
+                var fileName = HintUtils.splitPath(name).file;
+                FileIndexManager.getFilenameMatches("all", fileName)
+                    .done(function (files) {
+                        var file;
+                        files = files.filter(function (file) {
+                            var pos = file.fullPath.length - name.length;
+                            return pos === file.fullPath.lastIndexOf(name);
+                        });
+                        
+                        if (files.length === 1) {
+                            file = files[0];
+                        }
+                        if (file) {
+                            getDocText(file.fullPath).fail(function () {
+                                replyWith(name, "");
+                            });
+                        } else {
+                            replyWith(name, "");
+                        }
+                        
+                    })
+                    .fail(function () {
+                        replyWith(name, "");
+                    });
+            }
+    
+            getDocText(name).fail(function () {
+                getDocText(rootTernDir + name).fail(function () {
+                    // check relative to project root
+                    getDocText(projectRoot + name)
+                        // last look for any files that end with the right path
+                        // in the project
+                        .fail(findNameInProject);
+                });
+            });
+        }
+    
+        /**
+         *  Prime the pump for a fast first lookup.
+         *
+         * @param {string} path - full path of file
+         * @param {string} text - text of file
+         * @return {jQuery.Promise} - the promise for the request
+         */
+        function primePump(path, text) {
+            _postMessageByPass({
+                type        : MessageIds.TERN_PRIME_PUMP_MSG,
+                path        : path,
+                text        : text
+            });
+    
+            return addPendingRequest(path, 0, MessageIds.TERN_PRIME_PUMP_MSG);
+        }
+    
+        /**
+         * Handle the response from the tern web worker when
+         * it responds to the prime pump message.
+         *
+         * @param {{path:string, type: string}} response - the response from the worker
+         */
+        function handlePrimePumpCompletion(response) {
+    
+            var path = response.path,
+                type = response.type,
+                $deferredHints = getPendingRequest(path, 0, type);
+    
+            if ($deferredHints) {
+                $deferredHints.resolve();
+            }
+        }
+        
+        /**
+         *  Add new files to tern, keeping any previous files.
+         *  The tern server must be initialized before making
+         *  this call.
+         *
+         * @param {Array.<string>} files - array of file to add to tern.
+         * @return {boolean} - true if more files may be added, false if maximum has been reached.
+         */
+        function addFilesToTern(files) {
+            // limit the number of files added to tern.
+            if (numResolvedFiles + numAddedFiles < MAX_FILES_IN_PROJECT) {
+                var available = MAX_FILES_IN_PROJECT - numResolvedFiles - numAddedFiles;
+    
+                if (available < files.length) {
+                    files = files.slice(0, available);
+                }
+    
+                numAddedFiles += files.length;
+                ternPromise.done(function (worker) {
+                    worker.postMessage({
+                        type        : MessageIds.TERN_ADD_FILES_MSG,
+                        files       : files
+                    });
+                });
+    
+            } else {
+                stopAddingFiles = true;
+            }
+    
+            return stopAddingFiles;
+        }
+            
+        /**
+         *  Add the files in the directory and subdirectories of a given directory
+         *  to tern.
+         *
+         * @param {string} dir - the root directory to add.
+         * @param {function ()} doneCallback - called when all files have been
+         * added to tern.
+         */
+        function addAllFilesAndSubdirectories(dir, doneCallback) {
+    
+            var numDirectoriesLeft = 1;        // number of directories to process
+    
+            /**
+             *  Add the files in the directory and subdirectories of a given directory
+             *  to tern, excluding the rootTernDir).
+             *
+             * @param {string} dir - the root directory to add.
+             * @param {function()} successCallback - callback when
+             * done processing files.
+             */
+            function addAllFilesRecursively(dir, successCallback) {
+    
+                var files = [],
+                    dirs = [];
+    
+                function doneCallback() {
+                    numDirectoriesLeft--;
+    
+                    if (!stopAddingFiles && files.length > 0 &&
+                            (dir + "/") !== rootTernDir) {
+                        addFilesToTern(files);
+                    }
+    
+                    if (!stopAddingFiles) {
+                        dirs.forEach(function (path) {
+                            var dir = HintUtils.splitPath(path).dir;
+                            if (!stopAddingFiles) {
+                                numDirectoriesLeft++;
+                                addAllFilesRecursively(dir, successCallback);
                             }
                         });
-                    } else {
-                        addFilesDeferred.resolveWith(null, [_ternWorker]);
                     }
-                });
-            } else {
-                addFilesDeferred.resolveWith(null, [_ternWorker]);
+    
+                    if (numDirectoriesLeft === 0) {
+                        successCallback();
+                    }
+                }
+    
+                /**
+                 *  Add files to global list.
+                 *
+                 * @param path - full path of file.
+                 */
+                function fileCallback(path) {
+                    if (!excludedFilesRegEx.test(path)) {
+                        files.push(path);
+                    }
+                }
+    
+                /**
+                 *  For each directory, add all the files in its subdirectory.
+                 *
+                 * @param path
+                 */
+                function directoryCallback(path) {
+                    if (path !== rootTernDir) {
+                        dirs.push(path);
+                    }
+                }
+    
+                dir = FileUtils.canonicalizeFolderPath(dir);
+                forEachFileInDirectory(dir, doneCallback, fileCallback, directoryCallback);
             }
-
-        }, function () {
-            addFilesDeferred.resolveWith(null);
-        });
-    }
-
-    /**
-     * Called each time a new editor becomes active.
-     *
-     * @param {Session} session - the active hinting session
-     * @param {Document} document - the document of the editor that has changed
-     * @param {Document} previousDocument - the document of the editor is changing from
-     * @param {boolean} shouldPrimePump - true if the pump should be primed.
-     */
-    function handleEditorChange(session, document, previousDocument, shouldPrimePump) {
-        if (addFilesPromise === null) {
-            doEditorChange(session, document, previousDocument, shouldPrimePump);
-        } else {
-            addFilesPromise.done(function () {
-                doEditorChange(session, document, previousDocument, shouldPrimePump);
+    
+            addAllFilesRecursively(dir, function () {
+                doneCallback();
             });
         }
+            
+        /**
+         * Init the web worker that does all the code hinting work.
+         *
+         * If a worker already exists, then this will terminate that worker and
+         * start a new worker - this helps alleviate leaks that may be ocurring in 
+         * the code that the worker runs.  
+         */
+        function initTernWorker() {
+            if (_ternWorker) {
+                _ternWorker.terminate();
+            }
+            var workerDeferred = $.Deferred();
+            ternPromise = workerDeferred.promise();
+            var path = ExtensionUtils.getModulePath(module, "tern-worker.js");
+            _ternWorker = new Worker(path);
+    
+            _ternWorker.addEventListener("message", function (e) {
+                var response = e.data,
+                    type = response.type;
+    
+                if (type === MessageIds.TERN_COMPLETIONS_MSG ||
+                        type === MessageIds.TERN_CALLED_FUNC_TYPE_MSG) {
+                    // handle any completions the worker calculated
+                    handleTernCompletions(response);
+                } else if (type === MessageIds.TERN_GET_FILE_MSG) {
+                    // handle a request for the contents of a file
+                    handleTernGetFile(response);
+                } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
+                    handleJumptoDef(response);
+                } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
+                    handlePrimePumpCompletion(response);
+                } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
+                    handleGetGuesses(response);
+                } else if (type === MessageIds.TERN_UPDATE_FILE_MSG) {
+                    handleUpdateFile(response);
+                } else if (type === MessageIds.TERN_WORKER_READY) {
+                    workerDeferred.resolveWith(null, [_ternWorker]);
+                } else {
+                    console.log("Worker: " + (response.log || response));
+                }
+            });
+            
+        }
+        /**
+         * Create a new tern server.
+         */
+        function initTernServer(dir, files) {
+            initTernWorker();
+            numResolvedFiles = 0;
+            numAddedFiles = 0;
+            stopAddingFiles = false;
+            numInitialFiles = files.length;
+    
+            ternPromise.done(function (worker) {
+                worker.postMessage({
+                    type        : MessageIds.TERN_INIT_MSG,
+                    dir         : dir,
+                    files       : files,
+                    env         : ternEnvironment
+                });
+            });
+            rootTernDir = dir + "/";
+        }
+    
+        /**
+         *  We can skip tern initialization if we are opening a file that has
+         *  already been added to tern.
+         *
+         * @param {string} newFile - full path of new file being opened in the editor.
+         * @returns {boolean} - true if tern initialization should be skipped,
+         * false otherwise.
+         */
+        function canSkipTernInitialization(newFile) {
+            return resolvedFiles[newFile] !== undefined;
+        }
+    
+    
+        /**
+         *  Do the work to initialize a code hinting session.
+         *
+         * @param {Session} session - the active hinting session
+         * @param {Document} document - the document the editor has changed to
+         * @param {Document} previousDocument - the document the editor has changed from
+         * @param {boolean} shouldPrimePump - true if the pump should be primed.
+         */
+        function doEditorChange(session, document, previousDocument, shouldPrimePump, isReset) {
+            var path        = document.file.fullPath,
+                split       = HintUtils.splitPath(path),
+                dir         = split.dir,
+                files       = [],
+                file        = split.file,
+                pr;
+    
+            var addFilesDeferred = $.Deferred();
+    
+            _lastPrimePump = shouldPrimePump;
+            
+            addFilesPromise = addFilesDeferred.promise();
+            pr = ProjectManager.getProjectRoot() ? ProjectManager.getProjectRoot().fullPath : null;
+    
+            // avoid re-initializing tern if possible.
+            if (canSkipTernInitialization(path)) {
+    
+                // update the previous document in tern to prevent stale files.
+                if (isDocumentDirty && previousDocument) {
+                    var updateFilePromise = updateTernFile(previousDocument);
+                    updateFilePromise.done(function () {
+                        primePump(path, document.getText());
+                        addFilesDeferred.resolveWith(null, [_ternWorker]);
+                    });
+                } else {
+                    addFilesDeferred.resolveWith(null, [_ternWorker]);
+                }
+    
+                isDocumentDirty = false;
+                return;
+            }
+    
+            isDocumentDirty = false;
+            
+            resolvedFiles = {};
+    
+            projectRoot = pr;
+            getFilesInDirectory(dir, function (files) {
+                initTernServer(dir, files);
+    
+                if (shouldPrimePump) {
+                    var hintsPromise = primePump(path, document.getText());
+                    hintsPromise.done(function () {
+                        if (!usingModules()) {
+                            // Read the subdirectories of the new file's directory.
+                            // Read them first in case there are too many files to
+                            // read in the project.
+                            addAllFilesAndSubdirectories(dir, function () {
+                                // If the file is in the project root, then read
+                                // all the files under the project root.
+                                var currentDir = (dir + "/");
+                                if (projectRoot && currentDir !== projectRoot &&
+                                        currentDir.indexOf(projectRoot) === 0) {
+                                    addAllFilesAndSubdirectories(projectRoot, function () {
+                                        // prime the pump again but this time don't wait
+                                        // for completion.
+                                        primePump(path, document.getText());
+    
+                                        addFilesDeferred.resolveWith(null, [_ternWorker]);
+                                    });
+                                } else {
+                                    addFilesDeferred.resolveWith(null, [_ternWorker]);
+                                }
+                            });
+                        } else {
+                            addFilesDeferred.resolveWith(null, [_ternWorker]);
+                        }
+                    });
+                } else {
+                    addFilesDeferred.resolveWith(null, [_ternWorker]);
+                }
+    
+            }, function () {
+                addFilesDeferred.resolveWith(null);
+            });
+        }
+    
+        /**
+         * Called each time a new editor becomes active.
+         *
+         * @param {Session} session - the active hinting session
+         * @param {Document} document - the document of the editor that has changed
+         * @param {Document} previousDocument - the document of the editor is changing from
+         * @param {boolean} shouldPrimePump - true if the pump should be primed.
+         */
+        function handleEditorChange(session, document, previousDocument, shouldPrimePump) {
+            if (addFilesPromise === null) {
+                doEditorChange(session, document, previousDocument, shouldPrimePump);
+            } else {
+                addFilesPromise.done(function () {
+                    doEditorChange(session, document, previousDocument, shouldPrimePump);
+                });
+            }
+        }
+        
+        /**
+         * Do some cleanup when a project is closed.
+         *
+         * We can clean up the web worker we use to calculate hints now, since
+         * we know we will need to re-init it in any new project that is opened.  
+         */
+        function closeWorker() {
+            function terminateWorker() {
+                var worker = _ternWorker;
+                setTimeout(function () {
+                    // give pending requests a chance to finish
+                    worker.terminate();
+                    worker = null;
+                }, 1000);
+                _ternWorker = null;
+                resolvedFiles = {};
+            }
+            
+            if (_ternWorker) {
+                if (addFilesPromise) {
+                    // If we're in the middle of added files, don't terminate 
+                    // until we're done or we might get NPEs
+                    addFilesPromise.done(terminateWorker).fail(terminateWorker);
+                } else {
+                    terminateWorker();
+                }
+            }
+        }
+
+        function whenReady(func) {
+            addFilesPromise.done(func);
+        }
+        
+        this.closeWorker = closeWorker;
+        this.handleEditorChange = handleEditorChange;
+        this.postMessage = postMessage;
+        this.getResolvedPath = getResolvedPath;
+        this.whenReady = whenReady;
+        
+        return this;
     }
 
+    var reseting = false;
+    /**
+     * reset the tern worker thread, if necessary.  
+     *
+     * To avoid memory leaks in the worker thread we periodically kill
+     * the web worker instance, and start a new one.  To avoid a performance
+     * hit when we do this we start up a new worker, and don't kill the old
+     * one unitl the new one is initialized.
+     */
+    function maybeReset(session, document) {
+        var newWorker;
+        // if we're in the middle of a reset, don't have to check
+        // the new worker will be online soon
+        if (!reseting) {
+            if (++_hintCount > MAX_HINTS) {
+                reseting = true;
+                newWorker = new TernWorker();
+                newWorker.handleEditorChange(session, document, null, _lastPrimePump);
+                newWorker.whenReady(function () {
+                    // tell the old worker to shut down
+                    currentWorker.closeWorker();
+                    currentWorker = newWorker;
+                    // all done reseting
+                    reseting = false;
+                });
+                _hintCount = 0;
+            }
+        }
+    }
+    /**
+     * Request hints from Tern.
+     *
+     * Note that successive calls to getScope may return the same objects, so
+     * clients that wish to modify those objects (e.g., by annotating them based
+     * on some temporary context) should copy them first. See, e.g.,
+     * Session.getHints().
+     * 
+     * @param {Session} session - the active hinting session
+     * @param {Document} document - the document for which scope info is 
+     *      desired
+     * @return {jQuery.Promise} - The promise will not complete until the tern
+     *      hints have completed.
+     */
+    function requestHints(session, document) {
+        var path    = document.file.fullPath,
+            split   = HintUtils.splitPath(path),
+            dir     = split.dir,
+            file    = split.file;
+        
+        var $deferredHints = $.Deferred(),
+            hintPromise,
+            fnTypePromise,
+            text = session.getJavascriptText(),
+            offset = session.getOffset();
+
+        maybeReset(session, document);
+        
+        var sessionType = session.getType();
+        hintPromise = getTernHints(dir, path, offset, text, sessionType.property);
+
+        if (sessionType.showFunctionType) {
+            // Show function sig
+            fnTypePromise = getTernFunctionType(dir, path, sessionType.functionCallPos, offset, text);
+        } else {
+            var $fnTypeDeferred = $.Deferred();
+            fnTypePromise = $fnTypeDeferred.promise();
+            $fnTypeDeferred.resolveWith(null);
+        }
+
+        $.when(hintPromise, fnTypePromise).done(
+            function (completions, fnType) {
+                if (completions.completions) {
+                    session.setTernHints(completions.completions);
+                    session.setGuesses(null);
+                } else {
+                    session.setTernHints([]);
+                    session.setGuesses(completions.properties);
+                }
+
+                session.setFnType(fnType);
+                $deferredHints.resolveWith(null);
+            }
+        );
+        return {promise: $deferredHints.promise()};
+    }
+    
     /*
      * Called each time the file associated with the active editor changes.
      * Marks the file as being dirty.
@@ -971,26 +1074,33 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Called each time a new editor becomes active.
+     *
+     * @param {Session} session - the active hinting session
+     * @param {Document} document - the document of the editor that has changed
+     * @param {Document} previousDocument - the document of the editor is changing from
+     * @param {boolean} shouldPrimePump - true if the pump should be primed.
+     */
+    function handleEditorChange(session, document, previousDocument, shouldPrimePump) {
+
+//        pendingTernRequests = {};
+
+        if (!currentWorker) {
+            currentWorker = new TernWorker();
+        }
+        return currentWorker.handleEditorChange(session, document, previousDocument, shouldPrimePump);
+    }
+
+    /**
      * Do some cleanup when a project is closed.
      *
      * We can clean up the web worker we use to calculate hints now, since
      * we know we will need to re-init it in any new project that is opened.  
      */
     function handleProjectClose() {
-        function terminateWorker() {
-            _ternWorker.terminate();
-            _ternWorker = null;
-            resolvedFiles = {};
-        }
-        
-        if (_ternWorker) {
-            if (addFilesPromise) {
-                // If we're in the middle of added files, don't terminate 
-                // until we're done or we might get NPEs
-                addFilesPromise.done(terminateWorker).fail(terminateWorker);
-            } else {
-                terminateWorker();
-            }
+        if (currentWorker) {
+            currentWorker.closeWorker();
+            currentWorker = null;
         }
     }
 

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1083,8 +1083,6 @@ define(function (require, exports, module) {
      */
     function handleEditorChange(session, document, previousDocument, shouldPrimePump) {
 
-//        pendingTernRequests = {};
-
         if (!currentWorker) {
             currentWorker = new TernWorker();
         }


### PR DESCRIPTION
This avoids some memory leaks that we were encountering.  Still looking into those, but this should at least stabilize things and prevent the memory from growing so much it crashes brackets.

To avoid a noticeable performance hit when we restart the worker, we instead start a new worker, and only switch to it after it has finished intializing (including priming the pump).  So when we switch between the old and new worker it should be unoticeable to the user.

Had to move around a lot of code in ScopeManager - there are not a lot of actual changes, but the diff is messy due to this.
