### PR TITLE
Add persian language to german translation

### DIFF
--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -450,6 +450,7 @@ define({
     "LOCALE_DE"                                 : "Deutsch",
     "LOCALE_EN"                                 : "Englisch",
     "LOCALE_ES"                                 : "Spanisch",
+    "LOCALE_FA_IR"                              : "Persisch",
     "LOCALE_FI"                                 : "Finnisch",
     "LOCALE_FR"                                 : "Französisch",
     "LOCALE_IT"                                 : "Italienisch",


### PR DESCRIPTION
This adds a translation for `LOCALE_FA_IR` to the german `strings.js`.

Review: @couzteau
