### PR TITLE
Abort existing scan and start new one when switching projects

### DIFF
--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -29,241 +29,358 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var FileIndexManager,
-        ProjectManager,
-        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
+    var SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     describe("FileIndexManager", function () {
         
-        this.category = "integration";
-
-        var testPath = SpecRunnerUtils.getTestPath("/spec/FileIndexManager-test-files");
-        var brackets;
-
-        beforeEach(function () {
-        
-            runs(function () {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
-                    brackets = testWindow.brackets;
-
-                    // Load module instances from brackets.test
-                    FileIndexManager  = testWindow.brackets.test.FileIndexManager;
-                    ProjectManager = testWindow.brackets.test.ProjectManager;
+        describe("unit tests", function () {
+            var ProjectManager = require("project/ProjectManager"),
+                FileIndexManager = require("project/FileIndexManager"),
+                curProjectRoot;
+            
+            beforeEach(function () {
+                curProjectRoot = null;
+                spyOn(ProjectManager, "shouldShow").andCallFake(function () {
+                    return true;
+                });
+                spyOn(ProjectManager, "getProjectRoot").andCallFake(function () {
+                    return curProjectRoot;
                 });
             });
-        });
-
-        afterEach(function () {
-            brackets          = null;
-            FileIndexManager  = null;
-            ProjectManager    = null;
-            SpecRunnerUtils.closeTestWindow();
-        });
-        
-        it("should index files in directory", function () {
-            // Open a directory
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
-            var allFiles, cssFiles;
-            runs(function () {
-                FileIndexManager.getFileInfoList("all")
-                    .done(function (result) {
-                        allFiles = result;
-                    });
-            });
-            waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
             
-            runs(function () {
-                FileIndexManager.getFileInfoList("css")
-                    .done(function (result) {
-                        cssFiles = result;
-                    });
-            });
-            waitsFor(function () { return cssFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-
-            runs(function () {
-                expect(allFiles.length).toEqual(8);
-                expect(cssFiles.length).toEqual(3);
-            });
-            
-        });
-
-        it("should handle simultaneous requests without doing extra work", function () {  // #330
-            // Open a directory
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
-            var projectRoot;
-            var promise1, promise2;
-            var allFiles1, allFiles2;
-            runs(function () {
-                projectRoot = ProjectManager.getProjectRoot();
-                spyOn(projectRoot, "createReader").andCallThrough();
+            it("should abort a running scan and start a new one if another scan is requested while dirty", function () {
+                var firstCB, secondCB, firstFileInfoResult, secondFileInfoResult;
+                curProjectRoot = {
+                    fullPath: "fakeProject1",
+                    createReader: function () {
+                        return {
+                            readEntries: function (cb) {
+                                firstCB = cb;
+                            }
+                        };
+                    }
+                };
                 
-                // Kick off two index requests in parallel
-                promise1 = FileIndexManager.getFileInfoList("all")
-                    .done(function (result) {
-                        allFiles1 = result;
-                    });
-                promise2 = FileIndexManager.getFileInfoList("all")
-                    .done(function (result) {
-                        allFiles2 = result;
-                    });
+                // Ensure it's dirty to begin with
+                FileIndexManager.markDirty();
                 
-                waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
-                waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
-            });
-            
-            runs(function () {
-                // Correct response to both promises
-                expect(allFiles1.length).toEqual(8);
-                expect(allFiles2.length).toEqual(8);
+                // Request file infos for the first project. This should start a scan.
+                FileIndexManager.getFileInfoList("all").done(function (infos) {
+                    firstFileInfoResult = infos;
+                });
                 
-                // Didn't scan project tree twice
-                expect(projectRoot.createReader.callCount).toBe(1);
+                // "Switch" to a new project
+                curProjectRoot = {
+                    fullPath: "fakeProject2",
+                    createReader: function () {
+                        return {
+                            readEntries: function (cb) {
+                                secondCB = cb;
+                            }
+                        };
+                    }
+                };
+                
+                // Mark it dirty again and start a second file info request before the first one has "read" its folder
+                FileIndexManager.markDirty();
+                FileIndexManager.getFileInfoList("all").done(function (infos) {
+                    secondFileInfoResult = infos;
+                });
+                
+                // "Complete" the first scan's read request
+                firstCB([{ isFile: true, name: "fileInFirstProject.js", fullPath: "fileInFirstProject.js" }]);
+                
+                // Since the first scan was aborted, we shouldn't have gotten any result for it.
+                expect(firstFileInfoResult).toBeUndefined();
+                
+                // "Complete" the second scan's read request
+                secondCB([{ isFile: true, name: "fileInSecondProject.js", fullPath: "fileInSecondProject.js" }]);
+                
+                // Now both callers should have received the info from the second project.
+                expect(firstFileInfoResult.length).toBe(1);
+                expect(firstFileInfoResult[0].name).toEqual("fileInSecondProject.js");
+                expect(secondFileInfoResult.length).toBe(1);
+                expect(secondFileInfoResult[0].name).toEqual("fileInSecondProject.js");
+            });
+            
+            it("should not start a new scan if another scan is requested while not dirty", function () {
+                var firstCB, secondCB, firstFileInfoResult, secondFileInfoResult;
+                curProjectRoot = {
+                    fullPath: "fakeProject1",
+                    createReader: function () {
+                        return {
+                            readEntries: function (cb) {
+                                firstCB = cb;
+                            }
+                        };
+                    }
+                };
+                
+                // Ensure it's dirty to begin with
+                FileIndexManager.markDirty();
+                
+                // Start the first file info request
+                FileIndexManager.getFileInfoList("all").done(function (infos) {
+                    firstFileInfoResult = infos;
+                });
+                
+                // The first scan should have requested the project root
+                expect(ProjectManager.getProjectRoot).toHaveBeenCalled();
+                expect(ProjectManager.getProjectRoot.callCount).toBe(1);
+                
+                // Start a second file info request without marking dirty or changing the project root
+                FileIndexManager.getFileInfoList("all").done(function (infos) {
+                    secondFileInfoResult = infos;
+                });
+                
+                // We shouldn't have started a second scan, so the project root should not have been requested again.
+                expect(ProjectManager.getProjectRoot.callCount).toBe(1);
+                
+                // "Complete" the scan's read request
+                firstCB([{ isFile: true, name: "fileInFirstProject.js", fullPath: "fileInFirstProject.js" }]);
+                
+                // Both callers should have received the info from the first project.
+                expect(firstFileInfoResult.length).toBe(1);
+                expect(firstFileInfoResult[0].name).toEqual("fileInFirstProject.js");
+                expect(secondFileInfoResult.length).toBe(1);
+                expect(secondFileInfoResult[0].name).toEqual("fileInFirstProject.js");                
             });
         });
         
-        it("should match a specific filename and return the correct FileInfo", function () {
-            // Open a directory
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-            
-            var fileList;
-            
-            runs(function () {
-                FileIndexManager.getFilenameMatches("all", "file_four.css")
-                    .done(function (results) {
-                        fileList = results;
-                    });
-            });
-            
-            waitsFor(function () { return fileList; }, 1000);
-            
-            runs(function () {
-                expect(fileList.length).toEqual(1);
-                expect(fileList[0].name).toEqual("file_four.css");
-                expect(fileList[0].fullPath).toEqual(testPath + "/file_four.css");
-            });
-        });
+        describe("integration tests", function () {
         
-        it("should update the indicies on project change", function () {
-            // Load spec/FileIndexManager-test-files
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
-            var allFiles;
-            runs(function () {
-                FileIndexManager.getFileInfoList("all")
-                    .done(function (result) {
-                        allFiles = result;
+            this.category = "integration";
+    
+            var testPath = SpecRunnerUtils.getTestPath("/spec/FileIndexManager-test-files");
+            var FileIndexManager,
+                ProjectManager,
+                brackets;
+    
+            beforeEach(function () {
+            
+                runs(function () {
+                    SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
+                        brackets = testWindow.brackets;
+    
+                        // Load module instances from brackets.test
+                        FileIndexManager  = testWindow.brackets.test.FileIndexManager;
+                        ProjectManager = testWindow.brackets.test.ProjectManager;
                     });
+                });
             });
-
-            waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-            
-            runs(function () {
-                expect(allFiles.length).toEqual(8);
+    
+            afterEach(function () {
+                brackets          = null;
+                FileIndexManager  = null;
+                ProjectManager    = null;
+                SpecRunnerUtils.closeTestWindow();
             });
             
-            // load a subfolder in the test project
-            // spec/FileIndexManager-test-files/dir1/dir2
-            SpecRunnerUtils.loadProjectInTestWindow(testPath + "/dir1/dir2/");
-
-            var dir2Files;
-            runs(function () {
-                FileIndexManager.getFileInfoList("all")
-                    .done(function (result) {
-                        dir2Files = result;
-                    });
-            });
-
-            waitsFor(function () { return dir2Files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-            
-            runs(function () {
-                expect(dir2Files.length).toEqual(2);
-                expect(dir2Files[0].name).toEqual("file_eight.css");
-                expect(dir2Files[1].name).toEqual("file_seven.js");
-            });
-        });
-        
-        it("should update the indicies after being marked dirty", function () {
-            // Load spec/FileIndexManager-test-files
-            SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
-            var allFiles; // set by checkAllFileCount
-            
-            // helper function to validate base state of 8 files
-            function checkAllFileCount(fileCount) {
-                var files;
+            it("should index files in directory", function () {
+                // Open a directory
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+    
+                var allFiles, cssFiles;
                 runs(function () {
                     FileIndexManager.getFileInfoList("all")
                         .done(function (result) {
-                            files = result;
+                            allFiles = result;
+                        });
+                });
+                waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                
+                runs(function () {
+                    FileIndexManager.getFileInfoList("css")
+                        .done(function (result) {
+                            cssFiles = result;
+                        });
+                });
+                waitsFor(function () { return cssFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+    
+                runs(function () {
+                    expect(allFiles.length).toEqual(8);
+                    expect(cssFiles.length).toEqual(3);
+                });
+                
+            });
+    
+            it("should handle simultaneous requests without doing extra work", function () {  // #330
+                // Open a directory
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+    
+                var projectRoot;
+                var promise1, promise2;
+                var allFiles1, allFiles2;
+                runs(function () {
+                    projectRoot = ProjectManager.getProjectRoot();
+                    spyOn(projectRoot, "createReader").andCallThrough();
+                    
+                    // Kick off two index requests in parallel
+                    promise1 = FileIndexManager.getFileInfoList("all")
+                        .done(function (result) {
+                            allFiles1 = result;
+                        });
+                    promise2 = FileIndexManager.getFileInfoList("all")
+                        .done(function (result) {
+                            allFiles2 = result;
+                        });
+                    
+                    waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
+                    waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
+                });
+                
+                runs(function () {
+                    // Correct response to both promises
+                    expect(allFiles1.length).toEqual(8);
+                    expect(allFiles2.length).toEqual(8);
+                    
+                    // Didn't scan project tree twice
+                    expect(projectRoot.createReader.callCount).toBe(1);
+                });
+            });
+            
+            it("should match a specific filename and return the correct FileInfo", function () {
+                // Open a directory
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                
+                var fileList;
+                
+                runs(function () {
+                    FileIndexManager.getFilenameMatches("all", "file_four.css")
+                        .done(function (results) {
+                            fileList = results;
+                        });
+                });
+                
+                waitsFor(function () { return fileList; }, 1000);
+                
+                runs(function () {
+                    expect(fileList.length).toEqual(1);
+                    expect(fileList[0].name).toEqual("file_four.css");
+                    expect(fileList[0].fullPath).toEqual(testPath + "/file_four.css");
+                });
+            });
+            
+            it("should update the indicies on project change", function () {
+                // Load spec/FileIndexManager-test-files
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+    
+                var allFiles;
+                runs(function () {
+                    FileIndexManager.getFileInfoList("all")
+                        .done(function (result) {
+                            allFiles = result;
                         });
                 });
     
-                waitsFor(function () { return files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
                 
                 runs(function () {
-                    allFiles = files;
-                    expect(files.length).toEqual(fileCount);
+                    expect(allFiles.length).toEqual(8);
                 });
-            }
-            
-            // verify 8 files in base state
-            checkAllFileCount(8);
-            
-            // add a temporary file to the folder
-            var entry;
-            
-            // create a 9th file
-            runs(function () {
-                var root = ProjectManager.getProjectRoot();
-                root.getFile("new-file.txt",
-                             { create: true, exclusive: true },
-                             function (fileEntry) { entry = fileEntry; });
-            });
-            
-            waitsFor(function () { return entry; }, "getFile() timeout", 1000);
-            
-            runs(function () {
-                // mark FileIndexManager dirty after new file was created
-                FileIndexManager.markDirty();
-            });
-            
-            // verify 9 files
-            checkAllFileCount(9);
-            
-            var cleanupComplete = false;
-            
-            // verify the new file was added to the "all" index
-            runs(function () {
-                var filtered = allFiles.filter(function (value) {
-                    return (value.name === "new-file.txt");
-                });
-                expect(filtered.length).toEqual(1);
                 
-                // remove the 9th file
-                brackets.fs.unlink(entry.fullPath, function (err) {
-                    cleanupComplete = (err === brackets.fs.NO_ERROR);
+                // load a subfolder in the test project
+                // spec/FileIndexManager-test-files/dir1/dir2
+                SpecRunnerUtils.loadProjectInTestWindow(testPath + "/dir1/dir2/");
+    
+                var dir2Files;
+                runs(function () {
+                    FileIndexManager.getFileInfoList("all")
+                        .done(function (result) {
+                            dir2Files = result;
+                        });
+                });
+    
+                waitsFor(function () { return dir2Files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                
+                runs(function () {
+                    expect(dir2Files.length).toEqual(2);
+                    expect(dir2Files[0].name).toEqual("file_eight.css");
+                    expect(dir2Files[1].name).toEqual("file_seven.js");
                 });
             });
-
-            // wait for the file to be deleted
-            waitsFor(function () { return cleanupComplete; }, 1000);
             
-            runs(function () {
-                // mark FileIndexManager dirty after new file was deleted
-                FileIndexManager.markDirty();
-            });
-            
-            // verify that we're back to 8 files
-            checkAllFileCount(8);
-            
-            // make sure the 9th file was removed from the index
-            runs(function () {
-                var filtered = allFiles.filter(function (value) {
-                    return (value.name === "new-file.txt");
+            it("should update the indicies after being marked dirty", function () {
+                // Load spec/FileIndexManager-test-files
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+    
+                var allFiles; // set by checkAllFileCount
+                
+                // helper function to validate base state of 8 files
+                function checkAllFileCount(fileCount) {
+                    var files;
+                    runs(function () {
+                        FileIndexManager.getFileInfoList("all")
+                            .done(function (result) {
+                                files = result;
+                            });
+                    });
+        
+                    waitsFor(function () { return files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                    
+                    runs(function () {
+                        allFiles = files;
+                        expect(files.length).toEqual(fileCount);
+                    });
+                }
+                
+                // verify 8 files in base state
+                checkAllFileCount(8);
+                
+                // add a temporary file to the folder
+                var entry;
+                
+                // create a 9th file
+                runs(function () {
+                    var root = ProjectManager.getProjectRoot();
+                    root.getFile("new-file.txt",
+                                 { create: true, exclusive: true },
+                                 function (fileEntry) { entry = fileEntry; });
                 });
-                expect(filtered.length).toEqual(0);
+                
+                waitsFor(function () { return entry; }, "getFile() timeout", 1000);
+                
+                runs(function () {
+                    // mark FileIndexManager dirty after new file was created
+                    FileIndexManager.markDirty();
+                });
+                
+                // verify 9 files
+                checkAllFileCount(9);
+                
+                var cleanupComplete = false;
+                
+                // verify the new file was added to the "all" index
+                runs(function () {
+                    var filtered = allFiles.filter(function (value) {
+                        return (value.name === "new-file.txt");
+                    });
+                    expect(filtered.length).toEqual(1);
+                    
+                    // remove the 9th file
+                    brackets.fs.unlink(entry.fullPath, function (err) {
+                        cleanupComplete = (err === brackets.fs.NO_ERROR);
+                    });
+                });
+    
+                // wait for the file to be deleted
+                waitsFor(function () { return cleanupComplete; }, 1000);
+                
+                runs(function () {
+                    // mark FileIndexManager dirty after new file was deleted
+                    FileIndexManager.markDirty();
+                });
+                
+                // verify that we're back to 8 files
+                checkAllFileCount(8);
+                
+                // make sure the 9th file was removed from the index
+                runs(function () {
+                    var filtered = allFiles.filter(function (value) {
+                        return (value.name === "new-file.txt");
+                    });
+                    expect(filtered.length).toEqual(0);
+                });
             });
         });
     });

--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -90,19 +90,19 @@ define(function (require, exports, module) {
                 });
                 
                 // "Complete" the first scan's read request
-                firstCB([{ isFile: true, name: "fileInFirstProject.js", fullPath: "fileInFirstProject.js" }]);
+                firstCB([{ isFile: true, name: "test1FirstProjectFile.js", fullPath: "test1FirstProjectFile.js" }]);
                 
                 // Since the first scan was aborted, we shouldn't have gotten any result for it.
                 expect(firstFileInfoResult).toBeUndefined();
                 
                 // "Complete" the second scan's read request
-                secondCB([{ isFile: true, name: "fileInSecondProject.js", fullPath: "fileInSecondProject.js" }]);
+                secondCB([{ isFile: true, name: "test1SecondProjectFile.js", fullPath: "test1SecondProjectFile.js" }]);
                 
                 // Now both callers should have received the info from the second project.
                 expect(firstFileInfoResult.length).toBe(1);
-                expect(firstFileInfoResult[0].name).toEqual("fileInSecondProject.js");
+                expect(firstFileInfoResult[0].name).toEqual("test1SecondProjectFile.js");
                 expect(secondFileInfoResult.length).toBe(1);
-                expect(secondFileInfoResult[0].name).toEqual("fileInSecondProject.js");
+                expect(secondFileInfoResult[0].name).toEqual("test1SecondProjectFile.js");
                 
                 // Each readEntries should only have been called once.
                 expect(firstProject.readEntriesSpy.callCount).toBe(1);
@@ -135,17 +135,17 @@ define(function (require, exports, module) {
                 FileIndexManager.markDirty();
                 
                 // "Complete" the first scan's read request
-                firstCB([{ isFile: true, name: "fileInFirstProject.js", fullPath: "fileInFirstProject.js" }]);
+                firstCB([{ isFile: true, name: "test2FirstProjectFile.js", fullPath: "test2FirstProjectFile.js" }]);
                 
                 // Since the first scan was aborted, we shouldn't have gotten any result for it.
                 expect(firstFileInfoResult).toBeUndefined();
                 
                 // "Complete" the second scan's read request
-                secondCB([{ isFile: true, name: "fileInSecondProject.js", fullPath: "fileInSecondProject.js" }]);
+                secondCB([{ isFile: true, name: "test2SecondProjectFile.js", fullPath: "test2SecondProjectFile.js" }]);
                 
                 // Now the initial caller should have received the info from the second project.
                 expect(firstFileInfoResult.length).toBe(1);
-                expect(firstFileInfoResult[0].name).toEqual("fileInSecondProject.js");
+                expect(firstFileInfoResult[0].name).toEqual("test2SecondProjectFile.js");
                 
                 // Each readEntries should only have been called once.
                 expect(firstProject.readEntriesSpy.callCount).toBe(1);
@@ -180,13 +180,13 @@ define(function (require, exports, module) {
                 expect(curProjectRoot.readEntriesSpy.callCount).toBe(1);
                 
                 // "Complete" the scan's read request
-                firstCB([{ isFile: true, name: "fileInFirstProject.js", fullPath: "fileInFirstProject.js" }]);
+                firstCB([{ isFile: true, name: "test3ProjectFile.js", fullPath: "test3ProjectFile.js" }]);
                 
                 // Both callers should have received the info from the first project.
                 expect(firstFileInfoResult.length).toBe(1);
-                expect(firstFileInfoResult[0].name).toEqual("fileInFirstProject.js");
+                expect(firstFileInfoResult[0].name).toEqual("test3ProjectFile.js");
                 expect(secondFileInfoResult.length).toBe(1);
-                expect(secondFileInfoResult[0].name).toEqual("fileInFirstProject.js");
+                expect(secondFileInfoResult[0].name).toEqual("test3ProjectFile.js");
             });
         });
         


### PR DESCRIPTION
@peterflynn 

For #4407, makes it so that we don't finish an old FileIndexManager scan after the project has changed; instead, we kill the old scan and start a new one, and notify callers once it's done.
