### PR TITLE
Add alternate next/previous document shortcuts on Mac: Cmd-Shift-] and [

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -241,6 +241,10 @@
         {
             "key": "Ctrl-Tab",
             "platform": "mac"
+        },
+        {
+            "key": "Cmd-Shift-]",
+            "platform": "mac"
         }
     ],
     "navigate.prevDoc":  [
@@ -249,6 +253,10 @@
         },
         {
             "key": "Ctrl-Shift-Tab",
+            "platform": "mac"
+        },
+        {
+            "key": "Cmd-Shift-[",
             "platform": "mac"
         }
     ],


### PR DESCRIPTION
This will make these command more MacOS like, many other app use this key-binding
