### PR TITLE
Fix remoteTempDirectory() in unit tests

### DIFF
--- a/test/BootstrapReporterView.js
+++ b/test/BootstrapReporterView.js
@@ -107,9 +107,6 @@ define(function (require, exports, module) {
     BootstrapReporterView.prototype._handleRunnerStart = function (event, reporter) {
         var topLevelData,
             self = this;
-
-        // Make sure we don't have a temp folder when we start....
-        SpecRunnerUtils.removeTempDirectory();
         
         // create top level suite list navigation
         this._createSuiteList(reporter.suites, reporter.sortedNames, reporter.totalSpecCount);
@@ -132,9 +129,6 @@ define(function (require, exports, module) {
     };
     
     BootstrapReporterView.prototype._handleRunnerEnd = function (event, reporter) {
-        // Make sure we don't have a temp folder when we're finished....
-        SpecRunnerUtils.removeTempDirectory();
-
         if (this.$info) {
             this.$info.toggleClass("alert-info", false);
             

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, $, beforeEach, afterEach, jasmine, brackets */
+/*global require, define, $, waitsForDone, beforeEach, afterEach, beforeFirst, afterLast, jasmine, brackets */
 
 // Set the baseUrl to brackets/src
 require.config({
@@ -229,6 +229,38 @@ define(function (require, exports, module) {
         };
     }
     
+    function _registerBeforeAfterHandlers() {
+        // Initiailize unit test preferences for each spec
+        beforeEach(function () {
+            // Unique key for unit testing
+            localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
+
+            // Reset preferences from previous test runs
+            localStorage.removeItem("doLoadPreferences");
+            localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
+            
+            SpecRunnerUtils.runBeforeFirst();
+        });
+        
+        // Revert unit test preferences after each spec
+        afterEach(function () {
+            // Clean up preferencesKey
+            localStorage.removeItem("preferencesKey");
+            
+            SpecRunnerUtils.runAfterLast();
+        });
+        
+        // Delete temp folder before running the first test
+        beforeFirst(function () {
+            waitsForDone(SpecRunnerUtils.removeTempDirectory(), "Remove test/temp folder before running tests", 1000);
+        });
+        
+        // Delete temp folder after running the last test
+        afterLast(function () {
+            waitsForDone(SpecRunnerUtils.removeTempDirectory(), "Remove test/temp folder after running tests", 1000);
+        });
+    }
+    
     function init() {
         // Start up the node connection, which is held in the
         // _nodeConnectionDeferred module variable. (Use 
@@ -306,31 +338,14 @@ define(function (require, exports, module) {
         
         _loadExtensionTests(selectedSuites).done(function () {
             var jasmineEnv = jasmine.getEnv();
-            
-            // Initiailize unit test preferences for each spec
-            beforeEach(function () {
-                // Unique key for unit testing
-                localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
-
-                // Reset preferences from previous test runs
-                localStorage.removeItem("doLoadPreferences");
-                localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
-                
-                SpecRunnerUtils.runBeforeFirst();
-            });
-            
-            afterEach(function () {
-                // Clean up preferencesKey
-                localStorage.removeItem("preferencesKey");
-                
-                SpecRunnerUtils.runAfterLast();
-            });
-            
             jasmineEnv.updateInterval = 1000;
+            
+            _registerBeforeAfterHandlers();
             
             // Create the reporter, which is really a model class that just gathers
             // spec and performance data.
             reporter = new UnitTestReporter(jasmineEnv, topLevelFilter, params.get("spec"));
+            SpecRunnerUtils.setUnitTestReporter(reporter);
             
             // Optionally emit JUnit XML file for automated runs
             if (resultsPath) {

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
-            SpecRunnerUtils.removeTempDirectory();
+            waitsForDone(SpecRunnerUtils.removeTempDirectory(), "Remove temp directory after LowLevelFileIO-tests", 1000);
         });
 
         it("should have a brackets.fs namespace", function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -233,20 +233,65 @@ define(function (require, exports, module) {
         waitsForDone(deferred, "Create temp directory", 500);
     }
     
-    function removeTempDirectory() {
-        var baseDir = getTempDirectory();
+    function stat(pathname) {
+        var promise = new $.Deferred();
         
-        // Restore directory permissions before (otherwise the deletePath may fail)
-        // We need to make sure everything is read/write before we delete it or we won't
-        //  be able to delete the folder.  Ideally we should traverse the directory and 
-        //  change the mode for every file / directory we encounter but, for now,
-        //  since we only have these two folders which we make read / write only
-        //  just chmod these two folder.  This is a MAC only issue.
-        // TODO: Traverse baseDir and chmod everything before we delete.
-        waitsForDone(chmod(baseDir + "/cant_read_here", "777"), "reset permissions");
-        waitsForDone(chmod(baseDir + "/cant_write_here", "777"), "reset permissions");
-        // Remove the test data and anything else left behind from tests
-        waitsForDone(deletePath(baseDir, true), "delete temp files");
+        brackets.fs.stat(pathname, function (err, _stat) {
+            if (err === brackets.fs.NO_ERROR) {
+                promise.resolve(_stat);
+            } else {
+                promise.reject(err);
+            }
+        });
+        
+        return promise;
+    }
+    
+    function resetPermissionsOnSpecialTempFolders() {
+        var i,
+            folderCount,
+            resolvedCount = 0,
+            folders = [],
+            baseDir = getTempDirectory(),
+            promise = new $.Deferred();
+            
+        folders.push(baseDir + "/cant_read_here");
+        folders.push(baseDir + "/cant_write_here");
+        
+        folderCount = folders.length;
+            
+        var alwaysHandler = function () {
+            if (++resolvedCount === folderCount) {
+                promise.resolve();
+            }
+        };
+        
+        var resetPermissions = function (pathname) {
+            stat(folders[i]).then(chmod(pathname).always(alwaysHandler), alwaysHandler);
+        };
+        
+        for (i = 0; i < folderCount; i++) {
+            resetPermissions(folders[i]);
+        }
+        
+        return promise;
+    }
+    
+    
+    function removeTempDirectory() {
+        var promise = new $.Deferred(),
+            baseDir = getTempDirectory();
+        
+        resetPermissionsOnSpecialTempFolders().always(function () {
+            deletePath(baseDir, true)
+                .done(function () {
+                    promise.resolve();
+                })
+                .fail(function () {
+                    promise.reject();
+                });
+        });
+        return promise;
     }
     
     function getBracketsSourceRoot() {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -263,17 +263,19 @@ define(function (require, exports, module) {
         promise = Async.doSequentially(folders, function (folder) {
             var deferred = new $.Deferred();
             
-            _stat(folder).done(function () {
-                // Change permissions if the directory exists
-                chmod(folder, 777).then(deferred.resolve, deferred.reject);
-            }).fail(function (err) {
-                if (err === brackets.fs.ERR_NOT_FOUND) {
-                    // Resolve the promise since the folder to reset doesn't exist
-                    deferred.resolve();
-                } else {
-                    deferred.reject();
-                }
-            });
+            _stat(folder)
+                .done(function () {
+                    // Change permissions if the directory exists
+                    chmod(folder, 777).then(deferred.resolve, deferred.reject);
+                })
+                .fail(function (err) {
+                    if (err === brackets.fs.ERR_NOT_FOUND) {
+                        // Resolve the promise since the folder to reset doesn't exist
+                        deferred.resolve();
+                    } else {
+                        deferred.reject();
+                    }
+                });
             
             return deferred.promise();
         }, true);


### PR DESCRIPTION
Fix for #5109 
- Move `removeTempDirectory` from the `BootstrapReporterView` to `beforeFirst` and `afterLast` scoped to the `SpecRunner`
- Use `UnitTestReporter` in `SpecRunnerUtils` to track the last run spec
- Fix async and `ERR_NOT_FOUND` issues in `removeTempDirectory`
