### PR TITLE
Incorrectly using cached function type hint 

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -190,7 +190,9 @@ define(function (require, exports, module) {
                 cachedCursor.line !== cursor.line ||
                 type.property !== cachedType.property ||
                 type.context !== cachedType.context ||
-                type.showFunctionType !== cachedType.showFunctionType;
+                type.showFunctionType !== cachedType.showFunctionType ||
+                (type.functionCallPos && cachedType.functionCallPos &&
+                    type.functionCallPos.ch !== cachedType.functionCallPos.ch);
     };
 
     /**


### PR DESCRIPTION
needsNewHints() was not returning true for different function type hints on the same line.
