### PR TITLE
Fix #5062: Update notification is no longer modal

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -254,7 +254,6 @@ define(function (require, exports, module) {
             // check once a day, plus 2 minutes, 
             // as the check will skip if the last check was not -24h ago
             window.setInterval(UpdateNotification.checkForUpdate, 86520000);
-            UpdateNotification.checkForUpdate();
         }
     }
     

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -254,6 +254,11 @@ define(function (require, exports, module) {
             // check once a day, plus 2 minutes, 
             // as the check will skip if the last check was not -24h ago
             window.setInterval(UpdateNotification.checkForUpdate, 86520000);
+            
+            // Check for updates on App Ready
+            AppInit.appReady(function () {
+                UpdateNotification.checkForUpdate();
+            });
         }
     }
     

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -451,7 +451,7 @@
 .modal-backdrop {
     opacity: 0;
 }
-.modal-backdrop:last-child {
+.last-backdrop {
     /* Only show the last modal backdrop */
     opacity: 0.5;
 }

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -33,11 +33,12 @@ define(function (require, exports, module) {
     
     var Dialogs              = require("widgets/Dialogs"),
         DefaultDialogs       = require("widgets/DefaultDialogs"),
-        NativeApp            = require("utils/NativeApp"),
         PreferencesManager   = require("preferences/PreferencesManager"),
-        Strings              = require("strings"),
-        StringUtils          = require("utils/StringUtils"),
+        AppInit              = require("utils/AppInit"),
         Global               = require("utils/Global"),
+        NativeApp            = require("utils/NativeApp"),
+        StringUtils          = require("utils/StringUtils"),
+        Strings              = require("strings"),
         UpdateDialogTemplate = require("text!htmlContent/update-dialog.html"),
         UpdateListTemplate   = require("text!htmlContent/update-list.html");
     
@@ -208,6 +209,10 @@ define(function (require, exports, module) {
         
         updates.Strings = Strings;
         $updateList.html(Mustache.render(UpdateListTemplate, updates));
+        
+        AppInit.appReady(function () {
+            $dlg.find("button").focus();
+        });
     }
     
     /**

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -209,10 +209,6 @@ define(function (require, exports, module) {
         
         updates.Strings = Strings;
         $updateList.html(Mustache.render(UpdateListTemplate, updates));
-        
-        AppInit.appReady(function () {
-            $dlg.find("button").focus();
-        });
     }
     
     /**
@@ -335,6 +331,11 @@ define(function (require, exports, module) {
     // Append locale to version info URL
     _versionInfoURL = brackets.config.update_info_url + brackets.getLocale() + ".json";
     
+    // Check for updates on App Ready
+    AppInit.appReady(function () {
+        checkForUpdate();
+    });
+
     // Define public API
     exports.checkForUpdate = checkForUpdate;
 });

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -34,7 +34,6 @@ define(function (require, exports, module) {
     var Dialogs              = require("widgets/Dialogs"),
         DefaultDialogs       = require("widgets/DefaultDialogs"),
         PreferencesManager   = require("preferences/PreferencesManager"),
-        AppInit              = require("utils/AppInit"),
         Global               = require("utils/Global"),
         NativeApp            = require("utils/NativeApp"),
         StringUtils          = require("utils/StringUtils"),

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -330,11 +330,6 @@ define(function (require, exports, module) {
     
     // Append locale to version info URL
     _versionInfoURL = brackets.config.update_info_url + brackets.getLocale() + ".json";
-    
-    // Check for updates on App Ready
-    AppInit.appReady(function () {
-        checkForUpdate();
-    });
 
     // Define public API
     exports.checkForUpdate = checkForUpdate;

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -252,6 +252,7 @@ define(function (require, exports, module) {
             
             // Remove the dialog instance from the DOM.
             $dlg.remove();
+            $(".modal-backdrop:last").addClass("last-backdrop");
 
             // Remove our global keydown handler.
             KeyBindingManager.removeGlobalKeydownHook(keydownHook);
@@ -273,7 +274,9 @@ define(function (require, exports, module) {
                 _dismissDialog($dlg, $(this).attr("data-button-id"));
             });
         }
-
+        
+        $(".last-backdrop").removeClass("last-backdrop");
+        
         // Run the dialog
         $dlg
             .modal({
@@ -283,7 +286,9 @@ define(function (require, exports, module) {
             })
             // Updates the z-index of the modal dialog and the backdrop
             .css("z-index", zIndex + 1)
-            .next().css("z-index", zIndex);
+            .next()
+            .css("z-index", zIndex)
+            .addClass("last-backdrop");
         
         zIndex += 2;
         


### PR DESCRIPTION
Fix for issue #5062.
- Changed to using JavaScript to only show the last modal backdrop, since it can't be properly done in CSS.
- Added a new focus on AppReady to resend the focus to the dialog, since it gets lost when the file is open after the dialog.
