### PR TITLE
Make sure _liveDocument exists before dereferencing

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -569,7 +569,7 @@ define(function LiveDevelopment(require, exports, module) {
             // After (1) the interstitial page loads, (2) then browser navigation
             // to the base URL is completed, and (3) the agents finish loading
             // gather related documents and finally set status to STATUS_ACTIVE.
-            var doc = _liveDocument.doc;
+            var doc = (_liveDocument) ? _liveDocument.doc : null;
 
             if (doc) {
                 var status = STATUS_ACTIVE,


### PR DESCRIPTION
I discovered this while researching #5774 (but it's not a fix for #5774).

When `_liveDocument` is undefined, then this code throws an exception, and else clause is never executed, so deferred is not resolved. This could be causing some of the random hangs we see in Live Development.
