### PR TITLE
Fix wrong path of Getting Started directory in Polish version

### DIFF
--- a/src/nls/pl/urls.js
+++ b/src/nls/pl/urls.js
@@ -26,7 +26,7 @@
 
 define({
     // Relative to the samples folder
-    "GETTING_STARTED"           : "root/Szybki Start",
+    "GETTING_STARTED"           : "pl/Szybki Start",
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty_pl/",
     "WEB_PLATFORM_DOCS_LICENSE" : "http://creativecommons.org/licenses/by/3.0/deed.pl"
 });


### PR DESCRIPTION
I have just spotted that there was a wrong path to the "Getting Started" directory. Brackets wanted to load /root/<Polish name of Getting Started>, but of course the directory was not there. Just changed the path from /root to /pl and everything seems to work fine.

The wrong path caused an error on Brackets load which cannot be stopped unless closing the app.

All unit tests passes.
No other bugs found.
