### PR TITLE
Remove the default fuschia color on code blocks

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -816,5 +816,6 @@ strong {
 /* Type */
 
 code {
+  color: @bc-black;
   background-color: transparent;
 }


### PR DESCRIPTION
With the LESS/Bootstrap upgrade, `<code>` blocks are now colored fuschia by default: 

![fuschia](http://f.cl.ly/items/0A0U0B3V2U3i2O3w391v/Screen%20Shot%202013-06-04%20at%2012.48.35%20PM.png)

That's weird. They should probably be black by default.

CC @larz0 
