### PR TITLE
Update List of Ignore files

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
      * @type {RegExp}
      */
-    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$/;
+    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$/;
 
     /**
      * @private
@@ -649,7 +649,7 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        return !entry.name.match(_excludeFilesRegEx);
+        return !entry.name.match(_exclusionListRegEx);
     }
 
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -70,6 +70,27 @@ define(function (require, exports, module) {
         KeyEvent            = require("utils/KeyEvent"),
         Async               = require("utils/Async");
     
+    
+    var _excludeFilesList = [".git",
+                             ".gitignore",
+                             ".gitmodules",
+                             ".svn",
+                             "CVS",
+                             "RCS",
+                             "SCCS",
+                             ".cvsignore",
+                             ".arch-ids",
+                             "{arch}",
+                             ".bzr",
+                             ".bzrignore",
+                             ".bzrtags",
+                             ".DS_Store",
+                             "Thumbs.db",
+                             ".hg",
+                             ".hgignore",
+                             ".hgrags",
+                             "_darcs"];
+
     /**
      * @private
      * Reference to the tree control container div. Initialized by
@@ -639,11 +660,10 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        if ([".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db", ".hg"].indexOf(entry.name) > -1) {
+        if (_excludeFilesList.indexOf(entry.name) > -1) {
             return false;
         }
-        var extension = entry.name.split('.').pop();
-        if (["pyc"].indexOf(extension) > -1) {
+        if (/\.pyc?/.match(entry)) {
             return false;
         }
         return true;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -71,25 +71,14 @@ define(function (require, exports, module) {
         Async               = require("utils/Async");
     
     
-    var _excludeFilesList = [".git",
-                             ".gitignore",
-                             ".gitmodules",
-                             ".svn",
-                             "CVS",
-                             "RCS",
-                             "SCCS",
-                             ".cvsignore",
-                             ".arch-ids",
-                             "{arch}",
-                             ".bzr",
-                             ".bzrignore",
-                             ".bzrtags",
-                             ".DS_Store",
-                             "Thumbs.db",
-                             ".hg",
-                             ".hgignore",
-                             ".hgrags",
-                             "_darcs"];
+    /**
+     * @private
+     * File and Folder names which are not displayed or searched
+     * NOTE: This list is  based on the gnu tar project exclude list --
+     *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
+     * @type {RegExp}
+     */
+    var _excludeFilesRegEx = /\.pyc$|\.git|\.svn|CVS|RCS|SCCS|\.cvsignore|\.arch\-ids|\{arch\}|\.bzr|\.DS_Store|Thumbs\.db|\.hg|\_darcs/;
 
     /**
      * @private
@@ -660,13 +649,7 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        if (_excludeFilesList.indexOf(entry.name) > -1) {
-            return false;
-        }
-        if (/\.pyc?/.match(entry)) {
-            return false;
-        }
-        return true;
+        return !_excludeFilesRegEx.match(entry);
     }
 
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
      * @type {RegExp}
      */
-    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$/;
+    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$|^\.hgtags$|^\.hgignore$/;
 
     /**
      * @private

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -74,11 +74,11 @@ define(function (require, exports, module) {
     /**
      * @private
      * File and Folder names which are not displayed or searched
-     * NOTE: This list is  based on the gnu tar project exclude list --
+     * TODO: We should add the rest of the file names that TAR excludes:
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
      * @type {RegExp}
      */
-    var _excludeFilesRegEx = /\.pyc$|\.git|\.svn|CVS|RCS|SCCS|\.cvsignore|\.arch\-ids|\{arch\}|\.bzr|\.DS_Store|Thumbs\.db|\.hg|\_darcs/;
+    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|\^.cvsignore$/;
 
     /**
      * @private
@@ -649,7 +649,7 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        return !_excludeFilesRegEx.match(entry);
+        return !entry.name.match(_excludeFilesRegEx);
     }
 
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
      * @type {RegExp}
      */
-    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|\^.cvsignore$/;
+    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|\^\.cvsignore$|^\.gitattributes$/;
 
     /**
      * @private

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
      * @type {RegExp}
      */
-    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|\^\.cvsignore$|^\.gitattributes$/;
+    var _excludeFilesRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$/;
 
     /**
      * @private

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -509,10 +509,19 @@ define(function (require, exports, module) {
                     return { name: name };
                 };
                 
+                expect(shouldShow(makeEntry(".git"))).toBe(false);
+                expect(shouldShow(makeEntry(".svn"))).toBe(false);
+                expect(shouldShow(makeEntry(".DS_Store"))).toBe(false);
+                expect(shouldShow(makeEntry("Thumbs.db"))).toBe(false);
+                expect(shouldShow(makeEntry(".hg"))).toBe(false);
                 expect(shouldShow(makeEntry(".gitmodules"))).toBe(false);
+                expect(shouldShow(makeEntry(".gitignore"))).toBe(false);
                 expect(shouldShow(makeEntry("foobar"))).toBe(true);
                 expect(shouldShow(makeEntry("pyc.py"))).toBe(true);
                 expect(shouldShow(makeEntry("module.pyc"))).toBe(false);
+                expect(shouldShow(makeEntry(".gitattributes"))).toBe(false);
+                expect(shouldShow(makeEntry("CVS"))).toBe(false);
+                expect(shouldShow(makeEntry(".cvsignore"))).toBe(false);
             });
         });
 

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -522,6 +522,9 @@ define(function (require, exports, module) {
                 expect(shouldShow(makeEntry(".gitattributes"))).toBe(false);
                 expect(shouldShow(makeEntry("CVS"))).toBe(false);
                 expect(shouldShow(makeEntry(".cvsignore"))).toBe(false);
+                expect(shouldShow(makeEntry(".hgignore"))).toBe(false);
+                expect(shouldShow(makeEntry(".hgtags"))).toBe(false);
+                
             });
         });
 


### PR DESCRIPTION
- adds CVS repository folders and .cvsignore files to the list of files not seen or searched by Brackets (Fixes issue #4039)
- adds .gitattributes to the list of files not seen or searched by Brackets.
- converts the exclude list to a regex 
