### PR TITLE
Clear highlights and Find selection color when modal bar closes

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
                 findFirst(query);
             }
         });
-        $(modalBar).on("closeOk closeCancel closeBlur close", function (e, query) {
+        $(modalBar).on("closeOk close", function (e, query) {
             // Clear highlights but leave search state in place so Find Next/Previous work after closing
             clearHighlights(cm, state);
             

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
                 findFirst(query);
             }
         });
-        $(modalBar).on("closeOk closeCancel closeBlur", function (e, query) {
+        $(modalBar).on("closeOk closeCancel closeBlur close", function (e, query) {
             // Clear highlights but leave search state in place so Find Next/Previous work after closing
             clearHighlights(cm, state);
             

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -178,7 +178,7 @@ define(function (require, exports, module) {
             modalBar.close(true, animate);
         }
         modalBar = new ModalBar(template, autoClose, animate);
-        $(modalBar).on("closeOk closeBlur closeCancel", function () {
+        $(modalBar).on("commit close", function () {
             modalBar = null;
         });
     }
@@ -319,7 +319,7 @@ define(function (require, exports, module) {
         }
         
         createModalBar(queryDialog, true);
-        $(modalBar).on("closeOk", function (e, query) {
+        $(modalBar).on("commit", function (e, query) {
             if (!state.findNextCalled) {
                 // If findNextCalled is false, this means the user has *not*
                 // entered any search text *or* pressed Cmd-G/F3 to find the
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
                 findFirst(query);
             }
         });
-        $(modalBar).on("closeOk close", function (e, query) {
+        $(modalBar).on("commit close", function (e, query) {
             // Clear highlights but leave search state in place so Find Next/Previous work after closing
             clearHighlights(cm, state);
             
@@ -500,7 +500,7 @@ define(function (require, exports, module) {
     function replace(editor, all) {
         var cm = editor._codeMirror;
         createModalBar(replaceQueryDialog, true);
-        $(modalBar).on("closeOk", function (e, query) {
+        $(modalBar).on("commit", function (e, query) {
             if (!query) {
                 return;
             }
@@ -511,7 +511,7 @@ define(function (require, exports, module) {
             // Eventually we should rip out all this code (which comes from the old CodeMirror dialog
             // logic) and just change the content itself.
             createModalBar(replacementQueryDialog, true, false);
-            $(modalBar).on("closeOk", function (e, text) {
+            $(modalBar).on("commit", function (e, text) {
                 text = text || "";
                 var match,
                     fnMatch = function (w, i) { return match[i]; };

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -41,10 +41,9 @@ define(function (require, exports, module) {
      *
      * Creates a modal bar whose contents are the given template.
      * @param {string} template The HTML contents of the modal bar.
-     * @param {boolean} autoClose If true, then close the dialog if the user hits RETURN or ESC 
-     *      in the first input field, or if the modal bar loses focus to an outside item. Dispatches 
-     *      jQuery events for these cases: "closeOk" on RETURN, "closeCancel" on ESC, and "closeBlur" 
-     *      on focus loss.
+     * @param {boolean} autoClose If true, then close the dialog if the user hits RETURN
+     *      in the first input field. Dispatches jQuery events for these cases:
+     *      "commit" on RETURN and "close" always. 
      * @param {boolean} animate If true (the default), animate the dialog closed, otherwise
      *      close it immediately.
      */
@@ -195,7 +194,9 @@ define(function (require, exports, module) {
             
             var value = this._getFirstInput().val();
             this.close();
-            $(this).triggerHandler(e.keyCode === KeyEvent.DOM_VK_RETURN ? "closeOk" : "closeCancel", [value]);
+            if (e.keyCode === KeyEvent.DOM_VK_RETURN) {
+                $(this).triggerHandler("commit", [value]);
+            }
         }
     };
     
@@ -207,7 +208,6 @@ define(function (require, exports, module) {
         if (!$.contains(this._$root.get(0), e.target)) {
             var value = this._getFirstInput().val();
             this.close();
-            $(this).triggerHandler("closeBlur", [value]);
         }
     };
     

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -159,6 +159,8 @@ define(function (require, exports, module) {
         if (this._autoClose) {
             window.document.body.removeEventListener("focusin", this._handleFocusChange, true);
         }
+
+        $(this).triggerHandler("close");
         
         if (animate) {
             AnimationUtils.animateUsingClass(this._$root.get(0), "modal-bar-hide")


### PR DESCRIPTION
This is my second attempt at #5239. First attempt is #5240.

Read this comment: https://github.com/adobe/brackets/pull/5240#issuecomment-24966396

@njx This is just a simple "close" event (first bullet from comment above). All it does is clear highlights and reset selection color. Worst case is that it's called twice.

<del>Regarding your second bullet, I don't see the case that needs to fixed. Everything seems to work correctly with this code. Please let me know.</del>


I played around with only clearing hignlighting and reset selection colors on "close" event, and I think I discovered the case for second bullet: when Find field is pre-populated and Enter is pressed before Find Next. So, it now handles both "closeOk" and "close".
