### PR TITLE
Make FileSystemEntry.parentPath null for root directories

### DIFF
--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -138,7 +138,13 @@ define(function (require, exports, module) {
         }
         this._name = parts[parts.length - 1];
         parts.pop(); // Remove name
-        this._parentPath = parts.join("/") + "/";
+        
+        if (parts.length > 0) {
+            this._parentPath = parts.join("/") + "/";
+        } else {
+            // root directories have no parent path
+            this._parentPath = null;
+        }
 
         this._path = newPath;
     };

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -197,12 +197,19 @@ define(function (require, exports, module) {
                 expect(file.name).toBe("file3.txt");
                 expect(directory.name).toBe("foo");
             });
-            it("should have a parentPath property", function () {
+            it("should have a parentPath property if it is not a root directory", function () {
                 var file = fileSystem.getFileForPath("/subdir/file3.txt"),
                     directory = fileSystem.getDirectoryForPath("/subdir/foo/");
                 
                 expect(file.parentPath).toBe("/subdir/");
                 expect(directory.parentPath).toBe("/subdir/");
+            });
+            it("should not have a parentPath property if it is a root directory", function () {
+                var unixRootDir = fileSystem.getDirectoryForPath("/"),
+                    winRootDir = fileSystem.getDirectoryForPath("B:");
+                
+                expect(unixRootDir.parentPath).toBeNull();
+                expect(winRootDir.parentPath).toBeNull();
             });
         });
         


### PR DESCRIPTION
`FileSystemEntry.parentPath` should be null for root directories like `/` or `C:/`. This pull request fixes that and adds a unit test as confirmation. Addresses #5891.
