### PR TITLE
Show Error when unable to modify a folder

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -509,34 +509,35 @@ define(function (require, exports, module) {
                 "select_node.jstree",
                 function (event, data) {
                     var entry = data.rslt.obj.data("entry");
-                    if (entry.isFile) {
-                        var openResult = FileViewController.openAndSelectDocument(entry.fullPath, FileViewController.PROJECT_MANAGER);
-                    
-                        openResult.done(function () {
-                            // update when tree display state changes
-                            _redraw(true);
-                            _lastSelected = data.rslt.obj;
-                        }).fail(function () {
-                            if (_lastSelected) {
-                                // revert this new selection and restore previous selection
-                                _forceSelection(data.rslt.obj, _lastSelected);
-                            } else {
-                                _projectTree.jstree("deselect_all");
-                                _lastSelected = null;
-                            }
-                        });
-                    } else {
-                        FileViewController.setFileViewFocus(FileViewController.PROJECT_MANAGER);
-                        // show selection marker on folders
-                        _redraw(true);
+                    if (entry) {
+                        if (entry.isFile) {
+                            var openResult = FileViewController.openAndSelectDocument(entry.fullPath, FileViewController.PROJECT_MANAGER);
                         
-                        // toggle folder open/closed
-                        // suppress if this selection was triggered by clicking the disclousre triangle
-                        if (!suppressToggleOpen) {
-                            _projectTree.jstree("toggle_node", data.rslt.obj);
+                            openResult.done(function () {
+                                // update when tree display state changes
+                                _redraw(true);
+                                _lastSelected = data.rslt.obj;
+                            }).fail(function () {
+                                if (_lastSelected) {
+                                    // revert this new selection and restore previous selection
+                                    _forceSelection(data.rslt.obj, _lastSelected);
+                                } else {
+                                    _projectTree.jstree("deselect_all");
+                                    _lastSelected = null;
+                                }
+                            });
+                        } else {
+                            FileViewController.setFileViewFocus(FileViewController.PROJECT_MANAGER);
+                            // show selection marker on folders
+                            _redraw(true);
+                            
+                            // toggle folder open/closed
+                            // suppress if this selection was triggered by clicking the disclousre triangle
+                            if (!suppressToggleOpen) {
+                                _projectTree.jstree("toggle_node", data.rslt.obj);
+                            }
                         }
                     }
-                    
                     suppressToggleOpen = false;
                 }
             ).bind(
@@ -1265,7 +1266,7 @@ define(function (require, exports, module) {
                             DefaultDialogs.DIALOG_ID_ERROR,
                             StringUtils.format(Strings.ERROR_CREATING_FILE_TITLE, entryType),
                             StringUtils.format(Strings.ERROR_CREATING_FILE, entryType,
-                                Strings.breakableUrl(data.rslt.name), errString)
+                                StringUtils.breakableUrl(data.rslt.name), errString)
                         );
                     }
 


### PR DESCRIPTION
- Fixes client #4456 
- Adds another bit of safety when clicking on an item that isn't a file system object

The main problem was an exception was getting thrown because the folder was unwritable and Strings doesn't have a method breakableUrl().  That method comes from StringUtils so I fixed that and the message now appears and the file is removed after creation.  

The other check was working my way through -- I noticed that data("entry") was returning undefined when creating new files that do not yet exist on disk.  That may no longer be an issue since file entries that cannot be created are removed immediately by the ProjectManager but this check will prevent another crash if a non-existent file gets into the tree somehow in the future.  That code was throwing an exception before so it didn't get a chance to execute the removal code but that isn't to say that someone else could add a code path that shows a file that doesn't exist on disk.
