### PR TITLE
Add "close" event to NodeConnection

### DIFF
--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -202,7 +202,11 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Connect to the node server
+     * Connect to the node server. After connecting, the NodeConnection
+     * object will trigger a "close" event when the underlying socket
+     * is closed. If the connection is set to autoReconnect, then the
+     * event will also include a jQuery promise for the connection.
+     * 
      * @param {boolean} autoReconnect Whether to automatically try to
      *    reconnect to the server if the connection succeeds and then
      *    later disconnects. Note if this connection fails initially, the
@@ -224,9 +228,11 @@ define(function (require, exports, module) {
             function success() {
                 self._ws.onclose = function () {
                     if (self._autoReconnect) {
-                        self.connect(true);
+                        var $promise = self.connect(true);
+                        $(self).triggerHandler("close", [$promise]);
                     } else {
                         self._cleanup();
+                        $(self).triggerHandler("close");
                     }
                 };
                 deferred.resolve();

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -339,6 +339,15 @@ define(function (require, exports, module) {
                 CONNECTION_TIMEOUT,
                 "additional test commands should be defined in all connections"
             );
+            
+            var reconnectResolved = false, closeHandlerCalled = false;
+            $(connectionOne).on("close", function (e, reconnectPromise) {
+                closeHandlerCalled = true;
+                reconnectPromise.then(function () {
+                    reconnectResolved = true;
+                });
+            });
+            
             waitThenRunRestartServer(connectionOne);
             waitsFor(
                 function () {
@@ -365,6 +374,8 @@ define(function (require, exports, module) {
                 "test.reverse command should be re-registered"
             );
             runs(function () {
+                expect(closeHandlerCalled).toBe(true);
+                expect(reconnectResolved).toBe(true);
                 expect(connectionOne.domains.test.reverseAsync).toBeFalsy();
             });
 


### PR DESCRIPTION
This adds a `close` event to `NodeConnection` instances, which is triggered (after the initial connection) if the underlying socket is disconnected. If the `NodeConnection` is set to auto-reconnect, then the event also includes the re-connection promise. This allows Brackets client code to gracefully detect and handle failures with the Node process.

CC @peterflynn 
