### PR TITLE
Don't crash when running InlineEditorProvider tests on the mac

### DIFF
--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -243,9 +243,6 @@ define(function (require, exports, module) {
             afterEach(function () {
                 //debug visual confirmation of inline editor
                 //waits(1000);
-                runs(function () {
-                    SpecRunnerUtils.deletePath(tempPath);
-                });
                 
                 // revert files to original content with offset markup
                 SpecRunnerUtils.closeTestWindow();
@@ -1193,7 +1190,13 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
                 });
             });
-            
+        
+            it("should delete the temp directory", function () {
+                // Delete the temp directory once we've run all of the tests
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.deletePath(tempPath));
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
The avoids the crash when running the InlineEditorProvider tests on the mac (bug #4328). Rather than deleting the temp directory after _every_ spec, delete it once at the end of the suite. 

Prior to adobe/brackets-shell#265, `SpecRunnerUtils.deletePath(..)` didn't do anything if you passed in a directory. Now it deletes the directory immediately. 
