### PR TITLE
Fix exceptions during JS Code Hint Unit Tests

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -327,6 +327,11 @@ define(function (require, exports, module) {
      */
     function getSessionHints(query, cursor, type, token, $deferredHints) {
 
+        // We're getting here with a null session object in units tests
+        if (!session) {
+            return null;
+        }
+
         var hintResults = session.getHints(query, getStringMatcher());
         if (hintResults.needGuesses) {
             var guessesResponse = ScopeManager.requestGuesses(session,

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -327,7 +327,8 @@ define(function (require, exports, module) {
      */
     function getSessionHints(query, cursor, type, token, $deferredHints) {
 
-        // We're getting here with a null session object in units tests
+        // If editor is closed before deferred hints are resolved, then the session
+        // object may have already been released. No need to do anything.
         if (!session) {
             return null;
         }


### PR DESCRIPTION
This is for #5099.

This avoids exception, but I'm not sure about intent of code, and no unit tests are failing. Maybe this is a symptom of missing methods on some objects?

Note that this only happens during unit tests, so it might be a timing difference or maybe something it not setup right. Still seems like a good safety check.
