### PR TITLE
Fix #5173: wrong translation: Search result: Syntax is broken

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -141,7 +141,7 @@ define({
 
     "FIND_IN_FILES_TITLE_PART1"         : "\"",
     "FIND_IN_FILES_TITLE_PART2"         : "\" found",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} in {2} {3}",
+    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} in {3} {4}",
     "FIND_IN_FILES_SCOPED"              : "in <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "in project",
     "FIND_IN_FILES_FILE"                : "file",

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -352,12 +352,12 @@ define(function (require, exports, module) {
             if (maxHitsFoundInFile) {
                 numMatchesStr = Strings.FIND_IN_FILES_MORE_THAN;
             }
-            numMatchesStr += String(count.matches);
 
             // This text contains some formatting, so all the strings are assumed to be already escaped
             var summary = StringUtils.format(
                 Strings.FIND_IN_FILES_TITLE_PART3,
                 numMatchesStr,
+                String(count.matches),
                 (count.matches > 1) ? Strings.FIND_IN_FILES_MATCHES : Strings.FIND_IN_FILES_MATCH,
                 count.files,
                 (count.files > 1 ? Strings.FIND_IN_FILES_FILES : Strings.FIND_IN_FILES_FILE)


### PR DESCRIPTION
Moved the concatenated "Over" to the Find in Files Title String, to be able to fix issue #5173, in the translation strings.
