### PR TITLE
Minor code cleanups, docs improvements, console message clarifications

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -387,7 +387,7 @@ define(function (require, exports, module) {
         
         // skip if the key binding is invalid 
         if (!normalized) {
-            console.log("Failed to normalize " + key);
+            console.error("Unable to parse key binding " + key + ". Permitted modifiers: Ctrl, Cmd, Alt, Opt, Shift; separated by '-' (not '+').");
             return null;
         }
         

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -652,13 +652,15 @@ define(function (require, exports, module) {
      * if you are going to display its contents in a piece of UI - then you must addRef() the Document
      * and listen for changes on it. (Note: opening the Document in an Editor automatically manages
      * refs and listeners for that Editor UI).
+     * 
+     * If all you need is the Document's getText() value, use the faster getDocumentText() instead.
      *
      * @param {!string} fullPath
      * @return {$.Promise} A promise object that will be resolved with the Document, or rejected
      *      with a FileSystemError if the file is not yet open and can't be read from disk.
      */
     function getDocumentForPath(fullPath) {
-        var doc             = getOpenDocumentForPath(fullPath);
+        var doc = getOpenDocumentForPath(fullPath);
 
         if (doc) {
             // use existing document
@@ -765,7 +767,7 @@ define(function (require, exports, module) {
      * looks like /some-random-string/Untitled-counter.fileExt.
      *
      * @param {number} counter - used in the name of the new Document's File
-     * @param {string} fileExt - file extension of the new Document's File
+     * @param {string} fileExt - file extension of the new Document's File, including "."
      * @return {Document} - a new untitled Document
      */
     function createUntitledDocument(counter, fileExt) {

--- a/src/document/InMemoryFile.js
+++ b/src/document/InMemoryFile.js
@@ -31,7 +31,7 @@
  * InMemoryFile`), but it's better to check `doc.isUntitled` where possible.
  * 
  * Attempts to read/write an InMemoryFile will always fail, and exists() always yields false. InMemoryFile.fullPath
- * is just a placeholder, and should not be displayed anywhere in the UI.
+ * is just a placeholder, and should not be displayed anywhere in the UI; fullPath IS guaranteed to be unique, however.
  * 
  * An InMemoryFile is not added to the filesystem index, so if you ask the the filesystem anything about this
  * object, it won't know what you're talking about (`filesystem.getFileForPath(someInMemFile.fullPath)` will not
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
      *
      * Read a file as text. 
      *
-     * @param {object=} options Currently unused.
+     * @param {Object=} options Currently unused.
      * @param {function (number, string, object)} callback
      */
     InMemoryFile.prototype.read = function (options, callback) {

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -97,8 +97,8 @@ define(function (require, exports, module) {
     /**
      * Called once content is parented in the host editor's DOM. Useful for performing tasks like setting
      * focus or measuring content, which require htmlContent to be in the DOM tree.
-     * IMPORTANT: onAdded() must ensure that hostEditor.setInlineWidgetHeight() is called at least once in order
-     * to set the initial height of the widget and animate it open.
+     * IMPORTANT: onAdded() MUST be overridden to call hostEditor.setInlineWidgetHeight() at least once to
+     * set the initial height (required to animate it open). The widget will never open otherwise.
      */
     InlineWidget.prototype.onAdded = function () {
         $(this).triggerHandler("add");

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
             workingSet   = dm.getWorkingSet().slice(0),
             start = (mode === close_below) ? (targetIndex + 1) : 0,
             end   = (mode === close_above) ? (targetIndex) : (workingSet.length),
-            docList = [],
+            files = [],
             i;
         
         if (mode === close_others) {
@@ -54,10 +54,10 @@ define(function (require, exports, module) {
         }
         
         for (i = start; i < end; i++) {
-            docList.push(workingSet[i]);
+            files.push(workingSet[i]);
         }
         
-        CommandManager.execute(Commands.FILE_CLOSE_LIST, {documentList: docList});
+        CommandManager.execute(Commands.FILE_CLOSE_LIST, {fileList: files});
     }
 
     if (settings.close_below) {

--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
      * Read the contents of a Directory. 
      *
      * @param {Directory} directory Directory whose contents you want to get
-     * @param {function (?string, Array.<FileSystemEntry>=, Array.<FileSystemStats>=, object.<string: string>=)} callback
+     * @param {function (?string, Array.<FileSystemEntry>=, Array.<FileSystemStats>=, Object.<string, string>=)} callback
      *          Callback that is passed an error code or the stat-able contents
      *          of the directory along with the stats for these entries and a
      *          fullPath-to-FileSystemError string map of unstat-able entries
@@ -169,7 +169,7 @@ define(function (require, exports, module) {
                 try {
                     cb(err, this._contents, this._contentsStats, this._contentsStatsErrors);
                 } catch (ex) {
-                    console.warn("Unhandled exception in callback: ", ex);
+                    console.warn("Unhandled exception in Directory.getContents() callback: ", ex, "for " + this.fullPath);
                 }
             }, this);
         }.bind(this));

--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
     /**
      * Read a file.
      *
-     * @param {object=} options Currently unused.
+     * @param {Object=} options Currently unused.
      * @param {function (?string, string=, FileSystemStats=)} callback Callback that is passed the
      *              FileSystemError string or the file's contents and its stats.
      */

--- a/src/filesystem/FileIndex.js
+++ b/src/filesystem/FileIndex.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
     /**
      * Master index
      * 
-     * @type{object{string: File|Directory}} Maps a fullPath to a File or Directory object
+     * @type {Object.<string, File|Directory>} Maps a fullPath to a File or Directory object
      */
     FileIndex.prototype._index = null;
     

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -346,6 +346,9 @@ define(function (require, exports, module) {
      * 
      * Entries explicitly created via FileSystem.getFile/DirectoryForPath() are *always* added to the index regardless
      * of this filtering - but they will not be watched if the watch-root's filter excludes them.
+     * 
+     * @param {string} path Full path
+     * @param {string} name Name portion of the path
      */
     FileSystem.prototype._indexFilter = function (path, name) {
         var parentRoot = this._findWatchedRootForPath(path);
@@ -529,8 +532,10 @@ define(function (require, exports, module) {
      * @param {string} initialPath The folder opened inside the window initially. If initialPath
      *                          is not set, or it doesn't exist, the window would show the last
      *                          browsed folder depending on the OS preferences
-     * @param {Array.<string>} fileTypes List of extensions that are allowed to be opened. A null value
-     *                          allows any extension to be selected.
+     * @param {?Array.<string>} fileTypes (Currently *ignored* except on Mac - https://trello.com/c/430aXkpq)
+     *                          List of extensions that are allowed to be opened, without leading ".".
+     *                          Null or empty array allows all files to be selected. Not applicable
+     *                          when chooseDirectories = true.
      * @param {function (?string, Array.<string>=)} callback Callback resolved with a FileSystemError
      *                          string or the selected file(s)/directories. If the user cancels the
      *                          open dialog, the error will be falsy and the file/directory array will
@@ -682,8 +687,8 @@ define(function (require, exports, module) {
      * 
      * @param {FileSystemEntry} entry - The root entry to watch. If entry is a directory,
      *      all subdirectories that aren't explicitly filtered will also be watched.
-     * @param {function(string): boolean} filter - A function to determine whether
-     *      a particular name should be watched or ignored. Paths that are ignored are also
+     * @param {function(string): boolean} filter - Returns true if a particular item should
+     *      be watched, given its name (not full path). Items that are ignored are also
      *      filtered from Directory.getContents() results within this subtree.
      * @param {function(?string)=} callback - A function that is called when the watch has
      *      completed. If the watch fails, the function will have a non-null FileSystemError

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -218,8 +218,8 @@ define(function (require, exports, module) {
     };
         
     /**
-     * Unlink (delete) this entry. For Directories, this will delete the directory
-     * and all of its contents. 
+     * Permanently delete this entry. For Directories, this will delete the directory
+     * and all of its contents. For reversible delete, see moveToTrash().
      *
      * @param {function (?string)=} callback Callback with a single FileSystemError
      *      string parameter.
@@ -337,8 +337,8 @@ define(function (require, exports, module) {
      * Visit this entry and its descendents with the supplied visitor function.
      *
      * @param {function(FileSystemEntry): boolean} visitor - A visitor function, which is
-     *      applied to descendent FileSystemEntry objects. If the function returns false for
-     *      a particular Directory entry, that directory's descendents will not be visited.
+     *      applied to this entry and all descendent FileSystemEntry objects. If the function returns
+     *      false for a particular Directory entry, that directory's descendents will not be visited.
      * @param {{maxDepth: number=, maxEntries: number=}=} options
      * @param {function(?string)=} callback Callback with single FileSystemError string parameter.
      */

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -50,10 +50,19 @@ define(function (require, exports, module) {
      */
     var _nodeConnectionDeferred;
     
-    var _changeCallback,            // Callback to notify FileSystem of watcher changes
-        _changeTimeout,             // Timeout used to batch up file watcher changes
-        _pendingChanges = {};       // Pending file watcher changes
+    /**
+     * Callback to notify FileSystem of watcher changes
+     * @type {!function(string, FileSystemStats=)}
+     */
+    var _changeCallback;
+    
+    /** Id of setTimeout() used to batch up file watcher changes */
+    var _changeTimeout;
+    
+    /** @type {!Object.<string, boolean>}  Pending file watcher changes - set of fullPaths */
+    var _pendingChanges = {};
 
+    
     function _mapError(err) {
         if (!err) {
             return null;

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -177,7 +177,8 @@ define(function (require, exports, module) {
      */
     function _setLanguageForMode(mode, language) {
         if (_modeToLanguageMap[mode]) {
-            console.warn("CodeMirror mode \"" + mode + "\" is already used by language " + _modeToLanguageMap[mode]._name + ", won't register for " + language._name);
+            console.warn("CodeMirror mode \"" + mode + "\" is already used by language " + _modeToLanguageMap[mode]._name + " - cannot fully register language " + language._name +
+                         " using the same mode. Some features will treat all content with this mode as language " + _modeToLanguageMap[mode]._name);
             return;
         }
 

--- a/src/nls/README.md
+++ b/src/nls/README.md
@@ -1,4 +1,4 @@
-# How to add a new translation
+# How to add translations for a *new* locale
 
 1. Create a subfolder of the `nls` folder whose name is the language or locale you want to
    create a translation for.
@@ -7,10 +7,12 @@
     * If you're creating a locale-specific translation for a particular country, add a hyphen 
       and the country code in lowercase (e.g. `en-ca`, `en-gb`).
 2. Add an entry for your translation to the `module.exports` object in `nls/strings.js`.
-   (Eventually, we should remove this requirement and just scan the folder for available languages.)
-3. Copy the root `strings.js` file into your subfolder and start translating!
-4. Use the [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests) to
+3. Edit the root `strings.js` file and add a new `LOCALE_`* entry for your language, as seen in
+   the Debug > Switch Language UI.
+4. Copy the root `strings.js` file into your subfolder and start translating!
+5. Use the [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests) to
    see strings in context.
+6. Edit this file and update the list of languages below!
 
 Strings not specified in a given locale will fall back to the general language (without hyphen)
 first, and then will fall back to the English string from `nls/root/strings.js`.
@@ -26,7 +28,7 @@ providing a ``urls.js`` file that points to a localized directory under the
 localization (`src/nls/fr/urls.js`) for an example.
 
 
-# How to modify existing translations
+# How to modify *existing* translations
 
 ### Adobe-maintained translations
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1405,7 +1405,7 @@ define(function (require, exports, module) {
         node = selection;
  
         function createNode() {
-           // Create the node and open the editor
+            // Create the node and open the editor
             _projectTree.jstree("create", node, position, {data: initialName}, null, skipRename);
     
             if (!skipRename) {

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -887,8 +887,8 @@ define(function (require, exports, module) {
             // 'added' and 'removed' parameters to this function to easily determine
             // which files/folders have been added or removed.
             //
-            // In the meantime, do a quick check for directory changed events to see
-            // if any of the search results files have been deleted.
+            // In the meantime, at least check for directory changed events to see
+            // if any of the search results files have been deleted within Brackets.
             if (searchResultsPanel.isVisible()) {
                 entry.getContents(function (err, contents) {
                     if (!err) {
@@ -900,6 +900,7 @@ define(function (require, exports, module) {
                         
                         // Update the search results
                         _.forEach(searchResults, function (item, fullPath) {
+                            // Is entry the parent folder of this search result set? (simple approximate check)
                             if (fullPath.lastIndexOf("/") === entry.fullPath.length - 1) {
                                 // The changed directory includes this entry. Make sure the file still exits.
                                 if (!_includesPath(fullPath)) {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -37,25 +37,20 @@ define(function (require, exports, module) {
     var configJSON  = require("text!config.json"),
         UrlParams   = require("utils/UrlParams").UrlParams;
     
-    var params          = new UrlParams(),
-        hasNativeMenus  = "";
-    
-    // read URL params
-    params.parse();
-    
     // Define core brackets namespace if it isn't already defined
     //
     // We can't simply do 'brackets = {}' to define it in the global namespace because
     // we're in "use strict" mode. Most likely, 'window' will always point to the global
     // object when this code is running. However, in case it isn't (e.g. if we're running 
     // inside Node for CI testing) we use this trick to get the global object.
-    //
-    // Taken from:
-    //   http://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
         global.brackets = {};
     }
+    
+    // Parse URL params
+    var params = new UrlParams();
+    params.parse();
     
     // Parse src/config.json
     try {
@@ -74,6 +69,7 @@ define(function (require, exports, module) {
     // TODO: (issue #266) load conditionally
     global.brackets.shellAPI = require("utils/ShellAPI");
     
+    // Determine OS/platform
     if (global.navigator.platform === "MacIntel" || global.navigator.platform === "MacPPC") {
         global.brackets.platform = "mac";
     } else if (global.navigator.platform.indexOf("Linux") >= 0) {
@@ -84,14 +80,15 @@ define(function (require, exports, module) {
     
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
     
-    hasNativeMenus = params.get("hasNativeMenus");
-    
+    // Are we in a desktop shell with a native menu bar?
+    var hasNativeMenus = params.get("hasNativeMenus");
     if (hasNativeMenus) {
         global.brackets.nativeMenus = (hasNativeMenus === "true");
     } else {
         global.brackets.nativeMenus = (!global.brackets.inBrowser && (global.brackets.platform !== "linux"));
     }
     
+    // Locale-related APIs
     global.brackets.isLocaleDefault = function () {
         return !global.localStorage.getItem("locale");
     };

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -797,8 +797,8 @@ define(function (require, exports, module) {
     
     /**
      * Copy a directory source to a destination
-     * @param {!Directory} source Directory for the source directory to copy
-     * @param {!string} destination Destination path to copy the source directory
+     * @param {!Directory} source Directory to copy
+     * @param {!string} destination Destination path to copy the source directory to
      * @param {?{parseOffsets:boolean, infos:Object, removePrefix:boolean}}} options
      *     parseOffsets - allows optional offset markup parsing. File is written to the
      *       destination path without offsets. Offset data is passed to the


### PR DESCRIPTION
- Whole bunch of docs clarifications & type-annotation fixes
- Clarify Save As dialog cancelation handling -- and fix bug where promise was never resolved in the degenerate case that just calls doSave()
- Improved some console messages: more explanatory KeyBindingManager error; more info on Directory exceptions; clarify consequence of LanguageManager error
- Fix misleading use of "document" in identifiers in Close Others API & related code
- Improve readme instructions for adding new locale translations
