### PR TITLE
REVIEW ONLY: Add ability to create multiple global key handlers

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -632,7 +632,7 @@ define(function (require, exports, module) {
      * event, so we have to have some other way for one of the hooks to 
      * indicate that it wants to block the other hooks from running.)
      *
-     * @param {function(Event): boolean} hook The global handhookler to add.
+     * @param {function(Event): boolean} hook The global hook to add.
      */
     function addGlobalKeydownHook(hook) {
         _globalKeydownHooks.push(hook);

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -64,10 +64,10 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Stack of registered global keydown handlers.
+     * Stack of registered global keydown hooks.
      * @type {Array.<function(Event): boolean>}
      */
-    var _globalKeydownHandlers = [];
+    var _globalKeydownHooks = [];
 
     /**
      * @private
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
     function _reset() {
         _keyMap = {};
         _commandMap = {};
-        _globalKeydownHandlers = [];
+        _globalKeydownHooks = [];
     }
 
     /**
@@ -609,57 +609,57 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Adds a global keydown handler that gets first crack at keydown events 
+     * Adds a global keydown hook that gets first crack at keydown events 
      * before standard keybindings do. This is intended for use by modal or 
      * semi-modal UI elements like dialogs or the code hint list that should 
      * execute before normal command bindings are run. 
      * 
-     * The handler is passed one parameter, the original keyboard event. If the 
-     * handler handles the event (or wants to block other global handlers from 
+     * The hook is passed one parameter, the original keyboard event. If the 
+     * hook handles the event (or wants to block other global hooks from 
      * handling the event), it should return true. Note that this will *only*
-     * stop other global handlers and KeyBindingManager from handling the
+     * stop other global hooks and KeyBindingManager from handling the
      * event; to prevent further event propagation, you will need to call
      * stopPropagation(), stopImmediatePropagation(), and/or preventDefault()
      * as usual.
      *
-     * Multiple keydown handlers can be registered, and are executed in order, 
+     * Multiple keydown hooks can be registered, and are executed in order, 
      * most-recently-added first.
      * 
      * (We have to have a special API for this because (1) handlers are normally
      * called in least-recently-added order, and we want most-recently-added; 
      * (2) native DOM events don't have a way for us to find out if 
      * stopImmediatePropagation()/stopPropagation() has been called on the
-     * event, so we have to have some other way for one of the handlers to 
-     * indicate that it wants to block the other handlers from running.)
+     * event, so we have to have some other way for one of the hooks to 
+     * indicate that it wants to block the other hooks from running.)
      *
-     * @param {function(Event): boolean} handler The global handler to add.
+     * @param {function(Event): boolean} hook The global handhookler to add.
      */
-    function addGlobalKeydownHandler(handler) {
-        _globalKeydownHandlers.push(handler);
+    function addGlobalKeydownHook(hook) {
+        _globalKeydownHooks.push(hook);
     }
     
     /**
-     * Removes a global keydown handler added by `addGlobalKeydownHandler`.
-     * Does not need to be the most recently added handler.
+     * Removes a global keydown hook added by `addGlobalKeydownHook`.
+     * Does not need to be the most recently added hook.
      *
-     * @param {function(Event): boolean} handler The global handler to remove.
+     * @param {function(Event): boolean} hook The global hook to remove.
      */
-    function removeGlobalKeydownHandler(handler) {
-        var index = _globalKeydownHandlers.indexOf(handler);
+    function removeGlobalKeydownHook(hook) {
+        var index = _globalKeydownHooks.indexOf(hook);
         if (index !== -1) {
-            _globalKeydownHandlers.splice(index, 1);
+            _globalKeydownHooks.splice(index, 1);
         }
     }
     
     /**
-     * Handles a given keydown event, checking global handlers first before
+     * Handles a given keydown event, checking global hooks first before
      * deciding to handle it ourselves.
      * @param {Event} The keydown event to handle.
      */
     function _handleKeyEvent(event) {
         var i, handled = false;
-        for (i = _globalKeydownHandlers.length - 1; i >= 0; i--) {
-            if (_globalKeydownHandlers[i](event)) {
+        for (i = _globalKeydownHooks.length - 1; i >= 0; i--) {
+            if (_globalKeydownHooks[i](event)) {
                 handled = true;
                 break;
             }
@@ -694,8 +694,8 @@ define(function (require, exports, module) {
     exports.removeBinding = removeBinding;
     exports.formatKeyDescriptor = formatKeyDescriptor;
     exports.getKeyBindings = getKeyBindings;
-    exports.addGlobalKeydownHandler = addGlobalKeydownHandler;
-    exports.removeGlobalKeydownHandler = removeGlobalKeydownHandler;
+    exports.addGlobalKeydownHook = addGlobalKeydownHook;
+    exports.removeGlobalKeydownHook = removeGlobalKeydownHook;
     
     /**
      * Use windows-specific bindings if no other are found (e.g. Linux).

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
                         .hide())
                 .append("<ul class='dropdown-menu'></ul>");
         
-        this._handleKeydown = this._handleKeydown.bind(this);
+        this._keydownHook = this._keydownHook.bind(this);
     }
 
     /**
@@ -285,7 +285,7 @@ define(function (require, exports, module) {
      *
      * @param {KeyBoardEvent} keyEvent
      */
-    CodeHintList.prototype._handleKeydown = function (event) {
+    CodeHintList.prototype._keydownHook = function (event) {
         var keyCode,
             self = this;
 
@@ -376,7 +376,7 @@ define(function (require, exports, module) {
             return true;
         }
         
-        // If we didn't handle it, let other global handlers handle it.
+        // If we didn't handle it, let other global keydown hooks handle it.
         return false;
     };
 
@@ -418,7 +418,7 @@ define(function (require, exports, module) {
             
             PopUpManager.addPopUp(this.$hintMenu, this.handleClose, true);
             
-            KeyBindingManager.addGlobalKeydownHandler(this._handleKeydown);
+            KeyBindingManager.addGlobalKeydownHook(this._keydownHook);
         }
     };
 
@@ -449,7 +449,7 @@ define(function (require, exports, module) {
         PopUpManager.removePopUp(this.$hintMenu);
         this.$hintMenu.remove();
         
-        KeyBindingManager.removeGlobalKeydownHandler(this._handleKeydown);
+        KeyBindingManager.removeGlobalKeydownHook(this._keydownHook);
     };
 
     /**

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
         StringUtils     = require("utils/StringUtils"),
         PopUpManager    = require("widgets/PopUpManager"),
         ViewUtils       = require("utils/ViewUtils"),
+        KeyBindingManager = require("command/KeyBindingManager"),
         KeyEvent        = require("utils/KeyEvent");
     
     var CodeHintListHTML = require("text!htmlContent/code-hint-list.html");
@@ -103,6 +104,8 @@ define(function (require, exports, module) {
                 .append($("<a href='#' class='dropdown-toggle' data-toggle='dropdown'></a>")
                         .hide())
                 .append("<ul class='dropdown-menu'></ul>");
+        
+        this._handleKeydown = this._handleKeydown.bind(this);
     }
 
     /**
@@ -266,11 +269,23 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Check whether keyCode is one of the keys that we handle or not.
+     *
+     * @param {number} keyCode
+     */
+    CodeHintList.prototype.isHandlingKeyCode = function (keyCode) {
+        return (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN ||
+                keyCode === KeyEvent.DOM_VK_PAGE_UP || keyCode === KeyEvent.DOM_VK_PAGE_DOWN ||
+                keyCode === KeyEvent.DOM_VK_RETURN || keyCode === KeyEvent.DOM_VK_TAB);
+        
+    };
+
+    /**
      * Convert keydown events into hint list navigation actions.
      *
      * @param {KeyBoardEvent} keyEvent
      */
-    CodeHintList.prototype.handleKeyEvent = function (event) {
+    CodeHintList.prototype._handleKeydown = function (event) {
         var keyCode,
             self = this;
 
@@ -326,10 +341,20 @@ define(function (require, exports, module) {
         }
 
         // (page) up, (page) down, enter and tab key are handled by the list
-        if (event.type === "keydown") {
+        if (event.type === "keydown" && this.isHandlingKeyCode(event.keyCode)) {
             keyCode = event.keyCode;
 
-            if (keyCode === KeyEvent.DOM_VK_UP) {
+            if (event.shiftKey &&
+                    (event.keyCode === KeyEvent.DOM_VK_UP ||
+                     event.keyCode === KeyEvent.DOM_VK_DOWN ||
+                     event.keyCode === KeyEvent.DOM_VK_PAGE_UP ||
+                     event.keyCode === KeyEvent.DOM_VK_PAGE_DOWN)) {
+                this.handleClose();
+                
+                // Let the event bubble.
+                return false;
+            }
+            else if (keyCode === KeyEvent.DOM_VK_UP) {
                 _rotateSelection.call(this, -1);
             } else if (keyCode === KeyEvent.DOM_VK_DOWN) {
                 _rotateSelection.call(this, 1);
@@ -342,12 +367,17 @@ define(function (require, exports, module) {
                 // Trigger a click handler to commmit the selected item
                 $(this.$hintMenu.find("li")[this.selectedIndex]).trigger("click");
             } else {
-                // only prevent default handler when the list handles the event
-                return;
+                // Let the event bubble.
+                return false;
             }
             
+            event.stopImmediatePropagation();
             event.preventDefault();
+            return true;
         }
+        
+        // If we didn't handle it, let other global handlers handle it.
+        return false;
     };
 
     /**
@@ -387,6 +417,8 @@ define(function (require, exports, module) {
             this.opened = true;
             
             PopUpManager.addPopUp(this.$hintMenu, this.handleClose, true);
+            
+            KeyBindingManager.addGlobalKeydownHandler(this._handleKeydown);
         }
     };
 
@@ -416,6 +448,8 @@ define(function (require, exports, module) {
         
         PopUpManager.removePopUp(this.$hintMenu);
         this.$hintMenu.remove();
+        
+        KeyBindingManager.removeGlobalKeydownHandler(this._handleKeydown);
     };
 
     /**

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -28,14 +28,14 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var Menus           = require("command/Menus"),
-        StringUtils     = require("utils/StringUtils"),
-        PopUpManager    = require("widgets/PopUpManager"),
-        ViewUtils       = require("utils/ViewUtils"),
+    var Menus             = require("command/Menus"),
+        StringUtils       = require("utils/StringUtils"),
+        PopUpManager      = require("widgets/PopUpManager"),
+        ViewUtils         = require("utils/ViewUtils"),
         KeyBindingManager = require("command/KeyBindingManager"),
-        KeyEvent        = require("utils/KeyEvent");
+        KeyEvent          = require("utils/KeyEvent");
     
-    var CodeHintListHTML = require("text!htmlContent/code-hint-list.html");
+    var CodeHintListHTML  = require("text!htmlContent/code-hint-list.html");
 
     /**
      * Displays a popup list of hints for a given editor context.

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -458,18 +458,6 @@ define(function (require, exports, module) {
     function handleKeyEvent(editor, event) {
         keyDownEditor = editor;
         if (event.type === "keydown") {
-            if (_inSession(editor) && hintList.isOpen()) {
-                if (event.shiftKey &&
-                        (event.keyCode === KeyEvent.DOM_VK_UP ||
-                         event.keyCode === KeyEvent.DOM_VK_DOWN ||
-                         event.keyCode === KeyEvent.DOM_VK_PAGE_UP ||
-                         event.keyCode === KeyEvent.DOM_VK_PAGE_DOWN)) {
-                    _endSession();
-                } else {
-                    // Pass event to the hint list, if it's open
-                    hintList.handleKeyEvent(event);
-                }
-            }
             if (!(event.ctrlKey || event.altKey || event.metaKey) &&
                     (event.keyCode === KeyEvent.DOM_VK_ENTER ||
                      event.keyCode === KeyEvent.DOM_VK_RETURN ||

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
         return dlg.find("[data-button-id='" + buttonId + "']");
     }
 
-    var _handleKeyDown = function (e, autoDismiss) {
+    var _keydownHook = function (e, autoDismiss) {
         var primaryBtn = this.find(".primary"),
             buttonId = null,
             which = String.fromCharCode(e.which);
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
             e.preventDefault();
         }
         
-        // Stop any other global handlers from processing the event (but
+        // Stop any other global hooks from processing the event (but
         // allow it to continue bubbling if we haven't otherwise stopped it).
         return true;
     };
@@ -193,8 +193,8 @@ define(function (require, exports, module) {
             }
         });
 
-        var handleKeyDown = function (e) {
-            return _handleKeyDown.call($dlg, e, autoDismiss);
+        var keydownHook = function (e) {
+            return _keydownHook.call($dlg, e, autoDismiss);
         };
 
         // Pipe dialog-closing notification back to client code
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
             $dlg.remove();
 
             // Remove our global keydown handler.
-            KeyBindingManager.removeGlobalKeydownHandler(handleKeyDown);
+            KeyBindingManager.removeGlobalKeydownHook(keydownHook);
         }).one("shown", function () {
             // Set focus to the default button
             var primaryBtn = $dlg.find(".primary");
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
             }
 
             // Push our global keydown handler onto the global stack of handlers.
-            KeyBindingManager.addGlobalKeydownHandler(handleKeyDown);
+            KeyBindingManager.addGlobalKeydownHook(keydownHook);
         });
         
         // Click handler for buttons

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -202,7 +202,7 @@ define(function (require, exports, module) {
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
 
-                    CodeHintManager.handleKeyEvent(editor, e);
+                    CodeHintManager._getCodeHintList()._handleKeydown(e);
 
                     // doesn't matter what was inserted, but line should be different
                     var newPos = editor.getCursorPos();

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -396,23 +396,23 @@ define(function (require, exports, module) {
             
         });
         
-        describe("global handlers", function () {
-            var commandCalled, handler1Called, handler2Called, ctrlAEvent;
+        describe("global hooks", function () {
+            var commandCalled, hook1Called, hook2Called, ctrlAEvent;
             
-            function keydownHandler1(event) {
-                handler1Called = true;
+            function keydownHook1(event) {
+                hook1Called = true;
                 return true;
             }
             
-            function keydownHandler2(event) {
-                handler2Called = true;
+            function keydownHook2(event) {
+                hook2Called = true;
                 return true;
             }
             
             function makeKeyEvent() {
                 // We don't create a real native event object here--just a fake
                 // object with enough info for the key translation to work
-                // properly--since our mock handlers don't actually look at it
+                // properly--since our mock hooks don't actually look at it
                 // anyway.
                 return {
                     ctrlKey: true,
@@ -434,8 +434,8 @@ define(function (require, exports, module) {
             
             beforeEach(function () {
                 commandCalled = false;
-                handler1Called = false;
-                handler2Called = false;
+                hook1Called = false;
+                hook2Called = false;
                 ctrlAEvent = makeKeyEvent();
                 CommandManager.register("FakeUnitTestCommand", "unittest.fakeCommand", function () {
                     commandCalled = true;
@@ -443,24 +443,24 @@ define(function (require, exports, module) {
                 KeyBindingManager.addBinding("unittest.fakeCommand", "Ctrl-A");
             });
             
-            it("should block command execution if a global handler is added that prevents it", function () {
-                KeyBindingManager.addGlobalKeydownHandler(keydownHandler1);
+            it("should block command execution if a global hook is added that prevents it", function () {
+                KeyBindingManager.addGlobalKeydownHook(keydownHook1);
                 KeyBindingManager._handleKeyEvent(ctrlAEvent);
-                expect(handler1Called).toBe(true);
+                expect(hook1Called).toBe(true);
                 expect(commandCalled).toBe(false);
                 
-                // In this case, the event should not have been stopped, because our handler didn't stop it
+                // In this case, the event should not have been stopped, because our hook didn't stop it
                 // and KBM didn't handle it.
                 expect(ctrlAEvent.immediatePropagationStopped).toBe(false);
                 expect(ctrlAEvent.propagationStopped).toBe(false);
                 expect(ctrlAEvent.defaultPrevented).toBe(false);
             });
             
-            it("should not block command execution if a global handler is added then removed", function () {
-                KeyBindingManager.addGlobalKeydownHandler(keydownHandler1);
-                KeyBindingManager.removeGlobalKeydownHandler(keydownHandler1);
+            it("should not block command execution if a global hook is added then removed", function () {
+                KeyBindingManager.addGlobalKeydownHook(keydownHook1);
+                KeyBindingManager.removeGlobalKeydownHook(keydownHook1);
                 KeyBindingManager._handleKeyEvent(ctrlAEvent);
-                expect(handler1Called).toBe(false);
+                expect(hook1Called).toBe(false);
                 expect(commandCalled).toBe(true);
 
                 // In this case, the event should have been stopped (but not immediately) because
@@ -470,15 +470,15 @@ define(function (require, exports, module) {
                 expect(ctrlAEvent.defaultPrevented).toBe(true);
             });
             
-            it("should call the most recently added handler first", function () {
-                KeyBindingManager.addGlobalKeydownHandler(keydownHandler1);
-                KeyBindingManager.addGlobalKeydownHandler(keydownHandler2);
+            it("should call the most recently added hook first", function () {
+                KeyBindingManager.addGlobalKeydownHook(keydownHook1);
+                KeyBindingManager.addGlobalKeydownHook(keydownHook2);
                 KeyBindingManager._handleKeyEvent(ctrlAEvent);
-                expect(handler2Called).toBe(true);
-                expect(handler1Called).toBe(false);
+                expect(hook2Called).toBe(true);
+                expect(hook1Called).toBe(false);
                 expect(commandCalled).toBe(false);
 
-                // In this case, the event should not have been stopped, because our handler didn't stop it
+                // In this case, the event should not have been stopped, because our hook didn't stop it
                 // and KBM didn't handle it.
                 expect(ctrlAEvent.immediatePropagationStopped).toBe(false);
                 expect(ctrlAEvent.propagationStopped).toBe(false);


### PR DESCRIPTION
This is an alternate fix for #3975. It creates a more general mechanism for dealing with multiple global capture handlers for keydown.

I think this is a cleaner fix than #4032, and it has the advantage that we can also use this same mechanism to simplify the nested-dialog key handling in Dialogs.js. However, it is somewhat more invasive (though I don't think it's necessarily more risky than #4032 if we can convince ourselves that the logic is correct).

The semantics of these new global keydown handlers is a bit tricky. The idea is that you can install multiple global keydown handlers, with the last-added one running first. Any of these handlers can return true in order to indicate that it handled the key. However, this does _not_ have the same effect as the usual event `stopPropagation()`/`preventDefault()`; all it does is prevent the other global keydown handlers (including KeyBindingManager itself) from running. The desired intention is that this is the way modal/semi-modal key handling should work: only one modal should get to deal with the key, but it should be able to decide that the key should go through normal event handling (bypassing other modals further down the stack, including ordinary key bindings).

Also note that this introduces a subtle change in how keys are handled by code hints. It used to be that key events while the code hint list is up would come from CodeMirror, passed into CodeHintManager, and from there to the CodeHintList. Now, CodeHintList itself installs a global capture handler for the key events it cares about. I think this actually makes more sense, since the CodeHintList is basically a semi-modal UI, and should be trapping these key events directly, rather than relying on them coming from the editor.

I tested various cases to try to verify that this is working properly:
- the nested dialogs in ExtensionManager
- code hints without Emmet installed--tested that up/down arrows, Enter and Esc work as expected while code hints are up, and after they're dismissed nothing unusual happens
- code hints with Emmet installed--tested that this actually fixed the original bug :)
