### PR TITLE
add try/catch to async extension init to fix #4404

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
      * deferred. If we hit this timeout, we'll never have a node connection
      * for the installer in this run of Brackets.
      */
-    var NODE_CONNECTION_TIMEOUT = 30000; // 30 seconds - TODO: share with StaticServer?
+    var NODE_CONNECTION_TIMEOUT = 5000; // 5 seconds - TODO: share with StaticServer?
     
     /**
      * @private

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
      * deferred. If we hit this timeout, we'll never have a node connection
      * for the static server in this run of Brackets.
      */
-    var NODE_CONNECTION_TIMEOUT = 30000; // 30 seconds
+    var NODE_CONNECTION_TIMEOUT = 5000; // 5 seconds
     
     /**
      * @private

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
         return _nodeConnectionDeferred;
     }
     
-    function init() {
+    function initExtension() {
         // Start up the node connection, which is held in the
         // _nodeConnectionDeferred module variable. (Use 
         // _nodeConnectionDeferred.done() to access it.
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
         return _nodeConnectionDeferred.promise();
     }
 
-    exports.init = init;
+    exports.initExtension = initExtension;
 
     // For unit tests only
     exports._getStaticServerProvider = _getStaticServerProvider;

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -60,7 +60,7 @@ define(function (require, exports, module) {
                 if (!nodeConnection) {
                     runs(function () {
                         // wait for StaticServer/main to connect and load the StaticServerDomain
-                        main.init().done(function (conn) {
+                        main.initExtension().done(function (conn) {
                             nodeConnection = conn;
                         });
 

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -111,21 +111,21 @@ define(function (require, exports, module) {
 
                 _extensions[name] = module;
 
-                if (module && module.init && (typeof module.init === "function")) {
+                if (module && module.initExtension && (typeof module.initExtension === "function")) {
                     // optional async extension init 
                     try {
-                        initPromise = Async.withTimeout(module.init(), 5000);
+                        initPromise = Async.withTimeout(module.initExtension(), 5000);
                     } catch (err) {
-                        console.error("[Extension] Error -- error thrown during extension init for " + name + ": " + err);
+                        console.error("[Extension] Error -- error thrown during initExtension for " + name + ": " + err);
                         result.reject(err);
                     }
 
                     if (initPromise) {
                         initPromise.fail(function (err) {
                             if (err === Async.ERROR_TIMEOUT) {
-                                console.error("[Extension] Error -- timeout during extension init for " + name);
+                                console.error("[Extension] Error -- timeout during initExtension for " + name);
                             } else {
-                                console.error("[Extension] Error -- failed extension init for " + name + (err ? ": " + err : ""));
+                                console.error("[Extension] Error -- failed initExtension for " + name + (err ? ": " + err : ""));
                             }
                         });
 

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -113,7 +113,12 @@ define(function (require, exports, module) {
 
                 if (module && module.init && (typeof module.init === "function")) {
                     // optional async extension init 
-                    initPromise = module.init();
+                    try {
+                        initPromise = module.init();
+                    } catch (err) {
+                        console.error("[Extension] Error -- error thrown during extension init for " + name + ": " + err);
+                        result.reject(err);
+                    }
 
                     if (initPromise) {
                         promise = initPromise.then(result.resolve, result.reject);

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -38,6 +38,7 @@ define(function (require, exports, module) {
     require("spec/EditorOptionHandlers-test");
     require("spec/EditorManager-test");
     require("spec/ExtensionInstallation-test");
+    require("spec/ExtensionLoader-test");
     require("spec/ExtensionManager-test");
     require("spec/ExtensionUtils-test");
     require("spec/FileIndexManager-test");

--- a/test/spec/ExtensionLoader-test-files/BadRequire/main.js
+++ b/test/spec/ExtensionLoader-test-files/BadRequire/main.js
@@ -1,0 +1,7 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    require("notdefined");
+});

--- a/test/spec/ExtensionLoader-test-files/InitFail/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitFail/main.js
@@ -1,0 +1,10 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        // promise is rejected immediately
+        return new $.Deferred().reject();
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/InitFail/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitFail/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         // promise is rejected immediately
         return new $.Deferred().reject();
     };

--- a/test/spec/ExtensionLoader-test-files/InitFailWithError/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitFailWithError/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         // promise is rejected immediately with an error
         return new $.Deferred().reject("Didn't work");
     };

--- a/test/spec/ExtensionLoader-test-files/InitFailWithError/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitFailWithError/main.js
@@ -1,0 +1,10 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        // promise is rejected immediately with an error
+        return new $.Deferred().reject("Didn't work");
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/InitFailWithErrorAsync/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitFailWithErrorAsync/main.js
@@ -1,4 +1,4 @@
-/*global define, $, window */
+/*global define, $ */
 
 define(function (require, exports, module) {
     "use strict";
@@ -6,7 +6,7 @@ define(function (require, exports, module) {
     exports.initExtension = function () {
         var deferred = new $.Deferred();
 
-        window.setTimeout(function () { deferred.resolve(); }, 100);
+        window.setTimeout(function () { deferred.reject("Didn't work"); }, 100);
 
         return deferred.promise();
     };

--- a/test/spec/ExtensionLoader-test-files/InitResolved/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitResolved/main.js
@@ -1,0 +1,9 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        return new $.Deferred().resolve();
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/InitResolved/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitResolved/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         return new $.Deferred().resolve();
     };
 });

--- a/test/spec/ExtensionLoader-test-files/InitResolvedAsync/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitResolvedAsync/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         var deferred = new $.Deferred();
 
         window.setTimeout(function () { deferred.resolve(); }, 1000);

--- a/test/spec/ExtensionLoader-test-files/InitResolvedAsync/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitResolvedAsync/main.js
@@ -1,0 +1,13 @@
+/*global define, $, window */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        var deferred = new $.Deferred();
+
+        window.setTimeout(function () { deferred.resolve(); }, 1000);
+
+        return deferred.promise();
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/InitRuntimeError/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitRuntimeError/main.js
@@ -1,0 +1,12 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        // runtime error
+        isNotDefined();
+
+        return new $.Deferred();
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/InitRuntimeError/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitRuntimeError/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         // runtime error
         isNotDefined();
 

--- a/test/spec/ExtensionLoader-test-files/InitTimeout/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitTimeout/main.js
@@ -3,7 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    exports.init = function () {
+    exports.initExtension = function () {
         // promise is never resolved, expect default Async timeout
         return new $.Deferred();
     };

--- a/test/spec/ExtensionLoader-test-files/InitTimeout/main.js
+++ b/test/spec/ExtensionLoader-test-files/InitTimeout/main.js
@@ -1,0 +1,10 @@
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    exports.init = function () {
+        // promise is never resolved, expect default Async timeout
+        return new $.Deferred();
+    };
+});

--- a/test/spec/ExtensionLoader-test-files/NoInit/main.js
+++ b/test/spec/ExtensionLoader-test-files/NoInit/main.js
@@ -1,0 +1,5 @@
+/*global define */
+
+define(function (require, exports, module) {
+    "use strict";
+});

--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define: false, describe: false, it: false, expect: false, spyOn: false, waitsForDone: false, waitsForFail: false */
+
+define(function (require, exports, module) {
+    'use strict';
+    
+    // Load dependent modules
+    var ExtensionLoader = require("utils/ExtensionLoader"),
+        SpecRunnerUtils = require("spec/SpecRunnerUtils");
+
+    var testPath = SpecRunnerUtils.getTestPath("/spec/ExtensionLoader-test-files");
+    
+    describe("ExtensionLoader", function () {
+
+        function testLoadExtension(name, promiseState, error) {
+            var promise,
+                config = {
+                    baseUrl: testPath + "/" + name
+                };
+
+            runs(function () {
+                spyOn(console, "error").andCallThrough();
+                promise = ExtensionLoader.loadExtension(name, config, "main");
+
+                if (error) {
+                    waitsForFail(promise, "loadExtension", 10000);
+                } else {
+                    waitsForDone(promise, "loadExtension");
+                }
+            });
+
+            runs(function () {
+                if (error) {
+                    if (typeof error === "string") {
+                        expect(console.error.mostRecentCall.args[0]).toBe(error);
+                    } else {
+                        expect(console.error.mostRecentCall.args[0]).toMatch(error);
+                    }
+                }
+                
+                expect(promise.state()).toBe(promiseState);
+            });
+        }
+
+        it("should load a basic extension", function () {
+            testLoadExtension("NoInit", "resolved");
+        });
+
+        it("should load a basic extension with sync init", function () {
+            testLoadExtension("InitResolved", "resolved");
+        });
+
+        it("should load a basic extension with async init", function () {
+            testLoadExtension("InitResolvedAsync", "resolved");
+        });
+
+        it("should log an error if an extension fails to init", function () {
+            testLoadExtension("InitFail", "rejected", "[Extension] Error -- failed extension init for InitFail");
+        });
+
+        it("should log an error with a message if an extension fails to init", function () {
+            testLoadExtension("InitFailWithError", "rejected", "[Extension] Error -- failed extension init for InitFailWithError: Didn't work");
+        });
+
+        it("should log an error if an extension init fails with a timeout", function () {
+            testLoadExtension("InitTimeout", "rejected", "[Extension] Error -- timeout during extension init for InitTimeout");
+        });
+
+        it("should log an error if an extension init fails with a runtime error", function () {
+            testLoadExtension("InitRuntimeError", "rejected", "[Extension] Error -- error thrown during extension init for InitRuntimeError: ReferenceError: isNotDefined is not defined");
+        });
+
+        it("should log an error if an extension fails during RequireJS loading", function () {
+            testLoadExtension("BadRequire", "rejected", /\[Extension\] failed to load.*/);
+        });
+
+    });
+});

--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, expect: false, spyOn: false, waitsForDone: false, waitsForFail: false */
+/*global define: false, describe: false, it: false, expect: false, spyOn: false, runs: false, waitsForDone: false, waitsForFail: false */
 
 define(function (require, exports, module) {
     'use strict';
@@ -79,19 +79,19 @@ define(function (require, exports, module) {
         });
 
         it("should log an error if an extension fails to init", function () {
-            testLoadExtension("InitFail", "rejected", "[Extension] Error -- failed extension init for InitFail");
+            testLoadExtension("InitFail", "rejected", "[Extension] Error -- failed initExtension for InitFail");
         });
 
         it("should log an error with a message if an extension fails to init", function () {
-            testLoadExtension("InitFailWithError", "rejected", "[Extension] Error -- failed extension init for InitFailWithError: Didn't work");
+            testLoadExtension("InitFailWithError", "rejected", "[Extension] Error -- failed initExtension for InitFailWithError: Didn't work");
         });
 
         it("should log an error if an extension init fails with a timeout", function () {
-            testLoadExtension("InitTimeout", "rejected", "[Extension] Error -- timeout during extension init for InitTimeout");
+            testLoadExtension("InitTimeout", "rejected", "[Extension] Error -- timeout during initExtension for InitTimeout");
         });
 
         it("should log an error if an extension init fails with a runtime error", function () {
-            testLoadExtension("InitRuntimeError", "rejected", "[Extension] Error -- error thrown during extension init for InitRuntimeError: ReferenceError: isNotDefined is not defined");
+            testLoadExtension("InitRuntimeError", "rejected", "[Extension] Error -- error thrown during initExtension for InitRuntimeError: ReferenceError: isNotDefined is not defined");
         });
 
         it("should log an error if an extension fails during RequireJS loading", function () {

--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, expect: false, spyOn: false, runs: false, waitsForDone: false, waitsForFail: false */
+/*global define: false, describe: false, it: false, expect: false, spyOn: false, runs: false, waitsForDone: false, waitsForFail: false, beforeEach: false, afterEach: false */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -135,11 +135,12 @@ define(function (require, exports, module) {
      * @param {$.Promise} promise
      * @param {string} operationName  Name used for timeout error message
      */
-    window.waitsForFail = function (promise, operationName) {
+    window.waitsForFail = function (promise, operationName, timeout) {
+        timeout = timeout || 1000;
         expect(promise).toBeTruthy();
         waitsFor(function () {
             return promise.state() === "rejected";
-        }, "failure " + operationName, 1000);
+        }, "failure " + operationName, timeout);
     };
     
     /**


### PR DESCRIPTION
Fix for #4404 

Wrap extension initialization with a try/catch block to prevent runtime errors from halting brackets startup.
