### PR TITLE
[LiveHTML] Always parse strictly, even for full parse

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -642,9 +642,7 @@ define(function (require, exports, module) {
     };
     
     DOMUpdater.prototype.update = function () {
-        // If we're doing an incremental update, we want to do a stricter parse, and fail
-        // if there are any unbalanced tags.
-        var newSubtree = this.build(this.isIncremental),
+        var newSubtree = this.build(true),
             result = {
                 // default result if we didn't identify a changed portion
                 newDOM: newSubtree,


### PR DESCRIPTION
For #4734. @dangoor 

Originally, when updating after edits, we would do a strict parse for incremental reparses, but would do a lax parse for full reparses. I now think that's incorrect: we should basically refuse to do any updating while the document is incorrect. The _initial_ parse when loading a file can still be lax, so that basic highlighting will work as well as it can, but I don't think we should try to do any live HTML updating while the document is invalid, because our edits are pretty much guaranteed to be wrong.

I definitely think we should couple this with some UI that indicates that updating isn't happening because the doc is invalid. Let's talk about that for next sprint.
