### PR TITLE
fix "Integration / DocumentCommandHandler" unit tests

### DIFF
--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -107,6 +107,8 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_SAVE);
                     waitsForDone(promise, "Provide new filename");
                 });
+                
+                waits(10);    // wait for async save-as operation to complete and set the current document
 
                 runs(function () {
                     var noLongerUntitledDocument = DocumentManager.getCurrentDocument();
@@ -416,6 +418,8 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_SAVE_AS);
                     waitsForDone(promise, "Provide new filename", 1000);
                 });
+                
+                waits(10);    // wait for async save-as operation to complete and set the current document
 
                 runs(function () {
                     var currentDocument = DocumentManager.getCurrentDocument();
@@ -459,6 +463,8 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_SAVE_AS);
                     waitsForFail(promise, "Provide new filename", 1000);
                 });
+                
+                waits(10);    // wait for async save-as operation to complete and set the current document
 
                 runs(function () {
                     var currentDocument = DocumentManager.getCurrentDocument();


### PR DESCRIPTION
Pull Request #4437 broke the "Integration / Document CommandHandler" unit tests, which caused instability in the Jenkins builds.

The cause was that the unit tests were not allowing the (updated) file-save-as operations time to complete their asynchronous operation.  Consequently, when the unit tests then attempted to confirm the new "current document", the newly saved document hadn't yet been marked as such by the asynchronous handler.

The fix was to just add small delay to the unit tests, which allow the asynchronous operation to complete and set the new "current document".

I've confirmed that all "Unit", "Integration", and "Extensions" Spec Runner tests now complete successfully on both Windows and Mac.
