### PR TITLE
Revert "Workaround for the Tern crash."

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/marijnh/tern.git
 [submodule "src/extensions/default/JavaScriptCodeHints/thirdparty/acorn"]
 	path = src/extensions/default/JavaScriptCodeHints/thirdparty/acorn
-	url = https://github.com/dangoor/acorn.git
+	url = https://github.com/marijnh/acorn.git
 [submodule "src/thirdparty/requirejs"]
 	path = src/thirdparty/requirejs
 	url = https://github.com/jrburke/requirejs.git


### PR DESCRIPTION
This reverts commit 22fed2a8e230f07394b3b1b5dfb8691dd214d76f, which is no longer needed in Chromium 29.

**DO NOT MERGE UNTIL adobe/brackets-shell#287 IS MERGED!**

Note: you will need to run `git submodule sync` after pulling these changes, since the acorn submodule URL is changed back to marijn's repo.
