### PR TITLE
Add the Hungarian to the list of community-maintained translations

### DIFF
--- a/src/nls/README.md
+++ b/src/nls/README.md
@@ -60,6 +60,7 @@ The following languages have been contributed by the Brackets community:
 * Swedish (sv)
 * Turkish (tr)
 * Simplified Chinese (zh-cn)
+* Hungarian (hu)
 
 These translations _can be directly modified_ through our normal pull request
 process.


### PR DESCRIPTION
Hungarian translation is in the master branch, but not listed here.
