### PR TITLE
Add live preview 'sync error' status

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -239,7 +239,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         }
 
         this.errors = result.errors || [];
-        $(this).triggerHandler("error", [this]);
+        $(this).triggerHandler("statusChanged", [this]);
         
         // Debug-only: compare in-memory vs. in-browser DOM
         // edit this file or set a conditional breakpoint at the top of this function:

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -60,6 +60,8 @@ define(function HTMLDocumentModule(require, exports, module) {
      * @param {editor=} editor
      */
     var HTMLDocument = function HTMLDocument(doc, editor) {
+        var self = this;
+
         this.doc = doc;
         if (!editor) {
             return;
@@ -80,8 +82,9 @@ define(function HTMLDocumentModule(require, exports, module) {
             $(HighlightAgent).on("highlight", this.onHighlight);
         }
 
-        this.onChange = this.onChange.bind(this);
-        $(this.editor).on("change", this.onChange);
+        $(this.editor).on("change", function (event, editor, change) {
+            self.onChange(event, editor, change);
+        });
     };
     
     /**
@@ -222,21 +225,28 @@ define(function HTMLDocumentModule(require, exports, module) {
         // TODO: text changes should be easy to add
         // TODO: if new tags are added, need to instrument them
         var self                = this,
-            edits               = HTMLInstrumentation.getUnappliedEditList(editor, change),
-            applyEditsPromise   = RemoteAgent.call("applyDOMEdits", edits);
+            result              = HTMLInstrumentation.getUnappliedEditList(editor, change),
+            applyEditsPromise;
+        
+        if (result.edits) {
+            applyEditsPromise = RemoteAgent.call("applyDOMEdits", result.edits);
+    
+            applyEditsPromise.always(function () {
+                if (!isNestedTimer) {
+                    PerfUtils.addMeasurement(perfTimerName);
+                }
+            });
+        }
 
-        applyEditsPromise.always(function () {
-            if (!isNestedTimer) {
-                PerfUtils.addMeasurement(perfTimerName);
-            }
-        });
+        this.errors = result.errors || [];
+        $(this).triggerHandler("error", [this]);
         
         // Debug-only: compare in-memory vs. in-browser DOM
         // edit this file or set a conditional breakpoint at the top of this function:
         //     "this._debug = true, false"
         if (this._debug) {
             console.log("Edits applied to browser were:");
-            console.log(JSON.stringify(edits, null, 2));
+            console.log(JSON.stringify(result.edits, null, 2));
             applyEditsPromise.done(function () {
                 self._compareWithBrowser(change);
             });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -358,7 +358,7 @@ define(function LiveDevelopment(require, exports, module) {
             return null;
         }
 
-        $(liveDocument).on("error.livedev", function () {
+        $(liveDocument).on("statusChanged.livedev", function () {
             _handleLiveDocumentError(liveDocument);
         });
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, _, brackets, window */
+/*global define, $, brackets, window */
 
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -69,10 +69,17 @@ define(function main(require, exports, module) {
     };
     var _checkMark = "✓"; // Check mark character
     // Status labels/styles are ordered: error, not connected, progress1, progress2, connected.
-    var _statusTooltip = [Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED, Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED,
-                          Strings.LIVE_DEV_STATUS_TIP_PROGRESS1, Strings.LIVE_DEV_STATUS_TIP_PROGRESS2,
-                          Strings.LIVE_DEV_STATUS_TIP_CONNECTED, Strings.LIVE_DEV_STATUS_TIP_OUT_OF_SYNC];  // Status indicator tooltip
-    var _statusStyle = ["warning", "", "info", "info", "success", "out-of-sync"];  // Status indicator's CSS class
+    var _statusTooltip = [
+        Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED,
+        Strings.LIVE_DEV_STATUS_TIP_NOT_CONNECTED,
+        Strings.LIVE_DEV_STATUS_TIP_PROGRESS1,
+        Strings.LIVE_DEV_STATUS_TIP_PROGRESS2,
+        Strings.LIVE_DEV_STATUS_TIP_CONNECTED,
+        Strings.LIVE_DEV_STATUS_TIP_OUT_OF_SYNC,
+        Strings.LIVE_DEV_STATUS_TIP_SYNC_ERROR
+    ];
+
+    var _statusStyle = ["warning", "", "info", "info", "success", "out-of-sync", "sync-error"];  // Status indicator's CSS class
     var _allStatusStyles = _statusStyle.join(" ");
 
     var _$btnGoLive; // reference to the GoLive button

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -666,6 +666,9 @@ define(function (require, exports, module) {
         this._codeMirror.on("change", function (instance, changeList) {
             $(self).triggerHandler("change", [self, changeList]);
         });
+        this._codeMirror.on("beforeChange", function (instance, changeObj) {
+            $(self).triggerHandler("beforeChange", [self, changeObj]);
+        });
         this._codeMirror.on("cursorActivity", function (instance) {
             $(self).triggerHandler("cursorActivity", [self]);
         });

--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,6 @@
 
     <!-- Pre-load third party scripts that cannot be async loaded. -->
     <script src="thirdparty/jquery-2.0.1.min.js"></script>
-    <script src="thirdparty/lodash/dist/lodash.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
     <script src="thirdparty/CodeMirror2/addon/fold/xml-fold.js"></script>
     <script src="thirdparty/CodeMirror2/addon/edit/matchtags.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -45,6 +45,7 @@
 
     <!-- Pre-load third party scripts that cannot be async loaded. -->
     <script src="thirdparty/jquery-2.0.1.min.js"></script>
+    <script src="thirdparty/lodash/dist/lodash.js"></script>
     <script src="thirdparty/CodeMirror2/lib/codemirror.js"></script>
     <script src="thirdparty/CodeMirror2/addon/fold/xml-fold.js"></script>
     <script src="thirdparty/CodeMirror2/addon/edit/matchtags.js"></script>

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -505,7 +505,7 @@ define(function (require, exports, module) {
         var updater = new DOMUpdater(previousDOM, editor, changeList);
         var result = updater.update();
         if (!result) {
-            return null;
+            return { errors: updater.errors };
         }
         
         var edits = HTMLDOMDiff.domdiff(result.oldSubtree, result.newSubtree);
@@ -546,24 +546,27 @@ define(function (require, exports, module) {
      */
     function getUnappliedEditList(editor, changeList) {
         var cachedValue = _cachedValues[editor.document.file.fullPath];
+        
         // We might not have a previous DOM if the document was empty before this edit.
         if (!cachedValue || !cachedValue.dom || _cachedValues[editor.document.file.fullPath].invalid) {
             // We were in an invalid state, so do a full rebuild.
             changeList = null;
         }
+        
         var result = _updateDOM(cachedValue && cachedValue.dom, editor, changeList);
-        if (result) {
+        
+        if (!result.errors) {
             _cachedValues[editor.document.file.fullPath] = {
                 timestamp: editor.document.diskTimestamp,
                 dom: result.dom,
                 dirty: false
             };
-            return result.edits;
+            return { edits: result.edits };
         } else {
             if (cachedValue) {
                 cachedValue.invalid = true;
             }
-            return [];
+            return { errors: result.errors };
         }
     }
     

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -248,8 +248,8 @@ define(function (require, exports, module) {
 
     Builder.prototype._logError = function (token) {
         var error       = { token: token },
-            startPos    = token ? (token.startPos || token.endPos) : this.startOffset,
-            endPos      = token ? token.endPos : this.startOffset;
+            startPos    = token ? (token.startPos || token.endPos) : this.startOffsetPos,
+            endPos      = token ? token.endPos : this.startOffsetPos;
         
         error.startPos = _addPos(this.startOffsetPos, startPos);
         error.endPos = _addPos(this.startOffsetPos, endPos);

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -247,11 +247,12 @@ define(function (require, exports, module) {
     }
 
     Builder.prototype._logError = function (token) {
-        var error = { token: token },
-            startPos = token.startPos || this.startOffsetPos;
+        var error       = { token: token },
+            startPos    = token ? (token.startPos || token.endPos) : this.startOffset,
+            endPos      = token ? token.endPos : this.startOffset;
         
         error.startPos = _addPos(this.startOffsetPos, startPos);
-        error.endPos = _addPos(this.startOffsetPos, token.endPos);
+        error.endPos = _addPos(this.startOffsetPos, endPos);
 
         if (!this.errors) {
             this.errors = [];

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -245,6 +245,20 @@ define(function (require, exports, module) {
         this.startOffset = startOffset || 0;
         this.startOffsetPos = startOffsetPos || {line: 0, ch: 0};
     }
+
+    Builder.prototype._logError = function (token) {
+        var error = { token: token },
+            startPos = token.startPos || this.startOffsetPos;
+        
+        error.startPos = _addPos(this.startOffsetPos, startPos);
+        error.endPos = _addPos(this.startOffsetPos, token.endPos);
+
+        if (!this.errors) {
+            this.errors = [];
+        }
+
+        this.errors.push(error);
+    };
     
     /**
      * Builds the SimpleDOM.
@@ -288,6 +302,7 @@ define(function (require, exports, module) {
             if (token.type === "error") {
                 PerfUtils.finalizeMeasurement(timerBuildFull);  // discard
                 PerfUtils.addMeasurement(timerBuildPart);       // use
+                this._logError(token);
                 return null;
             } else if (token.type === "opentagname") {
                 var newTagName = token.contents.toLowerCase(),
@@ -365,6 +380,7 @@ define(function (require, exports, module) {
                         // If we're in strict mode, treat unbalanced tags as invalid.
                         PerfUtils.finalizeMeasurement(timerBuildFull);
                         PerfUtils.addMeasurement(timerBuildPart);
+                        this._logError(token);
                         return null;
                     }
                     if (i >= 0) {
@@ -386,6 +402,7 @@ define(function (require, exports, module) {
                         if (strict) {
                             PerfUtils.finalizeMeasurement(timerBuildFull);
                             PerfUtils.addMeasurement(timerBuildPart);
+                            this._logError(token);
                             return null;
                         }
                     }
@@ -430,6 +447,7 @@ define(function (require, exports, module) {
             if (strict) {
                 PerfUtils.finalizeMeasurement(timerBuildFull);
                 PerfUtils.addMeasurement(timerBuildPart);
+                this._logError(token);
                 return null;
             } else {
                 // Manually compute the position of the end of the text (we can't rely on the
@@ -448,6 +466,7 @@ define(function (require, exports, module) {
             // This can happen if the document has no nontrivial content, or if the user tries to
             // have something at the root other than the HTML tag. In all such cases, we treat the
             // document as invalid.
+            this._logError(token);
             return null;
         }
         

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -93,6 +93,7 @@ define({
     "LIVE_DEV_STATUS_TIP_PROGRESS2"     : "Live Preview: Initializing\u2026",
     "LIVE_DEV_STATUS_TIP_CONNECTED"     : "Disconnect Live Preview",
     "LIVE_DEV_STATUS_TIP_OUT_OF_SYNC"   : "Live Preview: Click to disconnect (Save file to update)",
+    "LIVE_DEV_STATUS_TIP_SYNC_ERROR"    : "Live Preview: Click to disconnect (Fix syntax errors to update)",
 
     "LIVE_DEV_DETACHED_REPLACED_WITH_DEVTOOLS" : "Live Preview was cancelled because the browser's developer tools were opened",
     "LIVE_DEV_DETACHED_TARGET_CLOSED"          : "Live Preview was cancelled because the page was closed in the browser",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1049,7 +1049,7 @@ label input {
 }
 
 /* Live Preview */
-.cm-s-default .CodeMirror-linenumber.live-preview-error {
+.live-preview-sync-error .CodeMirror-linenumber {
     background-color: @live-preview-sync-error-background;
     color: @live-preview-sync-error-color;
 }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -326,6 +326,10 @@ a, img {
     &.out-of-sync {
         .sprite-swap(0, 72px);
     }
+    // 'sync-error'
+    &.sync-error {
+        .sprite-swap(0, 96px);
+    }
 }
 
 #toolbar-extension-manager {
@@ -1042,4 +1046,10 @@ a, img {
 label input {
     position: relative;
     top: -2px;
+}
+
+/* Live Preview */
+.cm-s-default .CodeMirror-linenumber.live-preview-error {
+    background-color: @live-preview-sync-error-background;
+    color: @live-preview-sync-error-color;
 }

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -118,6 +118,10 @@
 @custom-scrollbar-thumb: rgba(0, 0, 0, 0.24);
 @custom-scrollbar-thumb-inactive: rgba(0, 0, 0, 0.12);
 
+/* live preview */
+@live-preview-sync-error-background: #d33682;
+@live-preview-sync-error-color: @bc-white;
+
 /* Code font formatting
  *
  * NOTE (JRB): In order to get the web font to load early enough, we have a div called "dummy-text" that

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -119,7 +119,7 @@
 @custom-scrollbar-thumb-inactive: rgba(0, 0, 0, 0.12);
 
 /* live preview */
-@live-preview-sync-error-background: #d33682;
+@live-preview-sync-error-background: #ff5d99;
 @live-preview-sync-error-color: @bc-white;
 
 /* Code font formatting

--- a/src/styles/images/live_development_sprites.svg
+++ b/src/styles/images/live_development_sprites.svg
@@ -2,9 +2,9 @@
 <!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="24px" height="112px" viewBox="-8.5 7.5 24 112" enable-background="new -8.5 7.5 24 112" xml:space="preserve">
+	 width="24px" height="144px" viewBox="-8.5 7.5 24 144" enable-background="new -8.5 7.5 24 144" xml:space="preserve">
 <g transform="translate(0, 1)">
-	<polygon id="bolt" fill="#BBBBBB" points="6.5,18.5 0.5,14.5 -7.5,24.5 0.5,19.5 6.5,23.5 14.5,13.5 	"/>
+	<polygon id="bolt" fill="#BBBBBB"    points="6.5,18.5 0.5,14.5 -7.5,24.5 0.5,19.5 6.5,23.5 14.5,13.5 	"/>
 </g>
 <g transform="translate(0, 33)">
 	<polygon id="bolt_2_" fill="#FBB03B" points="6.5,10.5 0.5,6.5 -7.5,16.5 0.5,11.5 6.5,15.5 14.5,5.5 	"/>
@@ -20,5 +20,8 @@
 		<polygon id="bolt_5_" fill="#FBB03B" points="6.5,10.5 0.5,6.5 -7.5,16.5 0.5,11.5 6.5,15.5 14.5,5.5 		"/>
 	</g>
 	<circle fill="#BBBBBB" cx="12.5" cy="13.5" r="2"/>
+</g>
+<g transform="translate(0, 105)">
+	<polygon id="bolt_3_" fill="#d33682" points="6.5,10.5 0.5,6.5 -7.5,16.5 0.5,11.5 6.5,15.5 14.5,5.5 	"/>
 </g>
 </svg>

--- a/src/styles/images/live_development_sprites.svg
+++ b/src/styles/images/live_development_sprites.svg
@@ -22,6 +22,6 @@
 	<circle fill="#BBBBBB" cx="12.5" cy="13.5" r="2"/>
 </g>
 <g transform="translate(0, 105)">
-	<polygon id="bolt_3_" fill="#d33682" points="6.5,10.5 0.5,6.5 -7.5,16.5 0.5,11.5 6.5,15.5 14.5,5.5 	"/>
+	<polygon id="bolt_3_" fill="#ff5d99" points="6.5,10.5 0.5,6.5 -7.5,16.5 0.5,11.5 6.5,15.5 14.5,5.5 	"/>
 </g>
 </svg>

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -1008,7 +1008,7 @@ define(function (require, exports, module) {
                     operationFn(i, pos);
                     result = HTMLInstrumentation._updateDOM(curDOM, editor, wasInvalid ? null : changeList);
                     if (!edits) {
-                        expect(result).toBeNull();
+                        expect(Array.isArray(result.errors)).toBe(true);
                         wasInvalid = true;
                     } else {
                         var expectedEdit = edits[i];


### PR DESCRIPTION
- Dispatch error events from `HTMLDocument` and handle gutter updates in `LiveDevelopment`
- Adds new `sync-error` status tooltip and SVG graphic
- Adds new gutter markers for errors
