### PR TITLE
Fix for native menus switch

### DIFF
--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -67,10 +67,6 @@ define(function (require, exports, module) {
     // TODO: (issue #266) load conditionally
     global.brackets.shellAPI = require("utils/ShellAPI");
     
-    global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
-
-    global.brackets.nativeMenus = (!global.brackets.inBrowser && (global.brackets.platform !== "linux"));
-    
     if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") {
         global.brackets.platform = "mac";
     } else if (global.navigator.platform.indexOf("Linux") >= 0) {
@@ -78,6 +74,10 @@ define(function (require, exports, module) {
     } else {
         global.brackets.platform = "win";
     }
+    
+    global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
+    
+    global.brackets.nativeMenus = (!global.brackets.inBrowser && (global.brackets.platform !== "linux"));
     
     global.brackets.isLocaleDefault = function () {
         return !global.localStorage.getItem("locale");


### PR DESCRIPTION
Don't check `global.brackets.platform` until it has _actually_ been set! This was reported in https://github.com/adobe/brackets/issues/4852.
