### PR TITLE
Guard against concurrent array mutation in Async.doInParallel

### DIFF
--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -88,20 +88,17 @@ define(function (require, exports, module) {
      * @return {$.Promise}
      */
     function doInParallel(items, beginProcessItem, failFast) {
-        var promises = [];
         var masterDeferred = new $.Deferred();
         
         if (items.length === 0) {
             masterDeferred.resolve();
             
         } else {
-            var numCompleted = 0;
+            var numRemaining = items.length;
             var hasFailed = false;
             
             items.forEach(function (item, i) {
                 var itemPromise = beginProcessItem(item, i);
-                promises.push(itemPromise);
-                
                 itemPromise.fail(function () {
                     if (failFast) {
                         masterDeferred.reject();
@@ -110,8 +107,8 @@ define(function (require, exports, module) {
                     }
                 });
                 itemPromise.always(function () {
-                    numCompleted++;
-                    if (numCompleted === items.length) {
+                    numRemaining--;
+                    if (numRemaining === 0) {
                         if (hasFailed) {
                             masterDeferred.reject();
                         } else {


### PR DESCRIPTION
If the array of items processed by `Async.doInParallel` is augmented concurrently, the returned master promise may neither resolve nor reject. This is because resolution and rejection happen only when the total number of resolved or rejected promises reaches the current size of the array of items, which, if augmented, is now larger than the total number of promises. Of course, failure of some sort is unsurprising with concurrent modification, but this simple change---counting down from the initial array length instead of counting up to the current array length---avoids this particular problem and is also slightly more efficient.

This PR also removes code that creates an array with the generated promises and then promptly throws it away.
