### PR TITLE
[HACK] [WHAT] [NO] Fix Mac command-key shortcuts in modal dialogs

### DIFF
--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -54,7 +54,9 @@ define(function (require, exports, module) {
                 return false;
             }
 
-            $dlg.trigger($.Event("shellCommand", { commandName: eventName }));
+            if ($dlg.length) {
+                $dlg.trigger($.Event("shellCommand", { commandName: eventName }));
+            }
             
             // Return false for all commands except file.close_window command for 
             // which we have to return true (issue #3152).

--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -45,13 +45,17 @@ define(function (require, exports, module) {
     function executeCommand(eventName) {
         // Temporary fix for #2616 - don't execute the command if a modal dialog is open.
         // This should really be fixed with proper menu enabling.
-        if ($(".modal.instance").length || !appReady) {
+        var $dlg = $(".modal.instance");
+        if ($dlg.length || !appReady) {
             // Another hack to fix issue #3219 so that all test windows are closed 
             // as before the fix for #3152 has been introduced. isBracketsTestWindow 
             // property is explicitly set in createTestWindowAndRun() in SpecRunnerUtils.js.
             if (window.isBracketsTestWindow) {
                 return false;
             }
+
+            $dlg.trigger($.Event("shellCommand", { commandName: eventName }));
+            
             // Return false for all commands except file.close_window command for 
             // which we have to return true (issue #3152).
             return (eventName === Commands.FILE_CLOSE_WINDOW);

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -199,6 +199,19 @@ define(function (require, exports, module) {
         var keydownHook = function (e) {
             return _keydownHook.call($dlg, e, autoDismiss);
         };
+        
+        var shellCommandHook = function (e) {
+            var bindings = KeyBindingManager.getKeyBindings(e.commandName);
+            
+            if (bindings.length === 1 && bindings[0].key.indexOf("Cmd-") === 0) {
+                var keydownEvent = $.Event("keydown");
+                keydownEvent.which = bindings[0].key.charCodeAt(4);
+                keydownEvent.metaKey = true;
+                keydownEvent.target = $dlg;
+                keydownHook(keydownEvent);
+                // $dlg.trigger(keydownEvent);
+            }
+        };
 
         // Pipe dialog-closing notification back to client code
         $dlg.one("hidden", function () {
@@ -217,6 +230,8 @@ define(function (require, exports, module) {
             // Remove the dialog instance from the DOM.
             $dlg.remove();
 
+            $dlg.off("shellCommand");
+            
             // Remove our global keydown handler.
             KeyBindingManager.removeGlobalKeydownHook(keydownHook);
         }).one("shown", function () {
@@ -229,6 +244,8 @@ define(function (require, exports, module) {
 
             // Push our global keydown handler onto the global stack of handlers.
             KeyBindingManager.addGlobalKeydownHook(keydownHook);
+            
+            $dlg.on("shellCommand", shellCommandHook);
         });
         
         // Click handler for buttons

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -209,7 +209,6 @@ define(function (require, exports, module) {
                 keydownEvent.metaKey = true;
                 keydownEvent.target = $dlg;
                 keydownHook(keydownEvent);
-                // $dlg.trigger(keydownEvent);
             }
         };
 


### PR DESCRIPTION
This terrible, horrible no-good pull request fixes Mac command-key shortcuts (like cmd-D to dismiss the save dialog) in modal dialogs. The problem arises from the operating system capturing keyboard events that correspond to shortcuts for menu commands. The shell handles these keyboard events and translates them into command names,  which are translated into commands and executed at the JavaScript level. This hack intercepts these command names and, when a modal dialog is open, forwards them as `shellCommand` events which are handled by open modal dialogs. The `shellCommand` events are then translated into their corresponding key bindings (e.g., `edit.duplicate` --> `Cmd-D`), which are used to manufacture a corresponding `keydown` event, and which are immediately handed off to the modal dialog's `keydown` handler. 

(You may wonder why the command name forwarded from the shell isn't immediately translated into a keyboard event. To do so requires importing `KeyBindingManager` into `ShellAPI`, which seems to cause a circular dependency that makes Brackets sad.)

So, yes, this is very ugly, but, hey, YOU CAN DISMISS SAVE DIALOGS WITH THE KEYBOARD! 
