### PR TITLE
Cleanups for HTMLTokenizer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2401,3 +2401,23 @@ FITNESS FOR A PARTICULAR PURPOSE AND
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Chris Winberry
+Copyright 2010, 2011, Chris Winberry <chris@winberry.net>. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -165,6 +165,16 @@ define(function (require, exports, module) {
             });
         });
         
+        it("should parse a comment", function () {
+            var t = new Tokenizer("<!--very important-->");
+            expect(t.nextToken()).toEqual({
+                type: "comment",
+                contents: "very important",
+                start: 4,
+                end: 18
+            });
+        });
+        
         describe("error cases", function () {
             function expectError(text, isError) {
                 if (isError === undefined) {


### PR DESCRIPTION
- Add JSDoc comments.
- Fix content of comments/CDATA to omit garbage at end.
- Some naming improvements.
- Add reference to license for original tokenizer to NOTICE.

@dangoor 
