### PR TITLE
Find In Files Pagination Fixes

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -134,8 +134,6 @@ define({
     "FIND_IN_FILES_MATCHES"             : "matches",
     "FIND_IN_FILES_MORE_THAN"           : "Over ",
     "FIND_IN_FILES_PAGING"              : "{0}&mdash;{1}",
-    "FIND_IN_FILES_LESS"                : " <a href='#' class='find-less'>Less</a>",
-    "FIND_IN_FILES_MORE"                : " <a href='#' class='find-more'>More</a>",
     "FIND_IN_FILES_FILE_PATH"           : "File: <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_LINE"                : "line: {0}",
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -553,6 +553,7 @@ define(function (require, exports, module) {
             dialog        = new FindInFilesDialog();
 
         searchResults      = {};
+        currentStart       = 0;
         currentQuery       = "";
         currentScope       = scope;
         maxHitsFoundInFile = false;


### PR DESCRIPTION
These 2 strings where using for the find in files pagination before the UI update, and I forgot to remove them. It is still to merge, since no other language has translated them, not even fr and ja. And is only a removal.

Update: I just found a nasty bug. The current start wasn't restored to 0 on a new search, so sometimes you could see no results at all.

@JeffryBooher Can you take a look please. We should merge this soon.
