### PR TITLE
Implement document proxy icon in Brackets editor

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     /** @type {string} String template for window title. Use emdash on mac only. */
-    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} - {1}" : "{0} \u2014 {1}";
+    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} - {1}" : "{0}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;
@@ -132,6 +132,8 @@ define(function (require, exports, module) {
         // current project or the full absolute path if it's not in the project.
         if (doc.isUntitled()) {
             return fullPath.substring(fullPath.lastIndexOf("/") + 1);
+        } else if (brackets.platform === "mac") {
+            return fullPath;
         } else {
             return ProjectManager.makeProjectRelativeIfPossible(fullPath);
         }


### PR DESCRIPTION
This change requires request adobe/brackets-shell#322 to be merged in.

On Mac, application name is not usually shown in window title. Instead a "document proxy icon" is shown as a shortcut for file access. This icon can be dragged to other applications (e.g. Mail or FTP client) or used to open containing folder in Finder.
