### PR TITLE
Strip out byte order mark before calling JSON.parse

### DIFF
--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -196,6 +196,12 @@ function validatePackageJSON(path, packageJSON, options, callback) {
             
             var metadata;
             
+            // JSON.parse doesn't like the byte order mark.
+            // Remove it if it's present.
+            if (data[0] === "\uFEFF") {
+                data = data.substring(1);
+            }
+
             try {
                 metadata = JSON.parse(data);
             } catch (e) {


### PR DESCRIPTION
Fixes an issue reported on the mailing list in which someone was unable to upload a package because the package.json couldn't be parsed. The problem was that the file had a byte order mark at the beginning. This change checks for that.
