### PR TITLE
Need to call onClosed of base class to clean up

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -200,11 +200,11 @@ define(function (require, exports, module) {
          * @private
          * Handle click
          */
-        function _onClick(event) {
+        function _onClickOutside(event) {
             var $container = $(event.target).closest(".stylesheet-dropdown");
 
             // If click is outside dropdown list, then close dropdown list
-            if ($container.length === 0) {
+            if ($container.length === 0 || $container[0] !== $dropdown[0]) {
                 _closeDropdown();
             }
         }
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
          * PopUpManager when the dropdown is closed.
          */
         function _cleanupDropdown() {
-            window.document.body.removeEventListener("click", _onClick, true);
+            window.document.body.removeEventListener("click", _onClickOutside, true);
             $(hostEditor).off("scroll", _closeDropdown);
             $(PanelManager).off("editorAreaResize", _closeDropdown);
             dropdownEventHandler = null;
@@ -274,7 +274,7 @@ define(function (require, exports, module) {
             
             $dropdown.focus();
             
-            window.document.body.addEventListener("click", _onClick, true);
+            window.document.body.addEventListener("click", _onClickOutside, true);
             $(hostEditor).on("scroll", _closeDropdown);
             $(PanelManager).on("editorAreaResize", _closeDropdown);
         }

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -383,10 +383,9 @@ define(function (require, exports, module) {
                 $(cssInlineEditor).on("add", function () {
                     inlineEditorDeferred.resolve();
                 });
-                cssInlineEditor.onClosed = function () {
+                $(cssInlineEditor).on("close", function () {
                     _closeDropdown();
-                    MultiRangeInlineEditor.MultiRangeInlineEditor.prototype.onClosed.apply(this, arguments);
-                };
+                });
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);
                 $newRuleButton = $("<button class='stylesheet-button btn btn-mini disabled'/>")

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -385,6 +385,7 @@ define(function (require, exports, module) {
                 });
                 cssInlineEditor.onClosed = function () {
                     _closeDropdown();
+                    MultiRangeInlineEditor.MultiRangeInlineEditor.prototype.onClosed.apply(this, arguments);
                 };
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -198,11 +198,24 @@ define(function (require, exports, module) {
         
         /**
          * @private
+         * Handle click
+         */
+        function _onClick(event) {
+            var $container = $(event.target).closest(".stylesheet-dropdown");
+
+            // If click is outside dropdown list, then close dropdown list
+            if ($container.length === 0) {
+                _closeDropdown();
+            }
+        }
+        
+        /**
+         * @private
          * Remove the various event handlers that close the dropdown. This is called by the
          * PopUpManager when the dropdown is closed.
          */
         function _cleanupDropdown() {
-            $("html").off("click", _closeDropdown);
+            window.document.body.removeEventListener("click", _onClick, true);
             $(hostEditor).off("scroll", _closeDropdown);
             $(PanelManager).off("editorAreaResize", _closeDropdown);
             dropdownEventHandler = null;
@@ -261,7 +274,7 @@ define(function (require, exports, module) {
             
             $dropdown.focus();
             
-            $("html").on("click", _closeDropdown);
+            window.document.body.addEventListener("click", _onClick, true);
             $(hostEditor).on("scroll", _closeDropdown);
             $(PanelManager).on("editorAreaResize", _closeDropdown);
         }

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -50,6 +50,7 @@ define(function (require, exports, module) {
         this.$closeBtn = this.$htmlContent.find(".close");
         this.$closeBtn.click(function (e) {
             self.close();
+            e.stopImmediatePropagation();
         });
 
         this.$htmlContent.on("keydown", function (e) {

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -50,7 +50,6 @@ define(function (require, exports, module) {
         this.$closeBtn = this.$htmlContent.find(".close");
         this.$closeBtn.click(function (e) {
             self.close();
-            e.stopImmediatePropagation();
         });
 
         this.$htmlContent.on("keydown", function (e) {
@@ -91,7 +90,7 @@ define(function (require, exports, module) {
      * Called any time inline is closed, whether manually or automatically.
      */
     InlineWidget.prototype.onClosed = function () {
-        // Does nothing in base implementation.
+        $(this).triggerHandler("close");
     };
 
     /**


### PR DESCRIPTION
This is for #6174.

This code overrides onClosed of base class so we can close dropdown, but wasn't calling the base class method.

cc @njx
