### PR TITLE
fix save as unit test on windows

### DIFF
--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -248,6 +248,8 @@ define(function (require, exports, module) {
 
                 runs(function () {
                     var currentDocument = DocumentManager.getCurrentDocument();
+                    // clean out the C: prefix on win, does nothing on mac as paths always start with /
+                    newFilePath = newFilePath.replace(/^\w:/, "");
                     expect(currentDocument.file.fullPath).toEqual(newFilePath);
                 });
 


### PR DESCRIPTION
a unit test was failing because the generic win path is prefixed with the drive name, i.e. C:

This is fixed with this submission by removing the prefix
