### PR TITLE
[ResearchLiveHTML] Hooking up more edits and invalid/valid handling to the UI

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -205,6 +205,11 @@ define(function RemoteAgent(require, exports, module) {
             self[methodName] = self._eval.bind(self, methodName);
         });
     }
+    
+    function _doEval(script) {
+        console.log("eval: " + script);
+        Inspector.Runtime.evaluate(script);
+    }
 
     RemoteElement.prototype._eval = function (method, varargs) {
         // Convert method arguments to JSON string to escape string args
@@ -212,18 +217,45 @@ define(function RemoteAgent(require, exports, module) {
             argsAssign      = "var args = JSON.parse(\"" + argsArray + "\");",
             fnApply         = "$result." + method + ".apply($result, args)";
 
-        return Inspector.Runtime.evaluate(argsAssign + this._queryBracketsId + fnApply);
+        return _doEval(argsAssign + this._queryBracketsId + fnApply);
+    };
+    
+    RemoteElement.prototype._getTextLocateScript = function (afterID) {
+        var result = this._queryBracketsId +
+            'var pos = 0, children = $result.contents();';
+        if (afterID) {
+            result += 
+                'var $afterNode = ' + $REMOTE + '("[data-brackets-id=\\"' + afterID + '\\"]");' +
+                "pos = children.indexOf($afterNode[0]) + 1;";
+        }
+        return result;
+    };
+    
+    RemoteElement.prototype.insertChild = function (childPos, content, isText) {
+        var escapedContent = content.replace(/\\/g, "\\\\").replace(/'/g, "\\\'"),
+            doInsert = this._queryBracketsId +
+                "var children = $result.contents()," +
+                "    toInsert = " + (isText 
+                                     ? "document.createTextNode('" + escapedContent + "');"
+                                     : "'" + escapedContent + "';") +
+                "if (" + childPos + " >= children.length) {" +
+                "    $result.append(toInsert);" +
+                "} else {" +
+                "    $($result.contents()[" + childPos + "]).before(toInsert);" +
+                "}";
+        return _doEval(doInsert);
     };
     
     RemoteElement.prototype.replaceChildText = function (afterID, text) {
-        var doReplace = "var pos = 0, $afterNode, children = $result.contents(), afterID = " + (afterID || "null") + ";" +
-            "if (afterID) {" +
-            "  $afterNode = " + $REMOTE + '("[data-brackets-id=\\"' + afterID + '\\"]");' +
-            "  pos = children.indexOf($afterNode[0]) + 1;" +
-            "}" +
+        var doReplace = this._getTextLocateScript(afterID) +
             "children[pos].nodeValue = '" + text.replace(/\\/g, "\\\\").replace(/'/g, "\\\'") + "';";
-        console.log("eval: " + this._queryBracketsId + doReplace);
-        return Inspector.Runtime.evaluate(this._queryBracketsId + doReplace);
+        return _doEval(doReplace);
+    };
+
+    RemoteElement.prototype.deleteChildText = function (afterID) {
+        var doDelete = this._getTextLocateScript(afterID) +
+            "children[pos].parentNode.removeChild(children[pos])";
+        return _doEval(doDelete);
     };
 
     function remoteElement(dataBracketsId) {

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -215,8 +215,14 @@ define(function RemoteAgent(require, exports, module) {
         return Inspector.Runtime.evaluate(argsAssign + this._queryBracketsId + fnApply);
     };
     
-    RemoteElement.prototype.replaceChildText = function (pos, text) {
-        var doReplace = "$result.contents()[" + pos + "].nodeValue = '" + text.replace(/\\/g, "\\\\").replace(/'/g, "\\\'") + "'";
+    RemoteElement.prototype.replaceChildText = function (afterID, text) {
+        var doReplace = "var pos = 0, $afterNode, children = $result.contents(), afterID = " + (afterID || "null") + ";" +
+            "if (afterID) {" +
+            "  $afterNode = " + $REMOTE + '("[data-brackets-id=\\"' + afterID + '\\"]");' +
+            "  pos = children.indexOf($afterNode[0]) + 1;" +
+            "}" +
+            "children[pos].nodeValue = '" + text.replace(/\\/g, "\\\\").replace(/'/g, "\\\'") + "';";
+        console.log("eval: " + this._queryBracketsId + doReplace);
         return Inspector.Runtime.evaluate(this._queryBracketsId + doReplace);
     };
 

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -207,7 +207,7 @@ define(function RemoteAgent(require, exports, module) {
     }
     
     function _doEval(script) {
-        console.log("eval: " + script);
+        //console.log("eval: " + script);
         Inspector.Runtime.evaluate(script);
     }
 

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -100,11 +100,13 @@ define(function HTMLDocumentModule(require, exports, module) {
      * @returns {{body: string}}
      */
     HTMLDocument.prototype.getResponseData = function getResponseData(enabled) {
-        var body = (this._instrumentationEnabled) ?
-                HTMLInstrumentation.generateInstrumentedHTML(this.doc) : this.doc.getText();
+        var body;
+        if (this._instrumentationEnabled) {
+            body = HTMLInstrumentation.generateInstrumentedHTML(this.doc);
+        }
         
         return {
-            body: body
+            body: body || this.doc.getText()
         };
     };
 

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -156,7 +156,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         var edits = HTMLInstrumentation.getUnappliedEditList(editor, change);
         edits.forEach(function (edit) {
             // Silly naming convention: $$ = remote $
-            var $$target = RemoteAgent.remoteElement(edit.tagID);
+            var $$target = RemoteAgent.remoteElement(edit.type === "textReplace" ? edit.parentID : edit.tagID);
             switch (edit.type) {
             case "attrChange":
             case "attrAdd":
@@ -166,7 +166,7 @@ define(function HTMLDocumentModule(require, exports, module) {
                 $$target.removeAttr(edit.attribute);
                 break;
             case "textReplace":
-                $$target.replaceChildText(edit.child, edit.content);
+                $$target.replaceChildText(edit.afterID, edit.content);
                 break;
             }
         });

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -452,7 +452,7 @@ define(function (require, exports, module) {
                 var newMarkRange = startMark.find();
                 if (newMarkRange) {
                     text = editor._codeMirror.getRange(newMarkRange.from, newMarkRange.to);
-                    console.log("incremental update: " + text);
+                    //console.log("incremental update: " + text);
                     this.changedTagID = startMark.tagID;
                     startOffset = editor._codeMirror.indexFromPos(newMarkRange.from);
                 }

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -293,7 +293,7 @@ define(function (require, exports, module) {
         if (childIndex === 0) {
             return textNode.parent.tagID + ".0";
         }
-        return textNode.parent.children[childIndex - 1] + "t";
+        return textNode.parent.children[childIndex - 1].tagID + "t";
     }
     
     SimpleDOMBuilder.prototype.build = function () {

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -377,6 +377,27 @@ define(function (require, exports, module) {
         return builder.build();
     }
     
+    function _dumpDOM(root) {
+        var result = "",
+            indent = "";
+        
+        function walk(node) {
+            if (node.tag) {
+                result += indent + "TAG " + node.tagID + " " + node.tag + " " + JSON.stringify(node.attributes) + "\n";
+            } else {
+                result += indent + "TEXT " + node.tagID + " " + node.content + "\n";
+            }
+            if (node.children) {
+                indent += "  ";
+                node.children.forEach(walk);
+                indent = indent.slice(2);
+            }
+        }
+        walk(root);
+        
+        return result;
+    }
+    
     // TODO: I'd be worried about stack overflows here
     function _markTags(cm, node) {
         node.children.forEach(function (childNode) {

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -779,6 +779,7 @@ define(function (require, exports, module) {
                             expect(newElement.tagID).not.toEqual(newElement.parent.tagID);
                             expect(newElement.children[0].content).toEqual("New Content");
                             expect(result.edits.length).toEqual(2);
+                            console.log(JSON.stringify(result.edits));
                             expect(result.edits[0]).toEqual({
                                 type: "elementInsert",
                                 tag: "div",

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -535,9 +535,8 @@ define(function (require, exports, module) {
                 expectationFn(result, previousDOM, false);
                 
                 // incremental test
-//                result = HTMLInstrumentation._updateDOM(previousDOM, editor, changeList);
-                // TODO: how to test that only an appropriate subtree was reparsed/diffed?
-//                expectationFn(result, previousDOM, true);
+                result = HTMLInstrumentation._updateDOM(previousDOM, editor, changeList);
+                expectationFn(result, previousDOM, true);
             }
             
             it("should re-instrument after document is dirtied", function () {
@@ -695,6 +694,7 @@ define(function (require, exports, module) {
                             origParent = previousDOM.children[3];
                         },
                         function (result, previousDOM, incremental) {
+                            console.log("should handle simple altered text - edits: " + JSON.stringify(result.edits));
                             expect(result.edits.length).toEqual(1);
                             expect(previousDOM.children[3].children[1].tag).toEqual("h1");
                             expect(result.edits[0]).toEqual({
@@ -716,7 +716,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            xit("should handle two incremental text edits in a row", function () {
+            it("should handle two incremental text edits in a row", function () {
                 runs(function () {
                     var previousDOM = HTMLInstrumentation._buildSimpleDOM(editor.document.getText()),
                         changeList,
@@ -738,8 +738,8 @@ define(function (require, exports, module) {
                     expect(result.dom.children[3].children[1].tagID).toEqual(tagID);
                     expect(result.edits[0]).toEqual({
                         type: "textReplace",
-                        tagID: tagID,
-                        child: 0,
+                        parentID: tagID,
+                        firstChild: true,
                         content: "GETTING AWESOMER WITH BRACKETS"
                     });
                     // make sure the parent of the change is still the same node as in the old tree
@@ -755,8 +755,8 @@ define(function (require, exports, module) {
                     expect(result.dom.children[3].children[1].tagID).toEqual(tagID);
                     expect(result.edits[0]).toEqual({
                         type: "textReplace",
-                        tagID: tagID,
-                        child: 0,
+                        parentID: tagID,
+                        firstChild: true,
                         content: "GETTING MOAR AWESOME WITH BRACKETS"
                     });
                     


### PR DESCRIPTION
Might want to review the commits individually. The code gets worse and worse in later commits :) But most of the gross code is in RemoteAgent/HTMLDocument, and that stuff is all throwaway/easy to recreate more nicely.

The commit messages should be pretty self-explanatory. Here are a few notes:
- With these changes, the UI should more or less handle all the various kinds of edits, with some caveats. Cases that work (at least in my limited testing on citrus completed):
  - the things that worked before (modifying existing text, changing the src of an img attribute)
  - deleting an entire text span at once
  - copying an `<img>` tag and pasting it in another location
  - editing the src attribute of the `<img>` tag that was just pasted
  - deleting an `<img>` tag
  - typing new attributes in a tag (see note below on valid/invalid states)
- Cases that don't work well:
  - typing an entirely new tag (see note below on valid/invalid states)--it gets confused as soon as you type a `<` before existing text. But if you paste something like `<img>` all at once, then type new attributes into it, it works.
  - doing multiple (non-text) edits in a row--for example, pasting multiple images in. I pretty much have to close and reopen the connection in between each edit. Not clear whether this is in the differ or in the incremental update stuff.
  - probably lots of other stuff :)
- All of the unit tests are passing now (including incremental tests) except one (simple tag insertion), but that was failing before my changes as well (though with different symptoms). I think what's happening is that the edit list for tag insertion might not be technically incorrect, but is deleting and recreating a node that could just be left alone.
- I didn't add tests for any of my new functionality. Sorry :)
- I also fixed the bug you noted before (about old node map entries not getting deleted), and also did work to properly add/update marked ranges based on the new subtree. Note that the add/update marked range code is very inefficient because there's no quick way to find the mark for a given tag ID--we probably need to cache the marks somewhere.
- The edit descriptors need some cleanup--there's some inconsistency between the various descriptor types in terms of usage of `parentID` vs. `tagID`, etc. Also, we should probably tune their structure towards what will make it easiest to do the update in the browser--right now some things are easier/harder to do based on the kinds of things that are available in jQuery (e.g. it's hard to select text nodes), which is part of the reason the RemoteAgent code I added is so terrible. If we switch to a pure DOM implementation on the backend, that will make other styles of update easier/harder.
- To deal with valid/invalid states, I did basically what we talked about: made the parser (and everything upstream of it) return null if it detects a bad state anywhere; in that case, we don't do any updates until the next time the parser returns a valid DOM node, at which time we fall back to a full diff. After I added another case in the parser to detect when we seem to have unbalanced open/close tags, it now seems to catch cases of invalid attribute syntax pretty well. However, it doesn't detect the very common case where I just type "<" to start a new tag immediately before some text--the tokenizer doesn't seem to notice that eventually you run into another "<" without having closed off the first tag. That leads to some weird behavior where we create a new bogus tag and then don't recover from it later.
- If I had time, the first thing I'd do is rewrite the stuff I added to RemoteAgent to use a small library of manipulation functions on the browser side (instead of just eval-ing whole chunks of code all the time), and do any on-the-fly code gen that we need through Mustache templates. But I ran out of time :), and to the extent that it works it's probably not that important to clean it up right now.
