### PR TITLE
Fix HTML hinting issues caused by new token types -- "error" and "tag error".

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -262,7 +262,8 @@ define(function (require, exports, module) {
             // So just return an empty tag info.
             if (isPriorAttr &&
                     (!ctx.token.type ||
-                    (ctx.token.type !== "attribute" && ctx.token.type.indexOf("error") === -1 &&
+                    (ctx.token.type && ctx.token.type !== "attribute" &&
+                        ctx.token.type.indexOf("error") === -1 &&
                         ctx.token.string.indexOf("<") !== -1))) {
                 return createTagInfo();
             }
@@ -329,7 +330,8 @@ define(function (require, exports, module) {
                 // pos has whitespace before it and non-whitespace after it, so use token after
                 ctx.token = testToken;
 
-                if (ctx.token.type === "tag" || ctx.token.type.indexOf("error") !== -1) {
+                if (ctx.token.type === "tag" ||
+                        (ctx.token.type && ctx.token.type.indexOf("error") !== -1)) {
                     // Check to see if the cursor is just before a "<" but not in any tag.
                     if (ctx.token.string.charAt(0) === "<") {
                         return createTagInfo();
@@ -395,7 +397,8 @@ define(function (require, exports, module) {
             }
         }
         
-        if (ctx.token.type === "tag" || ctx.token.type.indexOf("error") !== -1) {
+        if (ctx.token.type === "tag" ||
+                (ctx.token.type && ctx.token.type.indexOf("error") !== -1)) {
             // Check if the user just typed a white space after "<" that made an existing tag invalid.
             if (ctx.token.string.match(/^<\s+/) && offset !== 1) {
                 return createTagInfo();

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -262,7 +262,8 @@ define(function (require, exports, module) {
             // So just return an empty tag info.
             if (isPriorAttr &&
                     (!ctx.token.type ||
-                    (ctx.token.type !== "attribute" && ctx.token.string.indexOf("<") !== -1))) {
+                    (ctx.token.type !== "attribute" && ctx.token.type.indexOf("error") === -1 &&
+                        ctx.token.string.indexOf("<") !== -1))) {
                 return createTagInfo();
             }
             return createTagInfo(ATTR_NAME, offset, tagName, attrName);
@@ -328,7 +329,7 @@ define(function (require, exports, module) {
                 // pos has whitespace before it and non-whitespace after it, so use token after
                 ctx.token = testToken;
 
-                if (ctx.token.type === "tag" || ctx.token.type === "error") {
+                if (ctx.token.type === "tag" || ctx.token.type.indexOf("error") !== -1) {
                     // Check to see if the cursor is just before a "<" but not in any tag.
                     if (ctx.token.string.charAt(0) === "<") {
                         return createTagInfo();
@@ -394,7 +395,7 @@ define(function (require, exports, module) {
             }
         }
         
-        if (ctx.token.type === "tag" || ctx.token.type === "error") {
+        if (ctx.token.type === "tag" || ctx.token.type.indexOf("error") !== -1) {
             // Check if the user just typed a white space after "<" that made an existing tag invalid.
             if (ctx.token.string.match(/^<\s+/) && offset !== 1) {
                 return createTagInfo();


### PR DESCRIPTION
"error" was introduced in https://github.com/marijnh/CodeMirror/commit/32abe85e698644231dba3badac86e886312461fd and then caused #5343. "tag error" was introduced in https://github.com/marijnh/CodeMirror/commit/a6c2e01fce24c960c7bf58118fce337fd054a6db and will break tag hinting when we update CodeMirror for sprint-33. Tag hints won't show up when you type a `<`. So this needs to land in master before landing the next CodeMirror update.
