### PR TITLE
Linux: Fix test-integration task on linux

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,7 +142,8 @@ module.exports = function (grunt) {
         shell: {
             repo: grunt.option("shell-repo") || "../brackets-shell",
             mac: "<%= shell.repo %>/installer/mac/staging/<%= pkg.name %>.app",
-            win: "<%= shell.repo %>/installer/win/staging/<%= pkg.name %>.exe"
+            win: "<%= shell.repo %>/installer/win/staging/<%= pkg.name %>.exe",
+            linux: "<%= shell.repo %>/installer/linux/debian/package-root/opt/brackets/brackets"
         }
     });
 

--- a/tasks/lib/common.js
+++ b/tasks/lib/common.js
@@ -20,7 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  * 
  */
- /*global module, require, process*/
+/*jslint nomen:true */
+/*global module, require, process */
 module.exports = function (grunt) {
     "use strict";
 

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -43,10 +43,10 @@ module.exports = function (grunt) {
             specRunnerPath  = common.resolve("test/SpecRunner.html"),
             args            = " --startup-path=\"" + specRunnerPath + "?suite=" + encodeURIComponent(suite) + "&spec=" + encodeURIComponent(spec) + "&resultsPath=" + encodeURIComponent(resultsPath) + "\"";
 
-        if (platform === "win") {
-            cmd += args;
-        } else if (platform === "mac") {
+        if (platform === "mac") {
             cmd = "open \"" + cmd + "\" -W --args " + args;
+        } else {
+            cmd += args;
         }
         
         grunt.log.writeln(cmd);

--- a/tasks/write-config.js
+++ b/tasks/write-config.js
@@ -20,7 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  * 
  */
- /*global module, require*/
+/*global module, require*/
 module.exports = function (grunt) {
     "use strict";
 

--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -28,8 +28,10 @@
 define(function (require, exports, module) {
     'use strict';
     
-    // Don't run tests when running in browser
-    if (brackets.inBrowser) {
+    require("utils/Global");
+    
+    // Don't run tests when running in browser or linux
+    if (brackets.inBrowser || brackets.platform === "linux") {
         return;
     }
     


### PR DESCRIPTION
Requires https://github.com/adobe/brackets-shell/pull/329.
- Added missing path to brackets executable
- jslint cleanup
- Disable native menu tests for linux
