### PR TITLE
Fix and add error reporting for async tests failing on build machines

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
                             d.reject(error);
                         });
                 } else {
-                    d.reject();
+                    d.reject("NodeConnection became disconnected");
                 }
             })
             .fail(function (error) {
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
                             d.reject(error);
                         });
                 } else {
-                    d.reject();
+                    d.reject("NodeConnection became disconnected");
                 }
             })
             .fail(function (error) {

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
                 // getting caught by NodeConnection's error catcher
                 packageData = pd;
             }, function (err) {
-                expect("Error").toEqual("No error");
+                expect(err).toBeNull();
             });
             
             waitsForDone(promise, "package validation", 5000);

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, $, brackets */
+/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, waitsForFail, runs, $, brackets */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -40,29 +40,76 @@ define(function (require, exports, module) {
     describe("LowLevelFileIO", function () {
     
         var baseDir = SpecRunnerUtils.getTempDirectory();
+            
+        function readdirCallback() {
+            var callback = function (err, content) {
+                callback.error = err;
+                callback.content = content;
+                callback.wasCalled = true;
+            };
+            
+            callback.wasCalled = false;
+            
+            return callback;
+        }
+        
+        function statCallback() {
+            var callback = function (err, stat) {
+                callback.error = err;
+                callback.stat = stat;
+                callback.wasCalled = true;
+            };
+            
+            callback.wasCalled = false;
+            
+            return callback;
+        }
+        
+        function readFileCallback() {
+            var callback = function (err, content) {
+                callback.error = err;
+                callback.content = content;
+                callback.wasCalled = true;
+            };
+            
+            callback.wasCalled = false;
+            
+            return callback;
+        }
+        
+        function errCallback() {
+            var callback = function (err) {
+                callback.error = err;
+                callback.wasCalled = true;
+            };
+            
+            callback.wasCalled = false;
+            
+            return callback;
+        }
     
         beforeEach(function () {
             runs(function () {
                 // create the test folder and init the test files
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/LowLevelFileIO-test-files");
-                waitsForDone(SpecRunnerUtils.copyPath(testFiles, baseDir));
+                waitsForDone(SpecRunnerUtils.copyPath(testFiles, baseDir), "copy temp files");
             });
             runs(function () {
                 // Pre-test setup - set permissions on special directories 
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_read_here", "222"));
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_write_here", "444"));
+                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_read_here", "222"), "set permission");
+                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_write_here", "444"), "set permission");
             });
         });
 
         afterEach(function () {
             runs(function () {
                 // Restore directory permissions
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_read_here", "777"));
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_write_here", "777"));
+                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_read_here", "777"), "reset permissions");
+                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_write_here", "777"), "reset permissions");
             });
             runs(function () {
                 // Remove the test data and anything else left behind from tests
-                waitsForDone(SpecRunnerUtils.deletePath(baseDir));
+                waitsForDone(SpecRunnerUtils.deletePath(baseDir), "delete temp files");
             });
         });
 
@@ -71,558 +118,470 @@ define(function (require, exports, module) {
         });
     
         describe("readdir", function () {
-            var complete, error, content;
-        
-            beforeEach(function () {
-                complete = false;
-            });
         
             it("should read a directory from disk", function () {
+                var cb = readdirCallback();
+                
                 runs(function () {
-                    brackets.fs.readdir(baseDir, function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readdir(baseDir, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
+                    expect(cb.error).toBeFalsy();
                 
                     // Look for known files
-                    expect(content.indexOf("file_one.txt")).not.toBe(-1);
-                    expect(content.indexOf("file_two.txt")).not.toBe(-1);
-                    expect(content.indexOf("file_three.txt")).not.toBe(-1);
+                    expect(cb.content.indexOf("file_one.txt")).not.toBe(-1);
+                    expect(cb.content.indexOf("file_two.txt")).not.toBe(-1);
+                    expect(cb.content.indexOf("file_three.txt")).not.toBe(-1);
                 
                     // Make sure '.' and '..' are omitted
-                    expect(content.indexOf(".")).toBe(-1);
-                    expect(content.indexOf("..")).toBe(-1);
+                    expect(cb.content.indexOf(".")).toBe(-1);
+                    expect(cb.content.indexOf("..")).toBe(-1);
                 });
             });
 		
             it("should return an error if the directory doesn't exist", function () {
+                var cb = readdirCallback();
+                
                 runs(function () {
-                    brackets.fs.readdir("/This/directory/doesnt/exist", function (err, contents) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.readdir("/This/directory/doesnt/exist", cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(cb.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
 
             it("should return an error if the directory can't be read (Mac only)", function () {
                 if (brackets.platform === "mac") {
+                    var cb = readdirCallback();
+                    
                     runs(function () {
-                        brackets.fs.readdir(baseDir + "/cant_read_here", function (err, contents) {
-                            error = err;
-                            complete = true;
-                        });
+                        brackets.fs.readdir(baseDir + "/cant_read_here", cb);
                     });
                 
-                    waitsFor(function () { return complete; }, 1000);
+                    waitsFor(function () { return cb.wasCalled; }, 1000);
                 
                     runs(function () {
-                        expect(error).toBe(brackets.fs.ERR_CANT_READ);
+                        expect(cb.error).toBe(brackets.fs.ERR_CANT_READ);
                     });
                 }
 
             });
 
             it("should return an error if invalid parameters are passed", function () {
+                var cb = readdirCallback();
+                
                 runs(function () {
-                    brackets.fs.readdir(42, function (err, contents) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.readdir(42, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
+                    expect(cb.error).toBe(brackets.fs.ERR_INVALID_PARAMS);
                 });
             });
         }); // describe("readdir")
 
         describe("stat", function () {
-            var complete, error, stat;
-       
-            beforeEach(function () {
-                complete = false;
-            });
         
             it("should return correct information for a directory", function () {
+                var cb = statCallback();
+                
                 runs(function () {
-                    brackets.fs.stat(baseDir, function (err, _stat) {
-                        error = err;
-                        stat = _stat;
-                        complete = true;
-                    });
+                    brackets.fs.stat(baseDir, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
-                    expect(stat.isDirectory()).toBe(true);
-                    expect(stat.isFile()).toBe(false);
+                    expect(cb.error).toBeFalsy();
+                    expect(cb.stat.isDirectory()).toBe(true);
+                    expect(cb.stat.isFile()).toBe(false);
                 });
             });
         
             it("should return correct information for a file", function () {
+                var cb = statCallback();
+                
                 runs(function () {
-                    brackets.fs.stat(baseDir + "/file_one.txt", function (err, _stat) {
-                        error = err;
-                        stat = _stat;
-                        complete = true;
-                    });
+                    brackets.fs.stat(baseDir + "/file_one.txt", cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
-                    expect(stat.isDirectory()).toBe(false);
-                    expect(stat.isFile()).toBe(true);
+                    expect(cb.error).toBeFalsy();
+                    expect(cb.stat.isDirectory()).toBe(false);
+                    expect(cb.stat.isFile()).toBe(true);
                 });
             });
         
             it("should return an error if the file/directory doesn't exist", function () {
+                var cb = statCallback();
+                
                 runs(function () {
-                    brackets.fs.stat("/This/directory/doesnt/exist", function (err, _stat) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.stat("/This/directory/doesnt/exist", cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(cb.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
         
             it("should return an error if incorrect parameters are passed", function () {
+                var cb = statCallback();
+                
                 runs(function () {
-                    brackets.fs.stat(42, function (err, _stat) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.stat(42, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
+                    expect(cb.error).toBe(brackets.fs.ERR_INVALID_PARAMS);
                 });
             });
         
         }); // describe("stat")
 
         describe("readFile", function () {
-            var complete, error, content;
-        
-            beforeEach(function () {
-                complete = false;
-            });
         
             it("should read a text file", function () {
+                var cb = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF8, function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF8, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
-                    expect(content).toBe("Hello world");
+                    expect(cb.error).toBeFalsy();
+                    expect(cb.content).toBe("Hello world");
                 });
             });
         
             it("should return an error if trying to read a non-existent file", function () {
+                var cb = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.readFile("/This/file/doesnt/exist.txt", _FSEncodings.UTF8, function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readFile("/This/file/doesnt/exist.txt", _FSEncodings.UTF8, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(cb.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
         
             it("should return an error if trying to use an unsppported encoding", function () {
+                var cb = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF16, function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF16, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_UNSUPPORTED_ENCODING);
+                    expect(cb.error).toBe(brackets.fs.ERR_UNSUPPORTED_ENCODING);
                 });
             });
         
             it("should return an error if called with invalid parameters", function () {
+                var cb = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.readFile(42, [], function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(42, [], cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
+                    expect(cb.error).toBe(brackets.fs.ERR_INVALID_PARAMS);
                 });
             });
         
             it("should return an error if trying to read a directory", function () {
+                var cb = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.readFile(baseDir, _FSEncodings.UTF8, function (err, contents) {
-                        error = err;
-                        content = contents;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(baseDir, _FSEncodings.UTF8, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_CANT_READ);
+                    expect(cb.error).toBe(brackets.fs.ERR_CANT_READ);
                 });
             });
         }); // describe("readFile")
     
         describe("writeFile", function () {
-            var complete, error, content, contents = "This content was generated from LowLevelFileIO-test.js";
-        
-            beforeEach(function () {
-                complete = false;
-            });
+            
+            var contents = "This content was generated from LowLevelFileIO-test.js";
         
             it("should write the entire contents of a file", function () {
+                var cb = errCallback(),
+                    readFileCB = readFileCallback();
+                
                 runs(function () {
-                    brackets.fs.writeFile(baseDir + "/write_test.txt", contents, _FSEncodings.UTF8, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.writeFile(baseDir + "/write_test.txt", contents, _FSEncodings.UTF8, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
+                    expect(cb.error).toBeFalsy();
                 });
 
                 // Read contents to verify
                 runs(function () {
-                    complete = false;
-                    brackets.fs.readFile(baseDir + "/write_test.txt", _FSEncodings.UTF8, function (err, data) {
-                        error = err;
-                        content = data;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(baseDir + "/write_test.txt", _FSEncodings.UTF8, readFileCB);
                 });
 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return readFileCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
-                    expect(content).toBe(contents);
+                    expect(readFileCB.error).toBeFalsy();
+                    expect(readFileCB.content).toBe(contents);
                 });
             });
         
             it("should return an error if the file can't be written (Mac only)", function () {
                 if (brackets.platform === "mac") {
+                    var cb = errCallback();
+                
                     runs(function () {
-                        brackets.fs.writeFile(baseDir + "/cant_write_here/write_test.txt", contents, _FSEncodings.UTF8, function (err) {
-                            error = err;
-                            complete = true;
-                        });
+                        brackets.fs.writeFile(baseDir + "/cant_write_here/write_test.txt", contents, _FSEncodings.UTF8, cb);
                     });
                 
-                    waitsFor(function () { return complete; }, 1000);
+                    waitsFor(function () { return cb.wasCalled; }, 1000);
                 
                     runs(function () {
-                        expect(error).toBe(brackets.fs.ERR_CANT_WRITE);
+                        expect(cb.error).toBe(brackets.fs.ERR_CANT_WRITE);
                     });
                 }
 
             });
         
             it("should return an error if called with invalid parameters", function () {
+                var cb = errCallback();
+                
                 runs(function () {
-                    brackets.fs.writeFile(42, contents, 2, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.writeFile(42, contents, 2, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
+                    expect(cb.error).toBe(brackets.fs.ERR_INVALID_PARAMS);
                 });
             });
 
             it("should return an error if trying to write a directory", function () {
+                var cb = errCallback();
+                
                 runs(function () {
-                    brackets.fs.writeFile(baseDir, contents, _FSEncodings.UTF8, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.writeFile(baseDir, contents, _FSEncodings.UTF8, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
                     // Ideally we would get ERR_CANT_WRITE, but as long as we get some sort of error it's fine. 
-                    expect(error).toBeTruthy();
+                    expect(cb.error).toBeTruthy();
                 });
             });
         }); // describe("writeFile")
     
         describe("unlink", function () {
-            var complete, error, content, contents = "This content was generated from LowLevelFileIO-test.js";
-        
-            beforeEach(function () {
-                complete = false;
-            });
+            
+            var contents = "This content was generated from LowLevelFileIO-test.js";
         
             it("should remove a file", function () {
-                var filename = baseDir + "/remove_me.txt";
+                var filename    = baseDir + "/remove_me.txt",
+                    writeFileCB = errCallback(),
+                    readFileCB  = readFileCallback(),
+                    unlinkCB    = errCallback(),
+                    statCB      = statCallback();
             
                 runs(function () {
-                    brackets.fs.writeFile(filename, contents, _FSEncodings.UTF8, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.writeFile(filename, contents, _FSEncodings.UTF8, writeFileCB);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return writeFileCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
+                    expect(writeFileCB.error).toBeFalsy();
                 });
 
 
                 // Read contents to verify
                 runs(function () {
-                    complete = false;
-                    brackets.fs.readFile(filename, _FSEncodings.UTF8, function (err, data) {
-                        error = err;
-                        content = data;
-                        complete = true;
-                    });
+                    brackets.fs.readFile(filename, _FSEncodings.UTF8, readFileCB);
                 });
 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return readFileCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
-                    expect(content).toBe(contents);
+                    expect(readFileCB.error).toBeFalsy();
+                    expect(readFileCB.content).toBe(contents);
                 });
             
                 // Remove the file
                 runs(function () {
-                    complete = false;
-                    brackets.fs.unlink(filename, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.unlink(filename, unlinkCB);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return unlinkCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBeFalsy();
+                    expect(unlinkCB.error).toBeFalsy();
                 });
             
                 // Verify it is gone
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(filename, function (err, stat) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.stat(filename, statCB);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(statCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
 
             it("should return an error if the file doesn't exist", function () {
+                var cb = errCallback();
+                
                 runs(function () {
-                    brackets.fs.unlink("/This/file/doesnt/exist.txt", function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.unlink("/This/file/doesnt/exist.txt", cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(cb.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
 
             it("should return an error if called with invalid parameters", function () {
+                var cb = errCallback();
+                
                 runs(function () {
-                    brackets.fs.unlink(42, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.unlink(42, cb);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_INVALID_PARAMS);
+                    expect(cb.error).toBe(brackets.fs.ERR_INVALID_PARAMS);
                 });
             });
             
             it("should remove a directory", function () {
                 var isDirectory,
-                    delDirName = baseDir + "/unlink_dir";
+                    delDirName  = baseDir + "/unlink_dir",
+                    cb          = errCallback(),
+                    statCB      = statCallback(),
+                    unlinkCB    = errCallback();
                 
-                complete = false;
                 runs(function () {
-                    brackets.fs.makedir(delDirName, parseInt("777", 0), function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.makedir(delDirName, parseInt("777", 0), cb);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return cb.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(cb.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Verify directory was created
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(delDirName, function (err, stat) {
-                        error = err;
-                        isDirectory = stat.isDirectory();
-                        complete = true;
-                    });
+                    brackets.fs.stat(delDirName, statCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return statCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
-                    expect(isDirectory).toBe(true);
+                    expect(statCB.error).toBe(brackets.fs.NO_ERROR);
+                    expect(statCB.stat.isDirectory()).toBe(true);
                 });
                 
                 // Delete the directory
                 runs(function () {
-                    complete = false;
-                    brackets.fs.unlink(delDirName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.unlink(delDirName, unlinkCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return unlinkCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(cb.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Verify it is gone
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(delDirName, function (err, stat) {
-                        error = err;
-                        complete = true;
-                    });
+                    statCB = statCallback();
+                    brackets.fs.stat(delDirName, statCB);
                 });
             
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
             
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(statCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
         }); // describe("unlink")
         
         describe("makedir", function () {
-            var error, complete, isDirectory;
             
             it("should make a new directory", function () {
-                var newDirName = baseDir + "/new_dir";
+                var newDirName  = baseDir + "/new_dir",
+                    cb          = errCallback(),
+                    statCB      = statCallback(),
+                    trashCB     = errCallback();
                 
-                complete = false;
                 runs(function () {
-                    brackets.fs.makedir(newDirName, parseInt("777", 0), function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.makedir(newDirName, parseInt("777", 0), cb);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return cb.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(cb.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Verify directory was created
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(newDirName, function (err, stat) {
-                        error = err;
-                        isDirectory = stat.isDirectory();
-                        complete = true;
-                    });
+                    brackets.fs.stat(newDirName, statCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return statCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
-                    expect(isDirectory).toBe(true);
+                    expect(statCB.error).toBe(brackets.fs.NO_ERROR);
+                    expect(statCB.stat.isDirectory()).toBe(true);
                 });
                 
                 // Delete the directory
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(newDirName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.moveToTrash(newDirName, trashCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return trashCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(trashCB.error).toBe(brackets.fs.NO_ERROR);
                 });
             });
         });
@@ -631,169 +590,143 @@ define(function (require, exports, module) {
             var error, complete;
             
             it("should rename a file", function () {
-                var oldName = baseDir + "/file_one.txt",
-                    newName = baseDir + "/file_one_renamed.txt";
+                var oldName     = baseDir + "/file_one.txt",
+                    newName     = baseDir + "/file_one_renamed.txt",
+                    renameCB    = errCallback(),
+                    statCB      = statCallback();
                 
                 complete = false;
                 
                 runs(function () {
-                    brackets.fs.rename(oldName, newName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.rename(oldName, newName, renameCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return renameCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(renameCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Verify new file is found and old one is missing
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(oldName, function (err, stat) {
-                        complete = true;
-                        error = err;
-                    });
+                    brackets.fs.stat(oldName, statCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(statCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
 
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(newName, function (err, stat) {
-                        complete = true;
-                        error = err;
-                    });
+                    statCB = statCallback();
+                    brackets.fs.stat(newName, statCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(statCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Rename the file back to the old name
                 runs(function () {
-                    complete = false;
-                    brackets.fs.rename(newName, oldName, function (err) {
-                        complete = true;
-                        error = err;
-                    });
+                    renameCB = errCallback();
+                    brackets.fs.rename(newName, oldName, renameCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return renameCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(renameCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                     
             });
             it("should rename a folder", function () {
-                var oldName = baseDir + "/rename_me",
-                    newName = baseDir + "/renamed_folder";
+                var oldName     = baseDir + "/rename_me",
+                    newName     = baseDir + "/renamed_folder",
+                    renameCB    = errCallback(),
+                    statCB      = statCallback();
                 
                 complete = false;
                 
                 runs(function () {
-                    brackets.fs.rename(oldName, newName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.rename(oldName, newName, renameCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return renameCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(renameCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Verify new folder is found and old one is missing
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(oldName, function (err, stat) {
-                        complete = true;
-                        error = err;
-                    });
+                    brackets.fs.stat(oldName, statCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(statCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
 
                 runs(function () {
-                    complete = false;
-                    brackets.fs.stat(newName, function (err, stat) {
-                        complete = true;
-                        error = err;
-                    });
+                    statCB = statCallback();
+                    brackets.fs.stat(newName, statCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return statCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(statCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Rename the folder back to the old name
                 runs(function () {
-                    complete = false;
-                    brackets.fs.rename(newName, oldName, function (err) {
-                        complete = true;
-                        error = err;
-                    });
+                    renameCB = errCallback();
+                    brackets.fs.rename(newName, oldName, renameCB);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return renameCB.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(renameCB.error).toBe(brackets.fs.NO_ERROR);
                 });
             });
             it("should return an error if the new name already exists", function () {
                 var oldName = baseDir + "/file_one.txt",
-                    newName = baseDir + "/file_two.txt";
+                    newName = baseDir + "/file_two.txt",
+                    cb      = errCallback();
                 
                 complete = false;
                 
                 runs(function () {
-                    brackets.fs.rename(oldName, newName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.rename(oldName, newName, cb);
                 });
                 
-                waitsFor(function () { return complete; }, 1000);
+                waitsFor(function () { return cb.wasCalled; }, 1000);
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_FILE_EXISTS);
+                    expect(cb.error).toBe(brackets.fs.ERR_FILE_EXISTS);
                 });
             });
             it("should return an error if the parent folder is read only (Mac only)", function () {
                 if (brackets.platform === "mac") {
                     var oldName = baseDir + "/cant_write_here/readme.txt",
-                        newName = baseDir + "/cant_write_here/readme_renamed.txt";
+                        newName = baseDir + "/cant_write_here/readme_renamed.txt",
+                        cb      = errCallback();
                     
                     complete = false;
                     
                     runs(function () {
-                        brackets.fs.rename(oldName, newName, function (err) {
-                            error = err;
-                            complete = true;
-                        });
+                        brackets.fs.rename(oldName, newName, cb);
                     });
                     
-                    waitsFor(function () { return complete; }, 1000);
+                    waitsFor(function () { return cb.wasCalled; }, 1000);
                     
                     runs(function () {
-                        expect(error).toBe(brackets.fs.ERR_CANT_WRITE);
+                        expect(cb.error).toBe(brackets.fs.ERR_CANT_WRITE);
                     });
                 }
             });
@@ -804,118 +737,97 @@ define(function (require, exports, module) {
             var error, complete, isDirectory;
             
             it("should move a file to the trash", function () {
-                var newFileName = baseDir + "/delete_me.txt";
+                var newFileName = baseDir + "/delete_me.txt",
+                    writeFileCB = errCallback(),
+                    trashCB     = errCallback();
                 
                 // Create a file
                 runs(function () {
-                    complete = false;
-                    brackets.fs.writeFile(newFileName, "", _FSEncodings.UTF8, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.writeFile(newFileName, "", _FSEncodings.UTF8, writeFileCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return writeFileCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(writeFileCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Move it to the trash
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(newFileName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.moveToTrash(newFileName, trashCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return trashCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(trashCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Make sure it's gone
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(newFileName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    trashCB = errCallback();
+                    brackets.fs.moveToTrash(newFileName, trashCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return trashCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(trashCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
             
             it("should move a folder to the trash", function () {
-                var newDirName = baseDir + "/dir_to_delete";
+                var newDirName  = baseDir + "/dir_to_delete",
+                    makedirCB   = errCallback(),
+                    trashCB     = errCallback();
                 
                 // Create a file
                 runs(function () {
-                    complete = false;
-                    brackets.fs.makedir(newDirName, parseInt("777", 8), function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.makedir(newDirName, parseInt("777", 8), makedirCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return makedirCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(makedirCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Move it to the trash
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(newDirName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.moveToTrash(newDirName, trashCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return trashCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.NO_ERROR);
+                    expect(trashCB.error).toBe(brackets.fs.NO_ERROR);
                 });
                 
                 // Make sure it's gone
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(newDirName, function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    trashCB = errCallback();
+                    brackets.fs.moveToTrash(newDirName, trashCB);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return trashCB.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(trashCB.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
             
             it("should return an error if the item doesn't exsit", function () {
+                var cb = errCallback();
                 
                 // Move it to the trash
                 runs(function () {
-                    complete = false;
-                    brackets.fs.moveToTrash(baseDir + "/doesnt_exist", function (err) {
-                        error = err;
-                        complete = true;
-                    });
+                    brackets.fs.moveToTrash(baseDir + "/doesnt_exist", cb);
                 });
                 
-                waitsFor(function () { return complete; });
+                waitsFor(function () { return cb.wasCalled; });
                 
                 runs(function () {
-                    expect(error).toBe(brackets.fs.ERR_NOT_FOUND);
+                    expect(cb.error).toBe(brackets.fs.ERR_NOT_FOUND);
                 });
             });
         }); // moveToTrash

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
     
         var baseDir = SpecRunnerUtils.getTempDirectory();
             
-        function readdirCallback() {
+        function readdirSpy() {
             var callback = function (err, content) {
                 callback.error = err;
                 callback.content = content;
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
             return callback;
         }
         
-        function statCallback() {
+        function statSpy() {
             var callback = function (err, stat) {
                 callback.error = err;
                 callback.stat = stat;
@@ -65,7 +65,7 @@ define(function (require, exports, module) {
             return callback;
         }
         
-        function readFileCallback() {
+        function readFileSpy() {
             var callback = function (err, content) {
                 callback.error = err;
                 callback.content = content;
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
             return callback;
         }
         
-        function errCallback() {
+        function errSpy() {
             var callback = function (err) {
                 callback.error = err;
                 callback.wasCalled = true;
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
         describe("readdir", function () {
         
             it("should read a directory from disk", function () {
-                var cb = readdirCallback();
+                var cb = readdirSpy();
                 
                 runs(function () {
                     brackets.fs.readdir(baseDir, cb);
@@ -143,7 +143,7 @@ define(function (require, exports, module) {
             });
 		
             it("should return an error if the directory doesn't exist", function () {
-                var cb = readdirCallback();
+                var cb = readdirSpy();
                 
                 runs(function () {
                     brackets.fs.readdir("/This/directory/doesnt/exist", cb);
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
 
             it("should return an error if the directory can't be read (Mac only)", function () {
                 if (brackets.platform === "mac") {
-                    var cb = readdirCallback();
+                    var cb = readdirSpy();
                     
                     runs(function () {
                         brackets.fs.readdir(baseDir + "/cant_read_here", cb);
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an error if invalid parameters are passed", function () {
-                var cb = readdirCallback();
+                var cb = readdirSpy();
                 
                 runs(function () {
                     brackets.fs.readdir(42, cb);
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
         describe("stat", function () {
         
             it("should return correct information for a directory", function () {
-                var cb = statCallback();
+                var cb = statSpy();
                 
                 runs(function () {
                     brackets.fs.stat(baseDir, cb);
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
             });
         
             it("should return correct information for a file", function () {
-                var cb = statCallback();
+                var cb = statSpy();
                 
                 runs(function () {
                     brackets.fs.stat(baseDir + "/file_one.txt", cb);
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if the file/directory doesn't exist", function () {
-                var cb = statCallback();
+                var cb = statSpy();
                 
                 runs(function () {
                     brackets.fs.stat("/This/directory/doesnt/exist", cb);
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if incorrect parameters are passed", function () {
-                var cb = statCallback();
+                var cb = statSpy();
                 
                 runs(function () {
                     brackets.fs.stat(42, cb);
@@ -255,7 +255,7 @@ define(function (require, exports, module) {
         describe("readFile", function () {
         
             it("should read a text file", function () {
-                var cb = readFileCallback();
+                var cb = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF8, cb);
@@ -270,7 +270,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to read a non-existent file", function () {
-                var cb = readFileCallback();
+                var cb = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.readFile("/This/file/doesnt/exist.txt", _FSEncodings.UTF8, cb);
@@ -284,7 +284,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to use an unsppported encoding", function () {
-                var cb = readFileCallback();
+                var cb = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.readFile(baseDir + "/file_one.txt", _FSEncodings.UTF16, cb);
@@ -298,7 +298,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if called with invalid parameters", function () {
-                var cb = readFileCallback();
+                var cb = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.readFile(42, [], cb);
@@ -312,7 +312,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if trying to read a directory", function () {
-                var cb = readFileCallback();
+                var cb = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.readFile(baseDir, _FSEncodings.UTF8, cb);
@@ -331,8 +331,8 @@ define(function (require, exports, module) {
             var contents = "This content was generated from LowLevelFileIO-test.js";
         
             it("should write the entire contents of a file", function () {
-                var cb = errCallback(),
-                    readFileCB = readFileCallback();
+                var cb = errSpy(),
+                    readFileCB = readFileSpy();
                 
                 runs(function () {
                     brackets.fs.writeFile(baseDir + "/write_test.txt", contents, _FSEncodings.UTF8, cb);
@@ -359,7 +359,7 @@ define(function (require, exports, module) {
         
             it("should return an error if the file can't be written (Mac only)", function () {
                 if (brackets.platform === "mac") {
-                    var cb = errCallback();
+                    var cb = errSpy();
                 
                     runs(function () {
                         brackets.fs.writeFile(baseDir + "/cant_write_here/write_test.txt", contents, _FSEncodings.UTF8, cb);
@@ -375,7 +375,7 @@ define(function (require, exports, module) {
             });
         
             it("should return an error if called with invalid parameters", function () {
-                var cb = errCallback();
+                var cb = errSpy();
                 
                 runs(function () {
                     brackets.fs.writeFile(42, contents, 2, cb);
@@ -389,7 +389,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an error if trying to write a directory", function () {
-                var cb = errCallback();
+                var cb = errSpy();
                 
                 runs(function () {
                     brackets.fs.writeFile(baseDir, contents, _FSEncodings.UTF8, cb);
@@ -410,10 +410,10 @@ define(function (require, exports, module) {
         
             it("should remove a file", function () {
                 var filename    = baseDir + "/remove_me.txt",
-                    writeFileCB = errCallback(),
-                    readFileCB  = readFileCallback(),
-                    unlinkCB    = errCallback(),
-                    statCB      = statCallback();
+                    writeFileCB = errSpy(),
+                    readFileCB  = readFileSpy(),
+                    unlinkCB    = errSpy(),
+                    statCB      = statSpy();
             
                 runs(function () {
                     brackets.fs.writeFile(filename, contents, _FSEncodings.UTF8, writeFileCB);
@@ -462,7 +462,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an error if the file doesn't exist", function () {
-                var cb = errCallback();
+                var cb = errSpy();
                 
                 runs(function () {
                     brackets.fs.unlink("/This/file/doesnt/exist.txt", cb);
@@ -476,7 +476,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an error if called with invalid parameters", function () {
-                var cb = errCallback();
+                var cb = errSpy();
                 
                 runs(function () {
                     brackets.fs.unlink(42, cb);
@@ -492,9 +492,9 @@ define(function (require, exports, module) {
             it("should remove a directory", function () {
                 var isDirectory,
                     delDirName  = baseDir + "/unlink_dir",
-                    cb          = errCallback(),
-                    statCB      = statCallback(),
-                    unlinkCB    = errCallback();
+                    cb          = errSpy(),
+                    statCB      = statSpy(),
+                    unlinkCB    = errSpy();
                 
                 runs(function () {
                     brackets.fs.makedir(delDirName, parseInt("777", 0), cb);
@@ -531,7 +531,7 @@ define(function (require, exports, module) {
                 
                 // Verify it is gone
                 runs(function () {
-                    statCB = statCallback();
+                    statCB = statSpy();
                     brackets.fs.stat(delDirName, statCB);
                 });
             
@@ -547,9 +547,9 @@ define(function (require, exports, module) {
             
             it("should make a new directory", function () {
                 var newDirName  = baseDir + "/new_dir",
-                    cb          = errCallback(),
-                    statCB      = statCallback(),
-                    trashCB     = errCallback();
+                    cb          = errSpy(),
+                    statCB      = statSpy(),
+                    trashCB     = errSpy();
                 
                 runs(function () {
                     brackets.fs.makedir(newDirName, parseInt("777", 0), cb);
@@ -592,8 +592,8 @@ define(function (require, exports, module) {
             it("should rename a file", function () {
                 var oldName     = baseDir + "/file_one.txt",
                     newName     = baseDir + "/file_one_renamed.txt",
-                    renameCB    = errCallback(),
-                    statCB      = statCallback();
+                    renameCB    = errSpy(),
+                    statCB      = statSpy();
                 
                 complete = false;
                 
@@ -619,7 +619,7 @@ define(function (require, exports, module) {
                 });
 
                 runs(function () {
-                    statCB = statCallback();
+                    statCB = statSpy();
                     brackets.fs.stat(newName, statCB);
                 });
                 
@@ -631,7 +631,7 @@ define(function (require, exports, module) {
                 
                 // Rename the file back to the old name
                 runs(function () {
-                    renameCB = errCallback();
+                    renameCB = errSpy();
                     brackets.fs.rename(newName, oldName, renameCB);
                 });
                 
@@ -645,8 +645,8 @@ define(function (require, exports, module) {
             it("should rename a folder", function () {
                 var oldName     = baseDir + "/rename_me",
                     newName     = baseDir + "/renamed_folder",
-                    renameCB    = errCallback(),
-                    statCB      = statCallback();
+                    renameCB    = errSpy(),
+                    statCB      = statSpy();
                 
                 complete = false;
                 
@@ -672,7 +672,7 @@ define(function (require, exports, module) {
                 });
 
                 runs(function () {
-                    statCB = statCallback();
+                    statCB = statSpy();
                     brackets.fs.stat(newName, statCB);
                 });
                 
@@ -684,7 +684,7 @@ define(function (require, exports, module) {
                 
                 // Rename the folder back to the old name
                 runs(function () {
-                    renameCB = errCallback();
+                    renameCB = errSpy();
                     brackets.fs.rename(newName, oldName, renameCB);
                 });
                 
@@ -697,7 +697,7 @@ define(function (require, exports, module) {
             it("should return an error if the new name already exists", function () {
                 var oldName = baseDir + "/file_one.txt",
                     newName = baseDir + "/file_two.txt",
-                    cb      = errCallback();
+                    cb      = errSpy();
                 
                 complete = false;
                 
@@ -715,7 +715,7 @@ define(function (require, exports, module) {
                 if (brackets.platform === "mac") {
                     var oldName = baseDir + "/cant_write_here/readme.txt",
                         newName = baseDir + "/cant_write_here/readme_renamed.txt",
-                        cb      = errCallback();
+                        cb      = errSpy();
                     
                     complete = false;
                     
@@ -738,8 +738,8 @@ define(function (require, exports, module) {
             
             it("should move a file to the trash", function () {
                 var newFileName = baseDir + "/delete_me.txt",
-                    writeFileCB = errCallback(),
-                    trashCB     = errCallback();
+                    writeFileCB = errSpy(),
+                    trashCB     = errSpy();
                 
                 // Create a file
                 runs(function () {
@@ -765,7 +765,7 @@ define(function (require, exports, module) {
                 
                 // Make sure it's gone
                 runs(function () {
-                    trashCB = errCallback();
+                    trashCB = errSpy();
                     brackets.fs.moveToTrash(newFileName, trashCB);
                 });
                 
@@ -778,8 +778,8 @@ define(function (require, exports, module) {
             
             it("should move a folder to the trash", function () {
                 var newDirName  = baseDir + "/dir_to_delete",
-                    makedirCB   = errCallback(),
-                    trashCB     = errCallback();
+                    makedirCB   = errSpy(),
+                    trashCB     = errSpy();
                 
                 // Create a file
                 runs(function () {
@@ -805,7 +805,7 @@ define(function (require, exports, module) {
                 
                 // Make sure it's gone
                 runs(function () {
-                    trashCB = errCallback();
+                    trashCB = errSpy();
                     brackets.fs.moveToTrash(newDirName, trashCB);
                 });
                 
@@ -817,7 +817,7 @@ define(function (require, exports, module) {
             });
             
             it("should return an error if the item doesn't exsit", function () {
-                var cb = errCallback();
+                var cb = errSpy();
                 
                 // Move it to the trash
                 runs(function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -737,6 +737,7 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
         brackets.fs.unlink(fullPath, function (err) {
             if (err) {
+                console.error(err);
                 result.reject(err);
             } else {
                 result.resolve();


### PR DESCRIPTION
Fix for #4415
- Rewrite lowlevelfileio tests to avoid potential clobbering due to out-of-order callbacks
- Cleanup error reporting in failing async tests to help debug jenkins build
