### PR TITLE
Don't animate find bar repeatedly during replace operation

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -167,7 +167,7 @@ define(function (require, exports, module) {
         });
     }
     
-    function createModalBar(template, autoClose) {
+    function createModalBar(template, autoClose, animate) {
         // Normally, creating a new modal bar will simply cause the old one to close
         // automatically. This can cause timing issues because the focus change might
         // cause the new one to think it should close, too. The old CodeMirror version
@@ -175,9 +175,9 @@ define(function (require, exports, module) {
         // the modal bar to close. Rather than reinstate that hack, we simply explicitly
         // close the old modal bar before creating a new one.
         if (modalBar) {
-            modalBar.close();
+            modalBar.close(true, animate);
         }
-        modalBar = new ModalBar(template, autoClose);
+        modalBar = new ModalBar(template, autoClose, animate);
         $(modalBar).on("closeOk closeBlur closeCancel", function () {
             modalBar = null;
         });
@@ -506,7 +506,11 @@ define(function (require, exports, module) {
             }
 
             query = parseQuery(query);
-            createModalBar(replacementQueryDialog, true);
+            
+            // Don't animate since it should feel like we're just switching the content of the ModalBar.
+            // Eventually we should rip out all this code (which comes from the old CodeMirror dialog
+            // logic) and just change the content itself.
+            createModalBar(replacementQueryDialog, true, false);
             $(modalBar).on("closeOk", function (e, text) {
                 text = text || "";
                 var match,
@@ -542,7 +546,7 @@ define(function (require, exports, module) {
                             }
                         }
                         editor.setSelection(cursor.from(), cursor.to(), true, Editor.BOUNDARY_CHECK_NORMAL);
-                        createModalBar(doReplaceConfirm, true);
+                        createModalBar(doReplaceConfirm, true, false);
                         modalBar.getRoot().on("click", function (e) {
                             modalBar.close();
                             if (e.target.id === "replace-yes") {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -548,7 +548,7 @@ define(function (require, exports, module) {
                         editor.setSelection(cursor.from(), cursor.to(), true, Editor.BOUNDARY_CHECK_NORMAL);
                         createModalBar(doReplaceConfirm, true, false);
                         modalBar.getRoot().on("click", function (e) {
-                            modalBar.close();
+                            modalBar.close(true, false);
                             if (e.target.id === "replace-yes") {
                                 doReplace(match);
                             } else if (e.target.id === "replace-no") {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -548,7 +548,8 @@ define(function (require, exports, module) {
                         editor.setSelection(cursor.from(), cursor.to(), true, Editor.BOUNDARY_CHECK_NORMAL);
                         createModalBar(doReplaceConfirm, true, false);
                         modalBar.getRoot().on("click", function (e) {
-                            modalBar.close(true, false);
+                            var animate = (e.target.id !== "replace-yes" && e.target.id !== "replace-no");
+                            modalBar.close(true, animate);
                             if (e.target.id === "replace-yes") {
                                 doReplace(match);
                             } else if (e.target.id === "replace-no") {

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -45,19 +45,28 @@ define(function (require, exports, module) {
      *      in the first input field, or if the modal bar loses focus to an outside item. Dispatches 
      *      jQuery events for these cases: "closeOk" on RETURN, "closeCancel" on ESC, and "closeBlur" 
      *      on focus loss.
+     * @param {boolean} animate If true (the default), animate the dialog closed, otherwise
+     *      close it immediately.
      */
-    function ModalBar(template, autoClose) {
+    function ModalBar(template, autoClose, animate) {
+        if (animate === undefined) {
+            animate = true;
+        }
+        
         this._handleInputKeydown = this._handleInputKeydown.bind(this);
         this._handleFocusChange = this._handleFocusChange.bind(this);
         
-        this._$root = $("<div class='modal-bar modal-bar-hide'/>")
+        this._$root = $("<div class='modal-bar'/>")
             .html(template)
             .insertBefore("#editor-holder");
 
-        // Forcing the renderer to do a layout, which will cause it to apply the transform for the "modal-bar-hide"
-        // class, so it will animate when you remove the class.
-        window.getComputedStyle(this._$root.get(0)).getPropertyValue("top");
-        this._$root.removeClass("modal-bar-hide");
+        if (animate) {
+            this._$root.addClass("modal-bar-hide");
+            // Forcing the renderer to do a layout, which will cause it to apply the transform for the "modal-bar-hide"
+            // class, so it will animate when you remove the class.
+            window.getComputedStyle(this._$root.get(0)).getPropertyValue("top");
+            this._$root.removeClass("modal-bar-hide");
+        }
         
         // If something *other* than an editor (like another modal bar) has focus, set the focus 
         // to the editor here, before opening up the new modal bar. This ensures that the old
@@ -125,27 +134,38 @@ define(function (require, exports, module) {
      *     of the editor to account for the ModalBar disappearing. If not set, the caller
      *     should do it immediately on return of this function (before the animation completes),
      *     because the editor will already have been resized.
+     * @param {boolean=} animate If true (the default), animate the closing of the ModalBar,
+     *     otherwise close it immediately.
      * @return {$.Promise} promise resolved when close is finished
      */
-    ModalBar.prototype.close = function (restoreScrollPos) {
+    ModalBar.prototype.close = function (restoreScrollPos, animate) {
         if (restoreScrollPos === undefined) {
             restoreScrollPos = true;
+        }
+        if (animate === undefined) {
+            animate = true;
         }
         
         // Store our height before closing, while we can still measure it
         var result = new $.Deferred(),
-            barHeight = this.height();
+            barHeight = this.height(),
+            self = this;
+
+        function doRemove() {
+            self._$root.remove();
+            result.resolve();
+        }
 
         if (this._autoClose) {
             window.document.body.removeEventListener("focusin", this._handleFocusChange, true);
         }
         
-        var self = this;
-        AnimationUtils.animateUsingClass(this._$root.get(0), "modal-bar-hide")
-            .done(function () {
-                self._$root.remove();
-                result.resolve();
-            });
+        if (animate) {
+            AnimationUtils.animateUsingClass(this._$root.get(0), "modal-bar-hide")
+                .done(doRemove);
+        } else {
+            doRemove();
+        }
         
         // Preserve scroll position of the current full editor across the editor refresh, adjusting for the 
         // height of the modal bar so the code doesn't appear to shift if possible.


### PR DESCRIPTION
This is for #5168.

cc @njx @couzteau 
