### PR TITLE
Don't reparse HTML files on save

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -70,10 +70,8 @@ define(function HTMLDocumentModule(require, exports, module) {
         this._instrumentationEnabled = false;
 
         this.onCursorActivity = this.onCursorActivity.bind(this);
-        this.onDocumentSaved = this.onDocumentSaved.bind(this);
         
         $(this.editor).on("cursorActivity", this.onCursorActivity);
-        $(DocumentManager).on("documentSaved", this.onDocumentSaved);
         
         // Experimental code
         if (LiveDevelopment.config.experimental) {
@@ -130,7 +128,6 @@ define(function HTMLDocumentModule(require, exports, module) {
         }
 
         $(this.editor).off("cursorActivity", this.onCursorActivity);
-        $(DocumentManager).off("documentSaved", this.onDocumentSaved);
 
         // Experimental code
         if (LiveDevelopment.config.experimental) {
@@ -312,14 +309,6 @@ define(function HTMLDocumentModule(require, exports, module) {
         this._highlight = codeMirror.markText(from, to, { className: "highlight" });
     };
 
-    /** Triggered when a document is saved */
-    HTMLDocument.prototype.onDocumentSaved = function onDocumentSaved(event, doc) {
-        if (doc === this.doc) {
-            HTMLInstrumentation.scanDocument(this.doc);
-            HTMLInstrumentation._markText(this.editor);
-        }
-    };
-    
     // Export the class
     module.exports = HTMLDocument;
 });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -158,6 +158,7 @@ define(function (require, exports, module) {
             UpdateNotification      : require("utils/UpdateNotification"),
             InstallExtensionDialog  : require("extensibility/InstallExtensionDialog"),
             RemoteAgent             : require("LiveDevelopment/Agents/RemoteAgent"),
+            HTMLInstrumentation     : require("language/HTMLInstrumentation"),
             doneLoading             : false
         };
 

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -803,7 +803,7 @@ define(function (require, exports, module) {
                     // Spy on RemoteAgent
                     spyOn(testWindow.brackets.test.RemoteAgent, "call").andCallThrough();
 
-                    // Create syntax errors
+                    // Edit text
                     doc =  DocumentManager.getCurrentDocument();
                     doc.replaceRange("Live Preview in ", {line: 11, ch: 33});
                 });
@@ -817,6 +817,31 @@ define(function (require, exports, module) {
                     expect(args[0]).toEqual("applyDOMEdits");
                     expect(edit.type).toEqual("textReplace");
                     expect(edit.content).toEqual("Live Preview in Brackets is awesome!");
+                });
+            });
+            
+            it("should not reparse page on save (#5279)", function () {
+                var doc, saveDeferred = new $.Deferred();
+                
+                _openSimpleHTML();
+                
+                runs(function () {
+                    // Make an edit.
+                    doc = DocumentManager.getCurrentDocument();
+                    doc.replaceRange("Live Preview in ", {line: 11, ch: 33});
+                    
+                    // Save the document and see if "scanDocument" (which reparses the page) is called.
+                    spyOn(testWindow.brackets.test.HTMLInstrumentation, "scanDocument").andCallThrough();
+                    testWindow.$(DocumentManager).one("documentSaved", function (e, savedDoc) {
+                        expect(savedDoc === doc);
+                        saveDeferred.resolve();
+                    });
+                    CommandManager.execute(Commands.FILE_SAVE, { doc: doc });
+                    waitsForDone(saveDeferred.promise(), "file finished saving");
+                });
+                
+                runs(function () {
+                    expect(testWindow.brackets.test.HTMLInstrumentation.scanDocument.callCount).toBe(0);
                 });
             });
 


### PR DESCRIPTION
For #5279.

Back when we wanted to reload HTML files in the browser on save, it made sense to fully rescan/reparse the document on save, since we were going to serve up a new version of the instrumented HTML. However, now that we no longer reload the HTML file, we don't want to reparse the doc, because that will generate new IDs which won't be reflected in the browser (since the browser will never request the reinstrumented HTML).

@gruehle 
