### PR TITLE
Add support for dragging and dropping a folder onto Brackets

### DIFF
--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
     function isValidDrop(items) {
         var i, len = items.length;
         
-        for (i = 0; i < items.length; i++) {
+        for (i = 0; i < len; i++) {
             if (items[i].kind === "file") {
                 var entry = items[i].webkitGetAsEntry();
                 


### PR DESCRIPTION
@RaymondLim 

You can open a project by dropping a folder on to Brackets. If there are unsaved changes in the current project, you will be prompted to save before the new project is opened.

Dragging multiple folders is not supported. If you drag a combination of files and folders, the files will be opened, but _not_ the folder(s).
