### PR TITLE
Fix translation name: InlineBezierCurveEditor -> InlineTimingFunctionEditor

### DIFF
--- a/src/extensions/default/InlineTimingFunctionEditor/Localized.css
+++ b/src/extensions/default/InlineTimingFunctionEditor/Localized.css
@@ -1,15 +1,15 @@
 .timing-function-editor .coordinate-plane:after {
-    content: '{{INLINE_BEZIER_EDITOR_TIME}}';
+    content: '{{INLINE_TIMING_EDITOR_TIME}}';
 }
 
 .timing-function-editor .coordinate-plane:hover:before {
-    content: '{{INLINE_BEZIER_EDITOR_PROGRESSION}} (' attr(data-progression) '%)';
+    content: '{{INLINE_TIMING_EDITOR_PROGRESSION}} (' attr(data-progression) '%)';
 }
 
 .timing-function-editor .coordinate-plane:before {
-    content: '{{INLINE_BEZIER_EDITOR_PROGRESSION}}';
+    content: '{{INLINE_TIMING_EDITOR_PROGRESSION}}';
 }
 
 .timing-function-editor .coordinate-plane:hover:after {
-    content: '{{INLINE_BEZIER_EDITOR_TIME}} (' attr(data-time) '%)';
+    content: '{{INLINE_TIMING_EDITOR_TIME}} (' attr(data-time) '%)';
 }

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -461,9 +461,9 @@ define({
     "LOCALE_ZH_CN"                              : "Chinesisch, vereinfacht",
     "LOCALE_HU"                                 : "Ungarisch",
 
-    // extensions/default/InlineBezierCurveEditor
-    "INLINE_BEZIER_EDITOR_TIME"                 : "Zeit",
-    "INLINE_BEZIER_EDITOR_PROGRESSION"          : "Verlauf",
+    // extensions/default/InlineTimingFunctionEditor
+    "INLINE_TIMING_EDITOR_TIME"                 : "Zeit",
+    "INLINE_TIMING_EDITOR_PROGRESSION"          : "Verlauf",
 
     // extensions/default/InlineColorEditor
     "COLOR_EDITOR_CURRENT_COLOR_SWATCH_TIP"     : "Aktuelle Farbe",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -463,9 +463,9 @@ define({
     "LOCALE_ZH_CN"                              : "Chinese, simplified",
     "LOCALE_HU"                                 : "Hungarian",
     
-    // extensions/default/InlineBezierCurveEditor
-    "INLINE_BEZIER_EDITOR_TIME"                 : "Time",
-    "INLINE_BEZIER_EDITOR_PROGRESSION"          : "Progression",
+    // extensions/default/InlineTimingFunctionEditor
+    "INLINE_TIMING_EDITOR_TIME"                 : "Time",
+    "INLINE_TIMING_EDITOR_PROGRESSION"          : "Progression",
     
     // extensions/default/InlineColorEditor
     "COLOR_EDITOR_CURRENT_COLOR_SWATCH_TIP"     : "Current Color",


### PR DESCRIPTION
Quick fix to change the `strings.js` to use `INLINE_TIMING_EDITOR` instead of `INLINE_BEZIER_EDITOR`.

I mentioned this in [this comment](https://github.com/adobe/brackets/pull/5600#issuecomment-26823481).
#5600

@redmunds Please review
