### PR TITLE
Fix context menu width

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -905,10 +905,10 @@ a, img {
         }
     }
 
-    .navigator {    
-        display: none;        
-        button {    
-            margin: 2px 1px 3px;   
+    .navigator {
+        display: none;
+        button {
+            margin: 2px 1px 3px;
         }
     }
 }

--- a/src/styles/brackets_colors.less
+++ b/src/styles/brackets_colors.less
@@ -48,7 +48,7 @@
  */
 
 // use the "lighten" or "darken" function with integer multiples of this
-@bc-color-step-size: 10%;  
+@bc-color-step-size: 10%;
 
 @bc-black:       #000000;
 @bc-grey:        #808080;
@@ -70,7 +70,7 @@
 @tc-icon-down:                  0.5;
 @tc-disabled-opacity:           0.3;
 
-@tc-link:                          #0083e8;      
+@tc-link:                          #0083e8;
 @tc-link-hover:                    #0083e8;
 @tc-dropdown-shadow:               0 3px 9px rgba(0, 0, 0, 0.24);
 @tc-gray-panel:                    #dfe2e2;
@@ -112,5 +112,5 @@
 @tc-input-glow:                 0 0 0 2px #6fb5f1;
 @tc-light-weight-text:          #000;
 @tc-light-weight-quiet-text:    #777;
-@tc-warning-background:         #FDF5CC; 
+@tc-warning-background:         #FDF5CC;
 @tc-warning-text:               #635301;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -230,6 +230,7 @@ a:focus {
 
     // The 1px adjustments here are to account for the border around the top-level menu items.
     margin: (@toolbar-top-gap-px - @menubar-top-padding - 1) 0 (-@menubar-bottom-padding + 1) (-@menubar-h-padding + 4);
+    width:100%;
 
     // General item appearance
     a {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -230,7 +230,7 @@ a:focus {
 
     // The 1px adjustments here are to account for the border around the top-level menu items.
     margin: (@toolbar-top-gap-px - @menubar-top-padding - 1) 0 (-@menubar-bottom-padding + 1) (-@menubar-h-padding + 4);
-    width:100%;
+    width: 100%;
 
     // General item appearance
     a {


### PR DESCRIPTION
Fix for context menu when strings is longer than menu width. 
![context-menu](https://f.cloud.github.com/assets/4968007/1254252/cfbb3c2e-2b72-11e3-9526-8cdf6b46984e.PNG)
After this patch
![after](https://f.cloud.github.com/assets/4968007/1254285/571b3598-2b73-11e3-954d-cb9026e54e34.PNG)
Plus remove some unnecessary spaces.
