### PR TITLE
Fix issue #4693: Tree context menu behaves unpredictably while naming new file

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1553,6 +1553,10 @@ define(function (require, exports, module) {
         $("#open-files-container").on("contentChanged", function () {
             _redraw(false); // redraw jstree when working set size changes
         });
+        
+        $projectTreeContainer.on("contextmenu", function () {
+            forceFinishRename();
+        });
     });
 
     // Init PreferenceStorage

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1549,11 +1549,17 @@ define(function (require, exports, module) {
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
         $projectTreeContainer = $("#project-files-container");
-
+        
         $("#open-files-container").on("contentChanged", function () {
             _redraw(false); // redraw jstree when working set size changes
         });
         
+        $(".main-view").click(function (jqEvent) {
+            if (jqEvent.target.className !== "jstree-rename-input") {
+                forceFinishRename();
+            }
+        });
+            
         $projectTreeContainer.on("contextmenu", function () {
             forceFinishRename();
         });


### PR DESCRIPTION
Fix issue #4693: Tree context menu behaves unpredictably while naming new file
