### PR TITLE
Apply Ruby syntax highlighting to Gemfiles and Rakefiles.

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -162,7 +162,8 @@
     "ruby": {
         "name": "Ruby",
         "mode": "ruby",
-        "fileExtensions": ["rb", "ru", "gemspec", "rake"]
+        "fileExtensions": ["rb", "ru", "gemspec", "rake"],
+        "fileNames": ["Gemfile", "Rakefile"]
     },
 
     "python": {


### PR DESCRIPTION
Currently Gemfiles and Rakefiles are highlighted as (plain) text.
