### PR TITLE
Fixed language manager unit test. Issue #3957

### DIFF
--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -54,6 +54,7 @@ define(function (require, exports, module) {
         }
         
         function validateLanguage(expected, actual) {
+            var i = 0;
             if (!actual) {
                 actual = LanguageManager.getLanguage(expected.id);
             } else {
@@ -62,7 +63,9 @@ define(function (require, exports, module) {
             
             expect(actual.getId()).toBe(expected.id);
             expect(actual.getName()).toBe(expected.name);
-            expect(actual.getFileExtensions()).toEqual(expected.fileExtensions || []);
+            for (i = 0; i < actual.getFileExtensions.length; i++) {
+                expect(expected.fileExtensions).toContain(actual.getFileExtensions()[i] || []);
+            }
             expect(actual.getFileNames()).toEqual(expected.fileNames || []);
             
             if (expected.blockComment) {
@@ -99,7 +102,7 @@ define(function (require, exports, module) {
                     "id": "html",
                     "name": "HTML",
                     "mode": ["htmlmixed", "text/x-brackets-html"],
-                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp"],
+                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp", "phtml"],
                     "blockComment": {prefix: "<!--", suffix: "-->"}
                 };
                 

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -60,18 +60,10 @@ define(function (require, exports, module) {
                 expect(LanguageManager.getLanguage(expected.id)).toBe(actual);
             }
             
-            var i = 0;
-            var expectedFileExtensions;
-            
-            // Be sure that expectedFileExtensions is not undefined.  
-            if (expected.fileExtensions === undefined) {
-                expectedFileExtensions = [];
-            } else {
-                expectedFileExtensions = expected.fileExtensions;
-            }
-            
-            var expectedFileExtensionsLength = expectedFileExtensions.length;
-            var actualFileExtensions = actual.getFileExtensions();
+            var i = 0,
+                expectedFileExtensions = expected.fileExtensions || [],
+                expectedFileExtensionsLength = expectedFileExtensions.length,
+                actualFileExtensions = actual.getFileExtensions();
             
             expect(actual.getId()).toBe(expected.id);
             expect(actual.getName()).toBe(expected.name);

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -54,18 +54,32 @@ define(function (require, exports, module) {
         }
         
         function validateLanguage(expected, actual) {
-            var i = 0;
             if (!actual) {
                 actual = LanguageManager.getLanguage(expected.id);
             } else {
                 expect(LanguageManager.getLanguage(expected.id)).toBe(actual);
             }
             
+            var i = 0;
+            var expectedFileExtensions;
+            
+            // Be sure that expectedFileExtensions is not undefined.  
+            if (expected.fileExtensions === undefined) {
+                expectedFileExtensions = [];
+            } else {
+                expectedFileExtensions = expected.fileExtensions;
+            }
+            
+            var expectedFileExtensionsLength = expectedFileExtensions.length;
+            var actualFileExtensions = actual.getFileExtensions();
+            
             expect(actual.getId()).toBe(expected.id);
             expect(actual.getName()).toBe(expected.name);
-            for (i = 0; i < actual.getFileExtensions.length; i++) {
-                expect(expected.fileExtensions).toContain(actual.getFileExtensions()[i] || []);
+            
+            for (i; i < expectedFileExtensionsLength; i++) {
+                expect(actualFileExtensions).toContain(expectedFileExtensions[i]);
             }
+            
             expect(actual.getFileNames()).toEqual(expected.fileNames || []);
             
             if (expected.blockComment) {

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
                     "id": "html",
                     "name": "HTML",
                     "mode": ["htmlmixed", "text/x-brackets-html"],
-                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp", "phtml"],
+                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp"],
                     "blockComment": {prefix: "<!--", suffix: "-->"}
                 };
                 


### PR DESCRIPTION
This for (Issue #3957.

Okay.  I am opening this new pull request to fix all of the merge issues of my last pull request (Issue #4097).

The code here takes all of the array of expected file extensions and makes sure it contains the actual file extensions, thus doing away with the problem of having to make the file extension arrays match.

I have tested this under my Windows VM and everything appears to work.
