### PR TITLE
Fix styling of recent projects dropdown

### DIFF
--- a/src/extensions/default/RecentProjects/styles/styles.css
+++ b/src/extensions/default/RecentProjects/styles/styles.css
@@ -64,6 +64,10 @@
     white-space: nowrap;
 }
 
+#project-dropdown.dropdown-menu li a {
+    padding: 5px 15px;
+}
+
 #project-dropdown.dropdown-menu .recent-folder-link
 {
 	display: block;
@@ -78,6 +82,6 @@
     color: #aaa;
 }
 
-.dropdown-menu a:hover {
+#project-dropdown.dropdown-menu a:hover {
     background: #E0F0FA;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -217,72 +217,71 @@
         margin: 0;
     }
     
+    // Menu dropdown appearance
+    .dropdown-menu {
+        top: 34px; // Offset from top of menubar item
+        
+        margin-top: 0;
+        background-color: @bc-white;
+        border: 1px solid #c8c8c8;
+        .border-radius(0 0 3px 3px);
+        .box-shadow(0 6px 18px 0 rgba(0, 0, 0, .2));
+        
+        // Menu items
+        li {
+            a {
+                font-size: @menu-item-font-size;
+                line-height: 18px;
+                
+                // Slightly less padding on left to account for checkmark.
+                // More padding on top than bottom to center font within its bg highlight better.
+                padding: 2px 10px 0px 6px;
+                
+                color: @bc-black;
+                text-shadow: none;
+                white-space: nowrap;
+                .box-shadow(none);
+    
+                &.wide-result {
+                    white-space: normal;
+                }
+                
+                &:hover, &.highlight {
+                    color: @bc-black;
+                    background: @item-highlight-color;
+                }
+            
+                &.disabled {
+                    color: @bc-gray;
+            
+                    &:hover {
+                        background: @bc-white;
+                    }
+                }
+   
+                /* hidden checkmark for all list item content ensures consistent left spacing */
+                &::before {
+                    content: "✓\00a0"; /* non-breaking space */
+                    visibility: hidden;
+                }
+                /* toggle checkmark visibility */
+                &.checked::before {
+                    visibility: visible;
+                }
+            }
+        }
+        
+        .divider {
+            background-color: #eaeaea;
+            border: 0;
+        }
+    }
+    
     // Ensure a minimum amount of space to the left of the shortcut
     .menu-shortcut {
         margin-left: 15px;
     }
 }
-
-// Menu dropdown appearance
-.dropdown-menu {
-    top: 34px; // Offset from top of menubar item
-    
-    margin-top: 0;
-    background-color: @bc-white;
-    border: 1px solid #c8c8c8;
-    .border-radius(0 0 3px 3px);
-    .box-shadow(0 6px 18px 0 rgba(0, 0, 0, .2));
-    
-    // Menu items
-    li {
-        a {
-            font-size: @menu-item-font-size;
-            line-height: 18px;
-            
-            // Slightly less padding on left to account for checkmark.
-            // More padding on top than bottom to center font within its bg highlight better.
-            padding: 2px 10px 0px 6px;
-            
-            color: @bc-black;
-            text-shadow: none;
-            white-space: nowrap;
-            .box-shadow(none);
-
-            &.wide-result {
-                white-space: normal;
-            }
-
-            &:hover, &.highlight {
-                color: @bc-black;
-                background: @item-highlight-color;
-            }
-
-            &.disabled {
-                color: @bc-gray;
-
-                &:hover {
-                    background: @bc-white;
-                }
-            }
-
-            /* hidden checkmark for all list item content ensures consistent left spacing */
-            &::before {
-                content: "✓\00a0"; /* non-breaking space */
-                visibility: hidden;
-            }
-            /* toggle checkmark visibility */
-            &.checked::before {
-                visibility: visible;
-            }
-        }
-    }
-    
-    .divider {
-        background-color: #eaeaea;
-        border: 0;
-    }
-}
-
 
 
 /* Context menu styles */


### PR DESCRIPTION
Fix for #4073 

Move the `.dropdown-menu` selector back under `.toolbar .nav` and spot-fix the recent project dropdown styles.
