### PR TITLE
Add ellipses to Replace All button label

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -117,7 +117,7 @@ define({
     "WITH"                              : "With",
     "BUTTON_YES"                        : "Yes",
     "BUTTON_NO"                         : "No",
-    "BUTTON_ALL"                        : "All",
+    "BUTTON_REPLACE_ALL"                : "All\u2026",
     "BUTTON_STOP"                       : "Stop",
     "BUTTON_REPLACE"                    : "Replace",
 

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -427,7 +427,7 @@ define(function (require, exports, module) {
     var doReplaceConfirm = Strings.CMD_REPLACE +
             '? <button id="replace-yes" class="btn">' + Strings.BUTTON_YES +
             '</button> <button id="replace-no" class="btn">' + Strings.BUTTON_NO +
-            '</button> <button id="replace-all" class="btn">' + Strings.BUTTON_ALL +
+            '</button> <button id="replace-all" class="btn">' + Strings.BUTTON_REPLACE_ALL +
             '</button> <button id="replace-stop" class="btn">' + Strings.BUTTON_STOP + '</button>';
 
     function replace(editor, all) {


### PR DESCRIPTION
...so it's not as scary to click. Without ellipses it looks like it will replace every occurrence immediately, which
is how most "All" buttons in Find/Replace dialogs work.

@njx Seem reasonable?

@jasonsanjose I know this missed the string freeze date.  Do you think it'd be ok to land anyway, even if the change is only visible in English for now?  It seems like a worthwhile usability tweak.  (Alternatively it'd be easy to manually update the existing Fr/Ja/De translations... but I'm guessing that breaks with ALF?)
