### PR TITLE
Update CodeMirror for sprint 32. Avoid hang by setting width on mock editor holder in unit tests.

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -406,7 +406,7 @@ define(function (require, exports, module) {
     function createMockEditorForDocument(doc, visibleRange) {
         // Initialize EditorManager/PanelManager and position the editor-holder offscreen
         // (".content" may not exist, but that's ok for headless tests where editor height doesn't matter)
-        var $editorHolder = createMockElement().attr("id", "mock-editor-holder");
+        var $editorHolder = createMockElement().css("width", "1000px").attr("id", "mock-editor-holder");
         PanelManager._setMockDOM($(".content"), $editorHolder);
         EditorManager.setEditorHolder($editorHolder);
         


### PR DESCRIPTION
@RaymondLim 

See comments in #5179. I verified that all the automated tests pass and smoke tests are ok after this change.

Could you also verify that the issues caused by https://github.com/marijnh/CodeMirror/issues/1787 are also fixed after this update, and close that bug as well as our own related issues? Thanks.
