### PR TITLE
[LiveHTML] Allow edits *before* a deleted item to be relative to it

### DIFF
--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -123,12 +123,15 @@ define(function (require, exports, module) {
          * list. This function sets the `beforeID` on any pending edits and adds
          * them to the main list.
          *
-         * The beforeID set here will then be used as the `afterID` for text edits
-         * that follow.
+         * If this item is not being deleted, then it will be used as the `afterID`
+         * for text edits that follow.
          *
          * @param {int} beforeID ID to set on the pending edits
+         * @param {boolean} isBeingDeleted true if the given item is being deleted. If so,
+         *     we can't use it as the `afterID` for future edits--whatever previous item
+         *     was set as the `textAfterID` is still okay.
          */
-        var finalizeNewEdits = function (beforeID) {
+        var finalizeNewEdits = function (beforeID, isBeingDeleted) {
             newEdits.forEach(function (edit) {
                 // elementDeletes don't need any positioning information
                 if (edit.type !== "elementDelete") {
@@ -137,7 +140,13 @@ define(function (require, exports, module) {
             });
             edits.push.apply(edits, newEdits);
             newEdits = [];
-            textAfterID = beforeID;
+            
+            // If the item we made this set of edits relative to
+            // is being deleted, we can't use it as the afterID for future
+            // edits.
+            if (!isBeingDeleted) {
+                textAfterID = beforeID;
+            }
         };
         
         /**
@@ -191,6 +200,10 @@ define(function (require, exports, module) {
          */
         var addElementDelete = function () {
             if (!newNodeMap[oldChild.tagID]) {
+                // We can finalize existing edits relative to this node *before* it's
+                // deleted.
+                finalizeNewEdits(oldChild.tagID, true);
+                
                 newEdit = {
                     type: "elementDelete",
                     tagID: oldChild.tagID
@@ -402,7 +415,7 @@ define(function (require, exports, module) {
                     } else {
                         // Since this element hasn't moved, it is a suitable "beforeID"
                         // for the edits we've logged.
-                        finalizeNewEdits(oldChild.tagID);
+                        finalizeNewEdits(oldChild.tagID, false);
                         newIndex++;
                         oldIndex++;
                     }

--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -143,7 +143,9 @@ define(function (require, exports, module) {
             
             // If the item we made this set of edits relative to
             // is being deleted, we can't use it as the afterID for future
-            // edits.
+            // edits. It's okay to just keep the previous afterID, since
+            // this node will no longer be in the tree by the time we get
+            // to any future edit that needs an afterID.
             if (!isBeingDeleted) {
                 textAfterID = beforeID;
             }

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -2648,6 +2648,56 @@ define(function (require, exports, module) {
                     );
                 });
             });
+            
+            it("should handle pasting a tag over multiple tags and text", function () {
+                setupEditor("<h1>before<strong>Strong</strong>Hello<em>Emphasized</em>after</h1>");
+                var h1,
+                    strong,
+                    em;
+                runs(function () {
+                    doFullAndIncrementalEditTest(
+                        function (editor, previousDOM) {
+                            h1 = previousDOM;
+                            strong = previousDOM.children[1];
+                            em = previousDOM.children[3];
+                            editor.document.replaceRange("<i>Italic</i>", {line: 0, ch: 10}, {line: 0, ch: 57});
+                        },
+                        function (result, previousDOM, incremental) {
+                            var i = result.dom.children[1];
+                            
+                            expect(result.edits.length).toBe(5);
+                            expect(result.edits[0]).toEqual({
+                                type: "elementDelete",
+                                tagID: strong.tagID
+                            });
+                            expect(result.edits[1]).toEqual({
+                                type: "textReplace",
+                                parentID: h1.tagID,
+                                beforeID: em.tagID,
+                                content: "before"
+                            });
+                            expect(result.edits[2]).toEqual({
+                                type: "elementInsert",
+                                tag: "i",
+                                tagID: i.tagID,
+                                parentID: h1.tagID,
+                                attributes: {},
+                                beforeID: em.tagID
+                            });
+                            expect(result.edits[3]).toEqual({
+                                type: "elementDelete",
+                                tagID: em.tagID
+                            });
+                            expect(result.edits[4]).toEqual({
+                                type: "textInsert",
+                                parentID: i.tagID,
+                                content: "Italic",
+                                lastChild: true
+                            });
+                        }
+                    );
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
For #5154. @dangoor 

This fixes #5154 (and miraculously doesn't break any other tests) by making it so that edits that occur before the deletion of an element can use it as their `beforeID`. This makes it so we can avoid cases where text nodes around deleted elements can end up not being handled properly.

(I'm not sure why it doesn't affect any other tests, but it's probably because we don't generally test edits that involve the deletion of multiple nodes while others are being inserted. We might want to add more of those.)

I was originally worried that this would be problematic for moves, but my read of the code is that moves are really just like insertions in terms of the order they're processed in, so they should work the same way.
