### PR TITLE
fix #2957. fix unit tests by re-enabling multiple bindings.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,9 +157,8 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config']);
 
     // task: test
-    //grunt.registerTask('test', ['jshint', 'jasmine']);
-//    grunt.registerTask('test', ['jshint', 'jasmine-node']);
-    grunt.registerTask('test', ['jshint']);
+    grunt.registerTask('test', ['jshint:all', 'jasmine']);
+    //grunt.registerTask('test', ['jshint:all', 'jasmine', jasmine-node']);
 
     // task: set-sprint
     // Update sprint number in package.json and rewrite src/config.json

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "grunt-cli": "0.1.6",
         "phantomjs": "1.9.0-1",
         "grunt-lib-phantomjs": "0.3.0",
-        "grunt-contrib-jshint": "0.2.0",
+        "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.3.1",
         "grunt-contrib-jasmine": "0.4.2",
         "grunt-template-jasmine-requirejs": "0.1.0",

--- a/src/config.json
+++ b/src/config.json
@@ -34,7 +34,7 @@
         "grunt-cli": "0.1.6",
         "phantomjs": "1.9.0-1",
         "grunt-lib-phantomjs": "0.3.0",
-        "grunt-contrib-jshint": "0.2.0",
+        "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.3.1",
         "grunt-contrib-jasmine": "0.4.2",
         "grunt-template-jasmine-requirejs": "0.1.0",


### PR DESCRIPTION
Backs out change from #4305 since we still want to support multiple key bindings for a single command. Fixes failing unit test from build 0.27.0-8224. Also updates jshint to remove `boss` option to fix #2957.
