### PR TITLE
Gave search result panel a min-height

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -848,7 +848,7 @@ define(function (require, exports, module) {
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         var panelHtml = Mustache.render(searchPanelTemplate, Strings);
-        searchResultsPanel = PanelManager.createBottomPanel("find-in-files.results", $(panelHtml));
+        searchResultsPanel = PanelManager.createBottomPanel("find-in-files.results", $(panelHtml), 100);
         
         $searchResults = $("#search-results");
         $searchSummary = $searchResults.find(".title");

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
      * @param {!string} position Which side of the element can be dragged: one of the POSITION_* constants
      *                          (TOP/BOTTOM for vertical resizing or LEFT/RIGHT for horizontal).
      * @param {?number} minSize Minimum size (width or height) of the element's outer dimensions, including
-     *                          border & padding. Defaults to 0.
+     *                          border & padding. Defaults to 100.
      * @param {?boolean} collapsible Indicates the panel is collapsible on double click on the
      *                          resizer. Defaults to false.
      * @param {?string} forceLeft CSS selector indicating element whose 'left' should be locked to the
@@ -162,8 +162,11 @@ define(function (require, exports, module) {
             elementSizeFunction = direction === DIRECTION_HORIZONTAL ? $element.width : $element.height,
             resizerCSSPosition  = direction === DIRECTION_HORIZONTAL ? "left" : "top",
             contentSizeFunction = direction === DIRECTION_HORIZONTAL ? $resizableElement.width : $resizableElement.height;
-		
-        minSize = minSize || 0;
+
+        if (minSize === undefined) {
+            minSize = DEFAULT_MIN_SIZE;
+        }
+
         collapsible = collapsible || false;
         
         $element.prepend($resizer);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
      * @param {!string} position Which side of the element can be dragged: one of the POSITION_* constants
      *                          (TOP/BOTTOM for vertical resizing or LEFT/RIGHT for horizontal).
      * @param {?number} minSize Minimum size (width or height) of the element's outer dimensions, including
-     *                          border & padding. Defaults to 100.
+     *                          border & padding. Defaults to DEFAULT_MIN_SIZE.
      * @param {?boolean} collapsible Indicates the panel is collapsible on double click on the
      *                          resizer. Defaults to false.
      * @param {?string} forceLeft CSS selector indicating element whose 'left' should be locked to the

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
      * Represents a panel below the editor area (a child of ".content").
      * 
      * @param {!jQueryObject} $panel  The entire panel, including any chrome, already in the DOM.
-     * @param {number=} minSize  Minimum height of panel in px; default is DEFAULT_MIN_SIZE
+     * @param {number=} minSize  Minimum height of panel in px.
      */
     function Panel($panel, minSize) {
         this.$panel = $panel;

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
      * Represents a panel below the editor area (a child of ".content").
      * 
      * @param {!jQueryObject} $panel  The entire panel, including any chrome, already in the DOM.
-     * @param {number=} minSize  Minimum height of panel in px; default is 100
+     * @param {number=} minSize  Minimum height of panel in px; default is DEFAULT_MIN_SIZE
      */
     function Panel($panel, minSize) {
         this.$panel = $panel;
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
      * 
      * @param {!string} id  Unique id for this panel. Use package-style naming, e.g. "myextension.feature.panelname"
      * @param {!jQueryObject} $panel  DOM content to use as the panel. Need not be in the document yet.
-     * @param {number=} minSize  Minimum height of panel in px; default is 100
+     * @param {number=} minSize  Minimum height of panel in px; default is DEFAULT_MIN_SIZE
      * @return {!Panel}
      */
     function createBottomPanel(id, $panel, minSize) {

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
      * 
      * @param {!string} id  Unique id for this panel. Use package-style naming, e.g. "myextension.feature.panelname"
      * @param {!jQueryObject} $panel  DOM content to use as the panel. Need not be in the document yet.
-     * @param {number=} minSize  Minimum height of panel in px; default is DEFAULT_MIN_SIZE
+     * @param {number=} minSize  Minimum height of panel in px.
      * @return {!Panel}
      */
     function createBottomPanel(id, $panel, minSize) {

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
      * Represents a panel below the editor area (a child of ".content").
      * 
      * @param {!jQueryObject} $panel  The entire panel, including any chrome, already in the DOM.
-     * @param {number=} minSize  Minimum height of panel in px; default is 0
+     * @param {number=} minSize  Minimum height of panel in px; default is 100
      */
     function Panel($panel, minSize) {
         this.$panel = $panel;
@@ -187,7 +187,7 @@ define(function (require, exports, module) {
      * 
      * @param {!string} id  Unique id for this panel. Use package-style naming, e.g. "myextension.feature.panelname"
      * @param {!jQueryObject} $panel  DOM content to use as the panel. Need not be in the document yet.
-     * @param {number=} minSize  Minimum height of panel in px; default is 0
+     * @param {number=} minSize  Minimum height of panel in px; default is 100
      * @return {!Panel}
      */
     function createBottomPanel(id, $panel, minSize) {


### PR DESCRIPTION
Gave "search-results" panel a min-height, just like the "replace-all-results" and "problems-panel" already has.

Issue: #5175 
