### PR TITLE
Dialog.done should return itself for chaining

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -163,6 +163,7 @@ define(function (require, exports, module) {
      */
     Dialog.prototype.done = function (callback) {
         this._promise.done(callback);
+        return this;
     };
     
     


### PR DESCRIPTION
With the the recent modal dialog changes, `Dialogs.showModalDialogUsingTemplate()` returns a `Dialog` object that encapsulates a jQuery object representing the displayed dialog and a dismissal promise. For convenience and some measure of compatibility with the previous implementation, the `Dialog` object directly exposes the `done()` method of its promise. 

This is great, but it would be even better if the `Dialog.done()` returned itself to support the following idiom: 

```
var dlg = Dialogs.showModalDialogUsingTemplate(template).done(function () {
  // do something when the dialog closes
}); 

$otherThing.on("click", function () {
  // do something else and close the dialog
  dlg.close()
});
```

I like this because it reminds me of the promise chaining idiom that `Dialog.done()` mimicks.

This pull request just adds `return this;` to the definition of `Dialog.prototype.done` to accomplish this.

CC @TomMalbran 
