### PR TITLE
fix issue #4238- 'Save As on file in working set does not preserve working set order'

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -313,11 +313,12 @@ define(function (require, exports, module) {
     /**
      * Opens the given file, makes it the current document, AND adds it to the working set.
      * @param {!{fullPath:string}} Params for FILE_OPEN command
+     * @param {?Number} index - insert into the working set list at this 0-based index
      */
     function handleFileAddToWorkingSet(commandData) {
         return handleFileOpen(commandData).done(function (doc) {
             // addToWorkingSet is synchronous
-            DocumentManager.addToWorkingSet(doc.file);
+            DocumentManager.addToWorkingSet(doc.file, commandData.index);
         });
     }
 
@@ -616,12 +617,12 @@ define(function (require, exports, module) {
                         .always(_configureEditorAndResolve);
                 } else { // Working set  has file selection focus
                     // replace original file in working set with new file
+                    var index = DocumentManager.findInWorkingSet(doc.file.fullPath);
                     //  remove old file from working set.
                     DocumentManager.removeFromWorkingSet(doc.file);
                     //add new file to working set
                     FileViewController
-                        .addToWorkingSetAndSelect(path,
-                                        FileViewController.WORKING_SET_VIEW)
+                        .addToWorkingSetAndSelect(path, FileViewController.WORKING_SET_VIEW, index)
                         .always(_configureEditorAndResolve);
                 }
             }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -312,8 +312,7 @@ define(function (require, exports, module) {
 
     /**
      * Opens the given file, makes it the current document, AND adds it to the working set.
-     * @param {!{fullPath:string}} Params for FILE_OPEN command
-     * @param {?Number} index - insert into the working set list at this 0-based index
+     * @param {!{fullPath:string, index:number=}} Params for FILE_OPEN command
      */
     function handleFileAddToWorkingSet(commandData) {
         return handleFileOpen(commandData).done(function (doc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -618,7 +618,7 @@ define(function (require, exports, module) {
                     // replace original file in working set with new file
                     var index = DocumentManager.findInWorkingSet(doc.file.fullPath);
                     //  remove old file from working set.
-                    DocumentManager.removeFromWorkingSet(doc.file);
+                    DocumentManager.removeFromWorkingSet(doc.file, true);
                     //add new file to working set
                     FileViewController
                         .addToWorkingSetAndSelect(path, FileViewController.WORKING_SET_VIEW, index)

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
      * Adds the given file to the end of the working set list, if it is not already in the list.
      * Does not change which document is currently open in the editor. Completes synchronously.
      * @param {!FileEntry} file
-     * @param {?Number} index - insert into the working set list at this 0-based index
+     * @param {number=} index - insert into the working set list at this 0-based index
      */
     function addToWorkingSet(file, index) {
         // If doc is already in working set, don't add it again
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
         // Add to _workingSet making sure we store a different instance from the
         // one in the Document. See issue #1971 for more details.        
         file = new NativeFileSystem.FileEntry(file.fullPath);
-        if (!index || (index === -1)) {
+        if ((index === undefined) || (index === null) || (index === -1)) {
             // If no index is specified, just add the file to the end of the working set.
             _workingSet.push(file);
         } else {
@@ -251,7 +251,7 @@ define(function (require, exports, module) {
         _workingSetAddedOrder.unshift(file);
         
         // Dispatch event
-        if (!index || (index === -1)) {
+        if ((index === undefined) || (index === null) || (index === -1)) {
             $(exports).triggerHandler("workingSetAdd", file);
         } else {
             $(exports).triggerHandler("workingSetSort");

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -313,9 +313,7 @@ define(function (require, exports, module) {
         _workingSetAddedOrder.splice(findInWorkingSet(file.fullPath, _workingSetAddedOrder), 1);
         
         // Dispatch event
-        if ((suppressRedraw === undefined) || (suppressRedraw === null) || (suppressRedraw !== true)) {
-            $(exports).triggerHandler("workingSetRemove", file);
-        }
+        $(exports).triggerHandler("workingSetRemove", [file, suppressRedraw]);
     }
 
     /**

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -298,8 +298,9 @@ define(function (require, exports, module) {
      * Removes the given file from the working set list, if it was in the list. Does not change
      * the current editor even if it's for this file.
      * @param {!FileEntry} file
+     * @param {boolean=} true to suppress redraw after removal
      */
-    function removeFromWorkingSet(file) {
+    function removeFromWorkingSet(file, suppressRedraw) {
         // If doc isn't in working set, do nothing
         var index = findInWorkingSet(file.fullPath);
         if (index === -1) {
@@ -312,7 +313,9 @@ define(function (require, exports, module) {
         _workingSetAddedOrder.splice(findInWorkingSet(file.fullPath, _workingSetAddedOrder), 1);
         
         // Dispatch event
-        $(exports).triggerHandler("workingSetRemove", file);
+        if ((suppressRedraw === undefined) || (suppressRedraw === null) || (suppressRedraw !== true)) {
+            $(exports).triggerHandler("workingSetRemove", file);
+        }
     }
 
     /**

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -178,11 +178,12 @@ define(function (require, exports, module) {
      * @param {!fullPath}
      * @param {?String} selectIn - specify either WORING_SET_VIEW or PROJECT_MANAGER.
      *      Default is WORING_SET_VIEW.
+     * @param {?Number} index - insert into the working set list at this 0-based index
      * @return {!$.Promise}
      */
-    function addToWorkingSetAndSelect(fullPath, selectIn) {
+    function addToWorkingSetAndSelect(fullPath, selectIn, index) {
         var result = new $.Deferred(),
-            promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath});
+            promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: fullPath, index: index});
 
         // This properly handles sending the right nofications in cases where the document
         // is already the current one. In that case we will want to notify with

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
      * @param {!fullPath}
      * @param {?String} selectIn - specify either WORING_SET_VIEW or PROJECT_MANAGER.
      *      Default is WORING_SET_VIEW.
-     * @param {?Number} index - insert into the working set list at this 0-based index
+     * @param {number=} index - insert into the working set list at this 0-based index
      * @return {!$.Promise}
      */
     function addToWorkingSetAndSelect(fullPath, selectIn, index) {

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -511,7 +511,8 @@ define(function (require, exports, module) {
 
     /** 
      * @private
-     * @param {FileEntry, boolean=} file, flag to suppress redraw if true
+     * @param {FileEntry} file
+     * @param {boolean=} supporessRedraw If true, suppress redraw
      */
     function _handleFileRemoved(file, suppressRedraw) {
         var $listItem = _findListItemFromFile(file);

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -514,20 +514,20 @@ define(function (require, exports, module) {
      * @param {FileEntry, boolean=} file, flag to suppress redraw if true
      */
     function _handleFileRemoved(file, suppressRedraw) {
-        var $listItem = _findListItemFromFile(file);
-        if ($listItem) {
-            // Make the next file in the list show the close icon, 
-            // without having to move the mouse, if there is a next file.
-            var $nextListItem = $listItem.next();
-            if ($nextListItem && $nextListItem.length > 0) {
-                var canClose = ($listItem.find(".can-close").length === 1);
-                var isDirty = isOpenAndDirty($nextListItem.data(_FILE_KEY));
-                _updateFileStatusIcon($nextListItem, isDirty, canClose);
-            }
-            $listItem.remove();
-        }
-        
         if (!suppressRedraw) {
+            var $listItem = _findListItemFromFile(file);
+            if ($listItem) {
+                // Make the next file in the list show the close icon, 
+                // without having to move the mouse, if there is a next file.
+                var $nextListItem = $listItem.next();
+                if ($nextListItem && $nextListItem.length > 0) {
+                    var canClose = ($listItem.find(".can-close").length === 1);
+                    var isDirty = isOpenAndDirty($nextListItem.data(_FILE_KEY));
+                    _updateFileStatusIcon($nextListItem, isDirty, canClose);
+                }
+                $listItem.remove();
+            }
+            
             _redraw();
         }
     }

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -512,7 +512,7 @@ define(function (require, exports, module) {
     /** 
      * @private
      * @param {FileEntry} file
-     * @param {boolean=} supporessRedraw If true, suppress redraw
+     * @param {boolean=} suppressRedraw If true, suppress redraw
      */
     function _handleFileRemoved(file, suppressRedraw) {
         if (!suppressRedraw) {

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -511,9 +511,9 @@ define(function (require, exports, module) {
 
     /** 
      * @private
-     * @param {FileEntry} file 
+     * @param {FileEntry, suppressRedraw=} file, flag to suppress redraw if true
      */
-    function _handleFileRemoved(file) {
+    function _handleFileRemoved(file, suppressRedraw) {
         var $listItem = _findListItemFromFile(file);
         if ($listItem) {
             // Make the next file in the list show the close icon, 
@@ -527,7 +527,9 @@ define(function (require, exports, module) {
             $listItem.remove();
         }
         
-        _redraw();
+        if (!suppressRedraw) {
+            _redraw();
+        }
     }
 
     function _handleRemoveList(removedFiles) {
@@ -592,8 +594,8 @@ define(function (require, exports, module) {
             _handleFileListAdded(addedFiles);
         });
 
-        $(DocumentManager).on("workingSetRemove", function (event, removedFile) {
-            _handleFileRemoved(removedFile);
+        $(DocumentManager).on("workingSetRemove", function (event, removedFile, suppressRedraw) {
+            _handleFileRemoved(removedFile, suppressRedraw);
         });
 
         $(DocumentManager).on("workingSetRemoveList", function (event, removedFiles) {


### PR DESCRIPTION
alternate fix for issue #4238 that replaces previously submitted pull request #4329 

The other pull request tries to more intelligently swap out the working set entries, but fails to open the newly saved document.  This approach leverages the already existing workflow in opening and adding the newly saved file to the working set.  However, rather than just appending the new file to the end of the working set list, the new code now supports an optional parameter which specifies where to insert it.  Consequently, we can insert the file into the same working order as it was before the file-save-as event.
