### PR TITLE
Strings needed for Edge Code "default editor" feature

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -109,6 +109,9 @@ define({
     "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> has been modified on disk, but also has unsaved changes in {APP_NAME}.<br /><br />Which version do you want to keep?",
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> has been deleted on disk, but has unsaved changes in {APP_NAME}.<br /><br />Do you want to keep your changes?",
     
+    "DEFAULT_EDITOR_TITLE"              : "Default Editor",
+    "DEFAULT_EDITOR_MESSAGE"            : "Make {APP_NAME} your default editor for <span class='dialog-filename'>JS</span>, <span class='dialog-filename'>HTML</span>, and <span class='dialog-filename'>CSS</span> files?<br /><br />We'll only ask this once.",
+    
     // Find, Replace, Find in Files
     "SEARCH_REGEXP_INFO"                : "Use /re/ syntax for regexp search",
     "FIND_RESULT_COUNT"                 : "{0} results",


### PR DESCRIPTION
User story is currently in progress and _may_ land before Brackets Sprint 30 wraps up, so we need to get the strings in today to keep that option open.

@njx Want to review since you already looked at the string?

The dialog will look like this:
![file assoc dialog](https://f.cloud.github.com/assets/1197510/1018950/d53b8b2e-0c35-11e3-8e3d-69395fe4c954.png)

(CC @iwehrman @bchintx)
