### PR TITLE
Use CodeMirror setSize() instead of $.height() for editor resize

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -778,6 +778,15 @@ define(function (require, exports, module) {
         }
     };
     
+    /**
+     * Set the editor size in pixels or percentage
+     * @param {(number|string)} width
+     * @param {(number|string)} height
+     */
+    Editor.prototype.setSize = function (width, height) {
+        this._codeMirror.setSize(width, height);
+    };
+    
     var CENTERING_MARGIN = 0.15;
     
     /**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -439,12 +439,13 @@ define(function (require, exports, module) {
      *    determine whether it needs to refresh.
      */
     function _onEditorAreaResize(event, editorAreaHt, refreshFlag) {
-        
         if (_currentEditor) {
             var curRoot = _currentEditor.getRootElement(),
                 curWidth = $(curRoot).width();
             if (!curRoot.style.height || $(curRoot).height() !== editorAreaHt) {
-                $(curRoot).height(editorAreaHt);
+                // Call setSize() instead of $.height() to allow CodeMirror to
+                // check for options like line wrapping
+                _currentEditor.setSize(null, editorAreaHt);
                 if (refreshFlag === undefined) {
                     refreshFlag = REFRESH_FORCE;
                 }

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -115,7 +115,10 @@ define(function (require, exports, module) {
         
         // Immediately adjust editor's height, but skip the refresh since CodeMirror will call refresh()
         // itself when it sees the window resize event
-        triggerEditorResize("skip");
+        // triggerEditorResize("skip");
+
+        // FIXME (issue #4564) Workaround https://github.com/marijnh/CodeMirror/issues/1787
+        triggerEditorResize();
         
         if (!windowResizing) {
             windowResizing = true;


### PR DESCRIPTION
Workaround for #4564. Do not merge for sprint 30.
