### PR TITLE
fix 5962: Coordinates tag showing wrong coordinates while modal bar is open

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -55,8 +55,14 @@ define(function (require, exports, module) {
         }
     }
     
+    function _hideGuides() {
+        $("#img-tip").hide();
+        $(".img-guide").hide();
+    }
+    
     /** handle editor resize event, i.e. update scale sticker */
     function _onEditorAreaResize() {
+        _hideGuides();
         _updateScale($("#img-preview").width());
     }
         
@@ -258,8 +264,7 @@ define(function (require, exports, module) {
         // Hide image tip and guides only if the cursor is outside of the image.
         if (x < imagePos.left || x >= right ||
                 y < imagePos.top || y >= bottom) {
-            $("#img-tip").hide();
-            $(".img-guide").hide();
+            _hideGuides();
         }
     }
 

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -55,14 +55,14 @@ define(function (require, exports, module) {
         }
     }
     
-    function _hideGuides() {
+    function _hideGuidesAndTip() {
         $("#img-tip").hide();
         $(".img-guide").hide();
     }
     
     /** handle editor resize event, i.e. update scale sticker */
     function _onEditorAreaResize() {
-        _hideGuides();
+        _hideGuidesAndTip();
         _updateScale($("#img-preview").width());
     }
         
@@ -264,7 +264,7 @@ define(function (require, exports, module) {
         // Hide image tip and guides only if the cursor is outside of the image.
         if (x < imagePos.left || x >= right ||
                 y < imagePos.top || y >= bottom) {
-            _hideGuides();
+            _hideGuidesAndTip();
         }
     }
 


### PR DESCRIPTION
fix #5962: fixing by hiding guides when modal bar opens. 
