### PR TITLE
Ignore key and close code hint session if code hint list is invisible

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -339,6 +339,12 @@ define(function (require, exports, module) {
 
             return itemsPerPage;
         }
+        
+        // If we're no longer visible, skip handling the key and end the session.
+        if (!this.isOpen()) {
+            this.handleClose();
+            return false;
+        }
 
         // (page) up, (page) down, enter and tab key are handled by the list
         if (event.type === "keydown" && this.isHandlingKeyCode(event.keyCode)) {
@@ -470,8 +476,9 @@ define(function (require, exports, module) {
         // TODO: Due to #1381, this won't get called if the user clicks out of
         // the code hint menu. That's (sort of) okay right now since it doesn't
         // really matter if a single old invisible code hint list is lying 
-        // around (it'll get closed the next time the user pops up a code 
-        // hint). Once #1381 is fixed this issue should go away.
+        // around (it will ignore keydown events, and it'll get closed the next 
+        // time the user pops up a code hint). Once #1381 is fixed this issue 
+        // should go away.
         this.handleClose = callback;
     };
 

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -359,8 +359,7 @@ define(function (require, exports, module) {
                 
                 // Let the event bubble.
                 return false;
-            }
-            else if (keyCode === KeyEvent.DOM_VK_UP) {
+            } else if (keyCode === KeyEvent.DOM_VK_UP) {
                 _rotateSelection.call(this, -1);
             } else if (keyCode === KeyEvent.DOM_VK_DOWN) {
                 _rotateSelection.call(this, 1);

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         Commands        = require("command/Commands"),
         EditorManager,      // loaded from brackets.test
         CommandManager,
-        CodeHintManager;
+        CodeHintManager,
+        KeyBindingManager;
 
     var testPath = SpecRunnerUtils.getTestPath("/spec/CodeHint-test-files"),
         testWindow,
@@ -75,6 +76,7 @@ define(function (require, exports, module) {
                 CodeHintManager     = testWindow.brackets.test.CodeHintManager;
                 EditorManager       = testWindow.brackets.test.EditorManager;
                 CommandManager      = testWindow.brackets.test.CommandManager;
+                KeyBindingManager   = testWindow.brackets.test.KeyBindingManager;
             });
         });
     
@@ -266,6 +268,43 @@ define(function (require, exports, module) {
                     // verify list is no longer open
                     expectNoHints();
                 });
+            });
+            
+            it("should stop handling keydowns if closed by a click outside", function () {
+                var editor,
+                    pos = {line: 3, ch: 1};
+
+                // minimal markup with an open '<' before IP
+                // Note: line for pos is 0-based and editor lines numbers are 1-based
+                initCodeHintTest("test1.html", pos);
+
+                runs(function () {
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor).toBeTruthy();
+                    
+                    editor.document.replaceRange("di", pos);
+                    invokeCodeHints();
+                    
+                    // verify list is open
+                    expectSomeHints();
+                    
+                    // get the document text and make sure it doesn't change if we
+                    // click outside and then keydown
+                    var text = editor.document.getText();
+                    
+                    testWindow.$("body").click();
+                    KeyBindingManager._handleKeyEvent({
+                        keyCode: KeyEvent.DOM_VK_ENTER,
+                        stopImmediatePropagation: function () { },
+                        stopPropagation: function () { },
+                        preventDefault: function () { }                        
+                    });
+                    
+                    // verify list is now closed and text of document hasn't changed
+                    expectNoHints();
+                    expect(editor.document.getText()).toEqual(text);
+                });
+                
             });
         });
     });

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -297,10 +297,15 @@ define(function (require, exports, module) {
                         keyCode: KeyEvent.DOM_VK_ENTER,
                         stopImmediatePropagation: function () { },
                         stopPropagation: function () { },
-                        preventDefault: function () { }                        
+                        preventDefault: function () { }
                     });
                     
-                    // verify list is now closed and text of document hasn't changed
+                    // Verify that after the keydown, the session is closed 
+                    // (not just the hint popup). Because of #1381, we don't
+                    // actually have a way to close the session as soon as the
+                    // popup is dismissed by Bootstrap, so we do so on the next
+                    // keydown. Eventually, once that's fixed, we should be able
+                    // to move this expectNoHints() up after the click.
                     expectNoHints();
                     expect(editor.document.getText()).toEqual(text);
                 });


### PR DESCRIPTION
For #4172. 

The issue is the long-standing one of dropdowns not notifying us when they close due to the user clicking out (because Bootstrap just takes the class off the dropdown--there's no notification mechanism). This basically just checks in the keydown handler if we're no longer visible, and if so ends the session.

I'm not absolutely certain of this fix (though it's better than nothing). The concern is that the original key handling code, which was in CodeHintManager, would check a couple of other things besides `CodeHintList.isOpen()` before deciding whether to dispatch a key. I _think_ that in the case where the CodeHintList is actually handling the keydown, we only care about whether it's open.

In general, I think we need to clean up the control flow between CodeHintManager and CodeHintList...the fact that CodeHintManager knows about "sessions" but CodeHintList doesn't makes it hard to make the logic totally consistent here. Another symptom of this is that CHL can't just close itself, but calls a callback that is really just CodeHintManager's `_endSession()`. We should probably use events for that instead.
