### PR TITLE
Allow live preview session to live longer after a currentDocumentChange

### DIFF
--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -34,7 +34,7 @@ define(function NetworkAgent(require, exports, module) {
 
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
 
-    var _urlRequested; // url -> request info
+    var _urlRequested = {}; // url -> request info
 
     /** Return the URL without the query string
      * @param {string} URL
@@ -80,14 +80,14 @@ define(function NetworkAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        _urlRequested = {};
-
         $(Inspector.Page).on("frameNavigated.NetworkAgent", _onFrameNavigated);
         $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
     }
 
     /** Unload the agent */
     function unload() {
+        _urlRequested = {};
+
         $(Inspector.Page).off(".NetworkAgent");
         $(Inspector.Network).off(".NetworkAgent");
     }

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -71,14 +71,6 @@ define(function CSSDocumentModule(require, exports, module) {
         this.onDeleted = this.onDeleted.bind(this);
         $(this.doc).on("change", this.onChange);
         $(this.doc).on("deleted", this.onDeleted);
-
-        // get the style sheet
-        this.styleSheet = CSSAgent.styleForURL(this.doc.url);
-
-        // If the CSS document is dirty, push the changes into the browser now
-        if (doc.isDirty) {
-            CSSAgent.reloadCSSForDocument(this.doc);
-        }
         
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
         $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
@@ -126,6 +118,19 @@ define(function CSSDocumentModule(require, exports, module) {
         this.doc.releaseRef();
         this.detachFromEditor();
     };
+ 
+    /**
+     * Force the browser to update if the file is dirty
+     */
+    CSSDocument.prototype._updateBrowser = function () {
+        // get the style sheet
+        this.styleSheet = CSSAgent.styleForURL(this.doc.url);
+
+        // If the CSS document is dirty, push the changes into the browser now
+        if (this.doc.isDirty) {
+            CSSAgent.reloadCSSForDocument(this.doc);
+        }
+    };
 
     CSSDocument.prototype.attachToEditor = function (editor) {
         this.editor = editor;
@@ -158,6 +163,25 @@ define(function CSSDocumentModule(require, exports, module) {
             }
         }
     };
+    
+    /**
+     * Enable instrumented CSS
+     * @param enabled {boolean} 
+     */
+    CSSDocument.prototype.setInstrumentationEnabled = function setInstrumentationEnabled(enabled) {
+        // no-op
+        // "Instrumentation" is always enabled for CSS, we make no modifications
+    };
+    
+    /**
+     * Returns a JSON object with HTTP response overrides
+     * @returns {{body: string}}
+     */
+    CSSDocument.prototype.getResponseData = function getResponseData(enabled) {
+        return {
+            body: this.doc.getText()
+        };
+    };
 
     /** Event Handlers *******************************************************/
 
@@ -174,6 +198,7 @@ define(function CSSDocumentModule(require, exports, module) {
             HighlightAgent.redraw();
         }
     };
+
     /** Triggered if the Document's file is deleted */
     CSSDocument.prototype.onDeleted = function onDeleted(event, editor, change) {
         // clear the CSS

--- a/src/LiveDevelopment/Servers/BaseServer.js
+++ b/src/LiveDevelopment/Servers/BaseServer.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, brackets, window */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    /**
+     * @constructor
+     * Base class for live preview servers
+     *
+     * @param {!{baseUrl: string, root: string, pathResolver: function(string): string}} config
+     *    Configuration parameters for this server:
+     *        baseUrl       - Optional base URL (populated by the current project)
+     *        pathResolver  - Function to covert absolute native paths to project relative paths
+     *        root          - Native path to the project root (and base URL)
+     */
+    function BaseServer(config) {
+        this._baseUrl       = config.baseUrl;
+        this._root          = config.root;          // ProjectManager.getProjectRoot().fullPath
+        this._pathResolver  = config.pathResolver;  // ProjectManager.makeProjectRelativeIfPossible(doc.file.fullPath)
+        this._liveDocuments = {};
+    }
+
+    /**
+     * Returns a base url for current project. 
+     *
+     * @return {string}
+     * Base url for current project.
+     */
+    BaseServer.prototype.getBaseUrl = function () {
+        return this._baseUrl;
+    };
+
+    /**
+     * @private
+     * Augments the given Brackets document with information that's useful for live development
+     * @param {Object} liveDocument
+     */
+    BaseServer.prototype._setDocInfo = function (liveDocument) {
+        var parentUrl,
+            rootUrl,
+            matches,
+            doc = liveDocument.doc;
+
+        // FUTURE: some of these things should just be moved into core Document; others should
+        // be in a LiveDevelopment-specific object attached to the doc.
+        matches = /^(.*\/)(.+\.([^.]+))$/.exec(doc.file.fullPath);
+        if (!matches) {
+            return;
+        }
+
+        doc.extension = matches[3];
+
+        parentUrl = this.pathToUrl(matches[1]);
+        doc.url = parentUrl + encodeURI(matches[2]);
+
+        // the root represents the document that should be displayed in the browser
+        // for live development (the file for HTML files)
+        // TODO: Issue #2033 Improve how default page is determined
+        doc.root = { url: doc.url };
+
+        // TODO: Better workflow of liveDocument.doc.url assignment
+        // Force sync the browser after a URL is assigned
+        if (liveDocument._updateBrowser) {
+            liveDocument._updateBrowser();
+        }
+    };
+
+    /**
+     * Returns a URL for a given path
+     * @param {string} path Absolute path to covert to a URL
+     * @return {?string} Converts a path within the project root to a URL.
+     *  Returns null if the path is not a descendant of the project root.
+     */
+    BaseServer.prototype.pathToUrl = function (path) {
+        var url             = null,
+            baseUrl         = this.getBaseUrl(),
+            relativePath    = this._pathResolver(path);
+
+        // See if base url has been specified and path is within project
+        if (relativePath !== path) {
+            // Map to server url. Base url is already encoded, so don't encode again.
+            var encodedDocPath = encodeURI(path);
+            var encodedProjectPath = encodeURI(this._root);
+
+            return encodedDocPath.replace(encodedProjectPath, baseUrl);
+        }
+
+        return null;
+    };
+
+    /**
+     * Convert a URL to a local full file path
+     * @param {string} url
+     * @return {?string} The absolute path for given URL or null if the path is
+     *  not a descendant of the project.
+     */
+    BaseServer.prototype.urlToPath = function (url) {
+        var path,
+            baseUrl = "";
+
+        baseUrl = this.getBaseUrl();
+
+        if (baseUrl !== "" && url.indexOf(baseUrl) === 0) {
+            // Use base url to translate to local file path.
+            // Need to use encoded project path because it's decoded below.
+            path = url.replace(baseUrl, encodeURI(this._root));
+        
+            return decodeURI(path);
+        }
+
+        return null;
+    };
+
+    /**
+     * Called by LiveDevelopment before to prepare the server before navigating
+     * to the project's base URL. The provider returns a jQuery promise.
+     * The Live Development launch process waits until the promise
+     * is resolved or rejected. If the promise is rejected, an error window
+     * is shown and Live Development does not start..
+     *
+     * @return {jQuery.Promise} Promise that may be asynchronously resolved
+     *  when the server is ready to handle HTTP requests.
+     */
+    BaseServer.prototype.readyToServe = function () {
+        // Base implementation always resolves
+        return $.Deferred().resolve().promise();
+    };
+    
+    /**
+     * Determines if this server can serve local file. LiveDevServerManager
+     * calls this method when determining if a server can serve a file.
+     * @param {string} localPath A local path to file being served.
+     * @return {boolean} true When the file can be served, otherwise false.
+     */
+    BaseServer.prototype.canServe = function (localPath) {
+        return true;
+    };
+
+    BaseServer.prototype._documentKey = function (liveDocument) {
+        return "/" + encodeURI(this._pathResolver(liveDocument.doc.file.fullPath));
+    };
+
+    /**
+     * Adds a live document to server
+     * @param {Object} liveDocument
+     */
+    BaseServer.prototype.add = function (liveDocument) {
+        // use the project relative path as a key to lookup requests
+        var key = this._documentKey(liveDocument);
+        
+        this._setDocInfo(liveDocument);
+        this._liveDocuments[key] = liveDocument;
+    };
+
+    /**
+     * Removes a live document from the server
+     * @param {Object} liveDocument
+     */
+    BaseServer.prototype.remove = function (liveDocument) {
+        var key = this._liveDocuments[this._documentKey(liveDocument)];
+        
+        if (key) {
+            delete this._liveDocuments[key];
+        }
+    };
+
+    /**
+     * Clears all live documents currently attached to the server
+     */
+    BaseServer.prototype.clear = function () {
+        this._liveDocuments = {};
+    };
+
+    /**
+     * Start the server
+     */
+    BaseServer.prototype.start = function () {
+        // do nothing
+    };
+
+    /**
+     * Stop the server
+     */
+    BaseServer.prototype.stop = function () {
+        // do nothing
+    };
+
+    exports.BaseServer = BaseServer;
+});

--- a/src/LiveDevelopment/Servers/FileServer.js
+++ b/src/LiveDevelopment/Servers/FileServer.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, brackets, window */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var BaseServer  = require("LiveDevelopment/Servers/BaseServer").BaseServer,
+        FileUtils   = require("file/FileUtils");
+
+    // The path on Windows starts with a drive letter (e.g. "C:").
+    // In order to make it a valid file: URL we need to add an
+    // additional slash to the prefix.
+    var PREFIX = (brackets.platform === "win") ? "file:///" : "file://";
+
+    /**
+     * @constructor
+     * @extends {BaseServer}
+     * Server for file: URLs
+     * @param {!{baseUrl: string, root: string, pathResolver: function(string): string}} config
+     *    Configuration parameters for this server:
+     *        baseUrl       - Optional base URL (populated by the current project)
+     *        pathResolver  - Function to covert absolute native paths to project relative paths
+     *        root          - Native path to the project root (and base URL)
+     */
+    function FileServer(config) {
+        BaseServer.call(this, config);
+    }
+    
+    FileServer.prototype = Object.create(BaseServer.prototype);
+    FileServer.prototype.constructor = BaseServer;
+
+    /**
+     * Determines whether we can serve local file.
+     * @param {string} localPath A local path to file being served.
+     * @return {boolean} true for yes, otherwise false.
+     */
+    FileServer.prototype.canServe = function (localPath) {
+        // FileServer requires that the base URL is undefined and static HTML files
+        return (!this._baseUrl && FileUtils.isStaticHtmlFileExt(localPath));
+    };
+
+    /**
+     * Convert a file: URL to a absolute file path
+     * @param {string} url
+     * @return {?string} The absolute path for given file: URL or null if the path is
+     *  not a descendant of the project.
+     */
+    FileServer.prototype.urlToPath = function (url) {
+        if (url.indexOf(PREFIX) === 0) {
+            // Convert a file URL to local file path
+            return decodeURI(url.slice(PREFIX.length));
+        }
+
+        return null;
+    };
+
+    /**
+     * Returns a file: URL for a given absolute path
+     * @param {string} path Absolute path to covert to a file: URL
+     * @return {string} Converts an absolute path within the project root to a file: URL.
+     */
+    FileServer.prototype.pathToUrl = function (path) {
+        return encodeURI(PREFIX + path);
+    };
+
+    exports.FileServer = FileServer;
+});

--- a/src/LiveDevelopment/Servers/UserServer.js
+++ b/src/LiveDevelopment/Servers/UserServer.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
+/*global define, $, brackets, window */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var BaseServer  = require("LiveDevelopment/Servers/BaseServer").BaseServer,
+        FileUtils   = require("file/FileUtils");
+
+    /**
+     * @constructor
+     * @extends {BaseServer}
+     * Live preview server for user specified server as defined with Live Preview Base Url
+     * Project setting. In a clean installation of Brackets, this is the highest priority
+     * server provider, if defined.
+     *
+     * @param {!{baseUrl: string, root: string, pathResolver: function(string)}} config
+     *    Configuration parameters for this server:
+     *        baseUrl       - Optional base URL (populated by the current project)
+     *        pathResolver  - Function to covert absolute native paths to project relative paths
+     *        root          - Native path to the project root (and base URL)
+     */
+    function UserServer(config) {
+        BaseServer.call(this, config);
+    }
+    
+    UserServer.prototype = Object.create(BaseServer.prototype);
+    UserServer.prototype.constructor = BaseServer;
+
+    /**
+     * Determines whether we can serve local file.
+     * @param {string} localPath A local path to file being served.
+     * @return {boolean} true for yes, otherwise false.
+     */
+    UserServer.prototype.canServe = function (localPath) {
+        // UserServer can only function when the project specifies a base URL
+        if (!this._baseUrl) {
+            return false;
+        }
+
+        // If we can't transform the local path to a project relative path,
+        // the path cannot be served
+        if (localPath === this._pathResolver(localPath)) {
+            return false;
+        }
+
+        return FileUtils.isStaticHtmlFileExt(localPath) ||
+            FileUtils.isServerHtmlFileExt(localPath);
+    };
+
+    exports.UserServer = UserServer;
+});

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
+maxerr: 50, browser: true */
+/*global $, define, brackets */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var BaseServer  = brackets.getModule("LiveDevelopment/Servers/BaseServer").BaseServer,
+        FileUtils   = brackets.getModule("file/FileUtils");
+
+    /**
+     * @constructor
+     * @extends {BaseServer}
+     * Live preview server that uses a built-in HTTP server to serve static
+     * and instrumented files.
+     *
+     * @param {!{baseUrl: string, root: string, pathResolver: function(string), nodeConnection: NodeConnection}} config
+     *    Configuration parameters for this server:
+     *        baseUrl        - Optional base URL (populated by the current project)
+     *        pathResolver   - Function to covert absolute native paths to project relative paths
+     *        root           - Native path to the project root (and base URL)
+     *        nodeConnection - An active NodeConnection
+     */
+    function StaticServer(config) {
+        this._nodeConnection = config.nodeConnection;
+        this._onRequestFilter = this._onRequestFilter.bind(this);
+        
+        BaseServer.call(this, config);
+    }
+    
+    StaticServer.prototype = Object.create(BaseServer.prototype);
+    StaticServer.prototype.constructor = BaseServer;
+
+    /**
+     * Determines whether we can serve local file.
+     * @param {string} localPath A local path to file being served.
+     * @return {boolean} true for yes, otherwise false.
+     */
+    StaticServer.prototype.canServe = function (localPath) {
+        if (!this._nodeConnection.connected()) {
+            return false;
+        }
+        
+        // If we can't transform the local path to a project relative path,
+        // the path cannot be served
+        if (localPath === this._pathResolver(localPath)) {
+            return false;
+        }
+
+        // Url ending in "/" implies default file, which is usually index.html.
+        // Return true to indicate that we can serve it.
+        if (localPath.match(/\/$/)) {
+            return true;
+        }
+
+        // FUTURE: do a MIME Type lookup on file extension
+        return FileUtils.isStaticHtmlFileExt(localPath);
+    };
+
+    /**
+     * @private
+     * Update the list of paths that fire "request" events
+     * @return {jQuery.Promise} Resolved by the StaticServer domain when the message is acknowledged.
+     */
+    StaticServer.prototype._updateRequestFilterPaths = function () {
+        if (!this._nodeConnection.connected()) {
+            return;
+        }
+
+        var paths = [];
+
+        Object.keys(this._liveDocuments).forEach(function (path) {
+            paths.push(path);
+        });
+
+        return this._nodeConnection.domains.staticServer.setRequestFilterPaths(this._root, paths);
+    };
+
+    /**
+     * Gets the server details from the StaticServerDomain in node.
+     * The domain itself handles starting a server if necessary (when
+     * the staticServer.getServer command is called).
+     *
+     * @return {jQuery.Promise} A promise that resolves/rejects when 
+     *     the server is ready/failed.
+     */
+    StaticServer.prototype.readyToServe = function () {
+        var readyToServeDeferred = $.Deferred(),
+            self = this;
+
+        if (this._nodeConnection.connected()) {
+            this._nodeConnection.domains.staticServer.getServer(self._root).done(function (address) {
+                self._baseUrl = "http://" + address.address + ":" + address.port + "/";
+                readyToServeDeferred.resolve();
+            }).fail(function () {
+                self._baseUrl = "";
+                readyToServeDeferred.reject();
+            });
+        } else {
+            // nodeConnection has been connected once (because the deferred
+            // resolved, but is not currently connected).
+            //
+            // If we are in this case, then the node process has crashed
+            // and is in the process of restarting. Once that happens, the
+            // node connection will automatically reconnect and reload the
+            // domain. Unfortunately, we don't have any promise to wait on
+            // to know when that happens. The best we can do is reject this
+            // readyToServe so that the user gets an error message to try
+            // again later.
+            //
+            // The user will get the error immediately in this state, and
+            // the new node process should start up in a matter of seconds
+            // (assuming there isn't a more widespread error). So, asking
+            // them to retry in a second is reasonable.
+            readyToServeDeferred.reject();
+        }
+        
+        return readyToServeDeferred.promise();
+    };
+
+    /**
+     * See BaseServer#add. StaticServer ignores documents that do not have
+     * a setInstrumentationEnabled method. Updates request filters.
+     */
+    StaticServer.prototype.add = function (liveDocument) {
+        if (liveDocument.setInstrumentationEnabled) {
+            // enable instrumentation
+            liveDocument.setInstrumentationEnabled(true);
+        }
+        
+        BaseServer.prototype.add.call(this, liveDocument);
+        
+        // update the paths to watch
+        this._updateRequestFilterPaths();
+    };
+
+    /**
+     * See BaseServer#remove. Updates request filters.
+     */
+    StaticServer.prototype.remove = function (liveDocument) {
+        BaseServer.prototype.remove.call(this, liveDocument);
+        
+        this._updateRequestFilterPaths();
+    };
+
+    /**
+     * See BaseServer#clear. Updates request filters.
+     */
+    StaticServer.prototype.clear = function () {
+        BaseServer.prototype.clear.call(this);
+        
+        this._updateRequestFilterPaths();
+    };
+    
+    /**
+     * @private
+     * Send HTTP response data back to the StaticServerSomain
+     */
+    StaticServer.prototype._send = function (location, response) {
+        if (this._nodeConnection.connected()) {
+            this._nodeConnection.domains.staticServer.writeFilteredResponse(location.root, location.pathname, response);
+        }
+    };
+    
+    /**
+     * @private
+     * Event handler for StaticServerDomain requestFilter event
+     * @param {jQuery.Event} event
+     * @param {{hostname: string, pathname: string, port: number, root: string}} request
+     */
+    StaticServer.prototype._onRequestFilter = function (event, request) {
+        var key             = request.location.pathname,
+            liveDocument    = this._liveDocuments[key],
+            response        = null;
+
+        // send instrumented response or null to fallback to static file
+        if (liveDocument && liveDocument.getResponseData) {
+            response = liveDocument.getResponseData();
+        }
+        
+        this._send(request.location, response);
+    };
+    
+    /**
+     * See BaseServer#start. Starts listenting to StaticServerDomain events.
+     */
+    StaticServer.prototype.start = function () {
+        $(this._nodeConnection).on("staticServer.requestFilter", this._onRequestFilter);
+    };
+
+    /**
+     * See BaseServer#stop. Remove event handlers from StaticServerDomain.
+     */
+    StaticServer.prototype.stop = function () {
+        $(this._nodeConnection).off("staticServer.requestFilter", this._onRequestFilter);
+    };
+
+    exports.StaticServer = StaticServer;
+});

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine, beforeFirst, afterLast */
+/*global brackets, $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -33,7 +33,9 @@ define(function (require, exports, module) {
         StringUtils             = require("utils/StringUtils"),
         NativeFileSystem        = require("file/NativeFileSystem").NativeFileSystem,
         FileUtils               = require("file/FileUtils"),
-        DefaultDialogs          = require("widgets/DefaultDialogs");
+        DefaultDialogs          = require("widgets/DefaultDialogs"),
+        FileServer              = require("LiveDevelopment/Servers/FileServer").FileServer,
+        UserServer              = require("LiveDevelopment/Servers/UserServer").UserServer;
 
     // The following are all loaded from the test window
     var CommandManager,
@@ -474,7 +476,6 @@ define(function (require, exports, module) {
                     testWindow           = w;
                     Dialogs              = testWindow.brackets.test.Dialogs;
                     LiveDevelopment      = testWindow.brackets.test.LiveDevelopment;
-                    LiveDevServerManager = testWindow.brackets.test.LiveDevServerManager;
                     DOMAgent             = testWindow.brackets.test.DOMAgent;
                     DocumentManager      = testWindow.brackets.test.DocumentManager;
                     CommandManager       = testWindow.brackets.test.CommandManager;
@@ -491,7 +492,6 @@ define(function (require, exports, module) {
                     testWindow           = null;
                     Dialogs              = null;
                     LiveDevelopment      = null;
-                    LiveDevServerManager = null;
                     DOMAgent             = null;
                     DocumentManager      = null;
                     CommandManager       = null;
@@ -698,60 +698,67 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "Restoring the original html content");
                 });
             });
-
-            // This tests url mapping -- files do not need to exist on disk
-            it("should translate urls to/from local paths", function () {
-                // Define testing parameters
-                var projectPath     = testPath + "/",
-                    outsidePath     = testPath.substr(0, testPath.lastIndexOf("/") + 1),
-                    fileProtocol    = (testWindow.brackets.platform === "win") ? "file:///" : "file://",
-                    fileRelPath     = "subdir/index.html",
-                    baseUrl,
-                    provider;
-
-                // File paths used in tests:
-                //  * file1 - file inside  project
-                //  * file2 - file outside project
-                // Encode the URLs
-                var file1Path       = projectPath + fileRelPath,
-                    file2Path       = outsidePath + fileRelPath,
-                    file1FileUrl    = encodeURI(fileProtocol + projectPath + fileRelPath),
-                    file2FileUrl    = encodeURI(fileProtocol + outsidePath + fileRelPath),
-                    file1ServerUrl;
-
-                // Should use file url when no server provider
-                runs(function () {
-                    LiveDevelopment._setServerProvider(null);
-                    expect(LiveDevelopment._pathToUrl(file1Path)).toBe(file1FileUrl);
-                    expect(LiveDevelopment._urlToPath(file1FileUrl)).toBe(file1Path);
-                    expect(LiveDevelopment._pathToUrl(file2Path)).toBe(file2FileUrl);
-                    expect(LiveDevelopment._urlToPath(file2FileUrl)).toBe(file2Path);
-                });
-
-
-                // Set user defined base url, and then get provider
-                runs(function () {
-                    baseUrl         = "http://localhost/";
-                    file1ServerUrl  = baseUrl + encodeURI(fileRelPath);
-                    ProjectManager.setBaseUrl(baseUrl);
-                    provider = LiveDevServerManager.getProvider(file1Path);
-                    expect(provider).toBeTruthy();
-                    LiveDevelopment._setServerProvider(provider);
-
-                    // Should use server url with base url
-                    expect(LiveDevelopment._pathToUrl(file1Path)).toBe(file1ServerUrl);
-                    expect(LiveDevelopment._urlToPath(file1ServerUrl)).toBe(file1Path);
-
-                    // File outside project should still use file url
-                    expect(LiveDevelopment._pathToUrl(file2Path)).toBe(file2FileUrl);
-                    expect(LiveDevelopment._urlToPath(file2FileUrl)).toBe(file2Path);
-
-                    // Clear base url
-                    LiveDevelopment._setServerProvider(null);
-                    ProjectManager.setBaseUrl("");
-                });
-            });
         });
         
+    });
+
+    describe("Servers", function () {
+        // Define testing parameters, files do not need to exist on disk
+        // File paths used in tests:
+        //  * file1 - file inside  project
+        //  * file2 - file outside project
+        // Encode the URLs
+        var projectPath     = testPath + "/",
+            outsidePath     = testPath.substr(0, testPath.lastIndexOf("/") + 1),
+            fileProtocol    = (brackets.platform === "win") ? "file:///" : "file://",
+            fileRelPath     = "/subdir/index.html",
+            file1Path       = projectPath + fileRelPath,
+            file2Path       = outsidePath + fileRelPath,
+            file1FileUrl    = encodeURI(fileProtocol + projectPath + fileRelPath),
+            file2FileUrl    = encodeURI(fileProtocol + outsidePath + fileRelPath),
+            file1ServerUrl;
+
+        function createPathResolver(root) {
+            return function (path) {
+                if (path.indexOf(root) === 0) {
+                    return path.slice(root.length);
+                }
+
+                return path;
+            };
+        }
+
+        describe("UserServer", function () {
+
+            it("should translate local paths to server paths", function () {
+                var config = { baseUrl: "http://localhost/", root: projectPath, pathResolver: createPathResolver(projectPath) },
+                    server = new UserServer(config);
+
+                file1ServerUrl  = config.baseUrl + encodeURI(fileRelPath);
+
+                // Should use server url with base url
+                expect(server.pathToUrl(file1Path)).toBe(file1ServerUrl);
+                expect(server.urlToPath(file1ServerUrl)).toBe(file1Path);
+
+                // File outside project should still use file url
+                expect(server.pathToUrl(file2Path)).toBe(null);
+                expect(server.urlToPath(file2FileUrl)).toBe(null);
+            });
+
+        });
+
+        describe("FileServer", function () {
+
+            it("should translate local paths to file: URLs", function () {
+                var config = { baseUrl: "", root: projectPath, pathResolver: createPathResolver(projectPath) },
+                    server = new FileServer(config);
+
+                expect(server.pathToUrl(file1Path)).toBe(file1FileUrl);
+                expect(server.urlToPath(file1FileUrl)).toBe(file1Path);
+                expect(server.pathToUrl(file2Path)).toBe(file2FileUrl);
+                expect(server.urlToPath(file2FileUrl)).toBe(file2Path);
+            });
+
+        });
     });
 });


### PR DESCRIPTION
Fix for #3970 

Keeps live documents open longer. Previously documents would close after a `currentDocumentChange` event. Also refactors how/when we update the StaticServer request filters.
