### PR TITLE
Move require configuration to a new main.js file

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -25,18 +25,6 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global require, define, brackets: true, $, window, navigator, Mustache */
 
-require.config({
-    paths: {
-        "text"      : "thirdparty/text/text",
-        "i18n"      : "thirdparty/i18n/i18n"
-    },
-    // Use custom brackets property until CEF sets the correct navigator.language
-    // NOTE: When we change to navigator.language here, we also should change to
-    // navigator.language in ExtensionLoader (when making require contexts for each
-    // extension).
-    locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
-});
-
 /**
  * brackets is the root of the Brackets codebase. This file pulls in all other modules as
  * dependencies (or dependencies thereof), initializes the UI, and binds global menus & keyboard
@@ -119,10 +107,9 @@ define(function (require, exports, module) {
     require("file/NativeFileError");
     
     PerfUtils.addMeasurement("brackets module dependencies resolved");
-    
 
     // Initialize the file system
-    FileSystem.init(require("filesystem/impls/appshell/AppshellFileSystem"));
+    FileSystem.init(require("fileSystemImpl"));
     
     // Local variables
     var params = new UrlParams();

--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,7 @@
     -->
     
     <!-- All other scripts are loaded through require. -->
-    <script src="thirdparty/requirejs/require.js" data-main="brackets"></script>
+    <script src="thirdparty/requirejs/require.js" data-main="main"></script>
 
     <!-- Verify that all dependencies are loaded. -->
     <script src="dependencies.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/**
+ * The boostrapping module for brackets. This module sets up the require 
+ * configuration and loads the brackets module.
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global require, define, window, brackets, navigator */
+
+require.config({
+    paths: {
+        "text"              : "thirdparty/text/text",
+        "i18n"              : "thirdparty/i18n/i18n",
+        
+        // The file system implementation. Change this value to use different 
+        // implementations (e.g. cloud-based storage).
+        "fileSystemImpl"    : "filesystem/impls/appshell/AppshellFileSystem"
+    },
+    // Use custom brackets property until CEF sets the correct navigator.language
+    // NOTE: When we change to navigator.language here, we also should change to
+    // navigator.language in ExtensionLoader (when making require contexts for each
+    // extension).
+    locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
+});
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    // Load the brackets module. This is a self-running module that loads and runs the entire application.
+    require("brackets");
+});
+


### PR DESCRIPTION
Fix for #5869

Move require configuration to a new main.js file.

This way the global require configuration is separate from the main brackets module,
allowing global configuration changes without requiring changes to core source.

This pull request also changes the hard-coded file system impl path to a new require
path defined in the configuration.
