### PR TITLE
Add a check on the initial files array.

### DIFF
--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
         
         // If all files have custom viewers, then add back the last file
         // so that we open it in its custom viewer.
-        if (filteredFiles.length === 0) {
+        if (filteredFiles.length === 0 && files.length) {
             filteredFiles.push(files[files.length - 1]);
         }
         


### PR DESCRIPTION
On Mac this function gets call on launch with an empty files array. So we need to make sure that we're not accessing an item from the empty array.
