### PR TITLE
Added missing file extensions for C# web dev

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -30,7 +30,7 @@
     "html": {
         "name": "HTML",
         "mode": ["htmlmixed", "text/x-brackets-html"],
-        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "jsp"],
+        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "jsp", "aspx"],
         "blockComment": ["<!--", "-->"]
     },
     
@@ -59,7 +59,7 @@
     "xml": {
         "name": "XML",
         "mode": "xml",
-        "fileExtensions": ["svg", "xml", "wxs", "wxl", "wsdl", "rss", "atom", "rdf", "xslt", "xul", "xbl", "mathml"],
+        "fileExtensions": ["svg", "xml", "wxs", "wxl", "wsdl", "rss", "atom", "rdf", "xslt", "xul", "xbl", "mathml", "config"],
         "blockComment": ["<!--", "-->"]
     },
 
@@ -88,7 +88,7 @@
     "csharp": {
         "name": "C#",
         "mode": ["clike", "text/x-csharp"],
-        "fileExtensions": ["cs"],
+        "fileExtensions": ["cs", "cshtml", "asax", "ashx"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },


### PR DESCRIPTION
Some file extensions for C# web dev were missing:
.aspx should be highlighted as HTML
.config should be highlighted as XML
.cshtml, .asax, .ashx should be highlighted as C#
