### PR TITLE
[ARCH] Image preview draft

### DIFF
--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -72,13 +72,15 @@ define(function (require, exports, module) {
      * @param {!FileEntry} file  Need not lie within the project.
      * @param {!Date} initialTimestamp  File's timestamp when we read it off disk.
      * @param {!string} rawText  Text content of the file.
+     * @param {!string} template  Viewing instead of editing if present (specifies viewer type).  
      */
-    function Document(file, initialTimestamp, rawText) {
+    function Document(file, initialTimestamp, rawText, template) {
         if (!(this instanceof Document)) {  // error if constructor called without 'new'
             throw new Error("Document constructor must be called with 'new'");
         }
         
         this.file = file;
+        this.template = template;
         this._updateLanguage();
         this.refreshText(rawText, initialTimestamp);
     }
@@ -94,6 +96,12 @@ define(function (require, exports, module) {
      * @type {!FileEntry}
      */
     Document.prototype.file = null;
+
+    /**
+     * The template name for this document. Currently used to preview image file types.
+     * @type {!string}
+     */
+    Document.prototype.template = null;
 
     /**
      * The Language for this document. Will be resolved by file extension in the constructor

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -113,10 +113,11 @@ define(function (require, exports, module) {
      */
     function _setSizeAndRestoreScroll(fontSizeStyle, lineHeightStyle) {
         var editor      = EditorManager.getCurrentFullEditor(),
+            linesblock  = $(".CodeMirror-lines", editor.getRootElement()),
             oldWidth    = editor._codeMirror.defaultCharWidth(),
             oldHeight   = editor.getTextHeight(),
             scrollPos   = editor.getScrollPos(),
-            viewportTop = $(".CodeMirror-lines", editor.getRootElement()).parent().position().top,
+            viewportTop = linesblock.get(0)? linesblock.parent().position().top : 0,
             scrollTop   = scrollPos.y - viewportTop;
         
         // It's necessary to inject a new rule to address all editors.


### PR DESCRIPTION
Hi! 

It's not a final pull request, but I wanted to start a discussion about the feature. I've implemented the image preview in Brackets, but I don't like the way it's currently done. That's how it works:
- DocumentManager sends file path if it's an image instead of reading it as text;
- Document has a "template" parameter which is supposed to point to a custom rendering method;
- Editor _substitutes everything inside the CodeMirror wrapper for a custom template_ if the template name is set in the Document.

Now, the emphasised part is something I strongly dislike, but I couldn't find a way around it. Opening an image as a document feels like a natural way of doing this (that's how it's done in Espresso.app, for example); opening a modal for image file types, while a viable alternative, feels inconsistent in terms of user experience and blocks the UI.

As for the current architecture, Brackets is strongly tied to CodeMirror and there is no way of consistently working with the document area without using at least the wrapper (which is understandable, Brackets being a text editor and all). It would be perfect to have not just an Editor class, but a Viewer class with custom templates (somewhat like I did it in this fork) as well, and an ability to switch between the two depending on a file type, but I'm not familiar with Brackets well enough to even know if it's needed and supported by the core team, so I did what I did.

Currently, there's a few things I certainly need to do with this request before making it suitable for merging:
- code conventions (really sorry for that one!)
- template events (or at least a "before render" event for the status bar)
- template files (right now there is a temporary and ugly workaround)
- status bar (something has to be done instead of the hack in the current version, but I'm not sure what)

But before doing all this I need to make sure somebody actually needs this, and maybe somebody from the core team could help out with Editor/Viewer (or at least discuss this in detail) and the status bar.

The ugly architecture aside, it works as intended on both platforms: shows an image preview and dimensions in the status bar. It could be a start, I guess.

Regards,
Ed.

![screen shot 2013-07-17 at 8 07 57 pm](https://f.cloud.github.com/assets/145218/811825/f1caba38-eee1-11e2-8e99-5a7922bd0143.png)
