### PR TITLE
Don't call _fireSelectionChanged() twice

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -606,14 +606,6 @@ define(function (require, exports, module) {
 
     /** 
      * @private
-     */
-    function _handleDocumentSelectionChange() {
-        _updateListSelection();
-        _fireSelectionChanged();
-    }
-
-    /** 
-     * @private
      * @param {FileEntry} file
      * @param {boolean=} suppressRedraw If true, suppress redraw
      */
@@ -720,7 +712,7 @@ define(function (require, exports, module) {
             _handleFileNameChanged(oldName, newName);
         });
         
-        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _handleDocumentSelectionChange);
+        $(FileViewController).on("documentSelectionFocusChange fileViewFocusChange", _updateListSelection);
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow($openFilesContainer[0], null, true);


### PR DESCRIPTION
Working set selection was getting painted twice. `_updateListSelection()` already calls `_fireSelectionChanged()`, so don't call it again.

This saves ~50ms (of 190ms) on my Windows 7 system.

After removing `_fireSelectionChanged()` call from `_handleDocumentSelectionChange()`, there was nothing left except call to  `_updateListSelection()`, so I removed `_handleDocumentSelectionChange()` function and just call `_updateListSelection()` directly.

This is for #4757, but there may be more we can do.
