### PR TITLE
Added ESC, Y, A, N, and S as keyboard shortcuts to the Replace and Find ...

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -574,8 +574,7 @@ define(function (require, exports, module) {
                         }
                     });
                     modalBar.getRoot().on("keyup", function (e) {
-                        switch(e.keyCode)
-                        {
+                        switch (e.keyCode) {
                         case KeyEvent.DOM_VK_ESCAPE:
                             modalBar.close();
                             break;
@@ -590,8 +589,6 @@ define(function (require, exports, module) {
                             break;
                         case KeyEvent.DOM_VK_S:
                             modalBar.close();
-                            break;
-                        default:
                             break;
                         }
                     });

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -573,7 +573,7 @@ define(function (require, exports, module) {
                         }
                     });
                     modalBar.getRoot().on("keyup", function (e) {
-                        if (e.keyCode == 27 /*ESC*/ || e.keyCode == 89 /*Y*/ || e.keyCode == 65 /*A*/ || e.keyCode == 78 /*N*/ || e.keyCode == 83 /*S*/) {
+                        if (e.keyCode === 27 /*ESC*/ || e.keyCode === 89 /*Y*/ || e.keyCode === 65 /*A*/ || e.keyCode === 78 /*N*/ || e.keyCode === 83 /*S*/) {
                             if (e.keyCode === 27) {
                                 modalBar.prepareClose();
                                 modalBar.close();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -572,6 +572,30 @@ define(function (require, exports, module) {
                             modalBar = null;
                         }
                     });
+                    modalBar.getRoot().on("keyup", function (e) {
+                        if (e.keyCode == 27 /*ESC*/ || e.keyCode == 89 /*Y*/ || e.keyCode == 65 /*A*/ || e.keyCode == 78 /*N*/ || e.keyCode == 83 /*S*/) {
+                            if (e.keyCode == 27) {
+                                modalBar.prepareClose();
+                                modalBar.close();
+                            }
+                            if (e.keyCode == 89) {
+                                doReplace(match);
+                            }
+                            if (e.keyCode == 65) {
+                                _showReplaceAllPanel(editor, query, text);
+                            }
+                            if (e.keyCode == 78) {
+                                advance();
+                            }
+                            if (e.keyCode == 83) {
+                                modalBar.prepareClose();
+                                modalBar.close();
+                            }
+                        }
+                        // if (e.keyCode == 89)
+                        //     doReplace(match);
+                        // }
+                    });
                 };
                 var doReplace = function (match) {
                     cursor.replace(typeof query === "string" ? text : parseDollars(text, match));

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -576,23 +576,23 @@ define(function (require, exports, module) {
                     modalBar.getRoot().on("keyup", function (e) {
                         switch(e.keyCode)
                         {
-                            case KeyEvent.DOM_VK_ESCAPE:
-                                modalBar.close();
-                                break;
-                            case KeyEvent.DOM_VK_Y:
-                                doReplace(match);
-                                break;
-                            case KeyEvent.DOM_VK_A:
-                                _showReplaceAllPanel(editor, query, text);
-                                break;
-                            case KeyEvent.DOM_VK_N:
-                                advance();
-                                break;
-                            case KeyEvent.DOM_VK_S:
-                                modalBar.close();
-                                break;
-                            default:
-                                break;
+                        case KeyEvent.DOM_VK_ESCAPE:
+                            modalBar.close();
+                            break;
+                        case KeyEvent.DOM_VK_Y:
+                            doReplace(match);
+                            break;
+                        case KeyEvent.DOM_VK_A:
+                            _showReplaceAllPanel(editor, query, text);
+                            break;
+                        case KeyEvent.DOM_VK_N:
+                            advance();
+                            break;
+                        case KeyEvent.DOM_VK_S:
+                            modalBar.close();
+                            break;
+                        default:
+                            break;
                         }
                     });
                 };

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
         StringUtils         = require("utils/StringUtils"),
         Editor              = require("editor/Editor"),
         EditorManager       = require("editor/EditorManager"),
+        KeyEvent            = require("utils/KeyEvent"),
         ModalBar            = require("widgets/ModalBar").ModalBar,
         ScrollTrackMarkers  = require("search/ScrollTrackMarkers"),
         PanelManager        = require("view/PanelManager"),
@@ -573,28 +574,26 @@ define(function (require, exports, module) {
                         }
                     });
                     modalBar.getRoot().on("keyup", function (e) {
-                        if (e.keyCode === 27 /*ESC*/ || e.keyCode === 89 /*Y*/ || e.keyCode === 65 /*A*/ || e.keyCode === 78 /*N*/ || e.keyCode === 83 /*S*/) {
-                            if (e.keyCode === 27) {
-                                modalBar.prepareClose();
+                        switch(e.keyCode)
+                        {
+                            case KeyEvent.DOM_VK_ESCAPE:
                                 modalBar.close();
-                            }
-                            if (e.keyCode === 89) {
+                                break;
+                            case KeyEvent.DOM_VK_Y:
                                 doReplace(match);
-                            }
-                            if (e.keyCode === 65) {
+                                break;
+                            case KeyEvent.DOM_VK_A:
                                 _showReplaceAllPanel(editor, query, text);
-                            }
-                            if (e.keyCode === 78) {
+                                break;
+                            case KeyEvent.DOM_VK_N:
                                 advance();
-                            }
-                            if (e.keyCode === 83) {
-                                modalBar.prepareClose();
+                                break;
+                            case KeyEvent.DOM_VK_S:
                                 modalBar.close();
-                            }
+                                break;
+                            default:
+                                break;
                         }
-                        // if (e.keyCode == 89)
-                        //     doReplace(match);
-                        // }
                     });
                 };
                 var doReplace = function (match) {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -574,20 +574,20 @@ define(function (require, exports, module) {
                     });
                     modalBar.getRoot().on("keyup", function (e) {
                         if (e.keyCode == 27 /*ESC*/ || e.keyCode == 89 /*Y*/ || e.keyCode == 65 /*A*/ || e.keyCode == 78 /*N*/ || e.keyCode == 83 /*S*/) {
-                            if (e.keyCode == 27) {
+                            if (e.keyCode === 27) {
                                 modalBar.prepareClose();
                                 modalBar.close();
                             }
-                            if (e.keyCode == 89) {
+                            if (e.keyCode === 89) {
                                 doReplace(match);
                             }
-                            if (e.keyCode == 65) {
+                            if (e.keyCode === 65) {
                                 _showReplaceAllPanel(editor, query, text);
                             }
-                            if (e.keyCode == 78) {
+                            if (e.keyCode === 78) {
                                 advance();
                             }
-                            if (e.keyCode == 83) {
+                            if (e.keyCode === 83) {
                                 modalBar.prepareClose();
                                 modalBar.close();
                             }


### PR DESCRIPTION
Submitting fix to bug: https://github.com/adobe/brackets/issues/5005. ESC, Y, A, N, and S keyboard shortcuts were added to the Replace and Find function. No deletion of code was necessary. I simply attached a handler to the 'modalBar' object that watched for key events and performed the necessary functions fi the above keyCodes were realized.
