### PR TITLE
[LiveHTML] Test harness for applied patches

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -577,7 +577,7 @@ function RemoteFunctions(experimental) {
             moveNext        = start && start.nextSibling,
             current         = moveNext || (end && end.previousSibling) || targetElement.childNodes.item(targetElement.childNodes.length - 1),
             next,
-            textNode        = (edit.content !== undefined) ? document.createTextNode(edit.content) : null,
+            textNode        = (edit.content !== undefined) ? this.htmlDocument.createTextNode(edit.content) : null,
             lastRemovedWasText,
             isText;
         
@@ -645,7 +645,7 @@ function RemoteFunctions(experimental) {
                 targetElement.remove();
                 break;
             case "elementInsert":
-                var childElement = document.createElement(edit.tag);
+                var childElement = self.htmlDocument.createElement(edit.tag);
                 
                 Object.keys(edit.attributes).forEach(function (attr) {
                     childElement.setAttribute(attr, edit.attributes[attr]);
@@ -655,7 +655,7 @@ function RemoteFunctions(experimental) {
                 self._insertChildNode(targetElement, childElement, edit);
                 break;
             case "textInsert":
-                var textElement = document.createTextNode(edit.content);
+                var textElement = self.htmlDocument.createTextNode(edit.content);
                 self._insertChildNode(targetElement, textElement, edit);
                 break;
             case "textReplace":

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -667,7 +667,6 @@ define(function (require, exports, module) {
                     // Overwrite any node mappings in the parent DOM with the
                     // mappings for the new subtree. We keep the nodeMap around
                     // on the new subtree so that the differ can use it later.
-                    // TODO: should we ever null out the nodeMap on the subtree?
                     $.extend(this.previousDOM.nodeMap, newSubtree.nodeMap);
                     
                     // Update marked ranges for all items in the new subtree.
@@ -1078,6 +1077,12 @@ define(function (require, exports, module) {
         }
         
         var edits = domdiff(result.oldSubtree, result.newSubtree);
+        
+        // We're done with the nodeMap that was added to the subtree by the updater.
+        if (result.newSubtree !== result.newDOM) {
+            delete result.newSubtree.nodeMap;
+        }
+        
         return {
             dom: result.newDOM,
             edits: edits

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -86,6 +86,12 @@ define(function (require, exports, module) {
             }
         },
         remove: function () {
+            if (this.tagID) {
+                var nodeMap = this.getNodeMap();
+                if (nodeMap) {
+                    delete nodeMap[this.tagID];
+                }
+            }
             var siblings = this.siblings;
             var index = siblings.indexOf(this);
             siblings.splice(index, 1);
@@ -109,6 +115,7 @@ define(function (require, exports, module) {
         },
         setAttribute: function (key, value) {
             if (key === "data-brackets-id") {
+                this.tagID = value;
                 var nodeMap = this.getNodeMap();
                 if (nodeMap) {
                     nodeMap[key] = this;
@@ -129,6 +136,7 @@ define(function (require, exports, module) {
         compare: function (other) {
             if (this.children) {
                 expect(this.tag).toEqual(other.tag);
+                expect(this.tagID).toEqual(other.tagID);
                 delete this.attributes["data-brackets-id"];
                 expect(this.attributes).toEqual(other.attributes);
                 expect(this.children.length).toEqual(other.children.length);
@@ -204,11 +212,7 @@ define(function (require, exports, module) {
     function addDOMFeatures(node) {
         node[proto] = domFeatures;
         if (node.children) {
-            node.children.forEach(function (childNode) {
-                // put the parent back if it was cleared during cloneDOM
-                childNode.parent = node;
-                addDOMFeatures(childNode);
-            });
+            node.children.forEach(addDOMFeatures);
         }
     }
     


### PR DESCRIPTION
With this change, we not only test the contents of the patch but that the patched document is the same as the changed DOM. In other words, we verify that applying the list of edits to the old document using the browser-side code results in the same document that we have in Brackets.

To @njx or @jasonsanjose 
