### PR TITLE
Reduce editor initial layout time by first removing doc selection

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -533,6 +533,13 @@ define(function (require, exports, module) {
         var createdNewEditor = false;
         if (!document._masterEditor) {
             createdNewEditor = true;
+
+            // Performance (see #4650) Chrome wastes time messing with selection
+            // that will just be changed at end, so clear it for now
+            if (window.getSelection && window.getSelection().empty) {  // Chrome
+                window.getSelection().empty();
+            }
+            
             // Editor doesn't exist: populate a new Editor with the text
             _createFullEditorForDocument(document);
         }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -534,7 +534,7 @@ define(function (require, exports, module) {
         if (!document._masterEditor) {
             createdNewEditor = true;
 
-            // Performance (see #4650) Chrome wastes time messing with selection
+            // Performance (see #4757) Chrome wastes time messing with selection
             // that will just be changed at end, so clear it for now
             if (window.getSelection && window.getSelection().empty) {  // Chrome
                 window.getSelection().empty();


### PR DESCRIPTION
This is for #4757 (see notes).

In Brackets on Win7, I am seeing an reduction of ~400ms on initial page load.
