### PR TITLE
Disable all 'close' event handlers before disconnecting in NodeConnection-test.js

### DIFF
--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -106,6 +106,7 @@ define(function (require, exports, module) {
         
         afterEach(function () {
             _connectionsToAutoDisconnect.forEach(function (c) {
+                $(c).off("close");
                 c.disconnect();
             });
         });


### PR DESCRIPTION
There is an unhandled exception triggered by the final test in `NodeConnection-test.js`. It's caused by a `"close"` event handler that expects a reconnection promise which does not exist. Reconnection promises are provided for connections that are set to auto-reconnect, but **not** when the connection is explicitly closed with `disconnect()`. This pull request disables `"close"` event handlers before disconnecting all of the connections opened for testing in the `afterEach` handler.

Assigning to @dangoor. Should be easy to verify. 
