### PR TITLE
Don't load DOMAgent

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -132,7 +132,6 @@ define(function LiveDevelopment(require, exports, module) {
         "console"   : true,
         "remote"    : true,
         "network"   : true,
-        "dom"       : true,
         "css"       : true,
         "highlight" : true
     };


### PR DESCRIPTION
Fix for #4348 

Don't load DOMAgent by default (it's still loaded if the "experimental" flag is on).

If the live preview source is not valid HTML, the DOMAgent chokes and can't load the file. We aren't using the DOMAgent for any core features anyway, so it's safe to turn it off.
