### PR TITLE
Implementation of beforeAll/afterAll

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -314,11 +314,15 @@ define(function (require, exports, module) {
                 // Reset preferences from previous test runs
                 localStorage.removeItem("doLoadPreferences");
                 localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
+                
+                SpecRunnerUtils.runBeforeAll();
             });
             
             afterEach(function () {
                 // Clean up preferencesKey
                 localStorage.removeItem("preferencesKey");
+                
+                SpecRunnerUtils.runAfterAll();
             });
             
             jasmineEnv.updateInterval = 1000;

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -315,14 +315,14 @@ define(function (require, exports, module) {
                 localStorage.removeItem("doLoadPreferences");
                 localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
                 
-                SpecRunnerUtils.runBeforeAll();
+                SpecRunnerUtils.runBeforeFirst();
             });
             
             afterEach(function () {
                 // Clean up preferencesKey
                 localStorage.removeItem("preferencesKey");
                 
-                SpecRunnerUtils.runAfterAll();
+                SpecRunnerUtils.runAfterLast();
             });
             
             jasmineEnv.updateInterval = 1000;

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -23,22 +23,22 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, waits, waitsFor, expect, brackets, waitsForDone, waitsForFail, spyOn */
+/*global define, $, describe, beforeEach, afterEach, it, runs, waits, waitsFor, expect, brackets, waitsForDone, waitsForFail, spyOn, beforeAll, afterAll */
 
 define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var CommandManager,      // loaded from brackets.test
-        Commands,            // loaded from brackets.test
+    var CommandManager,          // loaded from brackets.test
+        Commands,                // loaded from brackets.test
         DocumentCommandHandlers, // loaded from brackets.test
-        DocumentManager,     // loaded from brackets.test
-        Dialogs,             // loaded from brackets.test
-        FileViewController,  // loaded from brackets.test
-        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
-        NativeFileSystem    = require("file/NativeFileSystem").NativeFileSystem,
-        FileUtils           = require("file/FileUtils"),
-        StringUtils         = require("utils/StringUtils");
+        DocumentManager,         // loaded from brackets.test
+        Dialogs,                 // loaded from brackets.test
+        FileViewController,      // loaded from brackets.test
+        SpecRunnerUtils          = require("spec/SpecRunnerUtils"),
+        NativeFileSystem         = require("file/NativeFileSystem").NativeFileSystem,
+        FileUtils                = require("file/FileUtils"),
+        StringUtils              = require("utils/StringUtils");
     
     describe("DocumentCommandHandlers", function () {
         this.category = "integration";
@@ -46,52 +46,47 @@ define(function (require, exports, module) {
         var topLevelSuite = this,
             testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
             testWindow,
-            specCount,
             promise;
 
         var TEST_JS_CONTENT = 'var myContent="This is awesome!";';
         var TEST_JS_NEW_CONTENT = "hello world";
         var TEST_JS_SECOND_NEW_CONTENT = "hello world 2";
+        
+        beforeAll(function () {
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
 
+                // Load module instances from brackets.test
+                CommandManager          = testWindow.brackets.test.CommandManager;
+                Commands                = testWindow.brackets.test.Commands;
+                DocumentCommandHandlers = testWindow.brackets.test.DocumentCommandHandlers;
+                DocumentManager         = testWindow.brackets.test.DocumentManager;
+                Dialogs                 = testWindow.brackets.test.Dialogs;
+                FileViewController      = testWindow.brackets.test.FileViewController;
+            });
+        });
+        
+        afterAll(function () {
+            testWindow              = null;
+            CommandManager          = null;
+            Commands                = null;
+            DocumentCommandHandlers = null;
+            DocumentManager         = null;
+            Dialogs                 = null;
+            FileViewController      = null;
+            SpecRunnerUtils.closeTestWindow();
+        });
+        
+        
         beforeEach(function () {
-            if (specCount === undefined) {
-                specCount = SpecRunnerUtils.countSpecs(topLevelSuite);
-            }
-
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
-
-                    // Load module instances from brackets.test
-                    CommandManager      = testWindow.brackets.test.CommandManager;
-                    Commands            = testWindow.brackets.test.Commands;
-                    DocumentCommandHandlers = testWindow.brackets.test.DocumentCommandHandlers;
-                    DocumentManager     = testWindow.brackets.test.DocumentManager;
-                    Dialogs             = testWindow.brackets.test.Dialogs;
-                    FileViewController  = testWindow.brackets.test.FileViewController;
-                });
-            }
-
             // Working set behavior is sensitive to whether file lives in the project or outside it, so make
             // the project root a known quantity.
             SpecRunnerUtils.loadProjectInTestWindow(testPath);
         });
 
         afterEach(function () {
-            specCount--;
             promise = null;
             testWindow.closeAllDocuments();
-
-            runs(function () {
-                if (specCount === 0) {
-                    testWindow              = null;
-                    CommandManager          = null;
-                    Commands                = null;
-                    DocumentCommandHandlers = null;
-                    DocumentManager         = null;
-                    SpecRunnerUtils.closeTestWindow();
-                }
-            });
         });
 
 

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, waits, waitsFor, expect, brackets, waitsForDone, waitsForFail, spyOn, beforeAll, afterAll */
+/*global define, $, describe, beforeEach, afterEach, it, runs, waits, waitsFor, expect, brackets, waitsForDone, waitsForFail, spyOn, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -43,8 +43,7 @@ define(function (require, exports, module) {
     describe("DocumentCommandHandlers", function () {
         this.category = "integration";
 
-        var topLevelSuite = this,
-            testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
+        var testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
             testWindow,
             promise;
 
@@ -52,7 +51,7 @@ define(function (require, exports, module) {
         var TEST_JS_NEW_CONTENT = "hello world";
         var TEST_JS_SECOND_NEW_CONTENT = "hello world 2";
         
-        beforeAll(function () {
+        beforeFirst(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
 
@@ -66,7 +65,7 @@ define(function (require, exports, module) {
             });
         });
         
-        afterAll(function () {
+        afterLast(function () {
             testWindow              = null;
             CommandManager          = null;
             Commands                = null;

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waits, runs, $, waitsForDone, beforeAll, afterAll */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waits, runs, $, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -2132,11 +2132,11 @@ define(function (require, exports, module) {
                               "    color: red;\n" +
                               "}";
             
-            beforeAll(function () {
+            beforeFirst(function () {
                 createTestWindow(this);
             });
             
-            afterAll(function () {
+            afterLast(function () {
                 closeTestWindow();
             });
             
@@ -2628,11 +2628,11 @@ define(function (require, exports, module) {
                           "    color: red;\n" +
                           "}";
             
-            beforeAll(function () {
+            beforeFirst(function () {
                 createTestWindow(this);
             });
             
-            afterAll(function () {
+            afterLast(function () {
                 closeTestWindow();
             });
             

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waits, runs, $, waitsForDone */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waits, runs, $, waitsForDone, beforeAll, afterAll */
 
 define(function (require, exports, module) {
     'use strict';
@@ -94,22 +94,23 @@ define(function (require, exports, module) {
         }
         
         
-        // Helper function for creating a window with an inline editor
-        function createWindowWithInlineEditor(spec) {
+        // Helper function for creating a test window
+        function createTestWindow(spec) {
+            SpecRunnerUtils.createTestWindowAndRun(spec, function (w) {
+                testWindow = w;
+                
+                // Load module instances from brackets.test
+                CommandManager      = testWindow.brackets.test.CommandManager;
+                Commands            = testWindow.brackets.test.Commands;
+                EditorManager       = testWindow.brackets.test.EditorManager;
+                
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            });
+        }
+        
+        // Helper function to open a new inline editor
+        function openInlineEditor(spec) {
             var promise;
-            
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(spec, function (w) {
-                    testWindow = w;
-                    
-                    // Load module instances from brackets.test
-                    CommandManager      = testWindow.brackets.test.CommandManager;
-                    Commands            = testWindow.brackets.test.Commands;
-                    EditorManager       = testWindow.brackets.test.EditorManager;
-                   
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
-                });
-            }
             
             runs(function () {
                 promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: testPath + "/test.html"});
@@ -142,17 +143,13 @@ define(function (require, exports, module) {
             });
         }
         
-        // Helper function for closing the test window. This must be used in the last spec in the suite.
+        // Helper function for closing the test window
         function closeTestWindow() {
-            runs(function () {
-                this.after(function () {
-                    SpecRunnerUtils.closeTestWindow();
-                    testWindow      = null;
-                    CommandManager  = null;
-                    Commands        = null;
-                    EditorManager   = null;
-                });
-            });
+            testWindow      = null;
+            CommandManager  = null;
+            Commands        = null;
+            EditorManager   = null;
+            SpecRunnerUtils.closeTestWindow();
         }
         
 
@@ -2135,8 +2132,16 @@ define(function (require, exports, module) {
                               "    color: red;\n" +
                               "}";
             
+            beforeAll(function () {
+                createTestWindow(this);
+            });
+            
+            afterAll(function () {
+                closeTestWindow();
+            });
+            
             beforeEach(function () {
-                createWindowWithInlineEditor(this);
+                openInlineEditor(this);
             });
             
             afterEach(function () {
@@ -2192,8 +2197,6 @@ define(function (require, exports, module) {
                 expect(myEditor.document.getText()).toEqual(expectedText);
                 expect(myEditor.getFirstVisibleLine()).toBe(0);
                 expect(myEditor.getLastVisibleLine()).toBe(2);
-                
-                closeTestWindow();
             });
         });
         
@@ -2625,13 +2628,22 @@ define(function (require, exports, module) {
                           "    color: red;\n" +
                           "}";
             
+            beforeAll(function () {
+                createTestWindow(this);
+            });
+            
+            afterAll(function () {
+                closeTestWindow();
+            });
+            
             beforeEach(function () {
-                createWindowWithInlineEditor(this);
+                openInlineEditor(this);
             });
             
             afterEach(function () {
                 closeFilesInTestWindow();
             });
+            
 
             it("should insert new line above the first line of the inline editor", function () {
                 myEditor.setSelection({line: 0, ch: 4}, {line: 0, ch: 6});
@@ -2709,8 +2721,6 @@ define(function (require, exports, module) {
                 expect(myEditor.document.getText()).toEqual(expectedText);
                 expect(myEditor.getFirstVisibleLine()).toBe(0);
                 expect(myEditor.getLastVisibleLine()).toBe(3);
-                
-                closeTestWindow();
             });
         });
     });

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone */
+/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone, beforeAll, afterAll */
 
 define(function (require, exports, module) {
     "use strict";
@@ -53,23 +53,32 @@ define(function (require, exports, module) {
             BACKSPACE     = 8;
         
         
-        beforeEach(function () {
+        beforeAll(function () {
             // Create a new window that will be shared by ALL tests in this spec.
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
-    
-                    // Load module instances from brackets.test
-                    CommandManager      = testWindow.brackets.test.CommandManager;
-                    Commands            = testWindow.brackets.test.Commands;
-                    EditorManager       = testWindow.brackets.test.EditorManager;
-                    DocumentManager     = testWindow.brackets.test.DocumentManager;
-                    FileViewController  = testWindow.brackets.test.FileViewController;
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
+
+                // Load module instances from brackets.test
+                CommandManager      = testWindow.brackets.test.CommandManager;
+                Commands            = testWindow.brackets.test.Commands;
+                EditorManager       = testWindow.brackets.test.EditorManager;
+                DocumentManager     = testWindow.brackets.test.DocumentManager;
+                FileViewController  = testWindow.brackets.test.FileViewController;
                    
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
-                });
-            }
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            });
         });
+        
+        afterAll(function () {
+            testWindow          = null;
+            CommandManager      = null;
+            Commands            = null;
+            EditorManager       = null;
+            DocumentManager     = null;
+            FileViewController  = null;
+            SpecRunnerUtils.closeTestWindow();
+        });
+        
 
         afterEach(function () {
             runs(function () {
@@ -437,20 +446,6 @@ define(function (require, exports, module) {
                     var editor = EditorManager.getCurrentFullEditor();
                     checkCloseBraces(editor, {line: 0, ch: 15}, null, SINGLE_QUOTE, "var myContent ='' \"This is awesome!\";");
                     checkCloseBraces(editor, {line: 1, ch: 7}, null, SINGLE_QUOTE, "// Yes, it is!");
-                });
-                
-                // This must be in the last spec in the suite. Note that it's possible to
-                // run a single test from suite, so this only works when running entire suite.
-                runs(function () {
-                    this.after(function () {
-                        testWindow          = null;
-                        CommandManager      = null;
-                        Commands            = null;
-                        EditorManager       = null;
-                        DocumentManager     = null;
-                        FileViewController  = null;
-                        SpecRunnerUtils.closeTestWindow();
-                    });
                 });
             });
         });

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone, beforeAll, afterAll */
+/*global define, $, describe, beforeEach, afterEach, it, runs, waitsFor, expect, brackets, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
             BACKSPACE     = 8;
         
         
-        beforeAll(function () {
+        beforeFirst(function () {
             // Create a new window that will be shared by ALL tests in this spec.
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
             });
         });
         
-        afterAll(function () {
+        afterLast(function () {
             testWindow          = null;
             CommandManager      = null;
             Commands            = null;

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, runs, $, waitsForDone, spyOn, jasmine, beforeAll, afterAll */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, runs, $, waitsForDone, spyOn, jasmine, beforeFirst, afterLast */
 /*unittests: Install Extension Dialog*/
 
 define(function (require, exports, module) {
@@ -40,13 +40,13 @@ define(function (require, exports, module) {
         
         this.category = "integration";
         
-        beforeAll(function () {
+        beforeFirst(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
             });
         });
         
-        afterAll(function () {
+        afterLast(function () {
             testWindow = null;
             SpecRunnerUtils.closeTestWindow();
         });

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, runs, $, waitsForDone, spyOn, jasmine */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, runs, $, waitsForDone, spyOn, jasmine, beforeAll, afterAll */
 /*unittests: Install Extension Dialog*/
 
 define(function (require, exports, module) {
@@ -40,12 +40,15 @@ define(function (require, exports, module) {
         
         this.category = "integration";
         
-        beforeEach(function () {
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
-                });
-            }
+        beforeAll(function () {
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
+            });
+        });
+        
+        afterAll(function () {
+            testWindow = null;
+            SpecRunnerUtils.closeTestWindow();
         });
 
         afterEach(function () {
@@ -715,12 +718,6 @@ define(function (require, exports, module) {
                 expect(fields.$url.is(":visible")).toBe(false);
                 deferred.resolve(successfulResult);
             });
-        });
-        
-        // THIS MUST BE THE LAST SPEC IN THE SUITE
-        it("should close the test window", function () {
-            testWindow = null;
-            SpecRunnerUtils.closeTestWindow();
         });
     });
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -965,17 +965,17 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Adds a new before all or after all function to the current suite. If requires it creates a new object to
-     * store the before all and after all functions and a spec counter for the current suite.
-     * @param {string} type  "beforeAll" or "afterAll"
+     * Adds a new before all or after all function to the current suite. If requires it creates a new
+     * object to store the before all and after all functions and a spec counter for the current suite.
+     * @param {string} type  "beforeFirst" or "afterLast"
      * @param {function} func  The function to store
      */
     function _addSuiteFunction(type, func) {
         var suiteId = jasmine.getEnv().currentSuite.id;
         if (!_testSuites[suiteId]) {
             _testSuites[suiteId] = {
-                beforeAll   : [],
-                afterAll    : [],
+                beforeFirst : [],
+                afterLast   : [],
                 specCounter : null
             };
         }
@@ -986,16 +986,16 @@ define(function (require, exports, module) {
      * Utility for tests that need to open a window or do something before every test in a suite
      * @param {function} func
      */
-    window.beforeAll = function (func) {
-        _addSuiteFunction("beforeAll", func);
+    window.beforeFirst = function (func) {
+        _addSuiteFunction("beforeFirst", func);
     };
     
     /**
      * Utility for tests that need to close a window or do something after every test in a suite
      * @param {function} func
      */
-    window.afterAll = function (func) {
-        _addSuiteFunction("afterAll", func);
+    window.afterLast = function (func) {
+        _addSuiteFunction("afterLast", func);
     };
     
     /**
@@ -1004,21 +1004,23 @@ define(function (require, exports, module) {
      * @param {Array.<function>} functions
      */
     function _callFunctions(functions) {
+        var spec = jasmine.getEnv().currentSpec;
         functions.forEach(function (func) {
-            func.apply(this);
+            func.apply(spec);
         });
     }
     
     /**
-     * Calls the before all functions and initialized the spec counter for the suites with the spec counter not
-     * initialized and parent of the currently running spec.
+     * Calls the before first functions for the parent suites of the current spec when is the first spec of each suite.
      */
-    function runBeforeAll() {
+    function runBeforeFirst() {
         var suite = jasmine.getEnv().currentSpec.suite;
         
+        // Iterate throught all the parent suites of the current spec
         while (suite) {
+            // If we have functions for this suite and it was never called, initialize the spec counter
             if (_testSuites[suite.id] && _testSuites[suite.id].specCounter === null) {
-                _callFunctions(_testSuites[suite.id].beforeAll);
+                _callFunctions(_testSuites[suite.id].beforeFirst);
                 _testSuites[suite.id].specCounter = countSpecs(suite);
             }
             suite = suite.parentSuite;
@@ -1026,18 +1028,20 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Reduces the spec counter of the suites parent of the current running spec (if available), and when the counter
-     * reached 0, it calls the after all functions and removes the object from the test suites.
+     * Calls the after last functions for the parent suites of the current spec when is the last spec of each suite.
      */
-    function runAfterAll() {
+    function runAfterLast() {
         var suite = jasmine.getEnv().currentSpec.suite;
         
+        // Iterate throught all the parent suites of the current spec
         while (suite) {
+            // If we have functions for this suite, reduce the spec counter
             if (_testSuites[suite.id] && _testSuites[suite.id].specCounter > 0) {
                 _testSuites[suite.id].specCounter--;
                 
+                // If this was the last spec of the suite run the after last functions and remove it
                 if (_testSuites[suite.id].specCounter === 0) {
-                    _callFunctions(_testSuites[suite.id].afterAll);
+                    _callFunctions(_testSuites[suite.id].afterLast);
                     delete _testSuites[suite.id];
                 }
             }
@@ -1117,6 +1121,6 @@ define(function (require, exports, module) {
     exports.parseOffsetsFromText            = parseOffsetsFromText;
     exports.findDOMText                     = findDOMText;
     exports.countSpecs                      = countSpecs;
-    exports.runBeforeAll                    = runBeforeAll;
-    exports.runAfterAll                     = runAfterAll;
+    exports.runBeforeFirst                  = runBeforeFirst;
+    exports.runAfterLast                    = runAfterLast;
 });

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, it, runs, expect, waitsForDone, beforeAll, afterAll */
+/*global define, describe, beforeEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         var CSS_FILE  = testPath + "/test.css",
             HTML_FILE = testPath + "/test.html";
         
-        beforeAll(function () {
+        beforeFirst(function () {
             var promise;
             
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
             });
         });
         
-        afterAll(function () {
+        afterLast(function () {
             testWindow          = null;
             CommandManager      = null;
             Commands            = null;

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, it, runs, expect, waitsForDone */
+/*global define, describe, beforeEach, it, runs, expect, waitsForDone, beforeAll, afterAll */
 
 define(function (require, exports, module) {
     "use strict";
@@ -42,35 +42,42 @@ define(function (require, exports, module) {
         var CSS_FILE  = testPath + "/test.css",
             HTML_FILE = testPath + "/test.html";
         
-        beforeEach(function () {
+        beforeAll(function () {
             var promise;
             
-            // Create a new window that will be shared by ALL tests in this spec.
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
     
-                    // Load module instances from brackets.test
-                    CommandManager      = testWindow.brackets.test.CommandManager;
-                    Commands            = testWindow.brackets.test.Commands;
-                    EditorManager       = testWindow.brackets.test.EditorManager;
-                    FileViewController  = testWindow.brackets.test.FileViewController;
-                   
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
-                });
+                // Load module instances from brackets.test
+                CommandManager      = testWindow.brackets.test.CommandManager;
+                Commands            = testWindow.brackets.test.Commands;
+                EditorManager       = testWindow.brackets.test.EditorManager;
+                FileViewController  = testWindow.brackets.test.FileViewController;
                 
-                runs(function () {
-                    promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: HTML_FILE});
-                    waitsForDone(promise, "Open into working set");
-                });
-                
-                runs(function () {
-                    // Open inline editor onto test.css's ".testClass" rule
-                    promise = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), {line: 8, ch: 11});
-                    waitsForDone(promise, "Open inline editor");
-                });
-            }
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            });
+            
+            runs(function () {
+                promise = CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, {fullPath: HTML_FILE});
+                waitsForDone(promise, "Open into working set");
+            });
+            
+            runs(function () {
+                // Open inline editor onto test.css's ".testClass" rule
+                promise = SpecRunnerUtils.toggleQuickEditAtOffset(EditorManager.getCurrentFullEditor(), {line: 8, ch: 11});
+                waitsForDone(promise, "Open inline editor");
+            });
         });
+        
+        afterAll(function () {
+            testWindow          = null;
+            CommandManager      = null;
+            Commands            = null;
+            EditorManager       = null;
+            FileViewController  = null;
+            SpecRunnerUtils.closeTestWindow();
+        });
+        
         
         function getEditors() {
             var editor = EditorManager.getCurrentFullEditor();
@@ -140,18 +147,6 @@ define(function (require, exports, module) {
                 runs(function () {
                     editor = EditorManager.getCurrentFullEditor();
                     expect(editor.getTextHeight()).toBeGreaterThan(originalSize);
-                });
-                
-                // This must be in the last spec in the suite.
-                runs(function () {
-                    this.after(function () {
-                        testWindow          = null;
-                        CommandManager      = null;
-                        Commands            = null;
-                        EditorManager       = null;
-                        FileViewController  = null;
-                        SpecRunnerUtils.closeTestWindow();
-                    });
                 });
             });
         });


### PR DESCRIPTION
This pull request adds the functions `beforeAll` and `afterAll` to be used inside any test suite. With these functions we can better create a test window for a complete test suite and close it at the end. Hopefully, if jasmine finally implements them, we won't need to rewrite anything besides removing the additional code added on this PR.

I then updated the test suites that used a single window for all the tests to use this new functions.
