### PR TITLE
Sprint 34 Hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Brackets",
-    "version": "0.34.0-0",
+    "version": "0.34.1-0",
     "apiVersion": "0.34.0",
     "homepage": "http://brackets.io",
     "issues": {

--- a/src/config.json
+++ b/src/config.json
@@ -18,7 +18,7 @@
         "linting.enabled_by_default": true
     },
     "name": "Brackets",
-    "version": "0.34.0-0",
+    "version": "0.34.1-0",
     "apiVersion": "0.34.0",
     "homepage": "http://brackets.io",
     "issues": {

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -201,12 +201,20 @@ define(function (require, exports, module) {
      * @return {boolean} true if excluded, false otherwise.
      */
     function isFileExcluded(file) {
+        if (file.name[0] === ".") {
+            return true;
+        }
+        
+        var languageID = LanguageManager.getLanguageForPath(file.fullPath).getId();
+        if (languageID !== HintUtils.LANGUAGE_ID) {
+            return true;
+        }
+        
         var excludes = preferences.getExcludedFiles();
-
         if (!excludes) {
             return false;
         }
-
+        
         return excludes.test(file.name);
     }
 
@@ -900,11 +908,8 @@ define(function (require, exports, module) {
             FileSystem.resolve(dir, function (err, directory) {
                 function visitor(entry) {
                     if (entry.isFile) {
-                        if (!isFileExcluded(entry) && entry.name.indexOf(".") !== 0) { // ignore .dotfiles
-                            var languageID = LanguageManager.getLanguageForPath(entry.fullPath).getId();
-                            if (languageID === HintUtils.LANGUAGE_ID) {
-                                addFilesToTern([entry.fullPath]);
-                            }
+                        if (!isFileExcluded(entry)) { // ignore .dotfiles and non-.js files
+                            addFilesToTern([entry.fullPath]);
                         }
                     } else {
                         return !isDirectoryExcluded(entry.fullPath) &&


### PR DESCRIPTION
Contains fixes from:
- https://github.com/adobe/brackets/pull/6058 Monkeypatch: in CodeMirror, revert less.js to a working version
- https://github.com/adobe/brackets/pull/6068 Filter out dotfiles in code hints

Also, update version strings to 0.34.1.

Please note that this pull request is merging to a new `sprint-34-hotfix` branch and not `master`.
