### PR TITLE
Fix missed rename in CodeHintManager unit test

### DIFF
--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -202,7 +202,7 @@ define(function (require, exports, module) {
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor).toBeTruthy();
 
-                    CodeHintManager._getCodeHintList()._handleKeydown(e);
+                    CodeHintManager._getCodeHintList()._keydownHook(e);
 
                     // doesn't matter what was inserted, but line should be different
                     var newPos = editor.getCursorPos();


### PR DESCRIPTION
For #4154. Just missed a rename after my last changes to CHM.
