### PR TITLE
Add keyboard shortcut for new rule

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -270,6 +270,9 @@
             "displayKey": "Alt-↓"
         }
     ],
+    "navigate.newRule":  [
+        "Cmd-Alt-N"
+    ],
     "file.rename":  [
         "F2"
     ]

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -116,6 +116,7 @@ define(function (require, exports, module) {
     exports.TOGGLE_QUICK_DOCS           = "navigate.toggleQuickDocs";   // EditorManager.js             _toggleInlineWidget()
     exports.QUICK_EDIT_NEXT_MATCH       = "navigate.nextMatch";         // MultiRangeInlineEditor.js    _nextRange()
     exports.QUICK_EDIT_PREV_MATCH       = "navigate.previousMatch";     // MultiRangeInlineEditor.js    _previousRange()
+    exports.CSS_QUICK_EDIT_NEW_RULE     = "navigate.newRule";           // CSSInlineEditor.js           _handleNewRule()
 
     // HELP
     exports.HELP_CHECK_FOR_UPDATE       = "help.checkForUpdate";        // HelpCommandHandlers.js       _handleCheckForUpdates()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -137,6 +137,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);
         menu.addMenuItem(Commands.QUICK_EDIT_PREV_MATCH);
         menu.addMenuItem(Commands.QUICK_EDIT_NEXT_MATCH);
+        menu.addMenuItem(Commands.CSS_QUICK_EDIT_NEW_RULE);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_QUICK_DOCS);
 

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -30,6 +30,8 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var CSSUtils                = require("language/CSSUtils"),
+        CommandManager          = require("command/CommandManager"),
+        Commands                = require("command/Commands"),
         DocumentManager         = require("document/DocumentManager"),
         DropdownEventHandler    = require("utils/DropdownEventHandler").DropdownEventHandler,
         EditorManager           = require("editor/EditorManager"),
@@ -37,11 +39,15 @@ define(function (require, exports, module) {
         FileIndexManager        = require("project/FileIndexManager"),
         HTMLUtils               = require("language/HTMLUtils"),
         Menus                   = require("command/Menus"),
-        MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
+        MultiRangeInlineEditor  = require("editor/MultiRangeInlineEditor"),
         PopUpManager            = require("widgets/PopUpManager"),
-        Strings                 = require("strings");
+        Strings                 = require("strings"),
+        _                       = require("lodash");
 
     var StylesheetsMenuTemplate = require("text!htmlContent/stylesheets-menu.html");
+    
+    var _newRuleCmd,
+        _newRuleHandlers = [];
 
     /**
      * Given a position in an HTML editor, returns the relevant selector for the attribute/tag
@@ -115,7 +121,23 @@ define(function (require, exports, module) {
             inlineEditor.editor.setCursorPos(newRuleInfo.pos.line, newRuleInfo.pos.ch);
         });
     }
-
+    
+    /**
+     * @private
+     * Handle the "new rule" menu item by dispatching it to the handler for the focused inline editor.
+     */
+    function _handleNewRule() {
+        var inlineEditor = MultiRangeInlineEditor.getFocusedMultiRangeInlineEditor();
+        if (inlineEditor) {
+            var handlerInfo = _.find(_newRuleHandlers, function (entry) {
+                return entry.inlineEditor === inlineEditor;
+            });
+            if (handlerInfo) {
+                handlerInfo.handler();
+            }
+        }
+    }
+    
     /**
      * This function is registered with EditManager as an inline editor provider. It creates a CSSInlineEditor
      * when cursor is on an HTML tag name, class attribute, or id attribute, find associated
@@ -230,28 +252,49 @@ define(function (require, exports, module) {
             return result;
         }
         
+        /**
+         * @private
+         * Update the enablement of associated menu commands.
+         */
+        function _updateCommands() {
+            _newRuleCmd.setEnabled(cssInlineEditor.hasFocus() && !$newRuleButton.hasClass("disabled"));
+        }
+        
+        /**
+         * @private
+         * Create a new rule on click.
+         */
+        function _handleNewRuleClick(e) {
+            if (!$newRuleButton.hasClass("disabled")) {
+                if (cssFileInfos.length === 1) {
+                    // Just go ahead and create the rule.
+                    _addRule(selectorName, cssInlineEditor, cssFileInfos[0].fullPath);
+                } else if ($dropdown) {
+                    _closeDropdown();
+                } else {
+                    _showDropdown();
+                }
+            }
+            if (e) {
+                e.stopPropagation();
+            }
+        }
+        
         CSSUtils.findMatchingRules(selectorName, hostEditor.document)
             .done(function (rules) {
-                cssInlineEditor = new MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [], _getNoRulesMsg, CSSUtils.getRangeSelectors);
+                cssInlineEditor = new MultiRangeInlineEditor.MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [],
+                                                                                    _getNoRulesMsg, CSSUtils.getRangeSelectors);
                 cssInlineEditor.load(hostEditor);
+                cssInlineEditor.$htmlContent
+                    .on("focusin", _updateCommands)
+                    .on("focusout", _updateCommands);
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);
                 $newRuleButton = $("<button class='stylesheet-button btn btn-mini disabled'/>")
                     .text(Strings.BUTTON_NEW_RULE)
-                    .on("click", function (e) {
-                        if (!$newRuleButton.hasClass("disabled")) {
-                            if (cssFileInfos.length === 1) {
-                                // Just go ahead and create the rule.
-                                _addRule(selectorName, cssInlineEditor, cssFileInfos[0].fullPath);
-                            } else if ($dropdown) {
-                                _closeDropdown();
-                            } else {
-                                _showDropdown();
-                            }
-                        }
-                        e.stopPropagation();
-                    });
+                    .on("click", _handleNewRuleClick);
                 $header.append($newRuleButton);
+                _newRuleHandlers.push({inlineEditor: cssInlineEditor, handler: _handleNewRuleClick});
                 
                 result.resolve(cssInlineEditor);
 
@@ -268,6 +311,8 @@ define(function (require, exports, module) {
                         if (cssFileInfos.length > 1) {
                             $newRuleButton.addClass("btn-dropdown");
                         }
+                        
+                        _updateCommands();
                     });
             })
             .fail(function () {
@@ -279,5 +324,7 @@ define(function (require, exports, module) {
     }
 
     EditorManager.registerInlineEditProvider(htmlToCSSProvider);
-
+    
+    _newRuleCmd = CommandManager.register(Strings.CMD_CSS_QUICK_EDIT_NEW_RULE, Commands.CSS_QUICK_EDIT_NEW_RULE, _handleNewRule);
+    _newRuleCmd.setEnabled(false);
 });

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -282,7 +282,7 @@ define(function (require, exports, module) {
         
         CSSUtils.findMatchingRules(selectorName, hostEditor.document)
             .done(function (rules) {
-                cssInlineEditor = new MultiRangeInlineEditor.MultiRangeInlineEditor(CSSUtils.consolidateRules(rules) || [],
+                cssInlineEditor = new MultiRangeInlineEditor.MultiRangeInlineEditor(CSSUtils.consolidateRules(rules),
                                                                                     _getNoRulesMsg, CSSUtils.getRangeSelectors);
                 cssInlineEditor.load(hostEditor);
                 cssInlineEditor.$htmlContent
@@ -307,6 +307,10 @@ define(function (require, exports, module) {
                         // here if there are any stylesheets in project
                         if (cssFileInfos.length > 0) {
                             $newRuleButton.removeClass("disabled");
+                            if (!rules.length) {
+                                // Force focus to the button so the user can create a new rule from the keyboard.
+                                $newRuleButton.focus();
+                            }
                         }
                         if (cssFileInfos.length > 1) {
                             $newRuleButton.addClass("btn-dropdown");

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -284,6 +284,7 @@ define({
     "CMD_TOGGLE_QUICK_DOCS"               : "Quick Docs",
     "CMD_QUICK_EDIT_PREV_MATCH"           : "Previous Match",
     "CMD_QUICK_EDIT_NEXT_MATCH"           : "Next Match",
+    "CMD_CSS_QUICK_EDIT_NEW_RULE"         : "New Rule",
     "CMD_NEXT_DOC"                        : "Next Document",
     "CMD_PREV_DOC"                        : "Previous Document",
     "CMD_SHOW_IN_TREE"                    : "Show in File Tree",


### PR DESCRIPTION
@dangoor 

This adds a menu item and keyboard shortcut (Cmd-Alt-N) for creating a new rule in the focused CSS inline editor (in the menus, it's added near the previous/next match commands). It also properly enables/disables the command (as well as the previous/next match commands) based on focus and availability.

One thing that I'd like @larz0 to look at is the case where there are no matching rules. Originally, opening the inline editor in this case wouldn't set focus to it, but that meant that the shortcut wouldn't work. So I made it so that if there are no matching rules, we set focus to the "New Rule" button, which is kind of nice since it draws attention to it and you can just hit Space to activate it (or Cmd-Alt-N to use the normal shortcut). However, the focused state looks rather strong for the mini button. We might want to tone it down for the mini button case.

@redmunds might also want to do a drive-by since this is related to his code. 
