### PR TITLE
Fix #6142. Check for the argument name to be falsy

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -443,7 +443,7 @@ var config = {};
                             name = inferType.argNames[i],
                             type = inferType.args[i];
 
-                        if (name === undefined) {
+                        if (!name) {
                             name = "param" + (i + 1);
                         }
 


### PR DESCRIPTION
In some cases (see #6142 for a minimized testcase), the argument name is
returned as null instead of undefined as the code expects. This fix
simply changes to check for name to be falsy (in which case it will be
assinged a generated name).
