### PR TITLE
Limit drag-and-drop of image files or opening them from Open File dialog...

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -148,6 +148,7 @@ define(function (require, exports, module) {
             CodeHintManager         : CodeHintManager,
             Dialogs                 : Dialogs,
             DefaultDialogs          : DefaultDialogs,
+            DragAndDrop             : DragAndDrop,
             CodeInspection          : CodeInspection,
             CSSUtils                : require("language/CSSUtils"),
             LiveDevelopment         : require("LiveDevelopment/LiveDevelopment"),

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -361,7 +361,9 @@ define(function (require, exports, module) {
     function handleFileAddToWorkingSet(commandData) {
         return handleFileOpen(commandData).done(function (doc) {
             // addToWorkingSet is synchronous
-            DocumentManager.addToWorkingSet(doc.file, commandData.index, commandData.forceRedraw);
+            if (doc) {
+                DocumentManager.addToWorkingSet(doc.file, commandData.index, commandData.forceRedraw);
+            }
         });
     }
 

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
         ProjectManager      = require("project/ProjectManager"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
-        ImageViewer         = require("editor/ImageViewer"),
         FileUtils           = require("file/FileUtils"),
         FileViewController  = require("project/FileViewController"),
         StringUtils         = require("utils/StringUtils"),
@@ -187,9 +186,9 @@ define(function (require, exports, module) {
                 PerfUtils.addMeasurement(perfTimerName);
             });
 
-            if (EditorManager.getCustomViewerForPath(fullPath)) {
-                var $imageHolder = ImageViewer.getImageHolder(fullPath);
-                EditorManager.showCustomViewer($imageHolder, fullPath);
+            var viewProvider = EditorManager.getCustomViewerForPath(fullPath);
+            if (viewProvider) {
+                EditorManager.showCustomViewer(viewProvider, fullPath);
                 result.resolve();
             } else {
                 // Load the file if it was never open before, and then switch to it in the UI

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -227,7 +227,8 @@ define(function (require, exports, module) {
     
     
     /**
-     * Adds the given file to the end of the working set list, if it is not already in the list.
+     * Adds the given file to the end of the working set list, if it is not already in the list
+     * and it does not have a custom viewer.
      * Does not change which document is currently open in the editor. Completes synchronously.
      * @param {!FileEntry} file
      * @param {number=} index  Position to add to list (defaults to last); -1 is ignored
@@ -237,6 +238,11 @@ define(function (require, exports, module) {
     function addToWorkingSet(file, index, forceRedraw) {
         var indexRequested = (index !== undefined && index !== null && index !== -1);
         
+        // If the file has a custom viewer, then don't add it to the working set.
+        if (EditorManager.getCustomViewerForPath(file.fullPath)) {
+            return;
+        }
+            
         // If doc is already in working set, don't add it again
         var curIndex = findInWorkingSet(file.fullPath);
         if (curIndex !== -1) {

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -283,6 +283,8 @@ define(function (require, exports, module) {
     
     /**
      * Adds the given file list to the end of the working set list.
+     * If a file in the list has its own custom viewer, then it 
+     * is not added into the working set.
      * Does not change which document is currently open in the editor.
      * More efficient than calling addToWorkingSet() (in a loop) for
      * a list of files because there's only 1 redraw at the end

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -613,9 +613,10 @@ define(function (require, exports, module) {
         _$currentCustomViewer = null;
     }
 
-    /** append custom view to editor-holder
-     *  @param {!JQuery} $customView  DOM node representing UI of custom view
-     *  @param {!string} fullPath  path to the file displayed in the custom view
+    /** 
+     * Append custom view to editor-holder
+     * @param {!JQuery} $customView  DOM node representing UI of custom view
+     * @param {!string} fullPath  path to the file displayed in the custom view
      */
     function showCustomViewer($customView, fullPath) {
         DocumentManager._clearCurrentDocument();
@@ -636,6 +637,26 @@ define(function (require, exports, module) {
         _setCurrentlyViewedPath(fullPath);
     }
 
+    /** 
+     * Return the provider of a custom viewer for the given path if one exists.
+     * Otherwise, return null.
+     *
+     * @param {!string} fullPath - file path to be checked for a custom viewer
+     * @return {?Object}
+     */
+    function getCustomViewerForPath(fullPath) {
+        var lang = LanguageManager.getLanguageForPath(fullPath);
+        if (lang.getId() === "image") {
+            // TODO: Extensibility
+            // For now we only have the image viewer, so just return ImageViewer object.
+            // Once we have each viewer registers with EditorManager as a provider,
+            // then we return the provider registered with the language id.
+            return ImageViewer;
+        }
+        
+        return null;
+    }
+    
     /** Handles changes to DocumentManager.getCurrentDocument() */
     function _onCurrentDocumentChange() {
         var doc = DocumentManager.getCurrentDocument(),
@@ -905,4 +926,5 @@ define(function (require, exports, module) {
     exports.getInlineEditors              = getInlineEditors;
     exports.closeInlineWidget             = closeInlineWidget;
     exports.showCustomViewer              = showCustomViewer;
+    exports.getCustomViewerForPath        = getCustomViewerForPath;
 });

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -615,10 +615,12 @@ define(function (require, exports, module) {
 
     /** 
      * Append custom view to editor-holder
-     * @param {!JQuery} $customView  DOM node representing UI of custom view
+     * @param {!Object} provider  custom view provider
      * @param {!string} fullPath  path to the file displayed in the custom view
      */
-    function showCustomViewer($customView, fullPath) {
+    function showCustomViewer(provider, fullPath) {
+        var $customView = provider.getCustomViewHolder(fullPath);
+
         DocumentManager._clearCurrentDocument();
     
         // Hide the not-editor
@@ -632,7 +634,7 @@ define(function (require, exports, module) {
         $("#editor-holder").append(_$currentCustomViewer);
         
         // add path, dimensions and file size to the view after loading image
-        ImageViewer.render(fullPath);
+        provider.render(fullPath);
         
         _setCurrentlyViewedPath(fullPath);
     }

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
      * @return {JQuery}
      *
      */
-    function getImageHolder(fullPath) {
+    function getCustomViewHolder(fullPath) {
         return $(Mustache.render(ImageHolderTemplate, {fullPath: fullPath}));
     }
     
@@ -107,6 +107,6 @@ define(function (require, exports, module) {
             _updateScale($(this).width());
         });
     }
-    exports.getImageHolder      = getImageHolder;
+    exports.getCustomViewHolder = getCustomViewHolder;
     exports.render              = render;
 });

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -41,6 +41,30 @@ define(function (require, exports, module) {
         StringUtils     = require("utils/StringUtils");
     
     /**
+     * Return an array of files excluding all files with a custom viewer. If all files
+     * in the array have their own custom viewers, then the last file is added back in
+     * the array since only one file with custom viewer can be open at a time.
+     *
+     * @param {Array.<string>} files Array of files to filter before opening.
+     * @return {Array.<string>}
+     */
+    function filterFilesToOpen(files) {
+        // Filter out all files that have their own custom viewers
+        // since we don't keep them in the working set.
+        var filteredFiles = files.filter(function (file) {
+            return !EditorManager.getCustomViewerForPath(file);
+        });
+        
+        // If all files have custom viewers, then add back the last file
+        // so that we open it in its custom viewer.
+        if (filteredFiles.length === 0) {
+            filteredFiles.push(files[files.length - 1]);
+        }
+        
+        return filteredFiles;
+    }
+    
+    /**
      * Returns true if the drag and drop items contains valid drop objects.
      * @param {Array.<DataTransferItem>} items Array of items being dragged
      * @return {boolean} True if one or more items can be dropped.
@@ -74,20 +98,7 @@ define(function (require, exports, module) {
      */
     function openDroppedFiles(files) {
         var errorFiles = [],
-            filteredFiles = [];
-        
-        // Filter out all files that have their own custom viewers
-        // since we don't keep them in the working set.
-        filteredFiles = files.filter(function (file) {
-            return !EditorManager.getCustomViewerForPath(file);
-        });
-        
-        // If all files have custom viewers, then add back the last file
-        // so that we open it in its custom viewer.
-        if (filteredFiles.length === 0) {
-            filteredFiles.push(files[files.length - 1]);
-        }
-        
+            filteredFiles = filterFilesToOpen(files);
         
         return Async.doInParallel(filteredFiles, function (file, idx) {
             var result = new $.Deferred();
@@ -158,4 +169,5 @@ define(function (require, exports, module) {
     // Export public API
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
+    exports.filterFilesToOpen   = filterFilesToOpen;
 });

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
     require("spec/Document-test");
     require("spec/DocumentCommandHandlers-test");
     require("spec/DocumentManager-test");
+    require("spec/DragAndDrop-test");
     require("spec/Editor-test");
     require("spec/EditorCommandHandlers-test");
     require("spec/EditorOptionHandlers-test");

--- a/test/spec/DragAndDrop-test.js
+++ b/test/spec/DragAndDrop-test.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, describe, beforeEach, afterEach, it, runs, expect, brackets, waitsForDone, beforeFirst, afterLast */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    // Load dependent modules
+    var DocumentManager,      // loaded from brackets.test
+        DragAndDrop,          // loaded from brackets.test
+        EditorManager,        // loaded from brackets.test
+        SpecRunnerUtils  = require("spec/SpecRunnerUtils");
+                    
+    
+    describe("DragAndDrop", function () {
+        this.category = "integration";
+
+        var testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
+            testWindow,
+            _$,
+            promise;
+        
+        beforeFirst(function () {
+            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                testWindow = w;
+                _$ = testWindow.$;
+
+                // Load module instances from brackets.test
+                DocumentManager = testWindow.brackets.test.DocumentManager;
+                DragAndDrop     = testWindow.brackets.test.DragAndDrop;
+                EditorManager   = testWindow.brackets.test.EditorManager;
+            });
+        });
+        
+        afterLast(function () {
+            testWindow      = null;
+            DocumentManager = null;
+            DragAndDrop     = null;
+            EditorManager   = null;
+            SpecRunnerUtils.closeTestWindow();
+        });
+        
+        
+        beforeEach(function () {
+            // Working set behavior is sensitive to whether file lives in the project or outside it, so make
+            // the project root a known quantity.
+            SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        });
+
+        afterEach(function () {
+            promise = null;
+            
+            runs(function () {
+                // Call closeAll() directly. Some tests set a spy on the save as
+                // dialog preventing SpecRunnerUtils.closeAllFiles() from
+                // working properly.
+                testWindow.brackets.test.DocumentManager.closeAll();
+            });
+        });
+        
+        describe("Testing openDroppedFiles function", function () {
+            
+            it("should NOT open any image file when a text file is in the dropped file list", function () {
+                var jsFilePath = testPath + "/test.js";
+                runs(function () {
+                    var files = [testPath + "/couz.png", testPath + "/couz2.png", jsFilePath];
+                    promise = DragAndDrop.openDroppedFiles(files);
+                    waitsForDone(promise, "opening dropped files");
+                });
+            
+                runs(function () {
+                    var editor = EditorManager.getActiveEditor();
+                    expect(editor.document.file.fullPath).toBe(jsFilePath);
+                    expect(EditorManager.getCurrentlyViewedPath()).toEqual(jsFilePath);
+                });
+            });
+
+            it("should show the image when a single image file is dropped", function () {
+                var path = testPath + "/couz.png";
+                runs(function () {
+                    promise = DragAndDrop.openDroppedFiles([path]);
+                    waitsForDone(promise, "opening a dropped image file");
+                });
+            
+                runs(function () {
+                    var editor = EditorManager.getActiveEditor();
+                    expect(editor).toBe(null);
+                    expect(EditorManager.getCurrentlyViewedPath()).toEqual(path);
+                });
+            });
+
+            it("should show the last image when multiple image files are dropped", function () {
+                var lastImagePath = testPath + "/couz2.png";
+                runs(function () {
+                    var files = [testPath + "/couz.png", lastImagePath];
+                    promise = DragAndDrop.openDroppedFiles(files);
+                    waitsForDone(promise, "opening last image file from the dropped files");
+                });
+            
+                runs(function () {
+                    var editor = EditorManager.getActiveEditor();
+                    expect(editor).toBe(null);
+                    expect(EditorManager.getCurrentlyViewedPath()).toEqual(lastImagePath);
+                });
+            });
+            
+        });
+    });
+});


### PR DESCRIPTION
... to be only one file. If multiple files are selected or dropped, then only non-image files get opened. If all of them are image files, then the last image file gets opened.

@couzteau and @peterflynn Can you review this first? I'll be submitting some drag-and-drop unit tests later.
