### PR TITLE
fix DocumentCommandHandlers and DragAndDrop  unit tests

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
             if (viewProvider) {
                 EditorManager.showCustomViewer(viewProvider, fullPath).always(function () {
                     result.resolve();
-                }); 
+                });
             } else {
                 // Load the file if it was never open before, and then switch to it in the UI
                 DocumentManager.getDocumentForPath(fullPath)

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -190,11 +190,9 @@ define(function (require, exports, module) {
 
             var viewProvider = EditorManager.getCustomViewerForPath(fullPath);
             if (viewProvider) {
-                EditorManager.showCustomViewer(viewProvider, fullPath).done(function () {
+                EditorManager.showCustomViewer(viewProvider, fullPath).always(function () {
                     result.resolve();
-                }).fail(function () {
-                    result.reject();
-                });
+                }); 
             } else {
                 // Load the file if it was never open before, and then switch to it in the UI
                 DocumentManager.getDocumentForPath(fullPath)

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -190,8 +190,11 @@ define(function (require, exports, module) {
 
             var viewProvider = EditorManager.getCustomViewerForPath(fullPath);
             if (viewProvider) {
-                EditorManager.showCustomViewer(viewProvider, fullPath);
-                result.resolve();
+                EditorManager.showCustomViewer(viewProvider, fullPath).done(function () {
+                    result.resolve();
+                }).fail(function () {
+                    result.reject();
+                });
             } else {
                 // Load the file if it was never open before, and then switch to it in the UI
                 DocumentManager.getDocumentForPath(fullPath)

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -647,33 +647,52 @@ define(function (require, exports, module) {
      * If param fullpath is provided then only if fullpath matches 
      * the currently viewed file an alternate file will be opened.
      * @param {?string} fullPath - file path of deleted file.
+     * @return {!Promise} A promise resolved after we opening an alternate file
+     * or showing no editor view.     
      */
     function notifyPathDeleted(fullPath) {
+        var result = new $.Deferred();
         function openAlternateFile() {
             var fileToOpen = DocumentManager.getNextPrevFile(1);
             if (fileToOpen) {
-                CommandManager.execute(Commands.FILE_OPEN, {fullPath: fileToOpen.fullPath});
+                CommandManager.execute(Commands.FILE_OPEN, {fullPath: fileToOpen.fullPath}).always(function () {
+                    result.resolve();
+                });
             } else {
                 _removeCustomViewer();
                 _showNoEditor();
                 _setCurrentlyViewedPath();
+                result.resolve();
             }
         }
         if (!fullPath || _currentlyViewedPath === fullPath) {
             openAlternateFile();
+        } else {
+            result.resolve();
         }
+        return result.promise();
     }
     
     /*
      * show a generic error or File Not Found in modal error dialog
+     * @param {!String} err - to display if file exists test failed
+     * @param {!String} fullPath - path to display if file exists test failed
+     * @return {!Promise} A promise resolved after we opening an alternate file
+     * or showing no editor view.
      */
     function _showErrorAndNotify(err, fullPath) {
-        var errorToShow = err || FileSystemError.NOT_FOUND;
+        var result = new $.Deferred(),
+            errorToShow = err || FileSystemError.NOT_FOUND;
+        
         FileUtils.showFileOpenError(errorToShow, fullPath).done(
             function () {
-                notifyPathDeleted();
+                notifyPathDeleted().done(function () {
+                    result.resolve();
+                });
             }
         );
+
+        return result.promise();
     }
 
     /*
@@ -709,15 +728,16 @@ define(function (require, exports, module) {
      * Append custom view to editor-holder
      * @param {!Object} provider  custom view provider
      * @param {!string} fullPath  path to the file displayed in the custom view
-     * @return {!Promise} A promise resolved after image is displayed, rejected when 
-     *   image file not found.
+     * @return {!Promise} A promise resolved after image is displayed, also resolved
+     * if image file not found.
      */
     function showCustomViewer(provider, fullPath) {
         var result = new $.Deferred();
         function _doShow(err, fileExists) {
             if (!fileExists) {
-                _showErrorAndNotify(err, fullPath);
-                result.resolve();
+                _showErrorAndNotify(err, fullPath).always(function () {
+                    result.resolve();
+                });
             } else {
                 // Don't show the same custom view again if file path
                 // and view provider are still the same.

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -717,7 +717,7 @@ define(function (require, exports, module) {
         function _doShow(err, fileExists) {
             if (!fileExists) {
                 _showErrorAndNotify(err, fullPath);
-                result.reject();
+                result.resolve();
             } else {
                 // Don't show the same custom view again if file path
                 // and view provider are still the same.

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -701,7 +701,7 @@ define(function (require, exports, module) {
      */
     function closeCustomViewer() {
         _removeCustomViewer();
-        _setCurrentlyViewedPath();
+        _currentlyViewedPath = "";
         _showNoEditor();
     }
     
@@ -709,16 +709,21 @@ define(function (require, exports, module) {
      * Append custom view to editor-holder
      * @param {!Object} provider  custom view provider
      * @param {!string} fullPath  path to the file displayed in the custom view
+     * @return {!Promise} A promise resolved after image is displayed, rejected when 
+     *   image file not found.
      */
     function showCustomViewer(provider, fullPath) {
+        var result = new $.Deferred();
         function _doShow(err, fileExists) {
             if (!fileExists) {
                 _showErrorAndNotify(err, fullPath);
+                result.reject();
             } else {
                 // Don't show the same custom view again if file path
                 // and view provider are still the same.
                 if (_currentlyViewedPath === fullPath &&
                         _currentViewProvider === provider) {
+                    result.resolve();
                     return;
                 }
                 
@@ -742,10 +747,13 @@ define(function (require, exports, module) {
                 // close and warn if the file is gone.
                 window.addEventListener("focus", _checkFileExists);
                 _setCurrentlyViewedPath(fullPath);
+                result.resolve();
             }
         }
         var file = FileSystem.getFileForPath(fullPath);
         file.exists(_doShow);
+        
+        return result.promise();
     }
                
 

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -701,7 +701,7 @@ define(function (require, exports, module) {
      */
     function closeCustomViewer() {
         _removeCustomViewer();
-        _currentlyViewedPath = "";
+        _currentlyViewedPath = null;
         _showNoEditor();
     }
     

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -1069,27 +1069,31 @@ define(function (require, exports, module) {
         describe("Opens image file and validates EditorManager APIs", function () {
             it("should return null after opening an image", function () {
                 var path = testPath + "/couz.png",
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: path }).done(function (result) {
-                        expect(EditorManager.getActiveEditor()).toEqual(null);
-                        expect(EditorManager.getCurrentFullEditor()).toEqual(null);
-                        expect(EditorManager.getFocusedEditor()).toEqual(null);
-                        expect(EditorManager.getCurrentlyViewedPath()).toEqual(path);
-                        var d = DocumentManager.getCurrentDocument();
-                        expect(d).toEqual(null);
-                    });
-                waitsForDone(promise, Commands.FILE_OPEN);
+                    promise;
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: path });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+
+                runs(function () {
+                    expect(EditorManager.getActiveEditor()).toEqual(null);
+                    expect(EditorManager.getCurrentFullEditor()).toEqual(null);
+                    expect(EditorManager.getFocusedEditor()).toEqual(null);
+                    expect(EditorManager.getCurrentlyViewedPath()).toEqual(path);
+                    var d = DocumentManager.getCurrentDocument();
+                    expect(d).toEqual(null);
+                });
             });
         });
         
         describe("Open image file while a text file is open", function () {
             it("should fire currentDocumentChange and activeEditorChange events", function () {
-
                 var promise,
                     docChangeListener = jasmine.createSpy(),
                     activeEditorChangeListener = jasmine.createSpy();
+                
                 docChangeListener.callCount = 0;
                 activeEditorChangeListener.callCount = 0;
-
 
                 runs(function () {
                     _$(DocumentManager).on("currentDocumentChange", docChangeListener);

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -1068,15 +1068,16 @@ define(function (require, exports, module) {
 
         describe("Opens image file and validates EditorManager APIs", function () {
             it("should return null after opening an image", function () {
-                var path = testPath + "/couz.png";
-                CommandManager.execute(Commands.FILE_OPEN, { fullPath: path }).done(function (result) {
-                    expect(EditorManager.getActiveEditor()).toEqual(null);
-                    expect(EditorManager.getCurrentFullEditor()).toEqual(null);
-                    expect(EditorManager.getFocusedEditor()).toEqual(null);
-                    expect(EditorManager.getCurrentlyViewedPath()).toEqual(path);
-                    var d = DocumentManager.getCurrentDocument();
-                    expect(d).toEqual(null);
-                });
+                var path = testPath + "/couz.png",
+                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: path }).done(function (result) {
+                        expect(EditorManager.getActiveEditor()).toEqual(null);
+                        expect(EditorManager.getCurrentFullEditor()).toEqual(null);
+                        expect(EditorManager.getFocusedEditor()).toEqual(null);
+                        expect(EditorManager.getCurrentlyViewedPath()).toEqual(path);
+                        var d = DocumentManager.getCurrentDocument();
+                        expect(d).toEqual(null);
+                    });
+                waitsForDone(promise, Commands.FILE_OPEN);
             });
         });
         
@@ -1086,6 +1087,8 @@ define(function (require, exports, module) {
                 var promise,
                     docChangeListener = jasmine.createSpy(),
                     activeEditorChangeListener = jasmine.createSpy();
+                docChangeListener.callCount = 0;
+                activeEditorChangeListener.callCount = 0;
 
 
                 runs(function () {


### PR DESCRIPTION
fix #5986
- fix bug revealed by unit tests: made EditorManager.showCustomViewer async to honor the async file.exists() test. fixing tests  by making sure image is fully displayed before evaluating expectations
- remove code that was forcing project tree refresh, this was causing doOpen to be run multiple times thus sending too many documentChange and editorChange events- reverting the fix for #5737
- fix test case. previous test case was still tearing down while new test case was running, hence
