### PR TITLE
Allow linux shell to use html menus

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -267,6 +267,11 @@ define(function (require, exports, module) {
         } else {
             $("body").addClass("in-appshell");
         }
+
+        // Enable/Disable HTML Menus
+        if (brackets.platform !== "linux") {
+            $("body").addClass("has-appshell-menu");
+        }
         
         // Localize MainViewHTML and inject into <BODY> tag
         $("body").html(Mustache.render(MainViewHTML, Strings));

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -270,7 +270,7 @@ define(function (require, exports, module) {
 
         // Enable/Disable HTML Menus
         if (brackets.platform !== "linux") {
-            $("body").addClass("has-appshell-menu");
+            $("body").addClass("has-appshell-menus");
         }
         
         // Localize MainViewHTML and inject into <BODY> tag

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     }
     
     function _isHTMLMenu(id) {
-        return (brackets.inBrowser || _isContextMenu(id));
+        return (brackets.platform === "linux") || (brackets.inBrowser || _isContextMenu(id));
     }
 
     /**

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     }
     
     function _isHTMLMenu(id) {
-        return (brackets.platform === "linux") || (brackets.inBrowser || _isContextMenu(id));
+        return (!$("body").hasClass("has-appshell-menus") || brackets.inBrowser) || _isContextMenu(id);
     }
 
     /**

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -82,7 +82,7 @@
 */
 #titlebar {
     // Visible only in-browser
-    body.in-appshell & {
+    body.has-appshell-menus & {
         display: none;
     }
     


### PR DESCRIPTION
Check `brackets.platform` when adding native menu support.
