### PR TITLE
Fixes the Open Line tests when the indentation is set as tabs in the main window

### DIFF
--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2412,14 +2412,16 @@ define(function (require, exports, module) {
         });
       
         describe("Open Line Above and Below", function () {
-            var indentUnit = Editor.getSpaceUnits();
-            
-            var indentation = (function () {
-                // generate indent string once
-                var spaces = [];
-                spaces.length = indentUnit + 1;
-                return spaces.join(" ");
-            }());
+            var indentUnit  = Editor.getUseTabChar() ? 1 : Editor.getSpaceUnits(),
+                indentation = (function () {
+                    // generate indent string once
+                    if (Editor.getUseTabChar()) {
+                        return "\t";
+                    }
+                    var spaces = [];
+                    spaces.length = indentUnit + 1;
+                    return spaces.join(" ");
+                }());
             
             beforeEach(setupFullEditor);
 
@@ -2514,11 +2516,11 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                lines.splice(2, 0, "    " + indentation);
+                lines.splice(2, 0, indentation + indentation);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
-                expectCursorAt({line: 2, ch: 4 + indentUnit});
+                expectCursorAt({line: 2, ch: indentUnit * 2});
             });
 
             it("should insert new line below when no selection", function () {
@@ -2598,11 +2600,11 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                lines.splice(3, 0, "    " + indentation);
+                lines.splice(3, 0, indentation + indentation);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
-                expectCursorAt({line: 3, ch: 4 + indentUnit});
+                expectCursorAt({line: 3, ch: indentUnit * 2});
             });
 
             it("should insert new line below when multiple line selection", function () {
@@ -2612,11 +2614,11 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
 
                 var lines = defaultContent.split("\n");
-                lines.splice(5, 0, "    " + indentation);
+                lines.splice(5, 0, indentation + indentation);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
-                expectCursorAt({line: 5, ch: 4 + indentUnit});
+                expectCursorAt({line: 5, ch: indentUnit * 2});
             });
         });
 

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2412,10 +2412,10 @@ define(function (require, exports, module) {
         });
       
         describe("Open Line Above and Below", function () {
-            var indentUnit  = Editor.getUseTabChar() ? 1 : Editor.getSpaceUnits(),
+            var indentUnit  = SpecRunnerUtils.EDITOR_USE_TABS ? 1 : SpecRunnerUtils.EDITOR_SPACE_UNITS,
                 indentation = (function () {
                     // generate indent string once
-                    if (Editor.getUseTabChar()) {
+                    if (SpecRunnerUtils.EDITOR_USE_TABS) {
                         return "\t";
                     }
                     var spaces = [];

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -40,6 +40,8 @@ define(function (require, exports, module) {
         LanguageManager     = require("language/LanguageManager");
     
     var TEST_PREFERENCES_KEY    = "com.adobe.brackets.test.preferences",
+        EDITOR_USE_TABS         = false,
+        EDITOR_SPACE_UNITS      = 4,
         OPEN_TAG                = "{{",
         CLOSE_TAG               = "}}",
         RE_MARKER               = /\{\{(\d+)\}\}/g,
@@ -262,6 +264,8 @@ define(function (require, exports, module) {
         
         // create Editor instance
         var editor = new Editor(doc, true, $editorHolder.get(0), visibleRange);
+        Editor.setUseTabChar(EDITOR_USE_TABS);
+        Editor.setSpaceUnits(EDITOR_SPACE_UNITS);
         EditorManager._notifyActiveEditorChanged(editor);
         
         return editor;
@@ -1120,8 +1124,10 @@ define(function (require, exports, module) {
         });
     });
     
-    exports.TEST_PREFERENCES_KEY    = TEST_PREFERENCES_KEY;
-    
+    exports.TEST_PREFERENCES_KEY            = TEST_PREFERENCES_KEY;
+    exports.EDITOR_USE_TABS                 = EDITOR_USE_TABS;
+    exports.EDITOR_SPACE_UNITS              = EDITOR_SPACE_UNITS;
+
     exports.chmod                           = chmod;
     exports.remove                          = remove;
     exports.getTestRoot                     = getTestRoot;


### PR DESCRIPTION
I was running the test when I saw some fails in the Open Line tests. After some investigation I found out that it was because I had Tabs set as my indentation. So I fixed the tests so that they pass when Spaces or Tabs are set in the main editor.
