### PR TITLE
do not wrap regular expresssions in '^' and '$', only strings.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Preferences.js
+++ b/src/extensions/default/JavaScriptCodeHints/Preferences.js
@@ -106,14 +106,16 @@ define(function (require, exports, module) {
                         // since we know it is a wildcard.
                         value = value.replace("\\?", ".?");
                         value = value.replace("\\*", ".*");
+
+                        // Add "^" and "$" to prevent matching in the middle of strings.
+                        value = "^" + value + "$";
                     }
 
                     if (index > 0) {
                         regExpString += "|";
                     }
 
-                    // Add "^" and "$" to prevent matching in the middle of strings.
-                    regExpString = regExpString.concat("^" + value + "$");
+                    regExpString = regExpString.concat(value);
                 }
             });
         }

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/preference-test-files/positive-test/.jscodehints
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/preference-test-files/positive-test/.jscodehints
@@ -1,5 +1,5 @@
 {
-    "excluded-directories" : ["excluded-dir1", "/excluded-dir2-[\\d]/"],
+    "excluded-directories" : ["excluded-dir1", "/^excluded-dir2-[\\d]$/"],
     "excluded-files" : ["file1?.js", "file2*.js", "file3.js", "/file4[x|y|z]?.js/"],
     "max-file-count": 512,
     "max-file-size": 100000

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -1449,6 +1449,7 @@ define(function (require, exports, module) {
                     expect(excludedFiles.test("file4z.js")).toBeTruthy();
                     expect(excludedFiles.test("file4b.js")).toBeFalsy();
                     expect(excludedFiles.test("file4xyz.js")).toBeFalsy();
+                    expect(excludedFiles.test("xfile4.js")).toBeTruthy();
 
                     // test builtin exclusions are also present
                     expect(excludedFiles.test("require.js")).toBeTruthy();


### PR DESCRIPTION
A regular expression is meant to be taken as is. The author can wrap it in '^' and '$' if they choose.
