### PR TITLE
Cleanup File I/O tests

### DIFF
--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
      * Opens a URL in the system default browser
      */
     function openURLInDefaultBrowser(url) {
-        brackets.app.openURLInDefaultBrowser(function (err) {}, url);
+        brackets.app.openURLInDefaultBrowser(url);
     }
     
 


### PR DESCRIPTION
- Makes callback arguments optional on some fs and native menu apis
- Adds support to permenantly delete folders
- Fixes #4272
