### PR TITLE
Fix live dev issues after ResearchLiveHTML merge

### DIFF
--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -73,7 +73,7 @@ define(function CSSDocumentModule(require, exports, module) {
         $(this.doc).on("deleted.CSSDocument", this.onDeleted);
         
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
-        $(EditorManager).on("activeEditorChange.CSSDocument", this.onActiveEditorChange);
+        $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
         
         if (editor) {
             // Attach now
@@ -113,9 +113,8 @@ define(function CSSDocumentModule(require, exports, module) {
  
     /** Close the document */
     CSSDocument.prototype.close = function close() {
-        $(this.doc).off("change.CSSDocument");
-        $(this.doc).off("deleted.CSSDocument");
-        $(EditorManager).off("activeEditorChange.CSSDocument");
+        $(this.doc).off(".CSSDocument");
+        $(EditorManager).off("activeEditorChange", this.onActiveEditorChange);
         this.doc.releaseRef();
         this.detachFromEditor();
     };
@@ -137,7 +136,7 @@ define(function CSSDocumentModule(require, exports, module) {
         this.editor = editor;
         
         if (this.editor) {
-            $(HighlightAgent).on("highlight.CSSDocument", this.onHighlight);
+            $(HighlightAgent).on("highlight", this.onHighlight);
             $(this.editor).on("cursorActivity.CSSDocument", this.onCursorActivity);
             this.updateHighlight();
         }
@@ -146,8 +145,8 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.detachFromEditor = function () {
         if (this.editor) {
             HighlightAgent.hide();
-            $(HighlightAgent).off("highlight.CSSDocument");
-            $(this.editor).off("cursorActivity.CSSDocument");
+            $(HighlightAgent).off("highlight", this.onHighlight);
+            $(this.editor).off(".CSSDocument");
             this.onHighlight();
             this.editor = null;
         }

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -69,11 +69,11 @@ define(function CSSDocumentModule(require, exports, module) {
         this.doc.addRef();
         this.onChange = this.onChange.bind(this);
         this.onDeleted = this.onDeleted.bind(this);
-        $(this.doc).on("change", this.onChange);
-        $(this.doc).on("deleted", this.onDeleted);
+        $(this.doc).on("change.CSSDocument", this.onChange);
+        $(this.doc).on("deleted.CSSDocument", this.onDeleted);
         
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
-        $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
+        $(EditorManager).on("activeEditorChange.CSSDocument", this.onActiveEditorChange);
         
         if (editor) {
             // Attach now
@@ -113,8 +113,9 @@ define(function CSSDocumentModule(require, exports, module) {
  
     /** Close the document */
     CSSDocument.prototype.close = function close() {
-        $(this.doc).off("change", this.onChange);
-        $(this.doc).off("deleted", this.onDeleted);
+        $(this.doc).off("change.CSSDocument");
+        $(this.doc).off("deleted.CSSDocument");
+        $(EditorManager).off("activeEditorChange.CSSDocument");
         this.doc.releaseRef();
         this.detachFromEditor();
     };
@@ -136,8 +137,8 @@ define(function CSSDocumentModule(require, exports, module) {
         this.editor = editor;
         
         if (this.editor) {
-            $(HighlightAgent).on("highlight", this.onHighlight);
-            $(this.editor).on("cursorActivity", this.onCursorActivity);
+            $(HighlightAgent).on("highlight.CSSDocument", this.onHighlight);
+            $(this.editor).on("cursorActivity.CSSDocument", this.onCursorActivity);
             this.updateHighlight();
         }
     };
@@ -145,8 +146,8 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.detachFromEditor = function () {
         if (this.editor) {
             HighlightAgent.hide();
-            $(HighlightAgent).off("highlight", this.onHighlight);
-            $(this.editor).off("cursorActivity", this.onCursorActivity);
+            $(HighlightAgent).off("highlight.CSSDocument");
+            $(this.editor).off("cursorActivity.CSSDocument");
             this.onHighlight();
             this.editor = null;
         }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -233,7 +233,7 @@ define(function LiveDevelopment(require, exports, module) {
         if (_relatedDocuments) {
             _relatedDocuments.forEach(function (liveDoc) {
                 liveDoc.close();
-                $(liveDoc).off("deleted", _handleRelatedDocumentDeleted);
+                $(liveDoc).off(".livedev");
             });
             
             _relatedDocuments = undefined;
@@ -289,7 +289,7 @@ define(function LiveDevelopment(require, exports, module) {
                                 _relatedDocuments.push(liveDoc);
                                 _server.add(liveDoc);
                                 
-                                $(liveDoc).on("deleted", _handleRelatedDocumentDeleted);
+                                $(liveDoc).on("deleted.livedev", _handleRelatedDocumentDeleted);
                             }
                         }
                         stylesheetDeferred.resolve();
@@ -534,8 +534,8 @@ define(function LiveDevelopment(require, exports, module) {
             deferred    = new $.Deferred(),
             connected   = Inspector.connected();
 
-        $(Inspector.Page).off("frameNavigated.livedev");
-        $(Inspector).off("disconnect.livedev");
+        $(Inspector.Page).off(".livedev");
+        $(Inspector).off(".livedev");
 
         unloadAgents();
         

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -238,7 +238,9 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         // Clear all documents from request filtering
-        _server.clear();
+        if (_server) {
+            _server.clear();
+        }
     }
 
     /**
@@ -543,8 +545,6 @@ define(function LiveDevelopment(require, exports, module) {
             // No longer in site, so terminate live dev, but don't close browser window
             Inspector.disconnect();
             _closeReason = "navigated_away";
-            _setStatus(STATUS_INACTIVE);
-            _server = null;
         }
     }
 
@@ -555,11 +555,16 @@ define(function LiveDevelopment(require, exports, module) {
 
         unloadAgents();
         
-        // Stop listening for requests when disconnected
-        _server.stop();
-        
         // Close live documents 
         _closeDocuments();
+        
+        if (_server) {
+            // Stop listening for requests when disconnected
+            _server.stop();
+
+            // Dispose server
+            _server = null;
+        }
         
         _setStatus(STATUS_INACTIVE);
     }
@@ -603,11 +608,15 @@ define(function LiveDevelopment(require, exports, module) {
         }
         
         if (Inspector.connected()) {
-            var timer = window.setTimeout(cleanup, 5000); // 5 seconds
-            Inspector.Runtime.evaluate("window.open('', '_self').close();", function (response) {
-                Inspector.disconnect();
-                window.clearTimeout(timer);
-                cleanup();
+            // Close the browser tab/window
+            var closePromise = Inspector.Runtime.evaluate("window.open('', '_self').close();");
+
+            // Add a timeout to force cleanup if Inspector does not respond
+            closePromise = Async.withTimeout(closePromise, 5000);
+
+            // Disconnect the Inspector after closing the tab/winow
+            closePromise.always(function () {
+                Inspector.disconnect().always(cleanup);
             });
         } else {
             cleanup();
@@ -932,23 +941,21 @@ define(function LiveDevelopment(require, exports, module) {
     function _onDocumentChange() {
         var doc = _getCurrentDocument();
         
-        if (!doc) {
+        if (!doc || !Inspector.connected()) {
             return;
         }
 
-        if (Inspector.connected()) {
-            hideHighlight();
-            
-            // close the current session and begin a new session if the current
-            // document changes to an HTML document that was not loaded yet
-            var wasRequested = agents.network && agents.network.wasURLRequested(doc.url),
-                isHTML = exports.config.experimental || _isHtmlFileExt(doc.extension);
-            
-            if (!wasRequested && isHTML) {
-                // TODO (jasonsanjose): optimize this by reusing the same connection
-                // no need to fully teardown.
-                close().done(open);
-            }
+        hideHighlight();
+        
+        // close the current session and begin a new session if the current
+        // document changes to an HTML document that was not loaded yet
+        var wasRequested = agents.network && agents.network.wasURLRequested(doc.url),
+            isViewable = exports.config.experimental || _server.canServe(doc.file.fullPath);
+        
+        if (!wasRequested && isViewable) {
+            // TODO (jasonsanjose): optimize this by reusing the same connection
+            // no need to fully teardown.
+            close().done(open);
         }
     }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -532,7 +532,7 @@ define(function LiveDevelopment(require, exports, module) {
             connected   = Inspector.connected();
 
         $(Inspector.Page).off("frameNavigated.livedev");
-        $(Inspector).off("disconnect.livedev")
+        $(Inspector).off("disconnect.livedev");
 
         unloadAgents();
         

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -213,7 +213,10 @@ define(function LiveDevelopment(require, exports, module) {
         
         if (index !== -1) {
             _relatedDocuments.splice(index, 1);
-            _server.remove(liveDoc);
+            
+            if (_server) {
+                _server.remove(liveDoc);
+            }
         }
     }
 
@@ -266,7 +269,7 @@ define(function LiveDevelopment(require, exports, module) {
         function createLiveStylesheet(url) {
             var stylesheetDeferred  = $.Deferred(),
                 promise             = stylesheetDeferred.promise(),
-                path                = _server.urlToPath(url);
+                path                = _server && _server.urlToPath(url);
 
             // path may be null if loading an external stylesheet
             if (path) {
@@ -998,7 +1001,7 @@ define(function LiveDevelopment(require, exports, module) {
         // close the current session and begin a new session if the current
         // document changes to an HTML document that was not loaded yet
         var wasRequested = agents.network && agents.network.wasURLRequested(doc.url),
-            isViewable = exports.config.experimental || _server.canServe(doc.file.fullPath);
+            isViewable = exports.config.experimental || (_server && _server.canServe(doc.file.fullPath));
         
         if (!wasRequested && isViewable) {
             // TODO (jasonsanjose): optimize this by reusing the same connection

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -641,7 +641,7 @@ define(function (require, exports, module) {
                 // Verify that we get the modified text in memory and not the original text on disk.
                 var originalNode;
                 runs(function () {
-                    originalNode = DOMAgent.nodeAtLocation(388);
+                    originalNode = DOMAgent.nodeAtLocation(396);
                     expect(originalNode.value).toBe("Live Preview in Brackets is awesome!");
                 });
                 
@@ -671,7 +671,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     testWindow.$(LiveDevelopment).off("statusChange", statusChangeHandler);
                     
-                    updatedNode = DOMAgent.nodeAtLocation(388);
+                    updatedNode = DOMAgent.nodeAtLocation(396);
                     var liveDoc = LiveDevelopment.getLiveDocForPath(testPath + "/simple1.css");
                     
                     liveDoc.getSourceFromBrowser().done(function (text) {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -511,10 +511,7 @@ define(function (require, exports, module) {
             
             afterEach(function () {
                 waitsForDone(LiveDevelopment.close(), "Waiting for browser to become inactive", 10000);
-                
-                runs(function () {
-                    testWindow.closeAllFiles();
-                });
+                testWindow.closeAllFiles();
             });
             
             it("should establish a browser connection for an opened html file", function () {
@@ -690,7 +687,7 @@ define(function (require, exports, module) {
                     // Verify that we still have modified text
                     expect(updatedNode.value).toBe("Live Preview in Brackets is awesome!");
                 });
-                    
+                
                 // Save original content back to the file after this test passes/fails
                 runs(function () {
                     htmlDoc.setText(origHtmlText);


### PR DESCRIPTION
Replaces pull #4969

Fixes #4966 and #4972.

Fixes failing unit "in-memory" live dev test where event handlers were not removed properly and caused an error in `RemoteAgent` when trying to communicate with a closed Inspector connection.
