### PR TITLE
HTML tag highlight added.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -363,6 +363,7 @@ define(function (require, exports, module) {
             lineWrapping: _wordWrap,
             styleActiveLine: _styleActiveLine,
             matchBrackets: true,
+            matchTags: true,
             dragDrop: false,
             extraKeys: codeMirrorKeyMap,
             autoCloseBrackets: _closeBrackets,

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
             lineWrapping: _wordWrap,
             styleActiveLine: _styleActiveLine,
             matchBrackets: true,
-            matchTags: true,
+            matchTags: {bothTags: true},
             dragDrop: false,
             extraKeys: codeMirrorKeyMap,
             autoCloseBrackets: _closeBrackets,

--- a/src/index.html
+++ b/src/index.html
@@ -99,6 +99,8 @@
     <!-- Pre-load third party scripts that cannot be async loaded. -->
     <script src="thirdparty/jquery-2.0.1.min.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
+    <script src="thirdparty/CodeMirror2/addon/fold/xml-fold.js"></script>
+    <script src="thirdparty/CodeMirror2/addon/edit/matchtags.js"></script>
     <script src="thirdparty/CodeMirror2/addon/edit/matchbrackets.js"></script>
     <script src="thirdparty/CodeMirror2/addon/edit/closebrackets.js"></script>
     <script src="thirdparty/CodeMirror2/addon/edit/closetag.js"></script>

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -176,6 +176,8 @@
     &.CodeMirror-focused .CodeMirror .CodeMirror-activeline-background {
         background: transparent !important; 
     }
+    
+    .CodeMirror-matchingtag { background:  @background-color-2; }
 }
 
 /*


### PR DESCRIPTION
Tag highlight functionality added.

![Image](https://lh6.googleusercontent.com/-3nfFux6Tzqc/UeeF9Tw5bhI/AAAAAAAAAfg/BHwiUV271ac/s335/HTML%2520Tag%2520Highlight%2520pull%2520request.png)

**_some tracks**_
[Google Group Discussion](https://groups.google.com/forum/#!topic/brackets-dev/Dl9mOPBNQUA)
[Trello Card](https://trello.com/c/rhKIGceF)
https://github.com/adobe/brackets/issues/3069

Code mirror's [matchTags extension](https://github.com/marijnh/CodeMirror/blob/master/addon/edit/matchtags.js) only highlight the other tag. In the above screenshot, i put cursor on start tag &lt;form, but it only highlights the other tag &lt;/form&gt;. If you want to to highlight both tags, i can rewrite this extension for brackets. 
