### PR TITLE
Show update notification icon on Extension Manager "Installed" tab

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -191,6 +191,7 @@ define(function (require, exports, module) {
                 $(this).tab("show");
             });
         
+        // Update & hide/show the notification overlay on a tab's icon, based on its model's notifyCount
         function updateNotificationIcon(index) {
             var model = models[index],
                 $notificationIcon = $dlg.find(".nav-tabs li").eq(index).find(".notification");

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -191,13 +191,35 @@ define(function (require, exports, module) {
                 $(this).tab("show");
             });
         
+        function updateNotificationIcon(index) {
+            var model = models[index],
+                $notificationIcon = $dlg.find(".nav-tabs li").eq(index).find(".notification");
+            if (model.notifyCount) {
+                $notificationIcon.text(model.notifyCount);
+                $notificationIcon.show();
+            } else {
+                $notificationIcon.hide();
+            }
+        }
+        
         // Initialize models and create a view for each model
         var modelInitPromise = Async.doInParallel(models, function (model, index) {
             var view    = new ExtensionManagerView(),
-                promise = view.initialize(model);
+                promise = view.initialize(model),
+                lastNotifyCount;
             
             promise.always(function () {
                 views[index] = view;
+                
+                lastNotifyCount = model.notifyCount;
+                updateNotificationIcon(index);
+            });
+            
+            $(model).on("change", function () {
+                if (lastNotifyCount !== model.notifyCount) {
+                    lastNotifyCount = model.notifyCount;
+                    updateNotificationIcon(index);
+                }
             });
             
             return promise;

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -407,6 +407,10 @@ define(function (require, exports, module) {
         });
     };
     
+    /**
+     * @private
+     * Updates notifyCount based on number of extensions with an update available
+     */
     InstalledViewModel.prototype._countUpdates = function () {
         var self = this;
         this.notifyCount = 0;

--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -5,7 +5,7 @@
                 <li><a href="#registry" class="registry" data-toggle="tab"><img src="styles/images/extension-manager-registry.svg"/><br/>{{Strings.EXTENSIONS_AVAILABLE_TITLE}}</a></li>
                 <!--<li><a href="#updates" class="updates" data-toggle="tab"><img src="styles/images/extension-manager-updates.svg"/><br/>{{Strings.EXTENSIONS_UPDATES_TITLE}}</a></li>-->
             {{/showRegistry}}
-            <li><a href="#installed" class="installed" data-toggle="tab"><img src="styles/images/extension-manager-installed.svg"/><br/>{{Strings.EXTENSIONS_INSTALLED_TITLE}}</a></li>
+            <li><a href="#installed" class="installed" data-toggle="tab"><img src="styles/images/extension-manager-installed.svg"/><br/>{{Strings.EXTENSIONS_INSTALLED_TITLE}}</a><span class="notification"></span></li>
         </ul>
         <div>
             <button class="search-clear"></button>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -732,7 +732,7 @@ a[href^="http"] {
                 position: relative;  // for positioning .notification icon
                 > .notification {
                     display: none;  // hidden by default
-                    background-color: #A83F3F;
+                    background-color: #91CC41;
                     color: white;
                     border-radius: 16px;
                     padding: 0 5px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -727,6 +727,20 @@ a[href^="http"] {
                 background-color: #dfe2e2;
                 border-color: #b4b7b7 #b4b7b7 transparent #b4b7b7;
             }
+            
+            > li {
+                position: relative;  // for positioning .notification icon
+                > .notification {
+                    display: none;  // hidden by default
+                    background-color: #A83F3F;
+                    color: white;
+                    border-radius: 16px;
+                    padding: 0 5px;
+                    position: absolute;
+                    right: 19px;
+                    top: 8px;
+                }
+            }
         }
 
         /* Search box */

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -1040,11 +1040,18 @@ define(function (require, exports, module) {
                                     item.metadata.name === "mock-legacy-extension") {
                                 expect(view).toHaveText(item.metadata.name);
                                 expect($button.length).toBe(1);
+                                
+                                // But no update button
+                                var $updateButton = $("button.update[data-extension-id=" + item.metadata.name + "]", view.$el);
+                                expect($updateButton.length).toBe(0);
                             } else {
                                 expect(view).not.toHaveText(item.metadata.name);
                                 expect($button.length).toBe(0);
                             }
                         });
+                        
+                        // And no overall update icon overlay
+                        expect(model.notifyCount).toBe(0);
                     });
                 });
                 
@@ -1172,6 +1179,7 @@ define(function (require, exports, module) {
                         var $button = $("button.update[data-extension-id=mock-extension]", view.$el);
                         expect($button.length).toBe(1);
                         expect($button.prop("disabled")).toBeFalsy();
+                        expect(model.notifyCount).toBe(1);
                         
                         expect($("button.install[data-extension-id=mock-extension]", view.$el).length).toBe(0);
                     });
@@ -1189,6 +1197,7 @@ define(function (require, exports, module) {
                         var $button = $("button.update[data-extension-id=mock-extension]", view.$el);
                         expect($button.length).toBe(1);
                         expect($button.prop("disabled")).toBeTruthy();
+                        expect(model.notifyCount).toBe(1);
                         
                         expect($("button.install[data-extension-id=mock-extension]", view.$el).length).toBe(0);
                         expect($(".alert.warning", view.$el).length).toBe(0);
@@ -1206,6 +1215,7 @@ define(function (require, exports, module) {
                         var $button = $("button.update[data-extension-id=mock-extension]", view.$el);
                         expect($button.length).toBe(1);
                         expect($button.prop("disabled")).toBeTruthy();
+                        expect(model.notifyCount).toBe(1);
                         
                         expect($("button.install[data-extension-id=mock-extension]", view.$el).length).toBe(0);
                         expect($(".alert.warning", view.$el).length).toBe(0);


### PR DESCRIPTION
Show an icon in the Extension Manager whenever updates to installed extensions are available: a red dot with counter overlaid on the Installed tab's icon.  This should help improve the visibility of extension updates now that the Installed tab isn't selected by default.

In the long run of course we'd like a way to filter the view down to _only_ extensions with updates available, and we'd also like update notifications to be pushed to the main UI just as they are for updates to Brackets itself... but this is an incremental, simpler step in that direction.

Screenshot:
![extman notification](https://f.cloud.github.com/assets/1197510/1463057/a38eec7e-451a-11e3-9122-d5c924d7ff5f.png)

(@larz0 Please let me know if there are any visual tweaks you'd suggest)
