### PR TITLE
update usage of key bindings to respect the new sort order

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -81,6 +81,30 @@ define(function (require, exports, module) {
         _commandMap = {};
         _globalKeydownHooks = [];
     }
+    
+    /**
+     * @private
+     * Sort key bindings in priority order based on platform
+     * @param {Object} a Key binding request
+     * @param {Object} b Key binding request
+     */
+    function _sortKeyBindings(a, b) {
+        if (a.platform === brackets.platform) {
+            // "a" is platform specific and matches
+            return -1;
+        } else if (b.platform === brackets.platform) {
+            // "b" is platform specific and matches
+            return 1;
+        } else if (!a.platform && b.platform) {
+            // "a" is generic and "b" is not matching
+            return -1;
+        } else if (!b.platform && a.platform) {
+            // "b" is generic and "a" is not matching
+            return 1;
+        } else {
+            return 0;
+        }
+    }
 
     /**
      * @private
@@ -464,7 +488,9 @@ define(function (require, exports, module) {
             explicitPlatform    : explicitPlatform
         };
         
+        // add the new bindings and re-sort based on priority
         _commandMap[commandID].push(result);
+        _commandMap[commandID].sort(_sortKeyBindings);
         
         // 1-to-1 key binding to commandID
         _keyMap[normalized] = {
@@ -557,23 +583,7 @@ define(function (require, exports, module) {
             var keyBinding, errors = [];
             results = [];
             
-            keyBindings.sort(function (a, b) {
-                if (a.platform === brackets.platform) {
-                    // "a" is platform specific and matches
-                    return -1;
-                } else if (b.platform === brackets.platform) {
-                    // "b" is platform specific and matches
-                    return 1;
-                } else if (!a.platform && b.platform) {
-                    // "a" is generic and "b" is not matching
-                    return -1;
-                } else if (!b.platform && a.platform) {
-                    // "b" is generic and "a" is not matching
-                    return 1;
-                } else {
-                    return 0;
-                }
-            });
+            keyBindings.sort(_sortKeyBindings);
             
             keyBindings.forEach(function addSingleBinding(keyBindingRequest) {
                 // attempt to add keybinding

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -211,8 +211,8 @@ define(function (require, exports, module) {
             binding = null;
         
         if (bindings.length > 0) {
-            // add the latest key binding
-            binding = bindings[bindings.length - 1];
+            // add the highest priority key binding
+            binding = bindings[0];
             _addKeyBindingToMenuItem($(_getHTMLMenuItem(menuItem.id)), binding.key, binding.displayKey);
         }
         
@@ -545,7 +545,8 @@ define(function (require, exports, module) {
                 displayStr = "";
             
             if (bindings && bindings.length > 0) {
-                binding = bindings[bindings.length - 1];
+                // Bindings are already sorted in priority order based on platform
+                binding = bindings[0];
                 bindingStr = binding.displayKey || binding.key;
             }
             
@@ -741,9 +742,13 @@ define(function (require, exports, module) {
      * @private
      * Updates MenuItem DOM with a keyboard shortcut label
      */
-    MenuItem.prototype._keyBindingAdded = function (event, keyBinding) {
+    MenuItem.prototype._keyBindingAdded = function (event, newKeyBinding) {
+        // always use the highest priority key binding for menus
+        var keyBindings = KeyBindingManager.getKeyBindings(this.getCommand().getID()),
+            keyBinding  = keyBindings[0] || newKeyBinding,
+            shortcutKey = keyBinding.displayKey || keyBinding.key;
+        
         if (this.isNative) {
-            var shortcutKey = keyBinding.displayKey || keyBinding.key;
             brackets.app.setMenuItemShortcut(this._command.getID(), shortcutKey, KeyBindingManager.formatKeyDescriptor(shortcutKey), function (err) {
                 if (err) {
                     console.error("Error setting menu item shortcut: " + err);


### PR DESCRIPTION
Fixes #4353 and #4354 

Changes previous assumptions of sort order on key bindings.
