### PR TITLE
Small extension manager bug fixes

### DIFF
--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -65,7 +65,6 @@ define(function (require, exports, module) {
         this._itemViews = {};
         this.$el = $("<div class='extension-list'/>");
         this._$emptyMessage = $("<div class='empty-message'/>")
-            .append(Strings.NO_EXTENSIONS)
             .appendTo(this.$el);
         this._$table = $("<table class='table'/>").appendTo(this.$el);
         
@@ -247,6 +246,7 @@ define(function (require, exports, module) {
     ExtensionManagerView.prototype._checkNoExtensions = function () {
         if (this.model.filterSet.length === 0) {
             this._$emptyMessage.css("display", "block");
+            this._$emptyMessage.html(this.model.sortedFullSet && this.model.sortedFullSet.length ? Strings.NO_EXTENSION_MATCHES : Strings.NO_EXTENSIONS);
             this._$table.css("display", "none");
         } else {
             this._$table.css("display", "");

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
      * @type {Object}
      * The list of all ids from the extension list, sorted with the current sort.
      */
-    ExtensionManagerViewModel.prototype._sortedFullSet = null;
+    ExtensionManagerViewModel.prototype.sortedFullSet = null;
     
     /**
      * @private
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
      */
     ExtensionManagerViewModel.prototype._setInitialFilter = function () {
         // Initial filtered list is the same as the sorted list.
-        this.filterSet = this._sortedFullSet.slice(0);
+        this.filterSet = this.sortedFullSet.slice(0);
         $(this).triggerHandler("filter");
     };
     
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
                 self.extensions = ExtensionManager.extensions;
                 
                 // Sort the registry by last published date and store the sorted list of IDs.
-                self._sortedFullSet = registry_utils.sortRegistry(self.extensions, "registryInfo")
+                self.sortedFullSet = registry_utils.sortRegistry(self.extensions, "registryInfo")
                     .filter(function (entry) {
                         return entry.registryInfo !== undefined;
                     })
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
         // Currently, we never need to re-sort the registry view since it's always sorted when we
         // grab it, and items are never added to the view. That might change in the future.
         if (this.source === ExtensionManagerViewModel.SOURCE_INSTALLED) {
-            this._sortedFullSet = this._sortedFullSet.sort(function (key1, key2) {
+            this.sortedFullSet = this.sortedFullSet.sort(function (key1, key2) {
                 var metadata1 = self.extensions[key1].installInfo.metadata,
                     metadata2 = self.extensions[key2].installInfo.metadata,
                     id1 = (metadata1.title || metadata1.name).toLowerCase(),
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
     ExtensionManagerViewModel.prototype._initializeFromInstalledExtensions = function () {
         var self = this;
         this.extensions = ExtensionManager.extensions;
-        this._sortedFullSet = Object.keys(this.extensions)
+        this.sortedFullSet = Object.keys(this.extensions)
             .filter(function (key) {
                 return self.extensions[key].installInfo &&
                     self.extensions[key].installInfo.locationType !== ExtensionManager.LOCATION_DEFAULT;
@@ -236,15 +236,15 @@ define(function (require, exports, module) {
         // remove this extension from the full set. If the full set has changed,
         // then we also need to refilter.
         if (this.source === ExtensionManagerViewModel.SOURCE_INSTALLED) {
-            var index = this._sortedFullSet.indexOf(id),
+            var index = this.sortedFullSet.indexOf(id),
                 refilter = false;
             if (index !== -1 && !this.extensions[id].installInfo) {
                 // This was in our set, but was uninstalled. Remove it.
-                this._sortedFullSet.splice(index, 1);
+                this.sortedFullSet.splice(index, 1);
                 refilter = true;
             } else if (index === -1 && this.extensions[id].installInfo) {
                 // This was not in our set, but is now installed. Add it and resort.
-                this._sortedFullSet.push(id);
+                this.sortedFullSet.push(id);
                 this._sortFullSet();
                 refilter = true;
             }
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
             initialList = this.filterSet;
         } else {
             // This is a new query, so start with the full list.
-            initialList = this._sortedFullSet;
+            initialList = this.sortedFullSet;
         }
         
         query = query.toLowerCase();

--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -1,7 +1,7 @@
 <div class="extension-manager-dialog modal">
     <div class="modal-header">
         <button class="search-clear"></button>
-        <input class="search" type="text" placeholder="Search">
+        <input class="search" type="text" placeholder="{{EXTENSION_SEARCH_PLACEHOLDER}}">
         <h1 class="dialog-title">{{EXTENSION_MANAGER_TITLE}}</h1>
     </div>
     <div class="modal-body no-padding table-striped"></div>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -362,7 +362,8 @@ define({
     "CHANGE_AND_QUIT"                      : "Change Extensions and Quit",
     "UPDATE_AND_QUIT"                      : "Update Extensions and Quit",
     "EXTENSION_NOT_INSTALLED"              : "Couldn't remove extension {0} because it wasn't installed.",
-    "NO_EXTENSIONS"                        : "No extensions installed yet.<br />Click the Install from URL button below to get started.",
+    "NO_EXTENSIONS"                        : "No extensions installed yet.<br>Click the Install from URL button below to get started.",
+    "NO_EXTENSION_MATCHES"                 : "No extensions match your search.",
     
     /**
      * Unit names

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -516,7 +516,7 @@
 .extension-manager-dialog {
     top: 50%;
     left: 50%;
-    margin-top: -325px;
+    margin-top: -275px;
     margin-left: -350px;
     
     .modal-header {
@@ -556,7 +556,7 @@
     }
     .modal-body {
         width: 730px;
-        height: 500px;
+        height: 400px;
         text-align: center;
         overflow-y: scroll;
         padding: 0;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -507,6 +507,9 @@
     width: 400px;
 }
 
+.install-extension-dialog {
+    margin-top: -125px;
+}
 .install-extension-dialog .modal-body input.url {
     margin: 10px 0;
     width: 550px;

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -47,6 +47,7 @@ define(function (require, exports, module) {
         Dialogs                   = require("widgets/Dialogs"),
         CommandManager            = require("command/CommandManager"),
         Commands                  = require("command/Commands"),
+        Strings                   = require("strings"),
         mockRegistryText          = require("text!spec/ExtensionManager-test-files/mockRegistry.json"),
         mockRegistryForSearch     = require("text!spec/ExtensionManager-test-files/mockRegistryForSearch.json"),
         mockExtensionList         = require("text!spec/ExtensionManager-test-files/mockExtensionList.json"),
@@ -853,6 +854,18 @@ define(function (require, exports, module) {
                     setupViewWithMockData(ExtensionManagerViewModel.SOURCE_INSTALLED);
                     runs(function () {
                         expect($(".empty-message", view.$el).css("display")).not.toBe("none");
+                        expect($(".empty-message", view.$el).html()).toEqual(Strings.NO_EXTENSIONS);
+                        expect($("table", view.$el).css("display")).toBe("none");
+                    });
+                });
+                           
+                it("should show the 'no extensions' message when there are extensions installed but none match the search query", function () {
+                    mockLoadExtensions(["user/mock-extension-3", "user/mock-extension-4", "user/mock-legacy-extension"]);
+                    setupViewWithMockData(ExtensionManagerViewModel.SOURCE_INSTALLED);
+                    runs(function () {
+                        view.filter("DON'T_FIND_ME_IN_THE_EXTENSION_LIST");
+                        expect($(".empty-message", view.$el).css("display")).not.toBe("none");
+                        expect($(".empty-message", view.$el).html()).toEqual(Strings.NO_EXTENSION_MATCHES);
                         expect($("table", view.$el).css("display")).toBe("none");
                     });
                 });


### PR DESCRIPTION
- For #3999, use localized string for search placeholder.
- For #4033, show "no extensions matched" instead of "no extensions installed" when query fails.
- Tweak the top offset so the dialog is more properly centered and isn't cut off at the top on small screens. Also tweak the position of the Install from URL dialog so it's better centered within the parent dialgo.
