### PR TITLE
Unit test preference cleanup, reuse test window for DocumentCommandHandlers-test

### DIFF
--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -495,6 +495,15 @@ define(function (require, exports, module) {
         return deferred.promise();
     };
     
+    /**
+     * @private
+     * Get the default timeout value
+     * @return {number} Timeout value in milliseconds
+     */
+    NodeConnection._getConnectionTimeout = function () {
+        return CONNECTION_TIMEOUT;
+    };
+    
     module.exports = NodeConnection;
     
 });

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -310,6 +310,10 @@ define(function (require, exports, module) {
             beforeEach(function () {
                 // Unique key for unit testing
                 localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
+
+                // Reset preferences from previous test runs
+                localStorage.removeItem("doLoadPreferences");
+                localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
             });
             
             afterEach(function () {

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -33,7 +33,8 @@ define(function (require, exports, module) {
     var SpecRunnerUtils  = require("spec/SpecRunnerUtils"),
         ExtensionLoader  = require("utils/ExtensionLoader"),
         NativeFileSystem = require("file/NativeFileSystem").NativeFileSystem,
-        Package          = require("extensibility/Package");
+        Package          = require("extensibility/Package"),
+        NodeConnection   = require("utils/NodeConnection");
     
     var testFilePath = SpecRunnerUtils.getTestPath("/spec/extension-test-files");
     
@@ -52,7 +53,8 @@ define(function (require, exports, module) {
         packageData = undefined;
         
         runs(function () {
-            waitsForDone(Package._getNodeConnectionDeferred(), "ExtensionManagerDomain load", 5000);
+            // Matches NodeConnection CONNECTION_TIMEOUT
+            waitsForDone(Package._getNodeConnectionDeferred(), "ExtensionManagerDomain load", NodeConnection._getConnectionTimeout());
         });
         
         runs(function () {

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -38,6 +38,8 @@ define(function (require, exports, module) {
         var testWindow, dialog, fields, goodInstaller, badInstaller, closed,
             url = "http://brackets.io/extensions/myextension.zip";
         
+        this.category = "integration";
+        
         beforeEach(function () {
             if (!testWindow) {
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {


### PR DESCRIPTION
- Removes existing preferences in case `doLoadPreferences` was somehow wedged due to a previous failure.
- Make `DocumentCommandHandlers-test` run faster by reusing the test window.
- Update save as tests for inside and outside of workspace files
