### PR TITLE
Duplicate file feature in project tree

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
     exports.FILE_PROJECT_SETTINGS       = "file.projectSettings";       // ProjectManager.js            _projectSettings()
     exports.FILE_RENAME                 = "file.rename";                // DocumentCommandHandlers.js   handleFileRename()
     exports.FILE_DELETE                 = "file.delete";                // DocumentCommandHandlers.js   handleFileDelete()
+    exports.FILE_DUPLICATE              = "file.duplicate";             // DocumentCommandHandlers.js   handleFileDuplicate()
     exports.FILE_EXTENSION_MANAGER      = "file.extensionManager";      // ExtensionManagerDialog.js    _showDialog()
     exports.FILE_REFRESH                = "file.refresh";               // ProjectManager.js            refreshFileTree()
     

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -188,6 +188,7 @@ define(function (require, exports, module) {
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
         project_cmenu.addMenuItem(Commands.FILE_RENAME);
         project_cmenu.addMenuItem(Commands.FILE_DELETE);
+        project_cmenu.addMenuItem(Commands.FILE_DUPLICATE);
         project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         project_cmenu.addMenuDivider();
         project_cmenu.addMenuItem(Commands.EDIT_FIND_IN_SUBTREE);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1298,7 +1298,7 @@ define(function (require, exports, module) {
             /* Create duplicated item */
             var pos = entry._name.lastIndexOf('.');
             var copiedFileName = entry._name.substring(0,pos) + '-copy.' + entry._name.substring(pos+1);
-            ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false);
+            ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false, entry._path);
             
         }
     }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1293,11 +1293,11 @@ define(function (require, exports, module) {
     function handleFileDuplicate() {
         var entry = ProjectManager.getSelectedItem();
         if (entry.isDirectory) {
-            console.error("Folder cannot be duplicated yet.");
+            ProjectManager.createNewItem(entry._parentPath, entry._name + "-copy", false, true, entry._path);
         } else {
             /* Create duplicated item */
             var pos = entry._name.lastIndexOf('.');
-            var copiedFileName = entry._name.substring(0,pos) + '-copy.' + entry._name.substring(pos+1);
+            var copiedFileName = entry._name.substring(0, pos) + '-copy.' + entry._name.substring(pos + 1);
             ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false, entry._path);
             
         }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1288,6 +1288,20 @@ define(function (require, exports, module) {
             ProjectManager.deleteItem(entry);
         }
     }
+    
+    /* Duplicate the selected file in the same folder. Filename will be original file name + '-copy'*/
+    function handleFileDuplicate() {
+        var entry = ProjectManager.getSelectedItem();
+        if (entry.isDirectory) {
+            console.error("Folder cannot be duplicated yet.");
+        } else {
+            /* Create duplicated item */
+            var pos = entry._name.lastIndexOf('.');
+            var copiedFileName = entry._name.substring(0,pos) + '-copy.' + entry._name.substring(pos+1);
+            ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false);
+            
+        }
+    }
 
     /** Show the selected sidebar (tree or working set) item in Finder/Explorer */
     function handleShowInOS() {
@@ -1327,6 +1341,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_SAVE_AS,       Commands.FILE_SAVE_AS, handleFileSaveAs);
     CommandManager.register(Strings.CMD_FILE_RENAME,        Commands.FILE_RENAME, handleFileRename);
     CommandManager.register(Strings.CMD_FILE_DELETE,        Commands.FILE_DELETE, handleFileDelete);
+    CommandManager.register(Strings.CMD_FILE_DUPLICATE,     Commands.FILE_DUPLICATE, handleFileDuplicate);
     
     CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
     CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
@@ -1342,6 +1357,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
     CommandManager.register(Strings.CMD_SHOW_IN_OS,         Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+
     
     // Those commands have no UI representation, and are only used internally 
     CommandManager.registerInternal(Commands.APP_ABORT_QUIT,        _handleAbortQuit);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1289,22 +1289,22 @@ define(function (require, exports, module) {
         }
     }
     
-    /* Duplicate the selected file in the same folder. Filename will be original file name + '-copy'*/
+    /* Duplicate the selected file in the same folder. Filename will be original file name with an added number and '-copy'*/
     function handleFileDuplicate() {
         var entry = ProjectManager.getSelectedItem();
-        if (entry.isDirectory) {
-            ProjectManager.createNewItem(entry._parentPath, entry._name + "-" + Strings.COPY_SUFFIX, false, true, entry._path);
-        } else {
+              
+        if (!entry.isDirectory) {
             /* Create duplicated item */
-            var pos = entry._name.lastIndexOf('.');
-            var copiedFileName;
-            if (pos !== -1) {
-                copiedFileName = entry._name.substring(0, pos) + "-" + Strings.COPY_SUFFIX + "." + entry._name.substring(pos + 1);
-            } else {
-                //No '.' found in filename.
-                copiedFileName = entry._name + "-" + Strings.COPY_SUFFIX;
-            }
-            ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false, entry._path);
+            var pointPos = FileUtils.getBaseName(entry._path).lastIndexOf('.');
+            var extensionName = "." + FileUtils.getFileExtension(entry._path);
+            var baseFileName = FileUtils.getBaseName(entry._path).replace(extensionName, "");
+            var createWithSuggestedName = function (suggestedBaseName) {
+                var suggestedFileName = suggestedBaseName + "-" + Strings.COPY_SUFFIX + (extensionName === "." ? "" : extensionName);
+                return ProjectManager.createNewItem(entry._parentPath, suggestedFileName, false, false, entry._path)
+                    .always(function () { fileNewInProgress = false; });
+            };
+            _getUntitledFileSuggestion(entry._path, baseFileName, false)
+                .then(createWithSuggestedName, createWithSuggestedName.bind(undefined, baseFileName));
         }
     }
 

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1293,13 +1293,18 @@ define(function (require, exports, module) {
     function handleFileDuplicate() {
         var entry = ProjectManager.getSelectedItem();
         if (entry.isDirectory) {
-            ProjectManager.createNewItem(entry._parentPath, entry._name + "-copy", false, true, entry._path);
+            ProjectManager.createNewItem(entry._parentPath, entry._name + "-" + Strings.COPY_SUFFIX, false, true, entry._path);
         } else {
             /* Create duplicated item */
             var pos = entry._name.lastIndexOf('.');
-            var copiedFileName = entry._name.substring(0, pos) + '-copy.' + entry._name.substring(pos + 1);
+            var copiedFileName;
+            if (pos !== -1) {
+                copiedFileName = entry._name.substring(0, pos) + "-" + Strings.COPY_SUFFIX + "." + entry._name.substring(pos + 1);
+            } else {
+                //No '.' found in filename.
+                copiedFileName = entry._name + "-" + Strings.COPY_SUFFIX;
+            }
             ProjectManager.createNewItem(entry._parentPath, copiedFileName, false, false, entry._path);
-            
         }
     }
 

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -149,6 +149,22 @@ define(function (require, exports, module) {
         this._path = newPath;
     };
     
+    //COPY
+    FileSystemEntry.prototype.copyItem = function (destination, options, callback) {
+        if (typeof (options) === "function") {
+            callback = options;
+            options = {};
+        }
+        
+        this._impl.copyItem(this._path, destination, function (err, data, stat) {
+            if (!err) {
+                this._stat = stat;
+                // this._contents = data;
+            }
+            callback(err, data, stat);
+        }.bind(this));
+    };
+    
     /**
      * Clear any cached data for this entry
      * @private

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -301,24 +301,17 @@ define(function (require, exports, module) {
         
     }
     
-    function copyItem(sourcePath, destinationPath, options, callback) {
-        //var encoding = options.encoding || "utf8";
-        
+    function copyItem(sourcePath, destinationPath, callback) {
         exists(sourcePath, function (err, alreadyExists) {
             if (err) {
                 callback(err);
                 return;
             }
-//            fs.copy('/tmp/myfile', '/tmp/mynewfile', function(err){
-//                if (err) return console.error(err);
-//            
-//                console.log("success!")
-//            }); //copies file
             appshell.fs.copyFile(sourcePath, destinationPath, function (err) {
                 if (err) {
                     return console.error(err);
                 }
-                console.log("success copying!");
+                callback(err);
             });
         });
     }

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -301,6 +301,28 @@ define(function (require, exports, module) {
         
     }
     
+    function copyItem(sourcePath, destinationPath, options, callback) {
+        //var encoding = options.encoding || "utf8";
+        
+        exists(sourcePath, function (err, alreadyExists) {
+            if (err) {
+                callback(err);
+                return;
+            }
+//            fs.copy('/tmp/myfile', '/tmp/mynewfile', function(err){
+//                if (err) return console.error(err);
+//            
+//                console.log("success!")
+//            }); //copies file
+            appshell.fs.copyFile(sourcePath, destinationPath, function (err) {
+                if (err) {
+                    return console.error(err);
+                }
+                console.log("success copying!");
+            });
+        });
+    }
+    
     function unlink(path, callback) {
         appshell.fs.unlink(path, function (err) {
             try {
@@ -419,6 +441,7 @@ define(function (require, exports, module) {
     exports.stat            = stat;
     exports.readFile        = readFile;
     exports.writeFile       = writeFile;
+    exports.copyItem        = copyItem;
     exports.unlink          = unlink;
     exports.moveToTrash     = moveToTrash;
     exports.initWatchers    = initWatchers;

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -223,6 +223,7 @@ define({
     "CMD_PROJECT_SETTINGS"                : "Project Settings\u2026",
     "CMD_FILE_RENAME"                     : "Rename",
     "CMD_FILE_DELETE"                     : "Delete",
+    "CMD_FILE_DUPLICATE"                  : "Duplicate",
     "CMD_INSTALL_EXTENSION"               : "Install Extension\u2026",
     "CMD_EXTENSION_MANAGER"               : "Extension Manager\u2026",
     "CMD_FILE_REFRESH"                    : "Refresh File Tree",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -313,6 +313,7 @@ define({
     "SAVE"                                 : "Save",
     "CANCEL"                               : "Cancel",
     "DELETE"                               : "Delete",
+    "COPY_SUFFIX"                          : "copy",
     "RELOAD_FROM_DISK"                     : "Reload from Disk",
     "KEEP_CHANGES_IN_EDITOR"               : "Keep Changes in Editor",
     "CLOSE_DONT_SAVE"                      : "Close (Don't Save)",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -313,7 +313,6 @@ define({
     "SAVE"                                 : "Save",
     "CANCEL"                               : "Cancel",
     "DELETE"                               : "Delete",
-    "COPY_SUFFIX"                          : "copy",
     "RELOAD_FROM_DISK"                     : "Reload from Disk",
     "KEEP_CHANGES_IN_EDITOR"               : "Keep Changes in Editor",
     "CLOSE_DONT_SAVE"                      : "Close (Don't Save)",
@@ -338,6 +337,9 @@ define({
     "BASEURL_ERROR_HASH_DISALLOWED"        : "The base URL can't contain hashes like \"{0}\".",
     "BASEURL_ERROR_INVALID_CHAR"           : "Special characters like '{0}' must be %-encoded.",
     "BASEURL_ERROR_UNKNOWN_ERROR"          : "Unknown error parsing Base URL",
+    
+    //The duplication-string that automatically adds when duplicating files.
+    "COPY_SUFFIX"                          : "copy",
     
     // CSS Quick Edit
     "BUTTON_NEW_RULE"                      : "New Rule",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1381,29 +1381,32 @@ define(function (require, exports, module) {
                                 }
                             });
                         } else {
-                            // Create an file
+                            // Create a file
                             var file = FileSystem.getFileForPath(newItemPath);
-                            //If a path is specified, copy that data into the file.
-                            if (copyFilePath) { 
-                                var copyFile = FileSystem.getFileForPath(copyFilePath);                               
-                                copyFile.read(function (readError, data) {
-                                    file.write(data, function (err) {
-                                        if (err) {
-                                            errorCallback(err);
-                                        } else {
-                                            successCallback(file);
-                                        }
-                                    });
-                                });
-                            } else {
-                                //No path is specified, so just create an empty file
-                                file.write("", function (err) {
+                            // Function to write data to a file
+                            var writeDataToFile = function (file, data) {
+                                file.write(data, function (err) {
                                     if (err) {
                                         errorCallback(err);
                                     } else {
                                         successCallback(file);
                                     }
                                 });
+                            };
+                            // If a path is specified, copy that data into the file.
+                            if (copyFilePath) {
+                                var copyFile = FileSystem.getFileForPath(copyFilePath);
+                                copyFile.read(function (readError, data) {
+                                    if (readError) {
+                                        // No need to write data if there is any read-error.
+                                        errorCallback(FileSystemError.NOT_READABLE, copyFilePath);
+                                    } else {
+                                        writeDataToFile(file, data);
+                                    }
+                                });
+                            } else {
+                                //No path is specified, so just create an empty file
+                                writeDataToFile(file, "");
                             }
                         }
                     }
@@ -1413,7 +1416,6 @@ define(function (require, exports, module) {
                 errorCleanup();
             }
         });
-        
         
         // TODO (issue #115): Need API to get tree node for baseDir.
         // In the meantime, pass null for node so new item is placed

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1233,11 +1233,12 @@ define(function (require, exports, module) {
      * @param initialName {string} Initial name for the item
      * @param skipRename {boolean} If true, don't allow the user to rename the item
      * @param isFolder {boolean} If true, create a folder instead of a file
+     * @param copyFilePath {File} If defined, this file will be used for duplicating the file
      * @return {$.Promise} A promise object that will be resolved with the File
      *  of the created object, or rejected if the user cancelled or entered an illegal
      *  filename.
      */
-    function createNewItem(baseDir, initialName, skipRename, isFolder, copyReadData) {
+    function createNewItem(baseDir, initialName, skipRename, isFolder, copyFilePath) {
         var node                = null,
             selection           = _projectTree.jstree("get_selected"),
             selectionEntry      = null,
@@ -1382,10 +1383,10 @@ define(function (require, exports, module) {
                         } else {
                             // Create an empty file
                             var file = FileSystem.getFileForPath(newItemPath);
-                            if (copyReadData) {
-                                var oldFile = FileSystem.getFileForPath(copyReadData);
-                                oldFile.read(function (err, data) {
-                                    
+                            if (copyFilePath) {
+                                var copyFile = FileSystem.getFileForPath(copyFilePath);
+                                
+                                copyFile.read(function (readError, data) {
                                     file.write(data, function (err) {
                                         if (err) {
                                             errorCallback(err);
@@ -1395,7 +1396,7 @@ define(function (require, exports, module) {
                                     });
                                 });
                             } else {
-                                file.write(data, function (err) {
+                                file.write("", function (err) {
                                     if (err) {
                                         errorCallback(err);
                                     } else {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1399,6 +1399,7 @@ define(function (require, exports, module) {
             }
         });
         
+        
         // TODO (issue #115): Need API to get tree node for baseDir.
         // In the meantime, pass null for node so new item is placed
         // relative to the selection

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1396,15 +1396,13 @@ define(function (require, exports, module) {
                             // If a path is specified, copy that data into the file.
                             if (copyFilePath) {
                                 var copyFile = FileSystem.getFileForPath(copyFilePath);
-//                                copyFile.read(function (readError, data) {
-//                                    if (readError) {
-//                                        // No need to write data if there is any read-error.
-//                                        errorCallback(FileSystemError.NOT_READABLE, copyFilePath);
-//                                    } else {
-//                                        writeDataToFile(file, data);
-//                                    }
-//                                });
-                                copyFile.copyItem(newItemPath);
+                                copyFile.copyItem(newItemPath, function (copyError) {
+                                    if (copyError) {
+                                        errorCallback(copyError);
+                                    } else {
+                                        successCallback(file);
+                                    }
+                                });
                             } else {
                                 //No path is specified, so just create an empty file
                                 writeDataToFile(file, "");

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1381,11 +1381,11 @@ define(function (require, exports, module) {
                                 }
                             });
                         } else {
-                            // Create an empty file
+                            // Create an file
                             var file = FileSystem.getFileForPath(newItemPath);
-                            if (copyFilePath) {
-                                var copyFile = FileSystem.getFileForPath(copyFilePath);
-                                
+                            //If a path is specified, copy that data into the file.
+                            if (copyFilePath) { 
+                                var copyFile = FileSystem.getFileForPath(copyFilePath);                               
                                 copyFile.read(function (readError, data) {
                                     file.write(data, function (err) {
                                         if (err) {
@@ -1396,6 +1396,7 @@ define(function (require, exports, module) {
                                     });
                                 });
                             } else {
+                                //No path is specified, so just create an empty file
                                 file.write("", function (err) {
                                     if (err) {
                                         errorCallback(err);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1237,7 +1237,7 @@ define(function (require, exports, module) {
      *  of the created object, or rejected if the user cancelled or entered an illegal
      *  filename.
      */
-    function createNewItem(baseDir, initialName, skipRename, isFolder) {
+    function createNewItem(baseDir, initialName, skipRename, isFolder, copyReadData) {
         var node                = null,
             selection           = _projectTree.jstree("get_selected"),
             selectionEntry      = null,
@@ -1382,14 +1382,27 @@ define(function (require, exports, module) {
                         } else {
                             // Create an empty file
                             var file = FileSystem.getFileForPath(newItemPath);
-                            
-                            file.write("", function (err) {
-                                if (err) {
-                                    errorCallback(err);
-                                } else {
-                                    successCallback(file);
-                                }
-                            });
+                            if (copyReadData) {
+                                var oldFile = FileSystem.getFileForPath(copyReadData);
+                                oldFile.read(function (err, data) {
+                                    
+                                    file.write(data, function (err) {
+                                        if (err) {
+                                            errorCallback(err);
+                                        } else {
+                                            successCallback(file);
+                                        }
+                                    });
+                                });
+                            } else {
+                                file.write(data, function (err) {
+                                    if (err) {
+                                        errorCallback(err);
+                                    } else {
+                                        successCallback(file);
+                                    }
+                                });
+                            }
                         }
                     }
                 });

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1396,14 +1396,15 @@ define(function (require, exports, module) {
                             // If a path is specified, copy that data into the file.
                             if (copyFilePath) {
                                 var copyFile = FileSystem.getFileForPath(copyFilePath);
-                                copyFile.read(function (readError, data) {
-                                    if (readError) {
-                                        // No need to write data if there is any read-error.
-                                        errorCallback(FileSystemError.NOT_READABLE, copyFilePath);
-                                    } else {
-                                        writeDataToFile(file, data);
-                                    }
-                                });
+//                                copyFile.read(function (readError, data) {
+//                                    if (readError) {
+//                                        // No need to write data if there is any read-error.
+//                                        errorCallback(FileSystemError.NOT_READABLE, copyFilePath);
+//                                    } else {
+//                                        writeDataToFile(file, data);
+//                                    }
+//                                });
+                                copyFile.copyItem(newItemPath);
                             } else {
                                 //No path is specified, so just create an empty file
                                 writeDataToFile(file, "");


### PR DESCRIPTION
https://trello.com/c/AUMtxj7D/754-create-file-w-duplicate
https://github.com/adobe/brackets/issues/1921
- Added a contextmenu option for duplicating a file/folder.
- Added a parameter at the createNewItem function in the projectManager to be able to choose if a new file should be empty or copied. (Might implement a duplicateItem function for that?).
- Folder copy does work, but the content of the folder isn't copied yet.

Question is should this be an extension or a core feature of Brackets?
Already discussed this with a few people on the #brackets channel, but I leave it up to the reviewers as I'm not sure what's the best choice.

Please be positevly harsh on me :) There is much to learn and I appreciate any from of comment! 

Did test this on Windows 8.1. Not on linux/mac yet.
