### PR TITLE
Extension Manager: Clears the update/remove flags when you cancel.

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -334,6 +334,14 @@ define(function (require, exports, module) {
                 brackets.fs.unlink(filename, function () { });
             }
         });
+        _idsToUpdate = {};
+    }
+    
+    /**
+     * Unmarks all extensions marked for removal.
+     */
+    function unmarkAllForRemoval() {
+        _idsToRemove = {};
     }
 
     /**
@@ -469,6 +477,7 @@ define(function (require, exports, module) {
     exports.cleanupUpdates = cleanupUpdates;
     exports.markForRemoval = markForRemoval;
     exports.isMarkedForRemoval = isMarkedForRemoval;
+    exports.unmarkAllForRemoval = unmarkAllForRemoval;
     exports.hasExtensionsToRemove = hasExtensionsToRemove;
     exports.updateFromDownload = updateFromDownload;
     exports.removeUpdate = removeUpdate;

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -131,6 +131,7 @@ define(function (require, exports, module) {
                             });
                     } else {
                         ExtensionManager.cleanupUpdates();
+                        ExtensionManager.unmarkAllForRemoval();
                     }
                 });
         }

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -1131,6 +1131,7 @@ define(function (require, exports, module) {
                             ExtensionManagerDialog._performChanges();
                             dialogDeferred.resolve("cancel");
                             expect(removedPath).toBeFalsy();
+                            expect(ExtensionManager.isMarkedForRemoval("mock-extension-3")).toBe(false);
                             expect(didQuit).toBe(false);
                         });
                     });
@@ -1179,6 +1180,7 @@ define(function (require, exports, module) {
                             ExtensionManagerDialog._performChanges();
                             dialogDeferred.resolve("cancel");
                             expect(removedPath).toBeFalsy();
+                            expect(ExtensionManager.isMarkedForUpdate("mock-extension-3")).toBe(false);
                             expect(didQuit).toBe(false);
                             expect(brackets.fs.unlink).toHaveBeenCalledWith(filename, jasmine.any(Function));
                         });


### PR DESCRIPTION
This is a fix for #4543. When you cancel the "Remove/Update and Quit"
dialog, it was not clearing the update/remove flags. So, the next time
you use the Extension Manager it would still think that it needed to
update or remove.
