### PR TITLE
Tweaked active-line highlight colors and selection colors.

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -1,22 +1,22 @@
 
 // Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
-//  
+//
 // Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-//  
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-//  
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 
@@ -24,7 +24,7 @@
  * Brackets Default Theme
  *
  * Defines all the variables that one can configure in a theme. This should
- * contain all variables / mixins for UI styling that we want to be able to 
+ * contain all variables / mixins for UI styling that we want to be able to
  * change in a theme.
  *
  * Throughout the rest of the LESS files we should _only_ use color
@@ -35,7 +35,7 @@
 
 /* Overall Colors */
 
-/* 
+/*
  * Background colors are ordered from least "intense" to most "intense"
  * So, if the background is light, then @background-color-3 should be
  * lightest, -2 should be darker, and -1 should be darker still.
@@ -108,11 +108,11 @@
 @open-working-file-ext-highlight: #8fddff;
 
 /* Selection colors */
-@selection-color-focused: #d2dcf8;
-@selection-color-unfocused: #d9d9d9;
+@selection-color-focused: #e0f0fa;
+@selection-color-unfocused: #e9e9e9;
 
 /* background color of the line that has the cursor */
-@activeline-bgcolor: #e8f2ff;
+@activeline-bgcolor: #e6e9e9;
 
 /* Code font formatting
  *


### PR DESCRIPTION
This is a fix for #4990. The light blue for text selection is now the same as the other light blue that's being used for item selection. 
