### PR TITLE
prevent Theseus instrumentation of RemoteFunctions.js

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -24,6 +24,7 @@
 
 /*jslint vars: true, plusplus: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global define, $, window, document, navigator */
+/*theseus instrument: false */
 
 /**
  * RemoteFunctions define the functions to be executed in the browser. This


### PR DESCRIPTION
The source of `RemoteFunctions.js` is concatenated with some other strings and evaluated in Chrome during Live Development, but Theseus' instrumentation causes the resulting code to be invalid. This comment prevents `RemoteFunctions.js` from being instrumented.
