### PR TITLE
enable preview for SVG

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -327,7 +327,7 @@ define(function (require, exports, module) {
     }
     
     /** @const - hard-coded for now, but may want to make these preferences */
-    var _staticHtmlFileExts = ["htm", "html"],
+    var _staticHtmlFileExts = ["htm", "html", "svg"],
         _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "asp", "aspx", "jsp", "jspx", "shtm", "shtml"];
 
     /**


### PR DESCRIPTION
fix https://github.com/adobe/brackets/issues/5124 - Enables to load SVG files into live preview. However the preview is not live as for HTML, meaning changes to the SVG need to be saved before they are visible in the browser preview. This limitation is currently due to the use of XML namespaces in SVG tags. Brackets currently has no way to honor XML namespaces in markup.
