### PR TITLE
[LiveHTML] Make tokenizer more strict for attribute syntax

### DIFF
--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -238,6 +238,12 @@ define(function (require, exports, module) {
             it("should fail for unfinished double-quoted value at EOF", function () {
                 expectError("<tag attr=\"unfinishedval");
             });
+            it("should fail for extra text between / and > in a self-close tag", function () {
+                expectError("<img / >");
+            });
+            it("should fail for unmatched double-quotes when there is a slash after the next double-quote", function () {
+                expectError("<p style=\"something></p><img src=\"foo/bar\">");
+            });
         });
     });
 });

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
         });
         
         it("should handle attributes", function () {
-            var t = new Tokenizer("<div class='foo bar' style='baz: quux'></div>");
+            var t = new Tokenizer("<div class='foo bar' style=\"baz: quux\" checked></div>");
             expect(t.nextToken()).toEqual({
                 type: "opentagname",
                 contents: "div",
@@ -111,16 +111,22 @@ define(function (require, exports, module) {
                 end: 37
             });
             expect(t.nextToken()).toEqual({
+                type: "attribname",
+                contents: "checked",
+                start: 39,
+                end: 46
+            });
+            expect(t.nextToken()).toEqual({
                 type: "opentagend",
                 contents: "",
                 start: -1,
-                end: 39
+                end: 47
             });
             expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "div",
-                start: 41,
-                end: 44
+                start: 49,
+                end: 52
             });
             expect(t.nextToken()).toEqual(null);
         });
@@ -202,6 +208,15 @@ define(function (require, exports, module) {
             it("should not fail for a tag with a mix of attribute styles", function () {
                 expectError("<goodtag goodname=goodvalue goodname='goodvalue' goodname=\"goodvalue\" goodemptyname attrwithspace = attrval></goodtag>", false);
             });
+            it("should not fail for a tag with a quoted attribute at the end of the tag", function () {
+                expectError("<goodtag goodname=\"goodvalue\"></goodtag>", false);
+            });
+            it("should not fail for a tag with a quoted attribute followed by whitespace at the end of the tag", function () {
+                expectError("<goodtag goodname=\"goodvalue\" ></goodtag>", false);
+            });
+            it("should not fail for a tag with an unquoted attribute followed by whitespace at the end of the tag", function () {
+                expectError("<goodtag goodname=goodvalue ></goodtag>", false);
+            });
             it("should fail for an angle bracket before a tag", function () {
                 expectError("<<notatag>");
             });
@@ -243,6 +258,9 @@ define(function (require, exports, module) {
             });
             it("should fail for unmatched double-quotes when there is a slash after the next double-quote", function () {
                 expectError("<p style=\"something></p><img src=\"foo/bar\">");
+            });
+            it("should fail if there is no whitespace between the end of an attribute and the next attribute name", function () {
+                expectError("<p attr=\"val\"attr2=\"val\"></p>");
             });
         });
     });


### PR DESCRIPTION
For #4713. @dangoor 

In general, the tokenizer was already handling most cases of mismatched double-quotes correctly by returning an error. For example:

`<p style="></p><img src="foo">`

was fine; the tokenizer would see the value of `style` as `"></p><img src="`, then try to parse `foo"` as an attribute name, and fail because `"` isn't legal in attribute names. (It actually should have failed for another reason--see below.)

However, the case in #4713 was equivalent to:

`<p style="></p><img src="foo/bar">`

When the tokenizer saw the `/` while trying to parse `foo` as an attribute name, it assumed it was the beginning of a self-closing tag, and then just ate all the characters up until the `>`.

I added three cases (following the HTML spec) where the tokenizer should be stricter in order to make it more likely to fail when there are mismatched attribute quotes:
- in self-closing tag syntax, the `/` must immediately be followed with the '>', with no characters in between (not even whitespace)
- a quoted attribute must be separated from the following attribute name (if there is one) by whitespace (this should have been the reason for the first case to fail)
- there must be nothing in a close tag following the tag name besides whitespace (this isn't directly related to this case, but would make it even more likely that we would detect an error)

There are still cases where we could potentially get confused--for example, if there were an unclosed quote in an attribute value, the next quoted attribute value in the document happened to start with `>` or `/>`, and the rest of the tags around the mistake happened to balance out properly. This seems very unlikely, though, and I think there really isn't anything we can do about that since it could technically be a valid HTML document.
