### PR TITLE
Add support for W3 Gradients in QuickView

### DIFF
--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
 
         // Check for gradient. -webkit-gradient() can have parens in parameters
         // nested 2 levels. Other gradients can only nest 1 level.
-        var gradientRegEx = /-webkit-gradient\((?:[^\(]*?(?:\((?:[^\(]*?(?:\([^\)]*?\))*?)*?\))*?)*?\)|(?:(?:-moz-|-ms-|-o-|-webkit-|\s)(linear-gradient)|(?:-moz-|-ms-|-o-|-webkit-)(radial-gradient))(\((?:[^\)]*?(?:\([^\)]*?\))*?)*?\))/gi,
+        var gradientRegEx = /-webkit-gradient\((?:[^\(]*?(?:\((?:[^\(]*?(?:\([^\)]*?\))*?)*?\))*?)*?\)|(?:(?:-moz-|-ms-|-o-|-webkit-|\s)((repeating-)?linear-gradient)|(?:-moz-|-ms-|-o-|-webkit-|\s)((repeating-)?radial-gradient))(\((?:[^\)]*?(?:\([^\)]*?\))*?)*?\))/gi,
             colorRegEx = new RegExp(ColorUtils.COLOR_REGEX);
 
         function execGradientMatch(line) {
@@ -189,24 +189,22 @@ define(function (require, exports, module) {
                     // sass variable. Ignore it since it won't be displayed correctly.
                     gradientMatch = null;
     
-                } else if (gradientMatch[0].indexOf("to ") !== -1) {
-                    // If the gradient match has "to " in it, it's most likely the new gradient
-                    // syntax which is not supported until Chrome 26, so we can't yet preview it
-                    gradientMatch = null;
-
                 } else {
-                    // If it was a linear-gradient or radial-gradient variant, prefix with
-                    // "-webkit-" so it shows up correctly in Brackets.
-                    if (gradientMatch[0].indexOf("-webkit-gradient") !== 0) {
+                    // If it was a linear-gradient or radial-gradient variant with a vendor prefix 
+                    // add "-webkit-" so it shows up correctly in Brackets.
+                    if (gradientMatch[0].match(/-o-|-moz-|-ms-|-webkit-/i)) {
                         prefix = "-webkit-";
                     }
                     
                     // For prefixed gradients, use the non-prefixed value as the color value.
-                    // "-webkit-" will be added before this value
+                    // "-webkit-" will be added before this value later
                     if (gradientMatch[1]) {
-                        colorValue = gradientMatch[1] + gradientMatch[3];    // linear gradiant
-                    } else if (gradientMatch[2]) {
-                        colorValue = gradientMatch[2] + gradientMatch[3];    // radial gradiant
+                        colorValue = gradientMatch[1] + gradientMatch[5];    // linear gradiant
+                    } else if (gradientMatch[3]) {
+                        colorValue = gradientMatch[3] + gradientMatch[5];    // radial gradiant
+                    } else if (gradientMatch[0]) {
+                        colorValue = gradientMatch[0];                       // -webkit-gradient
+                        prefix = "";                                         // do not prefix
                     }
                 }
             }

--- a/src/extensions/default/QuickView/unittest-files/test.css
+++ b/src/extensions/default/QuickView/unittest-files/test.css
@@ -162,4 +162,6 @@ background: -ms-linear-gradient(top,  #d2dfed 0%,#c8d7eb 26%,#bed0ea 51%,#a6c0e3
 
 .pixelGradient {
     background: -webkit-linear-gradient(top, rgba(0,0,0,0) 0%, green 300px, red 600px); 
+    background-image: repeating-linear-gradient(red, blue 20px, red 40px);
+    background-image: repeating-radial-gradient(red, blue 20px, red 40px);    
 }

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -201,19 +201,17 @@ define(function (require, exports, module) {
 
             it("Should show linear gradient preview for those with w3c standard syntax (no prefix)", function () {
                 runs(function () {
-                    checkGradientAtPos("-webkit-linear-gradient(#333, #CCC)",                  99, 50);
-                    checkGradientAtPos("-webkit-linear-gradient(135deg, #333, #CCC)",          101, 50);
+                    checkGradientAtPos("linear-gradient(#333, #CCC)",                  99, 50);
+                    checkGradientAtPos("linear-gradient(135deg, #333, #CCC)",          101, 50);
 
-                    // TODO (#3458): Keyword "to" not supported until Brackets upgrades to Chrome 26
-                    //checkGradientAtPos("-webkit-linear-gradient(to right, #333, #CCC)",        98, 50);
-                    //checkGradientAtPos("-webkit-linear-gradient(to bottom right, #333, #CCC)", 100, 50);
-                    expectNoPreviewAtPos(98, 50);
-                    expectNoPreviewAtPos(100, 50);
+                    checkGradientAtPos("linear-gradient(to right, #333, #CCC)",        98, 50);
+                    checkGradientAtPos("linear-gradient(to bottom right, #333, #CCC)", 100, 50);
+
 
                     // multiple colors
-                    checkGradientAtPos("-webkit-linear-gradient(#333, #CCC, #333)",             104, 50);
-                    checkGradientAtPos("-webkit-linear-gradient(#333 0%, #CCC 33%, #333 100%)", 105, 50);
-                    checkGradientAtPos("-webkit-linear-gradient(yellow, blue 20%, #0f0)",       106, 50);
+                    checkGradientAtPos("linear-gradient(#333, #CCC, #333)",             104, 50);
+                    checkGradientAtPos("linear-gradient(#333 0%, #CCC 33%, #333 100%)", 105, 50);
+                    checkGradientAtPos("linear-gradient(yellow, blue 20%, #0f0)",       106, 50);
                 });
             });
 
@@ -231,57 +229,45 @@ define(function (require, exports, module) {
 
             it("Should show radial gradient preview for those with w3c standard syntax (no prefix)", function () {
                 runs(function () {
-                    // TODO (#3458): support new W3C syntax
-//                    checkGradientAtPos("-webkit-radial-gradient(yellow, green)", 118, 35);
-//                    checkGradientAtPos("-webkit-radial-gradient(yellow, green)", 118, 40);
-
-                    // For now the color stops are just previewed in isolation
-                    expectNoPreviewAtPos(118, 35);
-                    checkColorAtPos("yellow", 118, 40);
+                    checkGradientAtPos("radial-gradient(yellow, green)", 118, 35);
+                    checkGradientAtPos("radial-gradient(yellow, green)", 118, 40);
                 });
             });
 
             it("Should show repeating linear gradient preview", function () {
                 runs(function () {
-                    // TODO (#3458): support repeat
-//                    checkGradientAtPos("repeating-linear-gradient(red, blue 20px, red 40px)", 122, 50);
-//                    checkGradientAtPos("repeating-linear-gradient(red 0px, white 0px, blue 0px)", 123, 50);
-//                    checkGradientAtPos("repeating-linear-gradient(red 0px, white .1px, blue .2px)", 124, 50);
-
-                    // For now the color stops are just previewed in isolation
-                    expectNoPreviewAtPos(122, 35);
-                    expectNoPreviewAtPos(123, 35);
-                    expectNoPreviewAtPos(124, 35);
-                    checkColorAtPos("red", 122, 50);
+                    checkGradientAtPos("repeating-linear-gradient(red, blue 50%, red 100%)", 122, 50);
+                    checkGradientAtPos("repeating-linear-gradient(red 0%, white 0%, blue 0%)", 123, 50);
+                    checkGradientAtPos("repeating-linear-gradient(red 0%, white 5%, blue 10%)", 124, 50);
                 });
             });
 
             it("Should show repeating radial gradient preview", function () {
                 runs(function () {
-                    // TODO (#3458): support repeat
-//                    checkGradientAtPos("repeating-radial-gradient(circle closest-side at 20px 30px, red, yellow, green 100%, yellow 150%, red 200%)", 128, 40);
-//                    checkGradientAtPos("repeating-radial-gradient(red, blue 20px, red 40px)", 129, 40);
-
-                    expectNoPreviewAtPos(128, 40);
-                    expectNoPreviewAtPos(129, 40);
+                    checkGradientAtPos("repeating-radial-gradient(circle closest-side at 20px 30px, red, yellow, green 100%, yellow 150%, red 200%)", 128, 40);
+                    checkGradientAtPos("repeating-radial-gradient(red, blue 50%, red 100%)", 129, 40);
                 });
             });
 
             it("Should show comma-separated gradients", function () {
                 runs(function () {
                     // line ending in comma
-                    checkGradientAtPos("-webkit-linear-gradient(63deg, #999 23%, transparent 23%)", 135,  50);
+                    checkGradientAtPos("linear-gradient(63deg, #999 23%, transparent 23%)", 135,  50);
 
                     // multiple gradients on a line
-                    checkGradientAtPos("-webkit-linear-gradient(63deg, transparent 74%, #999 78%)", 136,  50);
-                    checkGradientAtPos("-webkit-linear-gradient(63deg, transparent 0%, #999 38%, #999 58%, transparent 100%)",   136, 100);
+                    checkGradientAtPos("linear-gradient(63deg, transparent 74%, #999 78%)", 136,  50);
+                    checkGradientAtPos("linear-gradient(63deg, transparent 0%, #999 38%, #999 58%, transparent 100%)",   136, 100);
                 });
             });
             
             it("Should should convert gradients arguments from pixel to percent", function () {
                 runs(function () {
-                    // line ending in comma
+                    // linear gradient in px
                     checkGradientAtPos("-webkit-linear-gradient(top, rgba(0,0,0,0) 0%, green 50%, red 100%)", 163, 40);
+                    // repeating linear-gradient in pixels (no prefix)
+                    checkGradientAtPos("repeating-linear-gradient(red, blue 50%, red 100%)", 164, 40);
+                    // repeating radial-gradient in pixels (no prefix)
+                    checkGradientAtPos("repeating-radial-gradient(red, blue 50%, red 100%)", 165, 40);
                 });
             });
         });


### PR DESCRIPTION
- Fixes issue #3458
- Requires  CEF3.1453.1255 / Chromium 27.0.1453.73. which has support for W3 and -web-kit tags for gradients. the W3 (or unprefixed) have a different syntax in some situations and are not compatible.  This is in master

This pull request removes the incompatibility such that unprefixed tags are not given a -webkit- prefix and are previewed verbatim and the -moz-,-o-,-ms- tags are prefixed with -webkit- since their syntaxes are interchangeable but brackets' shell only displays -webkit- variants. .
