### PR TITLE
Remove check for subtree modification, since it can fire erroneously when $.find() is called

### DIFF
--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -208,10 +208,7 @@ define(function (require, exports, module) {
                 fields.$okButton.click();
                 installer.install.reset();
                 
-                var modSpy = jasmine.createSpy("modSpy");
-                fields.$dlg.on("DOMSubtreeModified", modSpy);
                 SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", fields.$dlg[0]);
-                expect(modSpy).not.toHaveBeenCalled();
                 expect(installer.install).not.toHaveBeenCalled();
                 expect(installer.cancel).not.toHaveBeenCalled();
                 


### PR DESCRIPTION
This fixes a failure in InstallExtensionDialog-test. The failure was introduced in a0f4b15, but it wasn't really a bug in that commit. The problem is that the unit test was using a DOM mutation event handler to try to ensure that the UI of the dialog didn't change if the user hit Enter while an install was occurring. a0f4b15 happened to add an extra call to `$.find()` with a complex selector, and it turns out that jQuery temporarily modifies the DOM when querying for a complex selector within a given element (adding an ID to the element being queried). This doesn't happen for simple ID/class/tag selectors.

We could modify the test to actually diff the subtree to ensure that it's the same before and after, but in this case it seems good enough to just test that neither of the installer's methods get called (which it was already doing). So I just removed the mutation check.
