### PR TITLE
Add event specifications to NodeConnection

### DIFF
--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -480,11 +480,17 @@ define(function (require, exports, module) {
             
             // TODO: Don't replace the domain object every time. Instead, merge.
             self.domains = {};
+            self.domainEvents = {};
             spec.forEach(function (domainSpec) {
                 self.domains[domainSpec.domain] = {};
                 domainSpec.commands.forEach(function (commandSpec) {
                     self.domains[domainSpec.domain][commandSpec.name] =
                         makeCommandFunction(domainSpec.domain, commandSpec);
+                });
+                self.domainEvents[domainSpec.domain] = {};
+                domainSpec.events.forEach(function (eventSpec) {
+                    var parameters = eventSpec.parameters.parameters;
+                    self.domainEvents[domainSpec.domain][eventSpec.name] = parameters;
                 });
             });
             deferred.resolve();

--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -489,7 +489,7 @@ define(function (require, exports, module) {
                 });
                 self.domainEvents[domainSpec.domain] = {};
                 domainSpec.events.forEach(function (eventSpec) {
-                    var parameters = eventSpec.parameters.parameters;
+                    var parameters = eventSpec.parameters;
                     self.domainEvents[domainSpec.domain][eventSpec.name] = parameters;
                 });
             });

--- a/test/spec/NodeConnection-test-files/TestCommandsOne.js
+++ b/test/spec/NodeConnection-test-files/TestCommandsOne.js
@@ -99,6 +99,22 @@ maxerr: 50, node: true */
             [{name: "message", type: "string"}],
             [] // no return
         );
+        _domainManager.registerEvent(
+            "test",
+            "eventOne",
+            [
+                {name: "argOne", type: "string"},
+                {name: "argTwo", type: "string"}
+            ]
+        );
+        _domainManager.registerEvent(
+            "test",
+            "eventTwo",
+            [
+                {name: "argOne", type: "boolean"},
+                {name: "argTwo", type: "boolean"}
+            ]
+        );
     }
     
     exports.init = init;

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -213,6 +213,24 @@ define(function (require, exports, module) {
             );
         });
         
+        it("should parse domain event specifications", function () {
+            var connection = createConnection();
+            runConnectAndWait(connection, false);
+            runLoadDomainsAndWait(connection, ["TestCommandsOne"], false);
+            runs(function () {
+                expect(connection.domainEvents.test.eventOne.length).toBe(2);
+                expect(connection.domainEvents.test.eventOne[0].name).toBe('argOne');
+                expect(connection.domainEvents.test.eventOne[0].type).toBe('string');
+                expect(connection.domainEvents.test.eventOne[1].name).toBe('argTwo');
+                expect(connection.domainEvents.test.eventOne[1].type).toBe('string');
+                expect(connection.domainEvents.test.eventTwo.length).toBe(2);
+                expect(connection.domainEvents.test.eventTwo[0].name).toBe('argOne');
+                expect(connection.domainEvents.test.eventTwo[0].type).toBe('boolean');
+                expect(connection.domainEvents.test.eventTwo[1].name).toBe('argTwo');
+                expect(connection.domainEvents.test.eventTwo[1].type).toBe('boolean');
+            });
+        });
+        
         it("should receive command errors and continue to run", function () {
             var connection = createConnection();
             var commandDeferred = null;


### PR DESCRIPTION
The `NodeConnection` class currently parses domain specifications in order to construct wrappers around the domain's commands, and to add those wrappers to the connection object. This pull request adds domain event parsing to go along with the command parsing. It just adds the event names and their signatures to the connection, accessible by `connection.domainEvents.someDomainName`. (It would have been better to add the event specifications in the same way as the commands, but this would have required either breaking changes or polluting the existing `domains` namespace. I decided to just create a separate `domainEvents` namespace where each domain's event specifications live.)

I'm submitting this pull request because I'm also working on another wrapper around `NodeConnection` that exposes a simple interface for its most common usage: loading a single domain, executing its commands and listening for its events. The wrapper abstracts connection management and domain loading (and reloading). The goal is to eliminate a lot of existing boilerplate. It works like this:

```
var myDomain = new NodeDomain("myDomain", "/path/to/MyDomainSpec.js");

myDomain.myCommand(param1, param2)
  .done(function(value) { 
    /* command succeeded; use the result! */
  })
  .fail(function (err) {
    /* command failed; deal with it! */
  });

$(myDomain).on("someEvent", function (param1, param2) {
  /* someEvent was fired! */
});
```
