### PR TITLE
Rearrange & regroup EditorCommandHandler tests

### DIFF
--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2548,21 +2548,22 @@ define(function (require, exports, module) {
 
         
         describe("EditorCommandHandlers Integration", function () {
-        
+            this.category = "integration";
+            
+            beforeFirst(function () {
+                createTestWindow(this);
+            });
+            
+            afterLast(function () {
+                closeTestWindow();
+            });
+            
+            
             describe("Move Lines Up/Down - inline editor", function () {
-                this.category = "integration";
                 
                 var moveContent = ".testClass {\n" +
                                   "    color: red;\n" +
                                   "}";
-                
-                beforeFirst(function () {
-                    createTestWindow(this);
-                });
-                
-                afterLast(function () {
-                    closeTestWindow();
-                });
                 
                 beforeEach(function () {
                     openInlineEditor(this);
@@ -2626,19 +2627,10 @@ define(function (require, exports, module) {
         
         
             describe("Open Line Above and Below - inline editor", function () {
-                this.category = "integration";
                 
                 var content = ".testClass {\n" +
                               "    color: red;\n" +
                               "}";
-                
-                beforeFirst(function () {
-                    createTestWindow(this);
-                });
-                
-                afterLast(function () {
-                    closeTestWindow();
-                });
                 
                 beforeEach(function () {
                     openInlineEditor(this);

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2125,82 +2125,6 @@ define(function (require, exports, module) {
         });
 
         
-        describe("Move Lines Up/Down - inline editor", function () {
-            this.category = "integration";
-            
-            var moveContent = ".testClass {\n" +
-                              "    color: red;\n" +
-                              "}";
-            
-            beforeFirst(function () {
-                createTestWindow(this);
-            });
-            
-            afterLast(function () {
-                closeTestWindow();
-            });
-            
-            beforeEach(function () {
-                openInlineEditor(this);
-            });
-            
-            afterEach(function () {
-                closeFilesInTestWindow();
-            });
-            
-            
-            it("should not move the first line of the inline editor up", function () {
-                myEditor.setCursorPos({line: 0, ch: 5});
-                CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
-                
-                expect(myEditor.document.getText()).toEqual(moveContent);
-                expect(myEditor._codeMirror.doc.historySize().undo).toBe(0);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(2);
-            });
-            
-            it("should not move the last line of the inline editor down", function () {
-                myEditor.setCursorPos({line: 2, ch: 5});
-                CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
-                
-                expect(myEditor.document.getText()).toEqual(moveContent);
-                expect(myEditor._codeMirror.doc.historySize().undo).toBe(0);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(2);
-            });
-            
-            it("should be able to move the second to last line of the inline editor down", function () {
-                myEditor.setCursorPos({line: 1, ch: 5});
-                CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
-                
-                var lines = moveContent.split("\n");
-                var temp = lines[1];
-                lines[1] = lines[2];
-                lines[2] = temp;
-                var expectedText = lines.join("\n");
-                
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(2);
-            });
-            
-            it("should be able to move the last line of the inline editor up", function () {
-                myEditor.setCursorPos({line: 2, ch: 0});
-                CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
-                
-                var lines = moveContent.split("\n");
-                var temp = lines[1];
-                lines[1] = lines[2];
-                lines[2] = temp;
-                var expectedText = lines.join("\n");
-                
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(2);
-            });
-        });
-        
-        
         describe("Delete Line", function () {
             beforeEach(setupFullEditor);
             
@@ -2623,106 +2547,185 @@ define(function (require, exports, module) {
         });
 
         
-        describe("Open Line Above and Below - inline editor", function () {
-            this.category = "integration";
-            
-            var content = ".testClass {\n" +
-                          "    color: red;\n" +
-                          "}";
-            
-            beforeFirst(function () {
-                createTestWindow(this);
+        describe("EditorCommandHandlers Integration", function () {
+        
+            describe("Move Lines Up/Down - inline editor", function () {
+                this.category = "integration";
+                
+                var moveContent = ".testClass {\n" +
+                                  "    color: red;\n" +
+                                  "}";
+                
+                beforeFirst(function () {
+                    createTestWindow(this);
+                });
+                
+                afterLast(function () {
+                    closeTestWindow();
+                });
+                
+                beforeEach(function () {
+                    openInlineEditor(this);
+                });
+                
+                afterEach(function () {
+                    closeFilesInTestWindow();
+                });
+                
+                
+                it("should not move the first line of the inline editor up", function () {
+                    myEditor.setCursorPos({line: 0, ch: 5});
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                    
+                    expect(myEditor.document.getText()).toEqual(moveContent);
+                    expect(myEditor._codeMirror.doc.historySize().undo).toBe(0);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(2);
+                });
+                
+                it("should not move the last line of the inline editor down", function () {
+                    myEditor.setCursorPos({line: 2, ch: 5});
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                    
+                    expect(myEditor.document.getText()).toEqual(moveContent);
+                    expect(myEditor._codeMirror.doc.historySize().undo).toBe(0);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(2);
+                });
+                
+                it("should be able to move the second to last line of the inline editor down", function () {
+                    myEditor.setCursorPos({line: 1, ch: 5});
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                    
+                    var lines = moveContent.split("\n");
+                    var temp = lines[1];
+                    lines[1] = lines[2];
+                    lines[2] = temp;
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(2);
+                });
+                
+                it("should be able to move the last line of the inline editor up", function () {
+                    myEditor.setCursorPos({line: 2, ch: 0});
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                    
+                    var lines = moveContent.split("\n");
+                    var temp = lines[1];
+                    lines[1] = lines[2];
+                    lines[2] = temp;
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(2);
+                });
             });
-            
-            afterLast(function () {
-                closeTestWindow();
-            });
-            
-            beforeEach(function () {
-                openInlineEditor(this);
-            });
-            
-            afterEach(function () {
-                closeFilesInTestWindow();
-            });
-            
-
-            it("should insert new line above the first line of the inline editor", function () {
-                myEditor.setSelection({line: 0, ch: 4}, {line: 0, ch: 6});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+        
+        
+            describe("Open Line Above and Below - inline editor", function () {
+                this.category = "integration";
                 
-                var lines = content.split("\n");
-                lines.splice(0, 0, "");
-                var expectedText = lines.join("\n");
+                var content = ".testClass {\n" +
+                              "    color: red;\n" +
+                              "}";
                 
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
-            });
-            
-            it("should insert new line below the first line of the inline editor", function () {
-                myEditor.setCursorPos({line: 0, ch: 3});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                beforeFirst(function () {
+                    createTestWindow(this);
+                });
                 
-                var lines = content.split("\n");
-                lines.splice(1, 0, "    ");
-                var expectedText = lines.join("\n");
+                afterLast(function () {
+                    closeTestWindow();
+                });
                 
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
-            });
-            
-            it("should insert new line above the last line of the inline editor", function () {
-                myEditor.setSelection({line: 2, ch: 0}, {line: 2, ch: 1});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                beforeEach(function () {
+                    openInlineEditor(this);
+                });
                 
-                var lines = content.split("\n");
-                lines.splice(2, 0, "    ");
-                var expectedText = lines.join("\n");
+                afterEach(function () {
+                    closeFilesInTestWindow();
+                });
                 
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
-            });
-
-            it("should insert new line below the last line of the inline editor", function () {
-                myEditor.setCursorPos({line: 3, ch: 0});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+    
+                it("should insert new line above the first line of the inline editor", function () {
+                    myEditor.setSelection({line: 0, ch: 4}, {line: 0, ch: 6});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(0, 0, "");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
                 
-                var lines = content.split("\n");
-                lines.splice(3, 0, "");
-                var expectedText = lines.join("\n");
+                it("should insert new line below the first line of the inline editor", function () {
+                    myEditor.setCursorPos({line: 0, ch: 3});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(1, 0, "    ");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
                 
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
-            });
-            
-            it("should insert new indented line above the second line of the inline editor", function () {
-                myEditor.setCursorPos({line: 1, ch: 5});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                it("should insert new line above the last line of the inline editor", function () {
+                    myEditor.setSelection({line: 2, ch: 0}, {line: 2, ch: 1});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(2, 0, "    ");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
+    
+                it("should insert new line below the last line of the inline editor", function () {
+                    myEditor.setCursorPos({line: 3, ch: 0});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(3, 0, "");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
                 
-                var lines = content.split("\n");
-                lines.splice(1, 0, "    ");
-                var expectedText = lines.join("\n");
+                it("should insert new indented line above the second line of the inline editor", function () {
+                    myEditor.setCursorPos({line: 1, ch: 5});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(1, 0, "    ");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
                 
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
-            });
-            
-            it("should insert new indented line below the second line of the inline editor", function () {
-                myEditor.setCursorPos({line: 1, ch: 5});
-                CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
-                
-                var lines = content.split("\n");
-                lines.splice(2, 0, "    ");
-                var expectedText = lines.join("\n");
-                
-                expect(myEditor.document.getText()).toEqual(expectedText);
-                expect(myEditor.getFirstVisibleLine()).toBe(0);
-                expect(myEditor.getLastVisibleLine()).toBe(3);
+                it("should insert new indented line below the second line of the inline editor", function () {
+                    myEditor.setCursorPos({line: 1, ch: 5});
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = content.split("\n");
+                    lines.splice(2, 0, "    ");
+                    var expectedText = lines.join("\n");
+                    
+                    expect(myEditor.document.getText()).toEqual(expectedText);
+                    expect(myEditor.getFirstVisibleLine()).toBe(0);
+                    expect(myEditor.getLastVisibleLine()).toBe(3);
+                });
             });
         });
     });


### PR DESCRIPTION
This is for problem discussed here: https://groups.google.com/forum/?fromgroups#!topic/brackets-dev/1K6s_HWD06E

I move one of the "category: integration" group down to be next to the other "category: integration" group, and then wrapped a describe() block around all of them (unfortunately, the diff makes it look more complicated than that -- probably because of the indenting that was introduced).
