### PR TITLE
Return the result of calling the original jquery focus() function

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
                 var defaultFocus = $.fn.focus;
                 $.fn.focus = function () {
                     if (!this.hasClass("dropdown-toggle")) {
-                        defaultFocus.apply(this, arguments);
+                        return defaultFocus.apply(this, arguments);
                     }
                 };
             }());


### PR DESCRIPTION
Same as PR #5346 - except without the conflicting 2nd commit that we wound up not needing due to #5350.
