### PR TITLE
[ResearchLiveHTML] Handle self-closing and unclosed tags when parsing.

### DIFF
--- a/test/spec/HTMLInstrumentation-test-files/omitEndTags.html
+++ b/test/spec/HTMLInstrumentation-test-files/omitEndTags.html
@@ -49,3 +49,7 @@
    //]]>
  </script>
  <FOOTER>SOME FOOTNOTE</FOOTER>
+ <p>unclosed p
+ <h1>heading</h1>
+ this text should be directly inside body because the p was closed by the h1
+      

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -41,10 +41,22 @@ define(function (require, exports, module) {
                 end: 5
             });
             expect(t.nextToken()).toEqual({
+                type: "opentagend",
+                contents: "",
+                start: -1,
+                end: 6
+            });
+            expect(t.nextToken()).toEqual({
                 type: "opentagname",
                 contents: "body",
                 start: 7,
                 end: 11
+            });
+            expect(t.nextToken()).toEqual({
+                type: "opentagend",
+                contents: "",
+                start: -1,
+                end: 12
             });
             expect(t.nextToken()).toEqual({
                 type: "text",
@@ -99,12 +111,58 @@ define(function (require, exports, module) {
                 end: 37
             });
             expect(t.nextToken()).toEqual({
+                type: "opentagend",
+                contents: "",
+                start: -1,
+                end: 39
+            });
+            expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "div",
                 start: 41,
                 end: 44
             });
             expect(t.nextToken()).toEqual(null);
+        });
+        
+        it("should notify of explicit shorttags like <br/>", function () {
+            var t = new Tokenizer("<p>hello<br/></p>");
+            expect(t.nextToken()).toEqual({
+                type: "opentagname",
+                contents: "p",
+                start: 1,
+                end: 2
+            });
+            expect(t.nextToken()).toEqual({
+                type: "opentagend",
+                contents: "",
+                start: -1,
+                end: 3
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "hello",
+                start: 3,
+                end: 8
+            });
+            expect(t.nextToken()).toEqual({
+                type: "opentagname",
+                contents: "br",
+                start: 9,
+                end: 11
+            });
+            expect(t.nextToken()).toEqual({
+                type: "selfclosingtag",
+                contents: "",
+                start: -1,
+                end: 13
+            });
+            expect(t.nextToken()).toEqual({
+                type: "closetag",
+                contents: "p",
+                start: 15,
+                end: 16
+            });
         });
     });
 });


### PR DESCRIPTION
- For implied-close tags, we properly close them when a new tag that forces
  closing is encountered.
- For unbalanced tags, we close tags up the stack until we get to a matching
  tag.
- This fixes all the existing HTMLInstrumentation tests, so they're now all
  re-enabled. (A few of them have been tweaked to match some new behavior
  in certain edge cases, and a few were added.)
- Removed the vestigial callbacks in HTMLTokenizer and replaced them with
  "special" tokens that mark the end of open tags and self-closing tags.

@dangoor 
