### PR TITLE
Upgrade JSLint to the commit we were using before switching to a submodule

### DIFF
--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -973,10 +973,10 @@ define(function (require, exports, module) {
                 
                 // Braces inside string; string inside rule (not inside selector)
                 css = "a::after { content: ' {' attr(href) '}'; } \n" +
-                    ".foo { color:red } \n" +
-                    "a::after { content: \" {\" attr(href) \"}\"; } \n" +
-                    "li::before { content: \"} h4 { color:black }\"; } \n" +
-                    "div { color:green }";
+                      ".foo { color:red } \n" +
+                      "a::after { content: \" {\" attr(href) \"}\"; } \n" +
+                      "li::before { content: \"} h4 { color:black }\"; } \n" +
+                      "div { color:green }";
                 
                 result = match(css, { tag: "a" });
                 expect(result.length).toBe(2);
@@ -999,7 +999,8 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(1);
                 
                 css = "@import \"null?\\\"{\"; \n" +   // a real-world CSS hack similar to the above case
-                    "div { color: red }";
+                      "div { color: red }";
+                
                 result = match(css, { tag: "div" });
                 expect(result.length).toBe(1);
                 
@@ -1051,9 +1052,10 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(1);
                 
                 css = ".foo\n" +
-                    "{\n" +
-                    "    color: red;\n" +
-                    "}";
+                      "{\n" +
+                      "    color: red;\n" +
+                      "}";
+                
                 result = match(css, { clazz: "foo" });
                 expect(result.length).toBe(1);
             });

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -129,21 +129,19 @@ define(function (require, exports, module) {
 
             function getBounds(object) {
                 return {
-                    left: object.offset().left,
-                    top: object.offset().top,
-                    right: object.offset().left + object.width(),
-                    bottom: object.offset().top + object.height()
+                    left   : object.offset().left,
+                    top    : object.offset().top,
+                    right  : object.offset().left + object.width(),
+                    bottom : object.offset().top + object.height()
                 };
             }
 
             function boundsInsideWindow(object) {
                 var bounds = getBounds(object);
-                return (
-                    bounds.left >= 0 &&
-                    bounds.right <= $(testWindow).width() &&
-                    bounds.top >= 0 &&
-                    bounds.bottom <= $(testWindow).height()
-                );
+                return bounds.left   >= 0 &&
+                       bounds.right  <= $(testWindow).width() &&
+                       bounds.top    >= 0 &&
+                       bounds.bottom <= $(testWindow).height();
             }
 
             it("context menu is not clipped", function () {
@@ -762,21 +760,19 @@ define(function (require, exports, module) {
 
             function getBounds(object) {
                 return {
-                    left:   object.offset().left,
-                    top:    object.offset().top,
-                    right:  object.offset().left + object.width(),
-                    bottom: object.offset().top + object.height()
+                    left   : object.offset().left,
+                    top    : object.offset().top,
+                    right  : object.offset().left + object.width(),
+                    bottom : object.offset().top + object.height()
                 };
             }
 
             function boundsInsideWindow(object) {
                 var bounds = getBounds(object);
-                return (
-                    bounds.left >= 0 &&
-                    bounds.right <= $(testWindow).width() &&
-                    bounds.top >= 0 &&
-                    bounds.bottom <= $(testWindow).height()
-                );
+                return bounds.left   >= 0 &&
+                       bounds.right  <= $(testWindow).width() &&
+                       bounds.top    >= 0 &&
+                       bounds.bottom <= $(testWindow).height();
             }
                 
             it("context menu is not clipped", function () {


### PR DESCRIPTION
As @peterflynn mentioned in #4467 I checked to a slightly older version of JSLint with switching to a submodule. I thought it wouldn't be an issue, but there are new indentation issues that can be seen now but not with the version we used to have, like in `EditorCommandHandlers`. This would also be fixed by #4557, but until then, this gives an easy fix.
