### PR TITLE
replace node fs-extra remove() with removeTempDirectory()

### DIFF
--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
         afterEach(function () {
             ExtensionLoader.getUserExtensionPath = realGetUserExtensionPath;
             ExtensionLoader.loadExtension = realLoadExtension;
-            var promise = SpecRunnerUtils.remove(mockGetUserExtensionPath());
+            var promise = SpecRunnerUtils.removeTempDirectory();
             waitsForDone(promise, "Mock Extension Removal", 2000);
         });
         

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
         afterEach(function () {
             ExtensionLoader.getUserExtensionPath = realGetUserExtensionPath;
             ExtensionLoader.loadExtension = realLoadExtension;
-            var promise = SpecRunnerUtils.removeTempDirectory();
+            var promise = SpecRunnerUtils.deletePath(mockGetUserExtensionPath(), true);
             waitsForDone(promise, "Mock Extension Removal", 2000);
         });
         


### PR DESCRIPTION
Fix intermittent failure (see 0.31.0.-9452 on windows) by replacing `fs-extra.remove()` in Node with `brackets.fs.unlink` via `SpecRunnerUtils.removeTempDirectory()`. Possible related issue from fs-extra rim-raf dependency https://github.com/isaacs/rimraf/issues/19.

```
Error: Expected { errno : 53, code : 'ENOTEMPTY', path : 'C:\ws\Brackets-git\brackets\test\temp\extensions\user\basic-valid-extension' } to be null.
    at new jasmine.ExpectationResult (file:///C:/ws/Brackets-git/brackets/test/thirdparty/jasmine-core/jasmine.js:102:32)
    at null.toBeNull (file:///C:/ws/Brackets-git/brackets/test/thirdparty/jasmine-core/jasmine.js:1194:29)
    at NodeConnection.<anonymous> (file:///C:/ws/Brackets-git/brackets/test/spec/ExtensionInstallation-test.js:67:29)
    at NodeConnection.<anonymous> (file:///C:/ws/Brackets-git/brackets/src/thirdparty/jquery-2.0.1.min.js:4:26181)
    at l (file:///C:/ws/Brackets-git/brackets/src/thirdparty/jquery-2.0.1.min.js:4:24797)
    at Object.c.fireWith (file:///C:/ws/Brackets-git/brackets/src/thirdparty/jquery-2.0.1.min.js:4:25618)
    at NodeConnection._receive (file:///C:/ws/Brackets-git/brackets/src/utils/NodeConnection.js:422:34)
```
