### PR TITLE
Fix scrollbar search tickmark bugs

### DIFF
--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -55,10 +55,14 @@ define(function (require, exports, module) {
     var marks = [];
     
     
+    function _getScrollbar(editor) {
+        // Be sure to select only the direct descendant, not also elements within nested inline editors
+        return $(editor.getRootElement()).children(".CodeMirror-vscrollbar");
+    }
+    
     /** Measure scrollbar track */
     function _calcScaling() {
-        var rootElem = editor.getRootElement();
-        var $sb = $(".CodeMirror-vscrollbar", rootElem);
+        var $sb = _getScrollbar(editor);
         
         trackHt = $sb[0].offsetHeight;
         
@@ -69,14 +73,14 @@ define(function (require, exports, module) {
             } else {
                 trackOffset = 0;             // No arrows
             }
+            trackHt -= trackOffset * 2;
             
         } else {
             // No scrollbar: use the height of the entire code content
-            trackHt = $(".CodeMirror-sizer", rootElem)[0].offsetHeight;
-            trackOffset = 0;
+            var codeContainer = $(editor.getRootElement()).find("> .CodeMirror-scroll > .CodeMirror-sizer > div > .CodeMirror-lines > div")[0];
+            trackHt = codeContainer.offsetHeight;
+            trackOffset = codeContainer.offsetTop;
         }
-        
-        trackHt -= trackOffset * 2;
     }
 
     /** Add all the given tickmarks to the DOM in a batch */
@@ -119,8 +123,7 @@ define(function (require, exports, module) {
                 return;
             }
             
-            var rootElem = editor.getRootElement();
-            var $sb = $(".CodeMirror-vscrollbar", rootElem);
+            var $sb = _getScrollbar(editor);
             var $overlay = $("<div class='tickmark-track'></div>");
             $sb.parent().append($overlay);
             
@@ -133,7 +136,7 @@ define(function (require, exports, module) {
                     $(".tickmark-track", editor.getRootElement()).empty();
                     _renderMarks(marks);
                 }
-            }), 300);
+            }, 300));
             
         } else {
             console.assert(editor === curEditor);


### PR DESCRIPTION
- Fix bug #6118 (Scrollbar search tickmarks duplicated inside inline editors) -- Be careful to use jQuery selectors that won't find additional matches when an inline editor is nested inside the target editor.
- Fix bug (injected at ca11256e) where exceptions are thrown on each window resize.
- More accurate height/offset calculation for the no-scrollbar case.
