### PR TITLE
Updated the flex property for the latest chrome version to fix #4602 and #4870

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -743,16 +743,16 @@ a, img {
         text-overflow: ellipsis;
     }
     .fixed-col {
-        .flex-item(0);
+        .flex-item(0, 0);
     }
     .pagination-col {
-        .flex-item(1);
+        .flex-item(1, 0);
         min-width: 100px;
     }
     .replace-col {
-        .flex-item(1);
+        .flex-item(1, 0);
         min-width: 120px;
-        padding-left: 20px;
+        padding: 0 15px;
     }
     .first-page,
     .prev-page,


### PR DESCRIPTION
The latest version of chrome started supporting the unprefixed version of flex and fixed some issues, which broke the fixes done for #4602 and #4870. This PR fixes that.

Test this using a shell with the new sprint, although it is also fixed with a previous shell.
