### PR TITLE
Adding css.erb to css file extensions

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -21,7 +21,7 @@
     "css": {
         "name": "CSS",
         "mode": "css",
-        "fileExtensions": ["css"],
+        "fileExtensions": ["css", "css.erb"],
         "blockComment": ["/*", "*/"]
     },
 


### PR DESCRIPTION
Sometimes you need to create a css.erb when using ruby on rails and it wasn't highlighting when opening that file type.
