### PR TITLE
Disable unit test for #5093

### DIFF
--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -811,7 +811,8 @@ define(function (require, exports, module) {
                    
                 });
                 
-                it("should open links in the native browser instead of in Brackets", function () {
+                // FORNOW: Disable - https://github.com/adobe/brackets/issues/5093
+                xit("should open links in the native browser instead of in Brackets", function () {
                     runs(function () {
                         mockRegistry = {
                             "basic-valid-extension": {


### PR DESCRIPTION
This temporarily disables unit test failure captured in: https://github.com/adobe/brackets/issues/5093
