### PR TITLE
Disallow tabbing to prev and next buttons

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -193,8 +193,8 @@ define(function (require, exports, module) {
     var queryDialog = Strings.CMD_FIND +
             ": <input type='text' style='width: 10em'/>" +
             "<div class='navigator'>" +
-                "<button id='find-prev' class='btn no-focus' title='" + Strings.BUTTON_PREV_HINT + "'>" + Strings.BUTTON_PREV + "</button>" +
-                "<button id='find-next' class='btn no-focus' title='" + Strings.BUTTON_NEXT_HINT + "'>" + Strings.BUTTON_NEXT + "</button>" +
+                "<button id='find-prev' class='btn no-focus' tabindex='-1' title='" + Strings.BUTTON_PREV_HINT + "'>" + Strings.BUTTON_PREV + "</button>" +
+                "<button id='find-next' class='btn no-focus' tabindex='-1' title='" + Strings.BUTTON_NEXT_HINT + "'>" + Strings.BUTTON_NEXT + "</button>" +
             "</div>" +
             "<div class='message'>" +
                 "<span id='find-counter'></span> " +


### PR DESCRIPTION
This is for #5766.

This restores Find dialog behavior to what it was before prev and next buttons were added so that tabbing dismisses dialog.

I also tried to add no-focus class to the Find dialog to disallow click to steal focus from the text field, but it doesn't seem to work.

We're eventually going to rewrite Find, Replace, and Find in Files dialogs, so I think this is sufficient for this bug.
