### PR TITLE
Apply HTML sytax highlighting to ASP.NET MVC View Master Page (.master) ...

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -36,7 +36,7 @@
     "html": {
         "name": "HTML",
         "mode": ["htmlmixed", "text/x-brackets-html"],
-        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "jsp", "aspx", "asp"],
+        "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "hbs", "handlebars", "kit", "jsp", "aspx", "asp", "master"],
         "blockComment": ["<!--", "-->"]
     },
     


### PR DESCRIPTION
...files. MVC View (.aspx) files already use HTML syntax highlighting. This pull request expands support to the template/layout pages used by the ASP.NET MVC framework.
