### PR TITLE
Improvements to middle-click closing files

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -42,6 +42,10 @@ define(function (require, exports, module) {
         ViewUtils             = require("utils/ViewUtils");
     
     
+    /** @const @type {number} Constants for event.which values */
+    var LEFT_BUTTON = 1,
+        MIDDLE_BUTTON = 2;
+    
     /** Each list item in the working set stores a references to the related document in the list item's data.  
      *  Use listItem.data(_FILE_KEY) to get the document reference
      */
@@ -239,21 +243,14 @@ define(function (require, exports, module) {
                 window.clearInterval(interval);
             }
             
-            // If file wasnt moved open or close it
+            // If item wasn't dragged, treat as a click
             if (!moved) {
-                if (!fromClose) {
-                /***/
-                    FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
-                /***
-                    // Backing out for Sprint 18 due to issues described in #2394, #2411
-                    if (selected) {
-                        CommandManager.execute(Commands.FILE_RENAME);
-                    } else {
-                        FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
-                    }
-                ***/
-                } else {
+                // Click on close icon, or middle click anywhere - close the item without selecting it first
+                if (fromClose || event.which === MIDDLE_BUTTON) {
                     CommandManager.execute(Commands.FILE_CLOSE, {file: $listItem.data(_FILE_KEY)});
+                } else {
+                    // Normal right and left click - select the item
+                    FileViewController.openAndSelectDocument($listItem.data(_FILE_KEY).fullPath, FileViewController.WORKING_SET_VIEW);
                 }
             
             } else {
@@ -276,7 +273,7 @@ define(function (require, exports, module) {
         
         // Only drag with the left mouse button, and control key is not down
         // on Mac, end the drop in other cases
-        if (event.which !== 1 || (event.ctrlKey && brackets.platform === "mac")) {
+        if (event.which !== LEFT_BUTTON || (event.ctrlKey && brackets.platform === "mac")) {
             drop();
             return;
         }
@@ -355,18 +352,9 @@ define(function (require, exports, module) {
     }
 
     function isOpenAndDirty(file) {
+        // working set item might never have been opened; if so, then it's definitely not dirty
         var docIfOpen = DocumentManager.getOpenDocumentForPath(file.fullPath);
         return (docIfOpen && docIfOpen.isDirty);
-    }
-    
-    /**
-     * @private
-     * @param {$.Event} event The Click Event to respond to.
-     */
-    function _handleMiddleMouseClick(event) {
-        var file = $(event.target).closest("li").data(_FILE_KEY);
-
-        CommandManager.execute(Commands.FILE_CLOSE, {file: file});
     }
     
     /** 
@@ -386,8 +374,6 @@ define(function (require, exports, module) {
 
         $openFilesContainer.find("ul").append($newItem);
         
-        // working set item might never have been opened; if so, then it's definitely not dirty
-        
         // Update the listItem's apperance
         _updateFileStatusIcon($newItem, isOpenAndDirty(file), false);
         _updateListItemSelection($newItem, curDoc);
@@ -397,13 +383,6 @@ define(function (require, exports, module) {
             e.preventDefault();
         });
         
-        $newItem.click(function (e) {
-            if (e.which === 2) {
-                _handleMiddleMouseClick(e);
-            }
-            e.preventDefault();
-        });
-
         $newItem.hover(
             function () {
                 _updateFileStatusIcon($(this), isOpenAndDirty(file), true);


### PR DESCRIPTION
Improved fix for #3889 (Middle click should close files)
- Don't go through normal selection-click handling codepath first: detect middle click in the same place we filter out close-button clicks. This means the file is closed instantly, as opposed to a delay while it's loaded / switched to first.  No longer need a separate middle-click listener as a result.
- Use constants for event.which
- Remove long-commented-out rename code
- Move misplaced comment ("might never have been opened") to its rightful home

@RaymondLim I think this conflicts a little bit with your advice in the original PR #3901, so maybe you could take a look?
