### PR TITLE
[FileSystem] Add an error parameter to the FileSystemEntry.exists callback

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -396,7 +396,12 @@ define(function (require, exports, module) {
             var path = dir + "/" + suggestedName;
             var entry = isFolder ? FileSystem.getDirectoryForPath(path) : FileSystem.getFileForPath(path);
             
-            entry.exists(function (exists) {
+            entry.exists(function (err, exists) {
+                if (err) {
+                    result.reject(err);
+                    return;
+                }
+                
                 if (exists) {
                     //file exists, notify to the next progress
                     result.notify(baseFileName + "-" + _nextUntitledIndexToUse++ + fileExt);

--- a/src/document/InMemoryFile.js
+++ b/src/document/InMemoryFile.js
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
     // Stub out invalid calls inherited from FileSystemEntry
     
     InMemoryFile.prototype.exists = function (callback) {
-        callback(false);
+        callback(null, false);
     };
     
     InMemoryFile.prototype.stat = function (callback) {

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -216,8 +216,8 @@ define(function (require, exports, module) {
             FileUtils.getNativeBracketsDirectoryPath() + "/../test/SpecRunner.html"
         );
         
-        file.exists(function (exists) {
-            if (exists) {
+        file.exists(function (err, exists) {
+            if (!err && exists) {
                 // If the SpecRunner.html file exists, enable the menu item.
                 // (menu item is already disabled, so no need to disable if the
                 // file doesn't exist).

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -172,8 +172,8 @@ define(function (require, exports, module) {
      * during the test, in which case the state of the entry should be considered
      * unknown.
      *
-     * @param {function (?string, boolean)} callback Callback with an error string
-     *      or a boolean indicating whether or not the file exists.
+     * @param {function (?string, boolean)} callback Callback with a FileSystemError
+     *      string or a boolean indicating whether or not the file exists.
      */
     FileSystemEntry.prototype.exists = function (callback) {
         this._impl.exists(this._path, callback);

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -165,9 +165,15 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Check to see if the entry exists on disk.
+     * Check to see if the entry exists on disk. Note that there will NOT be an
+     * error returned if the file does not exist on the disk; in that case the
+     * error parameter will be null and the boolean will be false. The error 
+     * parameter will only be truthy when an unexpected error was encountered
+     * during the test, in which case the state of the entry should be considered
+     * unknown.
      *
-     * @param {function (boolean)} callback Callback with a single parameter.
+     * @param {function (?string, boolean)} callback Callback with an error string
+     *      or a boolean indicating whether or not the file exists.
      */
     FileSystemEntry.prototype.exists = function (callback) {
         this._impl.exists(this._path, callback);

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -164,10 +164,15 @@ define(function (require, exports, module) {
     function exists(path, callback) {
         stat(path, function (err) {
             if (err) {
-                callback(false);
-            } else {
-                callback(true);
+                if (err === FileSystemError.NOT_FOUND) {
+                    callback(null, false);
+                } else {
+                    callback(err);
+                }
+                return;
             }
+
+            callback(null, true);
         });
     }
     
@@ -262,7 +267,12 @@ define(function (require, exports, module) {
     function writeFile(path, data, options, callback) {
         var encoding = options.encoding || "utf8";
         
-        exists(path, function (alreadyExists) {
+        exists(path, function (err, alreadyExists) {
+            if (err) {
+                callback(err);
+                return;
+            }
+            
             appshell.fs.writeFile(path, data, encoding, function (err) {
                 if (err) {
                     callback(_mapError(err));

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -972,7 +972,7 @@ define(function (require, exports, module) {
             }
             // Point at a real folder structure on local disk
             var rootEntry = FileSystem.getDirectoryForPath(rootPath);
-            rootEntry.exists(function (exists) {
+            rootEntry.exists(function (err, exists) {
                 if (exists) {
                     var projectRootChanged = (!_projectRoot || !rootEntry) ||
                         _projectRoot.fullPath !== rootEntry.fullPath;
@@ -1021,7 +1021,7 @@ define(function (require, exports, module) {
                         StringUtils.format(
                             Strings.REQUEST_NATIVE_FILE_SYSTEM_ERROR,
                             StringUtils.breakableUrl(rootPath),
-                            FileSystemError.NOT_FOUND
+                            err || FileSystemError.NOT_FOUND
                         )
                     ).done(function () {
                         // The project folder stored in preference doesn't exist, so load the default

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -159,7 +159,12 @@ define(function (require, exports, module) {
         // check if the file already exists
         var file = FileSystem.getFileForPath(path);
         
-        file.exists(function (exists) {
+        file.exists(function (err, exists) {
+            if (err) {
+                _writeResults.reject(err);
+                return;
+            }
+            
             if (exists) {
                 // file exists, do not overwrite
                 _writeResults.reject();

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -409,7 +409,8 @@ define(function (require, exports, module) {
                     cbCalled = false;
                 
                 runs(function () {
-                    directory.exists(function (exists) {
+                    directory.exists(function (err, exists) {
+                        expect(err).toBeFalsy();
                         expect(exists).toBe(false);
                         cbCalled = true;
                     });
@@ -421,7 +422,8 @@ define(function (require, exports, module) {
                 waitsFor(function () { return cb.wasCalled; });
                 runs(function () {
                     expect(cb.error).toBeFalsy();
-                    directory.exists(function (exists) {
+                    directory.exists(function (err, exists) {
+                        expect(err).toBeFalsy();
                         expect(exists).toBe(true);
                     });
                 });
@@ -487,7 +489,8 @@ define(function (require, exports, module) {
                     newContents = "New file contents";
                 
                 runs(function () {
-                    file.exists(function (exists) {
+                    file.exists(function (err, exists) {
+                        expect(err).toBeFalsy();
                         expect(exists).toBe(false);
                         cbCalled = true;
                     });

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
 
     function exists(path, callback) {
         var cb = _getCallback("exists", path, callback);
-        cb(!!_data[path]);
+        cb(null, !!_data[path]);
     }
     
     function readdir(path, callback) {
@@ -273,9 +273,15 @@ define(function (require, exports, module) {
             options = null;
         }
         
-        exists(path, function (exists) {
-            var cb = _getCallback("writeFile", path, callback),
-                notification = exists ? _sendWatcherNotification : _sendDirectoryWatcherNotification,
+        exists(path, function (err, exists) {
+            var cb = _getCallback("writeFile", path, callback);
+            
+            if (err) {
+                cb(err);
+                return;
+            }
+            
+            var notification = exists ? _sendWatcherNotification : _sendDirectoryWatcherNotification,
                 notify = _getNotification("writeFile", path, notification);
             
             if (!_data[path]) {


### PR DESCRIPTION
This pull request adds an error parameter to the `FileSystemEntry.exists` callback. Previously, the callback received a single boolean parameter. Now it receives an error string, which may be null, and an optional boolean. As with all the rest of the filesystem API, the second parameter will be defined iff the first parameter is falsey. 

Currently, failure to successfully stat an entry is interpreted by `exists` as non-existence of the entry. But this should not be the case for all errors. In fact, this should only be the case when the stat error is `FileSystemError.NOT_FOUND`. Otherwise, the existence of the file is unclear. The error parameter has been added to handle such scenarios in which existence cannot be reliably determined. 

**This pull request changes the client-facing filesystem API.** There are currently no extensions in the registry that rely on `exists`---probably because the method hasn't been shipped in a sprint build yet. Landing this breaking change _before_ the current sprint ends should thus be considered highly desirable!

As I understand it, @peterflynn has already signed off on the high-level idea of this change. I'd like @gruehle to do so too, so I'm tentatively assigning to him in order to force a :thumbsup: or :thumbsdown:, though he may wish to kick it back to @peterflynn to scrutinize my semicolons.
