### PR TITLE
[LiveHTML] Code cleanup in HTMLSimpleDOM

### DIFF
--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -29,6 +29,15 @@
 define(function (require, exports, module) {
     "use strict";
     
+    /**
+     * @private
+     *
+     * Determines the changes made to attributes and generates edits for those changes.
+     *
+     * @param {SimpleNode} oldNode node from old tree
+     * @param {SimpleNode} newNode node from new tree
+     * @return {Array.<Object>} list of edits to mutate attributes from the old node to the new
+     */
     function generateAttributeEdits(oldNode, newNode) {
         // shallow copy the old attributes object so that we can modify it
         var oldAttributes = $.extend({}, oldNode.attributes),
@@ -60,6 +69,8 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @private
+     *
      * Retrieve the parent tag ID of a SimpleDOM node.
      *
      * @param {Object} node SimpleDOM node for which to look up parent ID
@@ -70,6 +81,8 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @private
+     *
      * When the main loop (see below) determines that something has changed with
      * an element's immediate children, it calls this function to create edit
      * operations for those changes.
@@ -613,5 +626,6 @@ define(function (require, exports, module) {
         return edits;
     }
     
+    // Public API
     exports.domdiff = domdiff;
 });

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
      */
     function _markTags(cm, node) {
         node.children.forEach(function (childNode) {
-            if (childNode.children) {
+            if (childNode.isElement()) {
                 _markTags(cm, childNode);
             }
         });
@@ -343,7 +343,7 @@ define(function (require, exports, module) {
             // Any remaining updateIDs are new.
             updateIDs.forEach(function (id) {
                 var node = nodeMap[id], mark;
-                if (node.children) {
+                if (node.isElement()) {
                     mark = cm.markText(node.startPos, node.endPos);
                     mark.tagID = Number(id);
                 }
@@ -364,7 +364,7 @@ define(function (require, exports, module) {
             if (node.tagID) {
                 nodeMap[node.tagID] = node;
             }
-            if (node.children) {
+            if (node.isElement()) {
                 node.children.forEach(walk);
             }
         }
@@ -586,9 +586,9 @@ define(function (require, exports, module) {
                 // set parent
                 child.parent = elem;
                 
-                if (child.children) {
+                if (child.isElement()) {
                     _processElement(child);
-                } else if (child.content) {
+                } else if (child.isText()) {
                     child.update();
                     child.tagID = HTMLSimpleDOM.getTextNodeID(child);
                     
@@ -724,7 +724,7 @@ define(function (require, exports, module) {
                 lastIndex = insertIndex;
             }
             
-            if (node.children) {
+            if (node.isElement()) {
                 node.children.forEach(walk);
             }
         }

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -140,14 +140,14 @@ define(function (require, exports, module) {
          * * child node text
          */
         update: function () {
-            if (this.children) {
+            if (this.isElement()) {
                 var i,
                     subtreeHashes = "",
                     childHashes = "",
                     child;
                 for (i = 0; i < this.children.length; i++) {
                     child = this.children[i];
-                    if (child.children) {
+                    if (child.isElement()) {
                         childHashes += String(child.tagID);
                         subtreeHashes += String(child.tagID) + child.attributeSignature + child.subtreeSignature;
                     } else {
@@ -458,7 +458,7 @@ define(function (require, exports, module) {
             } else {
                 result += indent + "TEXT " + node.tagID + " " + node.content + "\n";
             }
-            if (node.children) {
+            if (node.isElement()) {
                 indent += "  ";
                 node.children.forEach(walk);
                 indent = indent.slice(2);

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -115,15 +115,16 @@ define(function (require, exports, module) {
         wbr: true
     };
     
-    function Builder(text, startOffset, startOffsetPos) {
-        this.stack = [];
-        this.text = text;
-        this.t = new Tokenizer(text);
-        this.currentTag = null;
-        this.startOffset = startOffset || 0;
-        this.startOffsetPos = startOffsetPos || {line: 0, ch: 0};
-    }
-    
+    /**
+     * @constructor
+     *
+     * A SimpleNode represents one node in a SimpleDOM tree. Each node can have
+     * any set of properties on it, though there are a couple of assumptions made.
+     * Elements will have `children` and `attributes` properties. Text nodes will have a `content`
+     * property. All Elements will have a `tagID` and text nodes *can* have one.
+     *
+     * @param {Object} properties the properties provided will be set on the new object.
+     */
     function SimpleNode(properties) {
         $.extend(this, properties);
     }
@@ -190,14 +191,10 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Generates a synthetic ID for text nodes. These IDs are only used
-     * for comparison purposes in the SimpleDOM structure, since we can't
-     * apply IDs to text nodes in the browser.
+     * @private
      *
-     * TODO/Note: When generating a diff, the decision to do a textReplace 
-     * edit rather than a textDelete/textInsert hinges on how this ID
-     * is treated (because it is currently based on the previous or
-     * parent node).
+     * Generates a synthetic ID for text nodes. These IDs are only used
+     * for convenience when reading a SimpleDOM that is dumped to the console.
      *
      * @param {Object} textNode new node for which we are generating an ID
      * @return {string} ID for the node
@@ -210,15 +207,53 @@ define(function (require, exports, module) {
         return textNode.parent.children[childIndex - 1].tagID + "t";
     }
     
+    /**
+     * @private
+     *
+     * Adds two positions.
+     */
     function addPos(pos1, pos2) {
         return {line: pos1.line + pos2.line, ch: (pos2.line === 0 ? pos1.ch + pos2.ch : pos2.ch)};
     }
     
+    /**
+     * @private
+     *
+     * Calculates a simple character offset. Not for general purpose use as it does not account
+     * for line boundaries.
+     */
     function offsetPos(pos, offset) {
         // Simple character offset. Only safe if the offset doesn't cross a line boundary.
         return {line: pos.line, ch: pos.ch + offset};
     }
-
+    
+    /**
+     * @constructor
+     *
+     * A Builder creates a SimpleDOM tree of SimpleNode objects representing the
+     * "important" contents of an HTML document. It does not include things like comments.
+     * The nodes include information about their position in the text provided.
+     * 
+     * @param {string} text The text to parse
+     * @param {?int} startOffset starting offset in the text
+     * @param {?{line: int, ch: int}} startOffsetPos line/ch position in the text
+     */
+    function Builder(text, startOffset, startOffsetPos) {
+        this.stack = [];
+        this.text = text;
+        this.t = new Tokenizer(text);
+        this.currentTag = null;
+        this.startOffset = startOffset || 0;
+        this.startOffsetPos = startOffsetPos || {line: 0, ch: 0};
+    }
+    
+    /**
+     * Builds the SimpleDOM.
+     *
+     * @param {?bool} strict if errors are detected, halt and return null
+     * @param {?Object} markCache a cache that can be used in ID generation (is passed to `getID`)
+     * @return {SimpleNode} root of tree or null if parsing failed
+     */
     Builder.prototype.build = function (strict, markCache) {
         var self = this;
         var token, lastClosedTag, lastTextNode, lastIndex = 0;
@@ -443,11 +478,27 @@ define(function (require, exports, module) {
      */
     Builder.prototype.getID = Builder.prototype.getNewID;
     
+    /**
+     * Builds a SimpleDOM from the text provided. If `strict` mode is true, parsing
+     * will halt as soon as any error is seen and null will be returned.
+     *
+     * @param {string} text Text of document to parse
+     * @param {bool} strict True for strict parsing
+     * @return {SimpleNode} root of tree or null if strict failed
+     */
     function build(text, strict) {
         var builder = new Builder(text);
         return builder.build(strict);
     }
     
+    /**
+     * @private
+     *
+     * Generates a string version of a SimpleDOM for debugging purposes.
+     *
+     * @param {SimpleNode} root root of the tree
+     * @return {string} Text version of the tree.
+     */
     function _dumpDOM(root) {
         var result = "",
             indent = "";
@@ -469,10 +520,13 @@ define(function (require, exports, module) {
         return result;
     }
     
-    exports._dumpDOM                    = _dumpDOM;
+    // Public API
     exports.build                       = build;
+    exports.Builder                     = Builder;
+    
+    // Private API
+    exports._dumpDOM                    = _dumpDOM;
     exports._offsetPos                  = offsetPos;
     exports._getTextNodeID              = getTextNodeID;
     exports._seed                       = seed;
-    exports.Builder                     = Builder;
 });

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -210,20 +210,19 @@ define(function (require, exports, module) {
     /**
      * @private
      *
-     * Adds two positions.
+     * Adds two {line, ch}-style positions, returning a new pos.
      */
-    function addPos(pos1, pos2) {
+    function _addPos(pos1, pos2) {
         return {line: pos1.line + pos2.line, ch: (pos2.line === 0 ? pos1.ch + pos2.ch : pos2.ch)};
     }
     
     /**
      * @private
      *
-     * Calculates a simple character offset. Not for general purpose use as it does not account
-     * for line boundaries.
+     * Offsets the character offset of the given {line, ch} pos by the given amount and returns a new
+     * pos. Not for general purpose use as it does not account for line boundaries.
      */
-    function offsetPos(pos, offset) {
-        // Simple character offset. Only safe if the offset doesn't cross a line boundary.
+    function _offsetPos(pos, offset) {
         return {line: pos.line, ch: pos.ch + offset};
     }
     
@@ -275,7 +274,7 @@ define(function (require, exports, module) {
             lastClosedTag.update();
             
             lastClosedTag.end = self.startOffset + endIndex;
-            lastClosedTag.endPos = addPos(self.startOffsetPos, endPos);
+            lastClosedTag.endPos = _addPos(self.startOffsetPos, endPos);
         }
         
         while ((token = this.t.nextToken()) !== null) {
@@ -299,7 +298,7 @@ define(function (require, exports, module) {
                     while (stack.length > 0 && closable.hasOwnProperty(stack[stack.length - 1].tag)) {
                         // Close the previous tag at the start of this tag.
                         // Adjust backwards for the < before the tag name.
-                        closeTag(token.start - 1, offsetPos(token.startPos, -1));
+                        closeTag(token.start - 1, _offsetPos(token.startPos, -1));
                     }
                 }
                 
@@ -309,7 +308,7 @@ define(function (require, exports, module) {
                     attributes: {},
                     parent: (stack.length ? stack[stack.length - 1] : null),
                     start: this.startOffset + token.start - 1,
-                    startPos: addPos(this.startOffsetPos, offsetPos(token.startPos, -1)) // ok because we know the previous char was a "<"
+                    startPos: _addPos(this.startOffsetPos, _offsetPos(token.startPos, -1)) // ok because we know the previous char was a "<"
                 });
                 newTag.tagID = this.getID(newTag, markCache);
                 
@@ -345,7 +344,7 @@ define(function (require, exports, module) {
                     // find a close tag for this tag, we'll update the signature to account for its
                     // children at that point (in the next "else" case).
                     this.currentTag.end = this.startOffset + token.end;
-                    this.currentTag.endPos = addPos(this.startOffsetPos, token.endPos);
+                    this.currentTag.endPos = _addPos(this.startOffsetPos, token.endPos);
                     lastClosedTag = this.currentTag;
                     this.currentTag.updateAttributeSignature();
                     this.currentTag = null;
@@ -376,9 +375,9 @@ define(function (require, exports, module) {
                             // implied end to be the end of the close tag (which is one character, ">", after the end of
                             // the tagname).
                             if (stack.length === i + 1) {
-                                closeTag(token.end + 1, offsetPos(token.endPos, 1));
+                                closeTag(token.end + 1, _offsetPos(token.endPos, 1));
                             } else {
-                                closeTag(token.start - 2, offsetPos(token.startPos, -2));
+                                closeTag(token.start - 2, _offsetPos(token.startPos, -2));
                             }
                         } while (stack.length > i);
                     } else {
@@ -526,7 +525,7 @@ define(function (require, exports, module) {
     
     // Private API
     exports._dumpDOM                    = _dumpDOM;
-    exports._offsetPos                  = offsetPos;
+    exports._offsetPos                  = _offsetPos;
     exports._getTextNodeID              = getTextNodeID;
     exports._seed                       = seed;
 });


### PR DESCRIPTION
Cleanup suggested in the domdiff cleanup pull request.
- Changed from use of `if (node.children)` to `if (node.isElement())`
- Added needed comments in HTMLSimpleDOM.
- Commented the last bit of HTMLDOMDiff

to @njx 
