### PR TITLE
Add debug mode to compare in-browser DOM

### DIFF
--- a/src/LiveDevelopment/Inspector/inspector.html
+++ b/src/LiveDevelopment/Inspector/inspector.html
@@ -4,7 +4,7 @@
 <title>Inspector 1.0 Documentation</title>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js"></script>
-<script src="http://twitter.github.com/bootstrap/assets/js/bootstrap-dropdown.js"></script>
+<script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
 <script>
 $(function () {
 var _domain = $(window.location.hash);
@@ -33,7 +33,7 @@ if (domainAndName.length > 1) symbol.effect("highlight", { color: "#ffc"}, 1000)
 });
 });
 </script>
-<link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
 <style>
 body {padding: 70px 0 20px 0;}
 h3, dl {font-family: Menlo, Monaco, "Courier New", monospace;}


### PR DESCRIPTION
@njx @dangoor 

Runtime debug mode to compare in-memory DOM with in-browser DOM.

In `HTMLDocument.onChange` add a conditional breakpoint `this._debug=true,false` to enable debugging.

Here's some example output when pasting in a new tag. I'm using the getting started content pasting the first `h2` immediately below itself on line 15:

```
# console output
Browser delta for change: {"from":{"line":14,"ch":8},"to":{"line":14,"ch":8},"text":["<h2>This is your guide!</h2>"],"removed":[""],"origin":"paste"} HTMLDocument.js:170
Object {parentID: 1, firstChild: true, type: "textDelete"} HTMLDocument.js:173
Object {parentID: 8, firstChild: true, type: "textDelete"} HTMLDocument.js:173
Object {parentID: 8, afterID: "175", type: "textDelete"} HTMLDocument.js:173
Object {parentID: 1, afterID: "8", type: "textDelete"} HTMLDocument.js:173
Object {type: "elementInsert", tagID: 234, tag: "div", attributes: Object, parentID: "8"…}
 HTMLDocument.js:173
Object {type: "textInsert", tagID: "8", child: 52, content: "↵"} HTMLDocument.js:173
Object {parentID: "8", afterID: "175", type: "textReplace", content: "↵        ↵        ↵        ↵        ↵        "} HTMLDocument.js:173
Object {parentID: "8", afterID: "10", type: "textReplace", content: "↵        ↵        "} HTMLDocument.js:173
Object {parentID: "8", afterID: "42", type: "textReplace", content: "↵↵    ↵↵"} HTMLDocument.js:173
```

Some things to note:
- We use the same diff algorithm by basically taking the browser's `outerHTML` and treating it as the "new" tree. The editor state (after applying the doc changes) is used as the "old" tree.
- In the above output, you can see whitespace was lost somewhere along the way (see `lost-whitespace` below)
- The `elementInsert` delta is actually the HTML element highlight we add via `RemoteFunctions`
- The "code the web" ascii art at the bottom of the file get's reparented into the body
- The pasted `h2` tag isn't inserted as expected (see `paste-result`)

So...there's still some noise that we have to filter out to make this a friendlier experience. However, we might have legitimate issues here like handling comments.

```
# lost-whitespace-1
# in-editor
<!DOCTYPE html>
<html>

    <head>
        <meta charset="utf-8">
...

# in-browser
<!DOCTYPE html><html data-brackets-id="1"><head data-brackets-id="2">
        <meta data-brackets-id="3" charset="utf-8">
...

# lost-whitespace-2
# in-editor
    <body>

        <h1>GETTING STARTED WITH BRACKETS</h1>
        <h2>This is your guide!</h2>
...

# in-browser
    <body data-brackets-id="8"><h1 data-brackets-id="9">GETTING STARTED WITH BRACKETS</h1>
        <h2 data-brackets-id="10">This is your guide!</h2>
...

# paste-result
# in-editor
        <h2>This is your guide!</h2>
        <h2>This is your guide!</h2>
        <!--
            MADE WITH <3 AND JAVASCRIPT
        -->
...

# in-browser
        <h2 data-brackets-id="10">This is your guide!</h2>

        <!--
            MADE WITH <3 AND JAVASCRIPT
        --><h2 data-brackets-id="175">This is your guide!</h2>
...
```

Also
- Alternate jslint fix for while loop change
- Fix web inspector API doc bootstrap dependencies
