### PR TITLE
Stop propagating keydown events that are handled by code hint list.

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -597,14 +597,15 @@ define(function (require, exports, module) {
 
     AppInit.htmlReady(function () {
         // Install keydown event listener.
-        $(window.document.body).on(
+        window.document.body.addEventListener(
             "keydown",
             function (event) {
                 if (handleKey(_translateKeyboardEvent(event))) {
                     event.stopPropagation();
                     event.preventDefault();
                 }
-            }
+            },
+            false
         );
     
         exports.useWindowsCompatibleBindings = (brackets.platform !== "mac") &&

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -600,12 +600,20 @@ define(function (require, exports, module) {
         window.document.body.addEventListener(
             "keydown",
             function (event) {
+                try {
+                    // "beforeKeyBindingManagerKeydown" event is exclusively for CodeHintManager
+                    // to handle keydown events before any other handlers or commands.
+                    $(exports).triggerHandler("beforeKeyBindingManagerKeydown", [event]);
+                } catch (err) {
+                    console.error(err);
+                }
+                
                 if (handleKey(_translateKeyboardEvent(event))) {
                     event.stopPropagation();
                     event.preventDefault();
                 }
             },
-            false
+            true
         );
         
         exports.useWindowsCompatibleBindings = (brackets.platform !== "mac") &&

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -597,17 +597,16 @@ define(function (require, exports, module) {
 
     AppInit.htmlReady(function () {
         // Install keydown event listener.
-        window.document.body.addEventListener(
+        $(window.document.body).on(
             "keydown",
             function (event) {
                 if (handleKey(_translateKeyboardEvent(event))) {
                     event.stopPropagation();
                     event.preventDefault();
                 }
-            },
-            true
+            }
         );
-        
+    
         exports.useWindowsCompatibleBindings = (brackets.platform !== "mac") &&
             (brackets.platform !== "win");
     });
@@ -625,7 +624,7 @@ define(function (require, exports, module) {
     exports.removeBinding = removeBinding;
     exports.formatKeyDescriptor = formatKeyDescriptor;
     exports.getKeyBindings = getKeyBindings;
-    
+     
     /**
      * Use windows-specific bindings if no other are found (e.g. Linux).
      * Core Brackets modules that use key bindings should always define at

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -607,7 +607,7 @@ define(function (require, exports, module) {
             },
             false
         );
-    
+        
         exports.useWindowsCompatibleBindings = (brackets.platform !== "mac") &&
             (brackets.platform !== "win");
     });
@@ -625,7 +625,7 @@ define(function (require, exports, module) {
     exports.removeBinding = removeBinding;
     exports.formatKeyDescriptor = formatKeyDescriptor;
     exports.getKeyBindings = getKeyBindings;
-     
+    
     /**
      * Use windows-specific bindings if no other are found (e.g. Linux).
      * Core Brackets modules that use key bindings should always define at

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -346,6 +346,8 @@ define(function (require, exports, module) {
                 return;
             }
             
+            // We handle it. So prevent others from handling these keys.
+            event.stopImmediatePropagation();
             event.preventDefault();
         }
     };

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -264,7 +264,19 @@ define(function (require, exports, module) {
 
         return {left: posLeft, top: posTop, width: availableWidth};
     };
-    
+
+    /**
+     * Check whether keyCode is one of the keys that we handle or not.
+     *
+     * @param {number} keyCode
+     */
+    CodeHintList.prototype.isHandlingKeyCode = function (keyCode) {
+        return (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN ||
+                keyCode === KeyEvent.DOM_VK_PAGE_UP || keyCode === KeyEvent.DOM_VK_PAGE_DOWN ||
+                keyCode === KeyEvent.DOM_VK_RETURN || keyCode === KeyEvent.DOM_VK_TAB);
+        
+    };
+        
     /**
      * Convert keydown events into hint list navigation actions.
      *
@@ -326,7 +338,7 @@ define(function (require, exports, module) {
         }
 
         // (page) up, (page) down, enter and tab key are handled by the list
-        if (event.type === "keydown") {
+        if (event.type === "keydown" && this.isHandlingKeyCode(event.keyCode)) {
             keyCode = event.keyCode;
 
             if (keyCode === KeyEvent.DOM_VK_UP) {

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -559,8 +559,6 @@ define(function (require, exports, module) {
      * @param {KeyboardEvent>} keydownEvent - keydown event passed from KeyBindingManager.
      */
     function _handleKeydownEvent(triggeredEvent, keydownEvent) {
-        var editor = EditorManager.getFocusedEditor();
-
         if (isOpen() && keydownEvent && hintList.isHandlingKeyCode(keydownEvent.keyCode)) {
             KeyBindingManager.setEnabled(false);
             disabledKeyBindingManager = true;

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -222,12 +222,13 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var Commands        = require("command/Commands"),
-        CommandManager  = require("command/CommandManager"),
-        EditorManager   = require("editor/EditorManager"),
-        Strings         = require("strings"),
-        KeyEvent        = require("utils/KeyEvent"),
-        CodeHintList    = require("editor/CodeHintList").CodeHintList;
+    var Commands          = require("command/Commands"),
+        CommandManager    = require("command/CommandManager"),
+        EditorManager     = require("editor/EditorManager"),
+        KeyBindingManager = require("command/KeyBindingManager"),
+        Strings           = require("strings"),
+        KeyEvent          = require("utils/KeyEvent"),
+        CodeHintList      = require("editor/CodeHintList").CodeHintList;
 
     var hintProviders   = { "all" : [] },
         lastChar        = null,
@@ -235,7 +236,8 @@ define(function (require, exports, module) {
         sessionEditor   = null,
         hintList        = null,
         deferredHints   = null,
-        keyDownEditor   = null;
+        keyDownEditor   = null,
+        disabledKeyBindingManager = false;
 
     /**
      * Comparator to sort providers from high to low priority
@@ -457,6 +459,13 @@ define(function (require, exports, module) {
      */
     function handleKeyEvent(editor, event) {
         keyDownEditor = editor;
+        
+        // If we have disabled KeyBindingManager, now is the time to re-enable it.
+        if (disabledKeyBindingManager) {
+            KeyBindingManager.setEnabled(true);
+            disabledKeyBindingManager = false;
+        }
+        
         if (event.type === "keydown") {
             if (_inSession(editor) && hintList.isOpen()) {
                 // Pass event to the hint list, if it's open
@@ -541,6 +550,30 @@ define(function (require, exports, module) {
         return hintList;
     }
 
+    /**
+     * Check keydown events passed from KeyBindingManager. If it is one of the keys handled by
+     * CodeHintList, then we disable KeyBindingManager to prevent it from handling this specific 
+     * keydown event.
+     *
+     * @param {Event} triggeredEvent - "beforeKeyBindingManagerKeydown" event.
+     * @param {KeyboardEvent>} keydownEvent - keydown event passed from KeyBindingManager.
+     */
+    function _handleKeydownEvent(triggeredEvent, keydownEvent) {
+        var editor = EditorManager.getFocusedEditor();
+
+        if (isOpen() && keydownEvent && hintList.isHandlingKeyCode(keydownEvent.keyCode)) {
+            KeyBindingManager.setEnabled(false);
+            disabledKeyBindingManager = true;
+        }
+    }
+    
+    // KeyBindingManager handles keydown events in the event capturing phase and 
+    // therefore any command that uses the same key as one of CodeHintList handled
+    // keys may hijack the key away from CodeHintList. (eg. Emmet extension issue #2455)
+    // So we use "beforeKeyBindingManagerKeydown" to make sure that CodeHintManager will 
+    // handle all these keydown events first.
+    $(KeyBindingManager).on("beforeKeyBindingManagerKeydown", _handleKeydownEvent);
+    
     // Dismiss code hints before executing any command since the command
     // may make the current hinting session irrevalent after execution. 
     // For example, when the user hits Ctrl+K to open Quick Doc, it is 


### PR DESCRIPTION
<del>Also switch to jQuery keydown event handler in KeyBindingManager so that event bubbling can be stopped by calling stopImmediatePropagation() in CodeHintList.</del>


This fixes issue #3975.

Update 1: We can't use jQuery keydown events since jQuery event object does not have "keyIdentifier" property that we need in KeyBindingManager. Instead of using jQuery keydown event, we just keep using native JavaScript event listener with event capturing "off" so that we can handle keydown events in bubbling phase.

Update 2: We can't handle keydown events in bubbling phase either. I just found out that Enter key may insert two lines when Emmet extension is installed since Emmet is inserting a formatted line break after CodeMirror inserts a line break. I'll be pushing another commit soon.
