### PR TITLE
Code changes for Node 0.10 upgrade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,8 +157,8 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config']);
 
     // task: test
-    grunt.registerTask('test', ['jshint:all', 'jasmine']);
-    //grunt.registerTask('test', ['jshint:all', 'jasmine', jasmine-node']);
+//    grunt.registerTask('test', ['jshint:all', 'jasmine']);
+    grunt.registerTask('test', ['jshint:all', 'jasmine', 'jasmine-node']);
 
     // task: set-sprint
     // Update sprint number in package.json and rewrite src/config.json

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
         StringUtils      = require("utils/StringUtils");
     
     // semver isn't a proper AMD module, so it will just load into the global namespace.
-    require("extensibility/node/node_modules/semver/semver");
+    var semver = require("extensibility/node/node_modules/semver/semver.browser");
     
     /**
      * Extension status constants.

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -33,6 +33,7 @@ var DecompressZip = require("decompress-zip"),
     http          = require("http"),
     request       = require("request"),
     os            = require("os"),
+    tmp           = require("tmp"),
     fs            = require("fs-extra");
 
 
@@ -143,6 +144,170 @@ function containsWords(wordlist, str) {
 }
 
 /**
+ * Finds the common prefix, if any, for the files in a package file.
+ *
+ * In some package files, all of the files are contained in a subdirectory, and this function
+ * will identify that directory if it exists.
+ *
+ * @param {string} extractDir directory into which the package was extracted
+ * @param {function(Error, string)} callback function to accept err, commonPrefix (which will be "" if there is none)
+ */
+function findCommonPrefix(extractDir, callback) {
+    fs.readdir(extractDir, function (err, files) {
+        if (err) {
+            callback(err);
+        } else if (files.length === 1) {
+            var name = files[0];
+            if (fs.statSync(path.join(extractDir, name)).isDirectory()) {
+                callback(null, name);
+            } else {
+                callback(null, "");
+            }
+        } else {
+            callback(null, "");
+        }
+    });
+}
+
+/**
+ * Validates the contents of package.json.
+ *
+ * @param {string} path path to package file (used in error reporting)
+ * @param {string} packageJSON path to the package.json file to check
+ * @param {Object} options validation options passed to `validate()`
+ * @param {function(Error, Array.<Array.<string, ...>>, Object)} callback function to call with array of errors and metadata
+ */
+function validatePackageJSON(path, packageJSON, options, callback) {
+    var errors = [];
+    if (fs.existsSync(packageJSON)) {
+        fs.readFile(packageJSON, {
+            encoding: "utf8"
+        }, function (err, data) {
+            if (err) {
+                callback(err, null, null);
+                return;
+            }
+            
+            var metadata;
+            
+            try {
+                metadata = JSON.parse(data);
+            } catch (e) {
+                errors.push([Errors.INVALID_PACKAGE_JSON, e.toString(), path]);
+                callback(null, errors, undefined);
+                return;
+            }
+            
+            // confirm required fields in the metadata
+            if (!metadata.name) {
+                errors.push([Errors.MISSING_PACKAGE_NAME, path]);
+            } else if (!validateName(metadata.name)) {
+                errors.push([Errors.BAD_PACKAGE_NAME, metadata.name]);
+            }
+            if (!metadata.version) {
+                errors.push([Errors.MISSING_PACKAGE_VERSION, path]);
+            } else if (!semver.valid(metadata.version)) {
+                errors.push([Errors.INVALID_VERSION_NUMBER, metadata.version, path]);
+            }
+            
+            // normalize the author
+            if (metadata.author) {
+                metadata.author = parsePersonString(metadata.author);
+            }
+            
+            // contributors should be an array of people.
+            // normalize each entry.
+            if (metadata.contributors) {
+                if (metadata.contributors.map) {
+                    metadata.contributors = metadata.contributors.map(function (person) {
+                        return parsePersonString(person);
+                    });
+                } else {
+                    metadata.contributors = [
+                        parsePersonString(metadata.contributors)
+                    ];
+                }
+            }
+            
+            if (metadata.engines && metadata.engines.brackets) {
+                var range = metadata.engines.brackets;
+                if (!semver.validRange(range)) {
+                    errors.push([Errors.INVALID_BRACKETS_VERSION, range, path]);
+                }
+            }
+            
+            if (options.disallowedWords) {
+                ["title", "description", "name"].forEach(function (field) {
+                    var words = containsWords(options.disallowedWords, metadata[field]);
+                    if (words.length > 0) {
+                        errors.push([Errors.DISALLOWED_WORDS, field, words.toString(), path]);
+                    }
+                });
+            }
+            callback(null, errors, metadata);
+        });
+    } else {
+        if (options.requirePackageJSON) {
+            errors.push([Errors.MISSING_PACKAGE_JSON, path]);
+        }
+        callback(null, errors, null);
+    }
+}
+
+/**
+ * Extracts the package into the given directory and then validates it.
+ *
+ * @param {string} zipPath path to package zip file
+ * @param {string} extractDir directory to extract package into
+ * @param {Object} options validation options
+ * @param {function(Error, {errors: Array, metadata: Object, commonPrefix: string, extractDir: string})} callback function to call with the result
+ */
+function extractAndValidateFiles(zipPath, extractDir, options, callback) {
+    var callbackCalled = false;
+    var metadata;
+    var foundMainIn = null;
+    
+    var unzipper = new DecompressZip(zipPath);
+    unzipper.on("error", function (err) {
+        // General error to report for problems reading the file
+        callback(null, {
+            errors: [[Errors.INVALID_ZIP_FILE, zipPath]]
+        });
+        return;
+    });
+    
+    unzipper.on("extract", function (log) {
+        findCommonPrefix(extractDir, function (err, commonPrefix) {
+            if (err) {
+                callback(err, null);
+                return;
+            }
+            var packageJSON = path.join(extractDir, commonPrefix, "package.json");
+            validatePackageJSON(zipPath, packageJSON, options, function (err, errors, metadata) {
+                if (err) {
+                    callback(err, null);
+                    return;
+                }
+                var mainJS = path.join(extractDir, commonPrefix, "main.js");
+                if (!fs.existsSync(mainJS)) {
+                    errors.push([Errors.MISSING_MAIN, zipPath, mainJS]);
+                }
+                callback(null, {
+                    errors: errors,
+                    metadata: metadata,
+                    commonPrefix: commonPrefix,
+                    extractDir: extractDir
+                });
+            });
+        });
+    });
+    
+    unzipper.extract({
+        path: extractDir
+    });
+}
+
+/**
  * Implements the "validate" command in the "extensions" domain.
  * Validates the zipped package at path.
  *
@@ -170,159 +335,16 @@ function validate(path, options, callback) {
             });
             return;
         }
-        var callbackCalled = false;
-        var metadata;
-        var foundMainIn = null;
-        var errors = [];
-        var commonPrefix = null;
-        
-        var readStream = fs.createReadStream(path);
-        
-        readStream
-            .pipe(unzip.Parse())
-            .on("error", function (exception) {
-                // General error to report for problems reading the file
-                errors.push([Errors.INVALID_ZIP_FILE, path]);
-                callback(null, {
-                    errors: errors
-                });
-                callbackCalled = true;
-                readStream.destroy();
-            })
-            .on("entry", function (entry) {
-                // look for the metadata
-                var fileName = entry.path;
-                
-                var slash = fileName.indexOf("/");
-                if (slash > -1) {
-                    var prefix = fileName.substring(0, slash);
-                    if (!ignoredPrefixes.hasOwnProperty(prefix)) {
-                        if (commonPrefix === null) {
-                            commonPrefix = prefix;
-                        } else if (prefix !== commonPrefix) {
-                            commonPrefix = "";
-                        }
-                        if (commonPrefix) {
-                            fileName = fileName.substring(commonPrefix.length + 1);
-                        }
-                    }
-                } else {
-                    commonPrefix = "";
-                }
-                
-                if (fileName === "package.json") {
-                    // This handles an edge case where we found a package.json in a
-                    // nested directory that we thought was a commonPrefix but
-                    // actually wasn't. We reset as if we never read that first
-                    // package.json
-                    if (metadata) {
-                        metadata = undefined;
-                        errors = [];
-                    }
-                    
-                    var packageJSON = "";
-                    entry
-                        .on("data", function (data) {
-                            // We're assuming utf8 encoding here, which is pretty safe
-                            // Note that I found that .setEncoding on the stream
-                            // would fail, so I convert the buffer to a string here.
-                            packageJSON += data.toString("utf8");
-                        })
-                        .on("error", function (exception) {
-                            // general exception handler. It is unknown what kinds of
-                            // errors we can get here.
-                            callback(exception, null);
-                            callbackCalled = true;
-                            readStream.destroy();
-                        })
-                        .on("end", function () {
-                            // attempt to parse the metadata
-                            try {
-                                metadata = JSON.parse(packageJSON);
-                            } catch (e) {
-                                errors.push([Errors.INVALID_PACKAGE_JSON, e.toString(), path]);
-                                return;
-                            }
-                            
-                            // confirm required fields in the metadata
-                            if (!metadata.name) {
-                                errors.push([Errors.MISSING_PACKAGE_NAME, path]);
-                            } else if (!validateName(metadata.name)) {
-                                errors.push([Errors.BAD_PACKAGE_NAME, metadata.name]);
-                            }
-                            if (!metadata.version) {
-                                errors.push([Errors.MISSING_PACKAGE_VERSION, path]);
-                            } else if (!semver.valid(metadata.version)) {
-                                errors.push([Errors.INVALID_VERSION_NUMBER, metadata.version, path]);
-                            }
-                            
-                            // normalize the author
-                            if (metadata.author) {
-                                metadata.author = parsePersonString(metadata.author);
-                            }
-                            
-                            // contributors should be an array of people.
-                            // normalize each entry.
-                            if (metadata.contributors) {
-                                if (metadata.contributors.map) {
-                                    metadata.contributors = metadata.contributors.map(function (person) {
-                                        return parsePersonString(person);
-                                    });
-                                } else {
-                                    metadata.contributors = [
-                                        parsePersonString(metadata.contributors)
-                                    ];
-                                }
-                            }
-                            
-                            if (metadata.engines && metadata.engines.brackets) {
-                                var range = metadata.engines.brackets;
-                                if (!semver.validRange(range)) {
-                                    errors.push([Errors.INVALID_BRACKETS_VERSION, range, path]);
-                                }
-                            }
-                            
-                            if (options.disallowedWords) {
-                                ["title", "description", "name"].forEach(function (field) {
-                                    var words = containsWords(options.disallowedWords, metadata[field]);
-                                    if (words.length > 0) {
-                                        errors.push([Errors.DISALLOWED_WORDS, field, words.toString(), path]);
-                                    }
-                                });
-                            }
-                        });
-                } else if (fileName === "main.js") {
-                    foundMainIn = commonPrefix;
-                }
-            })
-            .on("end", function () {
-                // Reached the end of the zipfile
-                // Report results
-                
-                // generally, if we hit an exception, we've already called the callback
-                if (callbackCalled) {
-                    return;
-                }
-                
-                if (foundMainIn === null || foundMainIn !== commonPrefix) {
-                    errors.push([Errors.MISSING_MAIN, path]);
-                }
-                
-                // No errors and no metadata means that we never found the metadata
-                if (errors.length === 0 && !metadata) {
-                    metadata = null;
-                }
-                
-                if (metadata === null && options.requirePackageJSON) {
-                    errors.push([Errors.MISSING_PACKAGE_JSON, path]);
-                }
-                
-                callback(null, {
-                    errors: errors,
-                    metadata: metadata,
-                    commonPrefix: commonPrefix
-                });
-            });
+        tmp.dir({
+            prefix: "bracketsPackage_",
+            unsafeCleanup: true
+        }, function _tempDirCreated(err, extractDir) {
+            if (err) {
+                callback(err, null);
+                return;
+            }
+            extractAndValidateFiles(path, extractDir, options, callback);
+        });
     });
 }
 

--- a/src/extensibility/node/package.json
+++ b/src/extensibility/node/package.json
@@ -5,10 +5,10 @@
     "dependencies": {
         "decompress-zip": "0.0.1",
         "tmp": "0.0.21",
-        "semver": ">1.1.0 <2.0.0",
-        "fs-extra": "0.5.x",
+        "semver": "2.x",
+        "fs-extra": "0.6.x",
         "async": "0.2.x",
-        "request": "2.16.x"
+        "request": "2.27.x"
     },
     "devDependencies": {
         "rewire": "1.1.x"

--- a/src/extensibility/node/package.json
+++ b/src/extensibility/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-extensibility",
     "description": "Used in the management of Brackets extensions",
-    "version": "0.27.0",
+    "version": "0.32.0",
     "dependencies": {
         "decompress-zip": "0.0.1",
         "tmp": "0.0.21",

--- a/src/extensibility/node/spec/Validation.spec.js
+++ b/src/extensibility/node/spec/Validation.spec.js
@@ -59,6 +59,7 @@ describe("Package Validation", function () {
     it("should handle a good package", function (done) {
         packageValidator.validate(basicValidExtension, {}, function (err, result) {
             expect(err).toBeNull();
+            expect(result.extractDir).toBeDefined();
             expect(result.errors.length).toEqual(0);
             var metadata = result.metadata;
             expect(metadata.name).toEqual("basic-valid-extension");


### PR DESCRIPTION
The bulk of this is the change from node-unzip to decompress-zip. decompress-zip only supports extraction to a directory, rather than reading from a zip file stream.

Note that this is set as a merge into the dangoor/node-10-deps branch which has a separate pull request to merge into master. Both of these pull requests rely on https://github.com/adobe/brackets-shell/pull/334.

To @ingorichter 
