### PR TITLE
Automatically scroll find selection into view

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -143,8 +143,8 @@ define(function (require, exports, module) {
                 // no need to scroll if the line with the match is in view
                 centerOptions = Editor.BOUNDARY_IGNORE_TOP;
             }
-            editor.setSelection(cursor.from(), cursor.to(), true, centerOptions);
             cm.scrollIntoView({from: cursor.from(), to: cursor.to()});
+            editor.setSelection(cursor.from(), cursor.to(), true, centerOptions);
             state.posFrom = cursor.from();
             state.posTo = cursor.to();
             state.findNextCalled = true;

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -144,6 +144,7 @@ define(function (require, exports, module) {
                 centerOptions = Editor.BOUNDARY_IGNORE_TOP;
             }
             editor.setSelection(cursor.from(), cursor.to(), true, centerOptions);
+            cm.scrollIntoView({from: cursor.from(), to: cursor.to()});
             state.posFrom = cursor.from();
             state.posTo = cursor.to();
             state.findNextCalled = true;


### PR DESCRIPTION
This PR fixes issue #3063 by forcing the editor to always scroll a find selection into view.
