### PR TITLE
Remove authentication source (e.g. github) from Extension Manager display and search

### DIFF
--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -254,6 +254,13 @@ define(function (require, exports, module) {
                     return cur.some(function (keyword) {
                         return keyword.toLowerCase().indexOf(query) !== -1;
                     });
+                } else if (fieldSpec[fieldSpec.length - 1] === "owner") {
+                    // Special handling: ignore the authentication source when querying,
+                    // since it's not useful to search on
+                    var components = cur.split(":");
+                    if (components[1].toLowerCase().indexOf(query) !== -1) {
+                        return true;
+                    }
                 } else if (cur.toLowerCase().indexOf(query) !== -1) {
                     return true;
                 }

--- a/src/extensibility/registry_utils.js
+++ b/src/extensibility/registry_utils.js
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
         var friendlyName;
         if (this.owner) {
             var nameComponents = this.owner.split(":");
-            friendlyName = nameComponents[1] + " (" + nameComponents[0] + ")";
+            friendlyName = nameComponents[1];
         }
         return friendlyName;
     };

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -691,10 +691,8 @@ define(function (require, exports, module) {
                                 }
                             });
                             
-                            // Owner--should show the parts, but might format them separately
-                            item.owner.split(":").forEach(function (part) {
-                                expect(view).toHaveText(part);
-                            });
+                            // Owner--should show only the owner name, not the authenticator
+                            expect(view).toHaveText(item.owner.split(":")[1]);
                         });
                     });
                 });
@@ -706,10 +704,8 @@ define(function (require, exports, module) {
                         console.log(view);
                         CollectionUtils.forEach(JSON.parse(mockExtensionList), function (item) {
                             if (item.installInfo && item.registryInfo) {
-                                // Owner--should show the parts, but might format them separately
-                                item.registryInfo.owner.split(":").forEach(function (part) {
-                                    expect(view).toHaveText(part);
-                                });
+                                // Owner--should show only the owner name, not the authenticator
+                                expect(view).toHaveText(item.registryInfo.owner.split(":")[1]);
                             }
                         });
                     });


### PR DESCRIPTION
I decided to go ahead and remove it in `registry_utils` since it doesn't seem that useful on the actual registry site either. I'll submit a pull request to brackets-registry to keep its version in sync.

@dangoor 
