### PR TITLE
fix 5705 - Cleanup for Peter's belated drive by comments

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -874,7 +874,8 @@ define(function (require, exports, module) {
         }
 
         // Close custom viewer if necessary
-        if (!DocumentManager.getCurrentDocument() && EditorManager.getCurrentlyViewedPath()) {
+        if (!file && !DocumentManager.getCurrentDocument() 
+            && EditorManager.getCurrentlyViewedPath()) {
             //_customViewerIsDisplayed = true;
                 // if there is no doc a custom viewer is displayed
             if (!file || file.fullPath === EditorManager.getCurrentlyViewedPath()) {
@@ -897,10 +898,7 @@ define(function (require, exports, module) {
             return promise;
         }
         
-        var doc;
-        if (DocumentManager.getCurrentDocument()) {
-            doc = DocumentManager.getOpenDocumentForPath(file.fullPath);
-        }
+        var doc = DocumentManager.getOpenDocumentForPath(file.fullPath);
         
         if (doc && doc.isDirty && !_forceClose) {
             // Document is dirty: prompt to save changes before closing

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -874,9 +874,9 @@ define(function (require, exports, module) {
         }
 
         // Close custom viewer if necessary
-        if (!file && !DocumentManager.getCurrentDocument() 
-            && EditorManager.getCurrentlyViewedPath()) {
-            //_customViewerIsDisplayed = true;
+        if (!file && !DocumentManager.getCurrentDocument()
+                && EditorManager.getCurrentlyViewedPath()) {
+            
                 // if there is no doc a custom viewer is displayed
             if (!file || file.fullPath === EditorManager.getCurrentlyViewedPath()) {
                 doCloseCustomViewer();

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -836,8 +836,7 @@ define(function (require, exports, module) {
     function handleFileClose(commandData) {
         var file,
             promptOnly,
-            _forceClose,
-            _customViewerIsDisplayed = false;
+            _forceClose;
         
         if (commandData) {
             file        = commandData.file;
@@ -874,8 +873,17 @@ define(function (require, exports, module) {
                 
         var result = new $.Deferred(), promise = result.promise();
         
+        // Close custom viewer if necessary
         if (!DocumentManager.getCurrentDocument() && EditorManager.getCurrentlyViewedPath()) {
-            _customViewerIsDisplayed = true;
+            //_customViewerIsDisplayed = true;
+                // if there is no doc a custom viewer is displayed
+            if(!file || file.fullPath === EditorManager.getCurrentlyViewedPath()){
+                doCloseCustomViewer();
+                return promise;
+            }else{
+                result.resolve();
+                return promise;
+            }
         }
         
         // Default to current document if doc is null
@@ -884,7 +892,7 @@ define(function (require, exports, module) {
         }
         
         // No-op if called when nothing is open; TODO: (issue #273) should command be grayed out instead?
-        if (!file && !_customViewerIsDisplayed) {
+        if (!file) {
             result.resolve();
             return promise;
         }
@@ -956,16 +964,10 @@ define(function (require, exports, module) {
                 EditorManager.focusEditor();
             });
         } else {
-            if (_customViewerIsDisplayed) {
-                // if there is no doc a custom viewer is displayed
-                doCloseCustomViewer();
-            } else {
-                // File is not open, or IS open but Document not dirty: close immediately
-                doClose(file);
-                EditorManager.focusEditor();
-                result.resolve();                
-            }
-
+            // File is not open, or IS open but Document not dirty: close immediately
+            doClose(file);
+            EditorManager.focusEditor();
+            result.resolve();
         }
         return promise;
     }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -861,9 +861,13 @@ define(function (require, exports, module) {
                 if (nextFile) {
                     // opening a text file will automatically close the custom viewer.
                     // This is done in the currentDocumentChange handler in EditorManager
-                    doOpen(nextFile.fullPath);
+                    doOpen(nextFile.fullPath).always(function() {
+                        EditorManager.focusEditor();
+                        result.resolve();
+                    });
                 } else {
                     EditorManager.closeCustomViewer();
+                    result.resolve();
                 }
             }
         }
@@ -875,10 +879,8 @@ define(function (require, exports, module) {
         }
         
         // Default to current document if doc is null
-        if (!file) {
-            if (DocumentManager.getCurrentDocument()) {
-                file = DocumentManager.getCurrentDocument().file;
-            }
+        if (!file && DocumentManager.getCurrentDocument()) {
+            file = DocumentManager.getCurrentDocument().file;
         }
         
         // No-op if called when nothing is open; TODO: (issue #273) should command be grayed out instead?
@@ -960,9 +962,10 @@ define(function (require, exports, module) {
             } else {
                 // File is not open, or IS open but Document not dirty: close immediately
                 doClose(file);
+                EditorManager.focusEditor();
+                result.resolve();                
             }
-            EditorManager.focusEditor();
-            result.resolve();
+
         }
         return promise;
     }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -877,10 +877,9 @@ define(function (require, exports, module) {
         // - a custom viewer is currently displayed and no file specified in command data
         // - a custom viewer is currently displayed and the file specified in command data 
         //   is the file in the custom viewer
-        if ((!DocumentManager.getCurrentDocument() && EditorManager.getCurrentlyViewedPath() && !file) ||
-                (!DocumentManager.getCurrentDocument() && file && file.fullPath === EditorManager.getCurrentlyViewedPath())) {
-
-            if (!file || file.fullPath === EditorManager.getCurrentlyViewedPath()) {
+        if (!DocumentManager.getCurrentDocument()) {
+            if ((EditorManager.getCurrentlyViewedPath() && !file) ||
+                    (file && file.fullPath === EditorManager.getCurrentlyViewedPath())) {
                 doCloseCustomViewer();
                 return promise;
             }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -854,13 +854,15 @@ define(function (require, exports, module) {
             }
         }
 
+        var result = new $.Deferred(), promise = result.promise();
+        
         function doCloseCustomViewer() {
             if (!promptOnly) {
                 var nextFile = DocumentManager.getNextPrevFile(1);
                 if (nextFile) {
                     // opening a text file will automatically close the custom viewer.
                     // This is done in the currentDocumentChange handler in EditorManager
-                    doOpen(nextFile.fullPath).always(function() {
+                    doOpen(nextFile.fullPath).always(function () {
                         EditorManager.focusEditor();
                         result.resolve();
                     });
@@ -870,17 +872,15 @@ define(function (require, exports, module) {
                 }
             }
         }
-                
-        var result = new $.Deferred(), promise = result.promise();
-        
+
         // Close custom viewer if necessary
         if (!DocumentManager.getCurrentDocument() && EditorManager.getCurrentlyViewedPath()) {
             //_customViewerIsDisplayed = true;
                 // if there is no doc a custom viewer is displayed
-            if(!file || file.fullPath === EditorManager.getCurrentlyViewedPath()){
+            if (!file || file.fullPath === EditorManager.getCurrentlyViewedPath()) {
                 doCloseCustomViewer();
                 return promise;
-            }else{
+            } else {
                 result.resolve();
                 return promise;
             }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -873,16 +873,15 @@ define(function (require, exports, module) {
             }
         }
 
-        // Close custom viewer if necessary
-        if (!file && !DocumentManager.getCurrentDocument()
-                && EditorManager.getCurrentlyViewedPath()) {
-            
-                // if there is no doc a custom viewer is displayed
+        // Close custom viewer if, either
+        // - a custom viewer is currently displayed and no file specified in command data
+        // - a custom viewer is currently displayed and the file specified in command data 
+        //   is the file in the custom viewer
+        if ((!DocumentManager.getCurrentDocument() && EditorManager.getCurrentlyViewedPath() && !file) ||
+                (!DocumentManager.getCurrentDocument() && file && file.fullPath === EditorManager.getCurrentlyViewedPath())) {
+
             if (!file || file.fullPath === EditorManager.getCurrentlyViewedPath()) {
                 doCloseCustomViewer();
-                return promise;
-            } else {
-                result.resolve();
                 return promise;
             }
         }
@@ -1070,17 +1069,20 @@ define(function (require, exports, module) {
      * @return {$.Promise} a promise that is resolved when all files are closed
      */
     function handleFileCloseAll(commandData) {
-        if (!DocumentManager.getCurrentDocument()) {
-            EditorManager.closeCustomViewer();
-        }
-        return _doCloseDocumentList(DocumentManager.getWorkingSet(), (commandData && commandData.promptOnly));
+        return _doCloseDocumentList(DocumentManager.getWorkingSet(),
+                                    (commandData && commandData.promptOnly)).done(function () {
+            if (!DocumentManager.getCurrentDocument()) {
+                EditorManager.closeCustomViewer();
+            }
+        });
     }
     
     function handleFileCloseList(commandData) {
-        if (!DocumentManager.getCurrentDocument()) {
-            EditorManager.closeCustomViewer();
-        }
-        return _doCloseDocumentList((commandData && commandData.documentList), false);
+        return _doCloseDocumentList((commandData && commandData.documentList), false).done(function () {
+            if (!DocumentManager.getCurrentDocument()) {
+                EditorManager.closeCustomViewer();
+            }
+        });
     }
     
     /**


### PR DESCRIPTION
fix #5705:  Image closed and no editor opened after if cancel quitting or closing project

Also fixes handleFileClose(imageFilePath) with image file path.
