### PR TITLE
[ResearchLiveHTML] Initial implementation of incremental update

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -153,7 +153,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         // Only handles attribute changes currently.
         // TODO: text changes should be easy to add
         // TODO: if new tags are added, need to instrument them
-        var edits = HTMLInstrumentation.getUnappliedEditList(editor);
+        var edits = HTMLInstrumentation.getUnappliedEditList(editor, change);
         edits.forEach(function (edit) {
             // Silly naming convention: $$ = remote $
             var $$target = RemoteAgent.remoteElement(edit.tagID);

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -452,8 +452,7 @@ define(function (require, exports, module) {
                 // default result if we didn't identify a changed portion
                 newDOM: newSubtree,
                 oldSubtree: this.previousDOM,
-                newSubtree: newSubtree,
-                subtreeOffset: 0
+                newSubtree: newSubtree
             };
 
         if (this.changedTagID) {


### PR DESCRIPTION
- `_updateDOM` now takes an optional CodeMirror change record. If specified, it tries to do an incremental update of just the range affected by the change.
- `DOMUpdater` takes that change record, and if it can determine that the affected range is a single subtree, it only rebuilds that subtree and substitutes it into the original tree, updating the id->node map and parent signatures.
- To make that easier, refactored out the signature computation into `_updateHash()`.
- Added a callback for `onopentagend` from the tokenizer so we can detect when an empty tag like `<meta>` is closed and set its end position properly (this fixes the problem Randy noted and is also necessary for some of the unit tests that edit empty tags to pass).
- Updated `SimpleDOMBuilder` to take a start offset, so that if it's only rebuilding a portion of the tree, the node start/end offsets it calculates are property relative to the full document rather than just the rebuilt portion.

I added some unit tests around these cases, but haven't added really granular unit tests to make sure that the new offsets are being properly calculated, etc. Manual testing also suggests that it's basically working, at least as long as you're only editing existing text or attributes rather than adding new things.
