### PR TITLE
Create a new command file.openDroppedFiles so that we can support folder drop on Brackets.

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -246,9 +246,7 @@ define(function (require, exports, module) {
                     // See if any startup files were passed to the application
                     if (brackets.app.getPendingFilesToOpen) {
                         brackets.app.getPendingFilesToOpen(function (err, files) {
-                            files.forEach(function (filename) {
-                                CommandManager.execute(Commands.FILE_OPEN, { fullPath: filename });
-                            });
+                            DragAndDrop.openDroppedFiles(files);
                         });
                     }
                 });

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -45,6 +45,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE_ALL              = "file.close_all";             // DocumentCommandHandlers.js   handleFileCloseAll()
     exports.FILE_CLOSE_LIST             = "file.close_list";            // DocumentCommandHandlers.js   handleFileCloseList()
     exports.FILE_ADD_TO_WORKING_SET     = "file.addToWorkingSet";       // DocumentCommandHandlers.js   handleFileAddToWorkingSet()
+    exports.FILE_OPEN_DROPPED_FILES     = "file.openDroppedFiles";      // DragAndDrop.js               openDroppedFiles()
     exports.FILE_LIVE_FILE_PREVIEW      = "file.liveFilePreview";       // LiveDevelopment/main.js      _handleGoLiveCommand()
     exports.FILE_LIVE_HIGHLIGHT         = "file.previewHighlight";      // LiveDevelopment/main.js      _handlePreviewHighlightCommand()
     exports.FILE_PROJECT_SETTINGS       = "file.projectSettings";       // ProjectManager.js            _projectSettings()

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -206,6 +206,7 @@ define({
     "CMD_FILE_NEW_FOLDER"                 : "New Folder",
     "CMD_FILE_OPEN"                       : "Open\u2026",
     "CMD_ADD_TO_WORKING_SET"              : "Add To Working Set",
+    "CMD_OPEN_DROPPED_FILES"              : "Open Dropped Files",
     "CMD_OPEN_FOLDER"                     : "Open Folder\u2026",
     "CMD_FILE_CLOSE"                      : "Close",
     "CMD_FILE_CLOSE_ALL"                  : "Close All",

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -138,6 +138,8 @@ define(function (require, exports, module) {
             });
     }
     
+    CommandManager.register(Strings.CMD_OPEN_DROPPED_FILES, Commands.FILE_OPEN_DROPPED_FILES, openDroppedFiles);
+
     // Export public API
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;


### PR DESCRIPTION
This pull request is to consolidate different code that handle the drag and drop of files and folders by creating a new command for openDroppedFiles in DragAndDrop.js and calling it for all drag-and-drop triggered from the shell code. So it is part of the fix for issue #5015. There are two more pull requests from brackets-shell to complement this.
