### PR TITLE
Fix bug #4536, No tooltip for author name in extension manager

### DIFF
--- a/src/extensibility/registry_utils.js
+++ b/src/extensibility/registry_utils.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
             if (result !== "") {
                 result += " / ";
             }
-            result += "<a href='" + htmlEscape(ownerLink) + "'>" + htmlEscape(userId) + "</a>";
+            result += "<a href='" + htmlEscape(ownerLink) + "' title='" + htmlEscape(ownerLink) + "'>" + htmlEscape(userId) + "</a>";
         }
         return result;
     };


### PR DESCRIPTION
I'm new and this is my first pull request. Anything to do better, let me know. 

The fix is simple: to add the tooltip of the author's url in the extension manager.
