### PR TITLE
Use brackets.app.quit() when running grunt test-integration task

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
             writeResults(resultsPath, reporter.toJSON());
         }
 
-        _writeResults.always(function () { window.close(); });
+        _writeResults.always(function () { brackets.app.quit(); });
     }
 
     /**


### PR DESCRIPTION
If test windows are open when the spec runner ends, use `brackets.app.quit()` to ensure Brackets quits instead of leaving test windows open. This should fix timeouts in Jenkins occasionally seen in the integration suite on mac, but it won't fix the test failures themselves.
