### PR TITLE
Exclude files with unwanted extensions from search

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -97,6 +97,9 @@ define(function (require, exports, module) {
     /** @type {Array.<File>} An array of the files where it should look or null/empty to search the entire project */
     var currentScope = null;
     
+    /** @type{Array.<string>} An array of the extensions that must be excluded from the search */
+    var excludedExtensions = ["png", "jpg"];
+    
     /** @type {boolean} True if the matches in a file reached FIND_IN_FILE_MAX */
     var maxHitsFoundInFile = false;
     

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -700,7 +700,7 @@ define(function (require, exports, module) {
                 Async.doInParallel(fileListResult, function (file) {
                     var result = new $.Deferred();
                     
-                    if (!_inScope(file, currentScope)) {
+                    if (!_inScope(file, currentScope) || _inExcludedExtensions(file)) {
                         result.resolve();
                     } else {
                         DocumentManager.getDocumentText(file)

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -630,6 +630,26 @@ define(function (require, exports, module) {
         }
         return true;
     }
+    
+     /**
+     * @private
+     * Return true if the extension of the file in question is included in the excluded extensions
+     * @param {!File} file File in question
+     * @return {boolean}
+     */
+    function _inExcludedExtensions(file) {
+        var filename = file._name;
+        var extension = filename.substring(filename.lastIndexOf(".") + 1, filename.length);
+        var i;
+
+        for (i = 0; i < excludedExtensions.length; i++) {
+            if (excludedExtensions[i] === extension) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
 
     /**
      * @private


### PR DESCRIPTION
Add array that contains the unwanted extensions. This array needs more extensions.
Add function that checks if the file should be excluded.
Modify _doSearch to exclude unwanted files.

Addresses #6157 
