### PR TITLE
Fix #5537: Start live development even if there is no open file

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1168,10 +1168,16 @@ define(function LiveDevelopment(require, exports, module) {
         // TODO: need to run _onDocumentChange() after load if doc != currentDocument here? Maybe not, since activeEditorChange
         // doesn't trigger it, while inline editors can still cause edits in doc other than currentDoc...
         _getInitialDocFromCurrent().done(function (doc) {
-            var prepareServerPromise = (doc && _prepareServer(doc)) || new $.Deferred().reject();
+            var prepareServerPromise = (doc && _prepareServer(doc)) || new $.Deferred().reject(),
+                otherDocumentsInWorkingFiles;
 
             if (doc && !doc._masterEditor) {
+                otherDocumentsInWorkingFiles = DocumentManager.getWorkingSet().length;
                 DocumentManager.addToWorkingSet(doc.file);
+
+                if (!otherDocumentsInWorkingFiles) {
+                    DocumentManager.setCurrentDocument(doc);
+                }
             }
 
             // wait for server (StaticServer, Base URL or file:)

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -569,7 +569,6 @@ define(function LiveDevelopment(require, exports, module) {
             // to the base URL is completed, and (3) the agents finish loading
             // gather related documents and finally set status to STATUS_ACTIVE.
             var doc = _getCurrentDocument();  // TODO: probably wrong...
-            console.log(doc);
 
             if (doc) {
                 var status = STATUS_ACTIVE,


### PR DESCRIPTION
This PR fixes the issue #5537 where you can't start Live Development if there is no open file even if there is an index.html in it.

It works, but please check to code to decide whether this is a good solution/fix or just a bad workaround.

The LiveDev tests ran fine, I haven't tested any others.
