### PR TITLE
[Initial review] Update rule label when selector is edited

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -243,10 +243,10 @@ define(function (require, exports, module) {
             });
             return result;
         }
-
+        
         CSSUtils.findMatchingRules(selectorName, hostEditor.document)
             .done(function (rules) {
-                cssInlineEditor = new MultiRangeInlineEditor(rules || [], _getNoRulesMsg);
+                cssInlineEditor = new MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [], _getNoRulesMsg);
                 cssInlineEditor.load(hostEditor);
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -246,7 +246,7 @@ define(function (require, exports, module) {
         
         CSSUtils.findMatchingRules(selectorName, hostEditor.document)
             .done(function (rules) {
-                cssInlineEditor = new MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [], _getNoRulesMsg);
+                cssInlineEditor = new MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [], _getNoRulesMsg, CSSUtils.getRangeSelectors);
                 cssInlineEditor.load(hostEditor);
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1268,6 +1268,23 @@ define(function (require, exports, module) {
         return newRules;
     }
     
+    /**
+     * Given a TextRange, extracts the selector(s) at the beginning of the range and returns it.
+     * @param {TextRange} range The range to extract the selector(s) from.
+     * @return {string} The selector(s) at the beginning of the range.
+     */
+    function getRangeSelectors(range) {
+        // There's currently no immediate way to access a given line in a Document, because it's just
+        // stored as a string. Eventually, we should have Documents cache the lines in the document
+        // as well, or make them use CodeMirror documents which do the same thing.
+        var i, startIndex = 0, text = range.document.getText();
+        for (i = 0; i < range.startLine; i++) {
+            startIndex = text.indexOf("\n", startIndex) + 1;
+        }
+        var nextBrace = text.indexOf("{", startIndex);
+        return text.substring(startIndex, nextBrace).trim().replace("\n", " ");
+    }
+        
     exports._findAllMatchingSelectorsInText = _findAllMatchingSelectorsInText; // For testing only
     exports.findMatchingRules = findMatchingRules;
     exports.extractAllSelectors = extractAllSelectors;
@@ -1276,6 +1293,7 @@ define(function (require, exports, module) {
     exports.reduceStyleSheetForRegExParsing = reduceStyleSheetForRegExParsing;
     exports.addRuleToDocument = addRuleToDocument;
     exports.consolidateRules = consolidateRules;
+    exports.getRangeSelectors = getRangeSelectors;
 
     exports.SELECTOR = SELECTOR;
     exports.PROP_NAME = PROP_NAME;

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -64,6 +64,7 @@ define(function (require, exports, module) {
     require("spec/QuickOpen-test");
     require("spec/RemoteFunctions-test");
     require("spec/StringMatch-test");
+    require("spec/TextRange-test");
     require("spec/UpdateNotification-test");
     require("spec/ViewCommandHandlers-test");
     require("spec/ViewUtils-test");

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1656,15 +1656,15 @@ define(function (require, exports, module) {
         });
         
         it("should extract selectors at the beginning of a text range", function () {
-            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar, #baz {}\nh2 {}\n"),
-                range = new TextRange(doc, 1, 1);
+            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar, #baz {\n    color: #fff;\n}\nh2 {}\n"),
+                range = new TextRange(doc, 1, 3);
             expect(CSSUtils.getRangeSelectors(range)).toBe(".bar, #baz");
             range.dispose();
         });
         
         it("should extract selectors spanning multiple lines at the beginning of a text range, with newlines replaced", function () {
-            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar,\n#baz {}\nh2 {}\n"),
-                range = new TextRange(doc, 1, 2);
+            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar,\n#baz {\n    color: #fff;\n}\nh2 {}\n"),
+                range = new TextRange(doc, 1, 3);
             expect(CSSUtils.getRangeSelectors(range)).toBe(".bar, #baz");
             range.dispose();
         });

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -646,6 +646,7 @@ define(function (require, exports, module) {
             it("should match a lone type selector given a type", function () {
                 var result = match("div { color:red }", { tag: "div" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = matchAgain({ tag: "span" });
                 expect(result.length).toBe(0);
@@ -660,6 +661,7 @@ define(function (require, exports, module) {
             it("should match a lone class selector given a class", function () {
                 var result = match(".foo { color:red }", { clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = matchAgain({ clazz: "bar" });
                 expect(result.length).toBe(0);
@@ -677,6 +679,7 @@ define(function (require, exports, module) {
             it("should match a lone id selector given an id", function () {
                 var result = match("#foo { color:red }", { id: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(0);
@@ -698,6 +701,7 @@ define(function (require, exports, module) {
                            
                 var result = match(css, { tag: "div" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 result = matchAgain({ tag: "foo" });
                 expect(result.length).toBe(0);
                 result = matchAgain({ tag: "bar" });
@@ -707,6 +711,7 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 result = matchAgain({ clazz: "bar" });
                 expect(result.length).toBe(0);
                 
@@ -716,6 +721,7 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
             });
             
             it("should be case-sensitive for all but types", function () {
@@ -1173,6 +1179,7 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = match("p h4 div { color:red }", { tag: "p" });
                 expect(result.length).toBe(0);
@@ -1180,6 +1187,7 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
                 result = matchAgain({ tag: "div" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = match(".foo h4 { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
@@ -1188,8 +1196,10 @@ define(function (require, exports, module) {
                 
                 result = match("div div { color:red }", { tag: "div" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 result = match(".foo .foo { color:red }", { clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 result = matchAgain({ tag: "foo" });
                 expect(result.length).toBe(0);
             });
@@ -1199,6 +1209,7 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBeUndefined();
                 
                 result = match(".foo > h4 { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
@@ -1280,42 +1291,63 @@ define(function (require, exports, module) {
                 // Comma- and space- separated
                 var result = match("h4, .foo, #bar { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 
                 // Comma only
                 result = match("h4,.foo,#bar { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4,.foo,#bar");
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4,.foo,#bar");
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4,.foo,#bar");
                 
                 // Newline-separated
                 result = match("h4,\n.foo,\r\n#bar { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo, #bar");
                 
                 // Space-separated with a space combinator
                 result = match("h4, .foo #bar { color:red }", { tag: "h4" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo #bar");
                 result = matchAgain({ clazz: "foo" });
                 expect(result.length).toBe(0);
                 result = matchAgain({ id: "bar" });
                 expect(result.length).toBe(1);
+                expect(result[0].selectorGroup).toBe("h4, .foo #bar");
                 
                 // Test items of each type in all positions (first, last, middle)
                 result = match("h4, h4, h4 { color:red }", { tag: "h4" });
                 expect(result.length).toBe(3);
+                var i;
+                for (i = 0; i < 3; i++) {
+                    expect(result[i].selectorGroup).toBe("h4, h4, h4");
+                }
                 result = match(".foo, .foo, .foo { color:red }", { clazz: "foo" });
                 expect(result.length).toBe(3);
+                for (i = 0; i < 3; i++) {
+                    expect(result[i].selectorGroup).toBe(".foo, .foo, .foo");
+                }
                 result = match("#bar, #bar, #bar { color:red }", { id: "bar" });
                 expect(result.length).toBe(3);
+                for (i = 0; i < 3; i++) {
+                    expect(result[i].selectorGroup).toBe("#bar, #bar, #bar");
+                }
             });
         }); // describe("Selector groups")        
 
@@ -1560,6 +1592,66 @@ define(function (require, exports, module) {
                     pos: { line: 2, ch: 4 }
                 }
             });
+        });
+        
+        it("should consolidate consecutive rules that refer to the same item", function () {
+            var doc1 = SpecRunnerUtils.createMockDocument(""),
+                doc2 = SpecRunnerUtils.createMockDocument(""),
+                rules = [
+                    {
+                        name: ".foo",
+                        doc: doc1,
+                        lineStart: 5,
+                        lineEnd: 7
+                    },
+                    {
+                        name: ".eek",
+                        doc: doc1,
+                        lineStart: 10,
+                        lineEnd: 12
+                    },
+                    {
+                        name: ".bar",
+                        doc: doc2,
+                        lineStart: 3,
+                        lineEnd: 5
+                    },
+                    {
+                        name: "#baz",
+                        doc: doc2,
+                        lineStart: 8,
+                        lineEnd: 12,
+                        selectorGroup: "#baz, h2"
+                    },
+                    {
+                        name: "h2",
+                        doc: doc2,
+                        lineStart: 8,
+                        lineEnd: 12,
+                        selectorGroup: "#baz, h2"
+                    },
+                    {
+                        name: ".argle",
+                        doc: doc2,
+                        lineStart: 15,
+                        lineEnd: 20
+                    }
+                ],
+                result = CSSUtils.consolidateRules(rules);
+            
+            expect(result).toEqual([
+                rules[0],
+                rules[1],
+                rules[2],
+                {
+                    name: "#baz, h2",
+                    doc: doc2,
+                    lineStart: 8,
+                    lineEnd: 12,
+                    selectorGroup: "#baz, h2"
+                },
+                rules[5]
+            ]);
         });
     });
 

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -32,7 +32,8 @@ define(function (require, exports, module) {
         FileUtils                  = require("file/FileUtils"),
         CSSUtils                   = require("language/CSSUtils"),
         HTMLUtils                  = require("language/HTMLUtils"),
-        SpecRunnerUtils            = require("spec/SpecRunnerUtils");
+        SpecRunnerUtils            = require("spec/SpecRunnerUtils"),
+        TextRange                  = require("document/TextRange").TextRange;
     
     var testPath                   = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
         simpleCssFileEntry         = new NativeFileSystem.FileEntry(testPath + "/simple.css"),
@@ -1652,6 +1653,20 @@ define(function (require, exports, module) {
                 },
                 rules[5]
             ]);
+        });
+        
+        it("should extract selectors at the beginning of a text range", function () {
+            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar, #baz {}\nh2 {}\n"),
+                range = new TextRange(doc, 1, 1);
+            expect(CSSUtils.getRangeSelectors(range)).toBe(".bar, #baz");
+            range.dispose();
+        });
+        
+        it("should extract selectors spanning multiple lines at the beginning of a text range, with newlines replaced", function () {
+            var doc = SpecRunnerUtils.createMockDocument(".foo {}\n.bar,\n#baz {}\nh2 {}\n"),
+                range = new TextRange(doc, 1, 2);
+            expect(CSSUtils.getRangeSelectors(range)).toBe(".bar, #baz");
+            range.dispose();
         });
     });
 

--- a/test/spec/TextRange-test.js
+++ b/test/spec/TextRange-test.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, describe, it, expect, beforeEach, afterEach, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var TextRange = require("document/TextRange").TextRange,
+        SpecRunnerUtils = require("spec/SpecRunnerUtils");
+    
+    var docText = "", i;
+    for (i = 0; i < 10; i++) {
+        docText += "line " + i + "\n";
+    }
+    
+    describe("TextRange", function () {
+        var doc,
+            range,
+            gotChange,
+            gotContentChange,
+            gotLostSync;
+        
+        beforeEach(function () {
+            var result = SpecRunnerUtils.createMockEditor(docText);
+            doc = result.doc;
+
+            gotChange = false;
+            gotContentChange = false;
+            gotLostSync = false;
+
+            range = new TextRange(doc, 4, 6);
+            $(range).on("change.unittest", function () {
+                expect(gotChange).toBe(false);
+                gotChange = true;
+            }).on("contentChange.unittest", function () {
+                expect(gotContentChange).toBe(false);
+                gotContentChange = true;
+            }).on("lostSync.unittest", function () {
+                expect(gotLostSync).toBe(false);
+                gotLostSync = true;
+            });
+        });
+        
+        afterEach(function () {
+            SpecRunnerUtils.destroyMockEditor(doc);
+            doc = null;
+            $(range).off(".unittest");
+            range.dispose();
+            range = null;
+        });
+        
+        it("should not update or fire events for an edit before that doesn't change the number of lines", function () {
+            doc.replaceRange("new line 2\nnew line 3", {line: 2, ch: 0}, {line: 3, ch: 6});
+            expect(gotChange).toBe(false);
+            expect(gotContentChange).toBe(false);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(4);
+            expect(range.endLine).toBe(6);
+        });
+        
+        it("should update and fire a change, but not a contentChange, for an edit before that deletes a line", function () {
+            doc.replaceRange("", {line: 2, ch: 0}, {line: 3, ch: 0});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(false);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(3);
+            expect(range.endLine).toBe(5);
+        });
+
+        it("should update and fire a change, but not a contentChange, for an edit before that inserts a line", function () {
+            doc.replaceRange("new extra line\n", {line: 2, ch: 0});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(false);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(5);
+            expect(range.endLine).toBe(7);
+        });
+        
+        it("should not update or fire events for an edit after even if it changes the number of lines", function () {
+            doc.replaceRange("new extra line\n", {line: 8, ch: 0});
+            expect(gotChange).toBe(false);
+            expect(gotContentChange).toBe(false);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(4);
+            expect(range.endLine).toBe(6);
+        });
+        
+        it("should lose sync if entire document is replaced", function () {
+            doc.replaceRange("new content", {line: 0, ch: 0}, {line: 9, ch: 6});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(true);
+            expect(range.startLine).toBe(null);
+            expect(range.endLine).toBe(null);
+        });
+        
+        it("should lose sync if entire range is replaced", function () {
+            doc.replaceRange("new content", {line: 3, ch: 0}, {line: 7, ch: 6});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(true);
+            expect(range.startLine).toBe(null);
+            expect(range.endLine).toBe(null);
+        });
+        
+        it("should lose sync if a change overlaps the beginning of the range", function () {
+            doc.replaceRange("new content", {line: 3, ch: 0}, {line: 5, ch: 6});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(true);
+            expect(range.startLine).toBe(null);
+            expect(range.endLine).toBe(null);
+        });
+
+        it("should lose sync if a change overlaps the end of the range", function () {
+            doc.replaceRange("new content", {line: 5, ch: 0}, {line: 7, ch: 6});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(true);
+            expect(range.startLine).toBe(null);
+            expect(range.endLine).toBe(null);
+        });
+        
+        it("should not update or send a change, but should send contentChange, if a change occurs inside range without changing # of lines", function () {
+            doc.replaceRange("new line 5", {line: 5, ch: 0}, {line: 5, ch: 6});
+            expect(gotChange).toBe(false);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(4);
+            expect(range.endLine).toBe(6);
+        });
+        
+        it("should update and send change/contentChange if a line is added inside range", function () {
+            doc.replaceRange("new added line\n", {line: 5, ch: 0});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(4);
+            expect(range.endLine).toBe(7);
+        });
+        
+        it("should update and send change/contentChange if a line is deleted inside range", function () {
+            doc.replaceRange("", {line: 5, ch: 0}, {line: 6, ch: 0});
+            expect(gotChange).toBe(true);
+            expect(gotContentChange).toBe(true);
+            expect(gotLostSync).toBe(false);
+            expect(range.startLine).toBe(4);
+            expect(range.endLine).toBe(5);
+        });
+    });
+});


### PR DESCRIPTION
@dangoor - note that this is branched off the `css-quick-edit-new-selector` branch from #5532 (I didn't want to disturb your review there). The commits in this one (607b35d, df1d141, 73e7414) are semantic so can be reviewed individually.
