### PR TITLE
Wait for inspector domains to acknowledge "enable" before attempting to load agents

### DIFF
--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -71,16 +71,21 @@ define(function ConsoleAgent(require, exports, module) {
     function _onMessagesCleared(event, res) {
         // res = {}
     }
+    
+    /**
+     * Enable the inspector Console domain
+     * @return {jQuery.Promise} A promise resolved when the Console.enable() command is successful.
+     */
+    function enable() {
+        return Inspector.Console.enable();
+    }
 
     /** Initialize the agent */
     function load() {
-        // FIXME Windows only: Somtimes enable() isn't acknowledged
-        return Inspector.retry(Inspector.Console.enable).done(function () {
-            $(Inspector.Console)
-                .on("messageAdded.ConsoleAgent", _onMessageAdded)
-                .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
-                .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
-        });
+        $(Inspector.Console)
+            .on("messageAdded.ConsoleAgent", _onMessageAdded)
+            .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
+            .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
     }
 
     /** Clean up */
@@ -89,6 +94,7 @@ define(function ConsoleAgent(require, exports, module) {
     }
 
     // Export public functions
+    exports.enable = enable;
     exports.load = load;
     exports.unload = unload;
 });

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -69,17 +69,21 @@ define(function NetworkAgent(require, exports, module) {
         // res = {frame}
         _logURL(res.frame.url);
     }
+    
+    /**
+     * Enable the inspector Network domain
+     * @return {jQuery.Promise} A promise resolved when the Network.enable() command is successful.
+     */
+    function enable() {
+        return Inspector.Network.enable();
+    }
 
     /** Initialize the agent */
     function load() {
         _urlRequested = {};
 
         $(Inspector.Page).on("frameNavigated.NetworkAgent", _onFrameNavigated);
-
-        // FIXME Windows only: Somtimes enable() isn't acknowledged
-        return Inspector.retry(Inspector.Network.enable).done(function () {
-            $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
-        });
+        $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
     }
 
     /** Unload the agent */
@@ -90,6 +94,7 @@ define(function NetworkAgent(require, exports, module) {
 
     // Export public functions
     exports.wasURLRequested = wasURLRequested;
+    exports.enable = enable;
     exports.load = load;
     exports.unload = unload;
 });

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -333,33 +333,6 @@ define(function Inspector(require, exports, module) {
         return _socket !== undefined && _socket.readyState === WebSocket.OPEN;
     }
 
-    function retry(fn, interval, retryCount) {
-        var deferred = new $.Deferred(),
-            countdown = retryCount || 4;
-
-        interval = interval || 250;
-
-        function _doRetry() {
-            // FIXME Windows only: Somtimes methods (e.g. Console.enable()) aren't acknowledged
-            Async.withTimeout(fn.call(), interval).done(function () {
-                deferred.resolve();
-            }).fail(function () {
-                countdown--;
-
-                if (countdown <= 0) {
-                    deferred.reject("Failed after " + retryCount + " tries");
-                    return;
-                }
-
-                _doRetry();
-            });
-        }
-
-        _doRetry();
-
-        return deferred.promise();
-    }
-
     /** Initialize the Inspector
      * Read the Inspector.json configuration and define the command objects
      * -> Inspector.domain.command()
@@ -389,6 +362,5 @@ define(function Inspector(require, exports, module) {
     exports.connect = connect;
     exports.connectToURL = connectToURL;
     exports.connected = connected;
-    exports.retry = retry;
     exports.init = init;
 });


### PR DESCRIPTION
Explicitly enable Console and Network domains before navigating to live preview URL. Remote retry workaround. Fixes #4111.
