### PR TITLE
(#5714) - Switch window.close to brackets.app.quit

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1127,7 +1127,7 @@ define(function (require, exports, module) {
         return _handleWindowGoingAway(
             commandData,
             function () {
-                window.close();
+                brackets.app.quit();
             },
             function () {
                 // if fail, tell the app to abort any pending quit operation.


### PR DESCRIPTION
Quitting brackets using alt + f4 or the close button at top right corner does not close the program with the first try. Although, it will close after the second time.

Using file -> Quit will quit brackets as expected.
I am using Kubuntu 12.04.

Changing window.close() to brackets.app.quit() seemed to fix the problem and not to break anything in the process.
