### PR TITLE
Remove workaround for blank line at end from hideLines()

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -978,21 +978,10 @@ define(function (require, exports, module) {
             return;
         }
         
-        // Handle hiding a single blank line at the end specially by moving the "from" backwards
-        // to include the last newline. Otherwise CodeMirror doesn't hide anything in this case.
-        var hideFrom, inclusiveLeft = true;
-        if (from === to - 1 && from === this._codeMirror.lineCount() - 1 && this._codeMirror.getLine(from).length === 0) {
-            hideFrom = {line: from - 1, ch: this._codeMirror.getLine(from - 1).length};
-            // Allow the cursor to be set immediately before the hidden newline.
-            inclusiveLeft = false;
-        } else {
-            hideFrom = {line: from, ch: 0};
-        }
-        
         var value = this._codeMirror.markText(
-            hideFrom,
+            {line: from, ch: 0},
             {line: to - 1, ch: this._codeMirror.getLine(to - 1).length},
-            {collapsed: true, inclusiveLeft: inclusiveLeft, inclusiveRight: true}
+            {collapsed: true, inclusiveLeft: true, inclusiveRight: true}
         );
         
         return value;


### PR DESCRIPTION
... since it's no longer necessary with latest CM. See notes in #5621. 

@dangoor - could you review this since you reviewed the original change? Thanks.
