### PR TITLE
Find In Files on an untitled document should initiate a Find session

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -416,6 +416,9 @@ define(function (require, exports, module) {
     function doFindInFiles(scope) {
 
         if (scope instanceof NativeFileSystem.InaccessibleFileEntry) {
+            CommandManager.execute(Commands.FILE_OPEN, { fullPath: scope.fullPath }).done(function () {
+                CommandManager.execute(Commands.EDIT_FIND);
+            });
             return;
         }
         


### PR DESCRIPTION
Addresses #4414 by starting a Find session when Find In (Subtree) is executed on an untitled document in the working set instead of silently doing nothing.

CC @peterflynn 
