### PR TITLE
Don't dismiss code hints on key up events except for Home and End keys.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -468,9 +468,7 @@ define(function (require, exports, module) {
             // Last inserted character, used later by handleChange
             lastChar = String.fromCharCode(event.charCode);
         } else if (event.type === "keyup" && _inSession(editor)) {
-            if ((event.keyCode !== 32 && event.ctrlKey) || event.altKey || event.metaKey ||
-                    event.keyCode === KeyEvent.DOM_VK_HOME || event.keyCode === KeyEvent.DOM_VK_END) {
-                // End the session if the user presses any key with a modifier (other than Ctrl+Space).
+            if (event.keyCode === KeyEvent.DOM_VK_HOME || event.keyCode === KeyEvent.DOM_VK_END) {
                 _endSession();
             } else if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
                        event.keyCode === KeyEvent.DOM_VK_RIGHT ||


### PR DESCRIPTION
This fixes an issue for @dloverin who needs to show function hints with Ctrl+Shift+Space shortcut. 

This also fixes some remaining issues in #2539 which can be reproduced with typing `$` on French keyboard layout that requires user to press Option+5 keys on Mac. When typing `$` with English keyboard layout in a JavaScript file, you will see code hints showing $. When trying with French keyboard layout on Mac, the code hint list pops up and then immediately gets dismissed.
