### PR TITLE
Fix #4091: Order of OK and Cancel buttons is reversed

### DIFF
--- a/src/htmlContent/install-extension-dialog.html
+++ b/src/htmlContent/install-extension-dialog.html
@@ -12,7 +12,7 @@
     </div>
     <div class="modal-footer">
         <button class="btn left browse-extensions">{{BROWSE_EXTENSIONS}}</button>
-        <button class="dialog-button btn primary" data-button-id="ok" disabled>{{INSTALL}}</button>
         <button class="dialog-button btn" data-button-id="cancel">{{CANCEL}}</button>
+        <button class="dialog-button btn primary" data-button-id="ok" disabled>{{INSTALL}}</button>
     </div>
 </div>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -389,6 +389,9 @@
     margin-left: 0;
     margin-right: 5px;
 }
+.modal-footer .btn:not(.left) {
+    margin-left: 5px;
+}
 
 .platform-win {
     /* Reverse Save/Cancel button order on Win */


### PR DESCRIPTION
This requests fix the inverted order of the buttons on the Install From Url Dialog and the margin between the right buttons on some dialogs, which should fix the issues I mention in #4091. Let me know if there is something else to fix for that issue.
