### PR TITLE
Redraw highlights after modifying in-browser DOM

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -649,6 +649,9 @@ function RemoteFunctions(experimental) {
                 break;
             }
         });
+        
+        // update highlight after applying diffs
+        redrawHighlights();
     }
     
     /**


### PR DESCRIPTION
Fix for #4692. Super simple fix. @dangoor or @njx.
