### PR TITLE
Fix Save As confusion; update docs for working set event change

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -183,7 +183,6 @@ define(function (require, exports, module) {
         project_cmenu.addMenuItem(Commands.FILE_NEW);
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
         project_cmenu.addMenuItem(Commands.FILE_RENAME);
-        project_cmenu.addMenuItem(Commands.FILE_SAVE_AS);
         project_cmenu.addMenuItem(Commands.FILE_DELETE);
         project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         project_cmenu.addMenuDivider();

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -760,18 +760,19 @@ define(function (require, exports, module) {
     function handleFileSaveAs(commandData) {
         // Default to current document if doc is null
         var doc = null,
-            activeEditor,
             settings;
         
         if (commandData) {
             doc = commandData.doc;
         } else {
-            activeEditor = EditorManager.getActiveEditor();
-            doc = activeEditor.document;
-            settings = {};
-            settings.selection = activeEditor.getSelection();
-            settings.cursorPos = activeEditor.getCursorPos();
-            settings.scrollPos = activeEditor.getScrollPos();
+            var activeEditor = EditorManager.getActiveEditor();
+            if (activeEditor) {
+                doc = activeEditor.document;
+                settings = {};
+                settings.selection = activeEditor.getSelection();
+                settings.cursorPos = activeEditor.getCursorPos();
+                settings.scrollPos = activeEditor.getScrollPos();
+            }
         }
             
         // doc may still be null, e.g. if no editors are open, but _doSaveAs() does a null check on

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -70,10 +70,11 @@
  *      2nd arg to the listener is the removed FileEntry.
  *    - workingSetRemoveList -- When multiple files are removed from the working set (e.g. project close).
  *      The 2nd arg to the listener is the array of removed FileEntry objects.
- *    - workingSetSort -- When the workingSet array is sorted. Notifies the working set view to redraw
- *      the new sorted list. Listener receives no arguments.
- *    - workingSetDisableAutoSorting -- When working set is manually re-sorted via dragging and dropping
- *      a file to disable automatic sorting. Listener receives no arguments.
+ *    - workingSetSort -- When the workingSet array is reordered without additions or removals.
+ *      Listener receives no arguments.
+ * 
+ *    - workingSetDisableAutoSorting -- Dispatched in addition to workingSetSort when the reorder was caused
+ *      by manual dragging and dropping. Listener receives no arguments.
  *
  *    - fileNameChange -- When the name of a file or folder has changed. The 2nd arg is the old name.
  *      The 3rd arg is the new name.
@@ -81,6 +82,8 @@
  *
  * These are jQuery events, so to listen for them you do something like this:
  *    $(DocumentManager).on("eventname", handler);
+ * 
+ * Document objects themselves also dispatch some events - see Document docs for details.
  */
 define(function (require, exports, module) {
     "use strict";


### PR DESCRIPTION
- Fix bug #4548 - remove Save As from folder tree context menu
- Fix exception thrown when File > Save As invoked with nothing open
- Update docs for working set events to reflect PR #4450
