### PR TITLE
Fix #5093: Unit Test Failing: ExtensionManager

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -52,7 +52,8 @@ define(function (require, exports, module) {
         UnitTestReporter        = require("test/UnitTestReporter").UnitTestReporter,
         NodeConnection          = require("utils/NodeConnection"),
         BootstrapReporterView   = require("test/BootstrapReporterView").BootstrapReporterView,
-        ColorUtils              = require("utils/ColorUtils");
+        ColorUtils              = require("utils/ColorUtils"),
+        NativeApp               = require("utils/NativeApp");
 
     // Load modules that self-register and just need to get included in the main project
     require("document/ChangedDocumentTracker");
@@ -357,6 +358,30 @@ define(function (require, exports, module) {
             
             $(window.document).ready(_documentReadyHandler);
         });
+        
+        
+        // Prevent clicks on any link from navigating to a different page (which could lose unsaved
+        // changes). We can't use a simple .on("click", "a") because of http://bugs.jquery.com/ticket/3861:
+        // jQuery hides non-left clicks from such event handlers, yet middle-clicks still cause CEF to
+        // navigate. Also, a capture handler is more reliable than bubble.
+        window.document.body.addEventListener("click", function (e) {
+            // Check parents too, in case link has inline formatting tags
+            var node = e.target, url;
+            console.log(1);
+            while (node) {
+                console.log(node.tagName);
+                if (node.tagName === "A") {
+                    url = node.getAttribute("href");
+                    console.log(url);
+                    if (url && url.match(/^http/)) {
+                        NativeApp.openURLInDefaultBrowser(url);
+                        e.preventDefault();
+                    }
+                    break;
+                }
+                node = node.parentElement;
+            }
+        }, true);
     }
 
     /**

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -619,6 +619,7 @@ define(function (require, exports, module) {
                     model = new ModelClass();
                     modelDisposed = false;
                     waitsForDone(view.initialize(model), "view initializing");
+                    view.$el.appendTo(document.body);
                 });
                 runs(function () {
                     spyOn(view.model, "dispose").andCallThrough();
@@ -650,8 +651,10 @@ define(function (require, exports, module) {
                 
             
             afterEach(function () {
-                view = null;
-                
+                if (view) {
+                    view.$el.remove();
+                    view = null;
+                }
                 if (model) {
                     model.dispose();
                 }
@@ -834,7 +837,10 @@ define(function (require, exports, module) {
                     runs(function () {
                         var origHref = window.location.href;
                         spyOn(NativeApp, "openURLInDefaultBrowser");
-                        $("a", view.$el).first().click();
+                        
+                        var event = new window.Event("click", { bubbles: false, cancelable: true });
+                        document.querySelector("a[href='https://github.com/someuser']").dispatchEvent(event);
+                        
                         expect(NativeApp.openURLInDefaultBrowser).toHaveBeenCalledWith("https://github.com/someuser");
                         expect(window.location.href).toBe(origHref);
                     });


### PR DESCRIPTION
Fix #5093

I managed to fix this by adding a variation of the link handle code into the spec window, appending the mock view to the document and using the JavaScript Event object to trigger the click event.
