### PR TITLE
For #6210: Graying out "Update" for "dev" extensions

### DIFF
--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -218,6 +218,7 @@ define(function (require, exports, module) {
         context.allowInstall = context.isCompatible && !context.isInstalled;
         context.allowRemove = (entry.installInfo && entry.installInfo.locationType === ExtensionManager.LOCATION_USER);
         context.allowUpdate = context.showUpdateButton && context.isCompatible && context.isCompatibleLatest;
+        context.allowUpdate_dev = context.allowRemove; // if the file is in the "dev" folder, we won't update it
 
         context.removalAllowed = this.model.source === "installed" &&
             !context.failedToStart && !context.isMarkedForUpdate && !context.isMarkedForRemoval;

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -216,9 +216,13 @@ define(function (require, exports, module) {
         context.showUpdateButton = context.updateAvailable && !context.isMarkedForUpdate && !context.isMarkedForRemoval;
 
         context.allowInstall = context.isCompatible && !context.isInstalled;
-        context.allowRemove = (entry.installInfo && entry.installInfo.locationType === ExtensionManager.LOCATION_USER);
-        context.allowUpdate = context.showUpdateButton && context.isCompatible && context.isCompatibleLatest;
-        context.allowUpdate_dev = context.allowRemove; // if the file is in the "dev" folder, we won't update it
+
+        var isInstalledInUserFolder = (entry.installInfo && entry.installInfo.locationType === ExtensionManager.LOCATION_USER);
+        context.allowRemove = isInstalledInUserFolder;
+        context.allowUpdate = context.showUpdateButton && context.isCompatible && context.isCompatibleLatest && isInstalledInUserFolder;
+        if (!context.allowUpdate) {
+            context.updateNotAllowedReason = isInstalledInUserFolder ? Strings.CANT_UPDATE : Strings.CANT_UPDATE_DEV;
+        }
 
         context.removalAllowed = this.model.source === "installed" &&
             !context.failedToStart && !context.isMarkedForUpdate && !context.isMarkedForRemoval;

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -51,7 +51,7 @@
         {{/showInstallButton}}
         {{#isInstalled}}
             {{#showUpdateButton}}
-                <button class="btn btn-mini update" data-extension-id="{{metadata.name}}" {{^allowUpdate}}disabled title="{{Strings.CANT_UPDATE}}"{{/allowUpdate}}>
+                <button class="btn btn-mini update" data-extension-id="{{metadata.name}}" {{^allowUpdate}}disabled title="{{Strings.CANT_UPDATE}}"{{/allowUpdate}} {{^allowUpdate_dev}}disabled title="{{Strings.CANT_UPDATE_DEV}}"{{/allowUpdate_dev}}>
                     {{Strings.UPDATE}}
                 </button>
             {{/showUpdateButton}}

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -51,7 +51,7 @@
         {{/showInstallButton}}
         {{#isInstalled}}
             {{#showUpdateButton}}
-                <button class="btn btn-mini update" data-extension-id="{{metadata.name}}" {{^allowUpdate}}disabled title="{{Strings.CANT_UPDATE}}"{{/allowUpdate}} {{^allowUpdate_dev}}disabled title="{{Strings.CANT_UPDATE_DEV}}"{{/allowUpdate_dev}}>
+                <button class="btn btn-mini update" data-extension-id="{{metadata.name}}" {{^allowUpdate}}disabled title="{{updateNotAllowedReason}}"{{/allowUpdate}}>
                     {{Strings.UPDATE}}
                 </button>
             {{/showUpdateButton}}

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -347,6 +347,7 @@ define({
     "OVERWRITE"                            : "Überschreiben",
     "CANT_REMOVE_DEV"                      : "Erweiterungen im \"dev\"-Ordner müssen manuell gelöscht werden.",
     "CANT_UPDATE"                          : "Das Update ist nicht kompatibel mit dieser Version von {APP_NAME}.",
+    "CANT_UPDATE_DEV"                      : "Erweiterungen im \"dev\"-Ordner können nicht automatisch aktualisiert werden.",
     "INSTALL_EXTENSION_TITLE"              : "Erweiterung installieren",
     "UPDATE_EXTENSION_TITLE"               : "Erweiterung updaten",
     "INSTALL_EXTENSION_LABEL"              : "Erweiterungs-URL",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -347,6 +347,7 @@ define({
     "OVERWRITE"                            : "Overwrite",
     "CANT_REMOVE_DEV"                      : "Extensions in the \"dev\" folder must be manually deleted.",
     "CANT_UPDATE"                          : "The update isn't compatible with this version of {APP_NAME}.",
+    "CANT_UPDATE_DEV"                      : "Extensions in the \"dev\" can't be updated automatically.",
     "INSTALL_EXTENSION_TITLE"              : "Install Extension",
     "UPDATE_EXTENSION_TITLE"               : "Update Extension",
     "INSTALL_EXTENSION_LABEL"              : "Extension URL",


### PR DESCRIPTION
Extensions that are in the dev folder can't be updated automatically any more (the "Update" button is grayed out).

This fixes #6210 @peterflynn
German translation @couzteau

Please test this, I couldn't test this as I've got no own extension to test with.
