### PR TITLE
Replace uses of doc.url with _server.pathToUrl()

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -446,9 +446,11 @@ define(function LiveDevelopment(require, exports, module) {
      * @param {Document} doc
      */
     function _docIsOutOfSync(doc) {
-        var docClass = _classForDocument(doc);
-        return (doc.isDirty && docClass !== CSSDocument &&
-                (!brackets.livehtml || docClass !== HTMLDocument));
+        var docClass    = _classForDocument(doc),
+            liveDoc     = _server && _server.get(doc.file.fullPath),
+            isLiveEditingEnabled = liveDoc && liveDoc.isLiveEditingEnabled();
+
+        return doc.isDirty && !isLiveEditingEnabled;
     }
     
     /** Triggered by Inspector.error */

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -958,7 +958,11 @@ define(function LiveDevelopment(require, exports, module) {
                 if (doc) {
                     // Navigate from interstitial to the document
                     // Fires a frameNavigated event
-                    Inspector.Page.navigate(doc.url);
+                    if (_server) {
+                        Inspector.Page.navigate(_server.pathToUrl(doc.file.fullPath));
+                    } else {
+                        console.error("LiveDevelopment._onInterstitialPageLoad(): No server active");
+                    }
                 } else {
                     // Unlikely that we would get to this state where
                     // a connection is in process but there is no current
@@ -1252,7 +1256,8 @@ define(function LiveDevelopment(require, exports, module) {
         
         // close the current session and begin a new session if the current
         // document changes to an HTML document that was not loaded yet
-        var wasRequested = agents.network && agents.network.wasURLRequested(doc.url),
+        var docUrl = _server && _server.pathToUrl(doc.file.fullPath),
+            wasRequested = agents.network && agents.network.wasURLRequested(docUrl),
             isViewable = exports.config.experimental || (_server && _server.canServe(doc.file.fullPath));
         
         if (!wasRequested && isViewable) {
@@ -1296,7 +1301,7 @@ define(function LiveDevelopment(require, exports, module) {
     /** Triggered by a change in dirty flag from the DocumentManager */
     function _onDirtyFlagChange(event, doc) {
         if (doc && Inspector.connected() &&
-                agents.network && agents.network.wasURLRequested(doc.url)) {
+                _server && agents.network && agents.network.wasURLRequested(_server.pathToUrl(doc.file.fullPath))) {
             // Set status to out of sync if dirty. Otherwise, set it to active status.
             _setStatus(_docIsOutOfSync(doc) ? STATUS_OUT_OF_SYNC : STATUS_ACTIVE);
         }

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -880,6 +880,9 @@ define(function (require, exports, module) {
                     // Edit a JavaScript doc
                     jsdoc.setText("window.onload = function () {document.getElementById('testId').style.backgroundColor = '#090'}");
                     
+                    // Make sure the live development dirty dot shows
+                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_OUT_OF_SYNC);
+
                     // Save changes to the test file
                     loadEventPromise = saveAndWaitForLoadEvent(jsdoc);
                 });

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -625,6 +625,9 @@ define(function (require, exports, module) {
                     localText = curDoc.getText();
                     localText += "\n .testClass { background-color:#090; }\n";
                     curDoc.setText(localText);
+
+                    // Document should not be marked dirty
+                    expect(LiveDevelopment.status).not.toBe(LiveDevelopment.STATUS_OUT_OF_SYNC);
                 });
                 
                 runs(function () {
@@ -670,6 +673,9 @@ define(function (require, exports, module) {
                     localCssText = curDoc.getText();
                     localCssText += "\n .testClass { background-color:#090; }\n";
                     curDoc.setText(localCssText);
+                    
+                    // Document should not be marked dirty
+                    expect(LiveDevelopment.status).not.toBe(LiveDevelopment.STATUS_OUT_OF_SYNC);
                 });
                 
                 runs(function () {
@@ -808,6 +814,9 @@ define(function (require, exports, module) {
                     // Edit text
                     doc =  DocumentManager.getCurrentDocument();
                     doc.replaceRange("Live Preview in ", {line: 11, ch: 33});
+
+                    // Document should not be marked dirty
+                    expect(LiveDevelopment.status).not.toBe(LiveDevelopment.STATUS_OUT_OF_SYNC);
                 });
 
                 runs(function () {
@@ -832,6 +841,9 @@ define(function (require, exports, module) {
                     doc = DocumentManager.getCurrentDocument();
                     doc.replaceRange("Live Preview in ", {line: 11, ch: 33});
                     
+                    // Document should not be marked dirty
+                    expect(LiveDevelopment.status).not.toBe(LiveDevelopment.STATUS_OUT_OF_SYNC);
+
                     // Save the document and see if "scanDocument" (which reparses the page) is called.
                     spyOn(testWindow.brackets.test.HTMLInstrumentation, "scanDocument").andCallThrough();
                     testWindow.$(DocumentManager).one("documentSaved", function (e, savedDoc) {


### PR DESCRIPTION
For #5317. `doc.url` was an old field that used to get set on the document before we refactored the live dev server management in 1f6b5aa, but there were still a few places referencing it.
