### PR TITLE
Make image guides look better against the background image.

### DIFF
--- a/src/styles/images/horizontal-dash.svg
+++ b/src/styles/images/horizontal-dash.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="8px" height="1px">
-    <line x1="0" y1="0" x2="4" y2="0" style="stroke:rgb(0,0,0);stroke-width:1"/>
-    <line x1="5" y1="0" x2="7" y2="0" style="stroke:rgba(255,255,255,0.5);stroke-width:1"/>
+    <line x1="0" y1="0" x2="4" y2="0" style="stroke:rgb(0,0,0);stroke-width:1;stroke-linecap:square"/>
+    <line x1="5" y1="0" x2="7" y2="0" style="stroke:rgba(255,255,255,0.5);stroke-width:1;stroke-linecap:square"/>
 </svg>

--- a/src/styles/images/vertical-dash.svg
+++ b/src/styles/images/vertical-dash.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1px" height="8px">
-    <line x1="0" y1="0" x2="0" y2="4" style="stroke:rgb(0,0,0);stroke-width:1"/>
-    <line x1="0" y1="5" x2="0" y2="7" style="stroke:rgba(255,255,255,0.5);stroke-width:1"/>
+    <line x1="0" y1="0" x2="0" y2="4" style="stroke:rgb(0,0,0);stroke-width:1;stroke-linecap:square"/>
+    <line x1="0" y1="5" x2="0" y2="7" style="stroke:rgba(255,255,255,0.5);stroke-width:1;stroke-linecap:square"/>
 </svg>


### PR DESCRIPTION
When I created these svg files, I noticed that the two line segments are not connected in @peterflynn's svg viewer. At first, I thought it is a bug in the svg viewer until I learned from Peter that svg line drawing has three different linecap settings. So this pull request it to fix the linecap in those svg files even though the difference is not really noticeable in using image guides.

@peterflynn Can you review this?
