### PR TITLE
[OPEN].wsgi files should use Python syntax highlighting

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -135,7 +135,7 @@
     "python": {
         "name": "Python",
         "mode": "python",
-        "fileExtensions": ["py", "pyw"]
+        "fileExtensions": ["py", "pyw", "wsgi"]
     },
 
     "sass": {


### PR DESCRIPTION
Use Python syntax highlighting for .wsgi file extensions, ie. Python web apps using mod_wsgi.
