### PR TITLE
Call new shell api setModal to enforce the modality of a JS dialog.

### DIFF
--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -43,19 +43,6 @@ define(function (require, exports, module) {
      * calling Brackets commands from the native shell.
      */
     function executeCommand(eventName) {
-        // Temporary fix for #2616 - don't execute the command if a modal dialog is open.
-        // This should really be fixed with proper menu enabling.
-        if ($(".modal.instance").length || !appReady) {
-            // Another hack to fix issue #3219 so that all test windows are closed 
-            // as before the fix for #3152 has been introduced. isBracketsTestWindow 
-            // property is explicitly set in createTestWindowAndRun() in SpecRunnerUtils.js.
-            if (window.isBracketsTestWindow) {
-                return false;
-            }
-            // Return false for all commands except file.close_window command for 
-            // which we have to return true (issue #3152).
-            return (eventName === Commands.FILE_CLOSE_WINDOW);
-        }
         var promise, e = new Error(), stackDepth = e.stack.split("\n").length;
         
         // This function should *only* be called as a top-level function. If the current

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -62,6 +62,7 @@ define(function (require, exports, module) {
         dlg.data("buttonId", buttonId);
         $(".clickable-link", dlg).off("click");
         dlg.modal("hide");
+        brackets.app.setModal(false);
     }
     
     function _hasButton(dlg, buttonId) {
@@ -175,6 +176,7 @@ define(function (require, exports, module) {
      * @return {Dialog}
      */
     function showModalDialogUsingTemplate(template, autoDismiss) {
+        brackets.app.setModal(true);
         if (autoDismiss === undefined) {
             autoDismiss = true;
         }

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -62,7 +62,6 @@ define(function (require, exports, module) {
         dlg.data("buttonId", buttonId);
         $(".clickable-link", dlg).off("click");
         dlg.modal("hide");
-        brackets.app.setModal(false);
     }
     
     function _hasButton(dlg, buttonId) {
@@ -218,6 +217,7 @@ define(function (require, exports, module) {
             
             // Remove the dialog instance from the DOM.
             $dlg.remove();
+            brackets.app.setModal(false);
 
             // Remove our global keydown handler.
             KeyBindingManager.removeGlobalKeydownHook(keydownHook);


### PR DESCRIPTION
This pull request goes with another one in brackets shell https://github.com/adobe/brackets-shell/pull/268.

Also remove all the hacks that we put in when switching to native menus. So after this pull request landed, we need to regress #2616, #3152, #3219 and #418.
