### PR TITLE
Re-open a file after renaming even if the file is open in a custom viewer.

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -205,15 +205,16 @@ define(function (require, exports, module) {
                                 // custom viewer but the file is still showing in the current custom viewer. This only
                                 // occurs on Mac since opening a non-text file always fails on Mac and triggers an error
                                 // message that in turn calls _cleanup() after the user clicks OK in the message box.
-                                // By calling result.resolve() we keep the file open in the current custom viewer and 
-                                // the user can rename it back using the keyboard shortcut F2.
-                                result.resolve();
+                                // So we need to explicitly close the currently viewing image file whose filename is  
+                                // no longer valid. Calling notifyPathDeleted will close the image vieer and then select 
+                                // the previously opened text file or show no-editor if none exists.
+                                EditorManager.notifyPathDeleted(fullPath);
                             } else {
                                 // For performance, we do lazy checking of file existence, so it may be in working set
                                 DocumentManager.removeFromWorkingSet(new NativeFileSystem.FileEntry(fullPath));
                                 EditorManager.focusEditor();
-                                result.reject();
                             }
+                            result.reject();
                         }
                         
                         if (silent) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -191,6 +191,10 @@ define(function (require, exports, module) {
             if (viewProvider) {
                 EditorManager.showCustomViewer(viewProvider, fullPath);
                 result.resolve();
+            } else if (EditorManager.showingCustomViewerForPath(fullPath)) {
+                // We get here only if the user opens a file that no longer has a custom
+                // viewer but the file is still showing in the current custom viewer.
+                result.resolve();
             } else {
                 // Load the file if it was never open before, and then switch to it in the UI
                 DocumentManager.getDocumentForPath(fullPath)

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -596,6 +596,8 @@ define(function (require, exports, module) {
             
             _currentEditorsDocument = null;
             _currentEditor = null;
+            _currentlyViewedPath = null;
+            
             // No other Editor is gaining focus, so in this one special case we must trigger event manually
             _notifyActiveEditorChanged(null);
         }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -76,6 +76,8 @@ define(function (require, exports, module) {
     var _currentlyViewedPath = null;
     /** @type {?JQuery} DOM node representing UI of custom view   */
     var _$currentCustomViewer = null;
+    /** @type {?Object} view provider */
+    var _currentViewProvider = null;
     
     /**
      * Currently focused Editor (full-size, inline, or otherwise)
@@ -626,6 +628,7 @@ define(function (require, exports, module) {
             _$currentCustomViewer.remove();
         }
         _$currentCustomViewer = null;
+        _currentViewProvider = null;
     }
     
     /** 
@@ -644,19 +647,24 @@ define(function (require, exports, module) {
      * @param {!string} fullPath  path to the file displayed in the custom view
      */
     function showCustomViewer(provider, fullPath) {
-        if (_currentlyViewedPath === fullPath) {
+        // Don't show the same custom view again if file path
+        // and view provider are still the same.
+        if (_currentlyViewedPath === fullPath &&
+                _currentViewProvider === provider) {
             return;
         }
         
+        // Clean up currently viewing document or custom viewer
         DocumentManager._clearCurrentDocument();
-    
-        // Hide the not-editor
-        $("#not-editor").css("display", "none");
-        
         _removeCustomViewer();
-        
+    
+        // Hide the not-editor or reset current editor
+        $("#not-editor").css("display", "none");
         _nullifyEditor();
+
+        _currentViewProvider = provider;
         _$currentCustomViewer = provider.getCustomViewHolder(fullPath);
+
         // place in window
         $("#editor-holder").append(_$currentCustomViewer);
         
@@ -666,7 +674,7 @@ define(function (require, exports, module) {
         _setCurrentlyViewedPath(fullPath);
     }
 
-    /** 
+    /**
      * Check whether the given file is currently open in a custom viewer.
      *
      * @param {!string} fullPath  file path to check
@@ -674,7 +682,7 @@ define(function (require, exports, module) {
      *     path matches the one in the custom viewer, false otherwise.
      */
     function showingCustomViewerForPath(fullPath) {
-        return (_$currentCustomViewer && _currentlyViewedPath === fullPath);
+        return (_currentViewProvider && _currentlyViewedPath === fullPath);
     }
     
     /**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -666,6 +666,17 @@ define(function (require, exports, module) {
         _setCurrentlyViewedPath(fullPath);
     }
 
+    /** 
+     * Check whether the given file is currently open in a custom viewer.
+     *
+     * @param {!string} fullPath  file path to check
+     * @return {boolean} true if we have a custom viewer showing and the given file
+     *     path matches the one in the custom viewer, false otherwise.
+     */
+    function showingCustomViewerForPath(fullPath) {
+        return (_$currentCustomViewer && _currentlyViewedPath === fullPath);
+    }
+    
     /**
      * Update file name if necessary
      */
@@ -985,4 +996,5 @@ define(function (require, exports, module) {
     exports.getCustomViewerForPath        = getCustomViewerForPath;
     exports.notifyPathDeleted             = notifyPathDeleted;
     exports.closeCustomViewer             = closeCustomViewer;
+    exports.showingCustomViewerForPath    = showingCustomViewerForPath;
 });

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -157,7 +157,8 @@ define(function (require, exports, module) {
         // trigger a currentDocumentChanged event, so we need to trigger a documentSelectionFocusChange 
         // in this case to signify the selection focus has changed even though the current document has not.
         var curDoc = DocumentManager.getCurrentDocument();
-        if (curDoc && curDoc.file.fullPath === fullPath) {
+        if (curDoc && curDoc.file.fullPath === fullPath &&
+                !EditorManager.getCustomViewerForPath(fullPath)) {
             _selectCurrentDocument();
             result = (new $.Deferred()).resolve().promise();
         } else {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1419,9 +1419,9 @@ define(function (require, exports, module) {
                 DocumentManager.notifyPathNameChanged(oldName, newName, isFolder);
                 
                 // Finally, re-open the selected document
-                if (DocumentManager.getCurrentDocument()) {
+                if (EditorManager.getCurrentlyViewedPath()) {
                     FileViewController.openAndSelectDocument(
-                        DocumentManager.getCurrentDocument().file.fullPath,
+                        EditorManager.getCurrentlyViewedPath(),
                         FileViewController.getFileSelectionFocus()
                     );
                 }


### PR DESCRIPTION
When reopening a renamed file, we can check with language manager again to determine whether to use a different custom viewer or to open it as a text file. So when an image file is renamed with a non-image file extension, then it will be re-opened as text file on Windows, but will trigger an error on Mac since we can't read in any binary file on Mac yet. In order to prevent the same error message repeatedly showing up on Mac, we will explicitly close the image viewer after the user dismisses the error dialog. So this fixes issue #5718. 
