### PR TITLE
[Close Others] Fix #6019: Contextual Close Others menu entries

### DIFF
--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -60,6 +60,33 @@ define(function (require, exports, module) {
         CommandManager.execute(Commands.FILE_CLOSE_LIST, {documentList: docList});
     }
 
+    function _currentDocChangedHandler() {
+        var doc = dm.getCurrentDocument();
+        
+        if (doc) {
+            var docIndex   = dm.findInWorkingSet(doc.file.fullPath),
+                workingSet = dm.getWorkingSet().slice(0);
+            
+            if (docIndex === workingSet.length - 1) { // hide "Close Others Below" when the last file in Working Files is selected
+                CommandManager.get(close_below).setEnabled(false);
+            } else {
+                CommandManager.get(close_below).setEnabled(true);
+            }
+            
+            if (workingSet.length === 1) { // hide "Close Others" when there is only one file in Working Files
+                CommandManager.get(close_others).setEnabled(false);
+            } else {
+                CommandManager.get(close_others).setEnabled(true);
+            }
+            
+            if (docIndex === 0) { // hide "Close Others Above" when the first file in Working Files is selected
+                CommandManager.get(close_above).setEnabled(false);
+            } else {
+                CommandManager.get(close_above).setEnabled(true);
+            }
+        }
+    }
+
     if (settings.close_below) {
         CommandManager.register(strings.CMD_FILE_CLOSE_BELOW, close_below, function () {
             handleClose(close_below);
@@ -80,4 +107,7 @@ define(function (require, exports, module) {
         });
         working_set_cmenu.addMenuItem(close_above, "", Menus.AFTER, Commands.FILE_CLOSE);
     }
+
+    // Add a document change handler
+    $(dm).on("currentDocumentChange", _currentDocChangedHandler);
 });

--- a/src/extensions/default/CloseOthers/unittests.js
+++ b/src/extensions/default/CloseOthers/unittests.js
@@ -37,14 +37,14 @@ define(function (require, exports, module) {
         FileSystem;
 
     describe("CloseOthers", function () {
-		var extensionPath = FileUtils.getNativeModuleDirectoryPath(module),
-			testPath      = extensionPath + "/unittest-files/",
-			testWindow,
-			$,
-			docSelectIndex,
-			cmdToRun,
-			brackets;
-		
+        var extensionPath = FileUtils.getNativeModuleDirectoryPath(module),
+            testPath      = extensionPath + "/unittest-files/",
+            testWindow,
+            $,
+            docSelectIndex,
+            cmdToRun,
+            brackets;
+        
         function createUntitled(count) {
             function doCreateUntitled(content) {
                 runs(function () {
@@ -84,12 +84,12 @@ define(function (require, exports, module) {
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     testWindow = w;
                     $ = testWindow.$;
-					brackets		= testWindow.brackets;
+                    brackets		= testWindow.brackets;
                     DocumentManager = testWindow.brackets.test.DocumentManager;
                     CommandManager  = testWindow.brackets.test.CommandManager;
                     EditorManager   = testWindow.brackets.test.EditorManager;
                     Dialogs			= testWindow.brackets.test.Dialogs;
-					Commands        = testWindow.brackets.test.Commands;
+                    Commands        = testWindow.brackets.test.Commands;
                     FileSystem      = testWindow.brackets.test.FileSystem;
                 });
             });
@@ -145,10 +145,10 @@ define(function (require, exports, module) {
             cmdToRun       = "file.close_others";
 
             runs(runCloseOthers);
-			
-			runs(function () {
-				expect(DocumentManager.getWorkingSet().length).toEqual(1);
-			});
+            
+            runs(function () {
+                expect(DocumentManager.getWorkingSet().length).toEqual(1);
+            });
         });
 
         it("Close others above", function () {


### PR DESCRIPTION
This is for #6019, it makes the Close Others context menu entries contextual so that they are dynamically disabled and enabled.
