### PR TITLE
Added .jsm extension for Mozilla JavaScript Module support

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -57,7 +57,7 @@
     "javascript": {
         "name": "JavaScript",
         "mode": "javascript",
-        "fileExtensions": ["js", "jsx", "js.erb"],
+        "fileExtensions": ["js", "jsx", "js.erb", "jsm"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },


### PR DESCRIPTION
Ensure .jsm files are parsed as JavaScript.  See: https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules
