### PR TITLE
Add Dust.js extension support and update "Setup for Hacking" directory

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -46,6 +46,13 @@
         "fileExtensions": ["ejs"],
         "blockComment": ["<!--", "-->"]
     },
+    
+    "dust": {
+        "name": "Dust.js",
+        "mode": ["htmlembedded", "application/x-ejs"],
+        "fileExtensions": ["dust"],
+        "blockComment": ["<!--", "-->"]
+    },
 
     "erb_html": {
         "name": "Embedded Ruby",

--- a/tools/setup_for_hacking.sh
+++ b/tools/setup_for_hacking.sh
@@ -8,7 +8,7 @@ if [[ "$platform" == 'Linux' ]]; then
    default_app_directory='/opt/brackets';
    symlink='dev';
 elif [[ "$platform" == 'Darwin' ]]; then # MAC OSX
-   default_app_directory='/Applications/Brackets Sprint 14.app';
+   default_app_directory='/Applications/Brackets Sprint 31.app';
    symlink='Contents/dev';
 else
    # Warn for unknown operating system?


### PR DESCRIPTION
Add Dust.js extension support to languages.json (http://linkedin.github.io/dustjs/) and update default directory to Release 31 in "setup for hacking" script. 
