### PR TITLE
Fix in decompress-zip to support proper directory creation on Windows.

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -364,7 +364,11 @@ define(function (require, exports, module) {
      */
     function formatError(error) {
         function localize(key) {
-            return Strings[key] || Strings.UNKNOWN_ERROR;
+            if (Strings[key]) {
+                return Strings[key];
+            }
+            console.log("Unknown installation error", key);
+            return Strings.UNKNOWN_ERROR;
         }
         
         if (Array.isArray(error)) {

--- a/src/extensibility/node/node_modules/decompress-zip/lib/extractors.js
+++ b/src/extensibility/node/node_modules/decompress-zip/lib/extractors.js
@@ -13,13 +13,14 @@ var cache = {};
 // Use a cache of promises for building the directory tree. This allows us to
 // correctly queue up file extractions for after their path has been created,
 // avoid trying to create the path twice and still be async.
+var windowsRoot = /^[A-Z]:\\$/; 
 var mkdir = function (dir) {
     dir = path.normalize(path.resolve(process.cwd(), dir) + path.sep);
 
     if (!cache[dir]) {
         var parent;
 
-        if (dir === '/') {
+        if (dir === '/' || (process.platform === "win32" && dir.match(windowsRoot))) {
             parent = new Q();
         } else {
             parent = mkdir(path.dirname(dir));


### PR DESCRIPTION
This small change to the decompress-zip project should fix extension installation on Windows. (Assuming this looks good here, I'll submit a pull request there...)

cc @bchintx @ingorichter 
