### PR TITLE
Clicking project-dropdown-toggle again closes the dropdown

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -393,7 +393,11 @@ define(function (require, exports, module) {
         // Have to do this stopProp to avoid the html click handler from firing when this returns.
         e.stopPropagation();
         
-        showDropdown();
+        if ($dropdown) {
+            closeDropdown(); //close if it's already visible
+        } else {
+            showDropdown();
+        }
     }
     
     /**


### PR DESCRIPTION
It hides the dropdown when you click on the button again (the behaviour before was really confusing to me)
