### PR TITLE
Fix #4268: Performace Data window cannot be closed.

### DIFF
--- a/src/extensions/default/DebugCommands/htmlContent/perf-dialog.html
+++ b/src/extensions/default/DebugCommands/htmlContent/perf-dialog.html
@@ -1,4 +1,4 @@
-<div class="modal">
+<div class="perf-dialog modal">
     <div class="modal-header">
         <a href="#" class="close" data-dismiss="modal">&times;</a>
         <h1 class="dialog-title">Performance Data</h1>
@@ -7,7 +7,7 @@
             <textarea rows="1" style="width:30px; height:8px; overflow: hidden; resize: none" id="brackets-perf-raw-data">{{delimitedPerfData}}</textarea>
         </div>
     </div>
-    <div class="modal-body" style="padding: 0; max-height: 500px; overflow: auto; width: 592px">
+    <div class="modal-body" style="padding: 0; max-height: 500px; overflow: auto; width: 610px">
         <table class="zebra-striped condensed-table">
             <thead><th>Operation</th><th>Time (ms)</th></thead>
             <tbody>


### PR DESCRIPTION
#4268

I added a class ID to the performance dialog to be able to close it.
