### PR TITLE
NodeDomain

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -81,6 +81,7 @@ define(function (require, exports, module) {
         Resizer                 = require("utils/Resizer"),
         LiveDevelopmentMain     = require("LiveDevelopment/main"),
         NodeConnection          = require("utils/NodeConnection"),
+        NodeDomain              = require("utils/NodeDomain"),
         ExtensionUtils          = require("utils/ExtensionUtils"),
         DragAndDrop             = require("utils/DragAndDrop"),
         ColorUtils              = require("utils/ColorUtils"),

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -157,17 +157,20 @@ define(function (require, exports, module) {
      * @private
      * Event handler for StaticServerDomain requestFilter event
      * @param {jQuery.Event} event
-     * @param {{hostname: string, pathname: string, port: number, root: string}} request
+     * @param {{hostname: string, pathname: string, port: number, root: string, id: number}} request
      */
     StaticServer.prototype._onRequestFilter = function (event, request) {
         var key             = request.location.pathname,
             liveDocument    = this._liveDocuments[key],
-            response        = null;
-
+            response;
+        
         // send instrumented response or null to fallback to static file
         if (liveDocument && liveDocument.getResponseData) {
             response = liveDocument.getResponseData();
+        } else {
+            response = {};
         }
+        response.id = request.id;
         
         this._send(request.location, response);
     };

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -34,31 +34,15 @@ define(function (require, exports, module) {
         FileUtils            = brackets.getModule("file/FileUtils"),
         LiveDevServerManager = brackets.getModule("LiveDevelopment/LiveDevServerManager"),
         BaseServer           = brackets.getModule("LiveDevelopment/Servers/BaseServer").BaseServer,
-        NodeConnection       = brackets.getModule("utils/NodeConnection"),
+        NodeDomain           = brackets.getModule("utils/NodeDomain"),
         ProjectManager       = brackets.getModule("project/ProjectManager"),
-        StaticServer         = require("StaticServer").StaticServer;
-
-    /**
-     * @const
-     * Amount of time to wait before automatically rejecting the connection
-     * deferred. If we hit this timeout, we'll never have a node connection
-     * for the static server in this run of Brackets.
-     */
-    var NODE_CONNECTION_TIMEOUT = 5000; // 5 seconds
+        StaticServer         = require("StaticServer");
     
     /**
      * @private
-     * @type{jQuery.Deferred.<NodeConnection>}
-     * A deferred which is resolved with a NodeConnection or rejected if
-     * we are unable to connect to Node.
+     * @type {NodeDomain}
      */
-    var _nodeConnectionDeferred = new $.Deferred();
-    
-    /**
-     * @private
-     * @type {NodeConnection}
-     */
-    var _nodeConnection = new NodeConnection();
+    var _nodeDomain;
     
     /**
      * @private
@@ -67,61 +51,26 @@ define(function (require, exports, module) {
      */
     function _createStaticServer() {
         var config = {
-            nodeConnection  : _nodeConnection,
+            nodeDomain      : _nodeDomain,
             pathResolver    : ProjectManager.makeProjectRelativeIfPossible,
             root            : ProjectManager.getProjectRoot().fullPath
         };
         
         return new StaticServer(config);
     }
-
-    /**
-     * Allows access to the deferred that manages the node connection. This
-     * is *only* for unit tests. Messing with this not in testing will
-     * potentially break everything.
-     *
-     * @private
-     * @return {jQuery.Deferred} The deferred that manages the node connection
-     */
-    function _getNodeConnectionDeferred() {
-        return _nodeConnectionDeferred;
-    }
     
     function initExtension() {
-        // Start up the node connection, which is held in the
-        // _nodeConnectionDeferred module variable. (Use 
-        // _nodeConnectionDeferred.done() to access it.
-        var connectionTimeout = setTimeout(function () {
-            console.error("[StaticServer] Timed out while trying to connect to node");
-            _nodeConnectionDeferred.reject();
-        }, NODE_CONNECTION_TIMEOUT);
-        
-        _nodeConnection.connect(true).then(function () {
-            _nodeConnection.loadDomains(
-                [ExtensionUtils.getModulePath(module, "node/StaticServerDomain")],
-                true
-            ).then(
-                function () {
-                    clearTimeout(connectionTimeout);
+        var modulePath = ExtensionUtils.getModulePath(module, "node/StaticServerDomain");
+        _nodeDomain = new NodeDomain("staticServer", modulePath);
 
-                    // Register as a Live Development server provider
-                    LiveDevServerManager.registerServer({ create: _createStaticServer }, 5);
-
-                    _nodeConnectionDeferred.resolveWith(null, [_nodeConnection]);
-                },
-                function () { // Failed to connect
-                    console.error("[StaticServer] Failed to connect to node", arguments);
-                    _nodeConnectionDeferred.reject();
-                }
-            );
+        return _nodeDomain.promise().then(function () {
+            LiveDevServerManager.registerServer({ create: _createStaticServer }, 5);
+            return _nodeDomain.connection;
         });
-
-        return _nodeConnectionDeferred.promise();
     }
 
     exports.initExtension = initExtension;
 
     // For unit tests only
     exports._getStaticServerProvider = _createStaticServer;
-    exports._getNodeConnectionDeferred = _getNodeConnectionDeferred;
 });

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -40,9 +40,15 @@ define(function (require, exports, module) {
     
     /**
      * @private
+     * @type {string} fullPath of the StaticServerDomain implementation
+     */
+    var _domainPath = ExtensionUtils.getModulePath(module, "node/StaticServerDomain");
+    
+    /**
+     * @private
      * @type {NodeDomain}
      */
-    var _nodeDomain;
+    var _nodeDomain = new NodeDomain("staticServer", _domainPath);
     
     /**
      * @private
@@ -59,18 +65,11 @@ define(function (require, exports, module) {
         return new StaticServer(config);
     }
     
-    function initExtension() {
-        var modulePath = ExtensionUtils.getModulePath(module, "node/StaticServerDomain");
-        _nodeDomain = new NodeDomain("staticServer", modulePath);
-
-        return _nodeDomain.promise().then(function () {
-            LiveDevServerManager.registerServer({ create: _createStaticServer }, 5);
-            return _nodeDomain.connection;
-        });
-    }
-
-    exports.initExtension = initExtension;
-
+    AppInit.appReady(function () {
+        LiveDevServerManager.registerServer({ create: _createStaticServer }, 5);
+    });
+    
     // For unit tests only
     exports._getStaticServerProvider = _createStaticServer;
+    exports._nodeDomain = _nodeDomain;
 });

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -75,7 +75,7 @@
     
     /**
      * @private
-     * @type {Object.<number, {Object.<string, http.ServerResponse>}}
+     * @type {Object.<string, {Object.<number, http.ServerResponse>}}
      * A map from a request identifier to its request/response mapping.
      */
     var _requests = {};

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -37,6 +37,13 @@
     var _domainManager;
 
     var FILTER_REQUEST_TIMEOUT = 5000;
+    
+    /**
+     * @private
+     * @type {number}
+     * Used to assign unique identifiers to each filter request
+     */
+    var _filterRequestCounter = 0;
 
     /**
      * @private
@@ -68,8 +75,8 @@
     
     /**
      * @private
-     * @type {Object.<string, {Object.<string, http.ServerResponse>}}
-     * A map from root paths to its request/response mapping.
+     * @type {Object.<number, {Object.<string, http.ServerResponse>}}
+     * A map from a request identifier to its request/response mapping.
      */
     var _requests = {};
     
@@ -139,6 +146,7 @@
         function rewrite(req, res, next) {
             var location = {pathname: parse(req).pathname},
                 hasListener = _rewritePaths[pathKey] && _rewritePaths[pathKey][location.pathname],
+                requestId = _filterRequestCounter++,
                 timeoutId;
             
             // ignore most HTTP methods and files that we're not watching
@@ -152,7 +160,7 @@
             function resume(doNext) {
                 // delete the callback after it's used or we hit the timeout.
                 // if this path is requested again, a new callback is generated.
-                delete _requests[pathKey][location.pathname];
+                delete _requests[pathKey][requestId];
 
                 // pass request to next middleware
                 if (doNext) {
@@ -163,12 +171,12 @@
             }
             
             // map request pathname to response callback
-            _requests[pathKey][location.pathname] = function (resData) {
+            _requests[pathKey][requestId] = function (resData) {
                 // clear timeout immediately when this callback is called
                 clearTimeout(timeoutId);
 
                 // response data is optional
-                if (resData) {
+                if (resData.body) {
                     // HTTP headers
                     var type    = mime.lookup(location.pathname),
                         charset = mime.charsets.lookup(type);
@@ -194,7 +202,8 @@
 
             var request = {
                 headers:    req.headers,
-                location:   location
+                location:   location,
+                id:         requestId
             };
             
             // dispatch request event
@@ -308,11 +317,11 @@
      *
      * @param {string} path The absolute path of the server
      * @param {string} root The relative path of the file beginning with a forward slash "/"
-     * @param {Object} resData Response data to use
+     * @param {!Object} resData Response data to use
      */
     function _cmdWriteFilteredResponse(root, path, resData) {
         var pathKey  = getPathKey(root),
-            callback = _requests[pathKey][path];
+            callback = _requests[pathKey][resData.id];
 
         if (callback) {
             callback(resData);
@@ -440,7 +449,7 @@
             "requestFilter",
             [{
                 name: "location",
-                type: "{hostname: string, pathname: string, port: number, root: string}",
+                type: "{hostname: string, pathname: string, port: number, root: string: id: number}",
                 description: "request path"
             }]
         );

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
         NodeConnection  = brackets.getModule("utils/NodeConnection"),
         FileUtils       = brackets.getModule("file/FileUtils"),
         SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
-        StaticServer    = require("StaticServer").StaticServer;
+        StaticServer    = require("StaticServer");
     
     var testFolder     = FileUtils.getNativeModuleDirectoryPath(module) + "/unittest-files";
     
@@ -517,7 +517,7 @@ define(function (require, exports, module) {
         // Unit tests for the StaticServerProvider that wraps the underlying node server.
         describe("StaticServer", function () {
             var projectPath         = testFolder + "/",
-                mockNodeConnection  = { connected: function () { return true; } },
+                mockNodeDomain      = { ready: function () { return true; } },
                 pathResolver        = function (path) {
                     if (path.indexOf(projectPath) === 0) {
                         return path.slice(projectPath.length);
@@ -527,7 +527,7 @@ define(function (require, exports, module) {
                 },
                 config              = {
                     baseUrl: "http://localhost/",
-                    nodeConnection: mockNodeConnection,
+                    nodeDomain: mockNodeDomain,
                     pathResolver: pathResolver,
                     root: projectPath
                 };
@@ -576,7 +576,7 @@ define(function (require, exports, module) {
             
             it("should decline serving if not connected to node", function () {
                 // mock NodeConnection state to be disconnected
-                config.nodeConnection = { connected: function () { return false; } };
+                config.nodeDomain = { ready: function () { return false; } };
 
                 var server = new StaticServer(config);
 

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
         // Unit tests for the underlying node server.
         describe("StaticServerDomain", function () {
             var nodeConnection,
+                nodeDomain,
                 logs;
             
             beforeEach(function () {
@@ -61,11 +62,10 @@ define(function (require, exports, module) {
                 if (!nodeConnection) {
                     runs(function () {
                         // wait for StaticServer/main to connect and load the StaticServerDomain
-                        main.initExtension().done(function (conn) {
-                            nodeConnection = conn;
-                        });
+                        nodeDomain = main._nodeDomain;
+                        nodeConnection = nodeDomain.connection;
 
-                        waitsFor(function () { return nodeConnection; }, "NodeConnection connected", CONNECT_TIMEOUT);
+                        waitsFor(function () { return nodeDomain.ready(); }, "NodeConnection connected", CONNECT_TIMEOUT);
                     });
 
                     runs(function () {
@@ -418,13 +418,11 @@ define(function (require, exports, module) {
                 var serverInfo,
                     path = testFolder + "/folder1",
                     text,
-                    location,
                     requestId = -1;
                 
                 spyOn(console, "warn").andCallThrough();
                 
                 onRequestFilter(function (request) {
-                    location = request.location;
                     requestId = request.id;
                 });
                 

--- a/src/utils/NodeDomain.js
+++ b/src/utils/NodeDomain.js
@@ -191,22 +191,26 @@ define(function (require, exports, module) {
             params = Array.prototype.slice.call(arguments, 1),
             execConnected = function () {
                 var domain  = connection.domains[this._domainName],
-                    fn      = domain && domain[name];
+                    fn      = domain && domain[name],
+                    execResult;
         
                 if (fn) {
-                    return fn.apply(domain, params);
+                    execResult = fn.apply(domain, params);
                 } else {
-                    return new $.Deferred().reject().promise();
+                    execResult = new $.Deferred().reject().promise();
                 }
+                return execResult;
             }.bind(this);
         
+        var result;
         if (this.ready()) {
-            return execConnected();
+            result = execConnected();
         } else if (this._connectionPromise) {
-            return this._connectionPromise.then(execConnected);
+            result = this._connectionPromise.then(execConnected);
         } else {
-            return new $.Deferred.reject().promise();
+            result = new $.Deferred.reject().promise();
         }
+        return result;
     };
         
     module.exports = NodeDomain;

--- a/src/utils/NodeDomain.js
+++ b/src/utils/NodeDomain.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, $ */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var NodeConnection = require("utils/NodeConnection");
+    
+    // Used to remove all listeners at once when the connection drops
+    var EVENT_NAMESPACE = ".NodeDomainEvent";
+    
+    /**
+     * Provides a simple abstraction for executing the commands of a single
+     * domain loaded via a NodeConnection. Automatically handles connection
+     * management and domain loading, and exposes each command in the domain as
+     * a promise-returning method that can safely be called regardless of the
+     * current status of the underlying connection. Example usage:
+     * 
+     * var myDomain = new NodeDomain("someDomain", pathToSomeDomainDef);
+     *     $result = myDomain.exec("someCommand", arg1, arg2);
+     * 
+     * $result.done(function (value) {
+     *     // the command succeeded!
+     * });
+     * 
+     * $result.fail(function (err) {
+     *     // the command failed; act accordingly!
+     * });
+     * 
+     * To handle domain events, just listen for the event on the domain:
+     * 
+     * $(myDomain).on("someEvent", someHandler);
+     */
+    function NodeDomain(domainName, domainPath) {
+        var connection = new NodeConnection();
+        
+        this.connection = connection;
+        this._domainName = domainName;
+        this._domainPath = domainPath;
+        this._domainLoaded = false;
+        this._connectionPromise = connection.connect(true)
+            .then(this._load.bind(this));
+        
+        $(connection).on("close", function (event, promise) {
+            $(this.connection).off(EVENT_NAMESPACE);
+            this._domainLoaded = false;
+            this._connectionPromise = promise.then(this._load.bind(this));
+        }.bind(this));
+    }
+    
+    /** 
+     * The underlying Node connection object for this domain.
+     * 
+     * @type {!NodeConnection} 
+     */
+    NodeDomain.prototype.connection = null;
+
+    /**
+     * A promise that is resolved once the NodeConnection is connected and the
+     * domain has been loaded.
+     * 
+     * @type {?jQuery.Promise}
+     * @private
+     */
+    NodeDomain.prototype._connectionPromise = null;
+    
+    /**
+     * The name of this domain.
+     * 
+     * @type {string}
+     * @private
+     */
+    NodeDomain.prototype._domainName = null;
+    
+    /**
+     * The path at which the Node definition of this domain resides.
+     * 
+     * @type {string}
+     * @private
+     */
+    NodeDomain.prototype._domainPath = null;
+    
+    /**
+     * Whether or not the domain has been successfully loaded.
+     * 
+     * @type {boolean}
+     * @private
+     */
+    NodeDomain.prototype._domainLoaded = false;
+    
+    /**
+     * Loads the domain via the underlying connection object and exposes the
+     * domain's commands as methods on this object. Assumes the underlying
+     * connection has already been opened.
+     * 
+     * @return {jQuery.Promise} Resolves once the domain is been loaded.
+     * @private
+     */
+    NodeDomain.prototype._load = function () {
+        var connection = this.connection;
+        return connection.loadDomains(this._domainPath, true)
+            .done(function () {
+                this._domainLoaded = true;
+                this._connectionPromise = null;
+                
+                var eventNames = Object.keys(connection.domainEvents[this._domainName]);
+                eventNames.forEach(function (domainEvent) {
+                    var connectionEvent = this._domainName + "." + domainEvent + EVENT_NAMESPACE;
+                    
+                    $(connection).on(connectionEvent, function () {
+                        var params = Array.prototype.slice.call(arguments, 1);
+                        $(this).triggerHandler(domainEvent, params);
+                    }.bind(this));
+                }, this);
+            }.bind(this));
+    };
+    
+    /**
+     * Synchronously determine whether the domain is ready; i.e., whether the
+     * connection is open and the domain is loaded.
+     * 
+     * @return {boolean} Whether or not the domain is currently ready.
+     */
+    NodeDomain.prototype.ready = function () {
+        return this._domainLoaded && this.connection.connected();
+    };
+    
+    /**
+     * Get a promise that resolves when the connection is open and the domain
+     * is loaded.
+     *
+     * @return {jQuery.Promise}
+     */
+    NodeDomain.prototype.promise = function () {
+        if (this._connectionPromise) {
+            return this._connectionPromise;
+        } else {
+            var deferred = $.Deferred();
+            
+            if (this.ready()) {
+                deferred.resolve();
+            } else {
+                deferred.reject();
+            }
+            
+            return deferred.promise();
+        }
+    };
+    
+    /**
+     * Applies the named command from the domain to a list of parameters, which
+     * are passed as extra arguments to this method. If the connection is open
+     * and the domain is loaded, the function is applied immediately. Otherwise
+     * the function is applied as soon as the connection has been opened and the
+     * domain has finished loading.
+     * 
+     * @param {string} name The name of the domain command to execute
+     * @return {jQuery.Promise} Resolves with the result of the command
+     */
+    NodeDomain.prototype.exec = function (name) {
+        var connection = this.connection,
+            params = Array.prototype.slice.call(arguments, 1),
+            execConnected = function () {
+                var domain  = connection.domains[this._domainName],
+                    fn      = domain && domain[name];
+        
+                if (fn) {
+                    return fn.apply(domain, params);
+                } else {
+                    return $.Deferred.reject().promise();
+                }
+            }.bind(this);
+        
+        if (this.ready()) {
+            return execConnected();
+        } else if (this._connectionPromise) {
+            return this._connectionPromise.then(execConnected);
+        } else {
+            return $.Deferred.reject().promise();
+        }
+    };
+        
+    module.exports = NodeDomain;
+});

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
         UrlParams               = require("utils/UrlParams").UrlParams,
         UnitTestReporter        = require("test/UnitTestReporter").UnitTestReporter,
         NodeConnection          = require("utils/NodeConnection"),
+        NodeDomain              = require("utils/NodeDomain"),
         BootstrapReporterView   = require("test/BootstrapReporterView").BootstrapReporterView,
         ColorUtils              = require("utils/ColorUtils"),
         NativeApp               = require("utils/NativeApp");


### PR DESCRIPTION
This pull request has three parts: 
1. A new `NodeDomain` module, which is a high-level wrapper around `NodeConnection`. This makes it easy to open a connection and load a single domain, and then execute the domain's commands and listen for its events. The wrapper handles, in particular, connection and domain loading and reloading.
   The inline documentation gives the following usage example:

```
var myDomain = new NodeDomain("someDomain", "/path/to/SomeDomainDef");
      $result = myDomain.exec("someCommand", arg1, arg2);

      $result.done(function (value) {
        // the command succeeded!
      });

      $result.fail(function (err) {
        // the command failed; act accordingly!
      });

      $(myDomain).on("someEvent", someHandler);
```
1. A refactoring of `StaticServer` to use `NodeDomain` instead of manipulating `NodeConnection` directly. The previous code had been copied and pasted regularly, but had a few shortcomings, including redundant timeouts (`NodeConnection` handles this already), failure to handle disconnected sockets, and, in some cases, a silent fail-fast behavior on command execution where simply waiting would suffice. (If the `NodeConnection` isn't connected, don't abort; just wait for it to come back up!)
2. Finally, it also fixes a race condition in `StaticServerDomain` that was causing the `LiveDevelopment` unit tests to fail unpredictably. 
   The problem is as follows: when `StaticServerDomain` receives an HTTP request for a filtered path, it emits a `filterRequest` event to Brackets to have the file contents at that path manipulated before sending the response. Brackets later calls the `writeFilteredResponse` command with the manipulated data, which triggers the HTTP response. `StaticServerDomain` connects these filtered responses to their original filter requests by way of a map of callbacks keyed on the requested paths. But, as a consequence, when the `StaticServerDomain` HTTP server receives _two_ concurrent requests for the same path, it only stores _one_ response callback. The second filtered response is then be dropped, no longer having any response callback at the given path, and the second request---whose response callback has been overwritten---will always time out. The problem is solved here by adding a unique identifier to each `filterRequest` and keying callbacks on this identifier.
