### PR TITLE
INITIAL REVIEW: Animate inline editors open.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1135,8 +1135,8 @@ define(function (require, exports, module) {
      * @param {InlineWidget} inlineWidget  an inline widget.
      */
     Editor.prototype._removeInlineWidgetFromList = function (inlineWidget) {
-        var i;
-        var l = this._inlineWidgets.length;
+        var l = this._inlineWidgets.length,
+            i;
         for (i = 0; i < l; i++) {
             if (this._inlineWidgets[i] === inlineWidget) {
                 this._inlineWidgets.splice(i, 1);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1068,6 +1068,7 @@ define(function (require, exports, module) {
     /**
      * Removes the given inline widget.
      * @param {number} inlineWidget The widget to remove.
+     * @return {$.Promise} A promise that is resolved when the inline widget is fully closed and removed from the DOM.
      */
     Editor.prototype.removeInlineWidget = function (inlineWidget) {
         if (!inlineWidget.closePromise) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -73,7 +73,8 @@ define(function (require, exports, module) {
         Strings            = require("strings"),
         TextRange          = require("document/TextRange").TextRange,
         TokenUtils         = require("utils/TokenUtils"),
-        ViewUtils          = require("utils/ViewUtils");
+        ViewUtils          = require("utils/ViewUtils"),
+        Async              = require("utils/Async");
     
     var defaultPrefs = { useTabChar: false, tabSize: 4, spaceUnits: 4, closeBrackets: false,
                          showLineNumbers: true, styleActiveLine: false, wordWrap: true };
@@ -992,29 +993,63 @@ define(function (require, exports, module) {
      * @param {!{line:number, ch:number}} pos  Position in text to anchor the inline.
      * @param {!InlineWidget} inlineWidget The widget to add.
      * @param {boolean=} scrollLineIntoView Scrolls the associated line into view. Default true.
+     * @return {$.Promise} A promise object that is resolved when the widget has been added (but might
+     *     still be animating open). Never rejected.
      */
     Editor.prototype.addInlineWidget = function (pos, inlineWidget, scrollLineIntoView) {
+        var self = this,
+            queue = this._inlineWidgetQueues[pos.line],
+            deferred = new $.Deferred();
+        if (!queue) {
+            queue = new Async.PromiseQueue();
+            this._inlineWidgetQueues[pos.line] = queue;
+        }
+        queue.add(function () {
+            self._addInlineWidgetInternal(pos, inlineWidget, scrollLineIntoView, deferred);
+            return deferred.promise();
+        });
+        return deferred.promise();
+    };
+    
+    /**
+     * @private
+     * Does the actual work of addInlineWidget().
+     */
+    Editor.prototype._addInlineWidgetInternal = function (pos, inlineWidget, scrollLineIntoView, deferred) {
         var self = this;
         
-        this.removeAllInlineWidgetsForLine(pos.line);
+        this.removeAllInlineWidgetsForLine(pos.line).done(function () {
+            if (scrollLineIntoView === undefined) {
+                scrollLineIntoView = true;
+            }
+    
+            if (scrollLineIntoView) {
+                self._codeMirror.scrollIntoView(pos);
+            }
+    
+            inlineWidget.info = self._codeMirror.addLineWidget(pos.line, inlineWidget.htmlContent,
+                                                               { coverGutter: true, noHScroll: true });
+            CodeMirror.on(inlineWidget.info.line, "delete", function () {
+                self._removeInlineWidgetInternal(inlineWidget);
+            });
+            self._inlineWidgets.push(inlineWidget);
 
-        if (scrollLineIntoView === undefined) {
-            scrollLineIntoView = true;
-        }
+            // Set up the widget to start closed, then animate open when its initial height is set.
+            inlineWidget.$htmlContent
+                .height(0)
+                .addClass("animating")
+                .one("webkitTransitionEnd", function () {
+                    inlineWidget.$htmlContent.removeClass("animating");
+                    deferred.resolve();
+                });
 
-        if (scrollLineIntoView) {
-            this._codeMirror.scrollIntoView(pos);
-        }
-
-        inlineWidget.info = this._codeMirror.addLineWidget(pos.line, inlineWidget.htmlContent,
-                                                           { coverGutter: true, noHScroll: true });
-        CodeMirror.on(inlineWidget.info.line, "delete", function () {
-            self._removeInlineWidgetInternal(inlineWidget);
+            // Callback to widget once parented to the editor. The widget should call back to
+            // setInlineWidgetHeight() in order to set its initial height and animate open.
+            // TODO: Should we make onAdded() return the desired height so that it's a
+            // required part of the API, instead of people just having to know that they
+            // need to call setInlineWidgetHeight() at least once?
+            inlineWidget.onAdded();    
         });
-        this._inlineWidgets.push(inlineWidget);
-
-        // Callback to widget once parented to the editor
-        inlineWidget.onAdded();
     };
     
     /**
@@ -1024,9 +1059,10 @@ define(function (require, exports, module) {
         // copy the array because _removeInlineWidgetInternal will modify the original
         var widgets = [].concat(this.getInlineWidgets());
         
-        widgets.forEach(function (widget) {
-            this.removeInlineWidget(widget);
-        }, this);
+        return Async.doInParallel(
+            widgets,
+            this.removeInlineWidget.bind(this)
+        );
     };
     
     /**
@@ -1034,10 +1070,29 @@ define(function (require, exports, module) {
      * @param {number} inlineWidget The widget to remove.
      */
     Editor.prototype.removeInlineWidget = function (inlineWidget) {
-        var lineNum = this._getInlineWidgetLineNumber(inlineWidget);
-        
-        this._codeMirror.removeLineWidget(inlineWidget.info);
-        this._removeInlineWidgetInternal(inlineWidget);
+        if (!inlineWidget.closePromise) {
+            var lineNum = this._getInlineWidgetLineNumber(inlineWidget),
+                deferred = new $.Deferred(),
+                self = this;
+            
+            // Remove the inline widget from our internal list immediately, so
+            // everyone external to us knows it's essentially already gone. We
+            // don't want to wait until it's done animating closed (but we do want
+            // the other stuff in _removeInlineWidgetInternal to wait until then).
+            self._removeInlineWidgetFromList(inlineWidget);
+            
+            inlineWidget.$htmlContent.addClass("animating")
+                .one("webkitTransitionEnd", function () {
+                    inlineWidget.$htmlContent.removeClass("animating");
+                    self._codeMirror.removeLineWidget(inlineWidget.info);
+                    self._removeInlineWidgetInternal(inlineWidget);
+                    deferred.resolve();
+                })
+                .height(0);
+                
+            inlineWidget.closePromise = deferred.promise();
+        }
+        return inlineWidget.closePromise;
     };
     
     /**
@@ -1056,29 +1111,47 @@ define(function (require, exports, module) {
                     return w.info;
                 });
 
-            widgetInfos.forEach(function (info) {
-                // Lookup the InlineWidget object using the same index
-                inlineWidget = self._inlineWidgets[allWidgetInfos.indexOf(info)];
-                self.removeInlineWidget(inlineWidget);
-            });
-
+            return Async.doInParallel(
+                widgetInfos,
+                function (info) {
+                    // Lookup the InlineWidget object using the same index
+                    inlineWidget = self._inlineWidgets[allWidgetInfos.indexOf(info)];
+                    if (inlineWidget) {
+                        return self.removeInlineWidget(inlineWidget);
+                    } else {
+                        return new $.Deferred().resolve().promise();
+                    }
+                }
+            );
+        } else {
+            return new $.Deferred().resolve().promise();
         }
     };
     
     /**
-     * Cleans up the given inline widget from our internal list of widgets.
-     * @param {number} inlineId  id returned by addInlineWidget().
+     * Cleans up the given inline widget from our internal list of widgets. It's okay
+     * to call this multiple times for the same widget--it will just do nothing if
+     * the widget has already been removed.
+     * @param {InlineWidget} inlineWidget  an inline widget.
+     */
+    Editor.prototype._removeInlineWidgetFromList = function (inlineWidget) {
+        var i;
+        var l = this._inlineWidgets.length;
+        for (i = 0; i < l; i++) {
+            if (this._inlineWidgets[i] === inlineWidget) {
+                this._inlineWidgets.splice(i, 1);
+                break;
+            }
+        }
+    };
+    
+    /**
+     * Removes the inline widget from the editor and notifies it to clean itself up.
+     * @param {InlineWidget} inlineWidget  an inline widget.
      */
     Editor.prototype._removeInlineWidgetInternal = function (inlineWidget) {
         if (!inlineWidget.isClosed) {
-            var i;
-            var l = this._inlineWidgets.length;
-            for (i = 0; i < l; i++) {
-                if (this._inlineWidgets[i] === inlineWidget) {
-                    this._inlineWidgets.splice(i, 1);
-                    break;
-                }
-            }
+            this._removeInlineWidgetFromList(inlineWidget);
             inlineWidget.onClosed();
             inlineWidget.isClosed = true;
         }
@@ -1119,14 +1192,30 @@ define(function (require, exports, module) {
             changed = (oldHeight !== height),
             isAttached = inlineWidget.info !== undefined;
 
+        function updateHeight() {
+            // Notify CodeMirror for the height change.
+            if (isAttached) {
+                inlineWidget.info.changed();
+            }
+        }
+        
+        function setOuterHeight() {
+            $(node).height(height);
+            if ($(node).hasClass("animating")) {
+                $(node).one("webkitTransitionEnd", updateHeight);
+            } else {
+                updateHeight();
+            }
+        }
+
         // Make sure we set an explicit height on the widget, so children can use things like
         // min-height if they want.
         if (changed || !node.style.height) {
-            $(node).height(height);
-
-            if (isAttached) {
-                // Notify CodeMirror for the height change
-                inlineWidget.info.changed();
+            // If we're animating, set the wrapper's height on a timeout so the layout is finished before we animate.
+            if ($(node).hasClass("animating")) {
+                window.setTimeout(setOuterHeight, 0);
+            } else {
+                setOuterHeight();
             }
         }
 
@@ -1324,6 +1413,12 @@ define(function (require, exports, module) {
      */
     Editor.prototype._visibleRange = null;
     
+    /**
+     * @private
+     * @type {Object}
+     * Promise queues for inline widgets being added to a given line.
+     */
+    Editor.prototype._inlineWidgetQueues = {};
     
     // Global settings that affect all Editor instances (both currently open Editors as well as those created
     // in the future)

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
         
         var maxWidth = 0;
         allHostedEditors.forEach(function (editor) {
-            var $gutter = $(editor._codeMirror.getGutterElement());
+            var $gutter = $(editor._codeMirror.getGutterElement()).find(".CodeMirror-linenumbers");
             $gutter.css("min-width", "");
             var curWidth = $gutter.width();
             if (curWidth > maxWidth) {
@@ -110,15 +110,17 @@ define(function (require, exports, module) {
         });
         
         if (allHostedEditors.length === 1) {
-            //There's only the host, just bail
-            allHostedEditors[0]._codeMirror.setOption("gutter", true);
+            //There's only the host, just refresh the gutter
+            allHostedEditors[0]._codeMirror.setOption("gutters", allHostedEditors[0]._codeMirror.getOption("gutters"));
             return;
         }
         
         maxWidth = maxWidth + "px";
         allHostedEditors.forEach(function (editor) {
-            $(editor._codeMirror.getGutterElement()).css("min-width", maxWidth);
-            editor._codeMirror.setOption("gutter", true);
+            $(editor._codeMirror.getGutterElement()).find(".CodeMirror-linenumbers").css("min-width", maxWidth);
+            
+            // Force CodeMirror to refresh the gutter
+            editor._codeMirror.setOption("gutters", editor._codeMirror.getOption("gutters"));
         });
     }
 

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -65,9 +65,10 @@ define(function (require, exports, module) {
     
     /**
      * Closes this inline widget and all its contained Editors
+     * @return {$.Promise} A promise that's resolved when the widget is fully closed.
      */
     InlineWidget.prototype.close = function () {
-        EditorManager.closeInlineWidget(this.hostEditor, this);
+        return EditorManager.closeInlineWidget(this.hostEditor, this);
         // closeInlineWidget() causes our onClosed() handler to be called
     };
     

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -181,10 +181,18 @@ define(function (require, exports, module) {
      * @override
      */
     MultiRangeInlineEditor.prototype.onAdded = function () {
+        var self = this;
+        
         // Before setting the inline widget height, force a height on the
         // floating related-container in order for CodeMirror to layout and
         // compute scrollbars
         this.$relatedContainer.height(this.$related.height());
+
+        // Update the position of the selected marker now that we're laid out, and then
+        // set it to animate for future updates.
+        this._updateSelectedMarker().done(function () {
+            self.$selectedMarker.addClass("animate");
+        });
 
         // Call super
         MultiRangeInlineEditor.prototype.parentClass.onAdded.apply(this, arguments);
@@ -302,7 +310,8 @@ define(function (require, exports, module) {
     };
 
     MultiRangeInlineEditor.prototype._updateSelectedMarker = function () {
-        var $rangeItem = this._ranges[this._selectedRangeIndex].$listItem;
+        var result = new $.Deferred(),
+            $rangeItem = this._ranges[this._selectedRangeIndex].$listItem;
         
         // scroll the selection to the rangeItem, use setTimeout to wait for DOM updates
         var self = this;
@@ -329,7 +338,11 @@ define(function (require, exports, module) {
                     self.$relatedContainer.scrollTop(itemBottom - containerHeight);
                 }
             }
+            
+            result.resolve();
         }, 0);
+        
+        return result.promise();
     };
 
     /**

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -55,6 +55,14 @@ html, body {
     
     /* Turn off subpixel antialiasing on Mac since it flickers during animations. */
     -webkit-font-smoothing: antialiased;
+    
+    /* This is a hack to avoid flicker when animations (like inline editors) that use the GPU complete.
+       It seems that we have to put it here rather than on the animated element in order to prevent the
+       entire window from flashing.
+       See: http://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform
+    */
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
 }
 
 body {
@@ -545,10 +553,22 @@ a, img {
 
 /* Styles for inline editors */
 .inline-widget {
+    position: relative;
+    overflow: hidden;
+
     background-color: @inline-background-color-1;
     min-width: 250px;
     cursor: default;
-    
+
+    &.animating {
+        // Make the animation use the GPU--especially important for retina.
+        -webkit-transform: translateZ(0);
+        transform: translateZ(0);
+        
+        -webkit-transition: height 0.15s ease-out;
+        transition: height 0.15s ease-out;
+    }
+
     .CodeMirror {
         /* remove CodeMirror default height: 300px */
         height: auto;
@@ -625,11 +645,14 @@ a, img {
         width: 100%;
         background: #d0d5d5;
         position: absolute;
-        -webkit-transition: height 0.1s ease-out;
-        -webkit-transition: top 0.1s ease-out;
         border-top: 1px solid darken(@inline-background-color-3, @bc-color-step-size);
         border-bottom: 1px solid lighten(@inline-background-color-3, @bc-color-step-size);
         top: @top-margin;
+        
+        &.animate {
+            -webkit-transition: height 0.1s ease-out;
+            -webkit-transition: top 0.1s ease-out;
+        }
     }
     
     /*

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -315,7 +315,66 @@ define(function (require, exports, module) {
         return wrapper.promise();
     }
     
+    /**
+     * @constructor
+     * Creates a queue of async operations that will be executed sequentially. Operations can be added to the
+     * queue at any time. If the queue is empty and nothing is currently executing when an operation is added, 
+     * it will execute immediately. Otherwise, it will execute when the last operation currently in the queue 
+     * has finished.
+     */
+    function PromiseQueue() {
+    }
     
+    /**
+     * @private
+     * @type {Array.<function(): $.Promise>}
+     * The queue of operations to execute sequentially. Note that even if this array is empty, there might
+     * still be an operation we need to wait on; that operation's promise is stored in _curPromise.
+     */
+    PromiseQueue.prototype._queue = [];
+    
+    /**
+     * @private
+     * @type {$.Promise}
+     * The promise we're currently waiting on, or null if there's nothing currently executing.
+     */
+    PromiseQueue.prototype._curPromise = null;
+    
+    /**
+     * Adds an operation to the queue. If nothing is currently executing, it will execute immediately (and
+     * the next operation added to the queue will wait for it to complete). Otherwise, it will wait until
+     * the last operation in the queue (or the currently executing operation if nothing is in the queue) is
+     * finished. The operation must return a promise that will be resolved or rejected when it's finished;
+     * the queue will continue with the next operation regardless of whether the current operation's promise
+     * is resolved or rejected.
+     * @param {function(): $.Promise} op The operation to add to the queue.
+     */
+    PromiseQueue.prototype.add = function (op) {
+        this._queue.push(op);
+
+        // If something is currently executing, then _doNext() will get called when it's done. If nothing
+        // is executing (in which case the queue should have been empty), we need to call _doNext() to kickstart
+        // the queue.
+        if (!this._curPromise) {
+            this._doNext();
+        }
+    };
+    
+    /**
+     * @private
+     * Pulls the next operation off the queue and executes it.
+     */
+    PromiseQueue.prototype._doNext = function () {
+        var self = this;
+        if (this._queue.length) {
+            var op = this._queue.shift();
+            this._curPromise = op();
+            this._curPromise.done(function () {
+                self._curPromise = null;
+                self._doNext();
+            });
+        }
+    };
 
     // Define public API
     exports.doInParallel   = doInParallel;
@@ -323,5 +382,6 @@ define(function (require, exports, module) {
     exports.doSequentiallyInBackground = doSequentiallyInBackground;
     exports.doInParallel_aggregateErrors = doInParallel_aggregateErrors;
     exports.withTimeout    = withTimeout;
+    exports.PromiseQueue   = PromiseQueue;
     exports.ERROR_TIMEOUT  = ERROR_TIMEOUT;
 });

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -26,6 +26,7 @@
 define(function (require, exports, module) {
     "use strict";
     
+    require("spec/Async-test");
     require("spec/CodeHint-test");
     require("spec/CodeHintUtils-test");
     require("spec/CommandManager-test");

--- a/test/spec/Async-test.js
+++ b/test/spec/Async-test.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, beforeEach, afterEach, it, runs, waits, waitsForDone, expect, $  */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var PromiseQueue = require("utils/Async").PromiseQueue;
+    
+    describe("Async PromiseQueue", function () {
+        var queue, calledFns;
+        
+        beforeEach(function () {
+            queue = new PromiseQueue();
+            calledFns = {};
+        });
+        
+        function makeFn(id, resolveNow) {
+            var result = new $.Deferred();
+            return {
+                fn: function () {
+                    calledFns[id] = true;
+                    if (resolveNow) {
+                        result.resolve();
+                    }
+                    return result.promise();
+                },
+                deferred: result
+            };
+        }
+        
+        it("should immediately execute a function when the queue is empty", function () {
+            var fnInfo = makeFn("one");
+            
+            queue.add(fnInfo.fn);
+            expect(calledFns.one).toBe(true);
+            
+            fnInfo.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+        
+        it("should wait to execute the second added function", function () {
+            var fnInfo1 = makeFn("one"),
+                fnInfo2 = makeFn("two");
+            
+            queue.add(fnInfo1.fn);
+            expect(calledFns.one).toBe(true);
+            
+            queue.add(fnInfo2.fn);
+            expect(calledFns.two).toBeUndefined();
+            
+            fnInfo1.deferred.resolve();
+            expect(calledFns.two).toBe(true);
+            
+            fnInfo2.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+        
+        it("should properly handle the case where the first function completes synchronously", function () {
+            var fnInfo1 = makeFn("one", true),
+                fnInfo2 = makeFn("two");
+            
+            queue.add(fnInfo1.fn);
+            expect(calledFns.one).toBe(true);
+            
+            queue.add(fnInfo2.fn);
+            expect(calledFns.two).toBe(true);
+            
+            fnInfo2.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+        
+        it("should sequentially execute a second and third function if they're both added while the first is executing", function () {
+            var fnInfo1 = makeFn("one"),
+                fnInfo2 = makeFn("two"),
+                fnInfo3 = makeFn("three");
+            
+            queue.add(fnInfo1.fn);
+            expect(calledFns.one).toBe(true);
+            
+            queue.add(fnInfo2.fn);
+            queue.add(fnInfo3.fn);
+            expect(calledFns.two).toBeUndefined();
+            expect(calledFns.three).toBeUndefined();
+            
+            fnInfo1.deferred.resolve();
+            expect(calledFns.two).toBe(true);
+            expect(calledFns.three).toBeUndefined();
+            
+            fnInfo2.deferred.resolve();
+            expect(calledFns.three).toBe(true);
+            
+            fnInfo3.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+
+        it("should sequentially execute a second and third function if the third is added while the second is executing", function () {
+            var fnInfo1 = makeFn("one"),
+                fnInfo2 = makeFn("two"),
+                fnInfo3 = makeFn("three");
+            
+            queue.add(fnInfo1.fn);
+            expect(calledFns.one).toBe(true);
+            
+            queue.add(fnInfo2.fn);
+            expect(calledFns.two).toBeUndefined();
+
+            fnInfo1.deferred.resolve();
+            expect(calledFns.two).toBe(true);
+
+            queue.add(fnInfo3.fn);
+            expect(calledFns.three).toBeUndefined();
+            
+            fnInfo2.deferred.resolve();
+            expect(calledFns.three).toBe(true);
+            
+            fnInfo3.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+        
+        it("should execute a second function when added to the empty queue after the first function has completed", function () {
+            var fnInfo1 = makeFn("one"),
+                fnInfo2 = makeFn("two");
+            
+            queue.add(fnInfo1.fn);
+            expect(calledFns.one).toBe(true);
+            
+            fnInfo1.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+            
+            queue.add(fnInfo2.fn);
+            expect(calledFns.two).toBe(true);
+
+            fnInfo2.deferred.resolve();
+            expect(queue._queue.length).toBe(0);
+            expect(queue._curPromise).toBe(null);
+        });
+    });
+});

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -102,8 +102,9 @@ define(function (require, exports, module) {
                     // Close inline editor
                     var hostEditor = EditorManager.getCurrentFullEditor();
                     var inlineWidget = hostEditor.getInlineWidgets()[0];
-                    EditorManager.closeInlineWidget(hostEditor, inlineWidget);
-                    
+                    waitsForDone(EditorManager.closeInlineWidget(hostEditor, inlineWidget), "close inline editor");
+                });
+                runs(function () {
                     // Now there are no parts of Brackets that need to keep the CSS Document alive (its only ref is its own master
                     // Editor and that Editor isn't accessible in the UI anywhere). It's ready to get "GCed" by DocumentManager as
                     // soon as it hits a trigger point for doing so.

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -128,6 +128,13 @@ define(function (require, exports, module) {
                 
                 inlineEditorResult.done(function (isOpened) {
                     inlineOpened = isOpened;
+                    
+                    var inlineWidgets = editor.getInlineWidgets();
+                    expect(inlineWidgets.length).toBe(1);
+                    
+                    // By the time we're called, the content of the widget should be in the DOM and have a nontrivial height.
+                    expect($.contains(testWindow.document.documentElement, inlineWidgets[0].htmlContent)).toBeTrue();
+                    expect(inlineWidgets[0].$htmlContent.height()).toBeGreaterThan(50);
                 }).fail(function () {
                     inlineOpened = false;
                 }).always(function () {
@@ -359,10 +366,16 @@ define(function (require, exports, module) {
                     expect(hostEditor.hasFocus()).toEqual(false);
                     
                     // close the editor
-                    EditorManager.closeInlineWidget(hostEditor, inlineWidget);
+                    waitsForDone(EditorManager.closeInlineWidget(hostEditor, inlineWidget), "closing inline widget");
                     
-                    // verify no inline widgets 
+                });
+                
+                runs(function () {
+                    // verify no inline widgets in list
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
+                    
+                    // verify that the inline widget's content has been removed from the DOM
+                    expect($.contains(testWindow.document.documentElement, inlineWidget.htmlContent)).toBe(false);
                     
                     // verify full editor cursor & focus restored
                     expect(savedPos).toEqual(hostEditor.getCursorPos());


### PR DESCRIPTION
Makes it so inline editors slide open and closed smoothly. Avoids various race conditions that can occur while inline editors are opening or closing.

While this seems to be working well, there are a few things I'm not sure about.
- In order for the animation to look smooth on retina, I force it to use the GPU by setting `transform: translateZ(0)` on the inline editor during the animation. However, that causes the entire window to flicker sometimes when an animation completes. The hack of setting `backface-visibility: hidden` on `body` appears to fix this. I don't _think_ this causes the entire window to use the GPU (I don't see any performance issues with it set vs. unset), but we should verify that.
- Because opening an inline editor now completes asynchronously, we return a promise that's resolved when the animation is done. The open animation is triggered by the inline editor calling `Editor.setInlineWidgetHeight()` once on its host editor. That's sort of weird from an API point of view--if the implementor of the inline editor doesn't know s/he needs to call this, the editor will never open and the promise will never resolve. I think it might already have been true that all inline editors needed to call this function even before adding the animation, so this isn't necessarily a new problem, but it does make me think we should clean up the API here--maybe requiring `onAdded()` to return a desired initial height?
- The initialization lifecycle of inline editors isn't clear. There's the constructor, `load()`, and `onAdded()`. Both `load()` and `onAdded()` are theoretically part of the external API (they're stubbed in InlineWidget), but `load()` is only ever used by inline editor providers themselves immediately after calling the constructor; it's never called by Editor (only `onAdded()` is). On top of that, it seems like there was at least one bug where something that happens in `MultiRangeInlineEditor.load()` that used to work when everything was synchronous now needs to happen in `onAdded()` instead (though it's not clear why). I added a workaround for that specific case, but it seems like we need to be clear about what should happen at construction time (before being added to the DOM) vs. after being added.

The question in my mind for the last two is whether we should do those cleanups now, or have a larger inline editor architecture cleanup that would deal with some of the other architectural messiness we've had for awhile as well (like InlineTextEditor, which is a sort of vestigial subclass that no one uses directly).
