### PR TITLE
Fix unit test failure from pull request #4878.  Added unit test for hiding Active Line highlight when editor has selection.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1478,6 +1478,14 @@ define(function (require, exports, module) {
     function _setEditorOption(value, cmOption) {
         _instances.forEach(function (editor) {
             editor._codeMirror.setOption(cmOption, value);
+            
+            // If there is a selection in the editor, temporarily hide Active Line Highlight
+            if ((cmOption === "styleActiveLine") && (value === true)) {
+                if (editor.hasSelection()) {
+                    editor._codeMirror.setOption("styleActiveLine", false);
+                }
+            }
+            
             $(editor).triggerHandler("optionChange", [cmOption, value]);
         });
     }
@@ -1569,15 +1577,10 @@ define(function (require, exports, module) {
     /**
      * Sets show active line option and reapply it to all open editors.
      * @param {boolean} value
-     * @param {Editor} editor Current, focused editor (main or inline)
      */
-    Editor.setShowActiveLine = function (value, editor) {
+    Editor.setShowActiveLine = function (value) {
         _styleActiveLine = value;
         _setEditorOptionAndPref(value, "styleActiveLine", "styleActiveLine");
-        
-        if (editor.hasSelection()) {
-            editor._codeMirror.setOption("styleActiveLine", false);
-        }
     };
     
     /** @type {boolean} Returns true if show active line is enabled for all editors */

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
      * Activates/Deactivates showing active line option
      */
     function _toggleActiveLine() {
-        Editor.setShowActiveLine(!Editor.getShowActiveLine(), EditorManager.getCurrentFullEditor());
+        Editor.setShowActiveLine(!Editor.getShowActiveLine());
         CommandManager.get(Commands.TOGGLE_ACTIVE_LINE).setChecked(Editor.getShowActiveLine());
     }
     

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -121,6 +121,13 @@ define(function (require, exports, module) {
             });
         }
         
+        function checkActiveLineOption(editor, shouldBe) {
+            runs(function () {
+                expect(editor).toBeTruthy();
+                expect(editor._codeMirror.getOption("styleActiveLine")).toBe(shouldBe);
+            });
+        }
+        
         function checkLineNumbers(editor, shouldShow) {
             runs(function () {
                 var gutterElement, $lineNumbers;
@@ -267,6 +274,16 @@ define(function (require, exports, module) {
                 runs(function () {
                     var editor = EditorManager.getCurrentFullEditor();
                     checkActiveLine(editor, 0, true);
+                });
+            });
+            
+            it("should have the active line option be FALSE when the editor has a selection", function () {
+                openEditor(CSS_FILE);
+                
+                runs(function () {
+                    var editor = EditorManager.getCurrentFullEditor();
+                    editor.setSelection({line: 0, ch: 0}, {line: 0, ch: 1});
+                    checkActiveLineOption(editor, false);
                 });
             });
             


### PR DESCRIPTION
Here's the fix for the unit test errors caused by pull request #4878.  I moved the check out of the toggle command code and into the _setEditorOption() code per the suggestion of @jasonsanjose.

I also added a new unit test to check for the temporary hiding of the Active Line Highlight when there is an editor selection.  Tested the positive and negative scenarios.  Ran the entire test suite.  Everything looks good.  There are still quite a few errors in the unit test suite right now, but none appear to be related to my changes.
