### PR TITLE
Adds a confirmation when an update has been successfully installed.

### DIFF
--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -653,14 +653,14 @@ define(function (require, exports, module) {
                     localPath: packageFilename
                 });
                 spyOn(testWindow.brackets.fs, "unlink");
-                fields.$okButton.click();
-                expect(testWindow.brackets.fs.unlink).not.toHaveBeenCalled();
-                expect(fields.$dlg.is(":visible")).toBe(false);
                 var dialogDone = false;
                 dialog._dialogDeferred.done(function (result) {
                     dialogDone = true;
                     expect(result.installationStatus).toBe("ALREADY_INSTALLED");
                 });
+                fields.$okButton.click();
+                expect(testWindow.brackets.fs.unlink).not.toHaveBeenCalled();
+                expect(fields.$dlg.is(":visible")).toBe(false);
                 expect(dialogDone).toBe(true);
             });
 
@@ -674,7 +674,11 @@ define(function (require, exports, module) {
                     installationStatus: "NEEDS_UPDATE",
                     localPath: packageFilename
                 });
-                expect(fields.$dlg.is(":visible")).toBe(false);
+                expect(fields.$dlg.is(":visible")).toBe(true);
+                expect(fields.$dlg.find(".message").text()).toBe(Strings.EXTENSION_UPDATE_INSTALLED);
+                expect(fields.$okButton.text()).toBe(Strings.CLOSE);
+                expect(fields.$cancelButton.is(":visible")).toBe(false);
+                fields.$okButton.click();
                 var dialogDone = false;
                 dialog._dialogDeferred.done(function (result) {
                     dialogDone = true;


### PR DESCRIPTION
This was per the review comments. Every other "install from URL"
case has a confirmation, and the appearance of the "Marked to update"
in the extension listing is too subtle to let the user know that the
update will be installed soon.

This is a fix for #4132 .
