### PR TITLE
Make JS code hint test runs more consistent

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/MessageIds.js
+++ b/src/extensions/default/JavaScriptCodeHints/MessageIds.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
         TERN_CALLED_FUNC_TYPE_MSG   = "FunctionType",
         TERN_PRIME_PUMP_MSG         = "PrimePump",
         TERN_GET_GUESSES_MSG        = "GetGuesses",
-        TERN_WORKER_READY           = "WorkerReady";
+        TERN_WORKER_READY           = "WorkerReady",
+        SET_CONFIG                  = "SetConfig";
 
     // Message parameter constants
     var TERN_FILE_INFO_TYPE_PART    = "part",
@@ -57,6 +58,7 @@ define(function (require, exports, module) {
     exports.TERN_FILE_INFO_TYPE_PART    = TERN_FILE_INFO_TYPE_PART;
     exports.TERN_FILE_INFO_TYPE_FULL    = TERN_FILE_INFO_TYPE_FULL;
     exports.TERN_FILE_INFO_TYPE_EMPTY   = TERN_FILE_INFO_TYPE_EMPTY;
+    exports.SET_CONFIG                  = SET_CONFIG;
 });
 
 

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1106,7 +1106,7 @@ define(function (require, exports, module) {
             // Set the initial configuration for the worker
             _ternWorker.postMessage({
                 type: MessageIds.SET_CONFIG,
-                config: brackets.configureJSCodeHints.config
+                config: config
             });
         }
         /**
@@ -1300,7 +1300,7 @@ define(function (require, exports, module) {
      *
      * During debugging, you can turn this automatic resetting behavior off
      * by running this in the console:
-     * brackets.configureJSCodeHints({ noReset: true })
+     * brackets._configureJSCodeHints({ noReset: true })
      *
      * This function is also used in unit testing with the "force" flag to
      * reset the worker for each test to start with a clean environment.
@@ -1308,7 +1308,8 @@ define(function (require, exports, module) {
      * @param {Session} session
      * @param {Document} document
      * @param {boolean} force true to force a reset regardless of how long since the last one
-     * @return {Promise} resolved when the new worker is ready (the new worker is passed to the callback)
+     * @return {Promise} Promise resolved when the worker is ready. 
+     *                   The new (or current, if there was no reset) worker is passed to the callback.
      */
     function _maybeReset(session, document, force) {
         var newWorker;
@@ -1508,7 +1509,7 @@ define(function (require, exports, module) {
      * Update the configuration in the worker.
      */
     function _setConfig(configUpdate) {
-        config = brackets.configureJSCodeHints.config;
+        config = brackets._configureJSCodeHints.config;
         postMessage({
             type: MessageIds.SET_CONFIG,
             config: configUpdate

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -56,6 +56,27 @@ define(function (require, exports, module) {
         ignoreChange;         // can ignore next "change" event if true;
 
     /**
+     * Sets the configuration, generally for testing/debugging use.
+     * Configuration keys are merged into the current configuration.
+     * The Tern worker is automatically updated to the new config as well.
+     *
+     * * debug: Set to true if you want verbose logging
+     * * noReset: Set to true if you don't want the worker to restart periodically
+     *
+     * @param {Object} configUpdate keys/values to merge into the config
+     */
+    function setConfig(configUpdate) {
+        var config = setConfig.config;
+        Object.keys(configUpdate).forEach(function (key) {
+            config[key] = configUpdate[key];
+        });
+        
+        ScopeManager._setConfig(configUpdate);
+    }
+    
+    setConfig.config = {};
+
+    /**
      *  Get the value of current session.
      *  Used for unit testing.
      * @return {Session} - the current session.
@@ -79,6 +100,10 @@ define(function (require, exports, module) {
         var trimmedQuery,
             formattedHints;
 
+        if (setConfig.config.debug) {
+            console.debug("Hints", _.pluck(hints, "label"));
+        }
+        
         /*
          * Returns a formatted list of hints with the query substring
          * highlighted.
@@ -578,8 +603,10 @@ define(function (require, exports, module) {
          *      for changes
          */
         function uninstallEditorListeners(editor) {
-            $(editor)
-                .off(HintUtils.eventName("change"));
+            if (editor) {
+                $(editor)
+                    .off(HintUtils.eventName("change"));
+            }
         }
 
         /*
@@ -745,9 +772,12 @@ define(function (require, exports, module) {
 
             return response;
         }
-
+        
         // Register quickEditHelper.
         brackets._jsCodeHintsHelper = quickEditHelper;
+        
+        // Configuration function used for debugging
+        brackets.configureJSCodeHints = setConfig;
   
         ExtensionUtils.loadStyleSheet(module, "styles/brackets-js-hints.css");
         

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -777,7 +777,7 @@ define(function (require, exports, module) {
         brackets._jsCodeHintsHelper = quickEditHelper;
         
         // Configuration function used for debugging
-        brackets.configureJSCodeHints = setConfig;
+        brackets._configureJSCodeHints = setConfig;
   
         ExtensionUtils.loadStyleSheet(module, "styles/brackets-js-hints.css");
         

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -482,33 +482,33 @@ var config = {};
 
                 var fnType = "";
                 try {
-                    ternServer.request(request, function (error, data) {
+                    ternServer.request(request, function (ternError, data) {
                         
-                        if (error) {
-                            _log("Error for Tern request: \n" + JSON.stringify(request) + "\n" + error);
-                            return;
-                        }
-                        
-                        var file = ternServer.findFile(fileInfo.name);
-
-                        // convert query from partial to full offsets
-                        var newOffset = offset;
-                        if (fileInfo.type === MessageIds.TERN_FILE_INFO_TYPE_PART) {
-                            newOffset = {line: offset.line + fileInfo.offsetLines, ch: offset.ch};
-                        }
-
-                        request = buildRequest(createEmptyUpdate(fileInfo.name), "type", newOffset);
-
-                        var expr = Tern.findQueryExpr(file, request.query);
-                        Infer.resetGuessing();
-                        var type = Infer.expressionType(expr);
-                        type = type.getFunctionType() || type.getType();
-                        
-                        if (type) {
-                            fnType = getParameters(type);
+                        if (ternError) {
+                            _log("Error for Tern request: \n" + JSON.stringify(request) + "\n" + ternError);
+                            error = ternError.toString();
                         } else {
-                            error = "No parameter type found";
-                            _log(error);
+                            var file = ternServer.findFile(fileInfo.name);
+    
+                            // convert query from partial to full offsets
+                            var newOffset = offset;
+                            if (fileInfo.type === MessageIds.TERN_FILE_INFO_TYPE_PART) {
+                                newOffset = {line: offset.line + fileInfo.offsetLines, ch: offset.ch};
+                            }
+    
+                            request = buildRequest(createEmptyUpdate(fileInfo.name), "type", newOffset);
+    
+                            var expr = Tern.findQueryExpr(file, request.query);
+                            Infer.resetGuessing();
+                            var type = Infer.expressionType(expr);
+                            type = type.getFunctionType() || type.getType();
+                            
+                            if (type) {
+                                fnType = getParameters(type);
+                            } else {
+                                ternError = "No parameter type found";
+                                _log(ternError);
+                            }
                         }
                     });
                 } catch (e) {

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -574,15 +574,11 @@ var config = {};
             
             /**
              * Updates the configuration, typically for debugging purposes.
-             * Keys set in the config object passed in are merged into the
-             * configuration.
              *
-             * @param {Object} configUpdate updated config keys
+             * @param {Object} configUpdate new configuration
              */
             function setConfig(configUpdate) {
-                Object.keys(configUpdate).forEach(function (key) {
-                    config[key] = configUpdate[key];
-                });
+                config = configUpdate;
             }
             
             self.addEventListener("message", function (e) {

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         HintUtils            = require("HintUtils"),
         HintUtils2           = require("HintUtils2"),
         ParameterHintManager = require("ParameterHintManager");
-
+    
     var extensionPath   = FileUtils.getNativeModuleDirectoryPath(module),
         testPath        = extensionPath + "/unittest-files/basic-test-files/file1.js",
         testHtmlPath    = extensionPath + "/unittest-files/basic-test-files/index.html",
@@ -471,7 +471,7 @@ define(function (require, exports, module) {
                 expectNoHints(JSCodeHints.jsHintProvider);
             });
 
-            xit("should list declared variable and function names in outer scope", function () {
+            it("should list declared variable and function names in outer scope", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["A2", "A3", "funB", "A1"]);
@@ -489,19 +489,19 @@ define(function (require, exports, module) {
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["break", "case", "catch"]);
             });
-/*            
-            it("should list explicitly defined globals from JSLint annotations", function () {
+
+            xit("should list explicitly defined globals from JSLint annotations", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["brackets", "$"]);
             });
             
-            it("should list implicitly defined globals from JSLint annotations", function () {
+            xit("should list implicitly defined globals from JSLint annotations", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["alert", "console", "confirm", "navigator", "window", "frames"]);
             });
- */
+ 
             it("should NOT list implicitly defined globals from missing JSLint annotations", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
@@ -549,13 +549,13 @@ define(function (require, exports, module) {
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["B1", "B2", "funC", "paramB1", "paramB2", "funB", "A1", "A2", "A3"]);
             });
-/*
-            it("should list string literals that occur in the file", function () {
+
+            xit("should list string literals that occur in the file", function () {
                 testEditor.setCursorPos({ line: 12, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
                 hintsPresent(hintObj, ["use strict"]);
             });
-*/
+
             it("should NOT list string literals from other files", function () {
                 testEditor.setCursorPos({ line: 6, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
@@ -652,18 +652,6 @@ define(function (require, exports, module) {
                 hintsPresent(hintObj, ["B1", "paramB1"]);
             });
 
-/*          Single quote and double quote keys cause hasHints() to return false.
-            It used to return true when string literals were supported.
-            it("should list implicit hints when typing string literals (single quote)", function () {
-                testEditor.setCursorPos({ line: 9, ch: 0 });
-                expectHints(JSCodeHints.jsHintProvider, "'");
-            });
-            
-            it("should list implicit hints when typing string literals (double quote)", function () {
-                testEditor.setCursorPos({ line: 9, ch: 0 });
-                expectHints(JSCodeHints.jsHintProvider, "\"");
-            });
-*/
             it("should give priority to identifier names associated with the current context", function () {
                 testEditor.setCursorPos({ line: 16, ch: 0 });
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
@@ -680,7 +668,7 @@ define(function (require, exports, module) {
                 hintsPresentOrdered(hintObj, ["funB", "funE"]);
             });
             
-/*            it("should choose the correct delimiter for string literal hints with no query", function () {
+            xit("should choose the correct delimiter for string literal hints with no query", function () {
                 var start = { line: 18, ch: 0 },
                     end   = { line: 18, ch: 18 };
 
@@ -692,7 +680,7 @@ define(function (require, exports, module) {
                     expect(testDoc.getRange(start, end)).toEqual('"hello\\\\\\" world!"');
                 });
             });
-*/
+            
             it("should insert value hints with no current query", function () {
                 var start = { line: 6, ch: 0 },
                     end   = { line: 6, ch: 2 };
@@ -954,7 +942,7 @@ define(function (require, exports, module) {
                 
             });
             
-            // parameter type anotation tests, due to another bug #3670: first argument has ? 
+            // parameter type anotation tests, due to another bug #3670: first argument has ?
             xit("should list parameter Date,boolean type", function () {
                 var start = { line: 109, ch: 0 },
                     testPos = { line: 109, ch: 11 };
@@ -967,7 +955,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            // parameter type anotation tests, due to another bug #3670: first argument has ? 
+            // parameter type anotation tests, due to another bug #3670: first argument has ?
             xit("should list parameter function type and best guess for its argument/return types", function () {
                 var testPos = { line: 123, ch: 11 };
                 
@@ -1073,6 +1061,7 @@ define(function (require, exports, module) {
                     editorJumped({line: 3, ch: 6});
                 });
             });
+            
             it("should jump to closure, early defined var", function () {
                 var start = { line: 17, ch: 9 };
                 
@@ -1209,8 +1198,7 @@ define(function (require, exports, module) {
                 });
             });
 
-            // Tern issue #208. Fixed in the latest tern
-            xit("should list parameter hint for optional parameters", function () {
+            it("should list parameter hint for optional parameters", function () {
                 var testPos = { line: 214, ch: 17 };
 
                 testEditor.setCursorPos(testPos);
@@ -1238,8 +1226,7 @@ define(function (require, exports, module) {
                 });
             });
 
-            // Tern is not returning the correct function type info for the array annotation
-            xit("should list parameter hint for a source array annotation", function () {
+            it("should list parameter hint for a source array annotation", function () {
                 var testPos = { line: 200, ch: 20 };
                 testEditor.setCursorPos(testPos);
                 runs(function () {
@@ -1453,7 +1440,9 @@ define(function (require, exports, module) {
                     hintsPresentExact(hintObj, ["addMessage", "name", "privilegedMethod", "publicMethod1"]);
                 });
             });
-            it("should read methods created in submodule", function () {
+            
+            // bug: wait for tern
+            xit("should read methods created in submodule", function () {
                 var start = { line: 19, ch: 15 };
 
                 runs(function () {
@@ -1474,7 +1463,8 @@ define(function (require, exports, module) {
                     hintsPresentExact(hintObj, ["addMessage", "name", "privilegedMethod", "publicMethod1"]);
                 });
             });
-            // bug: wait for tern 
+
+            // bug: wait for tern
             xit("should read methods created in submodule module", function () {
                 var start        = { line: 62, ch: 0 },
                     testPos          = { line: 62, ch: 13};
@@ -1506,6 +1496,7 @@ define(function (require, exports, module) {
                     hintsPresentExact(hintObj, ["color", "material", "size"]);
                 });
             });
+
             // tern bug: https://github.com/marijnh/tern/issues/147
             xit("should read properties from exported module", function () {
                 var start        = { line: 96, ch: 0 },
@@ -1519,7 +1510,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            // bug in test framework? can't run sequencial jump, verification is wrong 
+            // bug in test framework? can't run sequential jump, verification is wrong
             xit("should jump to a module, depending module", function () {
                 var start        = { line: 93, ch: 25 },
                     testPos      = { line: 8, ch: 35 };
@@ -1653,9 +1644,7 @@ define(function (require, exports, module) {
         
         describe("regression tests", function () {
 
-            // Test maybe valid javascript identifier
-            // FIXME (issue #3558)
-            xit("should return true for valid identifier, false for invalid one", function () {
+            it("should return true for valid identifier, false for invalid one", function () {
                 var identifierList = ["ᾩ", "ĦĔĽĻŎ", "〱〱〱〱", "जावास्क्रि",
                                       "KingGeorgeⅦ", "π", "ಠ_ಠ",
                                       "price_9̶9̶_89", "$_3423", "TRUE", "FALSE", "IV"];
@@ -1738,7 +1727,6 @@ define(function (require, exports, module) {
                 tearDownTest();
             });
 
-            // Test maybe valid javascript identifier
             // FIXME (issue #3558)
             xit("should return true for valid identifier, false for invalid one", function () {
                 var identifierList = ["ᾩ", "ĦĔĽĻŎ", "〱〱〱〱", "जावास्क्रि",
@@ -1769,6 +1757,7 @@ define(function (require, exports, module) {
                 tearDownTest();
                 
             });
+            
             // FIXME (issue #3915)
             xit("should read function name has double byte chars", function () {
                 var start   = { line: 15, ch: 8 },
@@ -1794,6 +1783,7 @@ define(function (require, exports, module) {
                     editorJumped({line: 12, ch: 20});
                 });
             });
+            
             // FIXME (issue #3915)
             xit("should read function name has non ascii chars", function () {
                 var start = { line: 16, ch: 16 };

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, describe, xdescribe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, beforeFirst, afterLast, spyOn */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, beforeFirst, afterLast, spyOn */
 
 define(function (require, exports, module) {
     "use strict";
@@ -447,13 +447,13 @@ define(function (require, exports, module) {
 
         describe("JavaScript Code Hinting Basic", function () {
             beforeFirst(function () {
-                brackets.configureJSCodeHints({
+                brackets._configureJSCodeHints({
                     noReset: true
                 });
             });
             
             afterLast(function () {
-                brackets.configureJSCodeHints({
+                brackets._configureJSCodeHints({
                     noReset: false
                 });
             });
@@ -1441,7 +1441,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            // bug: wait for tern
+            // bug: wait for fix in tern
             xit("should read methods created in submodule", function () {
                 var start = { line: 19, ch: 15 };
 

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waits, waitsForDone, spyOn */
+/*global define, describe, xdescribe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, beforeFirst, afterLast, spyOn */
 
 define(function (require, exports, module) {
     "use strict";
@@ -57,18 +57,7 @@ define(function (require, exports, module) {
         });
     });
     
-    /**
-     * Returns an Editor suitable for use in isolation, given a Document.
-     *
-     * @param {Document} doc - the document to be contained by the new Editor
-     * @return {Editor} - the mock editor object
-     */
-    function createMockEditor(doc) {
-        return SpecRunnerUtils.createMockEditorForDocument(doc);
-    }
-
     describe("JavaScript Code Hinting", function () {
-
         /*
          * Ask provider for hints at current cursor position; expect it to
          * return some
@@ -436,10 +425,10 @@ define(function (require, exports, module) {
 
             // create Editor instance (containing a CodeMirror instance)
             runs(function () {
-                testEditor = createMockEditor(testDoc);
+                testEditor = SpecRunnerUtils.createMockEditorForDocument(testDoc);
                 preTestText = testDoc.getText();
-                
                 waitsForDone(ScopeManager._readyPromise());
+                waitsForDone(ScopeManager._maybeReset(JSCodeHints.getSession(), testDoc, true));
             });
         }
 
@@ -457,7 +446,18 @@ define(function (require, exports, module) {
         }
 
         describe("JavaScript Code Hinting Basic", function () {
-
+            beforeFirst(function () {
+                brackets.configureJSCodeHints({
+                    noReset: true
+                });
+            });
+            
+            afterLast(function () {
+                brackets.configureJSCodeHints({
+                    noReset: false
+                });
+            });
+            
             beforeEach(function () {
                 setupTest(testPath, false);
             });
@@ -725,7 +725,7 @@ define(function (require, exports, module) {
                 var start   = { line: 6, ch: 0 },
                     middle  = { line: 6, ch: 3 },
                     end     = { line: 6, ch: 8 };
-
+                
                 testDoc.replaceRange("A1.", start, start);
                 testEditor.setCursorPos(middle);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);
@@ -896,7 +896,7 @@ define(function (require, exports, module) {
                 });
             });
 
-            xit("should list function defined from .prototype", function () {
+            it("should list function defined from .prototype", function () {
                 var start = { line: 59, ch: 5 };
                 
                 testEditor.setCursorPos(start);
@@ -904,10 +904,9 @@ define(function (require, exports, module) {
                 runs(function () {
                     hintsPresentExact(hintObj, ["calc"]);
                 });
-                
             });
 
-            xit("should list function type defined from .prototype", function () {
+            it("should list function type defined from .prototype", function () {
                 var start = { line: 59, ch: 10 };
                 testEditor.setCursorPos(start);
                 runs(function () {
@@ -915,7 +914,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            xit("should list function inherited from super class", function () {
+            it("should list function inherited from super class", function () {
                 var start = { line: 79, ch: 11 };
                 testEditor.setCursorPos(start);
                 var hintObj = expectHints(JSCodeHints.jsHintProvider);


### PR DESCRIPTION
I changed the resetting behavior for code hint tests to eliminate uncertainty that is causing some test failures. This change also adds some scaffolding that makes it easier to track down JS code hint issues.

Hopefully fixes #5754. This definitely fixes #5811.
