### PR TITLE
Fix for 4948: changing tags (based on master)

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -552,8 +552,12 @@ function RemoteFunctions(experimental) {
     DOMEditHandler.prototype._insertChildNode = function (targetElement, childElement, edit) {
         var before = this._queryBracketsID(edit.beforeID),
             after  = this._queryBracketsID(edit.afterID);
-
-        if (edit.firstChild) {
+        
+        if (edit.type === "elementReplace") {
+            // elementReplace is implemented by inserting the new element just before the one
+            // it is replacing.
+            before = this._queryBracketsID(edit.tagID);
+        } else if (edit.firstChild) {
             before = targetElement.firstChild;
         } else if (edit.lastChild) {
             after = targetElement.lastChild;
@@ -565,6 +569,12 @@ function RemoteFunctions(experimental) {
             targetElement.insertBefore(childElement, after.nextSibling);
         } else {
             targetElement.appendChild(childElement);
+        }
+        
+        // There's a special case for replacing an element. Once we've inserted the replacement
+        // before the element that is being replaced, we then remove the replaced element.
+        if (edit.type === "elementReplace") {
+            before.remove();
         }
     };
     
@@ -644,7 +654,7 @@ function RemoteFunctions(experimental) {
                 return;
             }
             
-            targetID = edit.type.match(/textReplace|textDelete|textInsert|elementInsert|elementMove/) ? edit.parentID : edit.tagID;
+            targetID = edit.type.match(/textReplace|textDelete|textInsert|elementInsert|elementMove|elementReplace/) ? edit.parentID : edit.tagID;
             targetElement = self._queryBracketsID(targetID);
             
             if (!targetElement && !editIsSpecialTag) {
@@ -664,6 +674,7 @@ function RemoteFunctions(experimental) {
                 targetElement.remove();
                 break;
             case "elementInsert":
+            case "elementReplace":
                 childElement = null;
                 if (editIsSpecialTag) {
                     // If we already have one of these elements (which we should), then

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -562,8 +562,8 @@ function RemoteFunctions(experimental) {
             }
         }
         
-        if (edit.beforeText && before
-                && before.previousSibling && before.previousSibling.nodeType === Node.TEXT_NODE) {
+        if (edit.beforeText && before &&
+                before.previousSibling && before.previousSibling.nodeType === Node.TEXT_NODE) {
             before = before.previousSibling;
         }
         

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -239,7 +239,7 @@ define(function (require, exports, module) {
                 child = node.children[i];
                 if (child.children) {
                     childHashes += String(child.tagID);
-                    subtreeHashes += String(child.tagID) + child.tag + child.attributeSignature + child.subtreeSignature;
+                    subtreeHashes += String(child.tagID) + child.attributeSignature + child.subtreeSignature;
                 } else {
                     childHashes += child.textSignature;
                     subtreeHashes += child.textSignature;
@@ -1117,20 +1117,15 @@ define(function (require, exports, module) {
             
             /**
              * If there have been elementInserts before an unchanged text, we need to
-             * let the browser side code node that these inserts should happen *before*
+             * let the browser side code know that these inserts should happen *before*
              * that unchanged text.
              */
             var fixupElementInsert = function () {
-                var editIndex = newEdits.length - 1,
-                    edit;
-                
-                while (editIndex >= 0) {
-                    edit = newEdits[editIndex];
+                newEdits.forEach(function (edit) {
                     if (edit.type === "elementInsert") {
                         edit.beforeText = true;
                     }
-                    editIndex--;
-                }
+                });
             };
             
             /**

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -884,6 +884,10 @@ define(function (require, exports, module) {
                 textAfterID;
             
             /**
+             * We initially put new edit objects into the `newEdits` array so that we
+             * can fix them up with proper positioning information. This function is
+             * responsible for doing that fixup.
+             *
              * The `beforeID` that appears in many edits tells the browser to make the
              * change before the element with the given ID. In other words, an
              * elementInsert with a `beforeID` of 32 would result in something like
@@ -899,7 +903,7 @@ define(function (require, exports, module) {
              *
              * @param {int} beforeID ID to set on the pending edits
              */
-            var addBeforeID = function (beforeID) {
+            var finalizeNewEdits = function (beforeID) {
                 newEdits.forEach(function (edit) {
                     // elementDeletes don't need any positioning information
                     if (edit.type !== "elementDelete") {
@@ -1182,7 +1186,7 @@ define(function (require, exports, module) {
                         } else {
                             // Since this element hasn't moved, it is a suitable "beforeID"
                             // for the edits we've logged.
-                            addBeforeID(oldChild.tagID);
+                            finalizeNewEdits(oldChild.tagID);
                             currentIndex++;
                             oldIndex++;
                         }

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -467,11 +467,24 @@ define(function (require, exports, module) {
         return dom;
     };
     
-    SimpleDOMBuilder.prototype.getID = function () {
+    /**
+     * Returns a new tag ID.
+     *
+     * @return {int} unique tag ID
+     */
+    SimpleDOMBuilder.prototype.getNewID = function () {
         return tagID++;
     };
     
-    SimpleDOMBuilder.prototype.getNewID = SimpleDOMBuilder.prototype.getID;
+    /**
+     * Returns the best tag ID for the new tag object given. 
+     * The default implementation just calls `getNewID`
+     * and returns a unique ID.
+     *
+     * @param {Object} newTag tag object to potentially inspect to choose an ID
+     * @return {int} unique tag ID
+     */
+    SimpleDOMBuilder.prototype.getID = SimpleDOMBuilder.prototype.getNewID;
     
     function _buildSimpleDOM(text, strict) {
         var builder = new SimpleDOMBuilder(text);
@@ -596,6 +609,13 @@ define(function (require, exports, module) {
         return !!ancestor;
     }
     
+    /**
+     * Overrides the `getID` method to return the tag ID from the document. If a viable tag
+     * ID cannot be found in the document marks, then a new ID is returned.
+     *
+     * @param {Object} newTag tag object for the current element
+     * @return {int} best ID
+     */
     DOMUpdater.prototype.getID = function (newTag) {
         // TODO: _getTagIDAtDocumentPos is likely a performance bottleneck
         // Get the mark at the start of the tagname (not before the beginning of the tag, because that's
@@ -890,7 +910,7 @@ define(function (require, exports, module) {
              */
             var addBeforeID = function (beforeID) {
                 newEdits.forEach(function (edit) {
-                    // elementDeletes don't need any positioning information
+                    // elementDeletes and elementReplaces don't need any positioning information
                     if (edit.type !== "elementDelete" && edit.type !== "elementReplace") {
                         edit.beforeID = beforeID;
                     }

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -611,7 +611,9 @@ define(function (require, exports, module) {
     
     /**
      * Overrides the `getID` method to return the tag ID from the document. If a viable tag
-     * ID cannot be found in the document marks, then a new ID is returned.
+     * ID cannot be found in the document marks, then a new ID is returned. This will also
+     * assign a new ID if the tag changed between the previous and current versions of this
+     * node.
      *
      * @param {Object} newTag tag object for the current element
      * @return {int} best ID
@@ -625,11 +627,13 @@ define(function (require, exports, module) {
         // If the new tag is in an unmarked range, or the marked range actually corresponds to an
         // ancestor tag, then this must be a newly inserted tag, so give it a new tag ID.
         if (currentTagID === -1 || hasAncestorWithID(newTag, currentTagID)) {
-            currentTagID = tagID++;
+            currentTagID = this.getNewID();
         } else {
+            // If the tag has changed between the previous DOM and the new one, we assign a new ID
+            // so that the old tag will be deleted and the new one inserted.
             var oldNode = this.previousDOM.nodeMap[currentTagID];
             if (!oldNode || oldNode.tag !== newTag.tag) {
-                currentTagID = tagID++;
+                currentTagID = this.getNewID();
             }
         }
         return currentTagID;

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -1115,6 +1115,11 @@ define(function (require, exports, module) {
                 return false;
             };
             
+            /**
+             * If there have been elementInserts before an unchanged text, we need to
+             * let the browser side code node that these inserts should happen *before*
+             * that unchanged text.
+             */
             var fixupElementInsert = function () {
                 var editIndex = newEdits.length - 1,
                     edit;

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -2433,9 +2433,7 @@ define(function (require, exports, module) {
                             editor.document.replaceRange("h3", { line: 13, ch: 25 }, { line: 13, ch: 27 });
                         },
                         function (result, previousDOM, incremental) {
-                            if (incremental) {
-                                return;
-                            }
+                            console.log("Edits", JSON.stringify(result.edits, null, 2));
                             expect(heading.tag).toBe("h2");
                             
                             expect(result.edits.length).toBe(2);
@@ -2451,6 +2449,34 @@ define(function (require, exports, module) {
                                 content: "This is your guide!",
                                 parentID: heading.tagID,
                                 lastChild: true
+                            });
+                        },
+                        false
+                    );
+                });
+            });
+            it("should handle void element tag changes", function () {
+                setupEditor(WellFormedDoc);
+                runs(function () {
+                    doEditTest(
+                        WellFormedDoc,
+                        function (editor, previousDOM) {
+                            editor.document.replaceRange("br", { line: 37, ch: 5 }, { line: 37, ch: 8 });
+                        },
+                        function (result, previousDOM, incremental) {
+                            var br = result.dom.children[3].children[9].children[1];
+                            expect(br.tag).toBe("br");
+                            
+                            expect(result.edits.length).toBe(1);
+                            expect(result.edits[0]).toEqual({
+                                type: "elementReplace",
+                                tagID: br.tagID,
+                                parentID: br.parent.tagID,
+                                attributes: {
+                                    "alt": "A screenshot showing CSS Quick Edit",
+                                    "src": "screenshots/brackets-quick-edit.png"
+                                },
+                                tag: "br"
                             });
                         },
                         false


### PR DESCRIPTION
This is a followup to #4968 and a fix for #4948. With this change, tags can change from one tag to another, including void elements like `<img>`.

To @njx to finish the review
