### PR TITLE
When InlineDocViewer has scrollbars, don't let keyboard scrolling events propagate

### DIFF
--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
@@ -3,7 +3,7 @@
         <h1>{{propName}}</h1>
         <div>{{{summary}}}</div>
     </div>
-    <div class="divider-holder">
+    <div class="divider-holder no-focus">
         <div class="divider"></div>
     </div>
     <div class="css-prop-values quiet-scrollbars">
@@ -17,5 +17,5 @@
         </div>
     </div>
     <div class="content-bottom"></div>
-    <a class="more-info" href="{{url}}" title="{{url}}">{{Strings.DOCS_MORE_LINK}}</a>
+    <a class="more-info no-focus" href="{{url}}" title="{{url}}">{{Strings.DOCS_MORE_LINK}}</a>
 </div>

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.html
@@ -17,5 +17,5 @@
         </div>
     </div>
     <div class="content-bottom"></div>
-    <a class="more-info no-focus" href="{{url}}" title="{{url}}">{{Strings.DOCS_MORE_LINK}}</a>
+    <a class="more-info" href="{{url}}" title="{{url}}">{{Strings.DOCS_MORE_LINK}}</a>
 </div>

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -96,9 +96,9 @@ define(function (require, exports, module) {
     InlineDocsViewer.prototype.$wrapperDiv = null;
     
     /**
-     * Convert keydown events into navigation actions.
+     * Handle scrolling.
      *
-     * @param {KeyBoardEvent} keyEvent
+     * @param {Event} event Keyboard event or mouse scrollwheel event
      * @param {boolean} scrollingUp Is event to scroll up?
      * @param {DOMElement} scroller Element to scroll
      * @return {boolean} indication whether key was handled

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -159,21 +159,25 @@ define(function (require, exports, module) {
             return false;
         }
 
-        $container = $(event.target).closest(".css-prop-defn");
-
-        // Only handle keys when target is inside doc viewer
-        if ($container.length === 0 || $container[0] !== this.$wrapperDiv[0]) {
-            return false;
-        }
-
+        // Only handle keydown event
         if (event.type === "keydown") {
-            scrollingUp = (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_PAGE_UP);
-            
-            // If content has no scrollbar, let host editor scroll normally
-            scroller = this.$scroller[0];
-            if (scroller.clientHeight >= scroller.scrollHeight) {
+
+            // Only handle keys when target is inside doc viewer
+            $container = $(event.target).closest(".css-prop-defn");
+            if ($container.length === 0 || $container[0] !== this.$wrapperDiv[0]) {
                 return false;
             }
+
+            // When target is not inside scroller, do nothing
+            scroller = this.$scroller[0];
+            $container = $(event.target).closest(".scroller");
+            if ($container.length === 0 || $container[0] !== scroller) {
+                event.stopPropagation();
+                event.preventDefault();
+                return true;
+            }
+
+            scrollingUp = (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_PAGE_UP);
             
             if (this._handleScrolling(event, scrollingUp, scroller)) {
                 // We handled this event

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -167,13 +167,7 @@ define(function (require, exports, module) {
         }
 
         if (event.type === "keydown") {
-            if (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_PAGE_UP) {
-                scrollingUp = true;
-            } else if (keyCode === KeyEvent.DOM_VK_DOWN || keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
-                scrollingUp = false;
-            } else {
-                return false;   // not scrolling
-            }
+            scrollingUp = (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_PAGE_UP);
             
             // If content has no scrollbar, let host editor scroll normally
             scroller = this.$scroller[0];

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -194,14 +194,14 @@ define(function (require, exports, module) {
 
         // Set focus
         this.$scroller[0].focus();
-        this.$wrapperDiv.on("keydown", this._onKeydown);
+        this.$wrapperDiv[0].addEventListener("keydown", this._onKeydown, true);
     };
     
     InlineDocsViewer.prototype.onClosed = function () {
         InlineDocsViewer.prototype.parentClass.onClosed.apply(this, arguments);
         
         $(window).off("resize", this._sizeEditorToContent);
-        this.$wrapperDiv.off("keydown", this._onKeydown);
+        this.$wrapperDiv[0].removeEventListener("keydown", this._onKeydown, true);
     };
     
     InlineDocsViewer.prototype._sizeEditorToContent = function () {

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -84,8 +84,9 @@ define(function (require, exports, module) {
         
         this._sizeEditorToContent   = this._sizeEditorToContent.bind(this);
         this._handleWheelScroll     = this._handleWheelScroll.bind(this);
-        
-        this.$wrapperDiv.find(".scroller").on("mousewheel", this._handleWheelScroll);
+
+        this.$scroller = this.$wrapperDiv.find(".scroller");
+        this.$scroller.on("mousewheel", this._handleWheelScroll);
         this._keydownHook = this._keydownHook.bind(this);
     }
     
@@ -94,6 +95,7 @@ define(function (require, exports, module) {
     InlineDocsViewer.prototype.parentClass = InlineWidget.prototype;
     
     InlineDocsViewer.prototype.$wrapperDiv = null;
+    InlineDocsViewer.prototype.$scroller = null;
     
     /**
      * Handle scrolling.
@@ -141,17 +143,30 @@ define(function (require, exports, module) {
      * @return {boolean} indication whether key was handled
      */
     InlineDocsViewer.prototype._keydownHook = function (event) {
-        var keyCode,
+        var keyCode = event.keyCode,
             scrollingUp,
-            scroller = this.$wrapperDiv.find(".scroller")[0];
+            scroller,
+            $container;
 
-        // Only handle keys when scroller is the target
-        if (scroller !== event.target) {
+        // Quick check of keys we're interested in
+        switch (keyCode) {
+        case KeyEvent.DOM_VK_UP:
+        case KeyEvent.DOM_VK_PAGE_UP:
+        case KeyEvent.DOM_VK_DOWN:
+        case KeyEvent.DOM_VK_PAGE_DOWN:
+            break;
+        default:
+            return false;
+        }
+
+        $container = $(event.target).closest(".css-prop-defn");
+
+        // Only handle keys when target is inside doc viewer
+        if ($container.length === 0 || $container[0] !== this.$wrapperDiv[0]) {
             return false;
         }
 
         if (event.type === "keydown") {
-            keyCode = event.keyCode;
             if (keyCode === KeyEvent.DOM_VK_UP || keyCode === KeyEvent.DOM_VK_PAGE_UP) {
                 scrollingUp = true;
             } else if (keyCode === KeyEvent.DOM_VK_DOWN || keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
@@ -161,6 +176,7 @@ define(function (require, exports, module) {
             }
             
             // If content has no scrollbar, let host editor scroll normally
+            scroller = this.$scroller[0];
             if (scroller.clientHeight >= scroller.scrollHeight) {
                 return false;
             }
@@ -184,7 +200,7 @@ define(function (require, exports, module) {
         $(window).on("resize", this._sizeEditorToContent);
 
         // Set focus
-        this.$wrapperDiv.find(".scroller")[0].focus();
+        this.$scroller[0].focus();
         KeyBindingManager.addGlobalKeydownHook(this._keydownHook);
     };
     


### PR DESCRIPTION
This is for #5884.
