### PR TITLE
[FOR DISCUSSION] Fixes client issue # 4178

### DIFF
--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
                         // or scanning additional directories once a max has been hit. Also notify the 
                         // user once via a dialog. This limit could be increased
                         // if files were indexed in a worker thread so scanning didn't block the UI
-                        if (state.fileCount > 10000) {
+                        if (state.fileCount > 15000) {
                             if (!state.maxFilesHit) {
                                 state.maxFilesHit = true;
                                 if (!_maxFileDialogDisplayed) {

--- a/src/project/FileIndexManager.js
+++ b/src/project/FileIndexManager.js
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
                         // or scanning additional directories once a max has been hit. Also notify the 
                         // user once via a dialog. This limit could be increased
                         // if files were indexed in a worker thread so scanning didn't block the UI
-                        if (state.fileCount > 15000) {
+                        if (state.fileCount > 16000) {
                             if (!state.maxFilesHit) {
                                 state.maxFilesHit = true;
                                 if (!_maxFileDialogDisplayed) {


### PR DESCRIPTION
This pull request is a fix for #4178.  
We had agreed to bump the file indexer up to 50,000 but, after talking with @dangoor, the performance of quick open did start to feel sluggish around 15,000 so I capped it at 15,000.  I've asked @rickbenetti how many files his project has to see if we can get away with just bumping it to 15,000 in fear that 50,000 may be too much.

I changed the limit to 100,000, however, and opened the top folder for mozilla-central (https://github.com/mozilla/mozilla-central) which has about 88,000+ files and it wasn't that much worse than the performance for 15,000 so maybe the performance penalty isn't worth worrying about.  
