### PR TITLE
Make undo/redo work in inline color editor.

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -820,7 +820,7 @@ define(function (require, exports, module) {
     }
 
     function handleUndoRedo(operation) {
-        var editor = EditorManager.getFocusedEditor();
+        var editor = EditorManager.getActiveEditor();
         var result = new $.Deferred();
         
         if (editor) {


### PR DESCRIPTION
When Undo/Redo is invoked from Edit menu, we need to use EditorManager.getActiveEditor() to get the actual editor that we want to perform the action. In the case of Inline Color Editor we want to restore the color value in the main editor and EditorManager.getActiveEditor() returns the main editor whereas EditorManager.getFocusedEditor() returns null since Inline Color Editor is not a text editor. Switching to getActiveEditor() has no differences for a text-based inline editor.
