### PR TITLE
Filter out dotfiles in code hints

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -201,18 +201,21 @@ define(function (require, exports, module) {
      * @return {boolean} true if excluded, false otherwise.
      */
     function isFileExcluded(file) {
+        if (file.name[0] === ".") {
+            return true;
+        }
+        
+        var languageID = LanguageManager.getLanguageForPath(file.fullPath).getId();
+        if (languageID !== HintUtils.LANGUAGE_ID) {
+            return true;
+        }
+        
         var excludes = preferences.getExcludedFiles();
-
         if (!excludes) {
             return false;
         }
         
-        var languageID = LanguageManager.getLanguageForPath(file.fullPath).getId();
-        if (languageID === HintUtils.LANGUAGE_ID) {
-            return file.name[0] === "." || excludes.test(file.name);
-        }
-        
-        return true;
+        return excludes.test(file.name);
     }
 
     /**

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -206,8 +206,13 @@ define(function (require, exports, module) {
         if (!excludes) {
             return false;
         }
-
-        return file.name[0] === "." || excludes.test(file.name);
+        
+        var languageID = LanguageManager.getLanguageForPath(file.fullPath).getId();
+        if (languageID === HintUtils.LANGUAGE_ID) {
+            return file.name[0] === "." || excludes.test(file.name);
+        }
+        
+        return true;
     }
 
     /**
@@ -900,14 +905,12 @@ define(function (require, exports, module) {
             FileSystem.resolve(dir, function (err, directory) {
                 function visitor(entry) {
                     if (entry.isFile) {
-                        if (!isFileExcluded(entry)) { // ignore .dotfiles
-                            var languageID = LanguageManager.getLanguageForPath(entry.fullPath).getId();
-                            if (languageID === HintUtils.LANGUAGE_ID) {
-                                addFilesToTern([entry.fullPath]);
-                            }
+                        if (!isFileExcluded(entry)) { // ignore .dotfiles and non-.js files
+                            addFilesToTern([entry.fullPath]);
                         }
                     } else {
                         return !isDirectoryExcluded(entry.fullPath) &&
+                            entry.name.indexOf(".") !== 0 &&
                             !stopAddingFiles;
                     }
                 }

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
             return false;
         }
 
-        return excludes.test(file.name);
+        return file.name[0] === "." || excludes.test(file.name);
     }
 
     /**
@@ -900,7 +900,7 @@ define(function (require, exports, module) {
             FileSystem.resolve(dir, function (err, directory) {
                 function visitor(entry) {
                     if (entry.isFile) {
-                        if (!isFileExcluded(entry) && entry.name.indexOf(".") !== 0) { // ignore .dotfiles
+                        if (!isFileExcluded(entry)) { // ignore .dotfiles
                             var languageID = LanguageManager.getLanguageForPath(entry.fullPath).getId();
                             if (languageID === HintUtils.LANGUAGE_ID) {
                                 addFilesToTern([entry.fullPath]);
@@ -908,7 +908,6 @@ define(function (require, exports, module) {
                         }
                     } else {
                         return !isDirectoryExcluded(entry.fullPath) &&
-                            entry.name.indexOf(".") !== 0 &&
                             !stopAddingFiles;
                     }
                 }


### PR DESCRIPTION
Quick fix for #6067, but this may not be the total fix if we want to filter out more than dotfiles
