### PR TITLE
Fix #4750: It still will switch language if you click the cancel button.

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -188,10 +188,8 @@ define(function (require, exports, module) {
                 });
                 
                 var template = Mustache.render(LanguageDialogTemplate, {languages: languages, Strings: Strings});
-                Dialogs.showModalDialogUsingTemplate(template).done(function () {
-                    if (locale === undefined) {
-                        return;
-                    } else if (locale !== curLocale) {
+                Dialogs.showModalDialogUsingTemplate(template).done(function (id) {
+                    if (id === Dialogs.DIALOG_BTN_OK && locale !== curLocale) {
                         brackets.setLocale(locale);
                         CommandManager.execute(DEBUG_REFRESH_WINDOW);
                     }


### PR DESCRIPTION
Fix #4750.

It should only change the language and reload the window when the OK button was pressed, since done only means that the dialog was closed, and not that was accepted.
