### PR TITLE
[LiveHTML] Parse more strictly during incremental update

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -344,7 +344,7 @@ define(function (require, exports, module) {
         return textNode.parent.children[childIndex - 1].tagID + "t";
     }
     
-    SimpleDOMBuilder.prototype.build = function () {
+    SimpleDOMBuilder.prototype.build = function (strict) {
         var self = this;
         var token, tagLabel, lastClosedTag, lastIndex = 0;
         var stack = this.stack;
@@ -418,8 +418,11 @@ define(function (require, exports, module) {
                             break;
                         }
                     }
+                    if (strict && i !== stack.length - 1) {
+                        // If we're in strict mode, treat unbalanced tags as invalid.
+                        return null;
+                    }
                     if (i >= 0) {
-                        // if (i !== stack.length - 1) console.log("Unbalanced tag close: " + token.contents);
                         do {
                             // For all tags we're implicitly closing (before we hit the matching tag), we want the
                             // implied end to be the beginning of the close tag (which is two characters, "</", before
@@ -428,10 +431,13 @@ define(function (require, exports, module) {
                             // the tagname).
                             closeTag(stack.length === i + 1 ? token.end + 1 : token.start - 2);
                         } while (stack.length > i);
-                    }
-                    // else {
-                    //     console.log("Unmatched close tag: " + token.contents);
-                    // }
+                    } else {
+                        // If we're in strict mode, treat unmatched close tags as invalid. Otherwise
+                        // we just silently ignore them.
+                        if (strict) {
+                            return null;
+                        }
+                    }                        
                 }
             } else if (token.type === "attribname") {
                 attributeName = token.contents.toLowerCase();
@@ -456,7 +462,11 @@ define(function (require, exports, module) {
             lastIndex = token.end;
         }
         
-        // If we have any tags hanging open (e.g. html or body), close them at the end of the document.
+        // If we have any tags hanging open (e.g. html or body), fail the parse if we're in strict mode,
+        // otherwise close them at the end of the document.
+        if (strict && stack.length) {
+            return null;
+        }
         while (stack.length) {
             closeTag(this.text.length - this.startOffset);
         }
@@ -471,9 +481,9 @@ define(function (require, exports, module) {
         return tagID++;
     };
     
-    function _buildSimpleDOM(text) {
+    function _buildSimpleDOM(text, strict) {
         var builder = new SimpleDOMBuilder(text);
-        return builder.build();
+        return builder.build(strict);
     }
     
     function _dumpDOM(root) {
@@ -528,6 +538,8 @@ define(function (require, exports, module) {
     function DOMUpdater(previousDOM, editor, changeList) {
         var text, startOffset = 0;
 
+        this.isIncremental = false;
+        
         // TODO: if there's more than one change in the changelist, we need to figure out how
         // to find all the affected ranges since we can't directly map the ranges of intermediate
         // changes to marked ranges after the fact. 
@@ -554,6 +566,7 @@ define(function (require, exports, module) {
                     //console.log("incremental update: " + text);
                     this.changedTagID = startMark.tagID;
                     startOffset = editor._codeMirror.indexFromPos(newMarkRange.from);
+                    this.isIncremental = true;
                 }
             }
         }
@@ -640,7 +653,9 @@ define(function (require, exports, module) {
     };
     
     DOMUpdater.prototype.update = function () {
-        var newSubtree = this.build(),
+        // If we're doing an incremental update, we want to do a stricter parse, and fail
+        // if there are any unbalanced tags.
+        var newSubtree = this.build(this.isIncremental),
             result = {
                 // default result if we didn't identify a changed portion
                 newDOM: newSubtree,
@@ -991,6 +1006,8 @@ define(function (require, exports, module) {
     exports.scanDocument = scanDocument;
     exports.generateInstrumentedHTML = generateInstrumentedHTML;
     exports.getUnappliedEditList = getUnappliedEditList;
+
+    // For unit testing
     exports._markText = _markText;
     exports._getMarkerAtDocumentPos = _getMarkerAtDocumentPos;
     exports._getTagIDAtDocumentPos = _getTagIDAtDocumentPos;
@@ -998,6 +1015,7 @@ define(function (require, exports, module) {
     exports._markTextFromDOM = _markTextFromDOM;
     exports._updateDOM = _updateDOM;
     exports._DOMNavigator = DOMNavigator;
-    exports._seed = seed;
+    exports._seed = seed;    
     exports._allowIncremental = allowIncremental;
+    exports._dumpDOM = _dumpDOM;
 });

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -536,6 +536,24 @@ define(function (require, exports, module) {
             });
         });
         
+        describe("Strict HTML parsing", function () {
+            it("should parse a document with balanced, void and self-closing tags", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<p><b>some</b>awesome text</p><p>and <img> another <br/> para</p>", true)).not.toBeNull();
+            });
+            it("should parse a document with an implied-close tag followed by a tag that forces it to close", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<p>unclosed para<h1>heading that closes para</h1>", true)).not.toBeNull();
+            });
+            it("should return null for an unclosed non-void/non-implied-close tag", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<p>this has an <b>unclosed bold tag</p>", true)).toBeNull();
+            });
+            it("should return null for an extra close tag", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<p>this has an unopened bold</b> tag</p>", true)).toBeNull();    
+            });
+            it("should return null if there are unclosed tags at the end of the document", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<div>this has <b>multiple unclosed tags", true)).toBeNull();
+            });
+        });
+        
         describe("HTML Instrumentation in dirty files", function () {
                 
             beforeEach(function () {
@@ -824,10 +842,14 @@ define(function (require, exports, module) {
                     doFullAndIncrementalEditTest(
                         function (editor, previousDOM) {
                             ed = editor;
+                            //console.log("original DOM: ");
+                            //console.log(HTMLInstrumentation._dumpDOM(previousDOM));
                             editor.document.replaceRange("<div>New Content</div>", {line: 15, ch: 0});
                         },
                         function (result, previousDOM, incremental) {
                             var newDOM = result.dom;
+                            //console.log("new DOM: ");
+                            //console.log(HTMLInstrumentation._dumpDOM(newDOM));
                             var newElement = newDOM.children[3].children[5];
                             expect(newElement.tag).toEqual("div");
                             expect(newElement.tagID).not.toEqual(newElement.parent.tagID);
@@ -859,6 +881,80 @@ define(function (require, exports, module) {
 //                            });
                         }
                     );
+                });
+            });
+            
+            // TODO: these tests aren't working yet.
+            xit("should represent simple new tag insert immediately after previous tag", function () {
+                runs(function () {
+                    var ed;
+                    
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            ed = editor;
+                            //console.log("original DOM: ");
+                            //console.log(HTMLInstrumentation._dumpDOM(previousDOM));
+                            editor.document.replaceRange("<div>New Content</div>", {line: 12, ch: 38});
+                        },
+                        function (result, previousDOM, incremental) {
+                            var newDOM = result.dom;
+                            console.log("new DOM: ");
+                            console.log(HTMLInstrumentation._dumpDOM(newDOM));
+                            
+                            // first child is whitespace, second child is <h1>, third child is new tag
+                            var newElement = newDOM.children[3].children[2];
+                            expect(newElement.tag).toEqual("div");
+                            expect(newElement.tagID).not.toEqual(newElement.parent.tagID);
+                            expect(newElement.children[0].content).toEqual("New Content");
+                            
+                            // 4 edits: 
+                            // - delete original \n
+                            // - insert new tag
+                            // - insert text in tag
+                            // - re-add \n after tag
+                            expect(result.edits.length).toEqual(4);
+                            expect(result.edits[1]).toEqual({
+                                type: "elementInsert",
+                                tag: "div",
+                                attributes: {},
+                                tagID: newElement.tagID,
+                                parentID: newElement.parent.tagID,
+                                child: 2
+                            });
+                            expect(result.edits[2]).toEqual({
+                                type: "textInsert",
+                                tagID: newElement.tagID,
+                                child: 0,
+                                content: "New Content"
+                            });
+                        }
+                    );
+                });
+            });
+            
+            // TODO: this isn't working yet--there are issues with the way text around comments 
+            // is being parsed in the test file
+            xit("should handle new text insert between tags", function () {
+                runs(function () {
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange("New Content", {line: 15, ch: 0});
+                        },
+                        function (result, previousDOM, incremental) {
+                            var newDOM = result.dom;
+                            var newElement = newDOM.children[3].children[5];
+                            expect(newElement.tagID).toBeUndefined();
+                            expect(newElement.content).toEqual("New Content");
+                            expect(result.edits.length).toEqual(3);
+                            expect(result.edits[1]).toEqual({
+                                type: "textInsert",
+                                tagID: newDOM.children[3].tagID,
+                                child: 0,
+                                content: "New Content"
+                            });
+                        }
+                    );
+                    
                 });
             });
         });


### PR DESCRIPTION
For #4644.

In addition to making valid implied-close/self-closing tags work, I also made the parser more lenient for unbalanced tags in order to fix the original HTMLInstrumentation unit tests. However, I had forgotten that part of our whole strategy for incremental update in live HTML editing relied on knowing when the HTML was in an invalid state and pausing incremental update until it becomes valid again.

This pull request adds a "strict" mode to the parser that still allows parsing of valid implied-close/self-closing tags, but returns null if there are unbalanced tags.

There are also a couple of (xited-out) unit tests in this pull request that I added to diagnose some other issues, but which aren't working yet.
