### PR TITLE
Redraw HTML highlights when toggled off/on

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -155,7 +155,7 @@ define(function HTMLDocumentModule(require, exports, module) {
             return;
         }
         this.updateHighlight();
-    }
+    };
     
     /**
      * @private

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -129,15 +129,9 @@ define(function HTMLDocumentModule(require, exports, module) {
 
         $(this.editor).off("change", this.onChange);
     };
-
-
-    /** Event Handlers *******************************************************/
-
-    /** Triggered on cursor activity by the editor */
-    HTMLDocument.prototype.onCursorActivity = function onCursorActivity(event, editor) {
-        if (!this.editor) {
-            return;
-        }
+    
+    /** Update the highlight */
+    HTMLDocument.prototype.updateHighlight = function () {
         var codeMirror = this.editor._codeMirror;
         if (Inspector.config.highlight) {
             var tagID = HTMLInstrumentation._getTagIDAtDocumentPos(
@@ -152,6 +146,16 @@ define(function HTMLDocumentModule(require, exports, module) {
             }
         }
     };
+
+    /** Event Handlers *******************************************************/
+
+    /** Triggered on cursor activity by the editor */
+    HTMLDocument.prototype.onCursorActivity = function onCursorActivity(event, editor) {
+        if (!this.editor) {
+            return;
+        }
+        this.updateHighlight();
+    }
     
     /**
      * @private

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -966,7 +966,7 @@ define(function LiveDevelopment(require, exports, module) {
     function showHighlight() {
         var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
         
-        if (doc instanceof CSSDocument) {
+        if (doc.updateHighlight) {
             doc.updateHighlight();
         }
     }


### PR DESCRIPTION
Fix for #4497 

Call `updateHighlight()` for all document types, not just CSS. Refactor HTMLDocument to add `updateHighlight()` method.
