### PR TITLE
Fix Issue #3863 - jump-to-def goes to exports line.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -208,6 +208,7 @@ define(function (require, exports, module) {
      * 
      * @param {{line: number, ch: number}} cursor - cursor position after
      *      which a token should be retrieved
+     * @param {boolean} skipWhitespace - true if this should skip over whitespace tokens 
      * @return {Object} - the CodeMirror token after the one at the given
      *      cursor position
      */

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -632,6 +632,7 @@ define(function (require, exports, module) {
              *
              * @param {number} start - the start of the selection
              * @param {number} end - the end of the selection
+             * @param {boolean} isFunction - true if we are jumping to the source of a function def
              */
             function setJumpSelection(start, end, isFunction) {
                 

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -591,8 +591,9 @@ define(function (require, exports, module) {
          */
         function handleJumpToDefinition() {
             var offset,
-                response;
+                handleJumpResponse;
 
+                        
             // Only provide jump-to-definition results when cursor is in JavaScript content
             if (session.editor.getModeForSelection() !== "javascript") {
                 return null;
@@ -600,34 +601,118 @@ define(function (require, exports, module) {
 
             var result = new $.Deferred();
 
-            offset = session.getOffset();
-            response = ScopeManager.requestJumptoDef(session, session.editor.document, offset);
-
-            if (response.hasOwnProperty("promise")) {
-                response.promise.done(function (jumpResp) {
-
-                    if (jumpResp.resultFile) {
-                        if (jumpResp.resultFile !== jumpResp.file) {
-                            var resolvedPath = ScopeManager.getResolvedPath(jumpResp.resultFile);
-                            if (resolvedPath) {
-                                CommandManager.execute(Commands.FILE_OPEN, {fullPath: resolvedPath})
-                                    .done(function () {
-                                        session.editor.setSelection(jumpResp.start, jumpResp.end, true);
-                                    });
-                            }
-                        } else {
-                            session.editor.setSelection(jumpResp.start, jumpResp.end, true);
-                        }
-                        result.resolve(true);
-                    } else {
+            /**
+             * Make a jump-to-def request based on the session and offset passed in.
+             * @param {Session} session - the session
+             * @param {number} offset - the offset of where to jump from
+             */
+            function requestJumpToDef(session, offset) {
+                var response = ScopeManager.requestJumptoDef(session, session.editor.document, offset);
+    
+                if (response.hasOwnProperty("promise")) {
+                    response.promise.done(handleJumpResponse).fail(function () {
                         result.reject();
-                    }
+                    });
+                }
+            }
+            
 
-                }).fail(function () {
-                    result.reject();
-                });
+            /**
+             * Sets the selection to move the cursor to the result position.
+             * Assumes that the editor has already changed files, if necessary.
+             *
+             * Additionally, this will check to see if the selection looks like an
+             * assignment to a member expression - if it is, and the type is a function,
+             * then we will attempt to jump to the RHS of the expression.
+             *
+             * 'exports.foo = foo'
+             *
+             * if the selection is 'foo' in 'exports.foo', then we will attempt to jump to def
+             * on the rhs of the assignment.
+             *
+             * @param {number} start - the start of the selection
+             * @param {number} end - the end of the selection
+             */
+            function setJumpSelection(start, end) {
+                
+                /**
+                 * helper function to decide if the tokens on the RHS of an assignment
+                 * look like an identifier, or member expr.
+                 */
+                function validIdOrProp(token) {
+                    if (token.string === ".") {
+                        return true;
+                    }
+                    var type = token.type;
+                    if (type === "variable-2" || type === "variable" || type === "property") {
+                        return true;
+                    }
+                    
+                    return false;
+                }
+                
+                // set the selection
+                session.editor.setSelection(start, end, true);
+                var cursor = session.getCursor(),
+                    prev = session._getPreviousToken(cursor),
+                    next,
+                    token,
+                    offset,
+                    madeNewRequest;
+
+                // see if the selection is preceded by a '.', indicating we're in a member expr
+                if (prev.string === ".") {
+                    cursor = session.getCursor();
+                    next = session.getNextToken(cursor, true);
+                    // check if the next token indicates an assignment
+                    if (next.string === "=") {
+                        next = session.getNextToken(cursor, true);
+                        // find the last token of the identifier, or member expr
+                        while (validIdOrProp(next)) {
+                            offset = session.getOffsetFromCursor({line: cursor.line, ch: next.end});
+                            next = session.getNextToken(cursor, false);
+                        }
+                        if (offset) {
+                            // trigger another jump to def based on the offset of the RHS
+                            requestJumpToDef(session, offset);
+                            madeNewRequest = true;
+                        }
+                    }
+                }
+                // We didn't make a new jump-to-def request, so we can resolve the promise
+                if (!madeNewRequest) {
+                    result.resolve(true);
+                }
             }
 
+            /**
+             * handle processing of the completed jump-to-def request.              
+             * will open the appropriate file, and set the selection based
+             * on the response.
+             */
+            handleJumpResponse = function (jumpResp) {
+
+                if (jumpResp.resultFile) {
+                    if (jumpResp.resultFile !== jumpResp.file) {
+                        var resolvedPath = ScopeManager.getResolvedPath(jumpResp.resultFile);
+                        if (resolvedPath) {
+                            CommandManager.execute(Commands.FILE_OPEN, {fullPath: resolvedPath})
+                                .done(function () {
+                                    setJumpSelection(jumpResp.start, jumpResp.end);
+                                });
+                        }
+                    } else {
+                        setJumpSelection(jumpResp.start, jumpResp.end);
+                    }
+                } else {
+                    result.reject();
+                }
+            };
+            
+            offset = session.getOffset();
+            // request a jump-to-def
+            requestJumpToDef(session, offset);
+            
             return result.promise();
         }
 

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -185,15 +185,26 @@ importScripts("thirdparty/requirejs/require.js");
                         self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG, file: fileInfo.name, offset: offset});
                         return;
                     }
-                    
-                    // Post a message back to the main thread with the definition
-                    self.postMessage({type: MessageIds.TERN_JUMPTODEF_MSG,
-                                      file: fileInfo.name,
-                                      resultFile: data.file,
-                                      offset: offset,
-                                      start: data.start,
-                                      end: data.end
-                                     });
+                    var isFunc = false,
+                        response = {type: MessageIds.TERN_JUMPTODEF_MSG,
+                                          file: fileInfo.name,
+                                          resultFile: data.file,
+                                          offset: offset,
+                                          start: data.start,
+                                          end: data.end
+                                         };
+
+                    request = buildRequest(fileInfo, "type", offset);
+                    // See if we can tell if the reference is to a Function type
+                    ternServer.request(request, function (error, data) {
+                        if (!error) {
+                            response.isFunction = data.type.length > 2 && data.type.substring(0, 2) === "fn";
+                        }
+                        
+                        // Post a message back to the main thread with the definition
+                        self.postMessage(response);
+                    });
+
                 });
             }
         

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/MyModule.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/MyModule.js
@@ -7,4 +7,10 @@ define(function (require, exports, module) {
         return "a string";
     };
     exports.j = "hi";
+    
+
+    function c() {
+    }
+    
+    exports.c = c;
 });

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file1.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file1.js
@@ -155,6 +155,11 @@ function testNonAscii() {
     
 }
 
+require(["MyModule"], function (myModule) {
+    'use strict';
+    var x = myModule.c;
+});
+
 /* Add large comment to make this test over 250 lines which will trigger
  *  partial updates to be used.
  *

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -291,13 +291,18 @@ define(function (require, exports, module) {
          * @param {{line:number, ch:number}} oldLocation - the original line/col
          * @param {Function} callback - the callback to apply once the editor has changed position
          */
-        function _waitForJump(oldLocation, callback) {
-            var cursor = null;
+        function _waitForJump(jumpPromise, callback) {
+            var cursor = null,
+                complete = false;
+            
+            jumpPromise.done(function () {
+                complete = true;
+            });
+            
             waitsFor(function () {
                 var activeEditor = EditorManager.getActiveEditor();
                 cursor = activeEditor.getCursorPos();
-                return (cursor.line !== oldLocation.line) ||
-                        (cursor.ch !== oldLocation.ch);
+                return complete;
             }, "Expected jump did not occur", 3000);
 
             runs(function () { callback(cursor); });
@@ -314,10 +319,10 @@ define(function (require, exports, module) {
         function editorJumped(expectedLocation) {
             var oldLocation = testEditor.getCursorPos();
             
-            JSCodeHints.handleJumpToDefinition();
+            var jumpPromise = JSCodeHints.handleJumpToDefinition();
             
             
-            _waitForJump(oldLocation, function (newCursor) {
+            _waitForJump(jumpPromise, function (newCursor) {
                 expect(newCursor.line).toBe(expectedLocation.line);
                 expect(newCursor.ch).toBe(expectedLocation.ch);
                 if (expectedLocation.file) {
@@ -739,7 +744,7 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos(start);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 runs(function () {
-                    hintsPresentExact(hintObj, ["a", "b", "j"]);
+                    hintsPresentExact(hintObj, ["a", "b", "c", "j"]);
                 });
             });
 
@@ -998,7 +1003,7 @@ define(function (require, exports, module) {
                     editorJumped({line: 4, ch: 13, file: "MyModule.js"}); //jump to another file
                 });
             });
-            
+
             it("should jump to the method definition in .prototype", function () {
                 var start = { line: 59, ch: 8 };
                 
@@ -1035,6 +1040,15 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should jump to the actual function definition, and not the exports line", function () {
+                var start = { line: 159, ch: 22 };
+                
+                testEditor.setCursorPos(start);
+                runs(function () {
+                    editorJumped({line: 11, ch: 14, file: "MyModule.js"}); //jump to another file
+                });
+            });
+            
             it("should not hint function, variable, or param decls", function () {
                 var func = { line: 7, ch: 12 },
                     param = { line: 7, ch: 18 },


### PR DESCRIPTION
When the result of jump-to-def looks like:
exports.foo = foo;

we now will try and jump-to-def on the rhs, as that's what the user most likely really wants.  Jumping to the exports line is rarely useful.

When we get the response for a jump-to-def, if it looks like we're jumping to a member expression like the example above, then we will grab the RHS, and trigger another jump-to-def on that, which should take us to the correct place.
