### PR TITLE
Fix "New Rule" dropdown issues

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -189,12 +189,22 @@ define(function (require, exports, module) {
         
         /**
          * @private
+         * When editor scrolls, close dropdown
+         */
+        function _onScroll() {
+            if (dropdownEventHandler) {
+                dropdownEventHandler.close();
+            }
+        }
+        
+        /**
+         * @private
          * Remove the various event handlers that close the dropdown. This is called by the
          * PopUpManager when the dropdown is closed.
          */
         function _cleanupDropdown() {
             $("html").off("click", _closeDropdown);
-            hostEditor._codeMirror.off("scroll");
+            $(hostEditor).off("scroll", _onScroll);
             dropdownEventHandler = null;
             $dropdown = null;
     
@@ -253,10 +263,7 @@ define(function (require, exports, module) {
             
             $dropdown.focus();
             
-            hostEditor._codeMirror.on("scroll", function (instance) {
-                // If host editor scrolls, close dropdown.
-                dropdownEventHandler.close();
-            });
+            $(hostEditor).on("scroll", _onScroll);
         }
         
         /**

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -220,15 +220,30 @@ define(function (require, exports, module) {
         function _showDropdown() {
             Menus.closeAll();
             
-            $dropdown = $(_renderList(cssFileInfos));
-            
-            var toggleOffset = $newRuleButton.offset();
-            $dropdown
-                .css({
-                    left: toggleOffset.left,
-                    top: toggleOffset.top + $newRuleButton.outerHeight()
-                })
+            $dropdown = $(_renderList(cssFileInfos))
                 .appendTo($("body"));
+            
+            var toggleOffset   = $newRuleButton.offset(),
+                $window        = $(window),
+                posLeft        = toggleOffset.left,
+                posTop         = toggleOffset.top + $newRuleButton.outerHeight(),
+                bottomOverhang = posTop  + $dropdown.height() - $window.height(),
+                rightOverhang  = posLeft + $dropdown.width()  - $window.width();
+            
+            if (bottomOverhang > 0) {
+                // Bottom is clipped, so move entire menu above button
+                posTop = Math.max(0, toggleOffset.top - $dropdown.height() - 4);
+            }
+            
+            if (rightOverhang > 0) {
+                // Right is clipped, so adjust left to fit menu in editor
+                posLeft = Math.max(0, posLeft - rightOverhang);
+            }
+            
+            $dropdown.css({
+                left: posLeft,
+                top: posTop
+            });
             
             $("html").on("click", _closeDropdown);
             

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -328,7 +328,7 @@ define(function (require, exports, module) {
             var dirSplit = fileInfo.fullPath.split("/"),
                 index = dirSplit.length - fileInfo.subDirCount - 2;
             
-            fileInfo.subDirStr = dirSplit[index] + "/" + fileInfo.subDirStr;
+            fileInfo.subDirStr = dirSplit.slice(index, dirSplit.length - 1).join("/");
             fileInfo.subDirCount++;
         }
         

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -194,6 +194,7 @@ define(function (require, exports, module) {
          */
         function _cleanupDropdown() {
             $("html").off("click", _closeDropdown);
+            hostEditor._codeMirror.off("scroll");
             dropdownEventHandler = null;
             $dropdown = null;
     
@@ -251,6 +252,11 @@ define(function (require, exports, module) {
             dropdownEventHandler.open();
             
             $dropdown.focus();
+            
+            hostEditor._codeMirror.on("scroll", function (instance) {
+                // If host editor scrolls, close dropdown.
+                dropdownEventHandler.close();
+            });
         }
         
         /**

--- a/src/htmlContent/stylesheets-menu.html
+++ b/src/htmlContent/stylesheets-menu.html
@@ -2,7 +2,7 @@
     {{#styleSheetList}}
     <li>
         <a class="stylesheet-link" data-path="{{fullPath}}">
-            <span class="stylesheet-name">{{name}}</span>
+            <span class="stylesheet-name">{{name}}{{#subDirStr.length}}<span class="stylesheet-dir"> — {{subDirStr}}{{/subDirStr.length}}</span></span>
         </a>
     </li>
     {{/styleSheetList}}

--- a/src/styles/brackets_colors.less
+++ b/src/styles/brackets_colors.less
@@ -98,6 +98,7 @@
 @tc-hover-highlight:            rgba(255, 255, 255, 0.6);
 @tc-text:                       #454545;
 @tc-emphasized-text:            #333;
+@tc-quiet-text:                 #aaa;
 @tc-text-shadow:                0 1px 0 #fff;
 @tc-call-to-action:             #288edf;
 @tc-call-to-action-border:      #0055ad;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -457,7 +457,7 @@ a:focus {
     }
     
     .stylesheet-dir {
-        color: @tc-light-weight-quiet-text;
+        color: @tc-quiet-text;
     }
     
     &.dropdown-menu a.selected {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -436,6 +436,7 @@ a:focus {
         max-height: 160px;
         overflow-y: auto;
         max-width: none;
+        min-width: 200px;
         z-index: @z-index-brackets-stylesheet-menu;
     }
     
@@ -453,6 +454,10 @@ a:focus {
     
     .stylesheet-name {
         color: @tc-text;
+    }
+    
+    .stylesheet-dir {
+        color: @tc-light-weight-quiet-text;
     }
     
     &.dropdown-menu a.selected {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -459,6 +459,10 @@ a:focus {
         background: @tc-highlight;
         color: @bc-black !important;
     }
+
+    &.dropdown-menu a:not(.selected):hover {
+         background: none;
+    }
 }
 
 

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
             }
         }
 
-        this._setSelectedIndex(pos);
+        this._setSelectedIndex(pos, true);
     };
 
     /**
@@ -241,7 +241,7 @@ define(function (require, exports, module) {
      * @private
      * @param {number} index
      */
-    DropdownEventHandler.prototype._setSelectedIndex = function (index) {
+    DropdownEventHandler.prototype._setSelectedIndex = function (index, scrollIntoView) {
         
         // Range check
         index = Math.max(-1, Math.min(index, this.$items.length - 1));
@@ -257,7 +257,9 @@ define(function (require, exports, module) {
         if (this._selectedIndex !== -1) {
             var $item = this.$items.eq(this._selectedIndex);
 
-            ViewUtils.scrollElementIntoView(this.$list, $item, false);
+            if (scrollIntoView) {
+                ViewUtils.scrollElementIntoView(this.$list, $item, false);
+            }
             $item.find("a").addClass("selected");
         }
     };
@@ -266,8 +268,7 @@ define(function (require, exports, module) {
      * Register mouse event handlers
      */
     DropdownEventHandler.prototype._registerMouseEvents = function () {
-        var self = this,
-            $highlightItem;
+        var self = this;
         
         this.$list
             .on("click", "a", function () {
@@ -275,8 +276,16 @@ define(function (require, exports, module) {
             })
             .on("mouseover", "a", function (e) {
                 var $link = $(e.currentTarget),
-                    $item = $link.closest("li");
-                self._setSelectedIndex(self.$items.index($item));
+                    $item = $link.closest("li"),
+                    viewOffset = self.$list.offset(),
+                    elementOffset = $item.offset();
+
+                // Only set selected if in view
+                if (elementOffset.top < viewOffset.top + self.$list.height()) {
+                    if (viewOffset.top <= elementOffset.top) {
+                        self._setSelectedIndex(self.$items.index($item), false);
+                    }
+                }
             });
     };
 


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/5611

@jasonsanjose Here's what I did:
1. Multiple stylesheets with same name are distinguished by displaying minimal number of sub-folders next to name.
2. Dropdown closes when main editor is scrolled.
3. If there's not enough room to display dropdown under button, then it's displayed above button. If there's not enough room to the right to display dropdown, then it's moved left so that it's not clipped.

@larz0 Please review how these changes.
