### PR TITLE
Add a colon after the 'Tab Size' and 'Spaces' in the status bar

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -176,8 +176,8 @@ define({
     "STATUSBAR_INDENT_TOOLTIP_TABS"         : "Click to switch indentation to tabs",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_SPACES"  : "Click to change number of spaces used when indenting",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_TABS"    : "Click to change tab character width",
-    "STATUSBAR_SPACES"                      : "Spaces",
-    "STATUSBAR_TAB_SIZE"                    : "Tab Size",
+    "STATUSBAR_SPACES"                      : "Spaces:",
+    "STATUSBAR_TAB_SIZE"                    : "Tab Size:",
     "STATUSBAR_LINE_COUNT_SINGULAR"         : "\u2014 {0} Line",
     "STATUSBAR_LINE_COUNT_PLURAL"           : "\u2014 {0} Lines",
 


### PR DESCRIPTION
![spaces](http://f.cl.ly/items/1M3p182b1j0Y1i2U2M2t/Screen%20Shot%202013-08-27%20at%204.53.16%20PM.png)

This is an improvement over the current, ungrammatical "Spaces 4".
