### PR TITLE
Simplify some JS code hints filesystem traversals

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -103,21 +103,6 @@ define(function (require, exports, module) {
     function hintableKey(key) {
         return (key === null || key === "." || maybeIdentifier(key));
     }
-
-    /**
-     * Divide a path into directory and filename parts
-     * 
-     * @param {string} path - a URI with directories separated by /
-     * @return {{dir: string, file: string}} - a pair of strings that
-     *      correspond to the directory and filename of the given path.
-     */
-    function splitPath(path) {
-        var index   = path.lastIndexOf("/"),
-            dir     = (index === -1) ? "" : path.substring(0, index),
-            file    = path.substring(index + 1, path.length);
-        
-        return {dir: dir, file: file };
-    }
     
     /*
      * Get a JS-hints-specific event name. Used to prevent event namespace
@@ -203,7 +188,6 @@ define(function (require, exports, module) {
     exports.hintable                    = hintable;
     exports.hintableKey                 = hintableKey;
     exports.maybeIdentifier             = maybeIdentifier;
-    exports.splitPath                   = splitPath;
     exports.eventName                   = eventName;
     exports.annotateLiterals            = annotateLiterals;
     exports.isSupportedLanguage         = isSupportedLanguage;

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -193,19 +193,17 @@ define(function (require, exports, module) {
     /**
      * Test if the file should be excluded from analysis.
      *
-     * @param {!string} path - full directory path.
+     * @param {!File} file - file to test for exclusion.
      * @return {boolean} true if excluded, false otherwise.
      */
-    function isFileExcluded(path) {
+    function isFileExcluded(file) {
         var excludes = preferences.getExcludedFiles();
 
         if (!excludes) {
             return false;
         }
 
-        var file = HintUtils.splitPath(path).file;
-
-        return excludes.test(file);
+        return excludes.test(file.name);
     }
 
     /**
@@ -768,7 +766,7 @@ define(function (require, exports, module) {
              */
             function findNameInProject() {
                 // check for any files in project that end with the right path.
-                var fileName = HintUtils.splitPath(name).file;
+                var fileName = name.substring(name.lastIndexOf("/"));
                 
                 function _fileFilter(entry) {
                     return entry.name === fileName;
@@ -882,7 +880,7 @@ define(function (require, exports, module) {
             FileSystem.resolve(dir, function (err, directory) {
                 function visitor(entry) {
                     if (entry.isFile) {
-                        if (!isFileExcluded(entry.fullPath) && entry.name.indexOf(".") !== 0) { // ignore .dotfiles
+                        if (!isFileExcluded(entry) && entry.name.indexOf(".") !== 0) { // ignore .dotfiles
                             var languageID = LanguageManager.getLanguageForPath(entry.fullPath).getId();
                             if (languageID === HintUtils.LANGUAGE_ID) {
                                 addFilesToTern([entry.fullPath]);
@@ -993,11 +991,10 @@ define(function (require, exports, module) {
          * @param {Document} previousDocument - the document the editor has changed from
          */
         function doEditorChange(session, document, previousDocument) {
-            var path        = document.file.fullPath,
-                split       = HintUtils.splitPath(path),
-                dir         = split.dir,
+            var file        = document.file,
+                path        = file.fullPath,
+                dir         = file.parentPath,
                 files       = [],
-                file        = split.file,
                 pr;
     
             var addFilesDeferred = $.Deferred();
@@ -1044,7 +1041,7 @@ define(function (require, exports, module) {
                         
                         var files = contents
                             .filter(function (entry) {
-                                return entry.isFile && !isFileExcluded(entry.fullPath);
+                                return entry.isFile && !isFileExcluded(entry);
                             })
                             .map(function (entry) {
                                 return entry.fullPath;


### PR DESCRIPTION
This is a code cleanup pull request---made possible by the new filesystem architecture---which removes a few buggy  filesystem traversal functions. I've tried to make ONLY local changes and to preserve the semantic (more or less) of the previous functions. It will surprise no one to hear that I really have no idea what is going on around this code, but the unit tests still pass with the changes and everything seems to work fine for me...

This change is also important because, in the near future, `FileSystemEntry.visit` will be smart enough to not blindly follow cycles of symbolic links forever (see #5892), which the existing filesystem traversal functions in the JS hinter happily do.

CC @gruehle @peterflynn 
