### PR TITLE
Work around #4554 (Extension Manager font hard to read on Windows)

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -653,6 +653,12 @@
                 .user-select(text);
                 cursor: text;
             }
+            .platform-win & {  // work around #4554
+                .ext-name, .ext-desc {
+                    font-weight: normal;
+                    color: #2e2e2e;
+                }
+            }
             .muted {
                 color: #888;
             }


### PR DESCRIPTION
Work around #4554 (Extension Manager font hard to read on Windows), which is a Chromium bug, by avoiding the lightest font-weight on Win. Lighten the text slightly so it's still a little muted, like the design looks on Mac and with older CEFs on Win.

I pinged @larz0 to ask whether we should try to tweak dialog box message text too -- see [screenshots posted in bug](https://github.com/adobe/brackets/issues/4554#issuecomment-21525145).  Other dialogs use text that's 1px bigger, so they don't look quite as bad but it's still noticeable.  But changing `.dialog-message` is a little riskier because it affects far more UI (including plenty of extensions).
