### PR TITLE
Don't show Find bar when invoked from the context menu of an image file.

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -793,12 +793,13 @@ define(function (require, exports, module) {
      * @param {?Entry} scope  Project file/subfolder to search within; else searches whole project.
      */
     function _doFindInFiles(scope) {
+        // If the scope is a file with a custom viewer, then we
+        // don't show find in files dialog.
+        if (scope && EditorManager.getCustomViewerForPath(scope.fullPath)) {
+            return;
+        }
+        
         if (scope instanceof NativeFileSystem.InaccessibleFileEntry) {
-            // If the scope is a file with a custom viewer, then we
-            // don't show find in files dialog.
-            if (EditorManager.getCustomViewerForPath(scope.fullPath)) {
-                return;
-            }
             CommandManager.execute(Commands.FILE_OPEN, { fullPath: scope.fullPath }).done(function () {
                 CommandManager.execute(Commands.EDIT_FIND);
             });

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -794,6 +794,11 @@ define(function (require, exports, module) {
      */
     function _doFindInFiles(scope) {
         if (scope instanceof NativeFileSystem.InaccessibleFileEntry) {
+            // If the scope is a file with a custom viewer, then we
+            // don't show find in files dialog.
+            if (EditorManager.getCustomViewerForPath(scope.fullPath)) {
+                return;
+            }
             CommandManager.execute(Commands.FILE_OPEN, { fullPath: scope.fullPath }).done(function () {
                 CommandManager.execute(Commands.EDIT_FIND);
             });


### PR DESCRIPTION
This fixes #5689, but we don't disable the menu item as mentioned in #5689 since we still need to allow users to do global search (ie. from Edit > Find in Files). So we just don't allow users to do search in the scope of a singe image file.
