### PR TITLE
enable DOMAgent for a single live preview unit test

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -135,8 +135,6 @@ define(function LiveDevelopment(require, exports, module) {
         "css"       : true,
         "highlight" : true
     };
-    
-    var _agentsToLoad;
 
     // store the names (matching property names in the 'agent' object) of agents that we've loaded
     var _loadedAgentNames = [];
@@ -505,6 +503,21 @@ define(function LiveDevelopment(require, exports, module) {
 
         return oneAgentPromise;
     }
+
+    function getEnabledAgents() {
+        var enabledAgents;
+
+        // Select agents to use
+        if (exports.config.experimental) {
+            // load all agents
+            enabledAgents = agents;
+        } else {
+            // load only enabled agents
+            enabledAgents = _enabledAgentNames;
+        }
+        
+        return Object.keys(enabledAgents);
+    }
     
     /**
      * @private
@@ -513,7 +526,7 @@ define(function LiveDevelopment(require, exports, module) {
     function _enableAgents() {
         // enable agents in parallel
         return Async.doInParallel(
-            _agentsToLoad,
+            getEnabledAgents(),
             function (name) {
                 return _invokeAgentMethod(name, "enable");
             },
@@ -532,7 +545,7 @@ define(function LiveDevelopment(require, exports, module) {
 
         // load agents in parallel
         allAgentsPromise = Async.doInParallel(
-            _agentsToLoad,
+            getEnabledAgents(),
             function (name) {
                 return _invokeAgentMethod(name, "load").done(function () {
                     _loadedAgentNames.push(name);
@@ -1095,17 +1108,6 @@ define(function LiveDevelopment(require, exports, module) {
         // Register user defined server provider
         var userServerProvider = new UserServerProvider();
         LiveDevServerManager.registerProvider(userServerProvider, 99);
-
-        // Select agents to use
-        if (exports.config.experimental) {
-            // load all agents
-            _agentsToLoad = agents;
-        } else {
-            // load only enabled agents
-            _agentsToLoad = _enabledAgentNames;
-        }
-        
-        _agentsToLoad = Object.keys(_agentsToLoad);
 
         // Initialize exports.status
         _setStatus(STATUS_INACTIVE);

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -125,6 +125,10 @@ define(function (require, exports, module) {
         });
     }
 
+    function enableAgent(liveDevModule, name) {
+        liveDevModule.enableAgent(name);
+    }
+
     describe("Live Development", function () {
         
         this.category = "integration";
@@ -330,6 +334,8 @@ define(function (require, exports, module) {
                 
                 var cssOpened = false;
                 runs(function () {
+                    enableAgent(LiveDevelopment, "dom");
+
                     SpecRunnerUtils.openProjectFiles(["simple1.css"]).fail(function () {
                         expect("Failed To Open").toBe("simple1.css");
                     }).always(function () {


### PR DESCRIPTION
Pull #4358 disabled DOMAgent to fix #4348. This patch selectively enables DOMAgent for a failing integration test and removes an optimization made earlier this sprint to define which agents are enabled.
