### PR TITLE
Remove deprecated FileUtils.getFilenameExtension() API

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -369,20 +369,6 @@ define(function (require, exports, module) {
         return baseName.substr(idx + 1);
     }
 
-    /**
-     * Similar to getFileExtension(), but includes the leading "." in the returned value.
-     * @deprecated Use getFileExtension() instead. This API will be removed soon.
-     */
-    function getFilenameExtension(fullPath) {
-        console.error("Warning: FileUtils.getFilenameExtension() is deprecated. Use FileUtils.getFileExtension() (which omits the '.') instead.");
-        
-        var ext = getFileExtension(fullPath);
-        if (ext !== "") {
-            ext = "." + ext;
-        }
-        return ext;
-    }
-
     /** @const - hard-coded for now, but may want to make these preferences */
     var _staticHtmlFileExts = ["htm", "html"],
         _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "asp", "aspx", "jsp", "jspx", "shtm", "shtml"];
@@ -481,6 +467,5 @@ define(function (require, exports, module) {
     exports.getDirectoryPath               = getDirectoryPath;
     exports.getBaseName                    = getBaseName;
     exports.getFileExtension               = getFileExtension;
-    exports.getFilenameExtension           = getFilenameExtension;
     exports.compareFilenames               = compareFilenames;
 });

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -101,28 +101,28 @@ define(function (require, exports, module) {
             });
         });
 
-        describe("getFilenameExtension", function () {
+        describe("getFileExtension", function () {
             
             it("should get the extension of a normalized win file path", function () {
-                expect(FileUtils.getFilenameExtension("C:/foo/bar/baz.txt")).toBe(".txt");
+                expect(FileUtils.getFileExtension("C:/foo/bar/baz.txt")).toBe("txt");
             });
             
             it("should get the extension of a posix file path", function () {
-                expect(FileUtils.getFilenameExtension("/foo/bar/baz.txt")).toBe(".txt");
+                expect(FileUtils.getFileExtension("/foo/bar/baz.txt")).toBe("txt");
             });
             
             it("should return empty extension for a normalized win directory path", function () {
-                expect(FileUtils.getFilenameExtension("C:/foo/bar/")).toBe("");
+                expect(FileUtils.getFileExtension("C:/foo/bar/")).toBe("");
             });
             
             it("should return empty extension for a posix directory path", function () {
-                expect(FileUtils.getFilenameExtension("bar")).toBe("");
+                expect(FileUtils.getFileExtension("bar")).toBe("");
             });
 
             it("should return the extension of a filename containing .", function () {
-                expect(FileUtils.getFilenameExtension("C:/foo/bar/.baz/jaz.txt")).toBe(".txt");
-                expect(FileUtils.getFilenameExtension("foo/bar/baz/.jaz.txt")).toBe(".txt");
-                expect(FileUtils.getFilenameExtension("foo.bar.baz..jaz.txt")).toBe(".txt");
+                expect(FileUtils.getFileExtension("C:/foo/bar/.baz/jaz.txt")).toBe("txt");
+                expect(FileUtils.getFileExtension("foo/bar/baz/.jaz.txt")).toBe("txt");
+                expect(FileUtils.getFileExtension("foo.bar.baz..jaz.txt")).toBe("txt");
             });
         });
     });


### PR DESCRIPTION
Removed the code for deprecated FileUtils.getFilenameExtension() as mentioned in Issue #5368: 
- deleted code for getFilenameExtension in src/file/FileUtils.js
- edited the test for getFilenameExtension in test/spec/FileUtils-test.js and changed it to match getFileExtension
