### PR TITLE
Fix shell tools for Linux

### DIFF
--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -33,7 +33,7 @@ fi
 
 link_name="${1}/$symlink"
 
-if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
+if [[ -L "$link_name" ]]; then
   rm "$link_name" || exit 1;
   echo "$1 has been restored to the installed configuration."
 fi

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 
+# Detect the user's operating system
+platform=`uname -s`;
+if [[ "$platform" == 'Linux' ]]; then
+   # This is the default directory for Ubuntu installations (if installed with the *.deb).
+   # May have to adjust if other operating systems use different directories.
+   default_app_directory='/opt/brackets';
+elif [[ "$platform" == 'Darwin' ]]; then # MAC OSX
+   default_app_directory='/Applications/Brackets Sprint 14.app';
+else
+   # Warn for unknown operating system?
+   default_app_directory='/opt/brackets';
+fi
+
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then
   echo "Usage: restore_installed_build.sh <application>"
   echo "Restore Brackets to use the installed HTML/CSS/JS files."
   echo ""
   echo "Parameters: application - full path to the Brackets application"
-  echo "Example: ./restore_installed_build.sh \"/Applications/Brackets Sprint 14.app\""
+  echo "Example: ./setup_for_hacking.sh \"$default_app_directory\""
   exit;
 fi
 

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -23,17 +23,17 @@ if [[ ${1} == "" ]]; then
   echo ""
   echo "Parameters: application - full path to the Brackets application"
   echo "Example: ./setup_for_hacking.sh \"$default_app_directory\""
-  exit;
+  exit 0;
 fi
 
 if [ ! -d "${1}" ]; then
   echo "$1 not found."
-  exit;
+  exit 1;
 fi
 
 link_name="${1}/$symlink"
 
 if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
-  rm "$link_name"
+  rm "$link_name" || exit 1;
   echo "$1 has been restored to the installed configuration."
 fi

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -6,11 +6,14 @@ if [[ "$platform" == 'Linux' ]]; then
    # This is the default directory for Ubuntu installations (if installed with the *.deb).
    # May have to adjust if other operating systems use different directories.
    default_app_directory='/opt/brackets';
+   symlink='dev';
 elif [[ "$platform" == 'Darwin' ]]; then # MAC OSX
    default_app_directory='/Applications/Brackets Sprint 14.app';
+   symlink='Contents/dev';
 else
    # Warn for unknown operating system?
    default_app_directory='/opt/brackets';
+   symlink='dev';
 fi
 
 # Make sure the appname was passed in and is valid
@@ -28,7 +31,9 @@ if [ ! -d "${1}" ]; then
   exit;
 fi
 
-if [[ -d "${1}/Contents/dev" || -n $(find -L "${1}/Contents/dev" -type l) ]]; then
-  rm "${1}/Contents/dev"
+link_name="${1}/$symlink"
+
+if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
+  rm "$link_name"
   echo "$1 has been restored to the installed configuration."
 fi

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -22,7 +22,7 @@ if [[ ${1} == "" ]]; then
   echo "Restore Brackets to use the installed HTML/CSS/JS files."
   echo ""
   echo "Parameters: application - full path to the Brackets application"
-  echo "Example: ./setup_for_hacking.sh \"$default_app_directory\""
+  echo "Example: ./restore_installed_build.sh \"$default_app_directory\""
   exit 0;
 fi
 

--- a/tools/restore_installed_build.sh
+++ b/tools/restore_installed_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -23,12 +23,12 @@ if [[ ${1} == "" ]]; then
   echo ""
   echo "Parameters: application - full path to the Brackets application"
   echo "Example: ./setup_for_hacking.sh \"$default_app_directory\""
-  exit;
+  exit 0;
 fi
 
 if [ ! -d "${1}" ]; then
   echo "$1 not found."
-  exit;
+  exit 1;
 fi
 
 # Get the full path of this script
@@ -45,11 +45,11 @@ link_name="${1}/$symlink"
 
 # Remove existing symlink, if present
 if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
-  rm "$link_name";
+  rm "$link_name" || exit 1;
 fi
 
 # Make new symlink
-ln -s "$root_dir" "$link_name";
+ln -s "$root_dir" "$link_name" || exit 1;
 
 echo "Brackets will now use the files in $root_dir"
 echo "Run the restore_installed_build.sh script to revert back to the installed source files"

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -6,11 +6,14 @@ if [[ "$platform" == 'Linux' ]]; then
    # This is the default directory for Ubuntu installations (if installed with the *.deb).
    # May have to adjust if other operating systems use different directories.
    default_app_directory='/opt/brackets';
+   symlink='dev';
 elif [[ "$platform" == 'Darwin' ]]; then # MAC OSX
    default_app_directory='/Applications/Brackets Sprint 14.app';
+   symlink='Contents/dev';
 else
    # Warn for unknown operating system?
    default_app_directory='/opt/brackets';
+   symlink='dev';
 fi
 
 # Make sure the appname was passed in and is valid
@@ -38,13 +41,15 @@ fi;
 # Remove /tools/setup_for_hacking.sh to get the root directory
 root_dir=${full_path%/*/*}
 
-# Remove existing "dev" symlink, if present
-if [[ -d "${1}/Contents/dev" || -n $(find -L "${1}/Contents/dev" -type l) ]]; then
-  rm "${1}/Contents/dev"
+link_name="${1}/$symlink"
+
+# Remove existing symlink, if present
+if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
+  rm "$link_name";
 fi
 
 # Make new symlink
-ln -s "$root_dir" "${1}/Contents/dev"
+ln -s "$root_dir" "$link_name";
 
 echo "Brackets will now use the files in $root_dir"
 echo "Run the restore_installed_build.sh script to revert back to the installed source files"

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -44,7 +44,7 @@ root_dir=${full_path%/*/*}
 link_name="${1}/$symlink"
 
 # Remove existing symlink, if present
-if [[ -d "$link_name" || -n $(find -L "$link_name" -type l) ]]; then
+if [[ -L "$link_name" ]]; then
   rm "$link_name" || exit 1;
 fi
 

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 
+# Detect the user's operating system
+platform=`uname -s`;
+if [[ "$platform" == 'Linux' ]]; then
+   # This is the default directory for Ubuntu installations (if installed with the *.deb).
+   # May have to adjust if other operating systems use different directories.
+   default_app_directory='/opt/brackets';
+elif [[ "$platform" == 'Darwin' ]]; then # MAC OSX
+   default_app_directory='/Applications/Brackets Sprint 14.app';
+else
+   # Warn for unknown operating system?
+   default_app_directory='/opt/brackets';
+fi
+
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then
   echo "Usage: setup_for_hacking.sh <application>"
   echo "Setup Brackets to use the HTML/CSS/JS files pulled from GitHub."
   echo ""
   echo "Parameters: application - full path to the Brackets application"
-  echo "Example: ./setup_for_hacking.sh \"/Applications/Brackets Sprint 14.app\""
+  echo "Example: ./setup_for_hacking.sh \"$default_app_directory\""
   exit;
 fi
 

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Make sure the appname was passed in and is valid
 if [[ ${1} == "" ]]; then

--- a/tools/setup_server_smokes.sh
+++ b/tools/setup_server_smokes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Make sure the server root folder was passed in and is valid
 if [[ ${1} == "" ]]; then

--- a/tools/setup_server_smokes.sh
+++ b/tools/setup_server_smokes.sh
@@ -7,12 +7,12 @@ if [[ ${1} == "" ]]; then
   echo ""
   echo "Parameters: server-root-path - local file path to server root folder"
   echo "Example: ./setup_server_smokes.sh \"/Library/WebServer/Documents\""
-  exit;
+  exit 0;
 fi
 
 if [ ! -d "${1}" ]; then
   echo "$1 not found."
-  exit;
+  exit 1;
 fi
 
 # Get the full path of this script
@@ -30,10 +30,10 @@ server_test_dir="$root_dir/test/smokes/server-tests"
 
 # Remove existing "server-tests" symlink, if present
 if [ -d "${1}/server-tests" ]; then
-  rm "${1}/server-tests"
+  rm "${1}/server-tests" || exit 1;
 fi
 
 # Make new symlink
-ln -s "$server_test_dir" "${1}/server-tests"
+ln -s "$server_test_dir" "${1}/server-tests" || exit 1;
 
 echo "Local server now has access to Brackets server-tests smoke test files"


### PR DESCRIPTION
The shell scripts in the repo currently do not work at all for Linux systems. These changes allow the scripts to be run on Linux based systems, while still detecting whether the user is running OSX, and adjusts accordingly. The commits also include some general cleanup and fixing of existing code.

I split up the changes into several smaller commits, which both makes it clearer what each change does, and allows me to if needed "remove" any changes which are deemed "unrelated" to this pull request.

Tested and confirmed working on Ubuntu, but not any other Linux-based operating systems. As I don't have a MAC, I am unable to test if the shell scripts still work for OSX systems.
