### PR TITLE
Makes the tokenizer return errors when low-level HTML syntax is incorrect...

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -362,7 +362,9 @@ define(function (require, exports, module) {
         }
         
         while ((token = this.t.nextToken()) !== null) {
-            if (token.type === "opentagname") {
+            if (token.type === "error") {
+                return null;
+            } else if (token.type === "opentagname") {
                 var newTag = {
                     tag: token.contents.toLowerCase(),
                     children: [],

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -552,6 +552,9 @@ define(function (require, exports, module) {
             it("should return null if there are unclosed tags at the end of the document", function () {
                 expect(HTMLInstrumentation._buildSimpleDOM("<div>this has <b>multiple unclosed tags", true)).toBeNull();
             });
+            it("should return null if there is a tokenization failure", function () {
+                expect(HTMLInstrumentation._buildSimpleDOM("<div<badtag></div>", true)).toBeNull();
+            });
         });
         
         describe("HTML Instrumentation in dirty files", function () {

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -164,5 +164,70 @@ define(function (require, exports, module) {
                 end: 16
             });
         });
+        
+        describe("error cases", function () {
+            function expectError(text, isError) {
+                if (isError === undefined) {
+                    isError = true;
+                }
+                var t = new Tokenizer(text),
+                    token = t.nextToken();
+                while (token) {
+                    if (token.type === "error") {
+                        if (!isError) {
+                            expect("found an error token").toBe(false);
+                        }
+                        return;
+                    }
+                    token = t.nextToken();
+                }
+                if (isError) {
+                    expect("found an error token").toBe(true);
+                }
+            }
+            
+            it("should not fail for a comment", function () {
+                expectError("<!--a comment-->", false);
+            });
+            it("should not fail for a tag with a mix of attribute styles", function () {
+                expectError("<goodtag goodname=goodvalue goodname='goodvalue' goodname=\"goodvalue\" goodemptyname attrwithspace = attrval></goodtag>", false);
+            });
+            it("should fail for an angle bracket before a tag", function () {
+                expectError("<<notatag>");
+            });
+            it("should fail for an angle bracket in a tag", function () {
+                expectError("<not<atag>");
+            });
+            it("should fail for an angle bracket before an attribute name", function () {
+                expectError("<tag <notattr>");
+            });
+            it("should fail for an angle bracket in an attribute name", function () {
+                expectError("<tag not<attr>");
+            });
+            it("should fail for an angle bracket before a value", function () {
+                expectError("<tag attr=<notvalue>");
+            });
+            it("should fail for an angle bracket inside a value", function () {
+                expectError("<tag attr=not<value>");
+            });
+            it("should fail for an angle bracket before a close tag", function () {
+                expectError("</<notatag>");
+            });
+            it("should fail for an angle bracket in a close tag", function () {
+                expectError("</not<atag>");
+            });
+            it("should fail for unclosed open tag at EOF", function () {
+                expectError("<unclosedopentag");
+            });
+            it("should fail for unfinished attr at EOF", function () {
+                expectError("<tag unfinishedattr=");
+            });
+            it("should fail for unfinished single-quoted value at EOF", function () {
+                expectError("<tag attr='unfinishedval");
+            });
+            it("should fail for unfinished double-quoted value at EOF", function () {
+                expectError("<tag attr=\"unfinishedval");
+            });
+        });
     });
 });


### PR DESCRIPTION
...and makes the parser return null if the tokenizer rejects the syntax.

This fix by itself makes #4644 no longer reproduce, although we also still want to fix the issue with later edits referring to nodes deleted by earlier edits. We might want to consider figuring out a different set of repro steps for that issue that doesn't rely on this tokenization problem, and filing it as a separate bug/unit test case.

@dangoor 
