### PR TITLE
Add native menus switch

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -271,7 +271,7 @@ define(function (require, exports, module) {
         }
 
         // Enable/Disable HTML Menus
-        if (brackets.platform !== "linux") {
+        if (brackets.nativeMenus) {
             $("body").addClass("has-appshell-menus");
         }
         

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -58,8 +58,8 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
         
-        // supress redundant quit menu item on mac
-        if (brackets.platform !== "mac" && brackets.nativeMenus) {
+        // suppress redundant quit menu item on mac
+        if (brackets.platform !== "mac" || !brackets.nativeMenus) {
             menu.addMenuDivider();
             menu.addMenuItem(Commands.FILE_QUIT);
         }

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
         
         // supress redundant quit menu item on mac
-        if (brackets.platform !== "mac" && !brackets.inBrowser) {
+        if (brackets.platform !== "mac" && brackets.nativeMenus) {
             menu.addMenuDivider();
             menu.addMenuItem(Commands.FILE_QUIT);
         }
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.HELP_SHOW_EXT_FOLDER);
 
 
-        var hasAboutItem = (brackets.platform !== "mac" || brackets.inBrowser);
+        var hasAboutItem = (brackets.platform !== "mac" || !brackets.nativeMenus);
         
         // Add final divider only if we have a twitter URL or about item
         if (hasAboutItem || brackets.config.twitter_url) {

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     }
     
     function _isHTMLMenu(id) {
-        return (brackets.nativeMenus || _isContextMenu(id));
+        return (!brackets.nativeMenus || _isContextMenu(id));
     }
 
     /**

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -174,7 +174,7 @@ define(function (require, exports, module) {
     }
     
     function _isHTMLMenu(id) {
-        return (!$("body").hasClass("has-appshell-menus") || brackets.inBrowser) || _isContextMenu(id);
+        return (brackets.nativeMenus || _isContextMenu(id));
     }
 
     /**

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
         var currentDoc = DocumentManager.getCurrentDocument(),
             windowTitle = brackets.config.app_title;
 
-        if (brackets.inBrowser) {
+        if (!brackets.nativeMenus) {
             if (currentDoc) {
                 _$title.text(_currentTitlePath);
                 _$title.attr("title", currentDoc.file.fullPath);

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -68,6 +68,8 @@ define(function (require, exports, module) {
     global.brackets.shellAPI = require("utils/ShellAPI");
     
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
+
+    global.brackets.nativeMenus = (!global.brackets.inBrowser && (global.brackets.platform !== "linux"));
     
     if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") {
         global.brackets.platform = "mac";


### PR DESCRIPTION
The linux branch uses a native file system and HTML menus, so the logic around `brackets.inBrowser` is getting a bit complicated. This change adds a new `brackets.nativeMenus` flag to simplify the logic.

Note, the real reason I added this was to be able to quickly test native menus on any platform by simply settting:

```
    global.brackets.nativeMenus = false;
```

@jasonsanjose Please review Linux logic.

/cc @peterflynn 
