### PR TITLE
[FOR REVIEW] Use SourceCodePro-Medium for all platforms.

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -124,15 +124,13 @@
     // Sizing via em will cause the code and line numbers to misalign
     line-height: 15px;
     font-size: 12px;
-    font-family: 'SourceCodePro', "ＭＳ ゴシック", "MS Gothic", monospace;
+    font-family: "SourceCodePro-Medium", "ＭＳ ゴシック", "MS Gothic", monospace;
 }
 
 .code-font-win() {
 }
 
 .code-font-mac() {
-    /* Use the Medium weight on the Mac to counterbalance the grayscale antialiasing. */
-    font-family: 'SourceCodePro-Medium', "ＭＳ ゴシック", "MS Gothic", monospace;
 }
 
 .code-cursor() {


### PR DESCRIPTION
This is a possible fix for #4391 

Use `SourceCodePro-Medium` on all platforms. Previously, we used medium on the Mac, and normal everywhere else.

Here is a Windows 8 screenshot with the "normal" weight:
![normal](https://f.cloud.github.com/assets/1060119/816216/351ebfc2-ef3d-11e2-8ca4-2c40d3aef2d3.PNG)

Here is a screenshot with the "medium" weight:
![medium](https://f.cloud.github.com/assets/1060119/816217/403a3d78-ef3d-11e2-8684-26cf2e49d6db.PNG)
