### PR TITLE
allow linux shell to use html menus

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -267,6 +267,11 @@ define(function (require, exports, module) {
         } else {
             $("body").addClass("in-appshell");
         }
+
+        // Enable/Disable HTML Menus
+        if (brackets.app.addMenu) {
+            $("body").addClass("has-appshell-menu");
+        }
         
         // Localize MainViewHTML and inject into <BODY> tag
         $("body").html(Mustache.render(MainViewHTML, Strings));

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     }
     
     function _isHTMLMenu(id) {
-        return (brackets.inBrowser || _isContextMenu(id));
+        return !brackets.app.addMenu || brackets.inBrowser || _isContextMenu(id);
     }
 
     /**

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -82,7 +82,7 @@
 */
 #titlebar {
     // Visible only in-browser
-    body.in-appshell & {
+    body.has-appshell-menus & {
         display: none;
     }
     


### PR DESCRIPTION
Changes how we hide the HTML menus by first looking for `brackets.app.addMenu`.
