### PR TITLE
Highlight the full active line and only hightlight in the focused editor

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -48,8 +48,13 @@
 .CodeMirror-focused .CodeMirror-activeline-background {
     background: @activeline-bgcolor;
 }
-.CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
-	background: @activeline-bgcolor;
+.CodeMirror-focused .CodeMirror-activeline {
+    & > div, .CodeMirror-gutter-elt {
+        height: 100%;
+    }
+    .CodeMirror-gutter-elt {
+        background: @activeline-bgcolor;
+    }
 }
 
 

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -42,9 +42,16 @@
 
 @code-padding: 15px;
 
-.CodeMirror-focused .CodeMirror-activeline-background {
-    background: @activeline-bgcolor; 
+.CodeMirror-activeline-background {
+    background: transparent;
 }
+.CodeMirror-focused .CodeMirror-activeline-background {
+    background: @activeline-bgcolor;
+}
+.CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
+	background: @activeline-bgcolor;
+}
+
 
 .cm-s-default {
     span.cm-keyword {color: @accent-keyword;}
@@ -181,11 +188,18 @@
         cursor: default;
     }
     
-    .CodeMirror-focused .CodeMirror-activeline-background {
-        background: darken(@activeline-bgcolor, @bc-color-step-size / 2); 
+    .CodeMirror .CodeMirror-activeline-background {
+        background: transparent;
     }
-    &.CodeMirror-focused .CodeMirror .CodeMirror-activeline-background {
-        background: transparent; 
+    .CodeMirror .CodeMirror-activeline .CodeMirror-gutter-elt {
+        background: transparent;
+    }
+    
+    .CodeMirror-focused .CodeMirror-activeline-background {
+        background: darken(@activeline-bgcolor, @bc-color-step-size / 2);
+    }
+    .CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
+        background: darken(@activeline-bgcolor, @bc-color-step-size / 2);
     }
 }
 


### PR DESCRIPTION
This fixes the "extend active line highlight to include line numbers" part of the issue #3191.

I also noticed a regression where the active line appeared on both main editor and inline editor, probably after the removal of some !important on the highlight rules, so I fixed this too without using !important.
