### PR TITLE
[LiveHTML] Performance Tests

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -50,6 +50,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         HTMLInstrumentation = require("language/HTMLInstrumentation"),
         Inspector           = require("LiveDevelopment/Inspector/Inspector"),
         LiveDevelopment     = require("LiveDevelopment/LiveDevelopment"),
+        PerfUtils           = require("utils/PerfUtils"),
         RemoteAgent         = require("LiveDevelopment/Agents/RemoteAgent"),
         StringUtils         = require("utils/StringUtils");
 
@@ -203,8 +204,13 @@ define(function HTMLDocumentModule(require, exports, module) {
         // TODO: text changes should be easy to add
         // TODO: if new tags are added, need to instrument them
         var self                = this,
+            perfTimerName       = PerfUtils.markStart("HTMLDocument applyDOMEdits"),
             edits               = HTMLInstrumentation.getUnappliedEditList(editor, change),
             applyEditsPromise   = RemoteAgent.call("applyDOMEdits", edits);
+
+        applyEditsPromise.always(function () {
+            PerfUtils.addMeasurement(perfTimerName);
+        });
         
         // Debug-only: compare in-memory vs. in-browser DOM
         // edit this file or set a conditional breakpoint at the top of this function:


### PR DESCRIPTION
This branch of ResearchLiveHTML adds timers for:
- building DOM
- applying HTML edits

These timers are _always_ run. To see data use: Debug > Show Performance Data 

Looks for these operations:
- HTMLInstr. Build DOM Full
- HTMLInstr. Build DOM Partial
- HTMLDocument applyDOMEdits

For multiple runs, the data is displayed as: min/avg/max/last

If you want to see array of times, you can click in tiny box in upper-right corner, press Ctrl+C to copy raw data, then paste it somewhere.

@dangoor, @njx 
Is this the kind of tests we want? Or automated tests? Or both?
