### PR TITLE
Fix Issue #5427- "Getting Started > main.css comment refers to Edge Code"

### DIFF
--- a/samples/root/Getting Started/main.css
+++ b/samples/root/Getting Started/main.css
@@ -27,7 +27,7 @@ h1, h2, h3, h4, h5, h6 {
 
 samp
 {
-    /* hide <samp> from the browser so we can show cool features when the user opens the .html in Brackets */
+    /* hide tutorial instructions so they don't show in the browser */
     display: none;
 }
 

--- a/samples/root/Getting Started/main.css
+++ b/samples/root/Getting Started/main.css
@@ -27,7 +27,7 @@ h1, h2, h3, h4, h5, h6 {
 
 samp
 {
-    /* hide <samp> from the browser so we can show cool features in Edge Code */
+    /* hide <samp> from the browser so we can show cool features when the user opens the .html in Brackets */
     display: none;
 }
 


### PR DESCRIPTION
Fix Issue #5427- "Getting Started > main.css comment refers to Edge Code"

Reword comment to replace Edge Code with Brackets app name.
