### PR TITLE
Verify folder exists before operating on it

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
     }
     
     function removeTempDirectory() {
-        var filePath, error, stat, promiseRead, promiseWrite, promiseDelete,
+        var error, stat, promise,
             baseDir = getTempDirectory(),
             complete = false;
         
@@ -256,11 +256,11 @@ define(function (require, exports, module) {
         
         runs(function () {
             if (error === brackets.fs.NO_ERROR) {
-                promiseRead = chmod(baseDir + "/cant_read_here", "777");
+                promise = chmod(baseDir + "/cant_read_here", "777");
             } else {
-                promiseRead = (new $.Deferred()).resolve().promise();
+                promise = (new $.Deferred()).resolve().promise();
             }
-            waitsForDone(promiseRead, "reset cant_read_here permissions", 2000);
+            waitsForDone(promise, "reset cant_read_here permissions", 2000);
         });
         
         runs(function () {
@@ -276,16 +276,20 @@ define(function (require, exports, module) {
         });
         
         runs(function () {
+            promise = null;
             if (error === brackets.fs.NO_ERROR) {
-                promiseWrite = chmod(baseDir + "/cant_write_here", "777");
+                promise = chmod(baseDir + "/cant_write_here", "777");
             } else {
-                promiseWrite = (new $.Deferred()).resolve().promise();
+                promise = (new $.Deferred()).resolve().promise();
             }
-            waitsForDone(promiseWrite, "reset cant_write_here permissions", 2000);
+            waitsForDone(promise, "reset cant_write_here permissions", 2000);
         });
         
         // Remove the test data and anything else left behind from tests
         runs(function () {
+            error = undefined;
+            stat = null;
+            complete = false;
             brackets.fs.stat(baseDir, function (err, _stat) {
                 error = err;
                 stat = _stat;
@@ -295,12 +299,13 @@ define(function (require, exports, module) {
         });
         
         runs(function () {
+            promise = null;
             if (error === brackets.fs.NO_ERROR) {
-                promiseDelete = deletePath(baseDir, true);
+                promise = deletePath(baseDir, true);
             } else {
-                promiseDelete = (new $.Deferred()).resolve().promise();
+                promise = (new $.Deferred()).resolve().promise();
             }
-            waitsForDone(promiseDelete, "delete temp files", 10000);
+            waitsForDone(promise, "delete temp files", 10000);
         });
     }
     


### PR DESCRIPTION
This is for #5109.

@RaymondLim is correct that `SpecRunnerUtils.removeTempDirectory()` is causing the problem. It is not causing other unit tests to fail, but is failing itself. Since it uses `WaitsForDone()` outside of any `it()` function, Jasmine does not know where to write errors, so they go to last test that was run.

`removeTempDirectory()` needs to be synchronous because it is now run at the _beginning_ of unit tests. When run at the _end_ of unit tests, it might be more desirable to have an async version that reports errors to console.

Another issue I discovered is that `removeTempDirectory()` is only executed when running an all sets of tests in a suite. It would be nice if this could also be run when only running a single set of tests or only a single test. After more research I discovered that `removeTempDirectory()` _is_ **synchronously** called for before and after any tests are run. But the **asynchronous** `runs()` blocks may or may not be run. So, **this code currently does not execute at the desired times**.

cc @JeffryBooher 
