### PR TITLE
Load core extensions before user extensions

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -201,7 +201,8 @@ define(function (require, exports, module) {
         LanguageManager.ready.always(function () {
             // Load all extensions. This promise will complete even if one or more
             // extensions fail to load.
-            var extensionLoaderPromise = ExtensionLoader.init(params.get("extensions"));
+            var extensionPathOverride = params.get("extensions");  // used by unit tests
+            var extensionLoaderPromise = ExtensionLoader.init(extensionPathOverride ? extensionPathOverride.split(",") : null);
             
             // Load the initial project after extensions have loaded
             extensionLoaderPromise.always(function () {

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         Strings          = require("strings"),
         StringUtils      = require("utils/StringUtils");
     
-    // semver isn't a proper AMD module, so it will just load into the global namespace.
+    // semver.browser is an AMD-compatible module
     var semver = require("extensibility/node/node_modules/semver/semver.browser");
     
     /**

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -150,6 +150,8 @@ define(function (require, exports, module) {
             console.warn("Overwriting existing inspection/linting provider for language " + languageId);
         }
         _providers[languageId] = provider;
+        
+        run();  // in case a file of this type is open currently
     }
 
     /**

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -311,9 +311,9 @@ define(function (require, exports, module) {
     /**
      * Load extensions.
      *
-     * @param {?string} A list containing references to extension source
-     *      location. A source location may be either (a) a folder path
-     *      relative to src/extensions or (b) an absolute path.
+     * @param {?Array.<string>} A list containing references to extension source
+     *      location. A source location may be either (a) a folder name inside
+     *      src/extensions or (b) an absolute path.
      * @return {!$.Promise} A promise object that is resolved when all extensions complete loading.
      */
     function init(paths) {
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
         }
         
         if (!paths) {
-            paths = "default,dev," + getUserExtensionPath();
+            paths = ["default", "dev", getUserExtensionPath()];
         }
 
         // Load extensions before restoring the project
@@ -345,7 +345,7 @@ define(function (require, exports, module) {
         new NativeFileSystem.DirectoryEntry().getDirectory(disabledExtensionPath,
                                                            {create: true});
         
-        var promise = Async.doInParallel(paths.split(","), function (item) {
+        var promise = Async.doSequentially(paths, function (item) {
             var extensionPath = item;
             
             // If the item has "/" in it, assume it is a full path. Otherwise, load
@@ -355,7 +355,7 @@ define(function (require, exports, module) {
             }
             
             return loadAllExtensionsInNativeDirectory(extensionPath);
-        });
+        }, false);
         
         promise.always(function () {
             _init = true;


### PR DESCRIPTION
This eliminates a race condition where core extensions and user extensions load in parallel, meaning that sometimes a core extension might initialize after some user extensions.

Now we wait for all core extensions to load first.  This fixes bug #5442, and fixes longstanding glitches with inconsistent menu item ordering.

There's also a fix to ensure that, when a new linter is installed via Extension Manager, the results panel updates to reflect it right away.
