### PR TITLE
Ignore empty lines when finding a fragment for partial updates.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -132,13 +132,13 @@ define(function (require, exports, module) {
                 } catch (e) {
                     // continue with null configObj which will result in
                     // default settings.
+                    console.log("Error parsing preference file: " + path);
                 }
                 preferences = new Preferences(configObj);
                 deferredPreferences.resolve();
             }).fail(function (error) {
                 preferences = new Preferences();
                 deferredPreferences.resolve();
-                console.log("Error parsing preference file: " + path);
             });
         }, function (error) {
             preferences = new Preferences();
@@ -505,12 +505,14 @@ define(function (require, exports, module) {
             document  = session.editor.document,
             p,
             min,
-            indent;
+            indent,
+            line;
 
         // expand range backwards
         for (p = start.line - 1, min = Math.max(0, p - 100); p >= min; --p) {
-            var line = session.getLine(p),
-                fn = line.search(/\bfunction\b/);
+            line = session.getLine(p);
+            var fn = line.search(/\bfunction\b/);
+            
             if (fn >= 0) {
                 indent = CodeMirror.countColumn(line, null, tabSize);
                 if (minIndent === null || minIndent > indent) {
@@ -534,7 +536,8 @@ define(function (require, exports, module) {
             endCh = 0;
 
         for (endLine = start.line + 1; endLine < max; ++endLine) {
-            var line = cm.getLine(endLine);
+            line = cm.getLine(endLine);
+
             if (line.length > 0) {
                 indent = CodeMirror.countColumn(line, null, tabSize);
                 if (indent <= minIndent) {

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -138,6 +138,7 @@ define(function (require, exports, module) {
             }).fail(function (error) {
                 preferences = new Preferences();
                 deferredPreferences.resolve();
+                console.log("Error parsing preference file: " + path);
             });
         }, function (error) {
             preferences = new Preferences();
@@ -507,7 +508,7 @@ define(function (require, exports, module) {
             indent;
 
         // expand range backwards
-        for (p = start.line - 1, min = Math.max(0, p - 50); p >= min; --p) {
+        for (p = start.line - 1, min = Math.max(0, p - 100); p >= min; --p) {
             var line = session.getLine(p),
                 fn = line.search(/\bfunction\b/);
             if (fn >= 0) {
@@ -529,16 +530,22 @@ define(function (require, exports, module) {
             minLine = min;
         }
 
-        var max = Math.min(cm.lastLine(), start.line + 90);
+        var max = Math.min(cm.lastLine(), start.line + 100),
+            endCh = 0;
+
         for (endLine = start.line + 1; endLine < max; ++endLine) {
-            indent = CodeMirror.countColumn(cm.getLine(endLine), null, tabSize);
-            if (indent <= minIndent) {
-                break;
+            var line = cm.getLine(endLine);
+            if (line.length > 0) {
+                indent = CodeMirror.countColumn(line, null, tabSize);
+                if (indent <= minIndent) {
+                    endCh = line.length;
+                    break;
+                }
             }
         }
 
         var from = {line: minLine, ch: 0},
-            to   = {line: endLine, ch: 0};
+            to   = {line: endLine, ch: endCh};
 
         return {type: MessageIds.TERN_FILE_INFO_TYPE_PART,
             name: document.file.fullPath,

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -241,6 +241,7 @@ define(function (require, exports, module) {
         function hintsPresentExact(hintObj, expectedHints) {
             _waitForHints(hintObj, function (hintList) {
                 expect(hintList).not.toBeNull();
+                expect(hintList.length).toBe(expectedHints.length);
                 expectedHints.forEach(function (expectedHint, index) {
                     expect(hintList[index].data("token").value).toBe(expectedHint);
                 });
@@ -1224,6 +1225,7 @@ define(function (require, exports, module) {
         describe("JavaScript Code Hinting without modules", function () {
             var testPath = extensionPath + "/unittest-files/non-module-test-files/app.js";
             ScopeManager.handleProjectOpen(extensionPath + "/unittest-files/non-module-test-files/");
+
             beforeEach(function () {
                 setupTest(testPath, true);
             });


### PR DESCRIPTION
Ignoring empty lines improves finding the end of the scope since the method is sensitive to indents. An empty line would prematurely end the search for the end of the scope.

Change hintsPrsentExact to verify number of entries match.
