### PR TITLE
Fix the unit test failure in JS Quick Edit and some typos in JSDoc.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
      *
      *  @param {{inFunctionCall: boolean, functionCallPos: {line: number, ch: number}}} functionInfo -
      *  tells if the caret is in a function call and the position
-     * of the function call.
+     *  of the function call.
      */
     function formatHint(functionInfo) {
         var hints = session.getParameterHint(functionInfo.functionCallPos),
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
      * Test if the function call at the cursor is different from the currently displayed
      * function hint.
      *
-     * @param functionCallPos
+     * @param {{line:number, ch:number}} functionCallPos - the offset of the function call.
      * @return {boolean}
      */
     function hasFunctionCallPosChanged(functionCallPos) {
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
      * figuring it out again.
      * @return {jQuery.Promise} - The promise will not complete until the
      *      hint has completed. Returns null, if the function hint is already
-     *      displayed or the there is no function hint at the cursor.
+     *      displayed or there is no function hint at the cursor.
      *
      */
     function popUpHint(pushExistingHint, hint, functionInfo) {
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
         var functionInfo = session.getFunctionInfo();
 
         if (functionInfo.inFunctionCall) {
-            // If in a different function hint, then dismiss the old one a
+            // If in a different function hint, then dismiss the old one and
             // display the new one if there is one on the stack
             if (hasFunctionCallPosChanged(functionInfo.functionCallPos)) {
                 if (popHintFromStack()) {
@@ -334,7 +334,7 @@ define(function (require, exports, module) {
     /**
      * Enable cursor tracking in the current session.
      *
-     * @param {Session} session - session to stop cursor tracking on.
+     * @param {Session} session - session to start cursor tracking on.
      */
     function startCursorTracking(session) {
         $(session.editor).on("cursorActivity", handleCursorActivity);

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1282,7 +1282,7 @@ define(function (require, exports, module) {
      * Request a parameter hint from Tern.
      *
      * @param {Session} session - the active hinting session
-     * @param {{line: number, ch: number}} functionOffset - the offset the function call.
+     * @param {{line: number, ch: number}} functionOffset - the offset of the function call.
      * @return {jQuery.Promise} - The promise will not complete until the
      *      hint has completed.
      */

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -635,7 +635,7 @@ define(function (require, exports, module) {
     /**
      * The position of the function call for the current fnType.
      *
-     * @param functionCallPos
+     * @param {{line:number, ch:number}} functionCallPos - the offset of the function call.
      */
     Session.prototype.setFunctionCallPos = function (functionCallPos) {
         this.functionCallPos = functionCallPos;


### PR DESCRIPTION
Fix the JS Quick Edit unit test failure introduced by #4637.
