### PR TITLE
Handle typing of html/head/body in live HTML

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -445,6 +445,13 @@ define(function (require, exports, module) {
         }
         
         var dom = lastClosedTag;
+        if (!dom) {
+            // This can happen if the document has no nontrivial content, or if the user tries to
+            // have something at the root other than the HTML tag. In all such cases, we treat the
+            // document as invalid.
+            return null;
+        }
+        
         dom.nodeMap = nodeMap;
         PerfUtils.addMeasurement(timerBuildFull);       // use
         PerfUtils.finalizeMeasurement(timerBuildPart);  // discard
@@ -829,7 +836,8 @@ define(function (require, exports, module) {
             currentElement,
             oldElement,
             moves = [],
-            elementDeletes = {};
+            elementDeletes = {},
+            oldNodeMap = oldNode ? oldNode.nodeMap : {};
         
         /**
          * When the main loop (see below) determines that something has changed with
@@ -890,7 +898,7 @@ define(function (require, exports, module) {
              * @return {boolean} true if an elementInsert was created
              */
             var addElementInsert = function () {
-                if (!oldNode.nodeMap[currentChild.tagID]) {
+                if (!oldNodeMap[currentChild.tagID]) {
                     newEdit = {
                         type: "elementInsert",
                         tag: currentChild.tag,
@@ -1036,7 +1044,7 @@ define(function (require, exports, module) {
                 // of insert. The check that we're doing here is looking up the current
                 // child's ID in the *old* map and seeing if this child used to have a 
                 // different parent.
-                var possiblyMovedElement = oldNode.nodeMap[currentChild.tagID];
+                var possiblyMovedElement = oldNodeMap[currentChild.tagID];
                 if (possiblyMovedElement &&
                         currentParent.tagID !== getParentID(possiblyMovedElement)) {
                     newEdit = {
@@ -1208,7 +1216,7 @@ define(function (require, exports, module) {
          * creates the elementInsert edit.
          */
         var queuePush = function (node) {
-            if (node.children && oldNode.nodeMap[node.tagID]) {
+            if (node.children && oldNodeMap[node.tagID]) {
                 queue.push(node);
             }
         };
@@ -1218,7 +1226,7 @@ define(function (require, exports, module) {
         
         do {
             currentElement = queue.pop();
-            oldElement = oldNode.nodeMap[currentElement.tagID];
+            oldElement = oldNodeMap[currentElement.tagID];
             
             // Do we need to compare elements?
             if (oldElement) {
@@ -1243,6 +1251,20 @@ define(function (require, exports, module) {
             // This is a new element, so go straight to generating child edits (which will
             // create the appropriate Insert edits).
             } else {
+                // If this is the root (html) tag, we need to manufacture an insert for it here,
+                // because it isn't the child of any other node. The browser-side code doesn't
+                // care about parentage/positioning in this case, and will handle just setting the 
+                // ID on the existing implied HTML tag in the browser without actually creating it.
+                if (!currentElement.parent) {
+                    edits.push({
+                        type: "elementInsert",
+                        tag: currentElement.tag,
+                        tagID: currentElement.tagID,
+                        parentID: null,
+                        attributes: currentElement.attributes
+                    });
+                }
+                
                 generateChildEdits(currentElement, null);
             }
         } while (queue.length);
@@ -1287,25 +1309,24 @@ define(function (require, exports, module) {
     
     function getUnappliedEditList(editor, changeList) {
         var cachedValue = _cachedValues[editor.document.file.fullPath];
-        if (!cachedValue || !cachedValue.dom) {
-            console.warn("No previous DOM to compare change against");
-            return [];
+        // We might not have a previous DOM if the document was empty before this edit.
+        if (!cachedValue || !cachedValue.dom || _cachedValues[editor.document.file.fullPath].invalid) {
+            // We were in an invalid state, so do a full rebuild.
+            changeList = null;
+        }
+        var result = _updateDOM(cachedValue && cachedValue.dom, editor, changeList);
+        if (result) {
+            _cachedValues[editor.document.file.fullPath] = {
+                timestamp: editor.document.diskTimestamp,
+                dom: result.dom,
+                dirty: false
+            };
+            return result.edits;
         } else {
-            if (_cachedValues[editor.document.file.fullPath].invalid) {
-                // We were in an invalid state, so do a full rebuild.
-                changeList = null;
+            if (cachedValue) {
+                cachedValue.invalid = true;
             }
-            var result = _updateDOM(cachedValue.dom, editor, changeList);
-            if (result) {
-                _cachedValues[editor.document.file.fullPath] = {
-                    timestamp: editor.document.diskTimestamp, // TODO: update?
-                    dom: result.dom
-                };
-                return result.edits;
-            } else {
-                _cachedValues[editor.document.file.fullPath].invalid = true;
-                return [];
-            }
+            return [];
         }
     }
     


### PR DESCRIPTION
Addresses #4881.
- Fixed various issues with starting from an empty document
- Made it so we generate an insert if the root element is new
- On the browser side, treat an elementInsert for html/head/body specially
  and just add the id and attributes to the existing implied node

To @dangoor for review. I manually tested starting from an empty document and everything seems to be working in the basic case (including things like typing `<title>` and adding attributes to `<body>`--kind of fun seeing the browser title update as you edit the `<title>` tag :)) I didn't try to stress it out by doing unconventional edits though.

Note that this is based off of `dangoor/4736-delete-across-tags`, since some of the changes I had to make were in the `domdiff` code, and I wanted to do them against the new version.

Also, note that I don't actually check whether the root tag is `<html>` as we had discussed--it turns out that would break some of the existing unit tests, which create simple documents that don't have an `<html>` tag. I can fix that, but ran out of time today. It seems like enough of an edge case (user creating a document without an `<html>` tag wrapping it) that I think we could treat it as a low-priority bug (although I could imagine someone doing it by mistake).

Also fixes a unit test for RemoteFunctions that's broken by the `attrDel` to `attrDelete` change that was made in the original branch.
