### PR TITLE
Fix #5310 (Editor HTML menus are broken).

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -273,6 +273,16 @@ define(function (require, exports, module) {
         // Enable/Disable HTML Menus
         if (brackets.nativeMenus) {
             $("body").addClass("has-appshell-menus");
+        } else {
+            // Prevent the menu item to grab the focus -- override focus implementation
+            (function () {
+                var defaultFocus = $.fn.focus;
+                $.fn.focus = function () {
+                    if (!this.hasClass("dropdown-toggle")) {
+                        defaultFocus.apply(this, arguments);
+                    }
+                };
+            }());
         }
         
         // Localize MainViewHTML and inject into <BODY> tag


### PR DESCRIPTION
Override the implementation of the jquery focus() to prevent HTML menus
(class "dropdown-toggle") grabbing the focus.

Bootstrap's dropdown implementation exlicitly calls focus() which causes
currently active CM instance to lose focus. As the result, when the
command is executed, it cannot get ahold of the current editor instance.
