### PR TITLE
replace FileUtils.parseUrl with own implementation getParent

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -621,7 +621,7 @@ define(function (require, exports, module) {
                 return doSave(doc);
             }
             // now save new document
-            var newPath = FileUtils.getParent(path);
+            var newPath = FileUtils.getDirectoryPath(path);
             // create empty file,  FileUtils.writeText will create content.
             brackets.fs.writeFile(path, "", NativeFileSystem._FSEncodings.UTF8, function (error) {
                 if (error) {
@@ -653,7 +653,7 @@ define(function (require, exports, module) {
         // If the there is no project, default to desktop.
         if (doc) {
             fullPath = doc.file.fullPath;
-            saveAsDefaultPath = FileUtils.getParent(fullPath);
+            saveAsDefaultPath = FileUtils.getDirectoryPath(fullPath);
             defaultName = PathUtils.parseUrl(fullPath).filename;
             NativeFileSystem.showSaveDialog(Strings.SAVE_FILE_AS, saveAsDefaultPath, defaultName,
                 _doSaveAfterSaveDialog,

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
 /*global define, $, brackets, PathUtils, window */
 
 define(function (require, exports, module) {
@@ -621,7 +621,7 @@ define(function (require, exports, module) {
                 return doSave(doc);
             }
             // now save new document
-            var newPath = PathUtils.parseUrl(path).directory;
+            var newPath = FileUtils.getParent(path);
             // create empty file,  FileUtils.writeText will create content.
             brackets.fs.writeFile(path, "", NativeFileSystem._FSEncodings.UTF8, function (error) {
                 if (error) {
@@ -653,7 +653,7 @@ define(function (require, exports, module) {
         // If the there is no project, default to desktop.
         if (doc) {
             fullPath = doc.file.fullPath;
-            saveAsDefaultPath = PathUtils.parseUrl(fullPath).directory;
+            saveAsDefaultPath = FileUtils.getParent(fullPath);
             defaultName = PathUtils.parseUrl(fullPath).filename;
             NativeFileSystem.showSaveDialog(Strings.SAVE_FILE_AS, saveAsDefaultPath, defaultName,
                 _doSaveAfterSaveDialog,

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -351,6 +351,18 @@ define(function (require, exports, module) {
 
         return (_serverHtmlFileExts.indexOf(_getFileExtension(fileExt).toLowerCase()) !== -1);
     }
+    
+    /**
+     * Determine the parent directory of a file or folder.
+     * @param {string} full path to a file or directory
+     * @return {string} Returns the path to the parent directory
+     */
+    function getParent(fullPath) {
+        var i = fullPath.lastIndexOf("/"),
+            parent = (i === -1 || i >= fullPath.length - 1) ? fullPath : fullPath.substr(0, i + 1);
+
+        return parent;
+    }
 
     // Define public API
     exports.LINE_ENDINGS_CRLF              = LINE_ENDINGS_CRLF;
@@ -371,4 +383,5 @@ define(function (require, exports, module) {
     exports.updateFileEntryPath            = updateFileEntryPath;
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
     exports.isServerHtmlFileExt            = isServerHtmlFileExt;
+    exports.getParent                      = getParent;
 });

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -353,9 +353,9 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Determine the parent directory of a file or folder.
+     * Get the parent directory of a file. If a directory is passed in the directory is returned.
      * @param {string} full path to a file or directory
-     * @return {string} Returns the path to the parent directory
+     * @return {string} Returns the path to the parent directory of a file or the path of a directory 
      */
     function getDirectoryPath(fullPath) {
         return fullPath.substr(0, fullPath.lastIndexOf("/") + 1);

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -357,11 +357,8 @@ define(function (require, exports, module) {
      * @param {string} full path to a file or directory
      * @return {string} Returns the path to the parent directory
      */
-    function getParent(fullPath) {
-        var i = fullPath.lastIndexOf("/"),
-            parent = (i === -1 || i >= fullPath.length - 1) ? fullPath : fullPath.substr(0, i + 1);
-
-        return parent;
+    function getDirectoryPath(fullPath) {
+        return fullPath.substr(0, fullPath.lastIndexOf("/") + 1);
     }
 
     // Define public API
@@ -383,5 +380,5 @@ define(function (require, exports, module) {
     exports.updateFileEntryPath            = updateFileEntryPath;
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
     exports.isServerHtmlFileExt            = isServerHtmlFileExt;
-    exports.getParent                      = getParent;
+    exports.getDirectoryPath               = getDirectoryPath;
 });

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -53,4 +53,25 @@ define(function (require, exports, module) {
             });
         });
     });
+    
+    describe("FileUtils", function () {
+        describe("getDirectoryPath", function () {
+            
+            it("should get the parent directory of a normalized win file path", function () {
+                expect(FileUtils.getDirectoryPath("C:/foo/bar/baz.txt")).toBe("C:/foo/bar/");
+            });
+            
+            it("should get the parent directory of a posix file path", function () {
+                expect(FileUtils.getDirectoryPath("/foo/bar/baz.txt")).toBe("/foo/bar/");
+            });
+            
+            it("should return the unchanged directory of a normalized win directory path", function () {
+                expect(FileUtils.getDirectoryPath("C:/foo/bar/")).toBe("C:/foo/bar/");
+            });
+            
+            it("should return the unchanged directory of a posix directory path", function () {
+                expect(FileUtils.getDirectoryPath("C:/foo/bar/")).toBe("C:/foo/bar/");
+            });
+        });
+    });
 });

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -52,9 +52,7 @@ define(function (require, exports, module) {
                 expect(FileUtils.convertWindowsPathToUnixPath("/some/back\\slash/path.txt")).toBe("/some/back\\slash/path.txt");
             });
         });
-    });
-    
-    describe("FileUtils", function () {
+
         describe("getDirectoryPath", function () {
             
             it("should get the parent directory of a normalized win file path", function () {


### PR DESCRIPTION
FileUtils.parseUrl erroneously remove the drive letter from the path on win which may result in a wrong default directory for the save as dialog.

getParent removes that error while maintaing the the same semantics as FileUtils.

There are about 20 instances in the brackets code using .lastIndexOf("/") that may potentially benefit from using the new API. I will send another pull request updating use cases where it makes sense to use the new API
