### PR TITLE
Find in Files Fixes (Issues #4751 and #4755)

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -134,8 +134,6 @@ define({
     "FIND_IN_FILES_MATCHES"             : "matches",
     "FIND_IN_FILES_MORE_THAN"           : "Over ",
     "FIND_IN_FILES_PAGING"              : "{0}&mdash;{1}",
-    "FIND_IN_FILES_LESS"                : " <a href='#' class='find-less'>Less</a>",
-    "FIND_IN_FILES_MORE"                : " <a href='#' class='find-more'>More</a>",
     "FIND_IN_FILES_FILE_PATH"           : "File: <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_LINE"                : "line: {0}",
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -310,14 +310,14 @@ define(function (require, exports, module) {
      * @return {{files: number, matches: number}}
      */
     function _countFilesMatches() {
-		var numFiles = 0, numMatches = 0;
+        var numFiles = 0, numMatches = 0;
         CollectionUtils.forEach(searchResults, function (item) {
             numFiles++;
             numMatches += item.matches.length;
         });
-        
+
         return {files: numFiles, matches: numMatches};
-	}
+    }
     
     /**
      * @private

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -338,7 +338,7 @@ define(function (require, exports, module) {
             );
             
             // The last result index displayed
-            var last = currentStart + RESULTS_PER_PAGE > numMatches ? numMatches : currentStart + RESULTS_PER_PAGE;
+            var last = Math.min(currentStart + RESULTS_PER_PAGE, numMatches);
             
             // Insert the search summary
             $searchSummary.html(Mustache.render(searchSummaryTemplate, {
@@ -440,7 +440,7 @@ define(function (require, exports, module) {
                 })
                 // The link to go to the last page
                 .one("click.searchList", ".last-page:not(.disabled)", function () {
-                    currentStart = Math.floor(numMatches / RESULTS_PER_PAGE) * RESULTS_PER_PAGE;
+                    currentStart = Math.floor((numMatches - 1) / RESULTS_PER_PAGE) * RESULTS_PER_PAGE;
                     _showSearchResults();
                 });
             

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -304,6 +304,31 @@ define(function (require, exports, module) {
         }
     }
     
+    /**
+     * @private
+     * Count the total number of matches and files
+     * @return {{files: number, matches: number}}
+     */
+    function _countFilesMatches() {
+		var numFiles = 0, numMatches = 0;
+        CollectionUtils.forEach(searchResults, function (item) {
+            numFiles++;
+            numMatches += item.matches.length;
+        });
+        
+        return {files: numFiles, matches: numMatches};
+	}
+    
+    /**
+     * @private
+     * Returns the last possible current start based on the given number of matches
+     * @param {number} numMatches
+     * @return {number}
+     */
+    function _getLastCurrentStart(numMatches) {
+        return Math.floor((numMatches - 1) / RESULTS_PER_PAGE) * RESULTS_PER_PAGE;
+    }
+    
     
     /**
      * @private
@@ -311,42 +336,36 @@ define(function (require, exports, module) {
      */
     function _showSearchResults() {
         if (!$.isEmptyObject(searchResults)) {
-            
-            // Count the total number of matches
-            var numFiles = 0, numMatches = 0;
-            CollectionUtils.forEach(searchResults, function (item) {
-                numFiles++;
-                numMatches += item.matches.length;
-            });
+            var count = _countFilesMatches();
             
             // Show result summary in header
             var numMatchesStr = "";
             if (maxHitsFoundInFile) {
                 numMatchesStr = Strings.FIND_IN_FILES_MORE_THAN;
             }
-            numMatchesStr += String(numMatches);
+            numMatchesStr += String(count.matches);
 
             // This text contains some formatting, so all the strings are assumed to be already escaped
             var summary = StringUtils.format(
                 Strings.FIND_IN_FILES_TITLE,
                 numMatchesStr,
-                (numMatches > 1) ? Strings.FIND_IN_FILES_MATCHES : Strings.FIND_IN_FILES_MATCH,
-                numFiles,
-                (numFiles > 1 ? Strings.FIND_IN_FILES_FILES : Strings.FIND_IN_FILES_FILE),
+                (count.matches > 1) ? Strings.FIND_IN_FILES_MATCHES : Strings.FIND_IN_FILES_MATCH,
+                count.files,
+                (count.files > 1 ? Strings.FIND_IN_FILES_FILES : Strings.FIND_IN_FILES_FILE),
                 StringUtils.htmlEscape(currentQuery),
                 currentScope ? _labelForScope(currentScope) : ""
             );
             
             // The last result index displayed
-            var last = Math.min(currentStart + RESULTS_PER_PAGE, numMatches);
+            var last = Math.min(currentStart + RESULTS_PER_PAGE, count.matches);
             
             // Insert the search summary
             $searchSummary.html(Mustache.render(searchSummaryTemplate, {
                 summary:  summary,
-                hasPages: numMatches > RESULTS_PER_PAGE,
+                hasPages: count.matches > RESULTS_PER_PAGE,
                 results:  StringUtils.format(Strings.FIND_IN_FILES_PAGING, currentStart + 1, last),
                 hasPrev:  currentStart > 0,
-                hasNext:  last < numMatches
+                hasNext:  last < count.matches
             }));
             
             // Create the results template search list
@@ -440,7 +459,7 @@ define(function (require, exports, module) {
                 })
                 // The link to go to the last page
                 .one("click.searchList", ".last-page:not(.disabled)", function () {
-                    currentStart = Math.floor((numMatches - 1) / RESULTS_PER_PAGE) * RESULTS_PER_PAGE;
+                    currentStart = _getLastCurrentStart(count.matches);
                     _showSearchResults();
                 });
             
@@ -664,7 +683,7 @@ define(function (require, exports, module) {
      * @param {string} path
      */
     function _pathDeletedHandler(event, path) {
-        var resultsChanged = false;
+        var resultsChanged = false, numMatches;
         
         if (searchResultsPanel.isVisible()) {
             // Update the search results
@@ -677,6 +696,10 @@ define(function (require, exports, module) {
             
             // Restore the results if needed
             if (resultsChanged) {
+                numMatches = _countFilesMatches().matches;
+                if (currentStart > numMatches) {
+                    currentStart = _getLastCurrentStart(numMatches);
+                }
                 _restoreSearchResults();
             }
         }


### PR DESCRIPTION
- By reducing the matches by 1 when calculating the last page it fixes issue #4751 since we are actually starting counting from 0.
- Resets the current start to the maximum possible start when after deleting a file the current start ends higher than the number of matches, fixing issue #4755.
- Removed 2 unused strings in Find in Files.
