### PR TITLE
When autoindenting, only insert a tab if the cursor doesn't move due to CodeMirror's indentation

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -140,10 +140,18 @@ define(function (require, exports, module) {
         if (indentAuto) {
             var currentLength = line.length;
             CodeMirror.commands.indentAuto(instance);
-            // If the amount of whitespace didn't change, insert another tab
+            
+            // If the amount of whitespace and the cursor position didn't change, we must have
+            // already been at the correct indentation level as far as CM is concerned, so insert 
+            // another tab.
             if (instance.getLine(from.line).length === currentLength) {
-                insertTab = true;
-                to.ch = 0;
+                var newFrom = instance.getCursor(true),
+                    newTo = instance.getCursor(false);
+                if (newFrom.line === from.line && newFrom.ch === from.ch &&
+                        newTo.line === to.line && newTo.ch === to.ch) {
+                    insertTab = true;
+                    to.ch = 0;
+                }
             }
         } else if (instance.somethingSelected() && from.line !== to.line) {
             CodeMirror.commands.indentMore(instance);


### PR DESCRIPTION
For #5068. This should get rid of the most common case where you can accidentally get extra whitespace at the end of a line.

Note that there's one minor issue remaining with this behavior: if a line is already at the right indent level, you click in the whitespace at the beginning, and you hit TAB, the indentation doesn't change and the cursor moves to the beginning of the text (which is correct), but the file gets marked dirty. I have a [comment](https://github.com/marijnh/CodeMirror/commit/759b3a0e9ab1ce6486341651252d968e417ffe5e#commitcomment-4491348) out to Marijn on this. I don't think it's a showstopper.
