### PR TITLE
Return the result of calling the original jquery focus() function

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
                 var defaultFocus = $.fn.focus;
                 $.fn.focus = function () {
                     if (!this.hasClass("dropdown-toggle")) {
-                        defaultFocus.apply(this, arguments);
+                        return defaultFocus.apply(this, arguments);
                     }
                 };
             }());

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -285,6 +285,7 @@ define(function (require, exports, module) {
             $("body").addClass("has-appshell-menus");
         } else {
             // Prevent the menu item to grab the focus -- override focus implementation
+            // BOOTSTRAP: workaround for https://github.com/adobe/brackets/issues/5310
             (function () {
                 var defaultFocus = $.fn.focus;
                 $.fn.focus = function () {


### PR DESCRIPTION
This commit
https://github.com/adobe/brackets/commit/8e5ad957333593fb5b6bc4f73d4c3121da811682
fixed a focus issue with HTML menus. On Linux (where we still use HTML
menues), the new implementation of focus didn't return the result when
calling the original jquery focus implementation.

The result was an error opening modal dialogs like Extension Manager,
About Box, etc.
The dialogs didn't work properly anymore due to this error:
"Uncaught TypeError: Cannot call method 'trigger' of undefined" in bootstrap-
modal.js

This fix returns the result from calling the original focus function.
