### PR TITLE
Fix unit test failure in EditorOptionHandlers caused by pull request #4778.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -259,7 +259,7 @@ define(function (require, exports, module) {
      */
     function _handleCursorActivity(jqEvent, editor, event) {
         // If there is a selection in the editor, temporarily hide Active Line Highlight
-        if (editor && editor.hasSelection()) {
+        if (editor.hasSelection()) {
             if (editor._codeMirror.getOption("styleActiveLine")) {
                 editor._codeMirror.setOption("styleActiveLine", false);
             }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -259,7 +259,7 @@ define(function (require, exports, module) {
      */
     function _handleCursorActivity(jqEvent, editor, event) {
         // If there is a selection in the editor, temporarily hide Active Line Highlight
-        if (editor.hasSelection()) {
+        if (editor && editor.hasSelection()) {
             if (editor._codeMirror.getOption("styleActiveLine")) {
                 editor._codeMirror.setOption("styleActiveLine", false);
             }
@@ -1575,7 +1575,7 @@ define(function (require, exports, module) {
         _styleActiveLine = value;
         _setEditorOptionAndPref(value, "styleActiveLine", "styleActiveLine");
         
-        if (editor.hasSelection()) {
+        if (editor && editor.hasSelection()) {
             editor._codeMirror.setOption("styleActiveLine", false);
         }
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -459,6 +459,7 @@ define(function (require, exports, module) {
         $(this.document).off("change", this._handleDocumentChange);
         $(this.document).off("deleted", this._handleDocumentDeleted);
         $(this.document).off("languageChanged", this._handleDocumentLanguageChanged);
+        $(this.document).off("cursorActivity", this._handleCursorActivity);
         
         if (this._visibleRange) {   // TextRange also refs the Document
             this._visibleRange.dispose();


### PR DESCRIPTION
Check editor is not null before calling its hasSelection function since we're not passing editor from unit tests and EditorManager.getCurrentFullEditor() returns null for test windows.
