### PR TITLE
Couzteau/fix 5749 language manger mode warning on binary file

### DIFF
--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -96,6 +96,18 @@
  *
  * If a mode is not shipped with our CodeMirror distribution, you need to first load it yourself.
  * If the mode is part of our CodeMirror distribution, it gets loaded automatically.
+ *
+ * You can also defines binary file types, i.e. Brackets supports image files by default, 
+ * such as *.jpg, *.png etc.
+ * Binary files do not require mode because modes are specific to code mirror, which
+ * only handles text based file types.
+ * To register a binary language the isBinary flag must be set, i.e.
+ *     LanguageManager.defineLanguage("audio", {
+ *         name: "Audio",
+ *         fileExtensions: ["mp3", "wav", "aif", "aiff", "ogg"],
+ *         isBinary: true    
+ *     }); 
+ * 
  */
 define(function (require, exports, module) {
     "use strict";
@@ -670,51 +682,49 @@ define(function (require, exports, module) {
             i,
             l;
         
-        if (!language._setId(id) || !language._setName(name) ||
-                (blockComment && !language.setBlockCommentSyntax(blockComment[0], blockComment[1])) ||
-                (lineComment && !language.setLineCommentSyntax(lineComment))) {
-            result.reject();
-            return result.promise();
-        }
-        
-        // track languages that are currently loading
-        _pendingLanguages[id] = language;
-        
-        if (definition.isBinary) {
+        function _finishRegisteringLanguage() {
             // register language file extensions for binary file extensions
             if (fileExtensions) {
                 for (i = 0, l = fileExtensions.length; i < l; i++) {
                     language.addFileExtension(fileExtensions[i]);
                 }
             }
+            // register language file names after mode has loaded
+            if (fileNames) {
+                for (i = 0, l = fileNames.length; i < l; i++) {
+                    language.addFileName(fileNames[i]);
+                }
+            }
+            // store language to language map
             _languages[language.getId()] = language;
-            // delete from pending languages after success and failure
-            delete _pendingLanguages[id];
+        }
+        
+        if (!language._setId(id) || !language._setName(name) ||
+                (blockComment && !language.setBlockCommentSyntax(blockComment[0], blockComment[1])) ||
+                (lineComment && !language.setLineCommentSyntax(lineComment))) {
+            result.reject();
+            return result.promise();
+        }
+
+        
+        if (definition.isBinary) {
+            // add file extensions and store language to language map
+            _finishRegisteringLanguage();
+            
             result.resolve(language);
             // Not notifying DocumentManager via event LanguageAdded, because DocumentManager
             // does not care about binary files.
         } else {
-
+            // track languages that are currently loading
+            _pendingLanguages[id] = language;
+            
             language._loadAndSetMode(definition.mode).done(function () {
-                // register language file extensions after mode has loaded
-                if (fileExtensions) {
-                    for (i = 0, l = fileExtensions.length; i < l; i++) {
-                        language.addFileExtension(fileExtensions[i]);
-                    }
-                }
-                
-                // register language file names after mode has loaded
-                if (fileNames) {
-                    for (i = 0, l = fileNames.length; i < l; i++) {
-                        language.addFileName(fileNames[i]);
-                    }
-                }
-                    
+  
                 // globally associate mode to language
                 _setLanguageForMode(language.getMode(), language);
                 
-                // finally, store language to _language map
-                _languages[language.getId()] = language;
+                // add file extensions and store language to language map
+                _finishRegisteringLanguage();
                 
                 // fire an event to notify DocumentManager of the new language
                 _triggerLanguageAdded(language);

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -99,7 +99,7 @@
  *
  * You can also defines binary file types, i.e. Brackets supports image files by default, 
  * such as *.jpg, *.png etc.
- * Binary files do not require mode because modes are specific to code mirror, which
+ * Binary files do not require mode because modes are specific to CodeMirror, which
  * only handles text based file types.
  * To register a binary language the isBinary flag must be set, i.e.
  *     LanguageManager.defineLanguage("audio", {
@@ -683,7 +683,6 @@ define(function (require, exports, module) {
             l;
         
         function _finishRegisteringLanguage() {
-            // register language file extensions for binary file extensions
             if (fileExtensions) {
                 for (i = 0, l = fileExtensions.length; i < l; i++) {
                     language.addFileExtension(fileExtensions[i]);

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -224,6 +224,7 @@
     "image": {
         "name": "Image",
         "mode": ["null", "text/plain"],
-        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg"]
+        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg"],
+        "isBinary": true
     }
 }

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -223,7 +223,6 @@
   
     "image": {
         "name": "Image",
-        "mode": ["null", "text/plain"],
         "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg"],
         "isBinary": true
     }


### PR DESCRIPTION
fix #5749: do not show warning when registering languages for binary file types. KM will still register the language and return a language by getlanguageForPath. Binary languages are defined by defining the isBinary member. languages for binary types do not have a CM mode.
