### PR TITLE
PreferencesManager's getClientID() Fails On 64-bit Windows

### DIFF
--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
         var pathExp, pathUrl, clientID;
         
         paths.some(function (path) {
-            if (module.uri.indexOf(path) === 0) {
+            if (module.uri.toLocaleLowerCase().indexOf(path.toLocaleLowerCase()) === 0) {
                 pathUrl = path;
                 return true;
             }

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -89,10 +89,7 @@ define(function (require, exports, module) {
         var pathExp, pathUrl, clientID;
         
         paths.some(function (path) {
-            // escape any parentheses in the path (eg. "C:\Program Files (x86)")
-            var searchPath = path.replace(/\(/g, "\\(").replace(/\)/g, "\\)");
-            pathExp = new RegExp("^" + searchPath);
-            if (module.uri.match(pathExp)) {
+            if (module.uri.indexOf(path) === 0) {
                 pathUrl = path;
                 return true;
             }

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -89,7 +89,9 @@ define(function (require, exports, module) {
         var pathExp, pathUrl, clientID;
         
         paths.some(function (path) {
-            pathExp = new RegExp("^" + path);
+            // escape any parentheses in the path (eg. "C:\Program Files (x86)")
+            var searchPath = path.replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+            pathExp = new RegExp("^" + searchPath);
             if (module.uri.match(pathExp)) {
                 pathUrl = path;
                 return true;


### PR DESCRIPTION
Problem:
Running Brackets Sprint 29 installed on 64-bit Windows, preference settings in different contexts (eg. extensions) are overlapping.  As a result, changing the value of one setting mistakenly changes the same-named preference setting in another context.

For example, "View > Enable JSLint" and "View > Quick View on Hover" both save their state using a preference setting named "enabled".  The Preference Manager is supposed to keep these two, different extension settings separate.  However, on Windows, the getClientID() function is failing and causing the Preference Manager to think both settings live in the same "com.adobe.brackets.main" context.  As a result, if you change the JSLint setting and restart Brackets, you'll see that Quick View on Hover has changed to match.

In a nutshell, on 64-bit Windows, Brackets and Edge Code are installed to the folder "C:\Program Files (x86)".  The parentheses are passed as the regex string and causing getClientID() to fail to find the subpath to the extensions folder.

Solution:
Escape parentheses in paths before passing it to the regex search.

Related issue: Edge Code issue # 225- "Hover Preview of Images should default 'enabled' on Windows" (https://git.corp.adobe.com/edge/edge-code/issues/225)
