### PR TITLE
Fix Quick Open integration test.

### DIFF
--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -96,8 +96,7 @@ define(function (require, exports, module) {
         it("can open a file and jump to a line, centering that line on the screen", function () {
             var err = false,
                 editor,
-                $scroller,
-                heightWithModal;
+                $scroller;
             
             SpecRunnerUtils.loadProjectInTestWindow(testPath);
             
@@ -125,7 +124,7 @@ define(function (require, exports, module) {
             
             waitsFor(function () {
                 editor = EditorManager.getCurrentFullEditor();
-                return editor !== null;
+                return editor !== null && getSearchBar().length === 0;
             }, "file opening timeout", 3000);
             
             runs(function () {
@@ -145,13 +144,12 @@ define(function (require, exports, module) {
             }, "goto line entry timeout", 1000);
             
             runs(function () {
-                heightWithModal = $scroller.height();
                 pressEnter();
             });
 
-            // wait for ModalBar to close, use editor height to detect change
+            // wait for ModalBar to close
             waitsFor(function () {
-                return heightWithModal !== $scroller.height();
+                return getSearchBar().length === 0;
             }, "ModalBar close", 1000);
 
             runs(function () {


### PR DESCRIPTION
The problem was that the modal bar is sometimes not completely removed
from the DOM before the new modal bar is opened. This update specifically
checks that the modal bar has been closed.

This is a fix for #4199 
