### PR TITLE
Workaround for the Tern crash.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/marijnh/tern.git
 [submodule "src/extensions/default/JavaScriptCodeHints/thirdparty/acorn"]
 	path = src/extensions/default/JavaScriptCodeHints/thirdparty/acorn
-	url = https://github.com/marijnh/acorn.git
+	url = https://github.com/dangoor/acorn.git
 [submodule "src/thirdparty/requirejs"]
 	path = src/thirdparty/requirejs
 	url = https://github.com/jrburke/requirejs.git


### PR DESCRIPTION
Change the Acorn submodule to point to a branch in my repository that
works around the crash by forcing a specific function to not be
optimized by v8.

You'll need to run `git submodule sync` in order to switch the repository URL. I think you also need to follow this up with `git submodule update`.

I can reproduce the original crash reliably using [this project](https://www.dropbox.com/s/o4g1c7hspkrhk7x/crasher.zip). What I usually do to reproduce the crash is:
1. open index.html
2. open app.js
3. type something like the code below, using ctrl-tab to switch between the two files frequently

``` javascript

var a = new Animation(elem, [
    [{opacity: "0.5"}, {opacity: "1.0"}],
    [{transform: "scale(0.5)"}, {transform: "scale(1)"}]
]);
```

It shouldn't actually matter what you type. Doing the frequent ctrl-tab switching causes a lot of reparsing of the polymer.min.js file which is actually the one that triggers the bug. You should be able to see the crash with the stock Brackets 27 and not with this workaround applied.

I did some performance testing of this fix. Without the fix, parsing polymer.min.js took an average of 268ms over 10 runs(1). With this fix, parsing polymer.min.js took an average of 287ms over 10 runs. So, the slowdown was only about 7% on that particular file.

The median without the fix was 279ms vs. 300ms with the fix which is again about 7%.

(1) it was actually 14 runs. There were 10 that completed and 4 that crashed. There were no crashes with the workaround in place.
