### PR TITLE
Provide Quick Docs for SCSS.

### DIFF
--- a/src/extensions/default/WebPlatformDocs/main.js
+++ b/src/extensions/default/WebPlatformDocs/main.js
@@ -84,9 +84,9 @@ define(function (require, exports, module) {
      * @return {?$.Promise} resolved with an InlineWidget; null if we're not going to provide anything
      */
     function inlineProvider(hostEditor, pos) {
+        var langId = hostEditor.getLanguageForSelection().getId();
         // Only provide docs when cursor is in CSS content
-        if (hostEditor.getLanguageForSelection().getId() !== "css" &&
-                hostEditor.getLanguageForSelection().getId() !== "scss") {
+        if (langId !== "css" && langId !== "scss") {
             return null;
         }
         

--- a/src/extensions/default/WebPlatformDocs/main.js
+++ b/src/extensions/default/WebPlatformDocs/main.js
@@ -85,7 +85,8 @@ define(function (require, exports, module) {
      */
     function inlineProvider(hostEditor, pos) {
         // Only provide docs when cursor is in CSS content
-        if (hostEditor.getLanguageForSelection().getId() !== "css") {
+        if (hostEditor.getLanguageForSelection().getId() !== "css" &&
+                hostEditor.getLanguageForSelection().getId() !== "scss") {
             return null;
         }
         


### PR DESCRIPTION
Just like providing CSS code hints for SCSS, we can also provide Quick Docs for SCSS since we already have the required code in CSSUtils.
