### PR TITLE
Reuse test windows during integration suites

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -286,6 +286,41 @@ define(function (require, exports, module) {
             });
         }
     }
+    
+    /**
+     * @private
+     * Remove a code hint provider
+     * @param {!CodeHintProvider} provider Code hint provider to remove
+     * @param {(string|Array.<string>)=} targetLanguageId Optional set of
+     *     language IDs for languages to remove the provider for. Defaults
+     *     to all languages.
+     */
+    function _removeHintProvider(provider, targetLanguageId) {
+        var languageId,
+            languages,
+            index,
+            providers,
+            targetLanguageIdArr;
+        
+        if (Array.isArray(targetLanguageId)) {
+            targetLanguageIdArr = targetLanguageId;
+        } else if (targetLanguageId) {
+            targetLanguageIdArr = [targetLanguageId];
+        } else {
+            targetLanguageIdArr = Object.keys(hintProviders);
+        }
+        
+        targetLanguageIdArr.forEach(function (languageId) {
+            providers = hintProviders[languageId];
+            
+            for (index = 0; index < providers.length; index++) {
+                if (providers[index].provider === provider) {
+                    providers.splice(index, 1);
+                    break;
+                }
+            }
+        });
+    }
 
     /** 
      *  Return the array of hint providers for the given language id.
@@ -546,6 +581,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SHOW_CODE_HINTS, Commands.SHOW_CODE_HINTS, _startNewSession);
 
     exports._getCodeHintList        = _getCodeHintList;
+    exports._removeHintProvider     = _removeHintProvider;
     
     // Define public API
     exports.isOpen                  = isOpen;

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, waits, waitsForDone, expect, $  */
+/*global define, describe, beforeEach, afterEach, it, runs, waits, waitsForDone, expect, $, beforeFirst, afterLast  */
 
 define(function (require, exports, module) {
     "use strict";
@@ -50,22 +50,21 @@ define(function (require, exports, module) {
          * @param {!string} openFile Project relative file path to open in a main editor.
          * @param {!number} openPos The pos within openFile to place the IP.
          */
-        var _initCodeHintTest = function (openFile, openPos) {
-            
+        function initCodeHintTest(openFile, openPos) {
             SpecRunnerUtils.loadProjectInTestWindow(testPath);
             
             runs(function () {
                 var promise = SpecRunnerUtils.openProjectFiles([openFile]);
                 waitsForDone(promise);
             });
+            
             runs(function () {
                 var editor = EditorManager.getCurrentFullEditor();
                 editor.setCursorPos(openPos.line, openPos.ch);
             });
-        };
-    
-        beforeEach(function () {
-            initCodeHintTest = _initCodeHintTest.bind(this);
+        }
+        
+        beforeFirst(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
     
@@ -79,9 +78,8 @@ define(function (require, exports, module) {
                 KeyBindingManager   = testWindow.brackets.test.KeyBindingManager;
             });
         });
-    
-        afterEach(function () {
-            initCodeHintTest    = null;
+        
+        afterLast(function () {
             testWindow          = null;
             CodeHintManager     = null;
             EditorManager       = null;
@@ -90,6 +88,11 @@ define(function (require, exports, module) {
             SpecRunnerUtils.closeTestWindow();
         });
         
+        afterEach(function () {
+            runs(function () {
+                testWindow.closeAllFiles();
+            });
+        });
         
         function invokeCodeHints() {
             CommandManager.execute(Commands.SHOW_CODE_HINTS);
@@ -100,13 +103,13 @@ define(function (require, exports, module) {
             var codeHintList = CodeHintManager._getCodeHintList();
             expect(codeHintList).toBeFalsy();
         }
+        
         function expectSomeHints() {
             var codeHintList = CodeHintManager._getCodeHintList();
             expect(codeHintList).toBeTruthy();
             expect(codeHintList.isOpen()).toBe(true);
             return codeHintList;
         }
-        
         
         describe("Hint Provider Registration", function () {
             beforeEach(function () {
@@ -144,6 +147,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     invokeCodeHints();
                     expectMockHints();
+                    
+                    CodeHintManager._removeHintProvider(mockProvider, ["clojure"], 0);
                 });
             });
             
@@ -156,6 +161,8 @@ define(function (require, exports, module) {
                     editor.setCursorPos(3, 1);
                     invokeCodeHints();
                     expectMockHints();
+                    
+                    CodeHintManager._removeHintProvider(mockProvider, ["html"], 1);
                 });
             });
             
@@ -174,6 +181,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     invokeCodeHints();
                     expectMockHints();
+                    
+                    CodeHintManager._removeHintProvider(mockProvider, ["all"], 0);
                 });
             });
         });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -85,7 +85,13 @@ define(function (require, exports, module) {
 
         afterEach(function () {
             promise = null;
-            testWindow.closeAllDocuments();
+            
+            runs(function () {
+                // Call closeAll() directly. Some tests set a spy on the save as
+                // dialog preventing SpecRunnerUtils.closeAllFiles() from
+                // working properly.
+                testWindow.brackets.test.DocumentManager.closeAll();
+            });
         });
 
 

--- a/test/spec/FileIndexManager-test.js
+++ b/test/spec/FileIndexManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, waitsFor, waitsForDone, expect, spyOn, jasmine */
+/*global define, describe, brackets, beforeEach, afterEach, it, runs, waitsFor, waitsForDone, expect, spyOn, jasmine, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -194,272 +194,272 @@ define(function (require, exports, module) {
         
             this.category = "integration";
     
-            var testPath = SpecRunnerUtils.getTestPath("/spec/FileIndexManager-test-files");
-            var FileIndexManager,
-                ProjectManager,
-                brackets;
-    
-            beforeEach(function () {
+            var testPath = SpecRunnerUtils.getTestPath("/spec/FileIndexManager-test-files"),
+                FileIndexManager,
+                ProjectManager;
             
-                runs(function () {
-                    SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
-                        brackets = testWindow.brackets;
-    
-                        // Load module instances from brackets.test
-                        FileIndexManager  = testWindow.brackets.test.FileIndexManager;
-                        ProjectManager = testWindow.brackets.test.ProjectManager;
-                    });
+            function createTestWindow(spec) {
+                SpecRunnerUtils.createTestWindowAndRun(spec, function (testWindow) {
+                    // Load module instances from brackets.test
+                    FileIndexManager  = testWindow.brackets.test.FileIndexManager;
+                    ProjectManager = testWindow.brackets.test.ProjectManager;
                 });
-            });
-    
-            afterEach(function () {
-                brackets          = null;
+            }
+            
+            function closeTestWindow() {
                 FileIndexManager  = null;
                 ProjectManager    = null;
                 SpecRunnerUtils.closeTestWindow();
-            });
+            }
             
-            it("should index files in directory", function () {
-                // Open a directory
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-    
-                var allFiles, cssFiles;
-                runs(function () {
-                    FileIndexManager.getFileInfoList("all")
-                        .done(function (result) {
-                            allFiles = result;
-                        });
-                });
-                waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-                
-                runs(function () {
-                    FileIndexManager.getFileInfoList("css")
-                        .done(function (result) {
-                            cssFiles = result;
-                        });
-                });
-                waitsFor(function () { return cssFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-    
-                runs(function () {
-                    expect(allFiles.length).toEqual(8);
-                    expect(cssFiles.length).toEqual(3);
+            describe("multiple requests", function () {
+                beforeEach(function () {
+                    createTestWindow(this);
+
+                    // Load spec/FileIndexManager-test-files
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 });
                 
-            });
-    
-            it("should handle identical simultaneous requests without doing extra work", function () {  // #330
-                var projectRoot,
-                    allFiles1,
-                    allFiles2;
+                afterEach(closeTestWindow);
                 
-                // Open a directory
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-    
-                runs(function () {
-                    projectRoot = ProjectManager.getProjectRoot();
-                    spyOn(projectRoot, "createReader").andCallThrough();
+                it("should handle identical simultaneous requests without doing extra work", function () {  // #330
+                    var projectRoot,
+                        allFiles1,
+                        allFiles2;
+        
+                    runs(function () {
+                        projectRoot = ProjectManager.getProjectRoot();
+                        spyOn(projectRoot, "createReader").andCallThrough();
+                        
+                        // Kick off two index requests in parallel
+                        var promise1 = FileIndexManager.getFileInfoList("all")
+                            .done(function (result) {
+                                allFiles1 = result;
+                            });
+                        var promise2 = FileIndexManager.getFileInfoList("all") // same request again
+                            .done(function (result) {
+                                allFiles2 = result;
+                            });
+                        
+                        waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
+                        waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
+                    });
                     
-                    // Kick off two index requests in parallel
-                    var promise1 = FileIndexManager.getFileInfoList("all")
-                        .done(function (result) {
-                            allFiles1 = result;
-                        });
-                    var promise2 = FileIndexManager.getFileInfoList("all") // same request again
-                        .done(function (result) {
-                            allFiles2 = result;
-                        });
-                    
-                    waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
-                    waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
+                    runs(function () {
+                        // Correct response to both promises
+                        expect(allFiles1.length).toEqual(8);
+                        expect(allFiles2.length).toEqual(8);
+                        
+                        // Didn't scan project tree twice
+                        expect(projectRoot.createReader.callCount).toBe(1);
+                    });
                 });
                 
-                runs(function () {
-                    // Correct response to both promises
-                    expect(allFiles1.length).toEqual(8);
-                    expect(allFiles2.length).toEqual(8);
+                it("should handle differing simultaneous requests without doing extra work", function () {  // #330
+                    var projectRoot,
+                        allFiles1,
+                        allFiles2;
+        
+                    runs(function () {
+                        projectRoot = ProjectManager.getProjectRoot();
+                        spyOn(projectRoot, "createReader").andCallThrough();
+                        
+                        // Kick off two index requests in parallel
+                        var promise1 = FileIndexManager.getFileInfoList("all")
+                            .done(function (result) {
+                                allFiles1 = result;
+                            });
+                        var promise2 = FileIndexManager.getFileInfoList("css") // different request in parallel
+                            .done(function (result) {
+                                allFiles2 = result;
+                            });
+                        
+                        waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
+                        waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
+                    });
                     
-                    // Didn't scan project tree twice
-                    expect(projectRoot.createReader.callCount).toBe(1);
-                });
-            });
-            
-            it("should handle differing simultaneous requests without doing extra work", function () {  // #330
-                var projectRoot,
-                    allFiles1,
-                    allFiles2;
-                
-                // Open a directory
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-    
-                runs(function () {
-                    projectRoot = ProjectManager.getProjectRoot();
-                    spyOn(projectRoot, "createReader").andCallThrough();
-                    
-                    // Kick off two index requests in parallel
-                    var promise1 = FileIndexManager.getFileInfoList("all")
-                        .done(function (result) {
-                            allFiles1 = result;
-                        });
-                    var promise2 = FileIndexManager.getFileInfoList("css") // different request in parallel
-                        .done(function (result) {
-                            allFiles2 = result;
-                        });
-                    
-                    waitsForDone(promise1, "First FileIndexManager.getFileInfoList()");
-                    waitsForDone(promise2, "Second FileIndexManager.getFileInfoList()");
-                });
-                
-                runs(function () {
-                    // Correct response to both promises
-                    expect(allFiles1.length).toEqual(8);
-                    expect(allFiles2.length).toEqual(3);
-                    
-                    // Didn't scan project tree twice
-                    expect(projectRoot.createReader.callCount).toBe(1);
+                    runs(function () {
+                        // Correct response to both promises
+                        expect(allFiles1.length).toEqual(8);
+                        expect(allFiles2.length).toEqual(3);
+                        
+                        // Didn't scan project tree twice
+                        expect(projectRoot.createReader.callCount).toBe(1);
+                    });
                 });
             });
             
-            it("should match a specific filename and return the correct FileInfo", function () {
-                // Open a directory
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-                
-                var fileList;
-                
-                runs(function () {
-                    FileIndexManager.getFilenameMatches("all", "file_four.css")
-                        .done(function (results) {
-                            fileList = results;
-                        });
+            describe("ProjectManager integration", function () {
+    
+                beforeFirst(function () {
+                    createTestWindow(this);
                 });
-                
-                waitsFor(function () { return fileList; }, 1000);
-                
-                runs(function () {
-                    expect(fileList.length).toEqual(1);
-                    expect(fileList[0].name).toEqual("file_four.css");
-                    expect(fileList[0].fullPath).toEqual(testPath + "/file_four.css");
-                });
-            });
             
-            it("should update the indicies on project change", function () {
-                // Load spec/FileIndexManager-test-files
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-    
-                var allFiles;
-                runs(function () {
-                    FileIndexManager.getFileInfoList("all")
-                        .done(function (result) {
-                            allFiles = result;
-                        });
-                });
-    
-                waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                afterLast(closeTestWindow);
                 
-                runs(function () {
-                    expect(allFiles.length).toEqual(8);
+                beforeEach(function () {
+                    // Load spec/FileIndexManager-test-files
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 });
                 
-                // load a subfolder in the test project
-                // spec/FileIndexManager-test-files/dir1/dir2
-                SpecRunnerUtils.loadProjectInTestWindow(testPath + "/dir1/dir2/");
-    
-                var dir2Files;
-                runs(function () {
-                    FileIndexManager.getFileInfoList("all")
-                        .done(function (result) {
-                            dir2Files = result;
-                        });
-                });
-    
-                waitsFor(function () { return dir2Files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
-                
-                runs(function () {
-                    expect(dir2Files.length).toEqual(2);
-                    expect(dir2Files[0].name).toEqual("file_eight.css");
-                    expect(dir2Files[1].name).toEqual("file_seven.js");
-                });
-            });
-            
-            it("should update the indicies after being marked dirty", function () {
-                // Load spec/FileIndexManager-test-files
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-    
-                var allFiles; // set by checkAllFileCount
-                
-                // helper function to validate base state of 8 files
-                function checkAllFileCount(fileCount) {
-                    var files;
+                it("should index files in directory", function () {
+                    var allFiles, cssFiles;
                     runs(function () {
                         FileIndexManager.getFileInfoList("all")
                             .done(function (result) {
-                                files = result;
+                                allFiles = result;
+                            });
+                    });
+                    waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                    
+                    runs(function () {
+                        FileIndexManager.getFileInfoList("css")
+                            .done(function (result) {
+                                cssFiles = result;
+                            });
+                    });
+                    waitsFor(function () { return cssFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+        
+                    runs(function () {
+                        expect(allFiles.length).toEqual(8);
+                        expect(cssFiles.length).toEqual(3);
+                    });
+                    
+                });
+                
+                it("should match a specific filename and return the correct FileInfo", function () {
+                    var fileList;
+                    
+                    runs(function () {
+                        FileIndexManager.getFilenameMatches("all", "file_four.css")
+                            .done(function (results) {
+                                fileList = results;
+                            });
+                    });
+                    
+                    waitsFor(function () { return fileList; }, 1000);
+                    
+                    runs(function () {
+                        expect(fileList.length).toEqual(1);
+                        expect(fileList[0].name).toEqual("file_four.css");
+                        expect(fileList[0].fullPath).toEqual(testPath + "/file_four.css");
+                    });
+                });
+                
+                it("should update the indicies on project change", function () {
+                    var allFiles;
+                    runs(function () {
+                        FileIndexManager.getFileInfoList("all")
+                            .done(function (result) {
+                                allFiles = result;
                             });
                     });
         
-                    waitsFor(function () { return files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                    waitsFor(function () { return allFiles; }, "FileIndexManager.getFileInfoList() timeout", 1000);
                     
                     runs(function () {
-                        allFiles = files;
-                        expect(files.length).toEqual(fileCount);
+                        expect(allFiles.length).toEqual(8);
                     });
-                }
-                
-                // verify 8 files in base state
-                checkAllFileCount(8);
-                
-                // add a temporary file to the folder
-                var entry;
-                
-                // create a 9th file
-                runs(function () {
-                    var root = ProjectManager.getProjectRoot();
-                    root.getFile("new-file.txt",
-                                 { create: true, exclusive: true },
-                                 function (fileEntry) { entry = fileEntry; });
-                });
-                
-                waitsFor(function () { return entry; }, "getFile() timeout", 1000);
-                
-                runs(function () {
-                    // mark FileIndexManager dirty after new file was created
-                    FileIndexManager.markDirty();
-                });
-                
-                // verify 9 files
-                checkAllFileCount(9);
-                
-                var cleanupComplete = false;
-                
-                // verify the new file was added to the "all" index
-                runs(function () {
-                    var filtered = allFiles.filter(function (value) {
-                        return (value.name === "new-file.txt");
-                    });
-                    expect(filtered.length).toEqual(1);
                     
-                    // remove the 9th file
-                    brackets.fs.unlink(entry.fullPath, function (err) {
-                        cleanupComplete = (err === brackets.fs.NO_ERROR);
+                    // load a subfolder in the test project
+                    // spec/FileIndexManager-test-files/dir1/dir2
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath + "/dir1/dir2/");
+        
+                    var dir2Files;
+                    runs(function () {
+                        FileIndexManager.getFileInfoList("all")
+                            .done(function (result) {
+                                dir2Files = result;
+                            });
+                    });
+        
+                    waitsFor(function () { return dir2Files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                    
+                    runs(function () {
+                        expect(dir2Files.length).toEqual(2);
+                        expect(dir2Files[0].name).toEqual("file_eight.css");
+                        expect(dir2Files[1].name).toEqual("file_seven.js");
                     });
                 });
-    
-                // wait for the file to be deleted
-                waitsFor(function () { return cleanupComplete; }, 1000);
                 
-                runs(function () {
-                    // mark FileIndexManager dirty after new file was deleted
-                    FileIndexManager.markDirty();
-                });
-                
-                // verify that we're back to 8 files
-                checkAllFileCount(8);
-                
-                // make sure the 9th file was removed from the index
-                runs(function () {
-                    var filtered = allFiles.filter(function (value) {
-                        return (value.name === "new-file.txt");
+                it("should update the indicies after being marked dirty", function () {
+                    var allFiles; // set by checkAllFileCount
+                    
+                    // helper function to validate base state of 8 files
+                    function checkAllFileCount(fileCount) {
+                        var files;
+                        runs(function () {
+                            FileIndexManager.getFileInfoList("all")
+                                .done(function (result) {
+                                    files = result;
+                                });
+                        });
+            
+                        waitsFor(function () { return files; }, "FileIndexManager.getFileInfoList() timeout", 1000);
+                        
+                        runs(function () {
+                            allFiles = files;
+                            expect(files.length).toEqual(fileCount);
+                        });
+                    }
+                    
+                    // verify 8 files in base state
+                    checkAllFileCount(8);
+                    
+                    // add a temporary file to the folder
+                    var entry;
+                    
+                    // create a 9th file
+                    runs(function () {
+                        var root = ProjectManager.getProjectRoot();
+                        root.getFile("new-file.txt",
+                                     { create: true, exclusive: true },
+                                     function (fileEntry) { entry = fileEntry; });
                     });
-                    expect(filtered.length).toEqual(0);
+                    
+                    waitsFor(function () { return entry; }, "getFile() timeout", 1000);
+                    
+                    runs(function () {
+                        // mark FileIndexManager dirty after new file was created
+                        FileIndexManager.markDirty();
+                    });
+                    
+                    // verify 9 files
+                    checkAllFileCount(9);
+                    
+                    var cleanupComplete = false;
+                    
+                    // verify the new file was added to the "all" index
+                    runs(function () {
+                        var filtered = allFiles.filter(function (value) {
+                            return (value.name === "new-file.txt");
+                        });
+                        expect(filtered.length).toEqual(1);
+                        
+                        // remove the 9th file
+                        brackets.fs.unlink(entry.fullPath, function (err) {
+                            cleanupComplete = (err === brackets.fs.NO_ERROR);
+                        });
+                    });
+        
+                    // wait for the file to be deleted
+                    waitsFor(function () { return cleanupComplete; }, 1000);
+                    
+                    runs(function () {
+                        // mark FileIndexManager dirty after new file was deleted
+                        FileIndexManager.markDirty();
+                    });
+                    
+                    // verify that we're back to 8 files
+                    checkAllFileCount(8);
+                    
+                    // make sure the 9th file was removed from the index
+                    runs(function () {
+                        var filtered = allFiles.filter(function (value) {
+                            return (value.name === "new-file.txt");
+                        });
+                        expect(filtered.length).toEqual(0);
+                    });
                 });
             });
         });

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
     
     var Commands,           // loaded from brackets.test
         EditorManager,      // loaded from brackets.test
+        FileIndexManager,   // loaded from brackets.test
         FileSyncManager,    // loaded from brackets.test
         DocumentManager,    // loaded from brackets.test
         FileViewController, // loaded from brackets.test
@@ -47,15 +48,14 @@ define(function (require, exports, module) {
         var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
             tempPath = SpecRunnerUtils.getTempDirectory(),
             testWindow,
-            initInlineTest;
+            infos = {};
         
         function toRange(startLine, endLine) {
             return {startLine: startLine, endLine: endLine};
         }
         
-        function rewriteProject(spec) {
+        function rewriteProject() {
             var result = new $.Deferred(),
-                infos = {},
                 options = {
                     parseOffsets    : true,
                     infos           : infos,
@@ -63,7 +63,6 @@ define(function (require, exports, module) {
                 };
             
             SpecRunnerUtils.copyPath(testPath, tempPath, options).done(function () {
-                spec.infos = infos;
                 result.resolve();
             }).fail(function () {
                 result.reject();
@@ -73,7 +72,7 @@ define(function (require, exports, module) {
         }
         
         /**
-         * Performs setup for an inline editor test. Parses offsets (saved to Spec.infos) for all files in
+         * Performs setup for an inline editor test. Parses offsets (saved to infos) for all files in
          * the test project (testPath) and saves files back to disk without offset markup.
          * When finished, open an editor for the specified project relative file path
          * then attempts opens an inline editor at the given offset. Installs an after()
@@ -83,25 +82,17 @@ define(function (require, exports, module) {
          * @param {number} openOffset  The offset index location within openFile to open an inline editor.
          * @param {?boolean} expectInline  Use false to verify that an inline editor should not be opened. Omit otherwise.
          */
-        var _initInlineTest = function (openFile, openOffset, expectInline, workingSet) {
+        function initInlineTest(openFile, openOffset, expectInline, workingSet) {
             var allFiles,
                 editor,
                 hostOpened = false,
                 err = false,
-                spec = this,
                 rewriteDone = false,
                 rewriteErr = false;
             
             workingSet = workingSet || [];
             
             expectInline = (expectInline !== undefined) ? expectInline : true;
-            
-            // load project to set CSSUtils scope
-            runs(function () {
-                waitsForDone(rewriteProject(spec), "rewriteProject timeout", 1000);
-            });
-            
-            SpecRunnerUtils.loadProjectInTestWindow(tempPath);
             
             runs(function () {
                 workingSet.push(openFile);
@@ -114,7 +105,7 @@ define(function (require, exports, module) {
                 // open inline editor at specified offset index
                 var inlineEditorResult = SpecRunnerUtils.toggleQuickEditAtOffset(
                     editor,
-                    spec.infos[openFile].offsets[openOffset]
+                    infos[openFile].offsets[openOffset]
                 );
                 
                 if (expectInline) {
@@ -136,8 +127,7 @@ define(function (require, exports, module) {
 
                 editor = null;
             });
-        };
-        
+        }
         
         // Utilities for testing Editor state
         function expectText(editor) {
@@ -148,6 +138,16 @@ define(function (require, exports, module) {
             expect(editor1._codeMirror.getValue()).toBe(editor2._codeMirror.getValue());
         }
 		
+        function isLineHidden(cm, lineNum) {
+            var markers = cm.findMarksAt({line: lineNum, pos: 0}),
+                i;
+            for (i = 0; i < markers.length; i++) {
+                if (markers[i].collapsed) {
+                    return true;
+                }
+            }
+            return false;
+        }
 
         /*
          * Note that the bulk of selector matching tests are in CSSutils-test.js.
@@ -155,18 +155,14 @@ define(function (require, exports, module) {
          */
         describe("htmlToCSSProvider", function () {
             
-            function isLineHidden(cm, lineNum) {
-                var markers = cm.findMarksAt({line: lineNum, pos: 0}),
-                    i;
-                for (i = 0; i < markers.length; i++) {
-                    if (markers[i].collapsed) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            
             beforeFirst(function () {
+                // rewrite the project for each spec
+                runs(function () {
+                    waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
+                });
+                
+                SpecRunnerUtils.createTempDirectory();
+                
                 // Create a new window that will be shared by ALL tests in this spec.
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     testWindow = w;
@@ -174,6 +170,7 @@ define(function (require, exports, module) {
                     // Load module instances from brackets.test
                     Commands            = testWindow.brackets.test.Commands;
                     EditorManager       = testWindow.brackets.test.EditorManager;
+                    FileIndexManager    = testWindow.brackets.test.FileIndexManager;
                     FileSyncManager     = testWindow.brackets.test.FileSyncManager;
                     DocumentManager     = testWindow.brackets.test.DocumentManager;
                     FileViewController  = testWindow.brackets.test.FileViewController;
@@ -188,13 +185,11 @@ define(function (require, exports, module) {
                 DocumentManager     = null;
                 FileViewController  = null;
                 SpecRunnerUtils.closeTestWindow();
+                SpecRunnerUtils.deletePath(SpecRunnerUtils.getTempDirectory());
             });
             
-    
             beforeEach(function () {
-                initInlineTest = _initInlineTest.bind(this);
                 this.addMatchers({
-                        
                     toHaveInlineEditorRange: function (range) {
                         var i = 0,
                             editor = this.actual,
@@ -253,6 +248,8 @@ define(function (require, exports, module) {
                             visibleRangeCheck;
                     }
                 });
+                
+                SpecRunnerUtils.loadProjectInTestWindow(tempPath);
             });
     
             afterEach(function () {
@@ -260,7 +257,6 @@ define(function (require, exports, module) {
                 //waits(1000);
                 
                 // revert files to original content with offset markup
-                initInlineTest = null;
                 testWindow.closeAllFiles();
             });
 
@@ -273,7 +269,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
                     inlineWidget = null;
                 });
@@ -287,7 +283,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
                     inlineWidget = null;
                 });
@@ -301,7 +297,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[1]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
                     inlineWidget = null;
                 });
@@ -315,7 +311,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[1]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
                     inlineWidget = null;
                 });
@@ -329,7 +325,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.html"].offsets[11]);
+                    expect(inlinePos).toEqual(infos["test1.html"].offsets[11]);
 
                     inlineWidget = null;
                 });
@@ -343,7 +339,7 @@ define(function (require, exports, module) {
                     var inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[2]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[2]);
 
                     inlineWidget = null;
                 });
@@ -361,7 +357,7 @@ define(function (require, exports, module) {
                     inlinePos = inlineWidget.editors[0].getCursorPos();
                     
                     // verify cursor position & focus in inline editor
-                    expect(inlinePos).toEqual(this.infos["test1.css"].offsets[0]);
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
                     expect(inlineWidget.hasFocus()).toEqual(true);
                     expect(hostEditor.hasFocus()).toEqual(false);
                     
@@ -474,7 +470,7 @@ define(function (require, exports, module) {
                     inlineEditor._codeMirror.replaceRange(
                         "",
                         inlineEditor.getCursorPos(),
-                        this.infos["test1.css"].offsets[3]
+                        infos["test1.css"].offsets[3]
                     );
                     
                     // verify widget resizes when contents is changed
@@ -495,6 +491,13 @@ define(function (require, exports, module) {
                     newText = "\n/* jasmine was here */",
                     savedText;
                 
+                this.after(function () {
+                    // rewrite the project after saving changes
+                    runs(function () {
+                        waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
+                    });
+                });
+                
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
                     inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
@@ -514,14 +517,8 @@ define(function (require, exports, module) {
                     expect(inlineEditor.hasFocus()).toBeTruthy();
                     
                     // execute file save command
-                    testWindow.executeCommand(Commands.FILE_SAVE).done(function () {
-                        saved = true;
-                    }).fail(function () {
-                        err = true;
-                    });
+                    waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-                
-                waitsFor(function () { return saved && !err; }, "save timeout", 1000);
                 
                 runs(function () {
                     // verify focus is still in inline editor
@@ -551,14 +548,20 @@ define(function (require, exports, module) {
             it("should not save changes in the host editor", function () {
                 initInlineTest("test1.html", 1);
                 
-                var saved = false,
-                    err = false,
+                var err = false,
                     hostEditor,
                     inlineEditor,
                     newInlineText = "/* jasmine was inline */\n",
                     newHostText = "/* jasmine was here */\n",
                     savedInlineText,
                     savedHostText;
+                
+                this.after(function () {
+                    // rewrite the project after saving changes
+                    runs(function () {
+                        waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
+                    });
+                });
                 
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
@@ -582,14 +585,8 @@ define(function (require, exports, module) {
                     expect(inlineEditor.hasFocus()).toBeTruthy();
                     
                     // execute file save command
-                    testWindow.executeCommand(Commands.FILE_SAVE).done(function () {
-                        saved = true;
-                    }).fail(function () {
-                        err = true;
-                    });
+                    waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-                
-                waitsFor(function () { return saved && !err; }, "save timeout", 1000);
                 
                 runs(function () {
                     // read saved inline file contents
@@ -611,7 +608,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     expect(savedInlineText).toEqual(newInlineText);
-                    expect(savedHostText).toEqual(this.infos["test1.html"].text); // i.e, should be unchanged
+                    expect(savedHostText).toEqual(infos["test1.html"].text); // i.e, should be unchanged
                     
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
@@ -630,16 +627,22 @@ define(function (require, exports, module) {
                         savedTempCSSFile = false;
 
                     runs(function () {
-                        SpecRunnerUtils.createTextFile(tempPath + "/tempCSS.css", "#anotherDiv {}")
+                        var promise = SpecRunnerUtils.createTextFile(tempPath + "/tempCSS.css", "#anotherDiv {}")
                             .done(function (entry) {
                                 fileToWrite = entry;
-                                savedTempCSSFile = true;
+                            })
+                            .fail(function (err) {
+                                console.log(err);
                             });
+                        
+                        waitsForDone(promise, "writeText tempCSS.css", 1000);
                     });
-                    waitsFor(function () { return savedTempCSSFile; }, "writeText timeout", 1000);
                     
                     // Open inline editor for that file
                     runs(function () {
+                        // force FileIndexManager to re-sync and pick up the new tempCSS.css file
+                        FileIndexManager.markDirty();
+                        
                         initInlineTest("test1.html", 6, true);
                     });
                     // initInlineTest() inserts a waitsFor() automatically, so must end runs() block here
@@ -669,7 +672,7 @@ define(function (require, exports, module) {
                     // them back to disk at the end (to restore any stripped offset markers). But in this
                     // case we really want the temp file to stay gone.
                     runs(function () {
-                        delete this.infos["tempCSS.css"];
+                        delete infos["tempCSS.css"];
                     });
                 });
                 
@@ -730,7 +733,7 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 0);
                     
                     runs(function () {
-                        var i = DocumentManager.findInWorkingSet(this.infos["test1.css"].fileEntry.fullPath);
+                        var i = DocumentManager.findInWorkingSet(infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(-1);
                     });
                 });
@@ -753,7 +756,7 @@ define(function (require, exports, module) {
                             inlineEditor.getCursorPos()
                         );
                         
-                        var i = DocumentManager.findInWorkingSet(this.infos["test1.css"].fileEntry.fullPath);
+                        var i = DocumentManager.findInWorkingSet(infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(1);
 
                         inlineEditor = null;
@@ -768,7 +771,7 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
                     
                     runs(function () {
-                        var cssPath = this.infos["test1.css"].fileEntry.fullPath;
+                        var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         
                         // edit the inline editor
@@ -824,7 +827,7 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
                     
                     runs(function () {
-                        var cssPath = this.infos["test1.css"].fileEntry.fullPath;
+                        var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
@@ -834,14 +837,14 @@ define(function (require, exports, module) {
                         fullEditor = EditorManager.getCurrentFullEditor();
                         
                         // alias offsets to nice names
-                        before = this.infos["test1.css"].offsets[4];
-                        start = this.infos["test1.css"].offsets[1];
-                        middle = this.infos["test1.css"].offsets[5];
+                        before = infos["test1.css"].offsets[4];
+                        start = infos["test1.css"].offsets[1];
+                        middle = infos["test1.css"].offsets[5];
                         middleOfMiddle = {line: middle.line, ch: 3};
-                        end = this.infos["test1.css"].offsets[6];
-                        endOfEnd = this.infos["test1.css"].offsets[3];
-                        after = this.infos["test1.css"].offsets[7];
-                        wayafter = this.infos["test1.css"].offsets[2];
+                        end = infos["test1.css"].offsets[6];
+                        endOfEnd = infos["test1.css"].offsets[3];
+                        after = infos["test1.css"].offsets[7];
+                        wayafter = infos["test1.css"].offsets[2];
                     });
                 });
 
@@ -1182,7 +1185,7 @@ define(function (require, exports, module) {
                         hostEditor.focus();
                         SpecRunnerUtils.toggleQuickEditAtOffset(
                             hostEditor,
-                            this.infos["test1.html"].offsets[8]
+                            infos["test1.html"].offsets[8]
                         ).done(function (isOpen) {
                             secondInlineOpen = isOpen;
                         });
@@ -1219,7 +1222,7 @@ define(function (require, exports, module) {
                     initInlineTest("test1.html", 5, true, ["testOneRuleFile.css"]);
                     
                     runs(function () {
-                        var cssPath = this.infos["testOneRuleFile.css"].fileEntry.fullPath;
+                        var cssPath = infos["testOneRuleFile.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editors[0];
@@ -1258,13 +1261,6 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
-                });
-            });
-        
-            it("should delete the temp directory", function () {
-                // Delete the temp directory once we've run all of the tests
-                runs(function () {
-                    waitsForDone(SpecRunnerUtils.deletePath(tempPath));
                 });
             });
         });

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine */
+/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -32,11 +32,13 @@ define(function (require, exports, module) {
         Strings                 = require("strings"),
         StringUtils             = require("utils/StringUtils"),
         NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
-        FileUtils               = require("file/FileUtils");
+        FileUtils               = require("file/FileUtils"),
+        DefaultDialogs          = require("widgets/DefaultDialogs");
 
     // The following are all loaded from the test window
     var CommandManager,
         Commands,
+        Dialogs,
         NativeApp,
         LiveDevelopment,
         LiveDevServerManager,
@@ -81,17 +83,14 @@ define(function (require, exports, module) {
         var localText,
             browserText;
         
-        //verify live dev isn't currently active
-        expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
-        
         runs(function () {
-            waitsForDone(SpecRunnerUtils.openProjectFiles([htmlFile]), "SpecRunnerUtils.openProjectFiles");
+            waitsForDone(SpecRunnerUtils.openProjectFiles([htmlFile]), "SpecRunnerUtils.openProjectFiles " + htmlFile, 1000);
         });
 
         openLiveDevelopmentAndWait();
         
         runs(function () {
-            waitsForDone(SpecRunnerUtils.openProjectFiles([cssFile]), "SpecRunnerUtils.openProjectFiles");
+            waitsForDone(SpecRunnerUtils.openProjectFiles([cssFile]), "SpecRunnerUtils.openProjectFiles " + cssFile, 1000);
         });
         
         runs(function () {
@@ -128,93 +127,369 @@ define(function (require, exports, module) {
     function enableAgent(liveDevModule, name) {
         liveDevModule.enableAgent(name);
     }
+        
+    describe("Inspector", function () {
+        
+        this.category = "integration";
+
+        it("should return a ready socket on Inspector.connect and close the socket on Inspector.disconnect", function () {
+            var id  = Math.floor(Math.random() * 100000),
+                url = LiveDevelopmentModule.launcherUrl + "?id=" + id,
+                connected = false,
+                failed = false;
+            
+            runs(function () {
+                waitsForDone(
+                    NativeAppModule.openLiveBrowser(url, true),
+                    "NativeApp.openLiveBrowser",
+                    5000
+                );
+            });
+            
+            runs(function () {
+                var retries = 0;
+                function tryConnect() {
+                    if (retries < 10) {
+                        retries++;
+                        InspectorModule.connectToURL(url)
+                            .done(function () {
+                                connected = true;
+                            })
+                            .fail(function () {
+                                window.setTimeout(tryConnect, 500);
+                            });
+                    } else {
+                        failed = true;
+                    }
+                }
+                tryConnect();
+            });
+            
+            waitsFor(function () { return connected || failed; }, 10000);
+            
+            runs(function () {
+                expect(failed).toBe(false);
+                expect(InspectorModule.connected()).toBeTruthy();
+            });
+            
+            runs(function () {
+                var promise = InspectorModule.Runtime.evaluate("window.open('', '_self').close()");
+                waitsForDone(promise, "Inspector.Runtime.evaluate", 5000);
+            });
+            
+            waitsFor(function () { return !InspectorModule.connected(); }, 10000);
+        });
+    });
+
+    describe("URL Mapping", function () {
+
+        it("should validate base urls", function () {
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost"))
+                .toBe("");
+
+            expect(PreferencesDialogs._validateBaseUrl("https://localhost:8080/sub%20folder"))
+                .toBe("");
+
+            expect(PreferencesDialogs._validateBaseUrl("ftp://localhost"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_PROTOCOL, "ftp:"));
+
+            expect(PreferencesDialogs._validateBaseUrl("localhost"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_PROTOCOL, ""));
+
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost/?id=123"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_SEARCH_DISALLOWED, "?id=123"));
+
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost/#anchor1"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_HASH_DISALLOWED, "#anchor1"));
+
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost/abc<123"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, "<"));
+
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost/?"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, "?"));
+
+            expect(PreferencesDialogs._validateBaseUrl("http://localhost/sub dir"))
+                .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, " "));
+        });
+    });
+    
+    describe("HighlightAgent", function () {
+        
+        describe("Highlighting elements in browser from a CSS rule", function () {
+            
+            var testDocument,
+                testEditor,
+                testCSSDoc,
+                liveDevelopmentConfig,
+                inspectorConfig;
+            
+            beforeEach(function () {
+                // save original configs
+                liveDevelopmentConfig = LiveDevelopmentModule.config;
+                inspectorConfig = InspectorModule.config;
+                
+                // force init
+                LiveDevelopmentModule.config = InspectorModule.config = {highlight: true};
+                HighlightAgentModule.load();
+                
+                // module spies
+                spyOn(CSSAgentModule, "styleForURL").andReturn("");
+                spyOn(CSSAgentModule, "reloadCSSForDocument").andCallFake(function () {});
+                spyOn(HighlightAgentModule, "redraw").andCallFake(function () {});
+                spyOn(HighlightAgentModule, "rule").andCallFake(function () {});
+                InspectorModule.CSS = {
+                    getStyleSheet   : jasmine.createSpy("getStyleSheet")
+                };
+                spyOn(LiveDevelopmentModule, "showHighlight").andCallFake(function () {});
+                spyOn(LiveDevelopmentModule, "hideHighlight").andCallFake(function () {});
+                
+                // document spies
+                var deferred = new $.Deferred();
+                spyOn(CSSDocumentModule.prototype, "getStyleSheetFromBrowser").andCallFake(function () {
+                    return deferred.promise();
+                });
+                
+                var mock = SpecRunnerUtils.createMockEditor("p {}\n\ndiv {}", "css");
+                testDocument = mock.doc;
+                testEditor = mock.editor;
+                testCSSDoc = new CSSDocumentModule(testDocument, testEditor);
+                
+                // resolve reloadRules()
+                deferred.resolve({rules: [
+                    {
+                        selectorText    : "p",
+                        selectorRange   : {start: 0},
+                        style           : {range: {end: 3}}
+                    },
+                    {
+                        selectorText    : "div",
+                        selectorRange   : {start: 6},
+                        style           : {range: {end: 11}}
+                    }
+                ]});
+            });
+            
+            afterEach(function () {
+                LiveDevelopmentModule.config = liveDevelopmentConfig;
+                InspectorModule.config = inspectorConfig;
+                
+                SpecRunnerUtils.destroyMockEditor(testDocument);
+                testDocument = null;
+                testEditor = null;
+                testCSSDoc = null;
+            });
+            
+            it("should toggle the highlight via a command", function () {
+                var cmd = CommandsManagerModule.get(CommandsModule.FILE_LIVE_HIGHLIGHT);
+                cmd.setEnabled(true);
+                
+                // Run our tests in order depending on whether highlighting is on or off
+                // presently. By setting the order like this, we'll also leave highlighting
+                // in the state we found it in.
+                if (cmd.getChecked()) {
+                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
+                    expect(LiveDevelopmentModule.hideHighlight).toHaveBeenCalled();
+                    
+                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
+                    expect(LiveDevelopmentModule.showHighlight).toHaveBeenCalled();
+                } else {
+                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
+                    expect(LiveDevelopmentModule.showHighlight).toHaveBeenCalled();
+                    
+                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
+                    expect(LiveDevelopmentModule.hideHighlight).toHaveBeenCalled();
+                }
+            });
+            
+            it("should redraw highlights when the document changes", function () {
+                testDocument.setText("body {}");
+                expect(HighlightAgentModule.redraw).toHaveBeenCalled();
+            });
+            
+            it("should redraw highlights when the cursor moves", function () {
+                testEditor.setCursorPos(0, 3);
+                expect(HighlightAgentModule.rule).toHaveBeenCalled();
+                expect(HighlightAgentModule.rule.mostRecentCall.args[0]).toEqual("p");
+                
+                testEditor.setCursorPos(2, 0);
+                expect(HighlightAgentModule.rule.calls.length).toEqual(3);
+                expect(HighlightAgentModule.rule.mostRecentCall.args[0]).toEqual("div");
+            });
+        });
+    
+        describe("Highlighting elements in browser from cursor positions in HTML page", function () {
+            
+            var testDocument,
+                testEditor,
+                testHTMLDoc,
+                liveDevelopmentConfig,
+                inspectorConfig,
+                fileContent = null,
+                instrumentedHtml = "",
+                elementIds = {},
+                testPath = SpecRunnerUtils.getTestPath("/spec/HTMLInstrumentation-test-files"),
+                WellFormedFileEntry = new NativeFileSystem.FileEntry(testPath + "/wellformed.html");
+          
+            function init(fileEntry) {
+                if (fileEntry) {
+                    runs(function () {
+                        FileUtils.readAsText(fileEntry)
+                            .done(function (text) {
+                                fileContent = text;
+                            });
+                    });
+                    
+                    waitsFor(function () { return (fileContent !== null); }, 1000);
+                }
+            }
+        
+            function createIdToTagMap(html) {
+                var elementIdRegEx = /<(\w+?)\s+(?:[^<]*?\s)*?data-brackets-id='(\S+?)'/gi,
+                    match,
+                    tagID,
+                    tagName;
+                
+                elementIds = {};
+                do {
+                    match = elementIdRegEx.exec(html);
+                    if (match) {
+                        tagID = match[2];
+                        tagName = match[1];
+                        
+                        // Verify that the newly found ID is unique.
+                        expect(elementIds[tagID]).toBeUndefined();
+                        
+                        elementIds[tagID] = tagName.toLowerCase();
+                    }
+                } while (match);
+            }
+            
+            function verifyTagWithId(line, ch, tag) {
+                testEditor.setCursorPos(line, ch);
+                var id = HighlightAgentModule.domElement.mostRecentCall.args[0];
+                expect(elementIds[id]).toEqual(tag);
+            }
+            
+            beforeEach(function () {
+                if (!fileContent) {
+                    init(WellFormedFileEntry);
+                }
+                
+                runs(function () {
+                    // save original configs
+                    liveDevelopmentConfig = LiveDevelopmentModule.config;
+                    inspectorConfig = InspectorModule.config;
+                    
+                    // force init
+                    LiveDevelopmentModule.config = InspectorModule.config = {highlight: true};
+                    HighlightAgentModule.load();
+                    
+                    // module spies -- used to mock actual API calls so that we can test those
+                    // APIs without having to actually launch the browser.
+                    spyOn(HighlightAgentModule, "hide").andCallFake(function () {});
+                    spyOn(HighlightAgentModule, "domElement").andCallFake(function () {});
+                    
+                    var mock = SpecRunnerUtils.createMockEditor(fileContent, "html");
+                    testDocument = mock.doc;
+                    testEditor = mock.editor;
+                    
+                    instrumentedHtml = HTMLInstrumentationModule.generateInstrumentedHTML(testDocument);
+                    createIdToTagMap(instrumentedHtml);
+                    testHTMLDoc = new HTMLDocumentModule(testDocument, testEditor);
+                    testHTMLDoc.setInstrumentationEnabled(true);
+                });
+            });
+            
+            afterEach(function () {
+                LiveDevelopmentModule.config = liveDevelopmentConfig;
+                InspectorModule.config = inspectorConfig;
+                
+                SpecRunnerUtils.destroyMockEditor(testDocument);
+                testDocument = null;
+                testEditor = null;
+                testHTMLDoc = null;
+                instrumentedHtml = "";
+                elementIds = {};
+            });
+            
+            it("should highlight the image for cursor positions inside img tag.", function () {
+                verifyTagWithId(58, 4, "img");  // before <img
+                verifyTagWithId(58, 95, "img"); // after />
+                verifyTagWithId(58, 65, "img"); // inside src attribute value
+    
+            });
+    
+            it("should highlight the parent link element for cursor positions between 'img' and its parent 'a' tag.", function () {
+                verifyTagWithId(58, 1, "a");  // before "   <img"
+                verifyTagWithId(59, 0, "a");  // before </a>
+            });
+    
+            it("No highlight when the cursor position is outside of the 'html' tag", function () {
+                var count = HighlightAgentModule.hide.callCount;
+                
+                testEditor.setCursorPos(0, 5);  // inside 'doctype' tag
+                expect(HighlightAgentModule.hide).toHaveBeenCalled();
+                expect(HighlightAgentModule.hide.callCount).toBe(count + 1);
+                expect(HighlightAgentModule.domElement).not.toHaveBeenCalled();
+    
+                testEditor.setCursorPos(147, 5);  // after </html>
+                expect(HighlightAgentModule.hide.callCount).toBe(count + 2);
+                expect(HighlightAgentModule.domElement).not.toHaveBeenCalled();
+            });
+    
+            it("Should highlight the entire body for all cursor positions inside an html comment", function () {
+                verifyTagWithId(15, 1, "body");  // cursor between < and ! in the comment start
+                verifyTagWithId(16, 15, "body");
+                verifyTagWithId(17, 3, "body");  // cursor after -->
+            });
+    
+            it("should highlight 'meta/link' tag for cursor positions in meta/link tags, not 'head' tag", function () {
+                verifyTagWithId(5, 60, "meta");
+                verifyTagWithId(8, 12, "link");
+            });
+    
+            it("Should highlight 'title' tag at cursor positions (either in the content or begin/end tag)", function () {
+                verifyTagWithId(6, 11, "title");  // inside the begin tag
+                verifyTagWithId(6, 30, "title");  // in the content
+                verifyTagWithId(6, 50, "title");  // inside the end tag
+            });
+    
+            it("Should get 'h2' tag at cursor positions (either in the content or begin or end tag)", function () {
+                verifyTagWithId(13, 1, "h2");  // inside the begin tag
+                verifyTagWithId(13, 20, "h2"); // in the content
+                verifyTagWithId(13, 27, "h2"); // inside the end tag
+            });
+        });
+    
+    });
 
     describe("Live Development", function () {
         
         this.category = "integration";
-        
-        describe("Inspector", function () {
-
-            it("should return a ready socket on Inspector.connect and close the socket on Inspector.disconnect", function () {
-                var id  = Math.floor(Math.random() * 100000),
-                    url = LiveDevelopmentModule.launcherUrl + "?id=" + id,
-                    connected = false,
-                    failed = false;
-                
-                runs(function () {
-                    waitsForDone(
-                        NativeAppModule.openLiveBrowser(url, true),
-                        "NativeApp.openLiveBrowser",
-                        5000
-                    );
-                });
-                   
-                runs(function () {
-                    var retries = 0;
-                    function tryConnect() {
-                        if (retries < 10) {
-                            retries++;
-                            InspectorModule.connectToURL(url)
-                                .done(function () {
-                                    connected = true;
-                                })
-                                .fail(function () {
-                                    window.setTimeout(tryConnect, 500);
-                                });
-                        } else {
-                            failed = true;
-                        }
-                    }
-                    tryConnect();
-                });
-                
-                waitsFor(function () { return connected || failed; }, 10000);
-                
-                runs(function () {
-                    expect(failed).toBe(false);
-                    expect(InspectorModule.connected()).toBeTruthy();
-                });
-                
-                runs(function () {
-                    var promise = InspectorModule.Runtime.evaluate("window.open('', '_self').close()");
-                    waitsForDone(promise, "Inspector.Runtime.evaluate", 5000);
-                });
-                
-                waitsFor(function () { return !InspectorModule.connected(); }, 10000);
-            });
-        });
 
         describe("CSS Editing", function () {
 
-            beforeEach(function () {
-                runs(function () {
-                    SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                        testWindow           = w;
-                        LiveDevelopment      = testWindow.brackets.test.LiveDevelopment;
-                        LiveDevServerManager = testWindow.brackets.test.LiveDevServerManager;
-                        DOMAgent             = testWindow.brackets.test.DOMAgent;
-                        DocumentManager      = testWindow.brackets.test.DocumentManager;
-                        CommandManager       = testWindow.brackets.test.CommandManager;
-                        Commands             = testWindow.brackets.test.Commands;
-                        NativeApp            = testWindow.brackets.test.NativeApp;
-                        ProjectManager       = testWindow.brackets.test.ProjectManager;
-                    });
-
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            beforeFirst(function () {
+                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                    testWindow           = w;
+                    Dialogs              = testWindow.brackets.test.Dialogs;
+                    LiveDevelopment      = testWindow.brackets.test.LiveDevelopment;
+                    LiveDevServerManager = testWindow.brackets.test.LiveDevServerManager;
+                    DOMAgent             = testWindow.brackets.test.DOMAgent;
+                    DocumentManager      = testWindow.brackets.test.DocumentManager;
+                    CommandManager       = testWindow.brackets.test.CommandManager;
+                    Commands             = testWindow.brackets.test.Commands;
+                    NativeApp            = testWindow.brackets.test.NativeApp;
+                    ProjectManager       = testWindow.brackets.test.ProjectManager;
                 });
+
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
             });
 
-            afterEach(function () {
-                runs(function () {
-                    LiveDevelopment.close();
-                });
-
-                waitsFor(function () {
-                    return (LiveDevelopment.status === LiveDevelopment.STATUS_INACTIVE);
-                }, "Waiting for browser to become inactive", 10000);
-
+            afterLast(function () {
                 runs(function () {
                     testWindow           = null;
+                    Dialogs              = null;
                     LiveDevelopment      = null;
                     LiveDevServerManager = null;
                     DOMAgent             = null;
@@ -227,12 +502,25 @@ define(function (require, exports, module) {
                 });
             });
             
+            beforeEach(function () {
+                // verify live dev isn't currently active
+                runs(function () {
+                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
+                });
+            });
+            
+            afterEach(function () {
+                waitsForDone(LiveDevelopment.close(), "Waiting for browser to become inactive", 10000);
+                
+                runs(function () {
+                    testWindow.closeAllFiles();
+                });
+            });
+            
             it("should establish a browser connection for an opened html file", function () {
                 //open a file
                 runs(function () {
-                    //verify live dev isn't currently active
-                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
-                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles");
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles simple1.html", 1000);
                 });
 
                 openLiveDevelopmentAndWait();
@@ -246,12 +534,9 @@ define(function (require, exports, module) {
             });
             
             it("should should not start a browser connection for an opened css file", function () {
-                //verify live dev isn't currently active
-                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
-                
                 //open a file
                 runs(function () {
-                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]), "SpecRunnerUtils.openProjectFiles");
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]), "SpecRunnerUtils.openProjectFiles simple1.css", 1000);
                 });
                 
                 //start live dev
@@ -260,6 +545,9 @@ define(function (require, exports, module) {
                 });
  
                 runs(function () {
+                    // close the error dialog
+                    Dialogs.cancelModalDialogIfOpen(DefaultDialogs.DIALOG_ID_ERROR);
+                    
                     expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
 
                     var doc = DocumentManager.getOpenDocumentForPath(testPath + "/simple1.css");
@@ -279,18 +567,9 @@ define(function (require, exports, module) {
                 var localText,
                     browserText;
                 
-                //verify live dev isn't currently active
-                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
-                
-                var cssOpened = false;
                 runs(function () {
-                    SpecRunnerUtils.openProjectFiles(["simple1.css"]).fail(function () {
-                        expect("Failed To Open").toBe("simple1.css");
-                    }).always(function () {
-                        cssOpened = true;
-                    });
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]), "SpecRunnerUtils.openProjectFiles simple1.css", 1000);
                 });
-                waitsFor(function () { return cssOpened; }, "cssOpened FILE_OPEN timeout", 1000);
                 
                 runs(function () {
                     var curDoc =  DocumentManager.getCurrentDocument();
@@ -300,7 +579,7 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css", "simple1.html"]), "SpecRunnerUtils.openProjectFiles");
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles simple1.html", 1000);
                 });
                 
                 openLiveDevelopmentAndWait();
@@ -329,20 +608,11 @@ define(function (require, exports, module) {
                     browserHtmlText,
                     htmlDoc;
                 
-                //verify live dev isn't currently active
-                expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_INACTIVE);
-                
-                var cssOpened = false;
                 runs(function () {
                     enableAgent(LiveDevelopment, "dom");
 
-                    SpecRunnerUtils.openProjectFiles(["simple1.css"]).fail(function () {
-                        expect("Failed To Open").toBe("simple1.css");
-                    }).always(function () {
-                        cssOpened = true;
-                    });
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]), "SpecRunnerUtils.openProjectFiles simple1.css", 1000);
                 });
-                waitsFor(function () { return cssOpened; }, "cssOpened FILE_OPEN timeout", 1000);
                 
                 runs(function () {
                     var curDoc =  DocumentManager.getCurrentDocument();
@@ -352,7 +622,7 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles");
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles simple1.html", 1000);
                 });
                 
                 // Modify some text in test file before starting live dev
@@ -482,283 +752,6 @@ define(function (require, exports, module) {
                 });
             });
         });
-
-        describe("URL Mapping", function () {
-
-            it("should validate base urls", function () {
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost"))
-                    .toBe("");
-
-                expect(PreferencesDialogs._validateBaseUrl("https://localhost:8080/sub%20folder"))
-                    .toBe("");
-
-                expect(PreferencesDialogs._validateBaseUrl("ftp://localhost"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_PROTOCOL, "ftp:"));
-
-                expect(PreferencesDialogs._validateBaseUrl("localhost"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_PROTOCOL, ""));
-
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost/?id=123"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_SEARCH_DISALLOWED, "?id=123"));
-
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost/#anchor1"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_HASH_DISALLOWED, "#anchor1"));
-
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost/abc<123"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, "<"));
-
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost/?"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, "?"));
-
-                expect(PreferencesDialogs._validateBaseUrl("http://localhost/sub dir"))
-                    .toBe(StringUtils.format(Strings.BASEURL_ERROR_INVALID_CHAR, " "));
-            });
-        });
         
-        describe("Highlighting elements in browser from a CSS rule", function () {
-            
-            var testDocument,
-                testEditor,
-                testCSSDoc,
-                liveDevelopmentConfig,
-                inspectorConfig;
-            
-            beforeEach(function () {
-                // save original configs
-                liveDevelopmentConfig = LiveDevelopmentModule.config;
-                inspectorConfig = InspectorModule.config;
-                
-                // force init
-                LiveDevelopmentModule.config = InspectorModule.config = {highlight: true};
-                HighlightAgentModule.load();
-                
-                // module spies
-                spyOn(CSSAgentModule, "styleForURL").andReturn("");
-                spyOn(CSSAgentModule, "reloadCSSForDocument").andCallFake(function () {});
-                spyOn(HighlightAgentModule, "redraw").andCallFake(function () {});
-                spyOn(HighlightAgentModule, "rule").andCallFake(function () {});
-                InspectorModule.CSS = {
-                    getStyleSheet   : jasmine.createSpy("getStyleSheet")
-                };
-                spyOn(LiveDevelopmentModule, "showHighlight").andCallFake(function () {});
-                spyOn(LiveDevelopmentModule, "hideHighlight").andCallFake(function () {});
-                
-                // document spies
-                var deferred = new $.Deferred();
-                spyOn(CSSDocumentModule.prototype, "getStyleSheetFromBrowser").andCallFake(function () {
-                    return deferred.promise();
-                });
-                
-                var mock = SpecRunnerUtils.createMockEditor("p {}\n\ndiv {}", "css");
-                testDocument = mock.doc;
-                testEditor = mock.editor;
-                testCSSDoc = new CSSDocumentModule(testDocument, testEditor);
-                
-                // resolve reloadRules()
-                deferred.resolve({rules: [
-                    {
-                        selectorText    : "p",
-                        selectorRange   : {start: 0},
-                        style           : {range: {end: 3}}
-                    },
-                    {
-                        selectorText    : "div",
-                        selectorRange   : {start: 6},
-                        style           : {range: {end: 11}}
-                    }
-                ]});
-            });
-            
-            afterEach(function () {
-                LiveDevelopmentModule.config = liveDevelopmentConfig;
-                InspectorModule.config = inspectorConfig;
-                
-                SpecRunnerUtils.destroyMockEditor(testDocument);
-                testDocument = null;
-                testEditor = null;
-                testCSSDoc = null;
-            });
-            
-            it("should toggle the highlight via a command", function () {
-                var cmd = CommandsManagerModule.get(CommandsModule.FILE_LIVE_HIGHLIGHT);
-                cmd.setEnabled(true);
-                
-                // Run our tests in order depending on whether highlighting is on or off
-                // presently. By setting the order like this, we'll also leave highlighting
-                // in the state we found it in.
-                if (cmd.getChecked()) {
-                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
-                    expect(LiveDevelopmentModule.hideHighlight).toHaveBeenCalled();
-                    
-                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
-                    expect(LiveDevelopmentModule.showHighlight).toHaveBeenCalled();
-                } else {
-                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
-                    expect(LiveDevelopmentModule.showHighlight).toHaveBeenCalled();
-                    
-                    CommandsManagerModule.execute(CommandsModule.FILE_LIVE_HIGHLIGHT);
-                    expect(LiveDevelopmentModule.hideHighlight).toHaveBeenCalled();
-                }
-            });
-            
-            it("should redraw highlights when the document changes", function () {
-                testDocument.setText("body {}");
-                expect(HighlightAgentModule.redraw).toHaveBeenCalled();
-            });
-            
-            it("should redraw highlights when the cursor moves", function () {
-                testEditor.setCursorPos(0, 3);
-                expect(HighlightAgentModule.rule).toHaveBeenCalled();
-                expect(HighlightAgentModule.rule.mostRecentCall.args[0]).toEqual("p");
-                
-                testEditor.setCursorPos(2, 0);
-                expect(HighlightAgentModule.rule.calls.length).toEqual(3);
-                expect(HighlightAgentModule.rule.mostRecentCall.args[0]).toEqual("div");
-            });
-        });
-
-        describe("Highlighting elements in browser from cursor positions in HTML page", function () {
-            
-            var testDocument,
-                testEditor,
-                testHTMLDoc,
-                liveDevelopmentConfig,
-                inspectorConfig,
-                fileContent = null,
-                instrumentedHtml = "",
-                elementIds = {},
-                testPath = SpecRunnerUtils.getTestPath("/spec/HTMLInstrumentation-test-files"),
-                WellFormedFileEntry = new NativeFileSystem.FileEntry(testPath + "/wellformed.html");
-          
-            function init(fileEntry) {
-                if (fileEntry) {
-                    runs(function () {
-                        FileUtils.readAsText(fileEntry)
-                            .done(function (text) {
-                                fileContent = text;
-                            });
-                    });
-                    
-                    waitsFor(function () { return (fileContent !== null); }, 1000);
-                }
-            }
-        
-            function createIdToTagMap(html) {
-                var elementIdRegEx = /<(\w+?)\s+(?:[^<]*?\s)*?data-brackets-id='(\S+?)'/gi,
-                    match,
-                    tagID,
-                    tagName;
-                
-                elementIds = {};
-                do {
-                    match = elementIdRegEx.exec(html);
-                    if (match) {
-                        tagID = match[2];
-                        tagName = match[1];
-                        
-                        // Verify that the newly found ID is unique.
-                        expect(elementIds[tagID]).toBeUndefined();
-                        
-                        elementIds[tagID] = tagName.toLowerCase();
-                    }
-                } while (match);
-            }
-            
-            function verifyTagWithId(line, ch, tag) {
-                testEditor.setCursorPos(line, ch);
-                var id = HighlightAgentModule.domElement.mostRecentCall.args[0];
-                expect(elementIds[id]).toEqual(tag);
-            }
-            
-            beforeEach(function () {
-                if (!fileContent) {
-                    init(WellFormedFileEntry);
-                }
-                
-                runs(function () {
-                    // save original configs
-                    liveDevelopmentConfig = LiveDevelopmentModule.config;
-                    inspectorConfig = InspectorModule.config;
-                    
-                    // force init
-                    LiveDevelopmentModule.config = InspectorModule.config = {highlight: true};
-                    HighlightAgentModule.load();
-                    
-                    // module spies -- used to mock actual API calls so that we can test those
-                    // APIs without having to actually launch the browser.
-                    spyOn(HighlightAgentModule, "hide").andCallFake(function () {});
-                    spyOn(HighlightAgentModule, "domElement").andCallFake(function () {});
-                    
-                    var mock = SpecRunnerUtils.createMockEditor(fileContent, "html");
-                    testDocument = mock.doc;
-                    testEditor = mock.editor;
-                    
-                    instrumentedHtml = HTMLInstrumentationModule.generateInstrumentedHTML(testDocument);
-                    createIdToTagMap(instrumentedHtml);
-                    testHTMLDoc = new HTMLDocumentModule(testDocument, testEditor);
-                    testHTMLDoc.setInstrumentationEnabled(true);
-                });
-            });
-            
-            afterEach(function () {
-                LiveDevelopmentModule.config = liveDevelopmentConfig;
-                InspectorModule.config = inspectorConfig;
-                
-                SpecRunnerUtils.destroyMockEditor(testDocument);
-                testDocument = null;
-                testEditor = null;
-                testHTMLDoc = null;
-                instrumentedHtml = "";
-                elementIds = {};
-            });
-            
-            it("should highlight the image for cursor positions inside img tag.", function () {
-                verifyTagWithId(58, 4, "img");  // before <img
-                verifyTagWithId(58, 95, "img"); // after />
-                verifyTagWithId(58, 65, "img"); // inside src attribute value
-
-            });
-
-            it("should highlight the parent link element for cursor positions between 'img' and its parent 'a' tag.", function () {
-                verifyTagWithId(58, 1, "a");  // before "   <img"
-                verifyTagWithId(59, 0, "a");  // before </a>
-            });
-
-            it("No highlight when the cursor position is outside of the 'html' tag", function () {
-                var count = HighlightAgentModule.hide.callCount;
-                
-                testEditor.setCursorPos(0, 5);  // inside 'doctype' tag
-                expect(HighlightAgentModule.hide).toHaveBeenCalled();
-                expect(HighlightAgentModule.hide.callCount).toBe(count + 1);
-                expect(HighlightAgentModule.domElement).not.toHaveBeenCalled();
-
-                testEditor.setCursorPos(147, 5);  // after </html>
-                expect(HighlightAgentModule.hide.callCount).toBe(count + 2);
-                expect(HighlightAgentModule.domElement).not.toHaveBeenCalled();
-            });
-
-            it("Should highlight the entire body for all cursor positions inside an html comment", function () {
-                verifyTagWithId(15, 1, "body");  // cursor between < and ! in the comment start
-                verifyTagWithId(16, 15, "body");
-                verifyTagWithId(17, 3, "body");  // cursor after -->
-            });
-
-            it("should highlight 'meta/link' tag for cursor positions in meta/link tags, not 'head' tag", function () {
-                verifyTagWithId(5, 60, "meta");
-                verifyTagWithId(8, 12, "link");
-            });
-
-            it("Should highlight 'title' tag at cursor positions (either in the content or begin/end tag)", function () {
-                verifyTagWithId(6, 11, "title");  // inside the begin tag
-                verifyTagWithId(6, 30, "title");  // in the content
-                verifyTagWithId(6, 50, "title");  // inside the end tag
-            });
-
-            it("Should get 'h2' tag at cursor positions (either in the content or begin or end tag)", function () {
-                verifyTagWithId(13, 1, "h2");  // inside the begin tag
-                verifyTagWithId(13, 20, "h2"); // in the content
-                verifyTagWithId(13, 27, "h2"); // inside the end tag
-            });
-        });
     });
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -358,10 +358,6 @@ define(function (require, exports, module) {
             _testWindow.executeCommand = function executeCommand(cmd, args) {
                 return _testWindow.brackets.test.CommandManager.execute(cmd, args);
             };
-
-            _testWindow.closeAllDocuments = function closeAllDocuments() {
-                _testWindow.brackets.test.DocumentManager.closeAll();
-            };
             
             _testWindow.closeAllFiles = function closeAllFiles() {
                 runs(function () {
@@ -572,15 +568,15 @@ define(function (require, exports, module) {
             FileViewController.addToWorkingSetAndSelect(path).done(function (doc) {
                 docs[keys[i]] = doc;
                 one.resolve();
-            }).fail(function () {
-                one.reject();
+            }).fail(function (err) {
+                one.reject(err);
             });
             
             return one.promise();
         }, false).done(function () {
             result.resolve(docs);
-        }).fail(function () {
-            result.reject();
+        }).fail(function (err) {
+            result.reject(err);
         }).always(function () {
             docs = null;
             FileViewController = null;
@@ -607,8 +603,8 @@ define(function (require, exports, module) {
                 }).fail(function () {
                     deferred.reject();
                 });
-            }, function error() {
-                deferred.reject();
+            }, function error(err) {
+                deferred.reject(err);
             });
         });
 


### PR DESCRIPTION
- Updates CodeHint, FileIndexManager and LiveDevelopment integration suites to reuse the same test window.
- Adds private `CodeHintManager._removeHintProvider` method to restore `CodeHintManager` state for unit tests
