### PR TITLE
Fix issue #4693: Tree context menu behaves unpredictably while naming new file

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1559,6 +1559,10 @@ define(function (require, exports, module) {
                 forceFinishRename();
             }
         });
+        
+        $projectTreeContainer.on("contextmenu", function () {
+            forceFinishRename();
+        });
     });
 
     // Init PreferenceStorage


### PR DESCRIPTION
Fix issue #4693: Tree context menu behaves unpredictably while naming new file
