### PR TITLE
No Quick View preview past end of line

### DIFF
--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -340,7 +340,7 @@ define(function (require, exports, module) {
                 // Gradients are matched first, then colors, so...
                 if (gradientMatch.match) {
                     // ... gradient match is past cursor -- stop looking for gradients, start searching for colors
-                    gradientMatch.match = null;
+                    gradientMatch = { match: null, prefix: "", colorValue: null };
                 } else {
                     // ... color match is past cursor -- stop looping
                     break;
@@ -588,8 +588,9 @@ define(function (require, exports, module) {
                 pos = cm.coordsChar({left: event.clientX, top: event.clientY}),
                 showImmediately = false;
             
+            // Bail if mouse is on same char as last event
             if (lastPos && lastPos.line === pos.line && lastPos.ch === pos.ch) {
-                return;  // bail if mouse is on same char as last event
+                return;
             }
             lastPos = pos;
             
@@ -604,6 +605,12 @@ define(function (require, exports, module) {
                     showImmediately = popoverState.visible;
                     hidePreview();
                 }
+            }
+            
+            // No preview if mouse is past last char on line
+            if (pos.ch >= editor.document.getLine(pos.line).length) {
+                hidePreview();
+                return;
             }
             
             // Initialize popoverState


### PR DESCRIPTION
This is for issue #5102.

This also fixes a color preview bug I noticed (which was introduced by my recent performance changes):
1. Paste this rule in a style sheet

```
.main {
    color: red; color: blue; background-image: -o-linear-gradient(#ffefaa,#ffe155); background-color: #333;
}
```
1. Move mouse over colors

Result:
Colors before gradient displays incorrect color (i.e. the gradient). Color after gradient displays correct color.
