### PR TITLE
Performance improvements for Live HTML

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -659,23 +659,26 @@ define(function (require, exports, module) {
         var updateIDs = Object.keys(nodeMap),
             cm = this.cm,
             marks = cm.getAllMarks();
-        marks.forEach(function (mark) {
-            if (mark.hasOwnProperty("tagID") && nodeMap[mark.tagID]) {
-                var node = nodeMap[mark.tagID];
-                mark.clear();
-                mark = cm.markText(node.startPos, node.endPos);
-                mark.tagID = node.tagID;
-                updateIDs.splice(updateIDs.indexOf(node.tagID), 1);
-            }
-        });
         
-        // Any remaining updateIDs are new.
-        updateIDs.forEach(function (id) {
-            var node = nodeMap[id], mark;
-            if (node.children) {
-                mark = cm.markText(node.startPos, node.endPos);
-                mark.tagID = Number(id);
-            }
+        cm.operation(function () {
+            marks.forEach(function (mark) {
+                if (mark.hasOwnProperty("tagID") && nodeMap[mark.tagID]) {
+                    var node = nodeMap[mark.tagID];
+                    mark.clear();
+                    mark = cm.markText(node.startPos, node.endPos);
+                    mark.tagID = node.tagID;
+                    updateIDs.splice(updateIDs.indexOf(node.tagID), 1);
+                }
+            });
+            
+            // Any remaining updateIDs are new.
+            updateIDs.forEach(function (id) {
+                var node = nodeMap[id], mark;
+                if (node.children) {
+                    mark = cm.markText(node.startPos, node.endPos);
+                    mark.tagID = Number(id);
+                }
+            });
         });
     };
     

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -537,7 +537,7 @@ define(function (require, exports, module) {
      */
     function _markTags(cm, node) {
         node.children.forEach(function (childNode) {
-            if (childNode.tag) {
+            if (childNode.children) {
                 _markTags(cm, childNode);
             }
         });
@@ -671,9 +671,11 @@ define(function (require, exports, module) {
         
         // Any remaining updateIDs are new.
         updateIDs.forEach(function (id) {
-            var node = nodeMap[id],
+            var node = nodeMap[id], mark;
+            if (node.children) {
                 mark = cm.markText(node.startPos, node.endPos);
-            mark.tagID = Number(id);
+                mark.tagID = Number(id);
+            }
         });
     };
     

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -33,48 +33,78 @@ define(function (require, exports, module) {
     
     describe("HTML Tokenizer", function () {
         it("should handle tags and text", function () {
-            var t = new Tokenizer("<html><body>Hello</body></html>");
+            var t = new Tokenizer("<html>\n<body>Hello</body>\n</html>");
             expect(t.nextToken()).toEqual({
                 type: "opentagname",
                 contents: "html",
                 start: 1,
-                end: 5
+                end: 5,
+                startPos: {line: 0, ch: 1},
+                endPos: {line: 0, ch: 5}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagend",
                 contents: "",
                 start: -1,
-                end: 6
+                end: 6,
+                startPos: null,
+                endPos: {line: 0, ch: 6}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "\n",
+                start: 6,
+                end: 7,
+                startPos: {line: 0, ch: 6},
+                endPos: {line: 1, ch: 0}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagname",
                 contents: "body",
-                start: 7,
-                end: 11
+                start: 8,
+                end: 12,
+                startPos: {line: 1, ch: 1},
+                endPos: {line: 1, ch: 5}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagend",
                 contents: "",
                 start: -1,
-                end: 12
+                end: 13,
+                startPos: null,
+                endPos: {line: 1, ch: 6}
             });
             expect(t.nextToken()).toEqual({
                 type: "text",
                 contents: "Hello",
-                start: 12,
-                end: 17
+                start: 13,
+                end: 18,
+                startPos: {line: 1, ch: 6},
+                endPos: {line: 1, ch: 11}
             });
             expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "body",
-                start: 19,
-                end: 23
+                start: 20,
+                end: 24,
+                startPos: {line: 1, ch: 13},
+                endPos: {line: 1, ch: 17}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "\n",
+                start: 25,
+                end: 26,
+                startPos: {line: 1, ch: 18},
+                endPos: {line: 2, ch: 0}
             });
             expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "html",
-                start: 26,
-                end: 30
+                start: 28,
+                end: 32,
+                startPos: {line: 2, ch: 2},
+                endPos: {line: 2, ch: 6}
             });
         });
         
@@ -84,51 +114,167 @@ define(function (require, exports, module) {
                 type: "opentagname",
                 contents: "div",
                 start: 1,
-                end: 4
+                end: 4,
+                startPos: {line: 0, ch: 1},
+                endPos: {line: 0, ch: 4}
             });
             expect(t.nextToken()).toEqual({
                 type: "attribname",
                 contents: "class",
                 start: 5,
-                end: 10
+                end: 10,
+                startPos: {line: 0, ch: 5},
+                endPos: {line: 0, ch: 10}
             });
             expect(t.nextToken()).toEqual({
                 type: "attribvalue",
                 contents: "foo bar",
                 start: 12,
-                end: 19
+                end: 19,
+                startPos: {line: 0, ch: 12},
+                endPos: {line: 0, ch: 19}
             });
             expect(t.nextToken()).toEqual({
                 type: "attribname",
                 contents: "style",
                 start: 21,
-                end: 26
+                end: 26,
+                startPos: {line: 0, ch: 21},
+                endPos: {line: 0, ch: 26}
             });
             expect(t.nextToken()).toEqual({
                 type: "attribvalue",
                 contents: "baz: quux",
                 start: 28,
-                end: 37
+                end: 37,
+                startPos: {line: 0, ch: 28},
+                endPos: {line: 0, ch: 37}
             });
             expect(t.nextToken()).toEqual({
                 type: "attribname",
                 contents: "checked",
                 start: 39,
-                end: 46
+                end: 46,
+                startPos: {line: 0, ch: 39},
+                endPos: {line: 0, ch: 46}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagend",
                 contents: "",
                 start: -1,
-                end: 47
+                end: 47,
+                startPos: null,
+                endPos: {line: 0, ch: 47}
             });
             expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "div",
                 start: 49,
-                end: 52
+                end: 52,
+                startPos: {line: 0, ch: 49},
+                endPos: {line: 0, ch: 52}
             });
             expect(t.nextToken()).toEqual(null);
+        });
+        
+        it("should handle various newline cases", function () {
+            var t = new Tokenizer("<div \n    class='foo'\n    checked>\n    some text\n    with a newline\n    <br/>\n<!--multiline\ncomment-->\n</div>");
+            expect(t.nextToken()).toEqual({
+                type: "opentagname",
+                contents: "div",
+                start: 1,
+                end: 4,
+                startPos: {line: 0, ch: 1},
+                endPos: {line: 0, ch: 4}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "attribname",
+                contents: "class",
+                start: 10,
+                end: 15,
+                startPos: {line: 1, ch: 4},
+                endPos: {line: 1, ch: 9}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "attribvalue",
+                contents: "foo",
+                start: 17,
+                end: 20,
+                startPos: {line: 1, ch: 11},
+                endPos: {line: 1, ch: 14}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "attribname",
+                contents: "checked",
+                start: 26,
+                end: 33,
+                startPos: {line: 2, ch: 4},
+                endPos: {line: 2, ch: 11}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "opentagend",
+                contents: "",
+                start: -1,
+                end: 34,
+                startPos: null,
+                endPos: {line: 2, ch: 12}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "\n    some text\n    with a newline\n    ",
+                start: 34,
+                end: 72,
+                startPos: {line: 2, ch: 12},
+                endPos: {line: 5, ch: 4}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "opentagname",
+                contents: "br",
+                start: 73,
+                end: 75,
+                startPos: {line: 5, ch: 5},
+                endPos: {line: 5, ch: 7}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "selfclosingtag",
+                contents: "",
+                start: -1,
+                end: 77,
+                startPos: null,
+                endPos: {line: 5, ch: 9}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "\n",
+                start: 77,
+                end: 78,
+                startPos: {line: 5, ch: 9},
+                endPos: {line: 6, ch: 0}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "comment",
+                contents: "multiline\ncomment",
+                start: 82,
+                end: 99,
+                startPos: {line: 6, ch: 4},
+                endPos: {line: 7, ch: 7}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "text",
+                contents: "\n",
+                start: 102,
+                end: 103,
+                startPos: {line: 7, ch: 10},
+                endPos: {line: 8, ch: 0}
+            });
+            expect(t.nextToken()).toEqual({
+                type: "closetag",
+                contents: "div",
+                start: 105,
+                end: 108,
+                startPos: {line: 8, ch: 2},
+                endPos: {line: 8, ch: 5}
+            });
         });
         
         it("should notify of explicit shorttags like <br/>", function () {
@@ -137,37 +283,49 @@ define(function (require, exports, module) {
                 type: "opentagname",
                 contents: "p",
                 start: 1,
-                end: 2
+                end: 2,
+                startPos: {line: 0, ch: 1},
+                endPos: {line: 0, ch: 2}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagend",
                 contents: "",
                 start: -1,
-                end: 3
+                end: 3,
+                startPos: null,
+                endPos: {line: 0, ch: 3}
             });
             expect(t.nextToken()).toEqual({
                 type: "text",
                 contents: "hello",
                 start: 3,
-                end: 8
+                end: 8,
+                startPos: {line: 0, ch: 3},
+                endPos: {line: 0, ch: 8}
             });
             expect(t.nextToken()).toEqual({
                 type: "opentagname",
                 contents: "br",
                 start: 9,
-                end: 11
+                end: 11,
+                startPos: {line: 0, ch: 9},
+                endPos: {line: 0, ch: 11}
             });
             expect(t.nextToken()).toEqual({
                 type: "selfclosingtag",
                 contents: "",
                 start: -1,
-                end: 13
+                end: 13,
+                startPos: null,
+                endPos: {line: 0, ch: 13}
             });
             expect(t.nextToken()).toEqual({
                 type: "closetag",
                 contents: "p",
                 start: 15,
-                end: 16
+                end: 16,
+                startPos: {line: 0, ch: 15},
+                endPos: {line: 0, ch: 16}
             });
         });
         
@@ -177,7 +335,9 @@ define(function (require, exports, module) {
                 type: "comment",
                 contents: "very important",
                 start: 4,
-                end: 18
+                end: 18,
+                startPos: {line: 0, ch: 4},
+                endPos: {line: 0, ch: 18}
             });
         });
         


### PR DESCRIPTION
Greatly improves structural edit times in large documents during live HTML editing by:
- caching mark ranges (because `mark.find()` is slow on large ranges)
- calculating line/ch positions during tokenizer/parsing instead of relying on `cm.posFromIndex()`, which is slow in large documents

@dangoor
