### PR TITLE
Reduce the set of extensions we test for HTML in LanguageManager-test

### DIFF
--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
                     "id": "html",
                     "name": "HTML",
                     "mode": ["htmlmixed", "text/x-brackets-html"],
-                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "ejs", "jsp"],
+                    "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml"],
                     "blockComment": {prefix: "<!--", suffix: "-->"}
                 };
                 


### PR DESCRIPTION
#4106 made it so the LanguageManager tests only expect the given set of extensions to be contained, not exact. However, it didn't actually remove any of the tested extensions for HTML. This makes it so we only test for a few extensions that we know are always going to be associated with HTML.
