### PR TITLE
Fixing issue #5603

### DIFF
--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -410,9 +410,6 @@ define({
     "CMD_SWITCH_LANGUAGE"                       : "Byt språk",
     "CMD_RUN_UNIT_TESTS"                        : "Kör tester",
     "CMD_SHOW_PERF_DATA"                        : "Visa prestandadata",
-    "CMD_ENABLE_NODE_DEBUGGER"                  : "Aktivera noddebugger",
-    "CMD_LOG_NODE_STATE"                        : "Skriv ut nodstatus till konsollen",
-    "CMD_RESTART_NODE"                          : "Starta om nod",
     
     "LANGUAGE_TITLE"                            : "Byt språk",
     "LANGUAGE_MESSAGE"                          : "Välj önskat språk i listan nedan:",


### PR DESCRIPTION
Removed the strings that shouldn't be translated. This way they fall back to the default language.
