### PR TITLE
Add a bottom-buttons container to the main toolbar

### DIFF
--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -95,7 +95,7 @@
                 <a id="toolbar-extension-manager" title="{{EXTENSION_MANAGER_TITLE}}" href="#"></a>
                 <a id="update-notification" title="{{UPDATE_NOTIFICATION_TOOLTIP}}" href="#" style="display: none"></a>
             </div>
-            <div class="buttons bottom-buttons"></div>
+            <div class="bottom-buttons"></div>
         </div>
         
         <!-- Hack to ensure that the code editor's web font is loaded early. -->

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -95,6 +95,7 @@
                 <a id="toolbar-extension-manager" title="{{EXTENSION_MANAGER_TITLE}}" href="#"></a>
                 <a id="update-notification" title="{{UPDATE_NOTIFICATION_TOOLTIP}}" href="#" style="display: none"></a>
             </div>
+            <div class="buttons bottom-buttons"></div>
         </div>
         
         <!-- Hack to ensure that the code editor's web font is loaded early. -->

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -142,6 +142,13 @@
         > a:active {
             background-color: rgba(0, 0, 0, 0.66) !important;
         }
+    }     
+    
+    @toolbar-bottom-gap-px: 5px;
+    
+    .bottom-buttons {
+        position: absolute;
+        bottom: @toolbar-bottom-gap-px;
     }
 }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -122,7 +122,8 @@
     .box-flex(1);
     text-align: center;
 
-    .buttons {
+    .buttons,
+    .bottom-buttons {
         text-align: center;
         margin: 0;
 
@@ -144,11 +145,9 @@
         }
     }     
     
-    @toolbar-bottom-gap-px: 5px;
-    
     .bottom-buttons {
         position: absolute;
-        bottom: @toolbar-bottom-gap-px;
+        bottom: 5px;
     }
 }
 


### PR DESCRIPTION
This adds a second `.buttons` div to the `#main-toolbar` div that additionally has a `.bottom-buttons` class which positions it at the bottom, hovering the same distance from the bottom edge of the window that the main buttons container hovers from the top edge. The default icon position looks like this: 

![bot](http://f.cl.ly/items/1q1G1S1I440t0w3u2j12/Screen%20Shot%202013-08-23%20at%2010.48.01%20AM.png)

CC @peterflynn @larz0 @njx 
