### PR TITLE
Update sidebar-selection width to match parent scrollWidth

### DIFF
--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -108,6 +108,14 @@ define(function (require, exports, module) {
         $openFilesContainer     = $("#open-files-container");
         $projectTitle           = $("#project-title");
         $projectFilesContainer  = $("#project-files-container");
+    
+        function _resizeSidebarSelection() {
+            var $element;
+            $sidebar.find(".sidebar-selection").each(function (index, element) {
+                $element = $(element);
+                $element.width($element.parent()[0].scrollWidth);
+            });
+        }
 
         // init
         WorkingSetView.create($openFilesContainer);
@@ -122,12 +130,7 @@ define(function (require, exports, module) {
         });
         
         $sidebar.on("panelResizeEnd", function (evt, width) {
-            var $element;
-            $sidebar.find(".sidebar-selection").each(function (index, element) {
-                $element = $(element);
-                $element.width($element.parent()[0].scrollWidth);
-            });
-            
+            _resizeSidebarSelection();
             $sidebar.find(".sidebar-selection-triangle").css("display", "block").css("left", width);
             $sidebar.find(".scroller-shadow").css("display", "block");
             $projectFilesContainer.triggerHandler("scroll");
@@ -140,7 +143,7 @@ define(function (require, exports, module) {
         
         $sidebar.on("panelExpanded", function (evt, width) {
             WorkingSetView.refresh();
-            $sidebar.find(".sidebar-selection").width(width);
+            _resizeSidebarSelection();
             $sidebar.find(".scroller-shadow").css("display", "block");
             $sidebar.find(".sidebar-selection-triangle").css("left", width);
             $projectFilesContainer.triggerHandler("scroll");

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -122,7 +122,12 @@ define(function (require, exports, module) {
         });
         
         $sidebar.on("panelResizeEnd", function (evt, width) {
-            $sidebar.find(".sidebar-selection").width(width);
+            var $element;
+            $sidebar.find(".sidebar-selection").each(function (index, element) {
+                $element = $(element);
+                $element.width($element.parent()[0].scrollWidth);
+            });
+            
             $sidebar.find(".sidebar-selection-triangle").css("display", "block").css("left", width);
             $sidebar.find(".scroller-shadow").css("display", "block");
             $projectFilesContainer.triggerHandler("scroll");


### PR DESCRIPTION
Fix for #4124 

Use the selectionMarker's parent scrollWidth instead of the sidebar's width.
