### PR TITLE
Avoid symbolic link cycles

### DIFF
--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -42,7 +42,8 @@ define(function (require, exports, module) {
         NOT_WRITABLE        : "NotWritable",
         OUT_OF_SPACE        : "OutOfSpace",
         TOO_MANY_ENTRIES    : "TooManyEntries",
-        ALREADY_EXISTS      : "AlreadyExists"
+        ALREADY_EXISTS      : "AlreadyExists",
+        LINK_CYCLE          : "LinkCycle"
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -42,8 +42,7 @@ define(function (require, exports, module) {
         NOT_WRITABLE        : "NotWritable",
         OUT_OF_SPACE        : "OutOfSpace",
         TOO_MANY_ENTRIES    : "TooManyEntries",
-        ALREADY_EXISTS      : "AlreadyExists",
-        LINK_CYCLE          : "LinkCycle"
+        ALREADY_EXISTS      : "AlreadyExists"
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/FileSystemStats.js
+++ b/src/filesystem/FileSystemStats.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
         this._isDirectory = !options.isFile;
         this._mtime = options.mtime;
         this._size = options.size;
+        this._realPath = options.realPath;
     }
     
     // Add "isFile", "isDirectory", "mtime" and "size" getters
@@ -59,6 +60,10 @@ define(function (require, exports, module) {
         "size": {
             get: function () { return this._size; },
             set: function () { throw new Error("Cannot set size"); }
+        },
+        "realPath": {
+            get: function () { return this._realPath; },
+            set: function () { throw new Error("Cannot set realPath"); }
         }
     });
     
@@ -85,6 +90,14 @@ define(function (require, exports, module) {
      * @type {Number}
      */
     FileSystemStats.prototype._size = null;
+    
+    /**
+     * The canonical path of this file or directory ONLY if it is a symbolic link,
+     * and null otherwise.
+     * 
+     * @type {?string}
+     */
+    FileSystemStats.prototype._realPath = null;
 
     module.exports = FileSystemStats;
 });

--- a/src/filesystem/FileSystemStats.js
+++ b/src/filesystem/FileSystemStats.js
@@ -33,14 +33,24 @@ define(function (require, exports, module) {
 
     /**
      * @constructor
-     * @param {{isFile: boolean, mtime: Date, size: Number}} options
+     * @param {{isFile: boolean, mtime: Date, size: Number, realPath: ?string}} options
      */
     function FileSystemStats(options) {
-        this._isFile = options.isFile;
-        this._isDirectory = !options.isFile;
+        var isFile = options.isFile;
+        
+        this._isFile = isFile;
+        this._isDirectory = !isFile;
         this._mtime = options.mtime;
         this._size = options.size;
-        this._realPath = options.realPath;
+        
+        var realPath = options.realPath;
+        if (realPath) {
+            if (!isFile && realPath[realPath.length - 1] !== "/") {
+                realPath += "/";
+            }
+        
+            this._realPath = realPath;
+        }
     }
     
     // Add "isFile", "isDirectory", "mtime" and "size" getters

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -153,8 +153,14 @@ define(function (require, exports, module) {
             if (err) {
                 callback(_mapError(err));
             } else {
-                var options = { isFile: stats.isFile(), mtime: stats.mtime, size: stats.size },
-                    fsStats = new FileSystemStats(options);
+                var options = {
+                    isFile: stats.isFile(),
+                    mtime: stats.mtime,
+                    size: stats.size,
+                    realPath: stats.realPath
+                };
+                    
+                var fsStats = new FileSystemStats(options);
                 
                 callback(null, fsStats);
             }

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -695,17 +695,15 @@ define(function (require, exports, module) {
                 waitsFor(function () { return cb.wasCalled; });
                 runs(function () {
                     expect(cb.error).toBeFalsy();
-                    expect(Object.keys(results).length).toBe(12);
+                    expect(Object.keys(results).length).toBe(8);
                     expect(results["/visit/"]).toBeTruthy();
                     expect(results["/visit/file.txt"]).toBeTruthy();
-                    expect(results["/visit/subdir1/"]).toBeTruthy();
-                    expect(results["/visit/subdir2/"]).toBeTruthy();
-                    expect(results["/visit/subdir1/subfile11.txt"]).toBeTruthy();
-                    expect(results["/visit/subdir1/subfile12.txt"]).toBeTruthy();
-                    expect(results["/visit/subdir2/subfile21.txt"]).toBeTruthy();
-                    expect(results["/visit/subdir2/subfile21.txt"]).toBeTruthy();
-                    expect(results["/visit/subdir1/subdir2link/subdir1link/subdir2link/"]).not.toBeTruthy();
-                    expect(results["/visit/subdir1/subdir1link/subdir2link/subdir1link/"]).not.toBeTruthy();
+                    expect(results["/visit/subdir1/"] || results["/visit/subdir2/subdir1link/"]).toBeTruthy();
+                    expect(results["/visit/subdir2/"] || results["/visit/subdir1/subdir2link/"]).toBeTruthy();
+                    expect(results["/visit/subdir1/"] && results["/visit/subdir2/subdir1link/"]).not.toBeTruthy();
+                    expect(results["/visit/subdir2/"] && results["/visit/subdir1/subdir2link/"]).not.toBeTruthy();
+                    expect(results["/visit/subdir1/subdir2link/subdir1link/"]).not.toBeTruthy();
+                    expect(results["/visit/subdir1/subdir1link/subdir2link/"]).not.toBeTruthy();
                     expect(results["/"]).not.toBeTruthy();
                 });
             });

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
     var Directory           = require("filesystem/Directory"),
         File                = require("filesystem/File"),
         FileSystem          = require("filesystem/FileSystem"),
+        FileSystemStats     = require("filesystem/FileSystemStats"),
         FileSystemError     = require("filesystem/FileSystemError"),
         MockFileSystemImpl  = require("./MockFileSystemImpl");
     
@@ -644,6 +645,67 @@ define(function (require, exports, module) {
                     expect(results["/visit/subdir1/subfile12.txt"]).toBeTruthy();
                     expect(results["/visit/subdir2/subfile21.txt"]).not.toBeTruthy();
                     expect(results["/visit/subdir2/subfile21.txt"]).not.toBeTruthy();
+                    expect(results["/"]).not.toBeTruthy();
+                });
+            });
+            
+            it("should converge when visiting directories with symlink cycles", function () {
+                
+                function addSymbolicLink(dir, name, target) {
+
+                    // Add the symbolic link to the base directory
+                    MockFileSystemImpl.when("readdir", dir, { callback: function (cb) {
+                        return function (err, contents, contentsStats, contentsStatsErrors) {
+                            contents.push("/" + name);
+                            contentsStats.push(new FileSystemStats({
+                                isFile: false,
+                                mtime: new Date(),
+                                realPath: target
+                            }));
+                            
+                            cb(err, contents, contentsStats, contentsStatsErrors);
+                        };
+                    }});
+                    
+                    // use the target's contents when listing the contents of the link
+                    MockFileSystemImpl.when("readdir", dir + name + "/", { callback: function (cb) {
+                        return function (err, contents, contentsStats, contentsStatsErrors) {
+                            MockFileSystemImpl.readdir(target, cb);
+                        };
+                    }});
+                    
+                    // clear cached data for the base directory so readdir will be called
+                    fileSystem.getDirectoryForPath(dir)._clearCachedData();
+                }
+                
+                addSymbolicLink("/visit/subdir1/", "subdir2link", "/visit/subdir2/");
+                addSymbolicLink("/visit/subdir2/", "subdir1link", "/visit/subdir1/");
+
+                var directory = fileSystem.getDirectoryForPath("/visit/"),
+                    results = {},
+                    visitor = function (entry) {
+                        results[entry.fullPath] = entry;
+                        return true;
+                    };
+                
+                var cb = getContentsCallback();
+                runs(function () {
+                    directory.visit(visitor, cb);
+                });
+                waitsFor(function () { return cb.wasCalled; });
+                runs(function () {
+                    expect(cb.error).toBeFalsy();
+                    expect(Object.keys(results).length).toBe(12);
+                    expect(results["/visit/"]).toBeTruthy();
+                    expect(results["/visit/file.txt"]).toBeTruthy();
+                    expect(results["/visit/subdir1/"]).toBeTruthy();
+                    expect(results["/visit/subdir2/"]).toBeTruthy();
+                    expect(results["/visit/subdir1/subfile11.txt"]).toBeTruthy();
+                    expect(results["/visit/subdir1/subfile12.txt"]).toBeTruthy();
+                    expect(results["/visit/subdir2/subfile21.txt"]).toBeTruthy();
+                    expect(results["/visit/subdir2/subfile21.txt"]).toBeTruthy();
+                    expect(results["/visit/subdir1/subdir2link/subdir1link/subdir2link/"]).not.toBeTruthy();
+                    expect(results["/visit/subdir1/subdir1link/subdir2link/subdir1link/"]).not.toBeTruthy();
                     expect(results["/"]).not.toBeTruthy();
                 });
             });


### PR DESCRIPTION
This pull request adds symbolic link cycle avoidance to `FileSystemEntry.visit`. It does this by declining to follow symbolic links in subdirectories with the same real path more than once. This ensures that calls to `visit` on directories that form part of a symbolic link cycle always converge. 

**Note 1:** Because this change does not affect the results of `Directory.getContents`, it is still possible to recurse into symbolic link cycles indefinitely. For example, this change does not affect manual expansion of link cycles in the file tree. Furthermore, code that naively traverses directory structures can still diverge! The only example I could find in the Brackets source that performs such a naive traversal is the JS code hinter. Pull request #5917 replaces these ad hoc traversals with calls to `visit`, which solves the problem.

**Note 2:** The `visit` method could also have been modified such that the object itself is not visited if its real path has previously been visited instead of performing this check on the children of Directory objects. This would have a somewhat cleaner implementation, but would require an additional `stat` call. Because Brackets is sensitive to the performance of the `visit` method, I opted against the slightly cleaner implementation in favor of a slightly more performant one.

**Note 3:** For this change to have any effect, a change is required in the behavior of `FileSystemImpl.stat` such that when applied to a symbolic link, the returned `FileSystemStats` object should have an additional property, `realPath`, which evaluates to the canonical path of the target of the link. The `size`, `mtime`, `isFile` and `isDirectory` properties must still describe the target of the link, not the link itself. (Do not confuse the semantics of this function with the semantics of POSIX `lstat`, for example.) For non-links, the behavior of `stat` is unchanged.

**Note 4:** _This change has not yet been made to `AppshellFileSystemImpl` and the Brackets shell._ Merging this change before the corresponding shell changes have landed won't make anything worse, but, still, this code should be considered for-review-only. In the meantime, it can be tested using the [Node filesystem branch](https://github.com/adobe/brackets/tree/iwehrman/nodefs), which makes use of the `NodeFileSystemImpl` for which the [semantics of stat have already been updated](https://github.com/iwehrman/brackets-node-filesystem/blob/master/node/NodeFileSystemDomain.js#L45).

Addresses #5892.
