### PR TITLE
Allow hyphens in tag names in live HTML

### DIFF
--- a/src/language/HTMLTokenizer.js
+++ b/src/language/HTMLTokenizer.js
@@ -114,7 +114,9 @@ define(function (require, exports, module) {
      * @return {boolean} true if c is legal in an HTML tag name
      */
     function isLegalInTagName(c) {
-        return (/[A-Za-z0-9]/).test(c);
+        // We allow "-" in tag names since they're popular in Angular custom tag names
+        // and will be legal in the web components spec.
+        return (/[A-Za-z0-9\-]/).test(c);
     }
     
     /**

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -422,6 +422,9 @@ define(function (require, exports, module) {
             it("should fail if there is no whitespace between the end of an attribute and the next attribute name", function () {
                 expectError("<p attr=\"val\"attr2=\"val\"></p>");
             });
+            it("should allow a hyphen in a custom tag name", function () {
+                expectError("<custom-tag></custom-tag>", false);
+            });
         });
     });
 });


### PR DESCRIPTION
Fixes #5642 and should fix #5101.
