### PR TITLE
fix: 5912: Resizing Brackets vertically does not resize the image currently in the window.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -272,7 +272,7 @@ a, img {
     }
 
     #img-header {
-        display: inline-block;
+        display: block;
         width: 100%;
         height: 38px;
         margin-bottom: 15px;


### PR DESCRIPTION
fix #5912: the img-header with style inline-block causes the resize problem. Setting to block. 
