### PR TITLE
Alternate fix for #4484 (Working set broken after Save As / save untitled outside project)

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -328,7 +328,7 @@ define(function (require, exports, module) {
 
     /**
      * Opens the given file, makes it the current document, AND adds it to the working set.
-     * @param {!{fullPath:string, index:number=, forceRedraw:boolean}} File to open; optional position in the
+     * @param {!{fullPath:string, index:number=, forceRedraw:boolean}} commandData  File to open; optional position in
      *   working set list (defaults to last); optional flag to force working set redraw
      */
     function handleFileAddToWorkingSet(commandData) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -328,13 +328,13 @@ define(function (require, exports, module) {
 
     /**
      * Opens the given file, makes it the current document, AND adds it to the working set.
-     * @param {!{fullPath:string, index:number=}} File to open and optional position in the working
-     *   set list (defaults to last)
+     * @param {!{fullPath:string, index:number=, forceRedraw:boolean}} File to open; optional position in the
+     *   working set list (defaults to last); optional flag to force working set redraw
      */
     function handleFileAddToWorkingSet(commandData) {
         return handleFileOpen(commandData).done(function (doc) {
             // addToWorkingSet is synchronous
-            DocumentManager.addToWorkingSet(doc.file, commandData.index);
+            DocumentManager.addToWorkingSet(doc.file, commandData.index, commandData.forceRedraw);
         });
     }
 
@@ -600,23 +600,23 @@ define(function (require, exports, module) {
             
             // Replace old document with new one in open editor & working set
             function openNewFile() {
-                var fileViewControllerPromise;
+                var fileOpenPromise;
 
                 if (FileViewController.getFileSelectionFocus() === FileViewController.PROJECT_MANAGER) {
-                    fileViewControllerPromise = FileViewController
+                    // If selection is in the tree, leave working set unchanged - even if orig file is in the list
+                    fileOpenPromise = FileViewController
                         .openAndSelectDocument(path, FileViewController.PROJECT_MANAGER);
-                } else { // Working set has file selection focus
-                    // replace original file in working set with new file
+                } else {
+                    // If selection is in working set, replace orig item in place with the new file
                     var index = DocumentManager.findInWorkingSet(doc.file.fullPath);
-                    //  remove old file from working set.
+                    // Remove old file from working set; no redraw yet since there's a pause before the new file is opened
                     DocumentManager.removeFromWorkingSet(doc.file, true);
-                    // add new file to working set
-                    fileViewControllerPromise = FileViewController
-                        .addToWorkingSetAndSelect(path, FileViewController.WORKING_SET_VIEW, index);
+                    // Add new file to working set, and ensure we now redraw (even if index hasn't changed)
+                    fileOpenPromise = handleFileAddToWorkingSet({fullPath: path, index: index, forceRedraw: true});
                 }
 
                 // always configure editor after file is opened
-                fileViewControllerPromise.always(function () {
+                fileOpenPromise.always(function () {
                     _configureEditorAndResolve();
                 });
             }

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -227,8 +227,8 @@ define(function (require, exports, module) {
      * Adds the given file to the end of the working set list, if it is not already in the list.
      * Does not change which document is currently open in the editor. Completes synchronously.
      * @param {!FileEntry} file
-     * @param {number=} index - position to add to list (defaults to end); -1 is ignored
-     * @param {boolean=} forceRedraw - if true, a working set change notification is always sent
+     * @param {number=} index  Position to add to list (defaults to last); -1 is ignored
+     * @param {boolean=} forceRedraw  If true, a working set change notification is always sent
      *    (useful if suppressRedraw was used with removeFromWorkingSet() earlier)
      */
     function addToWorkingSet(file, index, forceRedraw) {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -717,7 +717,7 @@ define(function (require, exports, module) {
                 var classToAdd = (wasNodeOpen) ? "jstree-closed" : "jstree-open";
                 
                 treeNode.removeClass("jstree-leaf jstree-closed jstree-open")
-                        .addClass(classToAdd);
+                    .addClass(classToAdd);
                 
                 // This is a workaround for a part of issue #2085, where the file creation process
                 // depends on the open_node.jstree event being triggered, which doesn't happen on 
@@ -1197,7 +1197,7 @@ define(function (require, exports, module) {
                     // This is a workaround for issue #149 where jstree would show this node as a leaf.
                     _projectTree.jstree(methodName, parent);
                     parent.removeClass("jstree-leaf jstree-closed jstree-open")
-                          .addClass(classToAdd);
+                        .addClass(classToAdd);
                 }
                 
                 result.reject();

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -486,9 +486,15 @@ define(function (require, exports, module) {
     /** 
      * @private
      */
-    function _handleFileAdded(file) {
-        _createNewListItem(file);
-        _redraw();
+    function _handleFileAdded(file, index) {
+        if (index === DocumentManager.getWorkingSet().length - 1) {
+            // Simple case: append item to list
+            _createNewListItem(file);
+            _redraw();
+        } else {
+            // Insertion mid-list: just rebuild whole list UI
+            _rebuildWorkingSet(true);
+        }
     }
 
     /**

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -719,7 +719,7 @@ define(function (require, exports, module) {
                     });
 
                     promise = CommandManager.execute(Commands.FILE_SAVE_AS);
-                    waitsForDone(promise, "Provide new filename", 1000);
+                    waitsForDone(promise, "Provide new filename");
                 });
 
                 runs(function () {
@@ -728,8 +728,8 @@ define(function (require, exports, module) {
                 });
 
                 runs(function () {
+                    // Only new file should appear in working set
                     expect(DocumentManager.findInWorkingSet(newFilePath)).toBeGreaterThan(-1);
-                    // old file will appear in working set
                     expect(DocumentManager.findInWorkingSet(filePath)).toEqual(-1);
                     
                     // Verify file exists & clean it up
@@ -760,7 +760,7 @@ define(function (require, exports, module) {
                     });
 
                     promise = CommandManager.execute(Commands.FILE_SAVE_AS);
-                    waitsForFail(promise, "Provide new filename", 1000);
+                    waitsForFail(promise, "Provide new filename");
                 });
 
                 runs(function () {
@@ -772,8 +772,57 @@ define(function (require, exports, module) {
                     expect(DocumentManager.findInWorkingSet(newFilePath)).toEqual(-1);
                 });
             });
-        });
+            
+            it("should maintain order within Working Set after Save As", function () {
+                var filePath    = testPath + "/test.js",
+                    newFilename = "testname.js",
+                    newFilePath = testPath + "/" + newFilename,
+                    index,
+                    targetDoc,
+                    promise;
 
+                runs(function () {
+                    // open the target file
+                    promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: filePath});
+
+                    waitsForDone(promise, "FILE_OPEN");
+                });
+                
+                runs(function () {
+                    index = DocumentManager.findInWorkingSet(filePath);
+                    targetDoc = DocumentManager.getOpenDocumentForPath(filePath);
+                });
+
+                runs(function () {
+                    // create an untitled document so that the file opened above isn't the last item in the working set list
+                    promise = CommandManager.execute(Commands.FILE_NEW_UNTITLED);
+
+                    waitsForDone(promise, "FILE_NEW_UNTITLED");
+                });
+
+                runs(function () {
+                    // save the file opened above to a different filename
+                    DocumentManager.setCurrentDocument(targetDoc);
+                    
+                    spyOn(testWindow.brackets.fs, 'showSaveDialog').andCallFake(function (dialogTitle, initialPath, proposedNewName, callback) {
+                        callback(undefined, newFilePath);
+                    });
+
+                    promise = CommandManager.execute(Commands.FILE_SAVE_AS);
+                    waitsForDone(promise, "Provide new filename");
+                });
+
+                runs(function () {
+                    // New file should appear in working set at old file's index; old file shouldn't appear at all
+                    expect(DocumentManager.findInWorkingSet(newFilePath)).toEqual(index);
+                    expect(DocumentManager.findInWorkingSet(filePath)).toEqual(-1);
+
+                    // Verify file exists & clean it up
+                    expectAndDelete(newFilePath);
+                });
+            });
+        });
+        
         describe("Dirty File Handling", function () {
 
             beforeEach(function () {


### PR DESCRIPTION
Alternate fix for #4484:
- addToWorkingSet() ensures item is moved to requested index, even if it was already in the working set at some other index
- Add a force flag, so we can guarantee a redraw after suppressing it during removal earlier
- addToWorkingSet() _always_ dispatches "workingSetAdd" if something was added to the list -- WorkingSetView now decides internally how big a refresh is needed, rather than addToWorkingSet() dictating it.  Insertion index is now passed with the event to aid this.
- Call handleFileAddToWorkingSet() directly from _doSaveAs() to simplify plumbing (no advantage to going through FileViewController now that "workingSetAdd" is consistently fired for additions).
- Includes unit test from PR #4479 

@bchintx Let me know what you think of this approach.  If it seems reasonable, do you want to close the other one?
