### PR TITLE
Cleanup unit tests temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ src/extensions/disabled
 .DS_Store
 
 # unit test working directory
-test/temp
 test/results
 
 # Netbeans

--- a/test/BootstrapReporterView.js
+++ b/test/BootstrapReporterView.js
@@ -108,6 +108,9 @@ define(function (require, exports, module) {
         var topLevelData,
             self = this;
 
+        // Make sure we don't have a temp folder when we start....
+        SpecRunnerUtils.removeTempDirectory();
+        
         // create top level suite list navigation
         this._createSuiteList(reporter.suites, reporter.sortedNames, reporter.totalSpecCount);
         
@@ -129,6 +132,9 @@ define(function (require, exports, module) {
     };
     
     BootstrapReporterView.prototype._handleRunnerEnd = function (event, reporter) {
+        // Make sure we don't have a temp folder when we're finished....
+        SpecRunnerUtils.removeTempDirectory();
+
         if (this.$info) {
             this.$info.toggleClass("alert-info", false);
             

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -102,15 +102,7 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
-            runs(function () {
-                // Restore directory permissions
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_read_here", "777"), "reset permissions");
-                waitsForDone(SpecRunnerUtils.chmod(baseDir + "/cant_write_here", "777"), "reset permissions");
-            });
-            runs(function () {
-                // Remove the test data and anything else left behind from tests
-                waitsForDone(SpecRunnerUtils.deletePath(baseDir), "delete temp files");
-            });
+            SpecRunnerUtils.removeTempDirectory();
         });
 
         it("should have a brackets.fs namespace", function () {


### PR DESCRIPTION
This PR Fixes #4971
- Add calls and functions to remove test/temp folder
- make remove temp folder from list of ignoreds
- Add an optional parameter to deletePath to surpress error messages
