### PR TITLE
Translate line endings before comparing file contents

### DIFF
--- a/test/spec/CSSUtils-test-files/groups.css
+++ b/test/spec/CSSUtils-test-files/groups.css
@@ -1,35 +1,35 @@
 h1, h2, h3 {
-    color: "red";
+    color: red;
 }
 
 h3, h1, h2 {
-    color: "green";
+    color: green;
 }
 
 h1 {
-    color: "orange";
+    color: orange;
 }
 
 h3, h2, h1 {
-    color: "yellow";
+    color: yellow;
 }
 
 h2 {
-    color: "white";
+    color: white;
 }
 
 h3 {
-    color: "black";
+    color: black;
 }
 
 .a,
 .b, .c,
 .d
 {
-    color: "black";
+    color: black;
 }
 
-.f { color: "black"; } .g,
+.f { color: black; } .g,
 .h {
-    color: "white";
+    color: white;
 }

--- a/test/spec/CSSUtils-test-files/selector-positions.css
+++ b/test/spec/CSSUtils-test-files/selector-positions.css
@@ -1,32 +1,32 @@
 div {
-    color: "green";
+    color: green;
 }
 
 div{
-    color: "green";
+    color: green;
 }
 
 div
 {
-    color: "green";
+    color: green;
 }
 /* spaces */
     div
 {
-    color: "green";
+    color: green;
 }
 /* tab */
 	div
 {
-    color: "green";
+    color: green;
 }
 
 h3, h2, h1
 {
-    color: "yellow";
+    color: yellow;
 }
 
     h3, h2, h1 
 {
-    color: "yellow";
+    color: yellow;
 }

--- a/test/spec/CSSUtils-test-files/simple.css
+++ b/test/spec/CSSUtils-test-files/simple.css
@@ -1,23 +1,23 @@
 html {
-    color: "red";
+    color: red;
 }
 
 HTML {
-    color: "orange";
+    color: orange;
 }
 
 .firstGrade {
-    color: "green";
+    color: green;
 }
 
 .FIRSTGRADE {
-    color: "yellow";
+    color: yellow;
 }
 
 #brack3ts {
-    color: "blue";
+    color: blue;
 }
 
 #BRACK3TS {
-    color: "black";
+    color: black;
 }

--- a/test/spec/CSSUtils-test-files/universal.css
+++ b/test/spec/CSSUtils-test-files/universal.css
@@ -1,15 +1,15 @@
 * {
-    color: "red";
+    color: red;
 }
 
 .firstGrade {
-    color: "white";
+    color: white;
 }
 
 p {
-    color: "blue";
+    color: blue;
 }
 
 #brack3ts {
-    color: "yellow";
+    color: yellow;
 }

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1540,7 +1540,12 @@ define(function (require, exports, module) {
             var mock = SpecRunnerUtils.createMockEditor(options.initialText, "css"),
                 doc = mock.doc,
                 result = CSSUtils.addRuleToDocument(doc, options.selector, options.useTab, options.indentUnit);
-            expect(doc.getText()).toEqual(options.resultText);
+
+            // Normalize line endings so tests pass on all Operating Systems
+            var normalizedDocText = FileUtils.translateLineEndings(doc.getText(), FileUtils.LINE_ENDINGS_LF),
+                normalizedResText = FileUtils.translateLineEndings(options.resultText, FileUtils.LINE_ENDINGS_LF);
+
+            expect(normalizedDocText).toEqual(normalizedResText);
             expect(result).toEqual(options.result);
             SpecRunnerUtils.destroyMockEditor(doc);
         }


### PR DESCRIPTION
This is for #5601 Windows (and maybe Linux) only.

Also fixed some text style sheets.
