### PR TITLE
Update List of Ignore files

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -70,6 +70,16 @@ define(function (require, exports, module) {
         KeyEvent            = require("utils/KeyEvent"),
         Async               = require("utils/Async");
     
+    
+    /**
+     * @private
+     * File and Folder names which are not displayed or searched
+     * TODO: We should add the rest of the file names that TAR excludes:
+     *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
+     * @type {RegExp}
+     */
+    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$|^\.hgtags$|^\.hgignore$/;
+
     /**
      * @private
      * Reference to the tree control container div. Initialized by
@@ -646,14 +656,7 @@ define(function (require, exports, module) {
      * @return boolean true if the file should be displayed
      */
     function shouldShow(entry) {
-        if ([".git", ".gitignore", ".gitmodules", ".svn", ".DS_Store", "Thumbs.db", ".hg"].indexOf(entry.name) > -1) {
-            return false;
-        }
-        var extension = entry.name.split('.').pop();
-        if (["pyc"].indexOf(extension) > -1) {
-            return false;
-        }
-        return true;
+        return !entry.name.match(_exclusionListRegEx);
     }
 
     /**

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -545,10 +545,22 @@ define(function (require, exports, module) {
                     return { name: name };
                 };
                 
+                expect(shouldShow(makeEntry(".git"))).toBe(false);
+                expect(shouldShow(makeEntry(".svn"))).toBe(false);
+                expect(shouldShow(makeEntry(".DS_Store"))).toBe(false);
+                expect(shouldShow(makeEntry("Thumbs.db"))).toBe(false);
+                expect(shouldShow(makeEntry(".hg"))).toBe(false);
                 expect(shouldShow(makeEntry(".gitmodules"))).toBe(false);
+                expect(shouldShow(makeEntry(".gitignore"))).toBe(false);
                 expect(shouldShow(makeEntry("foobar"))).toBe(true);
                 expect(shouldShow(makeEntry("pyc.py"))).toBe(true);
                 expect(shouldShow(makeEntry("module.pyc"))).toBe(false);
+                expect(shouldShow(makeEntry(".gitattributes"))).toBe(false);
+                expect(shouldShow(makeEntry("CVS"))).toBe(false);
+                expect(shouldShow(makeEntry(".cvsignore"))).toBe(false);
+                expect(shouldShow(makeEntry(".hgignore"))).toBe(false);
+                expect(shouldShow(makeEntry(".hgtags"))).toBe(false);
+                
             });
         });
 


### PR DESCRIPTION
- adds CVS repository folders and .cvsignore files to the list of files not seen or searched by Brackets (Fixes issue #4039)
- adds .gitattributes to the list of files not seen or searched by Brackets.
- converts the exclude list to a regex 
