### PR TITLE
[PM] Case conversion short cuts (Ctlr+U and Ctrl+I)

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -163,6 +163,12 @@
             "platform": "mac"
         }
     ],
+    "edit.toUpperCase": [
+        "Ctrl-U"
+    ],
+    "edit.toLowerCase": [
+        "Ctrl-I"
+    ],
     "view.hideSidebar":  [
         "Ctrl-Shift-H"
     ],

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -65,6 +65,8 @@ define(function (require, exports, module) {
     exports.EDIT_PASTE                  = "edit.paste";                 // EditorCommandHandlers.js     ignoreCommand()
     exports.EDIT_SELECT_ALL             = "edit.selectAll";             // EditorCommandHandlers.js     _handleSelectAll()
     
+    exports.EDIT_TO_UPPER_CASE          = "edit.toUpperCase";           // EditorCommandHandlers.js     toUpperCase()
+    exports.EDIT_TO_LOWER_CASE          = "edit.toLowerCase";           // EditorCommandHandlers.js     toLowerCase()
     exports.EDIT_SELECT_LINE            = "edit.selectLine";            // EditorCommandHandlers.js     selectLine()
     exports.EDIT_FIND                   = "edit.find";                  // FindReplace.js               _launchFind()
     exports.EDIT_FIND_IN_FILES          = "edit.findInFiles";           // FindInFiles.js               _doFindInFiles()

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -864,6 +864,30 @@ define(function (require, exports, module) {
 
         return result.promise();
     }
+    
+    function _convertToCase(editor, toCase) {
+        var textTo;
+        
+        if (!editor || !toCase || toCase === "") {
+            return;
+        }
+        
+        if (toCase === "l") {
+            textTo = editor.getSelectedText().toLowerCase();
+        } else {
+            textTo = editor.getSelectedText().toUpperCase();
+        }
+        
+        editor._codeMirror.replaceSelection(textTo);
+    }
+    
+    function toUpperCase(editor) {
+        _convertToCase(editor || EditorManager.getFocusedEditor(), "u");
+    }
+    
+    function toLowerCase(editor) {
+        _convertToCase(editor || EditorManager.getFocusedEditor(), "l");
+    }
         
     // Register commands
     CommandManager.register(Strings.CMD_INDENT,           Commands.EDIT_INDENT,           indentText);
@@ -877,6 +901,8 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_OPEN_LINE_ABOVE,  Commands.EDIT_OPEN_LINE_ABOVE,  openLineAbove);
     CommandManager.register(Strings.CMD_OPEN_LINE_BELOW,  Commands.EDIT_OPEN_LINE_BELOW,  openLineBelow);
     CommandManager.register(Strings.CMD_SELECT_LINE,      Commands.EDIT_SELECT_LINE,      selectLine);
+    CommandManager.register(Strings.CMD_TO_UPPER_CASE,    Commands.EDIT_TO_UPPER_CASE,    toUpperCase);
+    CommandManager.register(Strings.CMD_TO_LOWER_CASE,    Commands.EDIT_TO_LOWER_CASE,    toLowerCase);
 
     CommandManager.register(Strings.CMD_UNDO,             Commands.EDIT_UNDO,             handleUndo);
     CommandManager.register(Strings.CMD_REDO,             Commands.EDIT_REDO,             handleRedo);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -250,6 +250,8 @@ define({
     "CMD_OPEN_LINE_BELOW"                 : "Open Line Below",
     "CMD_TOGGLE_CLOSE_BRACKETS"           : "Auto Close Braces",
     "CMD_SHOW_CODE_HINTS"                 : "Show Code Hints",
+    "CMD_TO_UPPER_CASE"                   : "Convert To Upper Case",
+    "CMD_TO_LOWER_CASE"                   : "Convert To Lower Case",
     
     // View menu commands
     "VIEW_MENU"                           : "View",


### PR DESCRIPTION
Most of the editors have this short cut to convert selected text's case. `Ctrl + U` to upper case and `Ctrl + L` to lower case. But already, `Ctlr + L` has been assigned to "Select Line", so i used `Ctrl + I` for lower case  conversion. Let me know, if you like this short cut.
