### PR TITLE
Fix bug #5248 (Clicking disabled lint icon still sometimes opens panel)

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -152,6 +152,7 @@ define(function (require, exports, module) {
      */
     function run() {
         if (!_enabled) {
+            _lastResult = null;
             Resizer.hide($problemsPanel);
             StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-disabled", Strings.LINT_DISABLED);
             setGotoEnabled(false);


### PR DESCRIPTION
Fix bug #5248 (Clicking disabled lint icon still sometimes opens panel) -- Update `_lastResult` on every codepath in run() so it's never stale, since it's used to determine the status bar icon's click enablement.
