### PR TITLE
Better compartmentalize code that assumes no trailing "/"

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Preferences.js
+++ b/src/extensions/default/JavaScriptCodeHints/Preferences.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
      *  regular expression.
      *
      * @param {Array.<string|RegExp>} settings
-     * @param {RegExp} defaultRegExp - default regular expression to use
+     * @param {?RegExp} defaultRegExp - default regular expression to use
      * if none if provided.
      * @return {RegExp} Regular expression that captures the array of string
      * with optional wildcards.

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -238,7 +238,7 @@ define(function (require, exports, module) {
         }
 
         var testPath = ProjectManager.makeProjectRelativeIfPossible(path);
-        testPath = FileUtils.canonicalizeFolderPath(testPath);
+        testPath = FileUtils.stripTrailingSlash(testPath);
 
         return excludes.test(testPath);
     }
@@ -1021,7 +1021,7 @@ define(function (require, exports, module) {
                     }
                 }
     
-                dir = FileUtils.canonicalizeFolderPath(dir);
+                dir = FileUtils.stripTrailingSlash(dir);
                 forEachFileInDirectory(dir, doneCallback, fileCallback, directoryCallback);
             }
     

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -63,14 +63,15 @@ define(function (require, exports, module) {
     
     
     /**
-     * Get the stored list of recent projects, canonicalizing and updating paths as appropriate.
+     * Get the stored list of recent projects, fixing up paths as appropriate.
+     * Warning: unlike most paths in Brackets, these lack a trailing "/"
      */
     function getRecentProjects() {
         var recentProjects = prefs.getValue("recentProjects") || [],
             i;
         
         for (i = 0; i < recentProjects.length; i++) {
-            recentProjects[i] = FileUtils.canonicalizeFolderPath(ProjectManager.updateWelcomeProjectPath(recentProjects[i]));
+            recentProjects[i] = FileUtils.stripTrailingSlash(ProjectManager.updateWelcomeProjectPath(recentProjects[i]));
         }
         return recentProjects;
     }
@@ -79,7 +80,7 @@ define(function (require, exports, module) {
      * Add a project to the stored list of recent projects, up to MAX_PROJECTS.
      */
     function add() {
-        var root = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
+        var root = FileUtils.stripTrailingSlash(ProjectManager.getProjectRoot().fullPath),
             recentProjects = getRecentProjects(),
             index = recentProjects.indexOf(root);
         
@@ -319,7 +320,7 @@ define(function (require, exports, module) {
      */
     function renderList() {
         var recentProjects = getRecentProjects(),
-            currentProject = FileUtils.canonicalizeFolderPath(ProjectManager.getProjectRoot().fullPath),
+            currentProject = FileUtils.stripTrailingSlash(ProjectManager.getProjectRoot().fullPath),
             templateVars   = {
                 projectList : [],
                 Strings     : Strings

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -71,7 +71,8 @@ define(function (require, exports, module) {
             i;
         
         for (i = 0; i < recentProjects.length; i++) {
-            recentProjects[i] = FileUtils.stripTrailingSlash(ProjectManager.updateWelcomeProjectPath(recentProjects[i]));
+            // We have to canonicalize & then de-canonicalize the path here, since our pref format uses no trailing "/"
+            recentProjects[i] = FileUtils.stripTrailingSlash(ProjectManager.updateWelcomeProjectPath(recentProjects[i] + "/"));
         }
         return recentProjects;
     }

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
      * @return {string}
      */
     function stripTrailingSlash(path) {
-        if (path[path.length - 1] === "/") {
+        if (path && path[path.length - 1] === "/") {
             return path.slice(0, -1);
         } else {
             return path;

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -226,16 +226,32 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Canonicalizes a folder path to not include a trailing slash.
+     * Removes the trailing slash from a path, if it has one.
+     * Warning: this differs from the format of most paths used in Brackets! Use paths ending in "/"
+     * normally, as this is the format used by DirectoryEntry.fullPath.
+     * 
      * @param {string} path
      * @return {string}
      */
-    function canonicalizeFolderPath(path) {
-        if (path.length > 0 && path[path.length - 1] === "/") {
+    function stripTrailingSlash(path) {
+        if (path[path.length - 1] === "/") {
             return path.slice(0, -1);
         } else {
             return path;
         }
+    }
+    
+    /**
+     * Warning: Contrary to the name, this does NOT return a canonical path. The canonical format
+     * used by DirectoryEntry.fullPath actually DOES include the trailing "/"
+     * @deprecated
+     * 
+     * @param {string} path
+     * @return {string}
+     */
+    function canonicalizeFolderPath(path) {
+        console.error("Warning: FileUtils.canonicalizeFolderPath() is deprecated. Use paths ending in '/' if possible, like DirectoryEntry.fullPath");
+        return stripTrailingSlash(path);
     }
     
     /**
@@ -245,14 +261,20 @@ define(function (require, exports, module) {
      * directory
      */
     function getBaseName(fullPath) {
-        fullPath = canonicalizeFolderPath(fullPath);
-        return fullPath.substr(fullPath.lastIndexOf("/") + 1);
+        var lastSlash = fullPath.lastIndexOf("/");
+        if (lastSlash === fullPath.length - 1) {  // directory: exclude trailing "/" too
+            return fullPath.slice(fullPath.lastIndexOf("/", fullPath.length - 2) + 1, -1);
+        } else {
+            return fullPath.slice(lastSlash + 1);
+        }
     }
     
     /**
      * Returns a native absolute path to the 'brackets' source directory.
      * Note that this only works when run in brackets/src/index.html, so it does
      * not work for unit tests (which is run from brackets/test/SpecRunner.html)
+     * 
+     * WARNING: unlike most paths in Brackets, this path EXCLUDES the trailing "/".
      * @return {string}
      */
     function getNativeBracketsDirectoryPath() {
@@ -265,6 +287,8 @@ define(function (require, exports, module) {
      * Given the module object passed to JS module define function,
      * convert the path to a native absolute path.
      * Returns a native absolute path to the module folder.
+     * 
+     * WARNING: unlike most paths in Brackets, this path EXCLUDES the trailing "/".
      * @return {string}
      */
     function getNativeModuleDirectoryPath(module) {
@@ -449,6 +473,7 @@ define(function (require, exports, module) {
     exports.getNativeBracketsDirectoryPath = getNativeBracketsDirectoryPath;
     exports.getNativeModuleDirectoryPath   = getNativeModuleDirectoryPath;
     exports.canonicalizeFolderPath         = canonicalizeFolderPath;
+    exports.stripTrailingSlash             = stripTrailingSlash;
     exports.isAffectedWhenRenaming         = isAffectedWhenRenaming;
     exports.updateFileEntryPath            = updateFileEntryPath;
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -794,7 +794,6 @@ define(function (require, exports, module) {
     
     
     /** Returns the full path to the welcome project, which we open on first launch.
-     * Warning: unlike most paths in Brackets, this path EXCLUDES the trailing "/".
      * @private
      * @return {!string} fullPath reference
      */
@@ -807,28 +806,27 @@ define(function (require, exports, module) {
             initialPath = initialPath.substr(0, initialPath.lastIndexOf("/")) + "/samples/" + sampleUrl;
         }
 
-        return initialPath;
+        return initialPath + "/"; // paths above weren't canonical
     }
     
     /**
      * Returns true if the given path is the same as one of the welcome projects we've previously opened,
-     * or the one for the current build. A trailing "/" on the input path is optional.
+     * or the one for the current build.
      */
     function isWelcomeProjectPath(path) {
-        var pathNoSlash = FileUtils.stripTrailingSlash(path);
-        if (pathNoSlash === _getWelcomeProjectPath()) {
+        if (path === _getWelcomeProjectPath()) {
             return true;
         }
+        var pathNoSlash = FileUtils.stripTrailingSlash(path);  // "welcomeProjects" pref has standardized on no trailing "/"
         var welcomeProjects = _prefs.getValue("welcomeProjects") || [];
         return welcomeProjects.indexOf(pathNoSlash) !== -1;
     }
     
     /**
      * Adds the path to the list of welcome projects we've ever seen, if not on the list already.
-     * A trailing "/" on the input path is optional.
      */
     function addWelcomeProjectPath(path) {
-        var pathNoSlash = FileUtils.stripTrailingSlash(path);
+        var pathNoSlash = FileUtils.stripTrailingSlash(path);  // "welcomeProjects" pref has standardized on no trailing "/"
         
         var welcomeProjects = _prefs.getValue("welcomeProjects") || [];
         if (welcomeProjects.indexOf(pathNoSlash) === -1) {
@@ -839,9 +837,6 @@ define(function (require, exports, module) {
     
     /**
      * If the provided path is to an old welcome project, returns the current one instead.
-     * A trailing "/" on the input path is optional.
-     * Warning: unlike most paths in Brackets, this may return a path EXCLUDING the trailing "/"
-     * (even if the path passed in had one).
      */
     function updateWelcomeProjectPath(path) {
         if (isWelcomeProjectPath(path)) {
@@ -854,7 +849,6 @@ define(function (require, exports, module) {
     /**
      * Initial project path is stored in prefs, which defaults to the welcome project on
      * first launch.
-     * Warning: unlike most paths in Brackets, this may return a path EXCLUDING the trailing "/".
      */
     function getInitialProjectPath() {
         return updateWelcomeProjectPath(_prefs.getValue("projectPath"));
@@ -925,8 +919,7 @@ define(function (require, exports, module) {
                     // If this is the most current welcome project, record it. In future launches, we want
                     // to substitute the latest welcome project from the current build instead of using an
                     // outdated one (when loading recent projects or the last opened project).
-                    // TODO: Remove this once installs upgrade in place
-                    if (rootPath === _getWelcomeProjectPath() + "/") {
+                    if (rootPath === _getWelcomeProjectPath()) {
                         addWelcomeProjectPath(rootPath);
                     }
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -793,6 +793,19 @@ define(function (require, exports, module) {
     }
     
     
+    /**
+     * Although Brackets is generally standardized on folder paths with a trailing "/", some APIs here
+     * receive project paths without "/" due to legacy preference storage formats, etc.
+     * @param {!string} fullPath  Path that may or may not end in "/"
+     * @return {!string} Path that ends in "/"
+     */
+    function _ensureTrailingSlash(fullPath) {
+        if (fullPath[fullPath.length - 1] !== "/") {
+            return fullPath + "/";
+        }
+        return fullPath;
+    }
+    
     /** Returns the full path to the welcome project, which we open on first launch.
      * @private
      * @return {!string} fullPath reference
@@ -806,7 +819,7 @@ define(function (require, exports, module) {
             initialPath = initialPath.substr(0, initialPath.lastIndexOf("/")) + "/samples/" + sampleUrl;
         }
 
-        return initialPath + "/"; // paths above weren't canonical
+        return _ensureTrailingSlash(initialPath); // paths above weren't canonical
     }
     
     /**
@@ -870,9 +883,7 @@ define(function (require, exports, module) {
         forceFinishRename();    // in case we're in the middle of renaming a file in the project
         
         // Some legacy code calls this API with a non-canonical path
-        if (rootPath[rootPath.length - 1] !== "/") {
-            rootPath += "/";
-        }
+        rootPath = _ensureTrailingSlash(rootPath);
         
         if (!isUpdating) {
             if (_projectRoot && _projectRoot.fullPath === rootPath) {


### PR DESCRIPTION
The "canonical" folder path format used in DirectoryEntry.fullPath includes a trailing "/".  However, we have some Brackets code that requires or generates paths in the _opposite_ format.  This cleans up several of those cases:
- Rename FileUtils.canonicalizeFolderPath() to stripTrailingSlash() since it actually makes paths NOT canonical. Old API is **deprecated** but left in place for now (it's used by several extensions -- I'll file bugs once this lands).
- Add warning to docs for two other APIs that return non-canonical paths: FileUtils.getNativeBracketsDirectoryPath() & FileUtils.getNativeModuleDirectoryPath()
- Indicate explicitly that ProjectManager._loadProject() / openProject() support receiving non-canonical paths
- Fix several ProjectManager APIs that used to return and/or receive non-canonical paths -- getInitialProjectPath(), _getWelcomeProjectPath(), updateWelcomeProjectPath().  No extensions use these APIs.
- Centralize code that touches "welcomeProjects" pref storage, for clarity

This is an incremental improvement.  Not everything has been cleaned up:
- Some code still calls openProject() with non-canonical paths
- RecentProjects still works with non-canonical paths internally (including its pref storage)
- The list of previous "welcomeProjects" is still stored non-canonicalized
- ScopeManager (in JS code hints) still requires non-canonical paths in some places (while requiring _canonical_ paths in others! :joy:)
- The two getNative*() APIs above still return non-canonical paths -- though I think we can fix these soon.  It will be safer to change these once we have the new filesystem because it's more careful about handling duplicated slashes.
