### PR TITLE
Allow all files to be opened by drag and drop

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -149,10 +149,11 @@ define(function (require, exports, module) {
      * @private
      * Creates a document and displays an editor for the specified file path.
      * @param {!string} fullPath
+     * @param {boolean=} silent If true, don't show error message
      * @return {$.Promise} a jQuery promise that will be resolved with a
      *  document for the specified file path, or rejected if the file can not be read.
      */
-    function doOpen(fullPath) {
+    function doOpen(fullPath, silent) {
         var result = new $.Deferred();
 
         if (!fullPath) {
@@ -171,12 +172,18 @@ define(function (require, exports, module) {
                     result.resolve(doc);
                 })
                 .fail(function (fileError) {
-                    FileUtils.showFileOpenError(fileError.name, fullPath).done(function () {
+                    function _cleanup() {
                         // For performance, we do lazy checking of file existence, so it may be in working set
                         DocumentManager.removeFromWorkingSet(new NativeFileSystem.FileEntry(fullPath));
                         EditorManager.focusEditor();
                         result.reject();
-                    });
+                    }
+                    
+                    if (silent) {
+                        _cleanup();
+                    } else {
+                        FileUtils.showFileOpenError(fileError.name, fullPath).done(_cleanup);
+                    }
                 });
         }
 
@@ -194,10 +201,11 @@ define(function (require, exports, module) {
      * Creates a document and displays an editor for the specified file path. 
      * If no path is specified, a file prompt is provided for input.
      * @param {?string} fullPath - The path of the file to open; if it's null we'll prompt for it
+     * @param {?boolean} silent - If true, don't show error message
      * @return {$.Promise} a jQuery promise that will be resolved with a new 
      *  document for the specified file path, or rejected if the file can not be read.
      */
-    function _doOpenWithOptionalPath(fullPath) {
+    function _doOpenWithOptionalPath(fullPath, silent) {
         var result;
         if (!fullPath) {
             // Create placeholder deferred
@@ -219,7 +227,7 @@ define(function (require, exports, module) {
                         });
                         DocumentManager.addListToWorkingSet(filesToOpen);
                         
-                        doOpen(paths[paths.length - 1])
+                        doOpen(paths[paths.length - 1], silent)
                             .done(function (doc) {
                                 var url = PathUtils.parseUrl(doc.file.fullPath);
                                 //reconstruct the url but use the directory and stop there
@@ -235,7 +243,7 @@ define(function (require, exports, module) {
                     }
                 });
         } else {
-            result = doOpen(fullPath);
+            result = doOpen(fullPath, silent);
         }
         
         return result.promise();
@@ -273,8 +281,9 @@ define(function (require, exports, module) {
      * lineNumber and columnNumber are 1-origin: the very first line is line 1, and the very first column is column 1.
      */
     function handleFileOpen(commandData) {
-        var fileInfo = _parseDecoratedPath(commandData ? commandData.fullPath : null);
-        return _doOpenWithOptionalPath(fileInfo.path)
+        var fileInfo = _parseDecoratedPath(commandData ? commandData.fullPath : null),
+            silent = commandData ? commandData.silent : false;
+        return _doOpenWithOptionalPath(fileInfo.path, silent)
             .always(function () {
                 // If a line and column number were given, position the editor accordingly.
                 if (fileInfo.line !== null) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -201,7 +201,7 @@ define(function (require, exports, module) {
      * Creates a document and displays an editor for the specified file path. 
      * If no path is specified, a file prompt is provided for input.
      * @param {?string} fullPath - The path of the file to open; if it's null we'll prompt for it
-     * @param {?boolean} silent - If true, don't show error message
+     * @param {boolean=} silent - If true, don't show error message
      * @return {$.Promise} a jQuery promise that will be resolved with a new 
      *  document for the specified file path, or rejected if the file can not be read.
      */

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -361,30 +361,6 @@ define(function (require, exports, module) {
     function getDirectoryPath(fullPath) {
         return fullPath.substr(0, fullPath.lastIndexOf("/") + 1);
     }
-
-    /**
-     * Determine if a file is a text file. This function is only a quick best-guess.
-     * @param {string} path Path to check
-     * @return {boolean} True if the path is a text file, false if not.
-     */
-    function isTextFile(path) {
-        // We don't have an accurate way to quickly check if a file is a text file.
-        // To make a good guess, start by looking at the language of the file.
-        var language = LanguageManager.getLanguageForPath(path);
-        
-        if (language.getId() !== "unknown") {
-            // Language is known to Brackets, this must be a text file.
-            return true;
-        }
-        
-        // All other files end up with language === "unknown", including .txt files.
-        var extension = _getFileExtension(path),
-            textExtensionRegEx = /^(txt|gyp[i]?)$/;
-        
-        // If there is no extension, or the extension is known text extension, assume it is a text file.
-        // Files with other extensions, like .png or .jpg, will return false.
-        return (extension === path || textExtensionRegEx.test(extension.toLowerCase()));
-    }
     
     // Define public API
     exports.LINE_ENDINGS_CRLF              = LINE_ENDINGS_CRLF;
@@ -406,5 +382,4 @@ define(function (require, exports, module) {
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
     exports.isServerHtmlFileExt            = isServerHtmlFileExt;
     exports.getDirectoryPath               = getDirectoryPath;
-    exports.isTextFile                     = isTextFile;
 });

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
         return Async.doInParallel(files, function (file) {
             var result = new $.Deferred();
             
-            // Only open text files
+            // Only open files
             brackets.fs.stat(file, function (err, stat) {
                 if (!err && stat.isFile()) {
                     CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET,

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
             if (items[i].kind === "file") {
                 var entry = items[i].webkitGetAsEntry();
                 
-                if (entry.isFile && FileUtils.isTextFile(entry.fullPath)) {
+                if (entry.isFile) {
                     return true;
                 }
             }
@@ -74,9 +74,9 @@ define(function (require, exports, module) {
             
             // Only open text files
             brackets.fs.stat(file, function (err, stat) {
-                if (!err && stat.isFile() && FileUtils.isTextFile(file)) {
+                if (!err && stat.isFile()) {
                     CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET,
-                                           {fullPath: file})
+                                           {fullPath: file, silent: true})
                         .done(function () {
                             result.resolve();
                         })


### PR DESCRIPTION
@peterflynn @RaymondLim 

Remove `FileUtils.isTextFile()` since it was giving too many false negatives. The drag and drop code now accepts _all_ files, and relies on FILE_OPEN to determine which files can or cannot be opened.

This required adding an optional `silent` parameter to `FILE_OPEN`. When true, errors are not shown when opening files.

See [this comment](https://github.com/adobe/brackets/pull/4406#discussion_r5125307) for more details.
