### PR TITLE
Fix for issue #4562

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -115,13 +115,7 @@
     "scala": {
         "name": "Scala",
         "mode": ["clike", "text/x-scala"],
-        "fileExtensions": ["scala"]
-    },
-
-    "sbt": {
-        "name": "SBT",
-        "mode": ["clike", "text/x-scala"],
-        "fileExtensions": ["sbt"]
+        "fileExtensions": ["scala", "sbt"]
     },
 
     "coffeescript": {


### PR DESCRIPTION
Combined the file extensions .scala and .sbt into one language.  Removes the console log.
