### PR TITLE
UrlCodeHints should not try to handle filesystem changes until after appReady

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -755,17 +755,18 @@ define(function (require, exports, module) {
 
         var urlHints = new UrlCodeHints();
         CodeHintManager.registerHintProvider(urlHints, ["css", "html"], 5);
+        
+        function _clearCachedHints() {
+            // Cache may or may not be stale. Main benefit of cache is to limit async lookups
+            // during typing. File tree updates cannot happen during typing, so it's probably
+            // not worth determining whether cache may still be valid. Just delete it.
+            urlHints.cachedHints = null;
+        }
+        
+        FileSystem.on("change", _clearCachedHints);
+        FileSystem.on("rename", _clearCachedHints);
 
         // For unit testing
         exports.hintProvider = urlHints;
     });
-    
-    function _clearCachedHints() {
-        // Cache may or may not be stale. Main benefit of cache is to limit async lookups
-        // during typing. File tree updates cannot happen during typing, so it's probably
-        // not worth determining whether cache may still be valid. Just delete it.
-        exports.hintProvider.cachedHints = null;
-    }
-    FileSystem.on("change", _clearCachedHints);
-    FileSystem.on("rename", _clearCachedHints);
 });


### PR DESCRIPTION
This pull request just moves the filesystem change handler registration from the module scope to the `appReady` event handler. When the change handlers are registered in the module scope, it's possible to get a `ReferenceError` by trying to clear a property on the `CodeHintProvider` before it has been defined. 

I screwed this up during the filesystem merge. Sorry!
