### PR TITLE
Fix #4252: Do not copy entire Strings Object; pass by reference instead

### DIFF
--- a/src/extensions/default/DebugCommands/htmlContent/language-dialog.html
+++ b/src/extensions/default/DebugCommands/htmlContent/language-dialog.html
@@ -1,11 +1,11 @@
 <div class="switch-language modal">
     <div class="modal-header">
         <a href="#" class="close" data-dismiss="modal">&times;</a>
-        <h1 class="dialog-title">{{LANGUAGE_TITLE}}</h1>
+        <h1 class="dialog-title">{{Strings.LANGUAGE_TITLE}}</h1>
     </div>
     <div class="modal-body">
         <p class="dialog-message">
-            {{LANGUAGE_MESSAGE}}
+            {{Strings.LANGUAGE_MESSAGE}}
             <select>
                 {{#languages}}
                 <option value="{{language}}">{{label}}</option>
@@ -14,7 +14,7 @@
         </p>
     </div>
     <div class="modal-footer">
-        <button class="dialog-button btn primary" data-button-id="ok" disabled>{{LANGUAGE_SUBMIT}}</button>
-        <button class="dialog-button btn left" data-button-id="cancel">{{CANCEL}}</button>
+        <button class="dialog-button btn primary" data-button-id="ok" disabled>{{Strings.LANGUAGE_SUBMIT}}</button>
+        <button class="dialog-button btn left" data-button-id="cancel">{{Strings.CANCEL}}</button>
     </div>
 </div>

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
                     }
                 });
                 
-                var template = Mustache.render(LanguageDialogTemplate, $.extend({languages: languages}, Strings));
+                var template = Mustache.render(LanguageDialogTemplate, {languages: languages, Strings: Strings});
                 Dialogs.showModalDialogUsingTemplate(template).done(function () {
                     if (locale === undefined) {
                         return;

--- a/src/extensions/default/RecentProjects/htmlContent/projects-menu.html
+++ b/src/extensions/default/RecentProjects/htmlContent/projects-menu.html
@@ -8,9 +8,9 @@
     </li>
     {{/projectList}}
     
-    {{#hasProject}}
+    {{#projectList.length}}
     <li class="divider"></li>
-    {{/hasProject}}
+    {{/projectList.length}}
     
-    <li><a id="open-folder-link">{{CMD_OPEN_FOLDER}}</a></li>
+    <li><a id="open-folder-link">{{Strings.CMD_OPEN_FOLDER}}</a></li>
 </ul>

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -240,16 +240,18 @@ define(function (require, exports, module) {
     function renderList() {
         var recentProjects = getRecentProjects(),
             currentProject = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
-            projectList    = [];
+            templateVars   = {
+                projectList : [],
+                Strings     : Strings
+            };
         
         recentProjects.forEach(function (root) {
             if (root !== currentProject) {
-                projectList.push(parsePath(root));
+                templateVars.projectList.push(parsePath(root));
             }
         });
-        var templateVars = {projectList: projectList, hasProject: projectList.length};
         
-        return Mustache.render(ProjectsMenuTemplate, $.extend(templateVars, Strings));
+        return Mustache.render(ProjectsMenuTemplate, templateVars);
     }
     
     /**

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
@@ -17,5 +17,5 @@
         </div>
     </div>
     <div class="content-bottom"></div>
-    <a class="more-info" href="{{url}}" title="{{url}}">{{DOCS_MORE_LINK}}</a>
+    <a class="more-info" href="{{url}}" title="{{url}}">{{Strings.DOCS_MORE_LINK}}</a>
 </div>

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -55,12 +55,13 @@ define(function (require, exports, module) {
             return { value: valueInfo.TITLE, description: valueInfo.DESCRIPTION };
         });
         
-        var templateVars = $.extend({
-            propName: cssPropName,
-            summary: cssPropDetails.SUMMARY,
-            propValues: propValues,
-            url: cssPropDetails.URL
-        }, Strings);
+        var templateVars = {
+            propName    : cssPropName,
+            summary     : cssPropDetails.SUMMARY,
+            propValues  : propValues,
+            url         : cssPropDetails.URL,
+            Strings     : Strings
+        };
         
         var html = Mustache.render(inlineEditorTemplate, templateVars);
         

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -66,11 +66,12 @@ define(function (require, exports, module) {
     }
 
     function _handleAboutDialog() {
-        var templateVars = $.extend({
+        var templateVars = {
             ABOUT_ICON          : brackets.config.about_icon,
             APP_NAME_ABOUT_BOX  : brackets.config.app_name_about,
-            BUILD_INFO          : buildInfo || ""
-        }, Strings);
+            BUILD_INFO          : buildInfo || "",
+            Strings             : Strings
+        };
         
         Dialogs.showModalDialogUsingTemplate(Mustache.render(AboutDialogTemplate, templateVars));
         

--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -1,19 +1,19 @@
 <div class="about-dialog modal">
     <div class="modal-header">
-        <h1 class="dialog-title">{{ABOUT}}</h1>
+        <h1 class="dialog-title">{{Strings.ABOUT}}</h1>
     </div>
     <div class="modal-body">
         <img class="about-icon" src="{{ABOUT_ICON}}">
         <div class="about-text">
             <h2>{{APP_NAME_ABOUT_BOX}}</h2>
             <div class="about-info">
-                <p class="dialog-message">{{ABOUT_TEXT_LINE1}} <span id="about-build-number">{{BUILD_INFO}}</span></p>
+                <p class="dialog-message">{{Strings.ABOUT_TEXT_LINE1}} <span id="about-build-number">{{BUILD_INFO}}</span></p>
                 <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2012 - 2013 Adobe Systems Incorporated and its licensors. All rights reserved.</p>
-                <p class="dialog-message">{{{ABOUT_TEXT_WEB_PLATFORM_DOCS}}}</p>
-                <p class="dialog-message">{{{ABOUT_TEXT_LINE3}}}</p>
-                <p class="dialog-message">{{{ABOUT_TEXT_LINE4}}}</p>
+                <p class="dialog-message">{{{Strings.ABOUT_TEXT_WEB_PLATFORM_DOCS}}}</p>
+                <p class="dialog-message">{{{Strings.ABOUT_TEXT_LINE3}}}</p>
+                <p class="dialog-message">{{{Strings.ABOUT_TEXT_LINE4}}}</p>
                 <p class="dialog-message">
-                    {{ABOUT_TEXT_LINE5}}
+                    {{Strings.ABOUT_TEXT_LINE5}}
                     <span class="spinner"></span>
                 </p>
                 <div class="about-contributors">
@@ -22,6 +22,6 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button class="dialog-button btn primary" data-button-id="ok">{{CLOSE}}</button>
+        <button class="dialog-button btn primary" data-button-id="ok">{{Strings.CLOSE}}</button>
     </div>
 </div>

--- a/src/htmlContent/update-list.html
+++ b/src/htmlContent/update-list.html
@@ -1,6 +1,6 @@
 {{#.}}
 <div>
-    <h3>{{versionString}} - {{dateString}} (<a href="#" data-url="{{releaseNotesURL}}">{{RELEASE_NOTES}}</a>)</h3>
+    <h3>{{versionString}} - {{dateString}} (<a href="#" data-url="{{releaseNotesURL}}">{{Strings.RELEASE_NOTES}}</a>)</h3>
     <ul>
         {{#newFeatures}}
         <li><b>{{name}}</b> - {{description}}</li>

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -203,11 +203,11 @@ define(function (require, exports, module) {
             });
         
         // Populate the update data
-        var $dlg = $(".update-dialog.instance");
-        var $updateList = $dlg.find(".update-info");
-        var templateVars = $.extend(updates, Strings);
+        var $dlg        = $(".update-dialog.instance"),
+            $updateList = $dlg.find(".update-info");
         
-        $updateList.html(Mustache.render(UpdateListTemplate, templateVars));
+        updates.Strings = Strings;
+        $updateList.html(Mustache.render(UpdateListTemplate, updates));
         
         $dlg.on("click", "a", function (e) {
             var url = $(e.currentTarget).attr("data-url");


### PR DESCRIPTION
A fix for issue #4252. The modified files and corresponding templates are the ones mentioned in the issue plus an extra one I found in the Debug Commands extension.
