### PR TITLE
Prioritized inline editor and docs provider registration

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -92,14 +92,14 @@ define(function (require, exports, module) {
     /**
      * Registered inline-editor widget providers sorted descending by priority. 
      * See {@link #registerInlineEditProvider()}.
-     * @type {Array.<{priority:Number, provider:function(...)}>}
+     * @type {Array.<{priority:number, provider:function(...)}>}
      */
     var _inlineEditProviders = [];
     
     /**
      * Registered inline documentation widget providers sorted descending by priority.
      * See {@link #registerInlineDocsProvider()}.
-     * @type {Array.<{priority:Number, provider:function(...)}>}
+     * @type {Array.<{priority:number, provider:function(...)}>}
      */
     var _inlineDocsProviders = [];
     
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
      * Finds an inline widget provider from the given list that can offer a widget for the current cursor
      * position, and once the widget has been created inserts it into the editor.
      * @param {!Editor} editor The host editor
-     * @param {!Array.<{priority:Number, provider:function(!Editor, !{line:Number, ch:Number}):?$.Promise}>} prioritized providers
+     * @param {!Array.<{priority:number, provider:function(!Editor, !{line:number, ch:number}):?$.Promise}>} prioritized providers
      * @return {$.Promise} a promise that will be resolved when an InlineWidget 
      *      is created or rejected if no inline providers have offered one.
      */
@@ -193,7 +193,8 @@ define(function (require, exports, module) {
     /**
      * Inserts a prioritized provider object into the array in sorted (descending) order.
      *
-     * @param {Number} priority
+     * @param {Array.<{priority:number, provider:function(...)}>} array
+     * @param {number} priority
      * @param {function(...)} provider
      */
     function _insertProviderSorted(array, provider, priority) {
@@ -242,8 +243,8 @@ define(function (require, exports, module) {
      * An optional priority parameter is used to give providers with higher priority an opportunity
      * to provide an inline editor before providers with lower priority.
      * 
-     * @param {function(!Editor, !{line:Number, ch:Number}):?$.Promise} provider
-     * @param {?Number} priority 
+     * @param {function(!Editor, !{line:number, ch:number}):?$.Promise} provider
+     * @param {number=} priority 
      * The provider returns a promise that will be resolved with an InlineWidget, or returns null
      * to indicate the provider doesn't want to respond to this case.
      */
@@ -260,8 +261,8 @@ define(function (require, exports, module) {
      * An optional priority parameter is used to give providers with higher priority an opportunity
      * to provide an inline editor before providers with lower priority.
      * 
-     * @param {function(!Editor, !{line:Number, ch:Number}):?$.Promise} provider
-     * @param {?Number} priority 
+     * @param {function(!Editor, !{line:number, ch:number}):?$.Promise} provider
+     * @param {number=} priority 
      * The provider returns a promise that will be resolved with an InlineWidget, or returns null
      * to indicate the provider doesn't want to respond to this case.
      */
@@ -276,7 +277,7 @@ define(function (require, exports, module) {
      * Registers a new jump-to-definition provider. When jump-to-definition is invoked each
      * registered provider is asked if it wants to provide jump-to-definition results, given
      * the current editor and cursor location. 
-     * @param {function(!Editor, !{line:Number, ch:Number}):?$.Promise} provider
+     * @param {function(!Editor, !{line:number, ch:number}):?$.Promise} provider
      * The provider returns a promise that will be resolved with jump-to-definition results, or
      * returns null to indicate the provider doesn't want to respond to this case.
      */
@@ -696,7 +697,7 @@ define(function (require, exports, module) {
     /**
      * Closes any focused inline widget. Else, asynchronously asks providers to create one.
      *
-     * @param {Array.<{priority:Number, provider:function(...)}>} prioritized providers
+     * @param {Array.<{priority:number, provider:function(...)}>} prioritized providers
      * @return {!Promise} A promise resolved with true if an inline widget is opened or false
      *   when closed. Rejected if there is neither an existing widget to close nor a provider
      *   willing to create a widget (or if no editor is open).

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -90,14 +90,16 @@ define(function (require, exports, module) {
     var _lastEditorWidth = null;
     
     /**
-     * Registered inline-editor widget providers. See {@link #registerInlineEditProvider()}.
-     * @type {Array.<function(...)>}
+     * Registered inline-editor widget providers sorted descending by priority. 
+     * See {@link #registerInlineEditProvider()}.
+     * @type {Array.<{priority:Number, provider:function(...)}>}
      */
     var _inlineEditProviders = [];
     
     /**
-     * Registered inline documentation widget providers. See {@link #registerInlineDocsProvider()}.
-     * @type {Array.<function(...)>}
+     * Registered inline documentation widget providers sorted descending by priority.
+     * See {@link #registerInlineDocsProvider()}.
+     * @type {Array.<{priority:Number, provider:function(...)}>}
      */
     var _inlineDocsProviders = [];
     
@@ -149,7 +151,7 @@ define(function (require, exports, module) {
      * Finds an inline widget provider from the given list that can offer a widget for the current cursor
      * position, and once the widget has been created inserts it into the editor.
      * @param {!Editor} editor The host editor
-     * @param {!Array.<function(!Editor, !{line:Number, ch:Number}):?$.Promise>} providers
+     * @param {!Array.<{priority:Number, provider:function(!Editor, !{line:Number, ch:Number}):?$.Promise}>} prioritized providers
      * @return {$.Promise} a promise that will be resolved when an InlineWidget 
      *      is created or rejected if no inline providers have offered one.
      */
@@ -163,7 +165,7 @@ define(function (require, exports, module) {
             result = new $.Deferred();
         
         for (i = 0; i < providers.length && !inlinePromise; i++) {
-            var provider = providers[i];
+            var provider = providers[i].provider;
             inlinePromise = provider(editor, pos);
         }
         
@@ -186,6 +188,28 @@ define(function (require, exports, module) {
         }
         
         return result.promise();
+    }
+    
+    /**
+     * Inserts a prioritized provider object into the array in sorted (descending) order.
+     *
+     * @param {Number} priority
+     * @param {function(...)} provider
+     */
+    function _insertProviderSorted(array, provider, priority) {
+        var index,
+            prioritizedProvider = {
+                priority: priority,
+                provider: provider
+            };
+        
+        for (index = 0; index < array.length; index++) {
+            if (array[index].priority < priority) {
+                break;
+            }
+        }
+        
+        array.splice(index, 0, prioritizedProvider);
     }
     
     /**
@@ -215,25 +239,37 @@ define(function (require, exports, module) {
     /**
      * Registers a new inline editor provider. When Quick Edit is invoked each registered provider is
      * asked if it wants to provide an inline editor given the current editor and cursor location.
+     * An optional priority parameter is used to give providers with higher priority an opportunity
+     * to provide an inline editor before providers with lower priority.
      * 
      * @param {function(!Editor, !{line:Number, ch:Number}):?$.Promise} provider
+     * @param {?Number} priority 
      * The provider returns a promise that will be resolved with an InlineWidget, or returns null
      * to indicate the provider doesn't want to respond to this case.
      */
-    function registerInlineEditProvider(provider) {
-        _inlineEditProviders.push(provider);
+    function registerInlineEditProvider(provider, priority) {
+        if (priority === undefined) {
+            priority = 0;
+        }
+        _insertProviderSorted(_inlineEditProviders, provider, priority);
     }
 
     /**
      * Registers a new inline docs provider. When Quick Docs is invoked each registered provider is
      * asked if it wants to provide inline docs given the current editor and cursor location.
+     * An optional priority parameter is used to give providers with higher priority an opportunity
+     * to provide an inline editor before providers with lower priority.
      * 
      * @param {function(!Editor, !{line:Number, ch:Number}):?$.Promise} provider
+     * @param {?Number} priority 
      * The provider returns a promise that will be resolved with an InlineWidget, or returns null
      * to indicate the provider doesn't want to respond to this case.
      */
-    function registerInlineDocsProvider(provider) {
-        _inlineDocsProviders.push(provider);
+    function registerInlineDocsProvider(provider, priority) {
+        if (priority === undefined) {
+            priority = 0;
+        }
+        _insertProviderSorted(_inlineDocsProviders, provider, priority);
     }
     
     /**
@@ -659,6 +695,8 @@ define(function (require, exports, module) {
     
     /**
      * Closes any focused inline widget. Else, asynchronously asks providers to create one.
+     *
+     * @param {Array.<{priority:Number, provider:function(...)}>} prioritized providers
      * @return {!Promise} A promise resolved with true if an inline widget is opened or false
      *   when closed. Rejected if there is neither an existing widget to close nor a provider
      *   willing to create a widget (or if no editor is open).
@@ -673,7 +711,7 @@ define(function (require, exports, module) {
                 // an inline widget's editor has focus, so close it
                 PerfUtils.markStart(PerfUtils.INLINE_WIDGET_CLOSE);
                 inlineWidget.close().done(function () {
-                    PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_CLOSE);        
+                    PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_CLOSE);
                     // return a resolved promise to CommandManager
                     result.resolve(false);
                 });

--- a/src/extensions/default/InlineColorEditor/main.js
+++ b/src/extensions/default/InlineColorEditor/main.js
@@ -35,15 +35,14 @@ define(function (require, exports, module) {
     
     
     /**
-     * Registered as an inline editor provider: creates an InlineEditorColor when the cursor
-     * is on a color value (in any flavor of code).
+     * Prepare hostEditor for an InlineColorEditor at pos if possible. Return
+     * editor context if so; otherwise null.
      *
-     * @param {!Editor} hostEditor
-     * @param {!{line:Number, ch:Number}} pos
-     * @return {?$.Promise} synchronously resolved with an InlineWidget, or null if there's
-     *      no color at pos.
+     * @param {Editor} hostEditor
+     * @param {{line:Number, ch:Number}} pos
+     * @return {?{color:String, start:TextMarker, end:TextMarker}}
      */
-    function inlineColorEditorProvider(hostEditor, pos) {
+    function prepareEditorForProvider(hostEditor, pos) {
         var colorPicker, colorRegEx, cursorLine, inlineColorEditor, match, result,
             sel, start, end, startBookmark, endBookmark;
         
@@ -77,12 +76,37 @@ define(function (require, exports, module) {
         
         hostEditor.setSelection(pos, { line: pos.line, ch: end });
         
-        inlineColorEditor = new InlineColorEditor(match[0], startBookmark, endBookmark);
-        inlineColorEditor.load(hostEditor);
-
-        result = new $.Deferred();
-        result.resolve(inlineColorEditor);
-        return result.promise();
+        return {
+            color: match[0],
+            start: startBookmark,
+            end: endBookmark
+        };
+    }
+    
+    /**
+     * Registered as an inline editor provider: creates an InlineEditorColor when the cursor
+     * is on a color value (in any flavor of code).
+     *
+     * @param {!Editor} hostEditor
+     * @param {!{line:Number, ch:Number}} pos
+     * @return {?$.Promise} synchronously resolved with an InlineWidget, or null if there's
+     *      no color at pos.
+     */
+    function inlineColorEditorProvider(hostEditor, pos) {
+        var context = prepareEditorForProvider(hostEditor, pos),
+            inlineColorEditor,
+            result;
+        
+        if (!context) {
+            return null;
+        } else {
+            inlineColorEditor = new InlineColorEditor(context.color, context.start, context.end);
+            inlineColorEditor.load(hostEditor);
+    
+            result = new $.Deferred();
+            result.resolve(inlineColorEditor);
+            return result.promise();
+        }
     }
     
     
@@ -91,6 +115,8 @@ define(function (require, exports, module) {
     
     EditorManager.registerInlineEditProvider(inlineColorEditorProvider);
     
+    // for use by other InlineColorEditors
+    exports.prepareEditorForProvider = prepareEditorForProvider;
     
     // for unit tests only
     exports.inlineColorEditorProvider = inlineColorEditorProvider;


### PR DESCRIPTION
This pull request has two parts: 
1. Generalize `EditorManager.registerInlineEditProvider` and `EditorManager.registerInlineDocsProvider` with an additional, optional `priority` parameter. Providers are then store and queried in priority order. This allows multiple providers to register for a given editor context and have them queried in a predictable order.
2. Refactor the registration callback used by `InlineColorProvider` into an exportable function that can be re-used by other hypothetical inline editor providers.

CC @peterflynn and @gruehle 
