### PR TITLE
Make code hint insertion on tab key configurable

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -376,7 +376,7 @@ define(function (require, exports, module) {
                 _rotateSelection.call(this, _itemsPerPage());
             } else if (this.selectedIndex !== -1 &&
                     (keyCode === KeyEvent.DOM_VK_RETURN ||
-                    (keyCode === KeyEvent.DOM_VK_TAB && self.insertHintOnTab))) {
+                    (keyCode === KeyEvent.DOM_VK_TAB && this.insertHintOnTab))) {
                 // Trigger a click handler to commmit the selected item
                 $(this.$hintMenu.find("li")[this.selectedIndex]).trigger("click");
             } else {

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
      * @constructor
      * @param {Editor} editor
      */
-    function CodeHintList(editor) {
+    function CodeHintList(editor, insertHintOnTab) {
 
         /**
          * The list of hints to display
@@ -79,6 +79,13 @@ define(function (require, exports, module) {
          * @type {Editor}
          */
         this.editor = editor;
+        
+        /**
+         * Whether the currently selected hint should be inserted on a tab key event
+         *
+         * @type {boolean}
+         */
+        this.insertHintOnTab = insertHintOnTab;
 
         /**
          * The hint selection callback function
@@ -276,8 +283,8 @@ define(function (require, exports, module) {
     CodeHintList.prototype.isHandlingKeyCode = function (keyCode) {
         return (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_DOWN ||
                 keyCode === KeyEvent.DOM_VK_PAGE_UP || keyCode === KeyEvent.DOM_VK_PAGE_DOWN ||
-                keyCode === KeyEvent.DOM_VK_RETURN);
-        
+                keyCode === KeyEvent.DOM_VK_RETURN ||
+                (keyCode === KeyEvent.DOM_VK_TAB && this.insertHintOnTab));
     };
 
     /**
@@ -368,7 +375,8 @@ define(function (require, exports, module) {
             } else if (keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
                 _rotateSelection.call(this, _itemsPerPage());
             } else if (this.selectedIndex !== -1 &&
-                    (keyCode === KeyEvent.DOM_VK_RETURN)) {
+                    (keyCode === KeyEvent.DOM_VK_RETURN ||
+                    (keyCode === KeyEvent.DOM_VK_TAB && self.insertHintOnTab))) {
                 // Trigger a click handler to commmit the selected item
                 $(this.$hintMenu.find("li")[this.selectedIndex]).trigger("click");
             } else {

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -256,7 +256,7 @@ define(function (require, exports, module) {
      * setInsertHintOnTab(true) indicates that the currently selected code hint
      * should be inserted on tab key events. setInsertHintOnTab(false) indicates
      * that a tab character should be inserted into the editor on tab key events.
-     * The default behavior can be can be overridden by individual providers.
+     * The default behavior can be overridden by individual providers.
      *
      * @param {boolean} Indicates whether providers should insert the currently
      *      selected hint on tab key events.

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -212,6 +212,17 @@
  * return {boolean} 
  * Indicates whether the manager should follow hint insertion with an
  * explicit hint request.
+ *
+ *
+ * # CodeHintProvider.insertHintOnTab
+ * 
+ * type {?boolean} insertHintOnTab
+ * Indicates whether the CodeHintManager should request that the provider of 
+ * the current session insert the currently selected hint on tab key events,
+ * or if instead a tab character should be inserted into the editor. If omitted,
+ * the fallback behavior is determined by the CodeHintManager. The default
+ * behavior is to insert a tab character, but this can be changed with the
+ * CodeHintManager.setInsertHintOnTab() method.
  */
 
 
@@ -237,6 +248,23 @@ define(function (require, exports, module) {
         deferredHints   = null,
         keyDownEditor   = null;
 
+    
+    var _insertHintOnTabDefault = false;
+
+    /**
+     * Determines the default behavior of the CodeHintManager on tab key events.
+     * setInsertHintOnTab(true) indicates that the currently selected code hint
+     * should be inserted on tab key events. setInsertHintOnTab(false) indicates
+     * that a tab character should be inserted into the editor on tab key events.
+     * The default behavior can be can be overridden by individual providers.
+     *
+     * @param {boolean} Indicates whether providers should insert the currently
+     *      selected hint on tab key events.
+     */
+    function setInsertHintOnTab(insertHintOnTab) {
+        _insertHintOnTabDefault = insertHintOnTab;
+    }
+    
     /**
      * Comparator to sort providers from high to low priority
      */
@@ -439,9 +467,16 @@ define(function (require, exports, module) {
 
         // If a provider is found, initialize the hint list and update it
         if (sessionProvider) {
+            var insertHintOnTab;
+            if (sessionProvider.insertHintOnTab !== undefined) {
+                insertHintOnTab = sessionProvider.insertHintOnTab;
+            } else {
+                insertHintOnTab = _insertHintOnTabDefault;
+            }
+            
             sessionEditor = editor;
-
-            hintList = new CodeHintList(sessionEditor);
+            
+            hintList = new CodeHintList(sessionEditor, insertHintOnTab);
             hintList.onSelect(function (hint) {
                 var restart = sessionProvider.insertHint(hint),
                     previousEditor = sessionEditor;
@@ -589,4 +624,5 @@ define(function (require, exports, module) {
     exports.handleChange            = handleChange;
     exports.registerHintProvider    = registerHintProvider;
     exports.hasValidExclusion       = hasValidExclusion;
+    exports.setInsertHintOnTab      = setInsertHintOnTab;
 });


### PR DESCRIPTION
Addresses #4963 by making the behavior of the `CodeHintList` on tab key events configurable on a global and per-`CodeHintProvider` basis. The `CodeHintManager` provider registration API is generalized with an additional optional property, `insertHintOnTab`, that indicates whether the `CodeHintManager` should request that the provider of the current session insert the currently selected hint on tab key events, or if instead a tab character should be inserted into the editor. If a provider omits this property, the behavior is determined by the `CodeHintManager`. The default behavior is to insert a tab character into the editor, as is the case now. The default can be changed globally with the new `CodeHintManager.setInsertHintOnTab(bool)` method. For an example use of this method, see my awesome new extension: [iwehrman/brackets-insert-hint-on-tab](https://github.com/iwehrman/brackets-insert-hint-on-tab).

This was @peterflynn's idea!
