### PR TITLE
write SyntaxError.message to console log

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -133,6 +133,9 @@ define(function (require, exports, module) {
                     // continue with null configObj which will result in
                     // default settings.
                     console.log("Error parsing preference file: " + path);
+                    if (e instanceof SyntaxError) {
+                        console.log(e.message);
+                    }
                 }
                 preferences = new Preferences(configObj);
                 deferredPreferences.resolve();


### PR DESCRIPTION
May help people figure out what is wrong with the .jscodehint preference file.
