### PR TITLE
Remove the ability to switch language to the current language

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
                 
                 function setLanguage(event) {
                     locale = $select.val();
-                    $submit.prop("disabled", locale === (curLocale === null ? "" : curLocale));
+                    $submit.prop("disabled", locale === (curLocale || ""));
                 }
                 
                 // returns the localized label for the given locale

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -150,9 +150,9 @@ define(function (require, exports, module) {
                     languages = [];
                 
                 function setLanguage(event) {
-                    locale = $select.val();
-                    $submit.prop("disabled", false);
-                }
+                     locale = $select.val();
+                     $submit.prop("disabled", locale === (curLocale === null ? "" : curLocale));
+                 }
                 
                 // returns the localized label for the given locale
                 // or the locale, if nothing found

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -150,9 +150,9 @@ define(function (require, exports, module) {
                     languages = [];
                 
                 function setLanguage(event) {
-                     locale = $select.val();
-                     $submit.prop("disabled", locale === (curLocale === null ? "" : curLocale));
-                 }
+                    locale = $select.val();
+                    $submit.prop("disabled", locale === (curLocale === null ? "" : curLocale));
+                }
                 
                 // returns the localized label for the given locale
                 // or the locale, if nothing found


### PR DESCRIPTION
The "Restart brackets" button will be disabled if you select the current
lang in the "Switch Language" dialog.

Tested on Windows 8 with Brackets 0.32 master c05cfd5
