### PR TITLE
Add no-focus style to inline close button

### DIFF
--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
         
         // create the outer wrapper div
         this.htmlContent = window.document.createElement("div");
-        this.$htmlContent = $(this.htmlContent).addClass("inline-widget");
+        this.$htmlContent = $(this.htmlContent).addClass("inline-widget").attr("tabindex", "-1");
         this.$htmlContent.append("<div class='shadow top' />")
             .append("<div class='shadow bottom' />")
             .append("<a href='#' class='close no-focus'>&times;</a>");

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         this.$htmlContent = $(this.htmlContent).addClass("inline-widget");
         this.$htmlContent.append("<div class='shadow top' />")
             .append("<div class='shadow bottom' />")
-            .append("<a href='#' class='close'>&times;</a>");
+            .append("<a href='#' class='close no-focus'>&times;</a>");
 
         // create the close button
         this.$closeBtn = this.$htmlContent.find(".close");


### PR DESCRIPTION
This change ensures that focus will not change when clicking on the close button and therefore fixes fixes #5483.
