### PR TITLE
Fix unit test for new status with LiveHTML

### DIFF
--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -39,7 +39,7 @@ define(function HighlightAgent(require, exports, module) {
         LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
         RemoteAgent     = require("LiveDevelopment/Agents/RemoteAgent");
 
-    var _highlight; // active highlight
+    var _highlight = {}; // active highlight
 
     // Remote Event: Highlight
     function _onRemoteHighlight(event, res) {
@@ -99,7 +99,7 @@ define(function HighlightAgent(require, exports, module) {
      * @param {string} rule selector
      */
     function rule(name) {
-        if (_highlight && (_highlight.ref === name)) {
+        if (_highlight.ref === name) {
             return;
         }
         hide();
@@ -124,7 +124,6 @@ define(function HighlightAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        _highlight = {};
         if (LiveDevelopment.config.experimental) {
             $(RemoteAgent).on("highlight.HighlightAgent", _onRemoteHighlight);
         }

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -633,9 +633,10 @@ define(function (require, exports, module) {
                 openLiveDevelopmentAndWait();
                 
                 waitsFor(function () {
-                    return (LiveDevelopment.status === LiveDevelopment.STATUS_OUT_OF_SYNC) &&
-                        (DOMAgent.root);
-                }, "LiveDevelopment STATUS_OUT_OF_SYNC and DOMAgent.root", 10000);
+                    return (LiveDevelopment.status === LiveDevelopment.STATUS_OUT_OF_SYNC ||
+                            LiveDevelopment.status === LiveDevelopment.STATUS_ACTIVE) &&
+                            (DOMAgent.root);
+                }, "LiveDevelopment STATUS_OUT_OF_SYNC or STATUS_ACTIVE and DOMAgent.root", 10000);
                 
                 // Grab the node that we've just modified in Brackets.
                 // Verify that we get the modified text in memory and not the original text on disk.


### PR DESCRIPTION
Live Dev status longer goes to out-of-sync for most edits, so adjust test.
