### PR TITLE
Live Preview - Fix currentDocumentChange handling

### DIFF
--- a/src/LiveDevelopment/Inspector/inspector.html
+++ b/src/LiveDevelopment/Inspector/inspector.html
@@ -33,7 +33,7 @@ if (domainAndName.length > 1) symbol.effect("highlight", { color: "#ffc"}, 1000)
 });
 });
 </script>
-<link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet" rel="stylesheet">
 <style>
 body {padding: 70px 0 20px 0;}
 h3, dl {font-family: Menlo, Monaco, "Courier New", monospace;}

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -238,7 +238,9 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         // Clear all documents from request filtering
-        _server.clear();
+        if (_server) {
+            _server.clear();
+        }
     }
 
     /**
@@ -543,14 +545,16 @@ define(function LiveDevelopment(require, exports, module) {
 
         unloadAgents();
         
-        // Stop listening for requests when disconnected
-        _server.stop();
-        
         // Close live documents 
         _closeDocuments();
+        
+        if (_server) {
+            // Stop listening for requests when disconnected
+            _server.stop();
 
-        // Dispose server
-        _server = null;
+            // Dispose server
+            _server = null;
+        }
         
         _setStatus(STATUS_INACTIVE);
     }

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -511,10 +511,7 @@ define(function (require, exports, module) {
             
             afterEach(function () {
                 waitsForDone(LiveDevelopment.close(), "Waiting for browser to become inactive", 10000);
-                
-                runs(function () {
-                    testWindow.closeAllFiles();
-                });
+                testWindow.closeAllFiles();
             });
             
             it("should establish a browser connection for an opened html file", function () {
@@ -690,7 +687,7 @@ define(function (require, exports, module) {
                     // Verify that we still have modified text
                     expect(updatedNode.value).toBe("Live Preview in Brackets is awesome!");
                 });
-                    
+                
                 // Save original content back to the file after this test passes/fails
                 runs(function () {
                     htmlDoc.setText(origHtmlText);


### PR DESCRIPTION
Check if the server can display the new document before starting a new live dev session. Cleanup disconnect handling.

Fixes #4966. Also https://github.com/adobe/brackets/issues/4972.
