### PR TITLE
fix overflow in sidebar. 

### DIFF
--- a/src/extensions/default/RecentProjects/styles/styles.css
+++ b/src/extensions/default/RecentProjects/styles/styles.css
@@ -27,7 +27,7 @@
 
 #project-dropdown-toggle {
     border: 1px solid transparent;
-    display: inline-block;
+    display: block;
     /* adjust margins to keep position #project-title position stable after extension is loaded */
     margin: -3px 0px -2px -6px;
     padding: 0 5px;

--- a/src/extensions/default/RecentProjects/styles/styles.css
+++ b/src/extensions/default/RecentProjects/styles/styles.css
@@ -27,13 +27,12 @@
 
 #project-dropdown-toggle {
     border: 1px solid transparent;
-    display: block;
+    display: inline-table;
     /* adjust margins to keep position #project-title position stable after extension is loaded */
     margin: -3px 0px -2px -6px;
     padding: 0 5px;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;       
 }
 
 #project-title {

--- a/src/extensions/default/RecentProjects/styles/styles.css
+++ b/src/extensions/default/RecentProjects/styles/styles.css
@@ -30,9 +30,10 @@
     display: inline-block;
     /* adjust margins to keep position #project-title position stable after extension is loaded */
     margin: -3px 0px -2px -6px;
-    overflow: hidden;
     padding: 0 5px;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;       
 }
 
 #project-title {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -449,6 +449,9 @@ a, img {
     background: #3C3F41;
     color: @project-panel-text-2;
     text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;    
 }
 
 #sidebar {


### PR DESCRIPTION
When and image is displayed the working-set-header and project-dropdown-toggle bleed into the image holder, when the sidebar is narrow. This change fixes that.
![sidebar-bleeds-into-image](https://f.cloud.github.com/assets/887904/1411569/97ca4b70-3dba-11e3-935b-16fe044aaa5d.png)

Thanks @larz0 for finding this and bringing it to my attention.

This change also improves the sidebar look when the working set title and project dropdown are truncated by adding an ellipsis.
