### PR TITLE
Unit Test memory cleanup

### DIFF
--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -59,6 +59,10 @@ define(function (require, exports, module) {
         });
         
         afterEach(function () {
+            testWindow    = null;
+            $             = null;
+            brackets      = null;
+            EditorManager = null;
             SpecRunnerUtils.closeTestWindow();
         });
         

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -406,9 +406,6 @@ define(function (require, exports, module) {
                         testPos      = {line: 5, ch: 29},
                         testEditor;
 
-//                    initInlineTest("test.html");
-//                    initJSCodeHints();
-
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);
                         waitsForDone(openQuickEditor, "Open quick editor");
@@ -429,9 +426,6 @@ define(function (require, exports, module) {
                         testJumpPos  = {line: 6, ch: 5},
                         jumpPos      = {line: 3, ch: 6},
                         testEditor;
-
-//                    initInlineTest("test.html");
-//                    initJSCodeHints();
 
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);
@@ -458,9 +452,6 @@ define(function (require, exports, module) {
                         testPos      = {line: 5,  ch: 25},
                         jumpPos      = {line: 9, ch: 21},
                         testEditor;
-
-//                    initInlineTest("test.html");
-//                    initJSCodeHints();
 
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -189,6 +189,12 @@ define(function (require, exports, module) {
                 //waits(1000);
                 
                 // revert files to original content with offset markup
+                initInlineTest      = null;
+                testWindow          = null;
+                EditorManager       = null;
+                CommandManager      = null;
+                FileIndexManager    = null;
+                JSUtils             = null;
                 SpecRunnerUtils.closeTestWindow();
             });
 
@@ -386,14 +392,22 @@ define(function (require, exports, module) {
                     JSCodeHints = extensionRequire("main");
                 }
 
+                beforeEach(function () {
+                    initInlineTest("test.html");
+                    initJSCodeHints();
+                });
+                
+                afterEach(function () {
+                    JSCodeHints = null;
+                });
 
                 it("should see code hint lists in quick editor", function () {
                     var start        = {line: 13, ch: 11 },
                         testPos      = {line: 5, ch: 29},
                         testEditor;
 
-                    initInlineTest("test.html");
-                    initJSCodeHints();
+//                    initInlineTest("test.html");
+//                    initJSCodeHints();
 
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);
@@ -416,8 +430,8 @@ define(function (require, exports, module) {
                         jumpPos      = {line: 3, ch: 6},
                         testEditor;
 
-                    initInlineTest("test.html");
-                    initJSCodeHints();
+//                    initInlineTest("test.html");
+//                    initJSCodeHints();
 
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);
@@ -445,8 +459,8 @@ define(function (require, exports, module) {
                         jumpPos      = {line: 9, ch: 21},
                         testEditor;
 
-                    initInlineTest("test.html");
-                    initJSCodeHints();
+//                    initInlineTest("test.html");
+//                    initJSCodeHints();
 
                     runs(function () {
                         var openQuickEditor = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), start);
@@ -480,6 +494,10 @@ define(function (require, exports, module) {
             });
     
             afterEach(function () {
+                testWindow      = null;
+                CommandManager  = null;
+                EditorManager   = null;
+                PerfUtils       = null;
                 SpecRunnerUtils.closeTestWindow();
             });
             

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -392,18 +392,25 @@ define(function (require, exports, module) {
                     checkImagePathAtPos("img/Gradient.png", 154, 80);    // url()
                     checkImagePathAtPos("img/Gradient.png", 155, 80);    // ""
                 });
-
-                // This must be in the last spec in the suite.
-                runs(function () {
-                    this.after(function () {
-                        SpecRunnerUtils.closeTestWindow();
-                    });
-                });
             });
 
             it("Should show image preview for a data URI inside url()", function () {
                 runs(function () {
                     checkImageDataAtPos("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAABq0lEQVQoU11RPUgcURD+Zt/unnrcCf4QIugRMcS7a2xjmmArRlRIFRBFgrVtGgmBRFCwTBoLsQiBGMxiJ4iksLRSFEzQRC2EAwm5g727feP3LpyFy1tm5s33zcz7RnDvG4x0zFgMJRY/jiewhy/w8FKSJkyaTuG7Fumvi+ARbQiLpcMDvH/Qj1S6Bf6vI5SxKPUG4fGm5kMf6wr08MKHILCKldoZlk0OIeuHjNuDBBcNAqvvENTLwKii1ZFoF/7G2PQDpNo8dFUt1AcSGfymz42PVfI8ghxht1bHh9MpucCiegMFdJoUOtSD+MxLPtI5T/GaHWhg+NjRk3G5utPikwb5bjzhq40JSChs6Sx1eOYAojg/fCFv7yvnBLGCLPMqxS2dZrtXnDthhySuYebnpFw3ST2RtmUVIx5z1sIKdX9qgDcOTJAj7WsNa8eTUhrY0Gwqg2FldeZiduH5r9JHvqEDigzDS/4VJvYJfMh9VLmbNO9+s9hNg5D/qjkJ8I6uW0yFtkrwHydCg+AhVgsp/8Pnu00XI+0jYJ7gjANRiEsmQ3aNOXuJhG035i1QA6g+uONCrgAAAABJRU5ErkJggg==",  159, 26);
+                });
+
+                // This must be in the last spec in the suite.
+                runs(function () {
+                    this.after(function () {
+                        testWindow       = null;
+                        brackets         = null;
+                        CommandManager   = null;
+                        Commands         = null;
+                        EditorManager    = null;
+                        extensionRequire = null;
+                        QuickView        = null;
+                        SpecRunnerUtils.closeTestWindow();
+                    });
                 });
             });
         });

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -539,6 +539,10 @@ define(function (require, exports, module) {
             });
 
             afterEach(function () {
+                brackets            = null;
+                ProjectManager      = null;
+                extensionRequire    = null;
+                StaticServer        = null;
                 SpecRunnerUtils.closeTestWindow();
             });
             

--- a/test/perf/Performance-test.js
+++ b/test/perf/Performance-test.js
@@ -88,6 +88,12 @@ define(function (require, exports, module) {
         });
         
         afterEach(function () {
+            testWindow              = null;
+            CommandManager          = null;
+            Commands                = null;
+            DocumentCommandHandlers = null;
+            DocumentManager         = null;
+            PerfUtils               = null;
             SpecRunnerUtils.closeTestWindow();
         });
         

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1379,6 +1379,7 @@ define(function (require, exports, module) {
                 });
             });
             afterEach(function () {
+                CSSUtils = null;
                 SpecRunnerUtils.closeTestWindow();
             });
             
@@ -1424,6 +1425,11 @@ define(function (require, exports, module) {
             });
 
             afterEach(function () {
+                brackets            = null;
+                CSSUtils            = null;
+                DocumentManager     = null;
+                FileViewController  = null;
+                ProjectManager      = null;
                 SpecRunnerUtils.closeTestWindow();
             });
             
@@ -1450,6 +1456,8 @@ define(function (require, exports, module) {
                     // Look for ".FIRSTGRADE"
                     CSSUtils.findMatchingRules(".FIRSTGRADE")
                         .done(function (result) { rules = result; });
+                    
+                    doc = null;
                 });
                 
                 waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
@@ -1484,6 +1492,8 @@ define(function (require, exports, module) {
                     // Look for the selector we just created
                     CSSUtils.findMatchingRules(".TESTSELECTOR")
                         .done(function (result) { rules = result; });
+
+                    doc = null;
                 });
                 
                 waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -81,6 +81,12 @@ define(function (require, exports, module) {
         });
     
         afterEach(function () {
+            initCodeHintTest    = null;
+            testWindow          = null;
+            CodeHintManager     = null;
+            EditorManager       = null;
+            CommandManager      = null;
+            KeyBindingManager   = null;
             SpecRunnerUtils.closeTestWindow();
         });
         
@@ -213,12 +219,13 @@ define(function (require, exports, module) {
                     
                     // and popup should auto-close
                     expectNoHints();
+
+                    editor = null;
                 });
             });
 
             it("should dismiss code hints menu with Esc key", function () {
-                var editor,
-                    pos = {line: 3, ch: 1};
+                var pos = {line: 3, ch: 1};
 
                 // minimal markup with an open '<' before IP
                 // Note: line for pos is 0-based and editor lines numbers are 1-based
@@ -267,6 +274,8 @@ define(function (require, exports, module) {
                     
                     // verify list is no longer open
                     expectNoHints();
+
+                    editor = null;
                 });
             });
             
@@ -308,8 +317,9 @@ define(function (require, exports, module) {
                     // to move this expectNoHints() up after the click.
                     expectNoHints();
                     expect(editor.document.getText()).toEqual(text);
+
+                    editor = null;
                 });
-                
             });
         });
     });

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -57,6 +57,11 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow      = null;
+            CommandManager  = null;
+            Commands        = null;
+            EditorManager   = null;
+            DocumentManager = null;
             SpecRunnerUtils.closeTestWindow();
         });
         
@@ -118,8 +123,9 @@ define(function (require, exports, module) {
                     expect(cssDoc._masterEditor).toBeFalsy();
                     expect(testWindow.$(".CodeMirror").length).toBe(2);   // HTML editor (working set) & JS editor (current)
                 });
+
+                cssDoc = cssMasterEditor = null;
             });
-            
         });
     });
 });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -62,6 +62,11 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow              = null;
+            CommandManager          = null;
+            Commands                = null;
+            DocumentCommandHandlers = null;
+            DocumentManager         = null;
             SpecRunnerUtils.closeTestWindow();
         });
 

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -138,6 +138,7 @@ define(function (require, exports, module) {
                 if ($dlg.length) {
                     SpecRunnerUtils.clickDialogButton("dontsave");
                 }
+                $dlg = null;
             });
         }
         
@@ -146,7 +147,10 @@ define(function (require, exports, module) {
             runs(function () {
                 this.after(function () {
                     SpecRunnerUtils.closeTestWindow();
-                    testWindow = null;
+                    testWindow      = null;
+                    CommandManager  = null;
+                    Commands        = null;
+                    EditorManager   = null;
                 });
             });
         }

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -439,9 +439,16 @@ define(function (require, exports, module) {
                     checkCloseBraces(editor, {line: 1, ch: 7}, null, SINGLE_QUOTE, "// Yes, it is!");
                 });
                 
-                // This must be in the last spec in the suite.
+                // This must be in the last spec in the suite. Note that it's possible to
+                // run a single test from suite, so this only works when running entire suite.
                 runs(function () {
                     this.after(function () {
+                        testWindow          = null;
+                        CommandManager      = null;
+                        Commands            = null;
+                        EditorManager       = null;
+                        DocumentManager     = null;
+                        FileViewController  = null;
                         SpecRunnerUtils.closeTestWindow();
                     });
                 });

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -48,6 +48,8 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow      = null;
+            ExtensionUtils  = null;
             SpecRunnerUtils.closeTestWindow();
         });
 

--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -49,15 +49,14 @@ define(function (require, exports, module) {
                     // Load module instances from brackets.test
                     FileIndexManager  = testWindow.brackets.test.FileIndexManager;
                     ProjectManager = testWindow.brackets.test.ProjectManager;
-
-                    
                 });
             });
-
-
         });
 
         afterEach(function () {
+            brackets          = null;
+            FileIndexManager  = null;
+            ProjectManager    = null;
             SpecRunnerUtils.closeTestWindow();
         });
         

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -130,6 +130,8 @@ define(function (require, exports, module) {
                     inlineOpened = isOpened;
                 }).fail(function () {
                     inlineOpened = false;
+                }).always(function () {
+                    editor = null;
                 });
             });
             
@@ -248,6 +250,12 @@ define(function (require, exports, module) {
                 });
                 
                 // revert files to original content with offset markup
+                testWindow = null;
+                Commands            = null;
+                EditorManager       = null;
+                FileSyncManager     = null;
+                DocumentManager     = null;
+                FileViewController  = null;
                 SpecRunnerUtils.closeTestWindow();
             });
 
@@ -349,6 +357,8 @@ define(function (require, exports, module) {
                     // verify full editor cursor & focus restored
                     expect(savedPos).toEqual(hostEditor.getCursorPos());
                     expect(hostEditor.hasFocus()).toEqual(true);
+
+                    hostEditor = null;
                 });
             });
 
@@ -371,6 +381,9 @@ define(function (require, exports, module) {
 
                     // verify no inline widgets
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
+
+                    doc = null;
+                    hostEditor = null;
                 });
             });
 
@@ -417,6 +430,8 @@ define(function (require, exports, module) {
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(17);
                     expect(inlineEditor.totalHeight()).toBeGreaterThan(widgetHeight);
+                    
+                    inlineEditor = null;
                 });
             });
             
@@ -443,6 +458,8 @@ define(function (require, exports, module) {
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(10);
                     expect(inlineEditor.totalHeight()).toBeLessThan(widgetHeight);
+
+                    inlineEditor = null;
                 });
             });
             
@@ -504,6 +521,8 @@ define(function (require, exports, module) {
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
+
+                    inlineEditor = hostEditor = null;
                 });
             });
             
@@ -575,6 +594,8 @@ define(function (require, exports, module) {
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeTruthy();
+
+                    inlineEditor = hostEditor = null;
                 });
             });
             
@@ -672,6 +693,8 @@ define(function (require, exports, module) {
                     runs(function () {
                         // verify inline is closed
                         expect(hostEditor.getInlineWidgets().length).toBe(0);
+
+                        inlineEditor = hostEditor = null;
                     });
                 });
             });
@@ -710,6 +733,8 @@ define(function (require, exports, module) {
                         
                         var i = DocumentManager.findInWorkingSet(this.infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(1);
+
+                        inlineEditor = null;
                     });
                 });
             
@@ -751,6 +776,8 @@ define(function (require, exports, module) {
                             inlineEditor.getCursorPos()
                         );
                         expectTextToBeEqual(inlineEditor, fullEditor);
+
+                        inlineEditor = fullEditor = null;
                     });
                 });
             });
@@ -795,7 +822,11 @@ define(function (require, exports, module) {
                         wayafter = this.infos["test1.css"].offsets[2];
                     });
                 });
-            
+
+                afterEach(function () {
+                    fullEditor = hostEditor = inlineEditor = null;
+                });
+                
                 
                 it("should insert new line at start of range, and stay open on undo", function () {
                     // insert new line at start of inline range--the new line should be included in 
@@ -1114,7 +1145,11 @@ define(function (require, exports, module) {
                         inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
                     });
                 });
-            
+
+                afterEach(function () {
+                    hostEditor = inlineEditor = null;
+                });
+
 
                 it("should keep range consistent after undo/redo (bug #1031)", function () {
                     var secondInlineOpen = false, secondInlineEditor;
@@ -1145,6 +1180,8 @@ define(function (require, exports, module) {
                     runs(function () {
                         inlineEditor._codeMirror.undo();
                         expect(inlineEditor).toHaveInlineEditorRange(toRange(10, 12));
+
+                        secondInlineEditor = null;
                     });
                 });
             });
@@ -1170,6 +1207,10 @@ define(function (require, exports, module) {
                     });
                 });
             
+                afterEach(function () {
+                    fullEditor = hostEditor = inlineEditor = null;
+                });
+
                 it("should delete line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
                     

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -836,9 +836,10 @@ define(function (require, exports, module) {
                 });
 
                 afterEach(function () {
-                    fullEditor = hostEditor = inlineEditor = null;
+                    fullEditor   = null;
+                    hostEditor   = null;
+                    inlineEditor = null;
                 });
-                
                 
                 it("should insert new line at start of range, and stay open on undo", function () {
                     // insert new line at start of inline range--the new line should be included in 
@@ -1157,11 +1158,11 @@ define(function (require, exports, module) {
                         inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
                     });
                 });
-
+            
                 afterEach(function () {
-                    hostEditor = inlineEditor = null;
+                    hostEditor   = null;
+                    inlineEditor = null;
                 });
-
 
                 it("should keep range consistent after undo/redo (bug #1031)", function () {
                     var secondInlineOpen = false, secondInlineEditor;
@@ -1218,11 +1219,13 @@ define(function (require, exports, module) {
                         fullEditor = EditorManager.getCurrentFullEditor();
                     });
                 });
-            
+                
                 afterEach(function () {
-                    fullEditor = hostEditor = inlineEditor = null;
+                    fullEditor   = null;
+                    hostEditor   = null;
+                    inlineEditor = null;
                 });
-
+                
                 it("should delete line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
                     

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -250,7 +250,8 @@ define(function (require, exports, module) {
                 });
                 
                 // revert files to original content with offset markup
-                testWindow = null;
+                initInlineTest      = null;
+                testWindow          = null;
                 Commands            = null;
                 EditorManager       = null;
                 FileSyncManager     = null;
@@ -269,6 +270,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+
+                    inlineWidget = null;
                 });
             });
             
@@ -281,6 +284,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+
+                    inlineWidget = null;
                 });
             });
 
@@ -293,6 +298,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[1]);
+
+                    inlineWidget = null;
                 });
             });
 
@@ -305,6 +312,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[1]);
+
+                    inlineWidget = null;
                 });
             });
 
@@ -317,6 +326,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.html"].offsets[11]);
+
+                    inlineWidget = null;
                 });
             });
 
@@ -329,6 +340,8 @@ define(function (require, exports, module) {
                     
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(this.infos["test1.css"].offsets[2]);
+
+                    inlineWidget = null;
                 });
             });
 
@@ -358,7 +371,7 @@ define(function (require, exports, module) {
                     expect(savedPos).toEqual(hostEditor.getCursorPos());
                     expect(hostEditor.hasFocus()).toEqual(true);
 
-                    hostEditor = null;
+                    hostEditor = inlineWidget = null;
                 });
             });
 
@@ -382,8 +395,7 @@ define(function (require, exports, module) {
                     // verify no inline widgets
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
 
-                    doc = null;
-                    hostEditor = null;
+                    doc = hostEditor = inlineWidget = null;
                 });
             });
 

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
         Strings         = require("strings");
 
     describe("Install Extension Dialog", function () {
-        var testWindow, dialog, fields, goodInstaller, badInstaller, InstallExtensionDialog, closed,
+        var testWindow, dialog, fields, goodInstaller, badInstaller, closed,
             url = "http://brackets.io/extensions/myextension.zip";
         
         beforeEach(function () {
@@ -717,6 +717,7 @@ define(function (require, exports, module) {
         
         // THIS MUST BE THE LAST SPEC IN THE SUITE
         it("should close the test window", function () {
+            testWindow = null;
             SpecRunnerUtils.closeTestWindow();
         });
     });

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -56,8 +56,6 @@ define(function (require, exports, module) {
     var eof2JsFileEntry     = new NativeFileSystem.FileEntry(testPath + "/eof2.js");
 
     function init(spec, fileEntry) {
-        spec.fileJsContent = null;
-        
         if (fileEntry) {
             spec.addMatchers({toMatchFunctionName: toMatchFunctionName});
             
@@ -74,11 +72,19 @@ define(function (require, exports, module) {
         }
     }
 
+    function cleanup(spec) {
+        spec.fileJsContent = null;
+    }
+
 
     describe("JSUtils", function () {
 
         beforeEach(function () {
             init(this);
+        });
+        
+        afterEach(function () {
+            cleanup(this);
         });
         
         describe("basics", function () {
@@ -121,6 +127,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "simple1", [ {start:  0, end:  2} ]);
                     expectFunctionRanges(this, this.fileJsContent, "simple2", [ {start:  7, end:  9} ]);
                     expectFunctionRanges(this, this.fileJsContent, "simple3", [ {start: 11, end: 13} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -133,6 +141,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "param1", [ {start: 18, end: 19} ]);
                     expectFunctionRanges(this, this.fileJsContent, "param2", [ {start: 24, end: 26} ]);
                     expectFunctionRanges(this, this.fileJsContent, "param3", [ {start: 28, end: 32} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -145,6 +155,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "single1", [ {start: 35, end: 35} ]);
                     expectFunctionRanges(this, this.fileJsContent, "single2", [ {start: 36, end: 36} ]);
                     expectFunctionRanges(this, this.fileJsContent, "single3", [ {start: 37, end: 37} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -157,6 +169,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "nested1", [ {start: 42, end: 50} ]);
                     expectFunctionRanges(this, this.fileJsContent, "nested2", [ {start: 44, end: 49} ]);
                     expectFunctionRanges(this, this.fileJsContent, "nested3", [ {start: 47, end: 48} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -169,6 +183,8 @@ define(function (require, exports, module) {
                     //expectFunctionRanges(this, this.fileJsContent, "functionX",   [ {start: 53, end: 55} ]);
                     expectFunctionRanges(this, this.fileJsContent, "my_function", [ {start: 56, end: 57} ]);
                     expectFunctionRanges(this, this.fileJsContent, "function3",   [ {start: 58, end: 60} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -186,6 +202,8 @@ define(function (require, exports, module) {
                         result = JSUtils.findAllMatchingFunctionsInText(content, name);
                         expect(result.length).toBe(0);
                     });
+
+                    cleanup(this);
                 });
             });
             
@@ -196,6 +214,8 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "myMethod", [ {start: 66, end: 68} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -212,6 +232,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction", [ {start: 86, end: 88} ]);
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction2", [ {start: 90, end: 92} ]);
                     expectFunctionRanges(this, this.fileJsContent, "findMe", [ {start: 93, end: 93} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -224,6 +246,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "highAscÍÍChars", [ {start: 95, end: 97} ]);
                     expectFunctionRanges(this, this.fileJsContent, "moreHighAscÍÍChars", [ {start: 99, end: 101} ]);
                     expectFunctionRanges(this, this.fileJsContent, "ÅsciiExtendedIdentifierStart", [ {start: 103, end: 104} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -235,6 +259,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "ʸUnicodeModifierLettervalidIdentifierStart", [ {start: 106, end: 107} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeModifierLettervalidIdentifierPartʸ", [ {start: 112, end: 113} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -249,6 +275,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "unicodeEscapedIdentifierPart\u02b8", [ {start: 115, end: 116} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabBefore", [ {start: 118, end: 119} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabAfter", [ {start: 121, end: 122} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -261,6 +289,8 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "toString", [ {start: 1, end: 3} ]);
                     expectFunctionRanges(this, this.fileJsContent, "length", [ {start: 6, end: 8} ]);
                     expectFunctionRanges(this, this.fileJsContent, "hasOwnProperty", [ {start: 11, end: 13} ]);
+
+                    cleanup(this);
                 });
             });
             
@@ -273,6 +303,8 @@ define(function (require, exports, module) {
                     expectNoFunction(this.fileJsContent, "0digitIdentifierStart");
                     expectNoFunction(this.fileJsContent, ".punctuationIdentifierStart");
                     expectNoFunction(this.fileJsContent, "punctuation.IdentifierPart");
+
+                    cleanup(this);
                 });
             });
         });
@@ -282,6 +314,10 @@ define(function (require, exports, module) {
                 init(this, braceEndJsFileEntry);
             });
             
+            afterEach(function () {
+                cleanup(this);
+            });
+
             function expectEndBrace(spec, funcName) {
                 var startPos = spec.fileJsContent.indexOf("function " + funcName);
                 expect(startPos).toNotBe(-1);
@@ -334,6 +370,7 @@ define(function (require, exports, module) {
                 init(this, eofJsFileEntry);
                 runs(function () {
                     expect(JSUtils._getFunctionEndOffset(this.fileJsContent, 0)).toBe(this.fileJsContent.length);
+                    cleanup(this);
                 });
             });
         });
@@ -343,6 +380,7 @@ define(function (require, exports, module) {
                 init(this, eof2JsFileEntry);
                 runs(function () {
                     expect(JSUtils._getFunctionEndOffset(this.fileJsContent, 0)).toBe(this.fileJsContent.length);
+                    cleanup(this);
                 });
             });
         });
@@ -353,6 +391,10 @@ define(function (require, exports, module) {
                 init(this, jQueryJsFileEntry);
             });
             
+            afterEach(function () {
+                cleanup(this);
+            });
+
             it("should find the first instance of the pushStack function", function () {
                 var funcNames = JSUtils.findAllMatchingFunctionsInText(this.fileJsContent, "pushStack");
                 expect(funcNames).not.toBe(null);
@@ -405,6 +447,10 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            DocumentManager     = null;
+            FileIndexManager    = null;
+            FileViewController  = null;
+            JSUtils             = null;
             SpecRunnerUtils.closeTestWindow();
         });
         

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -38,7 +38,8 @@ define(function (require, exports, module) {
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
     var testPath = SpecRunnerUtils.getTestPath("/spec/JSUtils-test-files"),
-        testWindow;
+        testWindow,
+        doneLoading = false;
 
     // Verifies whether one of the results returned by JSUtils.findAllMatchingFunctionsInText()
     // came from the expected function name or not.
@@ -59,16 +60,15 @@ define(function (require, exports, module) {
         if (fileEntry) {
             spec.addMatchers({toMatchFunctionName: toMatchFunctionName});
             
-            var doneLoading = false;
-            
             runs(function () {
                 FileUtils.readAsText(fileEntry)
                     .done(function (text) {
                         spec.fileJsContent = text;
+                    })
+                    .always(function (text) {
+                        doneLoading = true;
                     });
             });
-            
-            waitsFor(function () { return (spec.fileJsContent !== null); }, 1000);
         }
     }
 
@@ -79,14 +79,6 @@ define(function (require, exports, module) {
 
     describe("JSUtils", function () {
 
-        beforeEach(function () {
-            init(this);
-        });
-        
-        afterEach(function () {
-            cleanup(this);
-        });
-        
         describe("basics", function () {
             
             it("should parse an empty string", function () {
@@ -99,6 +91,10 @@ define(function (require, exports, module) {
         
         // TODO (jason-sanjose): use offset markup in these test files
         describe("line offsets", function () {
+            
+            afterEach(function () {
+                cleanup(this);
+            });
             
             // Checks the lines ranges of the results returned by JSUtils. Expects the numbers of
             // results to equal the length of 'ranges'; each entry in range gives the {start, end}
@@ -120,78 +116,80 @@ define(function (require, exports, module) {
             
             it("should return correct start and end line numbers for simple functions", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "simple1", [ {start:  0, end:  2} ]);
                     expectFunctionRanges(this, this.fileJsContent, "simple2", [ {start:  7, end:  9} ]);
                     expectFunctionRanges(this, this.fileJsContent, "simple3", [ {start: 11, end: 13} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should return correct start and end line numbers for parameterized functions", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "param1", [ {start: 18, end: 19} ]);
                     expectFunctionRanges(this, this.fileJsContent, "param2", [ {start: 24, end: 26} ]);
                     expectFunctionRanges(this, this.fileJsContent, "param3", [ {start: 28, end: 32} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should return correct start and end line numbers for single line functions", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "single1", [ {start: 35, end: 35} ]);
                     expectFunctionRanges(this, this.fileJsContent, "single2", [ {start: 36, end: 36} ]);
                     expectFunctionRanges(this, this.fileJsContent, "single3", [ {start: 37, end: 37} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should return correct start and end line numbers for nested functions", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "nested1", [ {start: 42, end: 50} ]);
                     expectFunctionRanges(this, this.fileJsContent, "nested2", [ {start: 44, end: 49} ]);
                     expectFunctionRanges(this, this.fileJsContent, "nested3", [ {start: 47, end: 48} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should return correct start and end line numbers for functions with keyword 'function' in name", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     //expectFunctionRanges(this, this.fileJsContent, "functionX",   [ {start: 53, end: 55} ]);
                     expectFunctionRanges(this, this.fileJsContent, "my_function", [ {start: 56, end: 57} ]);
                     expectFunctionRanges(this, this.fileJsContent, "function3",   [ {start: 58, end: 60} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should ignore identifiers with whitespace", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     var negativeTests = ["invalid", "identifier", "invalid identifier"],
@@ -202,27 +200,27 @@ define(function (require, exports, module) {
                         result = JSUtils.findAllMatchingFunctionsInText(content, name);
                         expect(result.length).toBe(0);
                     });
-
-                    cleanup(this);
                 });
             });
             
             it("should return correct start and end line numbers for prototype method declarations", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "myMethod", [ {start: 66, end: 68} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should handle various whitespace variations", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceBeforeFunc", [ {start: 71, end: 71} ]);
@@ -232,86 +230,88 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction", [ {start: 86, end: 88} ]);
                     expectFunctionRanges(this, this.fileJsContent, "noSpaceAfterFunction2", [ {start: 90, end: 92} ]);
                     expectFunctionRanges(this, this.fileJsContent, "findMe", [ {start: 93, end: 93} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should work with high-ascii characters in function names", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "highAscÍÍChars", [ {start: 95, end: 97} ]);
                     expectFunctionRanges(this, this.fileJsContent, "moreHighAscÍÍChars", [ {start: 99, end: 101} ]);
                     expectFunctionRanges(this, this.fileJsContent, "ÅsciiExtendedIdentifierStart", [ {start: 103, end: 104} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should work with unicode characters in or around function names", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "ʸUnicodeModifierLettervalidIdentifierStart", [ {start: 106, end: 107} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeModifierLettervalidIdentifierPartʸ", [ {start: 112, end: 113} ]);
-
-                    cleanup(this);
                 });
             });
             
             // TODO (issue #1125): support escaped unicode
             xit("FAIL should work with unicode characters in or around function names", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, simpleJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "\u02b8UnicodeEscapedIdentifierStart", [ {start: 109, end: 110} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeEscapedIdentifierPart\u02b8", [ {start: 115, end: 116} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabBefore", [ {start: 118, end: 119} ]);
                     expectFunctionRanges(this, this.fileJsContent, "unicodeTabAfter", [ {start: 121, end: 122} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should work when colliding with prototype properties", function () { // #1390, #2813
                 runs(function () {
+                    doneLoading = false;
                     init(this, trickyJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectFunctionRanges(this, this.fileJsContent, "toString", [ {start: 1, end: 3} ]);
                     expectFunctionRanges(this, this.fileJsContent, "length", [ {start: 6, end: 8} ]);
                     expectFunctionRanges(this, this.fileJsContent, "hasOwnProperty", [ {start: 11, end: 13} ]);
-
-                    cleanup(this);
                 });
             });
             
             it("should fail with invalid function names", function () {
                 runs(function () {
+                    doneLoading = false;
                     init(this, invalidJsFileEntry);
                 });
+                waitsFor(function () { return doneLoading; }, 1000);
                 
                 runs(function () {
                     expectNoFunction(this.fileJsContent, "0digitIdentifierStart");
                     expectNoFunction(this.fileJsContent, ".punctuationIdentifierStart");
                     expectNoFunction(this.fileJsContent, "punctuation.IdentifierPart");
-
-                    cleanup(this);
                 });
             });
         });
         
         describe("brace ends of functions", function () {
             beforeEach(function () {
-                init(this, braceEndJsFileEntry);
+                runs(function () {
+                    doneLoading = false;
+                    init(this, braceEndJsFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
             });
             
             afterEach(function () {
@@ -367,7 +367,12 @@ define(function (require, exports, module) {
         
         describe("brace end of function that ends at end of file", function () {
             it("should find the end of a function that ends exactly at the end of the file", function () {
-                init(this, eofJsFileEntry);
+                runs(function () {
+                    doneLoading = false;
+                    init(this, eofJsFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
                 runs(function () {
                     expect(JSUtils._getFunctionEndOffset(this.fileJsContent, 0)).toBe(this.fileJsContent.length);
                     cleanup(this);
@@ -377,7 +382,12 @@ define(function (require, exports, module) {
         
         describe("end of function that's unclosed at end of file", function () {
             it("should find the end of a function that is unclosed at the end of the file", function () {
-                init(this, eof2JsFileEntry);
+                runs(function () {
+                    doneLoading = false;
+                    init(this, eof2JsFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
                 runs(function () {
                     expect(JSUtils._getFunctionEndOffset(this.fileJsContent, 0)).toBe(this.fileJsContent.length);
                     cleanup(this);
@@ -388,7 +398,11 @@ define(function (require, exports, module) {
         describe("with real-world jQuery JS code", function () {
             
             beforeEach(function () {
-                init(this, jQueryJsFileEntry);
+                runs(function () {
+                    doneLoading = false;
+                    init(this, jQueryJsFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
             });
             
             afterEach(function () {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -209,7 +209,18 @@ define(function (require, exports, module) {
                     return (LiveDevelopment.status === LiveDevelopment.STATUS_INACTIVE);
                 }, "Waiting for browser to become inactive", 10000);
 
-                SpecRunnerUtils.closeTestWindow();
+                runs(function () {
+                    testWindow           = null;
+                    LiveDevelopment      = null;
+                    LiveDevServerManager = null;
+                    DOMAgent             = null;
+                    DocumentManager      = null;
+                    CommandManager       = null;
+                    Commands             = null;
+                    NativeApp            = null;
+                    ProjectManager       = null;
+                    SpecRunnerUtils.closeTestWindow();
+                });
             });
             
             it("should establish a browser connection for an opened html file", function () {
@@ -559,6 +570,7 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.destroyMockEditor(testDocument);
                 testDocument = null;
                 testEditor = null;
+                testCSSDoc = null;
             });
             
             it("should toggle the highlight via a command", function () {
@@ -689,7 +701,7 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.destroyMockEditor(testDocument);
                 testDocument = null;
                 testEditor = null;
-                
+                testHTMLDoc = null;
                 instrumentedHtml = "";
                 elementIds = {};
             });

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -58,6 +58,11 @@ define(function (require, exports, module) {
                 });
 
                 this.after(function () {
+                    testWindow        = null;
+                    CommandManager    = null;
+                    Commands          = null;
+                    KeyBindingManager = null;
+                    Menus             = null;
                     SpecRunnerUtils.closeTestWindow();
                 });
             }

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -53,6 +53,10 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow     = null;
+            brackets       = null;
+            ProjectManager = null;
+            CommandManager = null;
             SpecRunnerUtils.closeTestWindow();
         });
 

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -50,11 +50,15 @@ define(function (require, exports, module) {
                     DocumentManager = brackets.test.DocumentManager;
                 });
             });
-
-
         });
 
         afterEach(function () {
+            testWindow      = null;
+            brackets        = null;
+            test$           = null;
+            executeCommand  = null;
+            EditorManager   = null;
+            DocumentManager = null;
             SpecRunnerUtils.closeTestWindow();
         });
         

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -313,6 +313,8 @@ define(function (require, exports, module) {
                 }
             });
             _testWindow.close();
+            _testWindow.executeCommand = null;
+            _testWindow = null;
         });
     }
     
@@ -516,6 +518,9 @@ define(function (require, exports, module) {
             result.resolve(docs);
         }).fail(function () {
             result.reject();
+        }).always(function () {
+            docs = null;
+            FileViewController = null;
         });
         
         return result.promise();

--- a/test/spec/UpdateNotification-test.js
+++ b/test/spec/UpdateNotification-test.js
@@ -48,6 +48,8 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow         = null;
+            UpdateNotification = null;
             SpecRunnerUtils.closeTestWindow();
         });
 

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -145,6 +145,11 @@ define(function (require, exports, module) {
                 // This must be in the last spec in the suite.
                 runs(function () {
                     this.after(function () {
+                        testWindow          = null;
+                        CommandManager      = null;
+                        Commands            = null;
+                        EditorManager       = null;
+                        FileViewController  = null;
                         SpecRunnerUtils.closeTestWindow();
                     });
                 });

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -91,6 +91,11 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
+            testWindow          = null;
+            CommandManager      = null;
+            Commands            = null;
+            DocumentManager     = null;
+            FileViewController  = null;
             SpecRunnerUtils.closeTestWindow();
         });
 


### PR DESCRIPTION
This is a first pass at fixing #4185. @jasonsanjose 

I updated all tests that use `SpecRunnerUtils.createTestWindowAndRun()` and tried to release all references to the test window and anything inside it so it will get released on call to `SpecRunnerUtils.closeTestWindow()`

On my Window 7 system, when running Integration Tests this reduces memory ~90M (~11%).
On Mac OSX 10.8 MBP Retina, Integration Tests only, reduces memory ~50M.

We should do a similar analysis of the other `SpecRunnerUtils` methods:

```
createMockDocument()
createMockActiveDocument()
createMockElement()
createMockEditorForDocument()
createMockEditor()
loadProjectInTestWindow()
openProjectFiles()
createTextFile()
```
