### PR TITLE
REVIEW ONLY: Better way to get marker at pos

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -180,24 +180,36 @@ define(function (require, exports, module) {
         var i,
             cm = editor._codeMirror,
             marks = cm.findMarksAt(pos),
-            match;
-        
-        var _distance = function (mark) {
+            match,
+            matchLength,
+            test,
+            indexPos = cm.indexFromPos(pos);
+
+        var _contains = function (mark) {
             var markerLoc = mark.find();
             if (markerLoc) {
-                var markPos = markerLoc.from;
-                return (cm.indexFromPos(pos) - cm.indexFromPos(markPos));
-            } else {
-                return Number.MAX_VALUE;
+                var indexFrom = cm.indexFromPos(markerLoc.from),
+                    indexTo   = cm.indexFromPos(markerLoc.to);
+                if (indexFrom <= indexPos && indexPos <= indexTo) {
+                    return { contains: true, length: (indexTo - indexFrom) };
+                }
             }
+
+            return { contains: false };
         };
+
         
         for (i = 0; i < marks.length; i++) {
-            if (!match) {
-                match = marks[i];
-            } else {
-                if (_distance(marks[i]) < _distance(match)) {
+            test = _contains(marks[i]);
+            if (test.contains) {
+                if (!match) {
                     match = marks[i];
+                    matchLength = test.length;
+                } else {
+                    if (test.length < matchLength) {
+                        match = marks[i];
+                        matchLength = test.length;
+                    }
                 }
             }
         }


### PR DESCRIPTION
DON'T MERGE THIS YET -- it breaks as many tests as if fixed, and the units tests haven't been updated yet anyway.

Reading the intent of the test, I think this is how we want to "get marker at pos", but maybe I'm misunderstanding the intent.

The existing code measures "distance" from start of range, which I don't think that we want, but it seems to work in some cases because setting the **text marker seems to be broken for empty tags** (e.g. `<meta>`, `<link>`, `<img />`). They extend to EOF.
