### PR TITLE
Use one window for all specs in the suite on more integration tests

### DIFF
--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -22,10 +22,10 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, xdescribe: false, it: false, xit: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false, CodeMirror: false */
+/*global define, describe, xdescribe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, CodeMirror, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
     
     var NativeFileSystem           = require("file/NativeFileSystem").NativeFileSystem,
         Async                      = require("utils/Async"),
@@ -568,7 +568,7 @@ define(function (require, exports, module) {
     }); // describe("CSSUtils")
 
     
-    describe("CSS Parsing: ", function () {
+    describe("CSS Parsing", function () {
         
         var lastCssCode,
             match,
@@ -639,7 +639,7 @@ define(function (require, exports, module) {
         });
 
 
-        describe("Simple selectors: ", function () {
+        describe("Simple selectors", function () {
         
             it("should match a lone type selector given a type", function () {
                 var result = match("div { color:red }", { tag: "div" });
@@ -1366,143 +1366,136 @@ define(function (require, exports, module) {
             
         }); // describe("Known Issues")    
 
-
-        describe("Working with real public CSSUtils API", function () {
-            this.category = "integration";
-            
-            var CSSUtils;
-            
-            beforeEach(function () {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
-                    // Load module instances from brackets.test
-                    CSSUtils = testWindow.brackets.test.CSSUtils;
-                    
-                    // Load test project
-                    var testPath = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files");
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
-                });
-            });
-            afterEach(function () {
-                CSSUtils = null;
-                SpecRunnerUtils.closeTestWindow();
-            });
-            
-            it("should include comment preceding selector (issue #403)", function () {
-                var rules;
-                runs(function () {
-                    CSSUtils.findMatchingRules("#issue403")
-                        .done(function (result) { rules = result; });
-                });
-                waitsFor(function () { return rules !== undefined; }, "CSSUtils.findMatchingRules() timeout", 1000);
-                
-                runs(function () {
-                    expect(rules.length).toBe(1);
-                    expect(rules[0].lineStart).toBe(4);
-                    expect(rules[0].lineEnd).toBe(7);
-                });
-            });
-            
-        });
         
-        
-        describe("Working with unsaved changes", function () {
+        describe("CSS Intgration Tests", function () {
             this.category = "integration";
             
             var testPath = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
+                testWindow,
                 CSSUtils,
                 DocumentManager,
                 FileViewController;
-    
-            beforeEach(function () {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (testWindow) {
+            
+            beforeFirst(function () {
+                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                    testWindow = w;
+                    
                     // Load module instances from brackets.test
                     CSSUtils            = testWindow.brackets.test.CSSUtils;
                     DocumentManager     = testWindow.brackets.test.DocumentManager;
                     FileViewController  = testWindow.brackets.test.FileViewController;
-
+                    
+                    // Load test project
                     SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 });
             });
-
-            afterEach(function () {
+            
+            afterLast(function () {
                 CSSUtils            = null;
                 DocumentManager     = null;
                 FileViewController  = null;
                 SpecRunnerUtils.closeTestWindow();
             });
             
-            it("should return the correct offsets if the file has changed", function () {
-                var didOpen = false,
-                    gotError = false;
+            afterEach(function () {
+                testWindow.closeAllFiles();
+            });
+            
+            
+            describe("Working with real public CSSUtils API", function () {
                 
-                runs(function () {
-                    FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
-                        .done(function () { didOpen = true; })
-                        .fail(function () { gotError = true; });
-                });
-                
-                waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
-                
-                var rules = null;
-                
-                runs(function () {
-                    var doc = DocumentManager.getCurrentDocument();
+                it("should include comment preceding selector (issue #403)", function () {
+                    var rules;
+                    runs(function () {
+                        CSSUtils.findMatchingRules("#issue403")
+                            .done(function (result) { rules = result; });
+                    });
+                    waitsFor(function () { return rules !== undefined; }, "CSSUtils.findMatchingRules() timeout", 1000);
                     
-                    // Add several blank lines at the beginning of the text
-                    doc.setText("\n\n\n\n" + doc.getText());
-                    
-                    // Look for ".FIRSTGRADE"
-                    CSSUtils.findMatchingRules(".FIRSTGRADE")
-                        .done(function (result) { rules = result; });
-                    
-                    doc = null;
-                });
-                
-                waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
-                
-                runs(function () {
-                    expect(rules.length).toBe(1);
-                    expect(rules[0].lineStart).toBe(16);
-                    expect(rules[0].lineEnd).toBe(18);
+                    runs(function () {
+                        expect(rules.length).toBe(1);
+                        expect(rules[0].lineStart).toBe(4);
+                        expect(rules[0].lineEnd).toBe(7);
+                    });
                 });
             });
             
-            it("should return a newly created rule in an unsaved file", function () {
-                var didOpen = false,
-                    gotError = false;
+            describe("Working with unsaved changes", function () {
                 
-                runs(function () {
-                    FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
-                        .done(function () { didOpen = true; })
-                        .fail(function () { gotError = true; });
+                it("should return the correct offsets if the file has changed", function () {
+                    var didOpen = false,
+                        gotError = false;
+                    
+                    runs(function () {
+                        FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
+                            .done(function () { didOpen = true; })
+                            .fail(function () { gotError = true; });
+                    });
+                    
+                    waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
+                    
+                    var rules = null;
+                    
+                    runs(function () {
+                        var doc = DocumentManager.getCurrentDocument();
+                        
+                        // Add several blank lines at the beginning of the text
+                        doc.setText("\n\n\n\n" + doc.getText());
+                        
+                        // Look for ".FIRSTGRADE"
+                        CSSUtils.findMatchingRules(".FIRSTGRADE")
+                            .done(function (result) { rules = result; });
+                        
+                        doc = null;
+                    });
+                    
+                    waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
+                    
+                    runs(function () {
+                        expect(rules.length).toBe(1);
+                        expect(rules[0].lineStart).toBe(16);
+                        expect(rules[0].lineEnd).toBe(18);
+                    });
                 });
                 
-                waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
-                
-                var rules = null;
-                
-                runs(function () {
-                    var doc = DocumentManager.getCurrentDocument();
+                it("should return a newly created rule in an unsaved file", function () {
+                    var didOpen = false,
+                        gotError = false;
                     
-                    // Add a new selector to the file
-                    doc.setText(doc.getText() + "\n\n.TESTSELECTOR {\n    font-size: 12px;\n}\n");
+                    runs(function () {
+                        FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
+                            .done(function () { didOpen = true; })
+                            .fail(function () { gotError = true; });
+                    });
                     
-                    // Look for the selector we just created
-                    CSSUtils.findMatchingRules(".TESTSELECTOR")
-                        .done(function (result) { rules = result; });
-
-                    doc = null;
-                });
-                
-                waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
-                
-                runs(function () {
-                    expect(rules.length).toBe(1);
-                    expect(rules[0].lineStart).toBe(24);
-                    expect(rules[0].lineEnd).toBe(26);
+                    waitsFor(function () { return didOpen && !gotError; }, "FileViewController.addToWorkingSetAndSelect() timeout", 1000);
+                    
+                    var rules = null;
+                    
+                    runs(function () {
+                        var doc = DocumentManager.getCurrentDocument();
+                        
+                        // Add a new selector to the file
+                        doc.setText(doc.getText() + "\n\n.TESTSELECTOR {\n    font-size: 12px;\n}\n");
+                        
+                        // Look for the selector we just created
+                        CSSUtils.findMatchingRules(".TESTSELECTOR")
+                            .done(function (result) { rules = result; });
+    
+                        doc = null;
+                    });
+                    
+                    waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
+                    
+                    runs(function () {
+                        expect(rules.length).toBe(1);
+                        expect(rules[0].lineStart).toBe(24);
+                        expect(rules[0].lineEnd).toBe(26);
+                    });
                 });
             });
         });
+        
     }); //describe("CSS Parsing")
 
     // Unit Tests: "HTMLUtils (css)"

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -21,13 +21,14 @@
  * 
  */
 
+
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, waitsForFail */
+/*global $, define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, waitsForFail, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
-    var ExtensionUtils,
+    var ExtensionUtils,     // Load from brackets.test
         FileUtils           = require("file/FileUtils"),
         SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         LESS_RESULT         = require("text!spec/ExtensionUtils-test-files/less.text");
@@ -38,7 +39,7 @@ define(function (require, exports, module) {
 
         var testWindow;
 
-        beforeEach(function () {
+        beforeFirst(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
 
@@ -47,7 +48,7 @@ define(function (require, exports, module) {
             });
         });
 
-        afterEach(function () {
+        afterLast(function () {
             testWindow      = null;
             ExtensionUtils  = null;
             SpecRunnerUtils.closeTestWindow();

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -21,19 +21,19 @@
  * 
  */
 
+
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, brackets, $ */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, brackets, $, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
 
-    var CommandManager,
-        Commands,
-        KeyBindingManager,
-        Menus,
-        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
-        KeyEvent        = require("utils/KeyEvent");
-
+    var CommandManager,     // Load from brackets.test
+        Commands,           // Load from brackets.test
+        KeyBindingManager,  // Load from brackets.test
+        Menus,              // Load from brackets.test
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
+        KeyEvent            = require("utils/KeyEvent");
 
 
     describe("Menus", function () {
@@ -42,30 +42,28 @@ define(function (require, exports, module) {
 
         var testWindow;
 
-        beforeEach(function () {
+        beforeFirst(function () {
             // Create a new window that will be shared by ALL tests in this spec. (We need the tests to
             // run in a real Brackets window since HTMLCodeHints requires various core modules (it can't
             // run 100% in isolation), but popping a new window per testcase is unneeded overhead).
-            if (!testWindow) {
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
 
-                    // Load module instances from brackets.test
-                    CommandManager    = testWindow.brackets.test.CommandManager;
-                    Commands          = testWindow.brackets.test.Commands;
-                    KeyBindingManager = testWindow.brackets.test.KeyBindingManager;
-                    Menus             = testWindow.brackets.test.Menus;
-                });
-
-                this.after(function () {
-                    testWindow        = null;
-                    CommandManager    = null;
-                    Commands          = null;
-                    KeyBindingManager = null;
-                    Menus             = null;
-                    SpecRunnerUtils.closeTestWindow();
-                });
-            }
+                // Load module instances from brackets.test
+                CommandManager    = testWindow.brackets.test.CommandManager;
+                Commands          = testWindow.brackets.test.Commands;
+                KeyBindingManager = testWindow.brackets.test.KeyBindingManager;
+                Menus             = testWindow.brackets.test.Menus;
+            });
+        });
+        
+        afterLast(function () {
+            testWindow        = null;
+            CommandManager    = null;
+            Commands          = null;
+            KeyBindingManager = null;
+            Menus             = null;
+            SpecRunnerUtils.closeTestWindow();
         });
 
 
@@ -140,10 +138,12 @@ define(function (require, exports, module) {
 
             function boundsInsideWindow(object) {
                 var bounds = getBounds(object);
-                return bounds.left >= 0 &&
-                       bounds.right <= $(testWindow).width() &&
-                       bounds.top >= 0 &&
-                       bounds.bottom <= $(testWindow).height();
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= $(testWindow).width() &&
+                    bounds.top >= 0 &&
+                    bounds.bottom <= $(testWindow).height()
+                );
             }
 
             it("context menu is not clipped", function () {
@@ -771,10 +771,12 @@ define(function (require, exports, module) {
 
             function boundsInsideWindow(object) {
                 var bounds = getBounds(object);
-                return bounds.left >= 0 &&
-                       bounds.right <= $(testWindow).width() &&
-                       bounds.top >= 0 &&
-                       bounds.bottom <= $(testWindow).height();
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= $(testWindow).width() &&
+                    bounds.top >= 0 &&
+                    bounds.bottom <= $(testWindow).height()
+                );
             }
                 
             it("context menu is not clipped", function () {

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -23,15 +23,18 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, require, describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone */
+/*global $, define, require, describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
+
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
     
-    // Load dependent modules
     var ProjectManager,     // Load from brackets.test
         CommandManager,     // Load from brackets.test
+        Dialogs             = require("widgets/Dialogs"),
+        DefaultDialogs      = require("widgets/DefaultDialogs"),
         Commands            = require("command/Commands"),
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");
+
 
     describe("ProjectManager", function () {
         
@@ -41,30 +44,31 @@ define(function (require, exports, module) {
             testWindow,
             brackets;
 
-        beforeEach(function () {
+        beforeFirst(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
                 
                 // Load module instances from brackets.test
-                brackets = testWindow.brackets;
+                brackets       = testWindow.brackets;
                 ProjectManager = testWindow.brackets.test.ProjectManager;
                 CommandManager = testWindow.brackets.test.CommandManager;
+                
+                SpecRunnerUtils.loadProjectInTestWindow(testPath);
             });
         });
 
-        afterEach(function () {
+        afterLast(function () {
             testWindow     = null;
             brackets       = null;
             ProjectManager = null;
             CommandManager = null;
             SpecRunnerUtils.closeTestWindow();
         });
+        
 
         describe("createNewItem", function () {
             it("should create a new file with a given name", function () {
                 var didCreate = false, gotError = false;
-
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 runs(function () {
                     // skip rename
@@ -110,8 +114,6 @@ define(function (require, exports, module) {
             it("should fail when a file already exists", function () {
                 var didCreate = false, gotError = false;
 
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
                 runs(function () {
                     // skip rename
                     ProjectManager.createNewItem(testPath, "file.js", true)
@@ -123,13 +125,13 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(gotError).toBeTruthy();
                     expect(didCreate).toBeFalsy();
+                    
+                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK);
                 });
             });
 
             it("should fail when a file name matches a directory that already exists", function () {
                 var didCreate = false, gotError = false;
-
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 runs(function () {
                     // skip rename
@@ -142,6 +144,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(gotError).toBeTruthy();
                     expect(didCreate).toBeFalsy();
+                    
+                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK);
                 });
             });
 
@@ -150,8 +154,6 @@ define(function (require, exports, module) {
                 var i = 0;
                 var len = chars.length;
                 var charAt, didCreate, gotError;
-
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 function createFile() {
                     // skip rename
@@ -167,6 +169,8 @@ define(function (require, exports, module) {
                 function assertFile() {
                     expect(gotError).toBeTruthy();
                     expect(didCreate).toBeFalsy();
+                    
+                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK);
                 }
                 
                 for (i = 0; i < len; i++) {
@@ -187,8 +191,6 @@ define(function (require, exports, module) {
                 var len = files.length;
                 var fileAt, didCreate, gotError;
 
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-
                 function createFile() {
                     // skip rename
                     ProjectManager.createNewItem(testPath, fileAt, true)
@@ -203,6 +205,8 @@ define(function (require, exports, module) {
                 function assertFile() {
                     expect(gotError).toBeTruthy();
                     expect(didCreate).toBeFalsy();
+                    
+                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK);
                 }
                 
                 for (i = 0; i < len; i++) {
@@ -234,8 +238,6 @@ define(function (require, exports, module) {
                     });
                 });
                 waitsFor(function () { return complete; }, "clean up leftover files timeout", 1000);
-
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 // Create a file and select it in the project tree.
                 runs(function () {
@@ -310,8 +312,6 @@ define(function (require, exports, module) {
                     });
                 });
                 waitsFor(function () { return complete; }, "clean up leftover files timeout", 1000);
-
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
 
                 // Create a folder
                 runs(function () {
@@ -419,8 +419,9 @@ define(function (require, exports, module) {
         describe("Selection indicator", function () {
             
             function expectSelected(fullPath) {
-                var $projectTreeItems = testWindow.$("#project-files-container > ul").children();
-                var $selectedItem = $projectTreeItems.find("a.jstree-clicked");
+                var $projectTreeItems = testWindow.$("#project-files-container > ul").children(),
+                    $selectedItem     = $projectTreeItems.find("a.jstree-clicked");
+                
                 if (!fullPath) {
                     expect($selectedItem.length).toBe(0);
                 } else {
@@ -430,7 +431,6 @@ define(function (require, exports, module) {
             }
             
             it("should deselect after opening file not rendered in tree", function () {
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 var promise,
                     exposedFile   = testPath + "/file.js",
                     unexposedFile = testPath + "/directory/file.js";
@@ -453,6 +453,7 @@ define(function (require, exports, module) {
             function findExtantNode(fullPath) {
                 var $treeItems = testWindow.$("#project-files-container li"),
                     $result;
+                
                 $treeItems.is(function () {
                     var $treeNode = testWindow.$(this),
                         entry = $treeNode.data("entry");
@@ -464,6 +465,7 @@ define(function (require, exports, module) {
                 });
                 return $result;
             }
+            
             function toggleFolder(fullPath, open) {
                 var $treeNode = findExtantNode(fullPath);
                 
@@ -479,7 +481,6 @@ define(function (require, exports, module) {
             }
             
             it("should reselect previously selected file when made visible again", function () {
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 var promise,
                     initialFile  = testPath + "/file.js",
                     folder       = testPath + "/directory/",
@@ -507,11 +508,11 @@ define(function (require, exports, module) {
                 });
                 runs(function () {
                     expectSelected(fileInFolder);
+                    toggleFolder(folder, false);    // close folder
                 });
             });
             
             it("should deselect after opening file hidden in tree, but select when made visible again", function () {
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 var promise,
                     initialFile  = testPath + "/file.js",
                     folder       = testPath + "/directory/",
@@ -538,6 +539,7 @@ define(function (require, exports, module) {
                 });
                 runs(function () {
                     expectSelected(fileInFolder);
+                    toggleFolder(folder, false);    // close folder
                 });
             });
         });

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -23,27 +23,47 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $: false, define: false, describe: false, it: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false */
+/*global $, define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
-    'use strict';
+    "use strict";
     
-    // Load dependent modules from brackets.test
-    var CommandManager,
-        Commands,
-        DocumentManager,
-        FileViewController,
-        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
+    var CommandManager,         // Load from brackets.test
+        Commands,               // Load from brackets.test
+        DocumentManager,        // Load from brackets.test
+        FileViewController,     // Load from brackets.test
+        SpecRunnerUtils         = require("spec/SpecRunnerUtils");
+
 
     describe("WorkingSetView", function () {
         
         this.category = "integration";
     
-        var testPath = SpecRunnerUtils.getTestPath("/spec/WorkingSetView-test-files");
-        var testWindow;
+        var testPath = SpecRunnerUtils.getTestPath("/spec/WorkingSetView-test-files"),
+            testWindow,
+            workingSetCount;
+        
+        
+        function openAndMakeDirty(path) {
+            var doc, didOpen = false, gotError = false;
+                
+            // open file
+            runs(function () {
+                FileViewController.openAndSelectDocument(path, FileViewController.PROJECT_MANAGER)
+                    .done(function () { didOpen = true; })
+                    .fail(function () { gotError = true; });
+            });
+            waitsFor(function () { return didOpen && !gotError; }, "FILE_OPEN on file timeout", 1000);
 
-        beforeEach(function () {
-            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+            // change editor content to make doc dirty which adds it to the working set
+            runs(function () {
+                doc = DocumentManager.getCurrentDocument();
+                doc.setText("dirty document");
+            });
+        }
+        
+        function createTestWindow(spec, loadProject) {
+            SpecRunnerUtils.createTestWindowAndRun(spec, function (w) {
                 testWindow = w;
 
                 // Load module instances from brackets.test
@@ -53,10 +73,10 @@ define(function (require, exports, module) {
                 FileViewController  = testWindow.brackets.test.FileViewController;
 
                 // Open a directory
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                if (loadProject) {
+                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                }
             });
-
-            var workingSetCount = 0;
             
             runs(function () {
                 // Initialize: register listeners
@@ -64,24 +84,26 @@ define(function (require, exports, module) {
                     workingSetCount++;
                 });
             });
-            
-            var openAndMakeDirty = function (path) {
-                var doc, didOpen = false, gotError = false;
-                
-                // open file
-                runs(function () {
-                    FileViewController.openAndSelectDocument(path, FileViewController.PROJECT_MANAGER)
-                        .done(function () { didOpen = true; })
-                        .fail(function () { gotError = true; });
-                });
-                waitsFor(function () { return didOpen && !gotError; }, "FILE_OPEN on file timeout", 1000);
-
-                // change editor content to make doc dirty which adds it to the working set
-                runs(function () {
-                    doc = DocumentManager.getCurrentDocument();
-                    doc.setText("dirty document");
-                });
-            };
+        }
+        
+        function closeTestWindow() {
+            testWindow          = null;
+            CommandManager      = null;
+            Commands            = null;
+            DocumentManager     = null;
+            FileViewController  = null;
+            SpecRunnerUtils.closeTestWindow();
+        }
+        
+        
+        beforeFirst(function () {
+            createTestWindow(this, true);
+        });
+        
+        afterLast(closeTestWindow);
+        
+        beforeEach(function () {
+            workingSetCount = 0;
             
             openAndMakeDirty(testPath + "/file_one.js");
             openAndMakeDirty(testPath + "/file_two.js");
@@ -89,15 +111,12 @@ define(function (require, exports, module) {
             // Wait for both files to be added to the working set
             waitsFor(function () { return workingSetCount === 2; }, 1000);
         });
-
+        
         afterEach(function () {
-            testWindow          = null;
-            CommandManager      = null;
-            Commands            = null;
-            DocumentManager     = null;
-            FileViewController  = null;
-            SpecRunnerUtils.closeTestWindow();
+            testWindow.closeAllFiles();
         });
+
+        
 
         it("should add a list item when a file is dirtied", function () {
             // check if files are added to work set and dirty icons are present
@@ -153,12 +172,10 @@ define(function (require, exports, module) {
             });
 
             // close test window while working set has 2 files (see beforeEach())
-            SpecRunnerUtils.closeTestWindow();
+            closeTestWindow();
 
             // reopen brackets test window to initialize unit test working set
-            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                testWindow = w;
-            });
+            createTestWindow(this, false);
             
             var $listItems;
             
@@ -188,7 +205,7 @@ define(function (require, exports, module) {
         it("should close a file when the user clicks the close button", function () {
             var $ = testWindow.$;
             var didClose = false;
-                    
+            
             // make 2nd doc clean
             var fileList = DocumentManager.getWorkingSet();
 
@@ -196,16 +213,16 @@ define(function (require, exports, module) {
                 var doc0 = DocumentManager.getOpenDocumentForPath(fileList[0].fullPath);
                 var doc1 = DocumentManager.getOpenDocumentForPath(fileList[1].fullPath);
                 doc1._markClean();
-                                
+                
                 // make the first one active
                 DocumentManager.setCurrentDocument(doc0);
-                                
+                
                 // hover over and click on close icon of 2nd list item
                 var secondItem =  $($("#open-files-container > ul").children()[1]);
                 secondItem.trigger('mouseover');
                 var closeIcon = secondItem.find(".file-status-icon");
                 expect(closeIcon.length).toBe(1);
-                                
+                
                 // simulate click
                 $(DocumentManager).on("workingSetRemove", function (event, removedFile) {
                     didClose = true;


### PR DESCRIPTION
I just integrated the specs on the following tests into a single window:
- CSSUtils-test
- ExtensionUtils-test
- Menu-test
- ProjectManager-test
- WorkingSetView-test

@jasonsanjose Want to review these too? Most were pretty simple to join and all tests are passing fast!!

Is so much nicer to run all integration tests now :)
