### PR TITLE
Explicitly enable JSLint before running JSLint unit tests

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -313,4 +313,7 @@ define(function (require, exports, module) {
         toggleCollapsed(_prefs.getValue("collapsed"));
                 
     });
+    
+    // for unit tests
+    exports.setEnabled = setEnabled;
 });

--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -35,6 +35,8 @@ define(function (require, exports, module) {
             testWindow,
             $,
             brackets,
+            extensionRequire,
+            JSLint,
             EditorManager;
         
         var toggleJSLintResults = function (visible) {
@@ -50,6 +52,9 @@ define(function (require, exports, module) {
                     $ = testWindow.$;
                     brackets = testWindow.brackets;
                     EditorManager = testWindow.brackets.test.EditorManager;
+                    extensionRequire = brackets.test.ExtensionLoader.getRequireContextForExtension("JSLint");
+                    JSLint = extensionRequire("main");
+                    JSLint.setEnabled(true);
                 });
             });
             
@@ -63,6 +68,8 @@ define(function (require, exports, module) {
             $             = null;
             brackets      = null;
             EditorManager = null;
+            extensionRequire    = null;
+            JSLint              = null;
             SpecRunnerUtils.closeTestWindow();
         });
         


### PR DESCRIPTION
Edge Code disables JSLint by default, so the new JSLint unit tests fail because JSLint is not enabled. This pull updates the unit tests to explicitly enable JSLint in the test window before running each test.
