### PR TITLE
Working set context menu pops closed when right-clicking file that hasn't been opened yet

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
             }
 
             // reposition the selection triangle
-            $projectTreeContainer.triggerHandler("scroll");
+            $projectTreeContainer.triggerHandler("selectionRedraw");
             
             // in-lieu of resize events, manually trigger contentChanged for every
             // FileViewController focus change. This event triggers scroll shadows

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -275,6 +275,7 @@ define(function (require, exports, module) {
         
         $listElement.on("selectionChanged", updateSelectionMarker);
         $scrollerElement.on("scroll", updateSelectionTriangle);
+        $scrollerElement.on("selectionRedraw", updateSelectionTriangle);
         
         // update immediately
         updateSelectionMarker();


### PR DESCRIPTION
Fix for issue #1910: Working set context menu pops closed when right-clicking file that hasn't been opened yet.
