### PR TITLE
Replacing not-editor's gray background with Brackets' theme background

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -237,7 +237,7 @@ a, img {
         .vbox;
         .box-pack(center);
         .box-align(center);
-        background: @background-color-2 url('images/no_content_bg.svg') no-repeat center 45%;
+        background: @background-color-3 url('images/no_content_bg.svg') no-repeat center 45%;
     }
 }
 


### PR DESCRIPTION
This stop modal bar from flashing. (Modal bar will always show a bit of the theme's background color due to the way it works.)
