### PR TITLE
Fixed issue #4489- "Save/Close All with multiple untitled documents gives ambiguous Save dialogs"

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -660,6 +660,11 @@ define(function (require, exports, module) {
             origPath = doc.file.fullPath;
             // If the document is an untitled document, we should default to project root.
             if (doc.isUntitled()) {
+                // (Issue #4489) if we're saving an untitled document, go ahead and switch to this document
+                //   in the editor, so that if we're, for example, saving several files (ie. Save All),
+                //   then the user can visually tell which document we're currently prompting them to save.
+                DocumentManager.setCurrentDocument(doc);
+
                 // If the document is untitled, default to project root.
                 saveAsDefaultPath = ProjectManager.getProjectRoot().fullPath;
             } else {


### PR DESCRIPTION
Fixed issue #4489- "Save/Close All with multiple untitled documents gives ambiguous Save dialogs"

When prompting to save-as an untitled document, activate that document in the editor.  This causes the untitled document to display in the editor _and_ prepopulate the untitled document's name (eg. "Untitled-1") in the Save As dialog.

As a result, if the user does, for example, a Save All, then as each untitled document is prompting to save, Brackets will switch to and display that specific document.

Successfully completed all 'Unit", "Integration", and "Extensions" unit tests on both Mac and Win.
