### PR TITLE
Remove default extension from untitled documents and new files

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -434,7 +434,7 @@ define(function (require, exports, module) {
         
         // Create the new node. The createNewItem function does all the heavy work
         // of validating file name, creating the new file and selecting.
-        var deferred = _getUntitledFileSuggestion(baseDir, Strings.UNTITLED, isFolder ? "" : ".js", isFolder);
+        var deferred = _getUntitledFileSuggestion(baseDir, Strings.UNTITLED, "", isFolder);
         var createWithSuggestedName = function (suggestedName) {
             ProjectManager.createNewItem(baseDir, suggestedName, false, isFolder)
                 .then(deferred.resolve, deferred.reject, deferred.notify)
@@ -442,7 +442,7 @@ define(function (require, exports, module) {
         };
 
         deferred.done(createWithSuggestedName);
-        deferred.fail(function createWithDefault() { createWithSuggestedName(isFolder ? "Untitled" : "Untitled.js"); });
+        deferred.fail(function createWithDefault() { createWithSuggestedName("Untitled"); });
         return deferred;
     }
 
@@ -450,7 +450,7 @@ define(function (require, exports, module) {
      * Create a new untitled document
      */
     function handleFileNew() {
-        var doc = DocumentManager.createUntitledDocument(_nextUntitledIndexToUse++, ".js");
+        var doc = DocumentManager.createUntitledDocument(_nextUntitledIndexToUse++, "");
         DocumentManager.setCurrentDocument(doc);
         EditorManager.focusEditor();
     }

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -369,11 +369,6 @@ define(function (require, exports, module) {
      * @return {boolean} - can the provider provide hints for this session?
      */
     JSHints.prototype.hasHints = function (editor, key) {
-        if (editor && editor.document.isUntitled()) {
-            // no hints for untitled documents
-            return false;
-        }
-        
         if (session && HintUtils.hintableKey(key)) {
             
             if (isHTMLFile(session.editor.document)) {
@@ -552,7 +547,7 @@ define(function (require, exports, module) {
             // always clean up cached scope and hint info
             resetCachedHintContext();
 
-            if (editor && !editor.document.isUntitled() && HintUtils.isSupportedLanguage(LanguageManager.getLanguageForPath(editor.document.file.fullPath).getId())) {
+            if (editor && HintUtils.isSupportedLanguage(LanguageManager.getLanguageForPath(editor.document.file.fullPath).getId())) {
                 initializeSession(editor, previousEditor);
                 $(editor)
                     .on(HintUtils.eventName("change"), function (event, editor, changeList) {


### PR DESCRIPTION
This removes the default extension from untitled documents and new files. This causes untitled documents to be in text mode by instead of JavaScript mode, which is the simplest way of disabling the JS hinter and associated features on untitled documents. No extension is also a much more sane default than `.js`.

Addresses #4481. 
