### PR TITLE
Embedded Ruby support - redux

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -11,7 +11,6 @@
         "blockComment": ["/*", "*/"]
     },
 
-
     "scss": {
         "name": "SCSS",
         "mode": ["css", "text/x-scss"],
@@ -123,6 +122,12 @@
         "name": "Ruby",
         "mode": "ruby",
         "fileExtensions": ["rb", "ru", "gemspec", "rake"]
+    },
+
+	"erb": {
+        "name": "Embedded Ruby",
+        "mode": ["htmlembedded", "application/x-erb"],
+        "fileExtensions": ["erb", "erb.html"]
     },
 
     "python": {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -28,7 +28,7 @@
     "scss": {
         "name": "SCSS",
         "mode": ["css", "text/x-scss"],
-        "fileExtensions": ["scss"],
+        "fileExtensions": ["scss", "scss.erb"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -47,10 +47,17 @@
         "blockComment": ["<!--", "-->"]
     },
 
+    "erb_html": {
+        "name": "Embedded Ruby",
+        "mode": ["htmlembedded", "application/x-erb"],
+        "fileExtensions": ["erb", "html.erb", "htm.erb"],
+        "blockComment": ["<!--", "-->"]
+    },
+
     "javascript": {
         "name": "JavaScript",
         "mode": "javascript",
-        "fileExtensions": ["js", "jsx"],
+        "fileExtensions": ["js", "jsx", "js.erb"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -142,12 +149,6 @@
         "name": "Ruby",
         "mode": "ruby",
         "fileExtensions": ["rb", "ru", "gemspec", "rake"]
-    },
-
-    "erb": {
-        "name": "Embedded Ruby",
-        "mode": ["htmlembedded", "application/x-erb"],
-        "fileExtensions": ["erb", "erb.html"]
     },
 
     "python": {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -124,7 +124,7 @@
         "fileExtensions": ["rb", "ru", "gemspec", "rake"]
     },
 
-	"erb": {
+    "erb": {
         "name": "Embedded Ruby",
         "mode": ["htmlembedded", "application/x-erb"],
         "fileExtensions": ["erb", "erb.html"]

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -150,14 +150,14 @@ define(function (require, exports, module) {
                     html    = LanguageManager.getLanguage("html"),
                     unknown = LanguageManager.getLanguage("unknown");
                 
-                expect(LanguageManager.getLanguageForPath("foo.html.erb")).toBe(unknown);
-                expect(LanguageManager.getLanguageForPath("foo.erb")).toBe(unknown);
+                expect(LanguageManager.getLanguageForPath("foo.html.noSuchExt")).toBe(unknown);
+                expect(LanguageManager.getLanguageForPath("foo.noSuchExt")).toBe(unknown);
                 
-                html.addFileExtension("html.erb");
-                ruby.addFileExtension("erb");
+                html.addFileExtension("html.noSuchExt");
+                ruby.addFileExtension("noSuchExt");
                 
-                expect(LanguageManager.getLanguageForPath("foo.html.erb")).toBe(html);
-                expect(LanguageManager.getLanguageForPath("foo.erb")).toBe(ruby);
+                expect(LanguageManager.getLanguageForPath("foo.html.noSuchExt")).toBe(html);
+                expect(LanguageManager.getLanguageForPath("foo.noSuchExt")).toBe(ruby);
             });
             
             it("should map file names to languages", function () {


### PR DESCRIPTION
Includes all the base commits from PR #4320 and addresses the dangling code review comments there, plus a few other tweaks:
- Maps .js.erb to plain JS and .scss.erb to plain SCSS
- Tweak the file extension list for ERB HTML mode -- from what I've seen [and read](https://www.ruby-forum.com/topic/120053), .erb.html isn't really used while the reverse is common.
- Adds block comment support for ERB HTML
- Don't use a generic "erb" language ID, since there are now several outer-language-specific ERB mappings
