### PR TITLE
Changes to build.prop file to support Jenkins jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ src/brackets.min.css
 /node_modules
 /npm-debug.log
 
+# ignore compiled files
+/dist
 
 # ignore everything in the dev extension directory EXCEPT the README
 # (so that the directory is non-empty and can be in git)

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -100,18 +100,21 @@ module.exports = function (grunt) {
             return getGitInfo(shell_repo);
         }).then(function (json) {
             shell_git = json;
-
+        }, function (err) {
+            // shell git info is optional
+            grunt.log.writeln(err);
+        }).finally(function () {
             out += "brackets_build_version=" + version.substr(0, version.lastIndexOf("-") + 1) + www_git.commits + "\n";
             out += toProperties("brackets_www_", www_git);
-            out += toProperties("brackets_shell_", shell_git);
+            
+            if (shell_git) {
+                out += toProperties("brackets_shell_", shell_git);
+            }
 
             grunt.log.write(out);
             grunt.file.write("build.prop", out);
 
             done();
-        }, function (err) {
-            grunt.log.writeln(err);
-            done(false);
         });
     });
 };

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -25,7 +25,8 @@
 module.exports = function (grunt) {
     "use strict";
 
-    var child_process   = require("child_process"),
+    var build           = {},
+        child_process   = require("child_process"),
         path            = require("path"),
         q               = require("q"),
         qexec           = q.denodeify(child_process.exec);
@@ -117,4 +118,8 @@ module.exports = function (grunt) {
             done();
         });
     });
+    
+    build.getGitInfo = getGitInfo;
+    
+    return build;
 };


### PR DESCRIPTION
Change `grunt build-prop` task to
1. work when on a detached head (i.e. during jenkins build)
2. use bash compatible property key names
3. include shell git info

Example output:

```
brackets_build_version=0.34.0-10744
brackets_www_commits=10744
brackets_www_sha=a1addee49066ec75f89edccb882a39a7de3c6f10
brackets_www_branch=jasonsanjose/build-prop-keys
brackets_shell_commits=1068
brackets_shell_sha=2f543d2b7b8cdfebd66aac843b147881bd8c2597
brackets_shell_branch=release
```

This lets us parameterize Jenkins jobs for both master and release branches so that both branches can be built from the same job. Without this change, we would need to make copies of the current build jobs since they are hard coded to master.
