### PR TITLE
Fix #5575: Rule list hides as soon as there is only one rule left

### DIFF
--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -381,6 +381,10 @@ define(function (require, exports, module) {
             this._updateSelectedMarker();
         }
         
+        if (this._ranges.length === 1) {
+            this.$relatedContainer.remove();
+        }
+        
         this._updateCommands();
     };
     


### PR DESCRIPTION
This fixes #5575 where the CSS rule list wasn't hiding when you deleted a rule manually.

@njx
