### PR TITLE
Make sure an editor has focus before showing a ModalBar

### DIFF
--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -53,6 +53,14 @@ define(function (require, exports, module) {
             .html(template)
             .insertBefore("#editor-holder");
         
+        // If something *other* than an editor (like another modal bar) has focus, set the focus 
+        // to the editor here, before opening up the new modal bar. This ensures that the old
+        // focused item has time to react and close before the new modal bar is opened.
+        // See bugs #4287 and #3424
+        if (!EditorManager.getFocusedEditor()) {
+            EditorManager.focusEditor();
+        }
+        
         if (autoClose) {
             this._autoClose = true;
             var $firstInput = this._getFirstInput()


### PR DESCRIPTION
This is a fix for #4287 and #3424

Issue #4287 was caused by opening the "quick open" bar when the "find" bar was already open. Focusing the quick open bar blurs the find bar, causing it to close. When the find bar closes, it sets focus back to the editor, which blurs the quick open bar, causing _it_ to close. When this happens, the quick open bar is left in a semi-initialized state and leaves an orphaned smart autocomplete object in the DOM. 

This fix ensures that an editor always has focus before a ModalBar is opened. If a non-editor (like another ModalBar) had focus, it has time to clean up before the ModalBar is opened.

This does _not_ fix #4500, but it does change the behavior. Instead of both bars being open, they are now both closed.
