### PR TITLE
Correctly normalize UNC paths

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -107,9 +107,6 @@ define(function (require, exports, module) {
     require("file/NativeFileError");
     
     PerfUtils.addMeasurement("brackets module dependencies resolved");
-
-    // Initialize the file system
-    FileSystem.init(require("fileSystemImpl"));
     
     // Local variables
     var params = new UrlParams();

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -407,8 +407,7 @@ define(function (require, exports, module) {
             throw new Error("Paths must be absolute: '" + path + "'");  // expect only absolute paths
         }
         
-        var normalizeUNCPaths = this._impl && this._impl.normalizeUNCPaths,
-            isUNCPath = normalizeUNCPaths && path.search(_DUPLICATED_SLASH_RE) === 0;
+        var isUNCPath = this._impl.normalizeUNCPaths && path.search(_DUPLICATED_SLASH_RE) === 0;
         
         // Remove duplicated "/"es
         path = path.replace(_DUPLICATED_SLASH_RE, "/");
@@ -814,4 +813,7 @@ define(function (require, exports, module) {
     
     // Create the singleton instance
     _instance = new FileSystem();
+    
+    // Initialize the singleton instance
+    _instance.init(require("fileSystemImpl"));
 });

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -388,8 +388,11 @@ define(function (require, exports, module) {
         return (fullPath[0] === "/" || fullPath[1] === ":");
     };
     
-    // Matches continguous groups of forward slashes
-    var _duplicatedSlashRE = /\/{2,}/g;
+    /*
+     * Matches continguous groups of forward slashes
+     * @const
+     */
+    var _DUPLICATED_SLASH_RE = /\/{2,}/g;
     
     /**
      * Returns a canonical version of the path: no duplicated "/"es, no ".."s,
@@ -405,10 +408,10 @@ define(function (require, exports, module) {
         }
         
         var normalizeUNCPaths = this._impl && this._impl.normalizeUNCPaths,
-            isUNCPath = normalizeUNCPaths && path.search(_duplicatedSlashRE) === 0;
+            isUNCPath = normalizeUNCPaths && path.search(_DUPLICATED_SLASH_RE) === 0;
         
         // Remove duplicated "/"es
-        path = path.replace(_duplicatedSlashRE, "/");
+        path = path.replace(_DUPLICATED_SLASH_RE, "/");
         
         // Remove ".." segments
         if (path.indexOf("..") !== -1) {

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -419,4 +419,7 @@ define(function (require, exports, module) {
     exports.watchPath       = watchPath;
     exports.unwatchPath     = unwatchPath;
     exports.unwatchAll      = unwatchAll;
+    
+    // Only perform UNC path normalization on Windows
+    exports.normalizeUNCPaths = appshell.platform === "win";
 });

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -28,11 +28,12 @@
 require.config({
     baseUrl: "../src",
     paths: {
-        "test"      : "../test",
-        "perf"      : "../test/perf",
-        "spec"      : "../test/spec",
-        "text"      : "thirdparty/text/text",
-        "i18n"      : "thirdparty/i18n/i18n"
+        "test"              : "../test",
+        "perf"              : "../test/perf",
+        "spec"              : "../test/spec",
+        "text"              : "thirdparty/text/text",
+        "i18n"              : "thirdparty/i18n/i18n",
+        "fileSystemImpl"    : "filesystem/impls/appshell/AppshellFileSystem"
     }
 });
 
@@ -92,9 +93,6 @@ define(function (require, exports, module) {
      * for the installer in this run of Brackets.
      */
     var NODE_CONNECTION_TIMEOUT = 30000; // 30 seconds - TODO: share with StaticServer?
-
-    // Initialize the file system
-    FileSystem.init(require("filesystem/impls/appshell/AppshellFileSystem"));
     
     // parse URL parameters
     params.parse();

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -141,7 +141,9 @@ define(function (require, exports, module) {
             });
             
             it("should eliminate duplicated (contiguous) slashes", function () {
+                MockFileSystemImpl.normalizeUNCPaths = false;
                 testPrefixes(["", "c:"], function () {
+                    expectNormDir("/", "/");
                     expectNormDir("//", "/");
                     expectNormDir("///", "/");
                     expectNormDir("//foo", "/foo/");
@@ -151,6 +153,56 @@ define(function (require, exports, module) {
                     expectNormDir("/foo//bar", "/foo/bar/");
                     expectNormDir("/foo///bar", "/foo/bar/");
                     
+                    expectNormFile("/foo", "/foo");
+                    expectNormFile("//foo", "/foo");
+                    expectNormFile("///foo", "/foo");
+                    expectNormFile("/foo//bar", "/foo/bar");
+                    expectNormFile("/foo///bar", "/foo/bar");
+                    expectNormFile("//foo///bar", "/foo/bar");
+                    expectNormFile("///foo///bar", "/foo/bar");
+                    expectNormFile("///foo//bar", "/foo/bar");
+                    expectNormFile("///foo/bar", "/foo/bar");
+                });
+            });
+            
+            it("should normalize continguous-slash prefixes for UNC paths", function () {
+                // UNC paths should have leading slashes reduced to a single leading pair
+                MockFileSystemImpl.normalizeUNCPaths = true;
+                testPrefixes([""], function () {
+                    expectNormDir("/", "/");
+                    expectNormDir("//", "//");
+                    expectNormDir("///", "//");
+                    expectNormDir("//foo", "//foo/");
+                    expectNormDir("/foo//", "/foo/");
+                    expectNormDir("//foo//", "//foo/");
+                    expectNormDir("///foo///", "//foo/");
+                    expectNormDir("/foo//bar", "/foo/bar/");
+                    expectNormDir("/foo///bar", "/foo/bar/");
+                    
+                    expectNormFile("/foo", "/foo");
+                    expectNormFile("//foo", "//foo");
+                    expectNormFile("///foo", "//foo");
+                    expectNormFile("/foo//bar", "/foo/bar");
+                    expectNormFile("/foo///bar", "/foo/bar");
+                    expectNormFile("//foo///bar", "//foo/bar");
+                    expectNormFile("///foo///bar", "//foo/bar");
+                    expectNormFile("///foo//bar", "//foo/bar");
+                    expectNormFile("///foo/bar", "//foo/bar");
+                });
+                
+                // UNC paths do not begin with a letter, so normalization is unchanged 
+                testPrefixes(["c:"], function () {
+                    expectNormDir("/", "/");
+                    expectNormDir("//", "/");
+                    expectNormDir("///", "/");
+                    expectNormDir("//foo", "/foo/");
+                    expectNormDir("/foo//", "/foo/");
+                    expectNormDir("//foo//", "/foo/");
+                    expectNormDir("///foo///", "/foo/");
+                    expectNormDir("/foo//bar", "/foo/bar/");
+                    expectNormDir("/foo///bar", "/foo/bar/");
+                    
+                    expectNormFile("/foo", "/foo");
                     expectNormFile("//foo", "/foo");
                     expectNormFile("///foo", "/foo");
                     expectNormFile("/foo//bar", "/foo/bar");

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -65,6 +65,9 @@ define(function (require, exports, module) {
         }
     };
     
+    // Indicates whether, by default, the FS should perform UNC Path normalization
+    var _normalizeUNCPathsDefault = false;
+    
     // "Live" data for this instance of the file system. Use reset() to 
     // initialize with _initialData
     var _data;
@@ -339,11 +342,15 @@ define(function (require, exports, module) {
     exports.unwatchPath     = unwatchPath;
     exports.unwatchAll      = unwatchAll;
     
+    exports.normalizeUNCPaths = _normalizeUNCPathsDefault;
+    
     // Test methods
     exports.reset = function () {
         _data = {};
         $.extend(_data, _initialData);
         _hooks = {};
+        
+        exports.normalizeUNCPaths = _normalizeUNCPathsDefault;
     };
     
     /**


### PR DESCRIPTION
Add support for normalization of UNC paths in the filesystem. `_normalizePath` is now a method of the `FileSystem` class. Its behavior w.r.t. UNC paths is controlled by a new `FileSystemImpl` flag, `normalizeUNCPaths`. If set, paths like `///server//foo/bar` are normalized to `//server/foo/bar/` instead of `/server/foo/bar/`. `AppshellFileSystemImpl.normalizeUNCPaths` is set at runtime for Windows only.

Addresses #6028 and #6029.

CC @gruehle @peterflynn 
