### PR TITLE
[REVIEW ONLY] File caching

### DIFF
--- a/src/filesystem/FileIndex.js
+++ b/src/filesystem/FileIndex.js
@@ -96,6 +96,8 @@ define(function (require, exports, module) {
             }
         }
         
+        entry._clearCachedData();
+        
         delete this._index[path];
         
         for (property in entry) {

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -222,11 +222,7 @@ define(function (require, exports, module) {
      */
     FileSystem.prototype._watchOrUnwatchEntry = function (entry, watchedRoot, callback, shouldWatch) {
         var watchPaths = [],
-            allChildren;
-        
-        if (!shouldWatch) {
             allChildren = [];
-        }
         
         var visitor = function (child) {
             if (watchedRoot.filter(child.name)) {
@@ -234,9 +230,7 @@ define(function (require, exports, module) {
                     watchPaths.push(child.fullPath);
                 }
                 
-                if (!shouldWatch) {
-                    allChildren.push(child);
-                }
+                allChildren.push(child);
             
                 return true;
             }
@@ -267,6 +261,9 @@ define(function (require, exports, module) {
                     watchPaths.forEach(function (path, index) {
                         this._impl.watchPath(path);
                     }, this);
+                    allChildren.forEach(function (child) {
+                        child._setWatched();
+                    });
                 } else {
                     watchPaths.forEach(function (path, index) {
                         this._impl.unwatchPath(path);
@@ -788,6 +785,10 @@ define(function (require, exports, module) {
     
     // Static public utility methods
     exports.isAbsolutePath = FileSystem.isAbsolutePath;
+
+    // Private methods
+    exports._findWatchedRootForPath = _wrap(FileSystem.prototype._findWatchedRootForPath);
+
     
     // Export "on" and "off" methods
     

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -387,6 +387,14 @@ define(function (require, exports, module) {
     FileSystem.isAbsolutePath = function (fullPath) {
         return (fullPath[0] === "/" || fullPath[1] === ":");
     };
+
+    function _appendTrailingSlash(path) {
+        if (path[path.length - 1] !== "/") {
+            path += "/";
+        }
+
+        return path;
+    }
     
     /**
      * Returns a canonical version of the path: no duplicated "/"es, no ".."s,
@@ -422,9 +430,7 @@ define(function (require, exports, module) {
         
         if (isDirectory) {
             // Make sure path DOES include trailing slash
-            if (path[path.length - 1] !== "/") {
-                path += "/";
-            }
+            path = _appendTrailingSlash(path);
         }
         
         return path;
@@ -476,20 +482,32 @@ define(function (require, exports, module) {
      *      with a FileSystemError string or with the entry for the provided path.
      */
     FileSystem.prototype.resolve = function (path, callback) {
-        // No need to normalize path here: assume underlying stat() does it internally,
-        // and it will be normalized anyway when ingested by get*ForPath() afterward
+        var normalizedPath = _normalizePath(path, false),
+            item = this._index.getEntry(normalizedPath);
+
+        if (!item) {
+            normalizedPath = _appendTrailingSlash(normalizedPath);
+            item = this._index.getEntry(normalizedPath);
+        }
+        
+        if (item && item._stat) {
+            callback(null, item, item._stat);
+            return;
+        }
         
         this._impl.stat(path, function (err, stat) {
-            var item;
-            
-            if (!err) {
-                if (stat.isFile) {
-                    item = this.getFileForPath(path);
-                } else {
-                    item = this.getDirectoryForPath(path);
-                }
+            if (err) {
+                callback(err);
+                return;
             }
-            callback(err, item, stat);
+            
+            if (stat.isFile) {
+                item = this.getFileForPath(path);
+            } else {
+                item = this.getDirectoryForPath(path);
+            }
+            
+            callback(null, item, stat);
         }.bind(this));
     };
     
@@ -570,9 +588,7 @@ define(function (require, exports, module) {
             // This is a "wholesale" change event
             // Clear all caches (at least those that won't do a stat() double-check before getting used)
             this._index.visitAll(function (entry) {
-                if (entry.isDirectory) {
-                    entry._clearCachedData();
-                }
+                entry._clearCachedData();
             });
             
             fireChangeEvent(null);

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -176,6 +176,11 @@ define(function (require, exports, module) {
      *      string or a boolean indicating whether or not the file exists.
      */
     FileSystemEntry.prototype.exists = function (callback) {
+        if (this._stat) {
+            callback(true);
+            return;
+        }
+        
         this._impl.exists(this._path, callback);
     };
     
@@ -186,6 +191,11 @@ define(function (require, exports, module) {
      *      FileSystemError string or FileSystemStats object.
      */
     FileSystemEntry.prototype.stat = function (callback) {
+        if (this._stat) {
+            callback(null, this._stat);
+            return;
+        }
+        
         this._impl.stat(this._path, function (err, stat) {
             if (!err) {
                 this._stat = stat;

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
      * @type {?FileSystemStats}
      */
     FileSystemEntry.prototype._stat = null;
-
+    
     /**
      * Parent file system.
      * @type {!FileSystem}
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
      */
     FileSystemEntry.prototype.exists = function (callback) {
         if (this._stat) {
-            callback(true);
+            callback(null, true);
             return;
         }
         

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -42,7 +42,8 @@ define(function (require, exports, module) {
         NOT_WRITABLE        : "NotWritable",
         OUT_OF_SPACE        : "OutOfSpace",
         TOO_MANY_ENTRIES    : "TooManyEntries",
-        ALREADY_EXISTS      : "AlreadyExists"
+        ALREADY_EXISTS      : "AlreadyExists",
+        CONTENTS_MODIFIED   : "ContentsModified"
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/FileSystemStats.js
+++ b/src/filesystem/FileSystemStats.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
         this._isDirectory = !options.isFile;
         this._mtime = options.mtime;
         this._size = options.size;
+        this._hash = options.hash;
     }
     
     // Add "isFile", "isDirectory", "mtime" and "size" getters

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -153,8 +153,14 @@ define(function (require, exports, module) {
             if (err) {
                 callback(_mapError(err));
             } else {
-                var options = { isFile: stats.isFile(), mtime: stats.mtime, size: stats.size },
-                    fsStats = new FileSystemStats(options);
+                var options = {
+                        isFile: stats.isFile(),
+                        mtime: stats.mtime,
+                        size: stats.size,
+                        hash: stats.mtime.getTime()
+                    };
+                
+                var fsStats = new FileSystemStats(options);
                 
                 callback(null, fsStats);
             }
@@ -264,15 +270,10 @@ define(function (require, exports, module) {
         });
     }
     
-    function writeFile(path, data, options, callback) {
+    function writeFile(path, data, hash, options, callback) {
         var encoding = options.encoding || "utf8";
         
-        exists(path, function (err, alreadyExists) {
-            if (err) {
-                callback(err);
-                return;
-            }
-            
+        function _finishWrite(alreadyExists) {
             appshell.fs.writeFile(path, data, encoding, function (err) {
                 if (err) {
                     callback(_mapError(err));
@@ -291,8 +292,28 @@ define(function (require, exports, module) {
                     });
                 }
             });
-        });
+        }
         
+        stat(path, function (err, stats) {
+            if (err) {
+                switch (err) {
+                case FileSystemError.NOT_FOUND:
+                    _finishWrite(false);
+                    break;
+                default:
+                    callback(err);
+                }
+                return;
+            }
+            
+            if (hash !== stats._hash) {
+                console.warn("Blind write attempted: ", path, stats._hash, hash);
+                callback(FileSystemError.CONTENTS_MODIFIED);
+                return;
+            }
+            
+            _finishWrite(path, data, encoding, true, callback);
+        });
     }
     
     function unlink(path, callback) {

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -306,7 +306,7 @@ define(function (require, exports, module) {
                 return;
             }
             
-            if (hash !== stats._hash) {
+            if (hash !== stats._hash && !options.blind) {
                 console.warn("Blind write attempted: ", path, stats._hash, hash);
                 callback(FileSystemError.CONTENTS_MODIFIED);
                 return;

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -270,7 +270,7 @@ define(function (require, exports, module) {
         });
     }
     
-    function writeFile(path, data, hash, options, callback) {
+    function writeFile(path, data, options, callback) {
         var encoding = options.encoding || "utf8";
         
         function _finishWrite(alreadyExists) {
@@ -306,13 +306,13 @@ define(function (require, exports, module) {
                 return;
             }
             
-            if (hash !== stats._hash && !options.blind) {
-                console.warn("Blind write attempted: ", path, stats._hash, hash);
+            if (options.hasOwnProperty("hash") && options.hash !== stats._hash) {
+                console.warn("Blind write attempted: ", path, stats._hash, options.hash);
                 callback(FileSystemError.CONTENTS_MODIFIED);
                 return;
             }
             
-            _finishWrite(path, data, encoding, true, callback);
+            _finishWrite(true);
         });
     }
     

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -708,7 +708,7 @@ define(function (require, exports, module) {
                         changeDone = true;
                     });
                     
-                    testFile.write("Foobar", function (err) {
+                    testFile.write("Foobar", { blind: true }, function (err) {
                         expect(err).toBeFalsy();
                         writeDone = true;
                     });
@@ -751,11 +751,11 @@ define(function (require, exports, module) {
                     
                     // We always *start* both operations together, synchronously
                     // What varies is when the impl callbacks for for each op, and when the impl's watcher notices each op
-                    fileSystem.getFileForPath("/file1.txt").write("Foobar 1", function (err) {
+                    fileSystem.getFileForPath("/file1.txt").write("Foobar 1", { blind: true }, function (err) {
                         expect(err).toBeFalsy();
                         write1Done = true;
                     });
-                    fileSystem.getFileForPath("/file2.txt").write("Foobar 2", function (err) {
+                    fileSystem.getFileForPath("/file2.txt").write("Foobar 2", { blind: true }, function (err) {
                         expect(err).toBeFalsy();
                         write2Done = true;
                     });

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -446,6 +446,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(firstReadCB.error).toBeFalsy();
                     expect(firstReadCB.data).toBe("File 4 Contents");
+                    expect(firstReadCB.stat).toBeTruthy();
                 });
                 
                 // Write new contents
@@ -465,6 +466,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(secondReadCB.error).toBeFalsy();
                     expect(secondReadCB.data).toBe(newContents);
+                    expect(secondReadCB.stat).toBeTruthy();
                 });
             });
             
@@ -478,6 +480,8 @@ define(function (require, exports, module) {
                 waitsFor(function () { return cb.wasCalled; });
                 runs(function () {
                     expect(cb.error).toBe(FileSystemError.NOT_FOUND);
+                    expect(cb.data).toBeFalsy();
+                    expect(cb.stat).toBeFalsy();
                 });
             });
             
@@ -508,6 +512,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(readCb.error).toBeFalsy();
                     expect(readCb.data).toBe(newContents);
+                    expect(readCb.stat).toBeTruthy();
                 });
             });
         });

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -268,7 +268,7 @@ define(function (require, exports, module) {
         }
     }
     
-    function writeFile(path, data, hash, options, callback) {
+    function writeFile(path, data, options, callback) {
         if (typeof (options) === "function") {
             callback = options;
             options = null;
@@ -283,7 +283,7 @@ define(function (require, exports, module) {
             }
             
             var exists = !!stats;
-            if (exists && hash !== stats._hash && !options.blind) {
+            if (exists && options.hasOwnProperty("hash") && options.hash !== stats._hash) {
                 cb(FileSystemError.CONTENTS_MODIFIED);
                 return;
             }

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -283,7 +283,7 @@ define(function (require, exports, module) {
             }
             
             var exists = !!stats;
-            if (exists && hash !== stats._hash) {
+            if (exists && hash !== stats._hash && !options.blind) {
                 cb(FileSystemError.CONTENTS_MODIFIED);
                 return;
             }

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -112,9 +112,9 @@ define(function (require, exports, module) {
         return stat;
     }
     
-    function _sendWatcherNotification(path) {
+    function _sendWatcherNotification(path, stats) {
         if (_watcherCallback) {
-            _watcherCallback(path);
+            _watcherCallback(path, stats);
         }
     }
     
@@ -301,8 +301,9 @@ define(function (require, exports, module) {
             
             _data[path].contents = data;
             _data[path].mtime = new Date();
-            cb(null, _getStat(path));
-            notify(path);
+            var newStat = _getStat(path);
+            cb(null, newStat);
+            notify(path, newStat);
         });
     }
     

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -50,9 +50,12 @@ define(function (require, exports, module) {
         _testSuites             = {},
         _testWindow,
         _doLoadExtensions,
-        nfs,
         _rootSuite              = { id: "__brackets__" },
         _unitTestReporter;
+    
+    function _getFileSystem() {
+        return _testWindow ? _testWindow.brackets.test.FileSystem : FileSystem;
+    }
     
     /**
      * Delete a path
@@ -62,7 +65,7 @@ define(function (require, exports, module) {
      */
     function deletePath(fullPath, silent) {
         var result = new $.Deferred();
-        FileSystem.resolve(fullPath, function (err, item) {
+        _getFileSystem().resolve(fullPath, function (err, item) {
             if (!err) {
                 item.unlink(function (err) {
                     if (!err) {
@@ -143,7 +146,7 @@ define(function (require, exports, module) {
     function resolveNativeFileSystemPath(path) {
         var result = new $.Deferred();
         
-        FileSystem.resolve(path, function (err, item) {
+        _getFileSystem().resolve(path, function (err, item) {
             if (!err) {
                 result.resolve(item);
             } else {
@@ -227,7 +230,7 @@ define(function (require, exports, module) {
         var deferred = new $.Deferred();
 
         runs(function () {
-            var dir = FileSystem.getDirectoryForPath(getTempDirectory()).create(function (err) {
+            var dir = _getFileSystem().getDirectoryForPath(getTempDirectory()).create(function (err) {
                 if (err && err !== FileSystemError.ALREADY_EXISTS) {
                     deferred.reject(err);
                 } else {
@@ -251,7 +254,7 @@ define(function (require, exports, module) {
         promise = Async.doSequentially(folders, function (folder) {
             var deferred = new $.Deferred();
             
-            FileSystem.resolve(folder, function (err, entry) {
+            _getFileSystem().resolve(folder, function (err, entry) {
                 if (!err) {
                     // Change permissions if the directory exists
                     chmod(folder, "777").then(deferred.resolve, deferred.reject);
@@ -317,7 +320,7 @@ define(function (require, exports, module) {
             content     = options.content || "";
         
         // Use unique filename to avoid collissions in open documents list
-        var dummyFile = FileSystem.getFileForPath(filename);
+        var dummyFile = _getFileSystem().getFileForPath(filename);
         var docToShim = new DocumentManager.Document(dummyFile, new Date(), content);
         
         // Prevent adding doc to working set
@@ -782,7 +785,7 @@ define(function (require, exports, module) {
                 }
                 
                 // create the new File
-                createTextFile(destination, text, FileSystem).done(function (entry) {
+                createTextFile(destination, text, _getFileSystem()).done(function (entry) {
                     deferred.resolve(entry, offsets, text);
                 }).fail(function (err) {
                     deferred.reject(err);
@@ -819,7 +822,7 @@ define(function (require, exports, module) {
         var parseOffsets    = options.parseOffsets || false,
             removePrefix    = options.removePrefix || true,
             deferred        = new $.Deferred(),
-            destDir         = FileSystem.getDirectoryForPath(destination);
+            destDir         = _getFileSystem().getDirectoryForPath(destination);
         
         // create the destination folder
         destDir.create(function (err) {


### PR DESCRIPTION
This is the first of what will become a two-part pull request. The first part adds file caching with consistency checks using the existing coarse cache-invalidation strategy (i.e., invalidate everything on focus). The second part will use file watchers to implement a more fine-grained cache-invalidation strategy.

Notes:
1. This pull request adds consistent cache support for all `FileSystemEntry` objects. In particular, stats are cached for `FileSystemEntry` objects, and additionally directory contents and children stat lists for `Directory` objects; and file contents for `File` objects.
2. Data is only cached for watched entries. For simplicity, this is checked only at cache update time, and not at cache read time. As a consequence, cached data is used whenever it is available. Cached data is _not_ purged when an entry transitions from a watched to an unwatched state because, in this case, the entry should no longer be accessed anyway. However, an entry can safely go from an unwatched to watched state, and so the watching infrastructure is responsible for calling `_setWatched` on each entry so that it knows to begin caching its data.
3. The _only_ time consistency checks happen are during file writes. In particular, calls to `stat` and `read` will immediately return cached data if available. This makes cached reads very fast. (On my machine, searches for occurrences of a single character in the entire Brackets project complete in under a second after data is cached.) Consistency is checked using a hash of the file's contents, which is provided by the impl. The only time the consistency hash is updated is when the contents of the are known: i.e., after reads and writes.
4. A consistency check can fail during writes if the impl determines that the hash of the file on disk is different from the hash in memory. In that case, the write will fail with a new error code `FileSystemError.CONTENTS_MODIFIED`. (This error should never occur if the file is created by the write.) If a write is attempted to an existing file that has never been read (i.e., a _blind write_), the consistency check will fail because there is no hash in memory. This is a case in which the consistency check may be too strict, and so it is possible for clients to override the check by setting `blind: true` in the options parameter to the write call. There were no instances of blind writes in Brackets that required this override.
5. If we fail to invalidate cached contents that have changed on disk then the user will not be notified of the change until she attempts to save. Brackets will not allow the new data on disk to be overwritten accidentally in this case because of the consistency check, but the experience would nonetheless be frustrating and disconcerting to the user. Timely cache invalidation is required to avoid this scenario. Consequently, this pull request should not be merged until file watchers can be used to perform this invalidation. 

CC @gruehle @peterflynn 
