### PR TITLE
Don't mark document as modified when ctrl-space is pressed

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -935,7 +935,7 @@ define(function (require, exports, module) {
             numAddedFiles = 0;
             stopAddingFiles = false;
             numInitialFiles = files.length;
-    
+
             ternPromise.done(function (worker) {
                 worker.postMessage({
                     type        : MessageIds.TERN_INIT_MSG,
@@ -979,7 +979,8 @@ define(function (require, exports, module) {
             var addFilesDeferred = $.Deferred();
     
             _lastPrimePump = shouldPrimePump;
-            
+            documentChanges = null;
+
             addFilesPromise = addFilesDeferred.promise();
             pr = ProjectManager.getProjectRoot() ? ProjectManager.getProjectRoot().fullPath : null;
     
@@ -1002,7 +1003,6 @@ define(function (require, exports, module) {
             }
     
             isDocumentDirty = false;
-            
             resolvedFiles = {};
     
             projectRoot = pr;

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -375,9 +375,10 @@ define(function (require, exports, module) {
             // Compute fresh hints if none exist, or if the session
             // type has changed since the last hint computation
             if (this.needNewHints(session)) {
-                // FIXME: passing null keys until can investigate a fix for "empty" updates
-                ScopeManager.handleFileChange({from: cursor, to: cursor, text: [key]});
-                ignoreChange = true;
+                if (key) {
+                    ScopeManager.handleFileChange({from: cursor, to: cursor, text: [key]});
+                    ignoreChange = true;
+                }
 
                 var scopeResponse   = ScopeManager.requestHints(session, session.editor.document);
 

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
         testPath        = extensionPath + "/unittest-files/basic-test-files/file1.js",
         testHtmlPath    = extensionPath + "/unittest-files/basic-test-files/index.html",
         testDoc         = null,
-        testEditor;
+        testEditor,
+        preTestText;
 
     CommandManager.register("test-file-open", Commands.FILE_OPEN, function (fileInfo) {
         // Register a command for FILE_OPEN, which the jump to def code will call
@@ -336,10 +337,15 @@ define(function (require, exports, module) {
             // create Editor instance (containing a CodeMirror instance)
             runs(function () {
                 testEditor = createMockEditor(testDoc);
+                preTestText = testDoc.getText();
             });
         }
 
         function tearDownTest() {
+            // Restore the pre-test version of the text here because the hinter
+            // will update the contents of the previous document in tern.
+            testDoc.setText(preTestText);
+
             // The following call ensures that the document is reloaded
             // from disk before each test
             DocumentManager.closeAll();
@@ -536,7 +542,8 @@ define(function (require, exports, module) {
             
             it("should list implicit hints when typing property lookups", function () {
                 testEditor.setCursorPos({ line: 17, ch: 10 });
-                expectHints(JSCodeHints.jsHintProvider, ".");
+                var hintObj = expectHints(JSCodeHints.jsHintProvider, ".");
+                hintsPresent(hintObj, ["B1", "paramB1"]);
             });
 
 /*          Single quote and double quote keys cause hasHints() to return false.
@@ -1075,7 +1082,6 @@ define(function (require, exports, module) {
             it("should show guessed argument type from current passing parameter", function () {
                 var start = { line: 80, ch: 0 },
                     testPos = { line: 80, ch: 24 };
-                console.log("should show guessed...");
                 testDoc.replaceRange("myCustomer.setAmountDue(10)", start);
                 testEditor.setCursorPos(testPos);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);


### PR DESCRIPTION
modified:   src/extensions/default/JavaScriptCodeHints/ScopeManager.jsDon't update the modified range when 'null' keys (ctrl-space) are hinted.

modified:   src/extensions/default/JavaScriptCodeHints/main.js
When changing files, reset documentChanges to null.

modified:   src/extensions/default/JavaScriptCodeHints/unittests.js
Restore that content of a file after each test.
Update a test to wait for hints after it asks for hints. If the hints are not waited for the editor will be torn down before the hint completes, causing a null pointer exception.
