### PR TITLE
Fix #4451 (EditorCommandHanler unit test failures)

### DIFF
--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2192,8 +2192,6 @@ define(function (require, exports, module) {
                 expect(myEditor.document.getText()).toEqual(expectedText);
                 expect(myEditor.getFirstVisibleLine()).toBe(0);
                 expect(myEditor.getLastVisibleLine()).toBe(2);
-                
-                closeTestWindow();
             });
         });
         


### PR DESCRIPTION
Fix #4451 (EditorCommandHandlers unit tests failures)

Removed a call to closeTestWindow in the midst of the testrun.
