### PR TITLE
Animate quick view popup

### DIFF
--- a/src/extensions/default/QuickView/QuickView.css
+++ b/src/extensions/default/QuickView/QuickView.css
@@ -1,15 +1,13 @@
 #quick-view-container {
     display: none;
-    -webkit-transition: opacity 0.2s  ease-in, -webkit-transform 0.2s, -webkit-transform-origin 0.2s;
-    -webkit-transform: scale(0);
-    -webkit-transform-origin: center bottom;
+
+    -webkit-transition: opacity 0.125s ease-in, -webkit-transform 0.125s;
     opacity: 0;
+    -webkit-transform: scale(0);
                                             
     background: #e0e1e3;
     position: absolute;
     z-index: 5000;
-    left: -20px;
-    top: -65px;
     pointer-events: none;
     
     padding: 8px;
@@ -20,9 +18,8 @@
 }
 
 #quick-view-container.active {
-    opacity: 1;
     -webkit-transform: scale(1);
-    height: auto; 
+    opacity: 1;
 }
 
 #quick-view-container .preview-content {
@@ -59,6 +56,10 @@
     text-shadow: 0 1px 0px #e8e8e8;
 }
 
+#quick-view-container.preview-bubble-above {
+    -webkit-transform-origin: center bottom;
+}
+
 #quick-view-container.preview-bubble-above:before {
     display: none;
 }
@@ -76,6 +77,9 @@
     display: block;
 }
 
+#quick-view-container.preview-bubble-below {
+    -webkit-transform-origin: center top;
+}
 
 #quick-view-container.preview-bubble-below:before {
     width: 24px;

--- a/src/extensions/default/QuickView/QuickView.css
+++ b/src/extensions/default/QuickView/QuickView.css
@@ -1,18 +1,28 @@
 #quick-view-container {
     display: none;
-    
+    -webkit-transition: opacity 0.2s  ease-in, -webkit-transform 0.2s, -webkit-transform-origin 0.2s;
+    -webkit-transform: scale(0);
+    -webkit-transform-origin: center bottom;
+    opacity: 0;
+                                            
     background: #e0e1e3;
     position: absolute;
     z-index: 5000;
-    left: 200px;
-    top: 40px;
+    left: -20px;
+    top: -65px;
     pointer-events: none;
     
-    padding: 15px;
+    padding: 8px;
     text-align: center;
 
-    border-radius: 5px;
+    border-radius: 4px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.25), inset 0 0 0 1px #a6a6a6, inset 0 0 0 2px #ebedec;
+}
+
+#quick-view-container.active {
+    opacity: 1;
+    -webkit-transform: scale(1);
+    height: auto; 
 }
 
 #quick-view-container .preview-content {
@@ -23,8 +33,8 @@
 
 
 #quick-view-container .color-swatch {
-    width: 100px;
-    height: 100px;
+    width: 40px;
+    height: 40px;
     background-size: 100%;
 }
 

--- a/src/extensions/default/QuickView/QuickView.css
+++ b/src/extensions/default/QuickView/QuickView.css
@@ -2,8 +2,11 @@
     display: none;
 
     -webkit-transition: opacity 0.125s ease-in, -webkit-transform 0.125s;
-    opacity: 0;
+    transition: opacity 0.125s ease-in, transform 0.125s;
+
     -webkit-transform: scale(0);
+    transform: scale(0);
+    opacity: 0;
                                             
     background: #e0e1e3;
     position: absolute;
@@ -19,6 +22,7 @@
 
 #quick-view-container.active {
     -webkit-transform: scale(1);
+    transform: scale(1);
     opacity: 1;
 }
 

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -52,9 +52,9 @@ define(function (require, exports, module) {
     var CMD_ENABLE_QUICK_VIEW       = "view.enableQuickView",
         HOVER_DELAY                 = 350,  // Time (ms) mouse must remain over a provider's matched text before popover appears
         POSITION_OFFSET             = 38,   // Distance between the bottom of the line and the bottom of the preview container
-        POINTER_LEFT_OFFSET         = 17,   // Half of the pointer width, used to find the center of the pointer
-        POINTER_TOP_OFFSET          =  7,   // Pointer height, used to shift popover above pointer
-        POSITION_BELOW_OFFSET       = 16,   // Amount to adjust to top position when the preview bubble is below the text
+        POINTER_LEFT_OFFSET         = -20,  // Half of the pointer width, used to find the center of the pointer
+        POINTER_TOP_OFFSET          = -65,  // Pointer height, used to shift popover above pointer
+        POSITION_BELOW_OFFSET       = 72,   // Amount to adjust to top position when the preview bubble is below the text
         POPOVER_HORZ_MARGIN         =  5;   // Horizontal margin
     
     /**
@@ -99,11 +99,12 @@ define(function (require, exports, module) {
             
             $previewContent.empty();
             $previewContainer.hide();
+            $previewContainer.removeClass("active");
+                        
             
         } else {
             window.clearTimeout(popoverState.hoverTimer);
         }
-        
         popoverState = null;
     }
     
@@ -118,16 +119,16 @@ define(function (require, exports, module) {
         left = Math.min(left, editorLeft + $editorHolder.width() - previewWidth - POPOVER_HORZ_MARGIN);
         
         if (top < 0) {
-            $previewContainer.removeClass("preview-bubble-above");
-            $previewContainer.addClass("preview-bubble-below");
+            $previewContainer.removeClass("preview-bubble-above active");
+            $previewContainer.addClass("preview-bubble-below active");
             top = ybot + POSITION_BELOW_OFFSET;
             $previewContainer.offset({
                 left: left,
                 top: top
             });
         } else {
-            $previewContainer.removeClass("preview-bubble-below");
-            $previewContainer.addClass("preview-bubble-above");
+            $previewContainer.removeClass("preview-bubble-below active");
+            $previewContainer.addClass("preview-bubble-above active");
             $previewContainer.offset({
                 left: left,
                 top: top - POINTER_TOP_OFFSET
@@ -433,6 +434,7 @@ define(function (require, exports, module) {
                     var showHandler = function () {
                         // Hide the preview container until the image is loaded.
                         $previewContainer.hide();
+                                                    
                         
                         $previewContainer.find(".image-preview > img").on("load", function () {
                             $previewContent

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -51,10 +51,7 @@ define(function (require, exports, module) {
     // Constants
     var CMD_ENABLE_QUICK_VIEW       = "view.enableQuickView",
         HOVER_DELAY                 = 350,  // Time (ms) mouse must remain over a provider's matched text before popover appears
-        POSITION_OFFSET             = 38,   // Distance between the bottom of the line and the bottom of the preview container
-        POINTER_LEFT_OFFSET         = -20,  // Half of the pointer width, used to find the center of the pointer
-        POINTER_TOP_OFFSET          = -65,  // Pointer height, used to shift popover above pointer
-        POSITION_BELOW_OFFSET       = 72,   // Amount to adjust to top position when the preview bubble is below the text
+        POINTER_HEIGHT              = 15,   // Pointer height, used to shift popover above pointer (plus a little bit of space)
         POPOVER_HORZ_MARGIN         =  5;   // Horizontal margin
     
     /**
@@ -72,7 +69,8 @@ define(function (require, exports, module) {
      *      start: !{line, ch},             - start of matched text range
      *      end: !{line, ch},               - end of matched text range
      *      content: !string,               - HTML content to display in popover
-     *      onShow: ?function():void,       - called once popover content added to the DOM (may never be called)
+     *      onShow: ?function():void,       - called once popover content added to the DOM (may never be called) 
+     *        - if specified, must call positionPreview()
      *      xpos: number,                   - x of center of popover
      *      ytop: number,                   - y of top of matched text (when popover placed above text, normally)
      *      ybot: number,                   - y of bottom of matched text (when popover moved below text, avoiding window top)
@@ -100,8 +98,6 @@ define(function (require, exports, module) {
             $previewContent.empty();
             $previewContainer.hide();
             $previewContainer.removeClass("active");
-                        
-            
         } else {
             window.clearTimeout(popoverState.hoverTimer);
         }
@@ -109,9 +105,9 @@ define(function (require, exports, module) {
     }
     
     function positionPreview(xpos, ypos, ybot) {
-        var previewWidth  = $previewContainer.width(),
-            top           = ypos - $previewContainer.height() - POSITION_OFFSET,
-            left          = xpos - previewWidth / 2 - POINTER_LEFT_OFFSET,
+        var previewWidth  = $previewContainer.outerWidth(),
+            top           = ypos - $previewContainer.outerHeight() - POINTER_HEIGHT,
+            left          = xpos - previewWidth / 2,
             $editorHolder = $("#editor-holder"),
             editorLeft    = $editorHolder.offset().left;
 
@@ -119,21 +115,21 @@ define(function (require, exports, module) {
         left = Math.min(left, editorLeft + $editorHolder.width() - previewWidth - POPOVER_HORZ_MARGIN);
         
         if (top < 0) {
-            $previewContainer.removeClass("preview-bubble-above active");
-            $previewContainer.addClass("preview-bubble-below active");
-            top = ybot + POSITION_BELOW_OFFSET;
-            $previewContainer.offset({
+            top = ybot + POINTER_HEIGHT;
+            $previewContainer
+                .removeClass("preview-bubble-above")
+                .addClass("preview-bubble-below");
+        } else {
+            $previewContainer
+                .removeClass("preview-bubble-below")
+                .addClass("preview-bubble-above");
+        }
+        $previewContainer
+            .css({
                 left: left,
                 top: top
-            });
-        } else {
-            $previewContainer.removeClass("preview-bubble-below active");
-            $previewContainer.addClass("preview-bubble-above active");
-            $previewContainer.offset({
-                left: left,
-                top: top - POINTER_TOP_OFFSET
-            });
-        }
+            })
+            .addClass("active");
     }
     
     /**
@@ -156,9 +152,9 @@ define(function (require, exports, module) {
         
         if (popoverState.onShow) {
             popoverState.onShow();
+        } else {
+            positionPreview(popoverState.xpos, popoverState.ytop, popoverState.ybot);
         }
-        
-        positionPreview(popoverState.xpos, popoverState.ytop, popoverState.ybot);
     }
     
     function divContainsMouse($div, event) {
@@ -438,7 +434,7 @@ define(function (require, exports, module) {
                         
                         $previewContainer.find(".image-preview > img").on("load", function () {
                             $previewContent
-                                .append("<div class='img-size'>"                                            +
+                                .append("<div class='img-size'>" +
                                             this.naturalWidth + " x " + this.naturalHeight + " " + Strings.UNIT_PIXELS +
                                         "</div>"
                                     );

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -289,18 +289,24 @@ define(function (require, exports, module) {
                 QuickView._forceShow(popoverInfo);
             }
 
-            function getBounds(object) {
+            function getBounds(object, useOffset) {
+                var left = (useOffset ? object.offset().left : parseInt(object.css("left"), 10)),
+                    top = (useOffset ? object.offset().top : parseInt(object.css("top"), 10));
                 return {
-                    left:   object.offset().left,
-                    top:    object.offset().top,
-                    right:  object.offset().left + object.width(),
-                    bottom: object.offset().top + object.height()
+                    left:   left,
+                    top:    top,
+                    right:  left + object.outerWidth(),
+                    bottom: top + object.outerHeight()
                 };
             }
 
             function boundsInsideWindow(object) {
-                var bounds = getBounds(object),
-                    editorBounds = getBounds(testWindow.$("#editor-holder"));
+                // For the popover, we can't use offset(), because jQuery gets confused by the
+                // scale factor and transform origin that the animation uses. Instead, we rely
+                // on the fact that its offset parent is body, and just test its explicit left/top 
+                // values.
+                var bounds = getBounds(object, false),
+                    editorBounds = getBounds(testWindow.$("#editor-holder"), true);
                 return bounds.left   >= editorBounds.left   &&
                        bounds.right  <= editorBounds.right  &&
                        bounds.top    >= editorBounds.top    &&

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -565,8 +565,8 @@ a, img {
         -webkit-transform: translateZ(0);
         transform: translateZ(0);
         
-        -webkit-transition: height 0.15s ease-out;
-        transition: height 0.15s ease-out;
+        -webkit-transition: height 0.125s ease-out;
+        transition: height 0.125s ease-out;
     }
 
     .CodeMirror {

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -53,7 +53,7 @@
     position: relative;
 }
 
-.jstree-brackets li {
+.jstree-brackets li {    
     line-height: 10px;
     vertical-align: baseline;
     a {
@@ -68,7 +68,13 @@
     .extension {
         color: @project-panel-text-2;
     }
-    &.jstree-closed, &.jstree-open {
+    &.jstree-closed {
+        margin-left: 10px;
+        > a {
+            color: @project-panel-text-2;
+        }
+    }
+    &.jstree-open {
         margin-left: 10px;
         > a {
             color: @project-panel-text-2;

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -53,7 +53,7 @@
     position: relative;
 }
 
-.jstree-brackets li {    
+.jstree-brackets li {
     line-height: 10px;
     vertical-align: baseline;
     a {
@@ -68,13 +68,7 @@
     .extension {
         color: @project-panel-text-2;
     }
-    &.jstree-closed {
-        margin-left: 10px;
-        > a {
-            color: @project-panel-text-2;
-        }
-    }
-    &.jstree-open {
+    &.jstree-closed, &.jstree-open {
         margin-left: 10px;
         > a {
             color: @project-panel-text-2;


### PR DESCRIPTION
Builds on the prototype from @larz0. A couple of notes:
- Simplified the logic for positioning the popup by measuring its outer height/width, so we no longer need to have constants to adjust for padding.
- Made the animation faster than in Larz's prototype--it's now 0.125s. (I also changed the inline editor animation timing to match.) The original timing felt just a tad sluggish to me.
- The animation grows from the bottom when the bubble is above and from the top when the bubble is below.

To @gruehle 
