### PR TITLE
For #5086, wait for old Quick Open bar to fully close before creating a new one.

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -173,7 +173,8 @@ define(function (require, exports, module) {
     }
     
     /**
-     * True if the dialog is currently open.
+     * True if the dialog is currently open. Note that this is set to false immediately
+     * when the dialog starts closing; it doesn't wait for the ModalBar animation to finish.
      * @type {boolean}
      */
     QuickNavigateDialog.prototype.isOpen = false;
@@ -458,6 +459,10 @@ define(function (require, exports, module) {
             return this._closeDeferred.promise();
         }
         this.isOpen = false;
+        
+        // We can't just return the ModalBar's `close()` promise because we need to do it on a
+        // setTimeout, so we create our own Deferred and cache it so we can return it if multiple
+        // callers happen to call `close()`.
         this._closeDeferred = new $.Deferred();
 
         var i;

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -854,14 +854,19 @@ define(function (require, exports, module) {
             _curDialog.showDialog(prefix, initialString);
         }
 
-        if (_curDialog && _curDialog.isOpen) {
-            _curDialog.setSearchFieldValue(prefix, initialString);
-        } else {
-            if (_curDialog) {
-                _curDialog.close().done(createDialog);
+        if (_curDialog) {
+            if (_curDialog.isOpen) {
+                // Just start a search using the existing dialog.
+                _curDialog.setSearchFieldValue(prefix, initialString);
             } else {
-                createDialog();
+                // The dialog is already closing. Wait till it's done closing,
+                // then open a new dialog. (Calling close() again returns the
+                // promise for the deferred that was already kicked off when it
+                // started closing.)
+                _curDialog.close().done(createDialog);
             }
+        } else {
+            createDialog();
         }
     }
 

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -120,9 +120,17 @@ define(function (require, exports, module) {
     /**
      * Closes the modal bar and returns focus to the active editor. Returns a promise that is
      * resolved when the bar is fully closed and the container is removed from the DOM.
+     * @param {boolean=} restoreScrollPos If true (the default), adjust the scroll position
+     *     of the editor to account for the ModalBar disappearing. If not set, the caller
+     *     should do it immediately on return of this function (before the animation completes),
+     *     because the editor will already have been resized.
      * @return {$.Promise} promise resolved when close is finished
      */
-    ModalBar.prototype.close = function () {
+    ModalBar.prototype.close = function (restoreScrollPos) {
+        if (restoreScrollPos === undefined) {
+            restoreScrollPos = true;
+        }
+        
         // Store our height before closing, while we can still measure it
         var result = new $.Deferred(),
             barHeight = this.height();
@@ -141,11 +149,11 @@ define(function (require, exports, module) {
         // height of the modal bar so the code doesn't appear to shift if possible.
         var fullEditor = EditorManager.getCurrentFullEditor(),
             scrollPos;
-        if (fullEditor) {
+        if (restoreScrollPos && fullEditor) {
             scrollPos = fullEditor.getScrollPos();
         }
         EditorManager.resizeEditor();
-        if (fullEditor) {
+        if (restoreScrollPos && fullEditor) {
             fullEditor._codeMirror.scrollTo(scrollPos.x, scrollPos.y - barHeight);
         }
         EditorManager.focusEditor();

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -118,11 +118,14 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Closes the modal bar and returns focus to the active editor.
+     * Closes the modal bar and returns focus to the active editor. Returns a promise that is
+     * resolved when the bar is fully closed and the container is removed from the DOM.
+     * @return {$.Promise} promise resolved when close is finished
      */
     ModalBar.prototype.close = function () {
         // Store our height before closing, while we can still measure it
-        var barHeight = this.height();
+        var result = new $.Deferred(),
+            barHeight = this.height();
 
         if (this._autoClose) {
             window.document.body.removeEventListener("focusin", this._handleFocusChange, true);
@@ -131,6 +134,7 @@ define(function (require, exports, module) {
         var self = this;
         this._$root.addClass("modal-bar-hide").one("webkitTransitionEnd", function () {
             self._$root.remove();
+            result.resolve();
         });
         
         // Preserve scroll position of the current full editor across the editor refresh, adjusting for the 
@@ -145,6 +149,8 @@ define(function (require, exports, module) {
             fullEditor._codeMirror.scrollTo(scrollPos.x, scrollPos.y - barHeight);
         }
         EditorManager.focusEditor();
+        
+        return result.promise();
     };
     
     /**


### PR DESCRIPTION
For #5086. Also moved some global state into the QuickNavigateDialog object to avoid reentrancy issues.

@peterflynn 
