### PR TITLE
Fix async issues when launching live development

### DIFF
--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -74,7 +74,8 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        return Inspector.Console.enable().done(function () {
+        // FIXME Windows only: Somtimes enable() isn't acknowledged
+        return Inspector.retry(Inspector.Console.enable).done(function () {
             $(Inspector.Console)
                 .on("messageAdded.ConsoleAgent", _onMessageAdded)
                 .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -99,7 +99,7 @@ define(function HighlightAgent(require, exports, module) {
      * @param {string} rule selector
      */
     function rule(name) {
-        if (_highlight.ref === name) {
+        if (_highlight && (_highlight.ref === name)) {
             return;
         }
         hide();

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -144,6 +144,7 @@ define(function LiveDevelopment(require, exports, module) {
     var _relatedDocuments;    // CSS and JS documents that are used by the live HTML document
     var _serverProvider;      // current LiveDevServerProvider
     var _closeReason;         // reason why live preview was closed
+    var _openDeferred;        // promise returned for each call to open()
     
     function _isHtmlFileExt(ext) {
         return (FileUtils.isStaticHtmlFileExt(ext) ||
@@ -359,7 +360,7 @@ define(function LiveDevelopment(require, exports, module) {
                 // Send custom HTTP response for the current live document
                 $(_serverProvider).on("request.livedev", function (event, request) {
                     // response can be null in which case the StaticServerDomain reverts to simple file serving.
-                    var response = _liveDocument.getResponseData ? _liveDocument.getResponseData() : null;
+                    var response = _liveDocument && _liveDocument.getResponseData ? _liveDocument.getResponseData() : null;
                     request.send(response);
                 });
             }
@@ -406,39 +407,6 @@ define(function LiveDevelopment(require, exports, module) {
         return Async.doInParallel(agents.css.getStylesheetURLs(),
                                   createLiveStylesheet,
                                   false); // don't fail fast
-    }
-
-    /** Unload the agents */
-    function unloadAgents() {
-        _loadedAgentNames.forEach(function (name) {
-            agents[name].unload();
-        });
-        _loadedAgentNames = [];
-    }
-
-    /** Load the agents */
-    function loadAgents() {
-        var name, promises = [], agentsToLoad, promise;
-
-        if (exports.config.experimental) {
-            // load all agents
-            agentsToLoad = agents;
-        } else {
-            // load only enabled agents
-            agentsToLoad = _enabledAgentNames;
-        }
-        for (name in agentsToLoad) {
-            if (agentsToLoad.hasOwnProperty(name) && agents[name] && agents[name].load) {
-                promise = agents[name].load();
-
-                if (promise) {
-                    promises.push(promise);
-                }
-
-                _loadedAgentNames.push(name);
-            }
-        }
-        return promises;
     }
 
     /** Enable an agent. Takes effect next time a connection is made. Does not affect
@@ -505,25 +473,105 @@ define(function LiveDevelopment(require, exports, module) {
         _setStatus(STATUS_ERROR);
     }
 
-    /** Run when all agents are loaded */
-    function _onLoad() {
-        var doc = _getCurrentDocument();
-        if (!doc) {
-            return;
+    /** Unload the agents */
+    function unloadAgents() {
+        _loadedAgentNames.forEach(function (name) {
+            agents[name].unload();
+        });
+        _loadedAgentNames = [];
+    }
+
+    /** Load the agents */
+    function loadAgents() {
+        var result = new $.Deferred(),
+            promises = [],
+            agentsToLoad,
+            allAgentsPromise,
+            loadOneAgent;
+
+        _setStatus(STATUS_LOADING_AGENTS);
+
+        if (exports.config.experimental) {
+            // load all agents
+            agentsToLoad = agents;
+        } else {
+            // load only enabled agents
+            agentsToLoad = _enabledAgentNames;
         }
 
-        var status = STATUS_ACTIVE;
+        loadOneAgent = function (name) {
+            var oneAgentPromise;
 
-        // Note: the following promise is never explicitly rejected, so there
-        // is no failure handler. If _getRelatedDocuments is changed so that rejection
-        // is possible, failure should be managed accordingly.
-        _getRelatedDocuments()
-            .done(function () {
-                if (doc.isDirty && _classForDocument(doc) !== CSSDocument) {
-                    status = STATUS_OUT_OF_SYNC;
-                }
-                _setStatus(status);
-            });
+            if (agents[name] && agents[name].load) {
+                oneAgentPromise = agents[name].load();
+            }
+
+            if (!oneAgentPromise) {
+                oneAgentPromise = new $.Deferred().resolve().promise();
+            } else {
+                oneAgentPromise.fail(function () {
+                    console.error("Failed to load agent", name);
+                });
+            }
+
+            _loadedAgentNames.push(name);
+
+            return oneAgentPromise;
+        };
+
+        // load agents in parallel
+        allAgentsPromise = Async.doInParallel(Object.keys(agentsToLoad), loadOneAgent, true);
+
+        // wrap agent loading with a timeout
+        allAgentsPromise = Async.withTimeout(allAgentsPromise, 10000);
+
+        allAgentsPromise.done(function () {
+            // After (1) the interstitial page loads, (2) then browser navigation
+            // to the base URL is completed, and (3) the agents finish loading
+            // gather related documents and finally set status to STATUS_ACTIVE.
+            var doc = _getCurrentDocument();
+
+            if (doc) {
+                var status = STATUS_ACTIVE,
+                    relatedDocumentsPromise;
+
+                // Note: the following promise is never explicitly rejected, so there
+                // is no failure handler. If _getRelatedDocuments is changed so that rejection
+                // is possible, failure should be managed accordingly.
+                relatedDocumentsPromise = Async.withTimeout(_getRelatedDocuments(), 5000);
+
+                relatedDocumentsPromise
+                    .done(function () {
+                        if (doc.isDirty && _classForDocument(doc) !== CSSDocument) {
+                            status = STATUS_OUT_OF_SYNC;
+                        }
+                        _setStatus(status);
+
+                        result.resolve();
+                    })
+                    .fail(result.reject);
+            } else {
+                result.reject();
+            }
+        });
+
+        allAgentsPromise.fail(result.reject);
+
+        // show error loading live dev dialog
+        result.fail(function () {
+            _setStatus(STATUS_ERROR);
+
+            Dialogs.showModalDialog(
+                Dialogs.DIALOG_ID_ERROR,
+                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
+                Strings.LIVE_DEV_LOADING_ERROR_MESSAGE
+            );
+        });
+
+        // resolve/reject the open() promise after agents complete
+        result.then(_openDeferred.resolve, _openDeferred.reject);
+
+        return result.promise();
     }
 
     // WebInspector Event: Page.frameNavigated
@@ -581,179 +629,12 @@ define(function LiveDevelopment(require, exports, module) {
         }
     }
 
+    /**
+     * Unload and reload agents
+     */
     function reconnect() {
         unloadAgents();
-        
-        _setStatus(STATUS_LOADING_AGENTS);
-        var promises = loadAgents();
-        $.when.apply(undefined, promises).done(_onLoad).fail(_onError);
-    }
-
-    /** Open the Connection and go live */
-    function open() {
-        var result = new $.Deferred(),
-            promise = result.promise();
-        var doc = _getCurrentDocument();
-        var browserStarted = false;
-        var retryCount = 0;
-
-        _closeReason = null;
-
-        function showWrongDocError() {
-            Dialogs.showModalDialog(
-                DefaultDialogs.DIALOG_ID_ERROR,
-                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
-                Strings.LIVE_DEV_NEED_HTML_MESSAGE
-            );
-            result.reject();
-        }
-
-        function showNeedBaseUrlError() {
-            PreferencesDialogs.showProjectPreferencesDialog("", Strings.LIVE_DEV_NEED_BASEURL_MESSAGE)
-                .done(function (id) {
-                    if (id === Dialogs.DIALOG_BTN_OK && ProjectManager.getBaseUrl()) {
-                        // If base url is specifed, then re-invoke open() to continue
-                        open();
-                        result.resolve();
-                    } else {
-                        result.reject();
-                    }
-                });
-        }
-
-        function showLiveDevServerNotReadyError() {
-            Dialogs.showModalDialog(
-                DefaultDialogs.DIALOG_ID_ERROR,
-                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
-                Strings.LIVE_DEV_SERVER_NOT_READY_MESSAGE
-            );
-            result.reject();
-        }
-        
-        // helper function that actually does the launch once we are sure we have
-        // a doc and the server for that doc is up and running.
-        function doLaunchAfterServerReady() {
-            _setStatus(STATUS_CONNECTING);
-            
-            _openDocument(doc, EditorManager.getCurrentFullEditor());
-
-            Inspector.connectToURL(launcherUrl).done(result.resolve).fail(function onConnectFail(err) {
-                if (err === "CANCEL") {
-                    result.reject(err);
-                    return;
-                }
-                if (retryCount > 6) {
-                    _setStatus(STATUS_ERROR);
-                    Dialogs.showModalDialog(
-                        DefaultDialogs.DIALOG_ID_LIVE_DEVELOPMENT,
-                        Strings.LIVE_DEVELOPMENT_RELAUNCH_TITLE,
-                        Strings.LIVE_DEVELOPMENT_ERROR_MESSAGE,
-                        [
-                            {
-                                className: Dialogs.DIALOG_BTN_CLASS_LEFT,
-                                id:        Dialogs.DIALOG_BTN_CANCEL,
-                                text:      Strings.CANCEL
-                            },
-                            {
-                                className: Dialogs.DIALOG_BTN_CLASS_PRIMARY,
-                                id:        Dialogs.DIALOG_BTN_OK,
-                                text:      Strings.RELAUNCH_CHROME
-                            }
-                        ]
-                    )
-                        .done(function (id) {
-                            if (id === Dialogs.DIALOG_BTN_OK) {
-                                // User has chosen to reload Chrome, quit the running instance
-                                _setStatus(STATUS_INACTIVE);
-                                NativeApp.closeLiveBrowser()
-                                    .done(function () {
-                                        browserStarted = false;
-                                        window.setTimeout(function () {
-                                            open().done(result.resolve).fail(result.reject);
-                                        });
-                                    })
-                                    .fail(function (err) {
-                                        // Report error?
-                                        _setStatus(STATUS_ERROR);
-                                        browserStarted = false;
-                                        result.reject("CLOSE_LIVE_BROWSER");
-                                    });
-                            } else {
-                                result.reject("CANCEL");
-                            }
-                        });
-                    return;
-                }
-                retryCount++;
-
-                if (!browserStarted && exports.status !== STATUS_ERROR) {
-                    NativeApp.openLiveBrowser(
-                        launcherUrl,
-                        true        // enable remote debugging
-                    )
-                        .done(function () {
-                            browserStarted = true;
-                        })
-                        .fail(function (err) {
-                            var message;
-
-                            _setStatus(STATUS_ERROR);
-                            if (err === NativeFileError.NOT_FOUND_ERR) {
-                                message = Strings.ERROR_CANT_FIND_CHROME;
-                            } else {
-                                message = StringUtils.format(Strings.ERROR_LAUNCHING_BROWSER, err);
-                            }
-                            
-                            // Append a message to direct users to the troubleshooting page.
-                            if (message) {
-                                message += " " + StringUtils.format(Strings.LIVE_DEVELOPMENT_TROUBLESHOOTING, brackets.config.troubleshoot_url);
-                            }
-
-                            Dialogs.showModalDialog(
-                                DefaultDialogs.DIALOG_ID_ERROR,
-                                Strings.ERROR_LAUNCHING_BROWSER_TITLE,
-                                message
-                            );
-
-                            result.reject("OPEN_LIVE_BROWSER");
-                        });
-                }
-                    
-                if (exports.status !== STATUS_ERROR) {
-                    window.setTimeout(function retryConnect() {
-                        Inspector.connectToURL(launcherUrl).done(result.resolve).fail(onConnectFail);
-                    }, 500);
-                }
-            });
-        }
-        
-        if (!doc || !doc.root) {
-            showWrongDocError();
-        } else {
-            _serverProvider = LiveDevServerManager.getProvider(doc.file.fullPath);
-            
-            if (!exports.config.experimental && !_serverProvider) {
-                if (FileUtils.isServerHtmlFileExt(doc.extension)) {
-                    showNeedBaseUrlError();
-                } else if (!FileUtils.isStaticHtmlFileExt(doc.extension)) {
-                    showWrongDocError();
-                } else {
-                    doLaunchAfterServerReady();   // fall-back to file://
-                }
-            } else {
-                var readyPromise = _serverProvider.readyToServe();
-                if (!readyPromise) {
-                    showLiveDevServerNotReadyError();
-                } else {
-                    readyPromise.then(
-                        doLaunchAfterServerReady,
-                        showLiveDevServerNotReadyError
-                    );
-                }
-            }
-        }
-
-        return promise;
+        loadAgents();
     }
 
     /**
@@ -786,36 +667,16 @@ define(function LiveDevelopment(require, exports, module) {
         } else {
             cleanup();
         }
+
+        if (_openDeferred && _openDeferred.state() === "pending") {
+            _openDeferred.reject();
+        }
         
         return deferred.promise();
     }
     
-    /** Enable highlighting */
-    function showHighlight() {
-        var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
-        
-        if (doc instanceof CSSDocument) {
-            doc.updateHighlight();
-        }
-    }
-
-    /** Hide any active highlighting */
-    function hideHighlight() {
-        if (Inspector.connected() && agents.highlight) {
-            agents.highlight.hide();
-        }
-    }
-    
-    /** Redraw highlights **/
-    function redrawHighlight() {
-        if (Inspector.connected() && agents.highlight) {
-            agents.highlight.redraw();
-        }
-    }
-    
     /** Triggered by Inspector.connect */
     function _onConnect(event) {
-        
         /* 
          * Create a promise that resolves when the interstitial page has
          * finished loading.
@@ -862,19 +723,24 @@ define(function LiveDevelopment(require, exports, module) {
         function onInterstitialPageLoad() {
             // Page domain must be enabled first before loading other agents
             Inspector.Page.enable().done(function () {
-                // Load the right document (some agents are waiting for the page's load event)
+                // Some agents (e.g. DOMAgent and RemoteAgent) require us to
+                // navigate to the page first before loading can complete.
+                // To accomodate this, we load all agents and navigate in
+                // parallel.
+                loadAgents();
+
                 var doc = _getCurrentDocument();
                 if (doc) {
+                    // Navigate from interstitial to the document
+                    // Fires a frameNavigated event
                     Inspector.Page.navigate(doc.root.url);
                 } else {
+                    // Unlikely that we would get to this state where
+                    // a connection is in process but there is no current
+                    // document
                     close();
                 }
             });
-
-            // Load agents
-            _setStatus(STATUS_LOADING_AGENTS);
-            var promises = loadAgents();
-            $.when.apply(undefined, promises).done(_onLoad).fail(_onError);
         }
         
         $(Inspector.Page).on("frameNavigated.livedev", _onFrameNavigated);
@@ -882,6 +748,7 @@ define(function LiveDevelopment(require, exports, module) {
         waitForInterstitialPageLoad()
             .fail(function () {
                 close();
+
                 Dialogs.showModalDialog(
                     DefaultDialogs.DIALOG_ID_ERROR,
                     Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
@@ -889,6 +756,204 @@ define(function LiveDevelopment(require, exports, module) {
                 );
             })
             .done(onInterstitialPageLoad);
+    }
+
+    /** Open the Connection and go live */
+    function open() {
+        _openDeferred = new $.Deferred();
+
+        var promise = _openDeferred.promise(),
+            doc = _getCurrentDocument(),
+            browserStarted = false,
+            retryCount = 0;
+
+        _closeReason = null;
+
+        function showWrongDocError() {
+            Dialogs.showModalDialog(
+                DefaultDialogs.DIALOG_ID_ERROR,
+                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
+                Strings.LIVE_DEV_NEED_HTML_MESSAGE
+            );
+            _openDeferred.reject();
+        }
+
+        function showNeedBaseUrlError() {
+            PreferencesDialogs.showProjectPreferencesDialog("", Strings.LIVE_DEV_NEED_BASEURL_MESSAGE)
+                .done(function (id) {
+                    if (id === Dialogs.DIALOG_BTN_OK && ProjectManager.getBaseUrl()) {
+                        // If base url is specifed, then re-invoke open() to continue
+                        open();
+                    } else {
+                        _openDeferred.reject();
+                    }
+                });
+        }
+
+        function showLiveDevServerNotReadyError() {
+            Dialogs.showModalDialog(
+                DefaultDialogs.DIALOG_ID_ERROR,
+                Strings.LIVE_DEVELOPMENT_ERROR_TITLE,
+                Strings.LIVE_DEV_SERVER_NOT_READY_MESSAGE
+            );
+            _openDeferred.reject();
+        }
+        
+        // helper function that actually does the launch once we are sure we have
+        // a doc and the server for that doc is up and running.
+        function doLaunchAfterServerReady() {
+            _setStatus(STATUS_CONNECTING);
+            
+            _openDocument(doc, EditorManager.getCurrentFullEditor());
+
+            // Install a one-time event handler when connected to the launcher page
+            $(Inspector).one("connect", _onConnect);
+
+            // Open the live browser if the connection fails, retry 6 times
+            Inspector.connectToURL(launcherUrl).fail(function onConnectFail(err) {
+                if (err === "CANCEL") {
+                    _openDeferred.reject(err);
+                    return;
+                }
+
+                if (retryCount > 6) {
+                    _setStatus(STATUS_ERROR);
+
+                    var dialogPromise = Dialogs.showModalDialog(
+                        DefaultDialogs.DIALOG_ID_LIVE_DEVELOPMENT,
+                        Strings.LIVE_DEVELOPMENT_RELAUNCH_TITLE,
+                        Strings.LIVE_DEVELOPMENT_ERROR_MESSAGE,
+                        [
+                            {
+                                className: Dialogs.DIALOG_BTN_CLASS_LEFT,
+                                id:        Dialogs.DIALOG_BTN_CANCEL,
+                                text:      Strings.CANCEL
+                            },
+                            {
+                                className: Dialogs.DIALOG_BTN_CLASS_PRIMARY,
+                                id:        Dialogs.DIALOG_BTN_OK,
+                                text:      Strings.RELAUNCH_CHROME
+                            }
+                        ]
+                    );
+
+                    dialogPromise.done(function (id) {
+                        if (id === Dialogs.DIALOG_BTN_OK) {
+                            // User has chosen to reload Chrome, quit the running instance
+                            _setStatus(STATUS_INACTIVE);
+                            NativeApp.closeLiveBrowser()
+                                .done(function () {
+                                    browserStarted = false;
+                                    window.setTimeout(function () {
+                                        open().fail(_openDeferred.reject);
+                                    });
+                                })
+                                .fail(function (err) {
+                                    // Report error?
+                                    _setStatus(STATUS_ERROR);
+                                    browserStarted = false;
+                                    _openDeferred.reject("CLOSE_LIVE_BROWSER");
+                                });
+                        } else {
+                            _openDeferred.reject("CANCEL");
+                        }
+                    });
+
+                    return;
+                }
+                retryCount++;
+
+                if (!browserStarted && exports.status !== STATUS_ERROR) {
+                    NativeApp.openLiveBrowser(
+                        launcherUrl,
+                        true        // enable remote debugging
+                    )
+                        .done(function () {
+                            browserStarted = true;
+                        })
+                        .fail(function (err) {
+                            var message;
+
+                            _setStatus(STATUS_ERROR);
+                            if (err === NativeFileError.NOT_FOUND_ERR) {
+                                message = Strings.ERROR_CANT_FIND_CHROME;
+                            } else {
+                                message = StringUtils.format(Strings.ERROR_LAUNCHING_BROWSER, err);
+                            }
+                            
+                            // Append a message to direct users to the troubleshooting page.
+                            if (message) {
+                                message += " " + StringUtils.format(Strings.LIVE_DEVELOPMENT_TROUBLESHOOTING, brackets.config.troubleshoot_url);
+                            }
+
+                            Dialogs.showModalDialog(
+                                DefaultDialogs.DIALOG_ID_ERROR,
+                                Strings.ERROR_LAUNCHING_BROWSER_TITLE,
+                                message
+                            );
+
+                            _openDeferred.reject("OPEN_LIVE_BROWSER");
+                        });
+                }
+                    
+                if (exports.status !== STATUS_ERROR) {
+                    window.setTimeout(function retryConnect() {
+                        Inspector.connectToURL(launcherUrl).fail(onConnectFail);
+                    }, 500);
+                }
+            });
+        }
+        
+        if (!doc || !doc.root) {
+            showWrongDocError();
+        } else {
+            _serverProvider = LiveDevServerManager.getProvider(doc.file.fullPath);
+            
+            if (!exports.config.experimental && !_serverProvider) {
+                if (FileUtils.isServerHtmlFileExt(doc.extension)) {
+                    showNeedBaseUrlError();
+                } else if (!FileUtils.isStaticHtmlFileExt(doc.extension)) {
+                    showWrongDocError();
+                } else {
+                    doLaunchAfterServerReady();   // fall-back to file://
+                }
+            } else {
+                var readyPromise = _serverProvider.readyToServe();
+                if (!readyPromise) {
+                    showLiveDevServerNotReadyError();
+                } else {
+                    readyPromise.then(
+                        doLaunchAfterServerReady,
+                        showLiveDevServerNotReadyError
+                    );
+                }
+            }
+        }
+
+        return promise;
+    }
+    
+    /** Enable highlighting */
+    function showHighlight() {
+        var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
+        
+        if (doc instanceof CSSDocument) {
+            doc.updateHighlight();
+        }
+    }
+
+    /** Hide any active highlighting */
+    function hideHighlight() {
+        if (Inspector.connected() && agents.highlight) {
+            agents.highlight.hide();
+        }
+    }
+    
+    /** Redraw highlights **/
+    function redrawHighlight() {
+        if (Inspector.connected() && agents.highlight) {
+            agents.highlight.redraw();
+        }
     }
 
     /** Triggered by a document change from the DocumentManager */
@@ -998,8 +1063,7 @@ define(function LiveDevelopment(require, exports, module) {
     /** Initialize the LiveDevelopment Session */
     function init(theConfig) {
         exports.config = theConfig;
-        $(Inspector).on("connect", _onConnect)
-            .on("disconnect", _onDisconnect)
+        $(Inspector).on("disconnect", _onDisconnect)
             .on("error", _onError);
         $(Inspector.Inspector).on("detached", _onDetached);
         $(DocumentManager).on("currentDocumentChange", _onDocumentChange)

--- a/src/LiveDevelopment/launch.html
+++ b/src/LiveDevelopment/launch.html
@@ -50,29 +50,10 @@
             margin: -55px auto 0;
             top: 50%;
         }
-        #spinner {
-            position: absolute;
-            top: 64px;
-            left: 22px;
-            width: 12px;
-            height: 12px;
-            background: url("../styles/images/small_spinner.svg");
-            -webkit-animation: rotating 1.5s linear infinite;
-        }
-        @-webkit-keyframes rotating {
-            0% {
-                -webkit-transform: rotate(0deg);
-            }
-
-            100% {
-                -webkit-transform: rotate(360deg);
-            }
-        }
     </style>
 </head>
 <body onload="handleLoad()">
     <div id="loading-image">
-        <div id="spinner"></div>
     </div>
 </body>
 

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -147,10 +147,10 @@ define(function (require, exports, module) {
             DOMAgent                : require("LiveDevelopment/Agents/DOMAgent"),
             Inspector               : require("LiveDevelopment/Inspector/Inspector"),
             NativeApp               : require("utils/NativeApp"),
+            ExtensionLoader         : ExtensionLoader,
             ExtensionUtils          : ExtensionUtils,
             UpdateNotification      : require("utils/UpdateNotification"),
             InstallExtensionDialog  : require("extensibility/InstallExtensionDialog"),
-            extensions              : {}, // place for extensions to hang modules for unit tests
             doneLoading             : false
         };
 

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -651,12 +651,6 @@ define(function (require, exports, module) {
 
     // Setup initial UI state
     setEnabled(prefs.getValue("enabled"));
-
-    AppInit.appReady(function () {
-        if (brackets.test) {
-            brackets.test.extensions.QuickView = module.exports;
-        }
-    });
     
     // For unit testing
     exports._queryPreviewProviders  = queryPreviewProviders;

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -32,7 +32,16 @@ define(function (require, exports, module) {
 
     describe("Quick View", function () {
         var testFolder = FileUtils.getNativeModuleDirectoryPath(module) + "/unittest-files/";
-        var testWindow, brackets, CommandManager, Commands, EditorManager, QuickView, editor;
+
+        // load from testWindow
+        var testWindow,
+            brackets,
+            extensionRequire,
+            CommandManager,
+            Commands,
+            EditorManager,
+            QuickView,
+            editor;
 
         beforeEach(function () {
             // Create a new window that will be shared by ALL tests in this spec.
@@ -42,10 +51,11 @@ define(function (require, exports, module) {
                         testWindow = w;
                         // Load module instances from brackets.test
                         brackets = testWindow.brackets;
-                        CommandManager = testWindow.brackets.test.CommandManager;
-                        Commands = testWindow.brackets.test.Commands;
+                        CommandManager = brackets.test.CommandManager;
+                        Commands = brackets.test.Commands;
                         EditorManager = brackets.test.EditorManager;
-                        QuickView = brackets.test.extensions.QuickView;
+                        extensionRequire = brackets.test.ExtensionLoader.getRequireContextForExtension("QuickView");
+                        QuickView = extensionRequire("main");
                     });
                 });
 

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      * A deferred which is resolved with a NodeConnection or rejected if
      * we are unable to connect to Node.
      */
-    var _nodeConnectionDeferred = $.Deferred();
+    var _nodeConnectionDeferred = new $.Deferred();
     
     /**
      * @private
@@ -228,10 +228,7 @@ define(function (require, exports, module) {
         return _nodeConnectionDeferred;
     }
     
-    AppInit.appReady(function () {
-        // Register as a Live Development server provider
-        LiveDevServerManager.registerProvider(_staticServerProvider, 5);
-        
+    function init() {
         // Start up the node connection, which is held in the
         // _nodeConnectionDeferred module variable. (Use 
         // _nodeConnectionDeferred.done() to access it.
@@ -260,6 +257,10 @@ define(function (require, exports, module) {
                     });
 
                     clearTimeout(connectionTimeout);
+
+                    // Register as a Live Development server provider
+                    LiveDevServerManager.registerProvider(_staticServerProvider, 5);
+
                     _nodeConnectionDeferred.resolveWith(null, [_nodeConnection]);
                 },
                 function () { // Failed to connect
@@ -268,11 +269,11 @@ define(function (require, exports, module) {
                 }
             );
         });
-        
-        if (brackets.test) {
-            brackets.test.extensions.StaticServer = module.exports;
-        }
-    });
+
+        return _nodeConnectionDeferred.promise();
+    }
+
+    exports.init = init;
 
     // For unit tests only
     exports._getStaticServerProvider = _getStaticServerProvider;

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
                 if (!nodeConnection) {
                     runs(function () {
                         // wait for StaticServer/main to connect and load the StaticServerDomain
-                        main._getNodeConnectionDeferred().done(function (conn) {
+                        main.init().done(function (conn) {
                             nodeConnection = conn;
                         });
 
@@ -517,23 +517,23 @@ define(function (require, exports, module) {
         describe("StaticServerProvider", function () {
             var brackets,
                 ProjectManager,
+                extensionRequire,
                 StaticServer;
             
             beforeEach(function () {
+                var ExtensionLoader;
+
                 runs(function () {
                     SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
                         // Load module instances from brackets.test
-                        brackets = testWindow.brackets;
-                        ProjectManager = testWindow.brackets.test.ProjectManager;
+                        brackets            = testWindow.brackets;
+                        ProjectManager      = testWindow.brackets.test.ProjectManager;
+                        extensionRequire    = brackets.test.ExtensionLoader.getRequireContextForExtension("StaticServer");
+                        StaticServer        = extensionRequire("main");
                     });
                 });
                 
-                waitsFor(function () {
-                    return brackets.test.extensions.StaticServer !== undefined;
-                }, "StaticServer to fully initialize");
-                
                 runs(function () {
-                    StaticServer = brackets.test.extensions.StaticServer;
                     waitsForDone(StaticServer._getNodeConnectionDeferred(), "connecting to node server", CONNECT_TIMEOUT);
                 });
             });

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -44,6 +44,7 @@ define(function (require, exports, module) {
         Async               = require("utils/Async");
     
     var _init       = false,
+        _extensions = {},
         /** @type {Object<string, Object>}  Stores require.js contexts of extensions */
         contexts    = {},
         srcPath     = FileUtils.getNativeBracketsDirectoryPath();
@@ -91,6 +92,7 @@ define(function (require, exports, module) {
      */
     function loadExtension(name, config, entryPoint) {
         var result = new $.Deferred(),
+            promise = result.promise(),
             extensionRequire = brackets.libRequire.config({
                 context: name,
                 baseUrl: config.baseUrl,
@@ -103,9 +105,23 @@ define(function (require, exports, module) {
         // console.log("[Extension] starting to load " + config.baseUrl);
         
         extensionRequire([entryPoint],
-            function () {
+            function (module) {
                 // console.log("[Extension] finished loading " + config.baseUrl);
-                result.resolve();
+                var initPromise;
+
+                _extensions[name] = module;
+
+                if (module && module.init && (typeof module.init === "function")) {
+                    // optional async extension init 
+                    initPromise = module.init();
+
+                    if (initPromise) {
+                        promise = initPromise.then(result.resolve, result.reject);
+                    }
+                } else {
+                    result.resolve();
+                }
+
                 $(exports).triggerHandler("load", config.baseUrl);
             },
             function errback(err) {
@@ -118,7 +134,7 @@ define(function (require, exports, module) {
                 $(exports).triggerHandler("loadFailed", config.baseUrl);
             });
         
-        return result.promise();
+        return promise;
     }
 
     /**
@@ -304,6 +320,7 @@ define(function (require, exports, module) {
         return promise;
     }
     
+    // public API
     exports.init = init;
     exports.getUserExtensionPath = getUserExtensionPath;
     exports.getRequireContextForExtension = getRequireContextForExtension;

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -287,6 +287,7 @@ define(function (require, exports, module) {
             function isBracketsDoneLoading() {
                 return _testWindow.brackets && _testWindow.brackets.test && _testWindow.brackets.test.doneLoading;
             },
+            "brackets.test.doneLoading",
             10000
         );
 


### PR DESCRIPTION
Fixes #3343:
- Guarantees extensions loading before app init completes
- Clean up async loading of Inspector agents
- Add 10s timeout to agent loading
- Remove duplicate code in live dev unit tests
- Fix Inspector startup sequence (enable page prior to enabling other agents)
- Remove missing asset from launcher/interstitial page

Squashed from #4093.
