### PR TITLE
Fix keybinding errant error message

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -448,6 +448,7 @@ define(function (require, exports, module) {
             if (isWindowsCompatible || isReplaceGeneric) {
                 bindingsToDelete.push(binding);
             } else {
+                // existing binding is platform-specific and the requested binding is generic
                 ignoreGeneric = binding.explicitPlatform && !explicitPlatform;
             }
         });
@@ -540,10 +541,12 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
+     *
      * Sort objects by platform property. Objects with a platform property come
      * before objects without a platform property.
      */
-    function sortByPlatform(a, b) {
+    function _sortByPlatform(a, b) {
         var a1 = (a.platform) ? 1 : 0,
             b1 = (b.platform) ? 1 : 0;
         return b1 - a1;
@@ -586,7 +589,7 @@ define(function (require, exports, module) {
             results = [];
 
             // process platform-specific bindings first
-            keyBindings.sort(sortByPlatform);
+            keyBindings.sort(_sortByPlatform);
             
             keyBindings.forEach(function addSingleBinding(keyBindingRequest) {
                 // attempt to add keybinding

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -349,7 +349,9 @@ define(function (require, exports, module) {
      *
      * @param {string} commandID
      * @param {string|{{key: string, displayKey: string}}} keyBinding - a single shortcut.
-     * @param {?string} platform - undefined indicates all platforms
+     * @param {?string} platform
+     *     - "all" indicates all platforms, not overridable
+     *     - undefined indicates all platforms, overridden by platform-specific binding
      * @return {?{key: string, displayKey:String}} Returns a record for valid key bindings.
      *     Returns null when key binding platform does not match, binding does not normalize,
      *     or is already assigned.
@@ -360,15 +362,22 @@ define(function (require, exports, module) {
             normalized,
             normalizedDisplay,
             explicitPlatform = keyBinding.platform || platform,
-            targetPlatform = explicitPlatform || brackets.platform,
+            targetPlatform,
             command,
             bindingsToDelete = [],
             existing;
+
+        // For platform: "all", use explicit current plaform
+        if (explicitPlatform && explicitPlatform !== "all") {
+            targetPlatform = explicitPlatform;
+        } else {
+            targetPlatform = brackets.platform;
+        }
         
         // if the request does not specify an explicit platform, and we're
         // currently on a mac, then replace Ctrl with Cmd.
         key = (keyBinding.key) || keyBinding;
-        if (brackets.platform === "mac" && explicitPlatform === undefined) {
+        if (brackets.platform === "mac" && (explicitPlatform === undefined || explicitPlatform === "all")) {
             key = key.replace("Ctrl", "Cmd");
             if (keyBinding.displayKey !== undefined) {
                 keyBinding.displayKey = keyBinding.displayKey.replace("Ctrl", "Cmd");
@@ -392,8 +401,9 @@ define(function (require, exports, module) {
             if (explicitPlatform === "win") {
                 // search for a generic or platform-specific binding if it
                 // already exists
-                if (existing &&
-                        (!existing.explicitPlatform || existing.explicitPlatform === brackets.platform)) {
+                if (existing && (!existing.explicitPlatform ||
+                                 existing.explicitPlatform === brackets.platform ||
+                                 existing.explicitPlatform === "all")) {
                     // do not clobber existing binding with windows-only binding
                     return null;
                 }

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -137,14 +137,17 @@ define(function (require, exports, module) {
                 // use a fake platform
                 brackets.platform = "test1";
                 
-                var results = KeyBindingManager.addBinding("test.foo", [{key: "Ctrl-A", platform: "test1"}, "Ctrl-1"]);
+                var results = KeyBindingManager.addBinding(
+                    "test.foo",
+                    [ {key: "Ctrl-A", platform: "test1"}, {key: "Ctrl-1", platform: "all"} ]
+                );
                 expect(results).toEqual([
                     key("Ctrl-A", null, "test1"),
-                    key("Ctrl-1")
+                    key("Ctrl-1", null, "all")
                 ]);
                 expect(KeyBindingManager.getKeyBindings("test.foo")).toEqual([
                     key("Ctrl-A", null, "test1"),
-                    key("Ctrl-1")
+                    key("Ctrl-1", null, "all")
                 ]);
                 
                 results = KeyBindingManager.addBinding("test.bar", [{key: "Ctrl-B"}, {key: "Ctrl-2", platform: "test2"}]);
@@ -158,7 +161,7 @@ define(function (require, exports, module) {
                 // only "test1" platform and cross-platform bindings
                 var expected = keyMap([
                     keyBinding("Ctrl-A", "test.foo", null, "test1"),
-                    keyBinding("Ctrl-1", "test.foo"),
+                    keyBinding("Ctrl-1", "test.foo", null, "all"),
                     keyBinding("Ctrl-B", "test.bar")
                 ]);
                 


### PR DESCRIPTION
This is for #4265. See [Peter Flynn's comment](https://github.com/adobe/brackets/issues/4265#issuecomment-23831957) for a good summary of the goal.

Logically, the code was already doing most of what is desired (all except PeterF's last point). The problem was that keybinding being reported as an error was a generic (no platform specified) keybinding being temporarily inserted into the keybinding table (and would have correctly been removed in a subsequent pass), but unfortunately conflicted with the keybinding of another command.

To fix this I changed 2 things:
1. Sort keybindings for command to insert platform-specific bindings first (which are never overridden), followed by the generic keybindings (which may be overridden). This prevents keybindings from being inserted which will later be removed. (Note might be able to cleanup some keybinding removal code here).
2. Delay declaring an error until command-specific keybindings are checked for overrides.

I also implemented **platform: "all"** as described in Peter's last point. Note that there are no cases in `keyboard.json` that require this, but it's required to fix a unit test.
