### PR TITLE
Change keyboard shortcuts so they don't overwrite Polish characters

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -9,7 +9,7 @@
         "Ctrl-W"
     ],
     "file.openFolder": [
-        "Ctrl-Alt-O"
+        "Ctrl-Alt-F"
     ],
     "file.close_all":  [
         "Ctrl-Shift-W"
@@ -18,7 +18,7 @@
         "Ctrl-S"
     ],
     "file.saveAll":  [
-        "Ctrl-Alt-S"
+        "Ctrl-Shift-S"
     ],
     "file.liveFilePreview":  [
         "Ctrl-Alt-P"


### PR DESCRIPTION
Shortcuts _ctrl-alt-{a,c,e,l,n,o,s,z,x}_ are used to type Polish diacritical letters: _ą,ć,ę,ł,ń,ó,ś,ż,ź_. Now Polish people cannot write _ó_ and _ś_ letters, so I propose to change Open Folder to _ctrl-alt-F_ and Save All to _ctrl-shift-S_ instead.
