### PR TITLE
Fix bug #4593 (Text wrap in context menus & HTML main menus)

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -267,8 +267,14 @@ a:focus {
     // Menu dropdown appearance
     .dropdown-menu {
         top: 34px; // Offset from top of menubar item
-
         margin-top: 0;
+        
+        // Fix for #4593: don't let narrow parent (menubar item) cause text wrap at the float boundary between
+        // the menu item label and keyboard shortcut. This takes away the "gotta get narrower" pressure.
+        // This technique won't work on all browsers; see comments in #4593 for alternative options.
+        width: -webkit-max-content;
+        width: -moz-max-content;
+
         background-color: @bc-white;
         .border-radius(0 0 3px 3px);
         box-shadow: @tc-dropdown-shadow;


### PR DESCRIPTION
See [my comments](https://github.com/adobe/brackets/issues/4593#issuecomment-25662976) in #4593 for all the gory details...

This fix preserves the current layout, where label & shortcut are not strictly separated columns -- notice how the two columns interlock like puzzle pieces in the working set context menu, for example.  But the downside is that this solution may not work in other browsers.

So eventually we may want a more cross-browser fix... but in the meantime this will be a real improvement for the Linux build (which has no native menubar yet).
