### PR TITLE
Add lua comments

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -181,7 +181,9 @@
     "lua": {
         "name": "Lua",
         "mode": "lua",
-        "fileExtensions": ["lua"]
+        "fileExtensions": ["lua"],
+        "blockComment": ["--[[", "]]"],
+        "lineComment": ["--"]
     },
 
     "sql": {


### PR DESCRIPTION
Was working through some lua code in Brackets today and noticed we included the language, but not the comments.

Here are the comments...
