### PR TITLE
Some preparatory work for incremental update

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -259,6 +259,7 @@ define(function (require, exports, module) {
         var token;
         var stack = this.stack;
         var attributeName = null;
+        var nodeMap = {};
         
         while ((token = this.t.nextToken()) !== null) {
             if (!token.contents) {
@@ -273,6 +274,7 @@ define(function (require, exports, module) {
                     weight: 0
                 };
                 newTag.tagID = this.getID(newTag);
+                nodeMap[newTag.tagID] = newTag;
                 if (newTag.parent) {
                     newTag.parent.children.push(newTag);
                 }
@@ -317,7 +319,9 @@ define(function (require, exports, module) {
             }
         }
         
-        return stack.length ? stack[0] : this.lastTag;
+        var dom = (stack.length ? stack[0] : this.lastTag);
+        dom.nodeMap = nodeMap;
+        return dom;
     };
     
     SimpleDOMBuilder.prototype.getID = function () {

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -519,6 +519,27 @@ define(function (require, exports, module) {
                 elementIds = {};
             });
             
+            function doFullAndIncrementalEditTest(editFn, expectationFn) {
+                var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText()),
+                    changeList,
+                    result;
+                HTMLInstrumentation._markTextFromDOM(editor, previousDOM);
+                $(editor).on("change.instrtest", function (event, editor, change) {
+                    changeList = change;
+                });
+                editFn(editor, previousDOM);
+                $(editor).off(".instrtest");
+                
+                // full test
+                result = HTMLInstrumentation._updateDOM(previousDOM, editor);
+                expectationFn(result, previousDOM);
+                
+                // incremental test
+                result = HTMLInstrumentation._updateDOM(previousDOM, editor, changeList);
+                // TODO: how to test that only an appropriate subtree was reparsed/diffed?
+                expectationFn(result, previousDOM);
+            }
+            
             it("should re-instrument after document is dirtied", function () {
                 runs(function () {
                     var pos = {line: 15, ch: 0};
@@ -575,65 +596,85 @@ define(function (require, exports, module) {
             
             it("should handle attribute change", function () {
                 runs(function () {
-                    var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText());
-                    HTMLInstrumentation._markTextFromDOM(editor, previousDOM);
-                    editor.document.replaceRange(", awesome", { line: 7, ch: 56 });
-                    var result = HTMLInstrumentation._updateDOM(previousDOM, editor);
-                    expect(result.edits.length).toEqual(1);
-                    expect(result.edits[0]).toEqual({
-                        type: "attrChange",
-                        tagID: previousDOM.children[1].children[7].tagID,
-                        attribute: "content",
-                        value: "An interactive, awesome getting started guide for Brackets."
-                    });
+                    var tagID;
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange(", awesome", { line: 7, ch: 56 });
+                            tagID = previousDOM.children[1].children[7].tagID;
+                        },
+                        function (result, previousDOM) {
+                            expect(result.edits.length).toEqual(1);
+                            expect(result.edits[0]).toEqual({
+                                type: "attrChange",
+                                tagID: tagID,
+                                attribute: "content",
+                                value: "An interactive, awesome getting started guide for Brackets."
+                            });
+                        }
+                    );
                 });
             });
             
             it("should handle new attributes", function () {
                 runs(function () {
-                    var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText());
-                    HTMLInstrumentation._markTextFromDOM(editor, previousDOM);
-                    editor.document.replaceRange(" class='supertitle'", { line: 12, ch: 3 });
-                    var result = HTMLInstrumentation._updateDOM(previousDOM, editor);
-                    expect(result.edits.length).toEqual(1);
-                    expect(result.edits[0]).toEqual({
-                        type: "attrAdd",
-                        tagID: previousDOM.children[3].children[1].tagID,
-                        attribute: "class",
-                        value: "supertitle"
-                    });
+                    var tagID;
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange(" class='supertitle'", { line: 12, ch: 3 });
+                            tagID = previousDOM.children[3].children[1].tagID;
+                        },
+                        function (result, previousDOM) {
+                            expect(result.edits.length).toEqual(1);
+                            expect(result.edits[0]).toEqual({
+                                type: "attrAdd",
+                                tagID: tagID,
+                                attribute: "class",
+                                value: "supertitle"
+                            });
+                        }
+                    );
                 });
             });
             
             it("should handle deleted attributes", function () {
                 runs(function () {
-                    var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText());
-                    HTMLInstrumentation._markTextFromDOM(editor, previousDOM);
-                    editor.document.replaceRange("", {line: 7, ch: 32}, {line: 7, ch: 93});
-                    var result = HTMLInstrumentation._updateDOM(previousDOM, editor);
-                    expect(result.edits.length).toEqual(1);
-                    expect(result.edits[0]).toEqual({
-                        type: "attrDel",
-                        tagID: previousDOM.children[1].children[7].tagID,
-                        attribute: "content"
-                    });
+                    var tagID;
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange("", {line: 7, ch: 32}, {line: 7, ch: 93});
+                            tagID = previousDOM.children[1].children[7].tagID;
+                        },
+                        function (result, previousDOM) {
+                            expect(result.edits.length).toEqual(1);
+                            expect(result.edits[0]).toEqual({
+                                type: "attrDel",
+                                tagID: tagID,
+                                attribute: "content"
+                            });
+                        }
+                    );
                 });
             });
             
             it("should handle simple altered text", function () {
                 runs(function () {
-                    var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText());
-                    HTMLInstrumentation._markTextFromDOM(editor, previousDOM);
-                    editor.document.replaceRange("AWESOMER", {line: 12, ch: 12}, {line: 12, ch: 19});
-                    var result = HTMLInstrumentation._updateDOM(previousDOM, editor);
-                    expect(result.edits.length).toEqual(1);
-                    expect(previousDOM.children[3].children[1].tag).toEqual("h1");
-                    expect(result.edits[0]).toEqual({
-                        type: "textReplace",
-                        tagID: previousDOM.children[3].children[1].tagID,
-                        child: 0,
-                        content: "GETTING AWESOMER WITH BRACKETS"
-                    });
+                    var tagID;
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange("AWESOMER", {line: 12, ch: 12}, {line: 12, ch: 19});
+                            tagID = previousDOM.children[3].children[1].tagID;
+                        },
+                        function (result, previousDOM) {
+                            expect(result.edits.length).toEqual(1);
+                            expect(previousDOM.children[3].children[1].tag).toEqual("h1");
+                            expect(result.edits[0]).toEqual({
+                                type: "textReplace",
+                                tagID: tagID,
+                                child: 0,
+                                content: "GETTING AWESOMER WITH BRACKETS"
+                            });
+                        }
+                    );
                 });
             });
             

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -551,6 +551,7 @@ define(function (require, exports, module) {
                     expect(titleContents.parent.weight).toEqual(29);
                     expect(titleContents.signature).toEqual(MurmurHash3.hashString(titleContents.content, titleContents.content.length, HTMLInstrumentation._seed));
                     expect(dom.children[1].parent).toEqual(dom);
+                    expect(dom.nodeMap[meta.tagID]).toBe(meta);
                 });
             });
             


### PR DESCRIPTION
@dangoor 

The first commit is straightforward--just adds an id->node map at the root of the DOM tree.

The second commit refactors the various edit tests to basically run them twice: once doing a full diff, the other capturing the changelist from the editor and passing that into `_updateDOM()`, making sure that we get the right tree edits in both cases. These tests still pass even though I haven't actually added the incremental update code yet, since the changelist is just ignored, so the "incremental" test is really just running the full diff again.

Not sure if you want to take that second one, but if it makes sense to you, I thought it would be good to go ahead and get this in so any new tests you write for editing functionality can follow the same pattern.

(Note that I made another change to the tests, to store any values from `previousDOM` that we want to test before actually doing the update. This is anticipating the fact that if we change the DOMUpdater in the way I suggested in my email to you, we can't compare to `previousDOM` after the update has occurred, since it will have been mutated to become the new DOM anyway.)
