### PR TITLE
[FindReplace] Remove right border-radius to match button pairs

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1126,6 +1126,8 @@ a, img {
     // Make button pairs snug
     #find-prev, #replace-yes, #find-case-sensitive {
         border-right: none;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
         margin-right: 0;
     }
     #find-next, #replace-all, #find-regexp {


### PR DESCRIPTION
This removes `border-top-right-radius` and `border-bottom-right-radius` to improve the match of the left and right buttons when they are a pair.
Related to #6175

Screens (zoom in):
Before:
![image](https://f.cloud.github.com/assets/2641501/1725456/19ebddd2-6280-11e3-8590-a2ad10c063dc.png)

After:
![image](https://f.cloud.github.com/assets/2641501/1725457/1cbbb3b6-6280-11e3-914d-e0043e73423e.png)
