### PR TITLE
Spanish strings and sample translations for Sprint 31

### DIFF
--- a/samples/es/Primeros Pasos/index.html
+++ b/samples/es/Primeros Pasos/index.html
@@ -45,7 +45,7 @@
         <p>
             Se acabó el estar saltando de documento en documento perdiendo de vista lo que estás haciendo. Mientras
             estás escribiendo HTML, usa el atajo de teclado <kbd>Cmd/Ctrl + E</kbd> para abrir un editor rápido en
-            línea con todo el contenido CSS relacionado. Ajusta tu CSS y pulsa <kbd>ESC</kbd> para volver a tu HTML, o simplemente
+            línea con todo el contenido CSS relacionado. Ajusta tu CSS y oprime <kbd>ESC</kbd> para volver a tu HTML, o simplemente
             mantén las reglas CSS abiertas para que pasen a formar parte de tu editor de HTML. Si pulsas <kbd>ESC</kbd>
             fuera de un editor rápido, todos se cerrarán a la vez.
         </p>
@@ -73,7 +73,7 @@
         <h3>Visualiza cambios en archivos HTML y CSS en vivo en el navegador</h3>
         <p>
             ¿Conoces ese baile de "guardar/recargar" que llevamos años haciendo? ¿Ése en el que haces cambios en tu
-            editor, pulsas guardar, cambias al navegador y recargas para por fin poder ver el  resultado? Con Brackets,
+            editor, oprimes guardar, cambias al navegador y recargas para por fin poder ver el  resultado? Con Brackets,
             ya no tienes que hacerlo.
         </p>
         <p>
@@ -124,7 +124,7 @@
         
         <samp>
             Para probar la previsualización tú mismo, coloca el cursor en la etiqueta <!-- <body> --> al principio de este
-            documento y pulsa <kbd>Cmd/Ctrl + E</kbd> para abrir un editor CSS. Ahora, simplemente mueve el ratón sobre
+            documento y oprime <kbd>Cmd/Ctrl + E</kbd> para abrir un editor CSS. Ahora, simplemente mueve el ratón sobre
             cualquiera de los colores dentro del CSS. También puedes verlo funcionando en gradientes abriendo un editor
             de CSS en la etiqueta <!-- <html> --> pasando el cursor por cualquiera de los valores para las imágenes de fondo.
             Para probar la vista previa de imágenes, coloca el cursor sobre la imagen con la captura de pantalla incluida

--- a/samples/es/Primeros Pasos/index.html
+++ b/samples/es/Primeros Pasos/index.html
@@ -51,7 +51,7 @@
         </p>
 
         <samp>
-            ¿Quieres verlo funcionando? Coloca tu cursor sobe la etiqueta <!-- <samp> --> y pulsa <kbd>Cmd/Ctrl + E</kbd>.
+            ¿Quieres verlo funcionando? Coloca tu cursor sobe la etiqueta <!-- <samp> --> y oprime <kbd>Cmd/Ctrl + E</kbd>.
             Deberías ver aparecer un editor rápido de CSS más arriba. A la derecha verás un listado de todas las reglas CSS
             relacionadas con esta etiqueta. Simplemente desplázate entre las reglas con <kbd>Alt + Arriba/Abajo</kbd> para
             encontrar la que quieres modificar.

--- a/samples/es/Primeros Pasos/index.html
+++ b/samples/es/Primeros Pasos/index.html
@@ -19,7 +19,7 @@
 
         <p>
             Bienvenido a una versión preliminar de Brackets, un nuevo editor de código abierto para la nueva
-            generación de Internet. Somos unos apasionados de los estándares y queremos construir mejores 
+            generación de Internet. Somos unos apasionados de los estándares y queremos construir mejores
             herramientas para JavaScript, HTML, CSS y el resto de tecnologías web. Éste es nuestro humilde
             comienzo.
         </p>
@@ -30,7 +30,7 @@
         <p>
             <em>Brackets es un editor diferente.</em>
             La gran diferencia es que está escrito en JavaScript, HTML y CSS. Esto significa que la mayoría de quienes
-            usan Brackets tiene las habilidades necesarias para modificar y extender el editor. De hecho, nosotros 
+            usan Brackets tiene las habilidades necesarias para modificar y extender el editor. De hecho, nosotros
             lo usamos todos los días para desarrollar Brackets. También tiene algunas características únicas como
             Edición Rápida, Desarrollo en Vivo y más que no encontrarás en otros editores.
             Sigue leyendo para saber más sobre cómo sacar provecho de estas características
@@ -43,17 +43,17 @@
         -->
         <h3>Edición rápida de CSS y JavaScript</h3>
         <p>
-            Se acabó el estar saltando de documento en documento perdiendo de vista lo que estás haciendo. Mientras 
-            estás escribiendo HTML, usa el atajo de teclado <kbd>Cmd/Ctrl + E</kbd> para abrir un editor rápido en 
-            línea con todo el contenido CSS relacionado. Ajusta tu CSS y pulsa <kbd>ESC</kbd> para volver a tu HTML, o simplemente 
-            mantén las reglas CSS abiertas para que pasen a formar parte de tu editor de HTML. Si pulsas <kbd>ESC</kbd> 
+            Se acabó el estar saltando de documento en documento perdiendo de vista lo que estás haciendo. Mientras
+            estás escribiendo HTML, usa el atajo de teclado <kbd>Cmd/Ctrl + E</kbd> para abrir un editor rápido en
+            línea con todo el contenido CSS relacionado. Ajusta tu CSS y pulsa <kbd>ESC</kbd> para volver a tu HTML, o simplemente
+            mantén las reglas CSS abiertas para que pasen a formar parte de tu editor de HTML. Si pulsas <kbd>ESC</kbd>
             fuera de un editor rápido, todos se cerrarán a la vez.
         </p>
 
         <samp>
-            ¿Quieres verlo funcionando? Coloca tu cursor sobe la etiqueta <!-- <samp> --> y pulsa <kbd>Cmd/Ctrl + E</kbd>. 
-            Deberías ver aparecer un editor rápido de CSS más arriba. A la derecha verás un listado de todas las reglas CSS 
-            relacionadas con esta etiqueta. Simplemente desplázate entre las reglas con <kbd>Alt + Arriba/Abajo</kbd> para 
+            ¿Quieres verlo funcionando? Coloca tu cursor sobe la etiqueta <!-- <samp> --> y pulsa <kbd>Cmd/Ctrl + E</kbd>.
+            Deberías ver aparecer un editor rápido de CSS más arriba. A la derecha verás un listado de todas las reglas CSS
+            relacionadas con esta etiqueta. Simplemente desplázate entre las reglas con <kbd>Alt + Arriba/Abajo</kbd> para
             encontrar la que quieres modificar.
         </samp>
         
@@ -63,71 +63,71 @@
         
         <p>
             Puedes usar el mismo atajo en JavaScript para ver el cuerpo de una función colocando el ratón sobre
-            el nombre de la llamada a la función que quieras examinar. Por ahora, no se pueden anidar editores en línea, por 
+            el nombre de la llamada a la función que quieras examinar. Por ahora, no se pueden anidar editores en línea, por
             lo que sólo puedes usar la característica de Edición Rápida cuando el cursor está en un editor "completo".
         </p>
 
         <!--
             LIVE PREVIEW
         -->
-        <h3>Visualiza cambios en archivos CSS en vivo en el navegador</h3>
+        <h3>Visualiza cambios en archivos HTML y CSS en vivo en el navegador</h3>
         <p>
-            ¿Conoces ese baile de "guardar/recargar" que llevamos años haciendo? ¿Ése en el que haces cambios en tu 
-            editor, pulsas guardar, cambias al navegador y recargas para por fin poder ver el  resultado? Con Brackets, 
+            ¿Conoces ese baile de "guardar/recargar" que llevamos años haciendo? ¿Ése en el que haces cambios en tu
+            editor, pulsas guardar, cambias al navegador y recargas para por fin poder ver el  resultado? Con Brackets,
             ya no tienes que hacerlo.
         </p>
         <p>
             ¡Brackets abrirá una <em>conexión en vivo</em> con tu navegador local y le enviará los cambios en el
-            archivo CSS conforme escribas! Puede que ya estés haciendo algo parecido con las herramientas de desarrollo  
-            del navegador, pero con Brackets ya no necesitas copiar y pegar las reglas CSS final de vuelta a tu editor. 
+            archivo HTML y CSS conforme escribas! Puede que ya estés haciendo algo parecido con las herramientas de desarrollo
+            del navegador, pero con Brackets ya no necesitas copiar y pegar el código final de vuelta a tu editor.
             ¡Tu código se ejecuta en el navegador, pero vive en tu editor!
         </p>
         
         <h3>Resaltado en vivo de elementos HTML y reglas CSS</h3>
         <p>
-            Brackets te ayuda a ver cómo los cambios en HTML y CSS afectan a tu página. Cuando tu cursor se encuentre 
-            sobre una regla de CSS, Brackets resaltará todos los elementos afectados en el navegador. Del mismo modo, 
-            cuando estés editando un archivo HTML, Brackets también resaltará los elementos correspondientes en tu 
+            Brackets te ayuda a ver cómo los cambios en HTML y CSS afectan a tu página. Cuando tu cursor se encuentre
+            sobre una regla de CSS, Brackets resaltará todos los elementos afectados en el navegador. Del mismo modo,
+            cuando estés editando un archivo HTML, Brackets también resaltará los elementos correspondientes en tu
             navegador.
         </p>
 
         <samp>
             Si tienes instalado Google Chrome, puedes probarlo tú mismo. Haz click sobre el icono del rayo de la
             esquina superior derecha o presiona <kbd>Cmd/Ctrl + Alt + P</kbd>. Cuando Desarrollo en Vivo está
-            funcionando en un documento HTML, todos los documentos CSS relacionados se pueden editar en 
+            funcionando en un documento HTML, todos los documentos CSS relacionados se pueden editar en
             tiempo real. El icono pasará de gris a dorado cuando Brackets consiga establecer una conexión
             con tu navegador.
             
-            Ahora, coloca el cursor sobre la etiqueta <!-- <img> --> que se encuentra un poco más arriba. Observa 
-            cómo aparece el resaltado azul alrededor de la imagen en Chrome. Luego, utiliza <kbd>Cmd/Ctrl + E</kbd> 
-            para abrir las reglas de CSS existentes. Intenta cambiar el tamaño del borde de 1 a 10 píxeles o el color 
-            del fondo de "dimgray" a "hotpink". Si Brackets y tu navegador están funcionando en paralelo, verás los 
+            Ahora, coloca el cursor sobre la etiqueta <!-- <img> --> que se encuentra un poco más arriba. Observa
+            cómo aparece el resaltado azul alrededor de la imagen en Chrome. Luego, utiliza <kbd>Cmd/Ctrl + E</kbd>
+            para abrir las reglas de CSS existentes. Intenta cambiar el tamaño del borde de 1 a 10 píxeles o el color
+            del fondo de "dimgray" a "hotpink". Si Brackets y tu navegador están funcionando en paralelo, verás los
             cambios reflejados de manera instantánea en tu navegador. Genial, ¿verdad?
         </samp>
         
         <p class="note">
-            Actualmente, Brackets sólo soporta Desarrollo en Vivo para CSS. Aún así, en la versión actual, los cambios 
-            en ficheros HTML y JavaScript son detectados y recargados automáticamente en el navegador cuando guardas. En 
-            estos momentos estamos trabajando en añadir soporte para Desarrollo en Vivo de HTML y JavaScript. Además, las 
-            actualizaciones automáticas sólo son posibles en Google Chrome, pero esperamos poder trasladar próximamente 
+            Actualmente, Brackets sólo soporta Desarrollo en Vivo para HTML y CSS. Aún así, en la versión actual, los cambios
+            en ficheros JavaScript son detectados y recargados automáticamente en el navegador cuando guardas. En
+            estos momentos estamos trabajando en añadir soporte para Desarrollo en Vivo para JavaScript. Además, las
+            actualizaciones automáticas sólo son posibles en Google Chrome, pero esperamos poder trasladar próximamente
             esta funcionalidad a todos los grandes navegadores.
         </p>
         
         <h3>Vista Rápida</h3>
         <p>
-            Para aquellos que todavía no han memorizado las equivalencias de color entre HEX y RGB, Brackets permite ver 
-            exactamente qué color se está utilizando rápida y fácilmente. Tanto en CSS como en HTML, simplemente mueve el 
+            Para aquellos que todavía no han memorizado las equivalencias de color entre Hex y RGB, Brackets permite ver
+            exactamente qué color se está utilizando rápida y fácilmente. Tanto en CSS como en HTML, simplemente mueve el
             cursor sobre cualquier valor de color o gradiente y Brackets mostrará una previsualización del mismo de manera
-            automática. Lo mismo sirve para imágenes: simplemente pasa el cursor sobre la dirección de una imagen en Brackets, 
+            automática. Lo mismo sirve para imágenes: simplemente pasa el cursor sobre la dirección de una imagen en Brackets,
             y éste mostrará una vista en miniatura de la misma.
         </p>
         
         <samp>
             Para probar la previsualización tú mismo, coloca el cursor en la etiqueta <!-- <body> --> al principio de este
-            documento y pulsa <kbd>Cmd/Ctrl + E</kbd> para abrir un editor CSS. Ahora, simplemente mueve el ratón sobre 
-            cualquiera de los colores dentro del CSS. También puedes verlo funcionando en gradientes abriendo un editor 
-            de CSS en la etiqueta <!-- <html> --> pasando el cursor por cualquiera de los valores para las imágenes de fondo. 
-            Para probar la vista previa de imágenes, coloca el cursor sobre la imagen con la captura de pantalla incluída 
+            documento y pulsa <kbd>Cmd/Ctrl + E</kbd> para abrir un editor CSS. Ahora, simplemente mueve el ratón sobre
+            cualquiera de los colores dentro del CSS. También puedes verlo funcionando en gradientes abriendo un editor
+            de CSS en la etiqueta <!-- <html> --> pasando el cursor por cualquiera de los valores para las imágenes de fondo.
+            Para probar la vista previa de imágenes, coloca el cursor sobre la imagen con la captura de pantalla incluida
             antes en este documento.
         </samp>
 

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -86,13 +86,14 @@ define({
     "LIVE_DEV_SERVER_NOT_READY_MESSAGE" : "Error iniciando el servidor HTTP para Desarrollo en Vivo. Vuelve a intentarlo, por favor.",
     "LIVE_DEVELOPMENT_INFO_TITLE"       : "¡Bienvenido a Desarrollo en Vivo!",
     "LIVE_DEVELOPMENT_INFO_MESSAGE"     : "Desarrollo en Vivo conecta {APP_NAME} con tu navegador. Lanza una vista previa de tu archivo HTML en el navegador y la actualiza a medida que modificas tu código.<br /><br />En esta versión preliminar de {APP_NAME}, Desarollo en Vivo sólo funciona para cambios de <strong>archivos CSS</strong> y únicamente con <strong>Google Chrome</strong>. ¡Pronto estará disponible también para HTML y JavaScript!<br /><br />(No volverás a ver este mensaje.)",
-    "LIVE_DEVELOPMENT_TROUBLESHOOTING"  : "Consulta <a href='{0}' title='{0}'>Resolución de Problemas de conexión en Desarrollo en Vivo</a> para más información.",
+    "LIVE_DEVELOPMENT_TROUBLESHOOTING"  : "Para más información, consulta <a href='{0}' title='{0}'>Resolución de Problemas de conexión en Desarrollo en Vivo</a>.",
     
     "LIVE_DEV_STATUS_TIP_NOT_CONNECTED" : "Desarrollo en Vivo",
     "LIVE_DEV_STATUS_TIP_PROGRESS1"     : "Desarrollo en Vivo: Conectando\u2026",
     "LIVE_DEV_STATUS_TIP_PROGRESS2"     : "Desarrollo en Vivo: Inicializando\u2026",
     "LIVE_DEV_STATUS_TIP_CONNECTED"     : "Terminar Desarrollo en Vivo",
-    "LIVE_DEV_STATUS_TIP_OUT_OF_SYNC"   : "Desarrollo en Vivo: Haz click para desconectar (Guarda el archivo para actualizar)",
+    "LIVE_DEV_STATUS_TIP_OUT_OF_SYNC"   : "Desarrollo en Vivo (guarda el archivo para actualizar)",
+    "LIVE_DEV_STATUS_TIP_SYNC_ERROR"    : "Desarrollo en Vivo (no se esta actualizando debido a un error de sintaxis)",
     
     "LIVE_DEV_DETACHED_REPLACED_WITH_DEVTOOLS" : "Desarrollo en Vivo se ha detenido porque se han abierto las herramientas de desarrollo",
     "LIVE_DEV_DETACHED_TARGET_CLOSED"          : "Desarrollo en Vivo se ha detenido porque se ha cerrado la página en el navegador",
@@ -120,7 +121,12 @@ define({
     "BUTTON_ALL"                        : "Todos\u2026",
     "BUTTON_STOP"                       : "Parar",
     "BUTTON_REPLACE"                    : "Reemplazar",
-
+    
+    "BUTTON_NEXT"                       : "\u25B6",
+    "BUTTON_PREV"                       : "\u25C0",
+    "BUTTON_NEXT_HINT"                  : "Siguiente coincidencia",
+    "BUTTON_PREV_HINT"                  : "Anterior coincidencia",
+    
     "OPEN_FILE"                         : "Abrir archivo",
     "SAVE_FILE_AS"                      : "Guardar archivo",
     "CHOOSE_FOLDER"                     : "Elige una carpeta",
@@ -144,9 +150,7 @@ define({
     "FIND_IN_FILES_MATCHES"             : "coincidencias",
     "FIND_IN_FILES_MORE_THAN"           : "Más de ",
     "FIND_IN_FILES_PAGING"              : "{0}&mdash;{1}",
-    "FIND_IN_FILES_FILE_PATH"           : "Archivo: <b>{0}</b>",
-    "FIND_IN_FILES_LINE"                : "línea: {0}",
-
+    "FIND_IN_FILES_FILE_PATH"           : "<span class='dialog-filename'>{0}</span> {2} <span class='dialog-path'>{1}</span>",
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Error obteniendo información sobre actualizaciones",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Ocurrió un problema al obtener la información sobre las últimas actualizaciones desde el servidor. Por favor, asegúrate de estar conectado a internet y vuelve a intentarlo.",
 
@@ -176,10 +180,20 @@ define({
     "STATUSBAR_INDENT_TOOLTIP_TABS"         : "Haz click para usar tabulaciones en la sangría",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_SPACES"  : "Haz click para cambiar el número de espacios usados en la sangría",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_TABS"    : "Haz click para cambiar el ancho de las tabulaciones",
-    "STATUSBAR_SPACES"                      : "Espacios",
-    "STATUSBAR_TAB_SIZE"                    : "Tamaño de tabulador",
+    "STATUSBAR_SPACES"                      : "Espacios:",
+    "STATUSBAR_TAB_SIZE"                    : "Tamaño de tabulador:",
     "STATUSBAR_LINE_COUNT_SINGULAR"         : "\u2014 {0} Línea",
     "STATUSBAR_LINE_COUNT_PLURAL"           : "\u2014 {0} Líneas",
+    
+    // CodeInspection: errors/warnings
+    "ERRORS_PANEL_TITLE"                    : "Errores de {0}",
+    "SINGLE_ERROR"                          : "1 Error de {0}",
+    "MULTIPLE_ERRORS"                       : "{1} Errores de {0}",
+    "NO_ERRORS"                             : "No hay errores de {0}. ¡Buen trabajo!",
+    "LINT_DISABLED"                         : "La inspección de código esta deshabilitado",
+    "NO_LINT_AVAILABLE"                     : "No hay inspección de código disponible para {0}",
+    "NOTHING_TO_LINT"                       : "No hay nada para inspeccionar",
+    
     
     /**
      * Command Name Constants
@@ -199,7 +213,6 @@ define({
     "CMD_FILE_SAVE_ALL"                   : "Guardar todo",
     "CMD_FILE_SAVE_AS"                    : "Guardar como\u2026",
     "CMD_LIVE_FILE_PREVIEW"               : "Desarrollo en Vivo",
-    "CMD_LIVE_HIGHLIGHT"                  : "Resaltado en Desarrollo en Vivo",
     "CMD_PROJECT_SETTINGS"                : "Configuración del proyecto\u2026",
     "CMD_FILE_RENAME"                     : "Renombrar",
     "CMD_FILE_DELETE"                     : "Eliminar",
@@ -250,6 +263,8 @@ define({
     "CMD_TOGGLE_LINE_NUMBERS"             : "Mostrar números de línea",
     "CMD_TOGGLE_ACTIVE_LINE"              : "Resaltar línea actual",
     "CMD_TOGGLE_WORD_WRAP"                : "Habilitar ajuste de línea",
+    "CMD_LIVE_HIGHLIGHT"                  : "Resaltado en Desarrollo en Vivo",
+    "CMD_VIEW_TOGGLE_INSPECTION"          : "Inspeccionar el código al guardar",
     "CMD_SORT_WORKINGSET_BY_ADDED"        : "Ordenar por Añadido",
     "CMD_SORT_WORKINGSET_BY_NAME"         : "Ordenar por Nombre",
     "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ordenar por Tipo",
@@ -260,6 +275,7 @@ define({
     "CMD_QUICK_OPEN"                      : "Apertura rápida",
     "CMD_GOTO_LINE"                       : "Ir a la línea",
     "CMD_GOTO_DEFINITION"                 : "Búsqueda rápida de definición",
+    "CMD_GOTO_FIRST_PROBLEM"              : "Ir al primer Error/Advertencia",
     "CMD_TOGGLE_QUICK_EDIT"               : "Edición rápida",
     "CMD_TOGGLE_QUICK_DOCS"               : "Documentación rápida",
     "CMD_QUICK_EDIT_PREV_MATCH"           : "Coincidencia anterior",
@@ -280,12 +296,6 @@ define({
     "CMD_TWITTER"                         : "{TWITTER_NAME} en Twitter",
     "CMD_ABOUT"                           : "Acerca de {APP_TITLE}",
     
-    
-    // Special commands invoked by the native shell
-    "CMD_CLOSE_WINDOW"                    : "Cerrar ventana",
-    "CMD_ABORT_QUIT"                      : "Cancelar salida",
-    "CMD_BEFORE_MENUPOPUP"                : "Antes del Menú Emergente",
-
     // Strings for main-view.html
     "EXPERIMENTAL_BUILD"                   : "versión experimental",
     "DEVELOPMENT_BUILD"                    : "versión de desarrollo",
@@ -402,6 +412,7 @@ define({
 
     "UNIT_PIXELS"                          : "píxeles",
 
+
     // extensions/default/DebugCommands
     "DEBUG_MENU"                                : "Desarrollo",
     "CMD_SHOW_DEV_TOOLS"                        : "Mostrar herramientas para desarrolladores",
@@ -420,9 +431,7 @@ define({
     "LANGUAGE_CANCEL"                           : "Cancelar",
     "LANGUAGE_SYSTEM_DEFAULT"                   : "Idioma predeterminado",
     
-    /**
-     * Locales
-     */
+    // Locales (used by Debug > Switch Language)
     "LOCALE_CS"                                 : "Checo",
     "LOCALE_DE"                                 : "Alemán",
     "LOCALE_EN"                                 : "Inglés",
@@ -436,6 +445,7 @@ define({
     "LOCALE_PT_BR"                              : "Portugués, Brasil",
     "LOCALE_PT_PT"                              : "Portugués",
     "LOCALE_RU"                                 : "Ruso",
+    "LOCALE_SK"                                 : "Eslovaco",
     "LOCALE_SV"                                 : "Sueco",
     "LOCALE_TR"                                 : "Turco",
     "LOCALE_ZH_CN"                              : "Chino, simplificado",
@@ -456,16 +466,13 @@ define({
     "NO_ARGUMENTS"                              : "<no hay parámetros>",
     
     // extensions/default/JSLint
-    "CMD_JSLINT"                                : "Habilitar JSLint",
-    "CMD_JSLINT_FIRST_ERROR"                    : "Ir al primer error de JSLint",
-    "JSLINT_ERRORS"                             : "Errores de JSLint",
-    "JSLINT_ERROR_INFORMATION"                  : "1 Error de JSLint",
-    "JSLINT_ERRORS_INFORMATION"                 : "{0} Errores de JSLint",
-    "JSLINT_NO_ERRORS"                          : "No hay errores de JSLint. ¡Buen trabajo!",
-    "JSLINT_DISABLED"                           : "JSLint está deshabilitado o no soporta el archivo actual",
+    "JSLINT_NAME"                               : "JSLint",
     
     // extensions/default/QuickView
     "CMD_ENABLE_QUICK_VIEW"                     : "Vista rápida con cursor",
+    
+    // extensions/default/RecentProjects
+    "CMD_TOGGLE_RECENT_PROJECTS"                : "Proyectos recientes",
     
     // extensions/default/WebPlatformDocs
     "DOCS_MORE_LINK"                            : "Más"

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -93,7 +93,7 @@ define({
     "LIVE_DEV_STATUS_TIP_PROGRESS2"     : "Desarrollo en Vivo: Inicializando\u2026",
     "LIVE_DEV_STATUS_TIP_CONNECTED"     : "Terminar Desarrollo en Vivo",
     "LIVE_DEV_STATUS_TIP_OUT_OF_SYNC"   : "Desarrollo en Vivo (guarda el archivo para actualizar)",
-    "LIVE_DEV_STATUS_TIP_SYNC_ERROR"    : "Desarrollo en Vivo (no se esta actualizando debido a un error de sintaxis)",
+    "LIVE_DEV_STATUS_TIP_SYNC_ERROR"    : "Desarrollo en Vivo (no se está actualizando debido a un error de sintaxis)",
     
     "LIVE_DEV_DETACHED_REPLACED_WITH_DEVTOOLS" : "Desarrollo en Vivo se ha detenido porque se han abierto las herramientas de desarrollo",
     "LIVE_DEV_DETACHED_TARGET_CLOSED"          : "Desarrollo en Vivo se ha detenido porque se ha cerrado la página en el navegador",


### PR DESCRIPTION
Spanish translation update

Note that most of the samples diff is caused by removing whitespaces at the end of the lines. Just a few lines where updated to mention the new HTML live update.
