### PR TITLE
Fix issue 4778: Do not show Active Line Highlight when editor has selection

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -249,8 +249,16 @@ define(function (require, exports, module) {
             }
         }
     }
-
+    
+    /**
+     * @private
+     * Handle any cursor movement in editor, including selecting and unselecting text.
+     * @param {jQueryObject} jqEvent jQuery event object
+     * @param {Editor} editor Current, focused editor (main or inline)
+     * @param {!Event} event
+     */
     function _handleCursorActivity(jqEvent, editor, event) {
+        // If there is a selection in the editor, temporarily hide Active Line Highlight
         if (editor.hasSelection()) {
             if (editor._codeMirror.getOption("styleActiveLine")) {
                 editor._codeMirror.setOption("styleActiveLine", false);
@@ -1561,7 +1569,7 @@ define(function (require, exports, module) {
     /**
      * Sets show active line option and reapply it to all open editors.
      * @param {boolean} value
-     * @param {Editor} Current editor
+     * @param {Editor} editor Current, focused editor (main or inline)
      */
     Editor.setShowActiveLine = function (value, editor) {
         _styleActiveLine = value;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1550,10 +1550,15 @@ define(function (require, exports, module) {
     /**
      * Sets show active line option and reapply it to all open editors.
      * @param {boolean} value
+     * @param {Editor} Current editor
      */
-    Editor.setShowActiveLine = function (value) {
+    Editor.setShowActiveLine = function (value, editor) {
         _styleActiveLine = value;
         _setEditorOptionAndPref(value, "styleActiveLine", "styleActiveLine");
+        
+        if (editor.hasSelection()) {
+            editor._codeMirror.setOption("styleActiveLine", false);
+        }
     };
     
     /** @type {boolean} Returns true if show active line is enabled for all editors */

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -250,6 +250,16 @@ define(function (require, exports, module) {
         }
     }
 
+    function _handleCursorActivity(jqEvent, editor, event) {
+        if (editor.hasSelection()) {
+            if (editor._codeMirror.getOption("styleActiveLine")) {
+                editor._codeMirror.setOption("styleActiveLine", false);
+            }
+        } else {
+            editor._codeMirror.setOption("styleActiveLine", _styleActiveLine);
+        }
+    }
+    
     function _handleKeyEvents(jqEvent, editor, event) {
         _checkElectricChars(jqEvent, editor, event);
 
@@ -382,6 +392,7 @@ define(function (require, exports, module) {
         this._installEditorListeners();
         
         $(this)
+            .on("cursorActivity", _handleCursorActivity)
             .on("keyEvent", _handleKeyEvents)
             .on("change", this._handleEditorChange.bind(this));
         

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     
     var AppInit                 = require("utils/AppInit"),
         Editor                  = require("editor/Editor").Editor,
+        EditorManager           = require("editor/EditorManager"),
         Commands                = require("command/Commands"),
         CommandManager          = require("command/CommandManager"),
         Strings                 = require("strings");
@@ -48,7 +49,7 @@ define(function (require, exports, module) {
      * Activates/Deactivates showing active line option
      */
     function _toggleActiveLine() {
-        Editor.setShowActiveLine(!Editor.getShowActiveLine());
+        Editor.setShowActiveLine(!Editor.getShowActiveLine(), EditorManager.getCurrentFullEditor());
         CommandManager.get(Commands.TOGGLE_ACTIVE_LINE).setChecked(Editor.getShowActiveLine());
     }
     


### PR DESCRIPTION
This fix hides the Active Line Highlight when there is a selection in the current editor.

It does not address the general delay with the Shift-Down-Arrow, a different problem that started showing up in the Dev version of Sprint 30.  It does, however, remove the really, really slow behavior associated with the having the Highlight Active Line turned on.  The delay should now be the same, regardless of the Highlight Active Line setting.

I'm not sure I should be setting the CodeMirror Option on every single call to cursorActivity, but I didn't notice any performance issues by doing so.  Let me know if you want me to set a flag or something to avoid excessive setOption calls.
