### PR TITLE
Make creation of instrumented string more efficient

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -211,19 +211,22 @@ define(function (require, exports, module) {
      */
     function generateInstrumentedHTML(doc) {
         var tags = scanDocument(doc).slice(),
-            gen = doc.getText();
+            orig = doc.getText(),
+            gen = "",
+            lastIndex = 0;
         
         // Walk through the tags and insert the 'data-brackets-id' attribute at the
         // end of the open tag
-        var i, insertCount = 0;
+        var i;
         tags.forEach(function (tag) {
             var attrText = " data-brackets-id='" + tag.tagID + "'";
 
             // Insert the attribute as the first attribute in the tag.
-            var insertIndex = tag.offset + tag.name.length + 1 + insertCount;
-            gen = gen.substr(0, insertIndex) + attrText + gen.substr(insertIndex);
-            insertCount += attrText.length;
+            var insertIndex = tag.offset + tag.name.length + 1;
+            gen += orig.substr(lastIndex, insertIndex - lastIndex) + attrText;
+            lastIndex = insertIndex;
         });
+        gen += orig.substr(lastIndex);
         
         return gen;
     }


### PR DESCRIPTION
For #4350.

The original code for generating the instrumented HTML string rewrote the entire generated string each time a new ID was inserted, which created a lot of garbage when the HTML file was large. This new version keeps the original string around, and pulls out a chunk at a time to append to the generated string.
