### PR TITLE
Replace percent-encoded characters in URL Code Hint List with regular characters

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -140,10 +140,18 @@ define(function (require, exports, module) {
         if (indentAuto) {
             var currentLength = line.length;
             CodeMirror.commands.indentAuto(instance);
-            // If the amount of whitespace didn't change, insert another tab
+            
+            // If the amount of whitespace and the cursor position didn't change, we must have
+            // already been at the correct indentation level as far as CM is concerned, so insert 
+            // another tab.
             if (instance.getLine(from.line).length === currentLength) {
-                insertTab = true;
-                to.ch = 0;
+                var newFrom = instance.getCursor(true),
+                    newTo = instance.getCursor(false);
+                if (newFrom.line === from.line && newFrom.ch === from.ch &&
+                        newTo.line === to.line && newTo.ch === to.ch) {
+                    insertTab = true;
+                    to.ch = 0;
+                }
             }
         } else if (instance.somethingSelected() && from.line !== to.line) {
             CodeMirror.commands.indentMore(instance);

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -139,9 +139,10 @@ define(function (require, exports, module) {
                             // convert to doc relative path
                             var entryStr = entry.fullPath.replace(docDir, "");
 
-                            // code hints show the same strings that are inserted into text,
-                            // so strings in list will be encoded. wysiwyg, baby!
-                            unfiltered.push(encodeURI(entryStr));
+                            // code hints show the unencoded string so the
+                            // choices are easier to read.  The encoded string
+                            // will still be inserted into the editor.
+                            unfiltered.push(entryStr);
                         }
                     });
 
@@ -225,7 +226,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Determines whether font hints are available in the current editor
+     * Determines whether url hints are available in the current editor
      * context.
      *
      * @param {Editor} editor
@@ -361,7 +362,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Returns a list of availble font hints, if possible, for the current
+     * Returns a list of available url hints, if possible, for the current
      * editor context.
      *
      * @return {jQuery.Deferred|{
@@ -504,6 +505,10 @@ define(function (require, exports, module) {
      */
     UrlCodeHints.prototype.insertHint = function (completion) {
         var mode = this.editor.getModeForSelection();
+        
+        // Encode the string just prior to inserting the hint into the editor
+        completion = encodeURI(completion);
+        
         if (mode === "html") {
             return this.insertHtmlHint(completion);
         } else if (mode === "css") {

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -226,39 +226,6 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Helper function that cleans partially or malformed encoded characters
-     * in a URI, then decodes it.
-     *
-     * @param {string} URI
-     * The current URI that needs to be cleaned and decoded
-     *
-     * @return {string}
-     * The clean, decoded URI.  Partially typed encoded characters at the end
-     * of the URI are stripped off.  Any encoded characters in the string that
-     * would make decodeURI() fail are interpreted as literal characters instead.
-     */
-    UrlCodeHints.prototype._cleanAndDecodeURI = function (URI) {
-        var matchResults,
-            finalURI = URI;
-        
-        // If there is a partially encoded character on the end, strip it off
-        matchResults = finalURI.match(/^[^%]+%[\dA-Fa-f]?$/); // e.g. "%", "%5", "%A", "%d"
-        if (matchResults) {
-            finalURI = finalURI.substring(0, matchResults.index);
-        }
-        
-        // Decode any encoded characters, checking for incorrect formatting
-        try {
-            finalURI = decodeURI(finalURI);
-        } catch (err) {
-            // do nothing, finalURI does not change...
-            // treat all characters as literal characters
-        }
-        
-        return finalURI;
-    };
-    
-    /**
      * Determines whether url hints are available in the current editor
      * context.
      *
@@ -373,8 +340,6 @@ define(function (require, exports, module) {
                     query = "";
                 }
                 
-                query = this._cleanAndDecodeURI(query);
-                
                 var hintsAndSortFunc = this._getUrlHints({queryStr: query});
                 var hints = hintsAndSortFunc.hints;
                 if (hints instanceof Array) {
@@ -485,9 +450,7 @@ define(function (require, exports, module) {
         } else {
             return null;
         }
-        
-        query.queryStr = this._cleanAndDecodeURI(query.queryStr);
-        
+
         if (query.queryStr !== null) {
             filter = query.queryStr;
             var hintsAndSortFunc = this._getUrlHints(query);

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -226,6 +226,39 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Helper function that cleans partially or malformed encoded characters
+     * in a URI, then decodes it.
+     *
+     * @param {string} URI
+     * The current URI that needs to be cleaned and decoded
+     *
+     * @return {string}
+     * The clean, decoded URI.  Partially typed encoded characters at the end
+     * of the URI are stripped off.  Any encoded characters in the string that
+     * would make decodeURI() fail are interpreted as literal characters instead.
+     */
+    UrlCodeHints.prototype._cleanAndDecodeURI = function (URI) {
+        var matchResults,
+            finalURI = URI;
+        
+        // If there is a partially encoded character on the end, strip it off
+        matchResults = finalURI.match(/%[\dA-Fa-f]?$/); // e.g. "%", "%5", "%A", "%d"
+        if (matchResults) {
+            finalURI = finalURI.substring(0, matchResults.index);
+        }
+        
+        // Decode any encoded characters, checking for incorrect formatting
+        try {
+            finalURI = decodeURI(finalURI);
+        } catch (err) {
+            // do nothing, finalURI does not change...
+            // treat all characters as literal characters
+        }
+        
+        return finalURI;
+    };
+    
+    /**
      * Determines whether url hints are available in the current editor
      * context.
      *
@@ -340,6 +373,8 @@ define(function (require, exports, module) {
                     query = "";
                 }
                 
+                query = this._cleanAndDecodeURI(query);
+                
                 var hintsAndSortFunc = this._getUrlHints({queryStr: query});
                 var hints = hintsAndSortFunc.hints;
                 if (hints instanceof Array) {
@@ -357,7 +392,7 @@ define(function (require, exports, module) {
                 }
             }
         }
-
+        
         return (query !== null);
     };
 
@@ -450,7 +485,9 @@ define(function (require, exports, module) {
         } else {
             return null;
         }
-
+        
+        query.queryStr = this._cleanAndDecodeURI(query.queryStr);
+        
         if (query.queryStr !== null) {
             filter = query.queryStr;
             var hintsAndSortFunc = this._getUrlHints(query);

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -242,7 +242,7 @@ define(function (require, exports, module) {
             finalURI = URI;
         
         // If there is a partially encoded character on the end, strip it off
-        matchResults = finalURI.match(/%[\dA-Fa-f]?$/); // e.g. "%", "%5", "%A", "%d"
+        matchResults = finalURI.match(/^[^%]+%[\dA-Fa-f]?$/); // e.g. "%", "%5", "%A", "%d"
         if (matchResults) {
             finalURI = finalURI.substring(0, matchResults.index);
         }

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -455,6 +455,7 @@ define({
 	"LOCALE_IT": "Italien",
 	"LOCALE_JA": "Japonais",
 	"LOCALE_NB": "Norvégien",
+	"LOCALE_FA_IR": "Perse",
 	"LOCALE_PL": "Polonais",
 	"LOCALE_PT_BR": "Portugais (Brésil)",
 	"LOCALE_PT_PT": "Portugais",

--- a/src/nls/ja/strings.js
+++ b/src/nls/ja/strings.js
@@ -455,6 +455,7 @@ define({
 	"LOCALE_IT": "イタリア語",
 	"LOCALE_JA": "日本語",
 	"LOCALE_NB": "ノルウェー語",
+	"LOCALE_FA_IR": "ペルシャ語",
 	"LOCALE_PL": "ポーランド語",
 	"LOCALE_PT_BR": "ポルトガル語 (ブラジル)",
 	"LOCALE_PT_PT": "ポルトガル語",


### PR DESCRIPTION
This PR fixes issue #5357.
