### PR TITLE
[UX] Issue #4174 - Add find next / previous buttons for easy navigation

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -111,7 +111,11 @@ define({
     "BUTTON_YES"                        : "Yes",
     "BUTTON_NO"                         : "No",
     "BUTTON_STOP"                       : "Stop",
-
+    "BUTTON_NEXT"                       : "\u25B6",
+    "BUTTON_PREV"                       : "\u25C0",
+    "BUTTON_NEXT_HINT"                  : "Next Match",
+    "BUTTON_PREV_HINT"                  : "Previous Match",
+    
     "OPEN_FILE"                         : "Open File",
     "CHOOSE_FOLDER"                     : "Choose a folder",
 

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -152,8 +152,14 @@ define(function (require, exports, module) {
     }
     
     var queryDialog = Strings.CMD_FIND +
-            ": <input type='text' style='width: 10em'/> <div class='message'><span id='find-counter'></span> " +
-            "<span style='color: #888'>(" + Strings.SEARCH_REGEXP_INFO  + ")</span></div><div class='error'></div>";
+            ": <input type='text' style='width: 10em'/>" +
+            "<div class='navigator'>" +
+                "<button id='find-prev' title='" + Strings.BUTTON_PREV_HINT + "'>" + Strings.BUTTON_PREV + "</button>" +
+                "<button id='find-next' title='" + Strings.BUTTON_NEXT_HINT + "'>" + Strings.BUTTON_NEXT + "</button>" +
+            "</div>" +
+            "<div class='message'><span id='find-counter'></span> " +
+            "<span style='color: #888'>(" + Strings.SEARCH_REGEXP_INFO  + ")</span></div>" +
+            "<div class='error'></div>";
 
     /**
      * If no search pending, opens the search dialog. If search is already open, moves to
@@ -173,6 +179,15 @@ define(function (require, exports, module) {
         // occurrence.
         var searchStartPos = cm.getCursor(true);
         
+        //Helper method to enable next / prev navigation in Find modal bar.
+        function enableFindNavigator(show) {
+            if (show) {
+                $(".modal-bar .navigator").css("display", "inline-block");
+            } else {
+                $(".modal-bar .navigator").css("display", "none");
+            }
+        }
+        
         // Called each time the search query changes while being typed. Jumps to the first matching
         // result, starting from the original cursor position
         function findFirst(query) {
@@ -185,6 +200,7 @@ define(function (require, exports, module) {
                 if (!state.query) {
                     // Search field is empty - no results
                     $("#find-counter").text("");
+                    enableFindNavigator(false);
                     cm.setCursor(searchStartPos);
                     if (modalBar) {
                         getDialogTextField().removeClass("no-results");
@@ -214,8 +230,10 @@ define(function (require, exports, module) {
                         }
                     }
                     $("#find-counter").text(StringUtils.format(Strings.FIND_RESULT_COUNT, resultCount));
+                    enableFindNavigator(resultCount > 0);
                 } else {
                     $("#find-counter").text("");
+                    enableFindNavigator(true);
                 }
                 
                 state.posFrom = state.posTo = searchStartPos;
@@ -251,6 +269,14 @@ define(function (require, exports, module) {
             
             // As soon as focus goes back to the editor, restore normal selection color
             $(cm.getWrapperElement()).removeClass("find-highlighting");
+        });
+        
+        modalBar.getRoot().on("click", function (e) {
+            if (e.target.id === "find-next") {
+                _findNext();
+            } else if (e.target.id === "find-prev") {
+                _findPrevious();
+            }
         });
         
         var $input = getDialogTextField();

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -753,6 +753,7 @@ a, img {
 
 .modal-bar .message {
     display: inline-block;
+    padding: 0 2px;
 }
 .modal-bar .error {
     display: none;
@@ -760,6 +761,18 @@ a, img {
     .alert {
         padding-top: 4px;
         padding-bottom: 4px;
+    }
+}
+
+.modal-bar .navigator {
+    display: none;
+    display: inline-block;
+    
+    button {
+        padding:5px 15px;
+        border:1px #999 solid;
+        border-radius:3px;
+        margin:2px 2px 5px;   
     }
 }
 


### PR DESCRIPTION
Add next/previous buttons to Find modal bar for easy navigation between matches.

Handles cases
1. Find has matching results
1. Find has no matching results
2. Large documents

![screen shot 2013-06-09 at 7 25 14 pm](https://f.cloud.github.com/assets/1189142/630072/d9e53b42-d18a-11e2-9c35-dc7915ed8a86.jpg)
![screen shot 2013-06-09 at 7 27 06 pm](https://f.cloud.github.com/assets/1189142/630073/d9f980ca-d18a-11e2-80c6-c33c05aed9cc.jpg)
![screen shot 2013-06-09 at 7 27 27 pm](https://f.cloud.github.com/assets/1189142/630074/da0dd516-d18a-11e2-80a5-058c653a1a8f.jpg)
![screen shot 2013-06-09 at 7 30 16 pm](https://f.cloud.github.com/assets/1189142/630075/da13be4a-d18a-11e2-9823-b4a09d70680c.jpg)
