### PR TITLE
Fix #5770: Replace with $1 and so on works in Replace All mode, too

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -476,7 +476,6 @@ define(function (require, exports, module) {
                     var match = results[$(checkedRow).data("match")],
                         rw    = typeof replaceWhat === "string" ? replaceWith : replaceWith.replace(/\$(\d)/g, function (w, i) { return match.match[i]; });
                     editor.document.replaceRange(rw, match.from, match.to, "+replaceAll");
-                    console.log(results);
                 });
             _closeReplaceAllPanel();
         });

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -410,19 +410,24 @@ define(function (require, exports, module) {
      * @param {Editor} editor - Currently active editor that was used to invoke this action.
      * @param {string|RegExp} replaceWhat - Query that will be passed into CodeMirror Cursor to search for results.
      * @param {string} replaceWith - String that should be used to replace chosen results.
-     * @param {?function} replaceFunction - If replaceWhat is a RegExp, than this function is used to replace matches in that RegExp.
      */
-    function _showReplaceAllPanel(editor, replaceWhat, replaceWith, replaceFunction) {
+    function _showReplaceAllPanel(editor, replaceWhat, replaceWith) {
         var results = [],
             cm      = editor._codeMirror,
             cursor  = getSearchCursor(cm, replaceWhat),
+            match,
             from,
             to,
             line,
             multiLine;
 
         // Collect all results from document
-        while (cursor.findNext()) {
+        do {
+            match = cursor.findNext();
+            if (!match) {
+                break;
+            }
+            
             from      = cursor.from();
             to        = cursor.to();
             line      = editor.document.getLine(from.line);
@@ -435,13 +440,14 @@ define(function (require, exports, module) {
                 line:      from.line + 1,
                 pre:       line.slice(0, from.ch),
                 highlight: line.slice(from.ch, multiLine ? undefined : to.ch),
-                post:      multiLine ? "\u2026" : line.slice(to.ch)
+                post:      multiLine ? "\u2026" : line.slice(to.ch),
+                match:     match
             });
 
             if (results.length >= REPLACE_ALL_MAX) {
                 break;
             }
-        }
+        } while (match);
 
         // This text contains some formatting, so all the strings are assumed to be already escaped
         var resultsLength = results.length,
@@ -468,8 +474,9 @@ define(function (require, exports, module) {
                 .reverse()
                 .forEach(function (checkedRow) {
                     var match = results[$(checkedRow).data("match")],
-                        rw    = typeof replaceWhat === "string" ? replaceWith : replaceWith.replace(/\$(\d)/g, replaceFunction);
+                        rw    = typeof replaceWhat === "string" ? replaceWith : replaceWith.replace(/\$(\d)/g, function (w, i) { return match.match[i]; });
                     editor.document.replaceRange(rw, match.from, match.to, "+replaceAll");
+                    console.log(results);
                 });
             _closeReplaceAllPanel();
         });
@@ -549,7 +556,7 @@ define(function (require, exports, module) {
                         } else if (e.target.id === "replace-no") {
                             advance();
                         } else if (e.target.id === "replace-all") {
-                            _showReplaceAllPanel(editor, query, text, function (w, i) { return match[i]; });
+                            _showReplaceAllPanel(editor, query, text);
                         } else if (e.target.id === "replace-stop") {
                             // Destroy modalBar on stop
                             modalBar = null;


### PR DESCRIPTION
This fixes #5770, where regexp replace works incorrectly while in Replace All mode.

My question: Is there anything better than a do-while loop with an if to break (there must be anything better ;) )

@njx
