### PR TITLE
Fix #3991: Always listen for sidebar resize events

### DIFF
--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -205,11 +205,9 @@ define(function (require, exports, module) {
         $windowContent = $(".content");
         $editorHolder = $("#editor-holder");
         
-        // Sidebar is a special case: a side panel rather than a bottom panel. It could still affect the
-        // editor-holder's height if changing .content's width causes the inBrowser titlebar to wrap/unwrap.
-        if (brackets.inBrowser) {
-            listenToResize($("#sidebar"));
-        }
+        // Sidebar is a special case: it isn't a Panel, and is not created dynamically. Need to explicitly
+        // listen for resize here.
+        listenToResize($("#sidebar"));
     });
     
     // Unit test only: allow passing in mock DOM notes, e.g. for use with SpecRunnerUtils.createMockEditor()


### PR DESCRIPTION
Fix for #3991 

Turns out we _do_ need to listen for sidebar resize events when Word Wrap is on. This change has a slight impact on sidebar resizing performance, but the difference is minimal.
