### PR TITLE
Adding condition for skipping symlinks when installing extensions via th...

### DIFF
--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -309,7 +309,10 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
     });
     
     unzipper.extract({
-        path: extractDir
+        path: extractDir,
+        filter: function (file) {
+            return file.type !== "SymbolicLink";
+        }
     });
 }
 


### PR DESCRIPTION
...e extension manager

When installing extensions that have symlinks via the extension
manager, they will fail with a message regarding an invalid zip file.
This can be tested with
https://github.com/MiguelCastillo/Brackets-SymbolicLinks
