### PR TITLE
 Fix #5362 (HTML menu z-index vs. bottom-panel)

### DIFF
--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -49,7 +49,7 @@
 @z-index-brackets-inline-editor-shadow: @z-index-brackets-ui;
 @z-index-brackets-toolbar: (@z-index-brackets-ui + 1);
 @z-index-brackets-max: @z-index-brackets-toolbar;
-@z-index-brackets-modalbar: @z-index-brackets-toolbar - 1;
+@z-index-brackets-modalbar: (@z-index-brackets-toolbar - 1);
 
 @z-index-brackets-sidebar-resizer: (@z-index-brackets-ui + 2);
 @z-index-brackets-resizer-div: (@z-index-brackets-sidebar-resizer + 1);

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -47,7 +47,7 @@
 @z-index-brackets-selection-triangle: (@z-index-brackets-ui + 1);
 @z-index-brackets-scroller-shadow: (@z-index-brackets-selection-triangle + 1);
 @z-index-brackets-inline-editor-shadow: @z-index-brackets-ui;
-@z-index-brackets-toolbar: @z-index-brackets-ui;
+@z-index-brackets-toolbar: (@z-index-brackets-ui + 1);
 @z-index-brackets-max: @z-index-brackets-toolbar;
 @z-index-brackets-modalbar: @z-index-brackets-toolbar - 1;
 


### PR DESCRIPTION
Raise toolbar +1 to be on top of the rest of the sibling panels.
Clean-up styling.
