### PR TITLE
[LiveHTML] Make sure DOM and marks are up to date when the browser re-requests...

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -103,7 +103,7 @@ define(function HTMLDocumentModule(require, exports, module) {
     HTMLDocument.prototype.getResponseData = function getResponseData(enabled) {
         var body;
         if (this._instrumentationEnabled) {
-            body = HTMLInstrumentation.generateInstrumentedHTML(this.doc);
+            body = HTMLInstrumentation.generateInstrumentedHTML(this.editor);
         }
         
         return {

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -1212,7 +1212,7 @@ define(function (require, exports, module) {
         }
         
         var cachedValue = _cachedValues[doc.file.fullPath];
-        if (cachedValue && !cachedValue.dirty && cachedValue.timestamp === doc.diskTimestamp) {
+        if (!doc.isDirty && cachedValue && !cachedValue.dirty && cachedValue.timestamp === doc.diskTimestamp) {
             return cachedValue.dom;
         }
         
@@ -1232,15 +1232,17 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Generate instrumented HTML for the specified document. Each tag has a "data-brackets-id"
-     * attribute with a unique ID for its value. For example, "<div>" becomes something like
-     * "<div data-brackets-id='45'>". The attribute value is just a number that is guaranteed
-     * to be unique. 
-     * @param {Document} doc The doc to scan. 
+     * Generate instrumented HTML for the specified editor's document, and mark the associated tag 
+     * ranges in the editor. Each tag has a "data-brackets-id" attribute with a unique ID for its 
+     * value. For example, "<div>" becomes something like "<div data-brackets-id='45'>". The attribute 
+     * value is just a number that is guaranteed to be unique. 
+     * @param {Editor} editor The editor whose document we're instrumenting, and which we should
+     *     mark ranges in.
      * @return {string} instrumented html content
      */
-    function generateInstrumentedHTML(doc) {
-        var dom = scanDocument(doc),
+    function generateInstrumentedHTML(editor) {
+        var doc = editor.document,
+            dom = scanDocument(doc),
             orig = doc.getText(),
             gen = "",
             lastIndex = 0;
@@ -1248,6 +1250,9 @@ define(function (require, exports, module) {
         if (!dom) {
             return null;
         }
+        
+        // Ensure that the marks in the editor are up to date with respect to the given DOM.
+        _markTextFromDOM(editor, dom);
         
         // Walk through the dom nodes and insert the 'data-brackets-id' attribute at the
         // end of the open tag        
@@ -1294,6 +1299,14 @@ define(function (require, exports, module) {
         
         _markTextFromDOM(editor, dom);
     }
+    
+    /**
+     * @private
+     * Clear the DOM cache. For unit testing only.
+     */
+    function _resetCache() {
+        _cachedValues = {};
+    }
 
     // private methods
     exports._markText                   = _markText;
@@ -1308,6 +1321,7 @@ define(function (require, exports, module) {
     exports._dumpDOM                    = _dumpDOM;
     exports._getBrowserDiff             = _getBrowserDiff;
     exports._findElementAndText         = _findElementAndText;
+    exports._resetCache                 = _resetCache;
     
     // public API
     exports.scanDocument                = scanDocument;

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -124,7 +124,37 @@ define(function (require, exports, module) {
                 }
             });
         }
+        
+        describe("interaction with document and editor", function () {
+            beforeEach(function () {
+                HTMLInstrumentation._resetCache();
+                
+                init(this, WellFormedFileEntry);
+                runs(function () {
+                    editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
+                    expect(editor).toBeTruthy();
+                });
+            });
             
+            it("should properly regenerate marks when instrumented HTML is re-requested after document is edited", function () {
+                runs(function () {
+                    var instrumented = HTMLInstrumentation.generateInstrumentedHTML(editor);
+                    getIdToTagMap(instrumented, elementIds);
+                    checkTagIdAtPos({line: 12, ch: 1}, "h1");
+                    
+                    editor.document.replaceRange("123456789012345678901234567890", {line: 12, ch: 0});
+                    instrumented = HTMLInstrumentation.generateInstrumentedHTML(editor);
+                    elementIds = {};
+                    getIdToTagMap(instrumented, elementIds);
+                    checkTagIdAtPos({line: 12, ch: 1}, "body");
+                    checkTagIdAtPos({line: 12, ch: 31}, "h1");
+                    
+                    var lines = instrumented.split("\n");
+                    expect(lines[12]).toMatch(/^123456789012345678901234567890<h1 data-brackets-id='[0-9]+'>GETTING STARTED WITH BRACKETS<\/h1>$/);
+                });
+            });
+        });
+                 
         describe("HTML Instrumentation in wellformed HTML", function () {
                 
             beforeEach(function () {
@@ -134,7 +164,7 @@ define(function (require, exports, module) {
                     expect(editor).toBeTruthy();
 
                     spyOn(editor.document, "getText").andCallThrough();
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
                     
                     if (elementCount) {
@@ -246,7 +276,7 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
 
                     if (elementCount) {
@@ -401,7 +431,7 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
 
                     if (elementCount) {
@@ -708,7 +738,7 @@ define(function (require, exports, module) {
                         changeList = change;
                     });
                     
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
                 });
             });
@@ -761,7 +791,7 @@ define(function (require, exports, module) {
                     var pos = {line: 15, ch: 0};
                     editor.document.replaceRange("<div>New Content</div>", pos);
                     
-                    var newInstrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document),
+                    var newInstrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor),
                         newElementIds = {},
                         newElementCount = getIdToTagMap(newInstrumentedHTML, newElementIds);
                     
@@ -1663,7 +1693,7 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
                 });
             });
@@ -1756,7 +1786,7 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor.document);
+                    instrumentedHTML = HTMLInstrumentation.generateInstrumentedHTML(editor);
                     elementCount = getIdToTagMap(instrumentedHTML, elementIds);
                 });
             });


### PR DESCRIPTION
...instrumented HTML on reload or document save.

For #4730. There were two issues:
- Originally, the instrumented HTML only needed to be parsed when the file changed on disk. Now we need to ensure that when a complete rethink is requested (which happens on browser reload or file save), the DOM is regenerated even if the file is just dirty in memory.
- `generateInstrumentedHTML()` didn't used to be responsible for updating the marks in the editor, so the marks would be stale if its call to `scanDocument()` recreated the DOM. Now we make it refresh the marks as well.

Note that this basically assumes that we want to do a full reparse of the DOM when the user saves the file or reloads in the browser. I think that's a good thing, because it gives the user an easy way to recover if they get into a bad state during incremental edits. If we didn't want to do that (and rely on the incrementally updated DOM when the browser reloads, for example), we could rejigger some of the logic here, but I like the idea of those two events forcing a "clean slate".
