### PR TITLE
REVIEW ONLY: Basic DOM manipulation via RemoteAgent

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -190,7 +190,8 @@ define(function RemoteAgent(require, exports, module) {
         "attr", "removeAttr",
         "before", "after", "append", "prepend",
         "text",
-        "detach", "remove"
+        "detach", "remove",
+        "html"
     ];
 
     function RemoteElement(dataBracketsId) {

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -49,7 +49,8 @@ define(function HTMLDocumentModule(require, exports, module) {
         HighlightAgent      = require("LiveDevelopment/Agents/HighlightAgent"),
         HTMLInstrumentation = require("language/HTMLInstrumentation"),
         Inspector           = require("LiveDevelopment/Inspector/Inspector"),
-        LiveDevelopment     = require("LiveDevelopment/LiveDevelopment");
+        LiveDevelopment     = require("LiveDevelopment/LiveDevelopment"),
+        RemoteAgent         = require("LiveDevelopment/Agents/RemoteAgent");
 
     /** Constructor
      *
@@ -74,10 +75,10 @@ define(function HTMLDocumentModule(require, exports, module) {
             // Used by highlight agent to highlight editor text as selected in browser
             this.onHighlight = this.onHighlight.bind(this);
             $(HighlightAgent).on("highlight", this.onHighlight);
-
-            this.onChange = this.onChange.bind(this);
-            $(this.editor).on("change", this.onChange);
         }
+
+        this.onChange = this.onChange.bind(this);
+        $(this.editor).on("change", this.onChange);
     };
     
     /**
@@ -149,17 +150,34 @@ define(function HTMLDocumentModule(require, exports, module) {
 
     /** Triggered on change by the editor */
     HTMLDocument.prototype.onChange = function onChange(event, editor, change) {
-        if (!this.editor) {
-            return;
+        var marker = HTMLInstrumentation._getMarkerAtDocumentPos(
+            this.editor,
+            editor.getCursorPos()
+        );
+
+        // HACK, replace the whole tag
+        if (marker && marker.tagID) {
+            var range   = marker.find(),
+                text    = marker.doc.getRange(range.from, range.to);
+
+            // HACK maintain ID
+            text = text.replace(">", " data-brackets-id='" + marker.tagID + "'>");
+
+            // FIXME incorrectly replaces body elements with content only, missing body element
+            RemoteAgent.remoteElement(marker.tagID).replaceWith(text);
         }
-        var codeMirror = this.editor._codeMirror;
-        while (change) {
-            var from = codeMirror.indexFromPos(change.from);
-            var to = codeMirror.indexFromPos(change.to);
-            var text = change.text.join("\n");
-            DOMAgent.applyChange(from, to, text);
-            change = change.next;
-        }
+
+        // if (!this.editor) {
+        //     return;
+        // }
+        // var codeMirror = this.editor._codeMirror;
+        // while (change) {
+        //     var from = codeMirror.indexFromPos(change.from);
+        //     var to = codeMirror.indexFromPos(change.to);
+        //     var text = change.text.join("\n");
+        //     DOMAgent.applyChange(from, to, text);
+        //     change = change.next;
+        // }
     };
 
     /** Triggered by the HighlightAgent to highlight a node in the editor */

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -269,19 +269,8 @@ define(function (require, exports, module) {
             mark.tagID = tag.tagID;
         });
     }
-    
-    /**
-     * Get the instrumented tagID at the specified position. Returns -1 if
-     * there are no instrumented tags at the location.
-     * The _markText() function must be called before calling this function.
-     *
-     * NOTE: This function is "private" for now (has a leading underscore), since
-     * the API is likely to change in the future.
-     *
-     * @param {Editor} editor The editor to scan. 
-     * @return {number} tagID at the specified position, or -1 if there is no tag
-     */
-    function _getTagIDAtDocumentPos(editor, pos) {
+
+    function _getMarkerAtDocumentPos(editor, pos) {
         var i,
             cm = editor._codeMirror,
             marks = cm.findMarksAt(pos),
@@ -307,11 +296,24 @@ define(function (require, exports, module) {
             }
         }
         
-        if (match) {
-            return match.tagID;
-        }
-        
-        return -1;
+        return match;
+    }
+    
+    /**
+     * Get the instrumented tagID at the specified position. Returns -1 if
+     * there are no instrumented tags at the location.
+     * The _markText() function must be called before calling this function.
+     *
+     * NOTE: This function is "private" for now (has a leading underscore), since
+     * the API is likely to change in the future.
+     *
+     * @param {Editor} editor The editor to scan. 
+     * @return {number} tagID at the specified position, or -1 if there is no tag
+     */
+    function _getTagIDAtDocumentPos(editor, pos) {
+        var match = _getMarkerAtDocumentPos(editor, pos);
+
+        return (match) ? match.tagID : -1;
     }
     
     $(DocumentManager).on("beforeDocumentDelete", _removeDocFromCache);
@@ -319,5 +321,6 @@ define(function (require, exports, module) {
     exports.scanDocument = scanDocument;
     exports.generateInstrumentedHTML = generateInstrumentedHTML;
     exports._markText = _markText;
+    exports._getMarkerAtDocumentPos = _getMarkerAtDocumentPos;
     exports._getTagIDAtDocumentPos = _getTagIDAtDocumentPos;
 });


### PR DESCRIPTION
Injects jQuery via RemoteAgent. Exposes basic DOM manipulation via `RemoteAgent.remoteElement(data-brackets-id)`. I used jQuery instead of the Inspector DOM APIs (https://developers.google.com/chrome-developer-tools/docs/protocol/tot/dom) for a few reasons:
- DOM API does not have a method for inserting new elements. The Inspector API can do just about everything else though: attribute CRUD, remove nodes (elements, attributes, text), etc.
- Lessens dependency on Chrome's Inspector API. Injecting jQuery may be desirable in the future for expanded live preview browser support.
- Using jQuery attribute selectors `$("[data-brackets-id=n]")` to modify DOM in-browser is easier than maintaining our own DOM tree (see `DOMAgent` and `DOMNode` modules), calling the DOM API, resolving the `RemoteObject`, and modifying the `RemoteObject` and requires less async calls :)
- Simplifies creation of new DOM elements, e.g. 

```
// insert a new sibling before element N
RemoteAgent.remoteElement(N).before(htmlString);
```

Use `HTMLInstrumentation._getTagIDAtDocumentPos(editor, cursor)` to get the `data-brackets-id` for the given cursor position.

The jQuery methods currently exposed on a `RemoteElement` are the following: attr, removeAttr, before, after, append, prepend, text, detach (in case we want try getting undo to work re-insert a node), remove and finally html in case we want to blow up the entire content of an element for difficult use cases like mixed content.
