### PR TITLE
Fix bug #4613 - Globally preventDefault() on *all* link clicks

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -339,6 +339,22 @@ define(function (require, exports, module) {
                 e.preventDefault();
             }
         });
+        
+        // Prevent clicks on any link from navigating to a different page (which could lose unsaved
+        // changes). We can't use a simple .on("click", "a") because of http://bugs.jquery.com/ticket/3861:
+        // jQuery hides non-left clicks from such event handlers, yet middle-clicks still cause CEF to
+        // navigate. Also, a capture handler is more reliable than bubble.
+        window.document.body.addEventListener("click", function (e) {
+            // Check parents too, in case link has inline formatting tags
+            var node = e.target;
+            while (node) {
+                if (node.tagName === "A") {
+                    e.preventDefault();
+                    break;
+                }
+                node = node.parentElement;
+            }
+        }, true);
     }
 
     // Dispatch htmlReady event

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -185,7 +185,6 @@ define(function (require, exports, module) {
         // Dialog tabs
         $dlg.find(".nav-tabs a")
             .on("click", function (event) {
-                event.preventDefault();
                 $(this).tab("show");
             });
         

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -148,11 +148,6 @@ define(function (require, exports, module) {
         // UI event handlers
         this.$el
             .on("click", "a", function (e) {
-                // Never allow the default behavior for links--we don't want
-                // them to navigate out of Brackets!
-                e.stopImmediatePropagation();
-                e.preventDefault();
-                
                 var $target = $(e.target);
                 if ($target.hasClass("undo-remove")) {
                     ExtensionManager.markForRemoval($target.attr("data-extension-id"), false);

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -97,7 +97,6 @@ define(function (require, exports, module) {
     
     /** Clicking any link should open it in browser, not in Brackets shell */
     InlineDocsViewer.prototype._handleLinkClick = function (event) {
-        event.preventDefault();
         var url = $(event.currentTarget).attr("href");
         if (url) {
             NativeApp.openURLInDefaultBrowser(url);


### PR DESCRIPTION
Fix bug #4613 - Globally preventDefault() on _all_ link clicks, since we never want CEF to navigate away from Bracket's index.html under any circumstances. Remove ad-hoc preventDefault() calls from individual bits of UI code.
