### PR TITLE
CSS code hints improvements

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -216,6 +216,10 @@ define(function (require, exports, module) {
         // Clear the exclusion if the user moves the cursor with left/right arrow key.
         this.updateExclusion(true);
 
+        if (this.info.offset === 0) {
+            return null;
+        }
+        
         if (context === CSSUtils.PROP_VALUE) {
             // When switching from a NAME to a VALUE context, restart the session
             // to give other more specialized providers a chance to intervene.

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -266,7 +266,7 @@ define(function (require, exports, module) {
         } else if (context === CSSUtils.PROP_NAME) {
             
             // Select initial property if anything has been typed
-            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
+            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1 || needle !== "") {
                 selectInitial = true;
             }
             

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
         // Clear the exclusion if the user moves the cursor with left/right arrow key.
         this.updateExclusion(true);
 
-        if (this.info.offset === 0) {
+        if (this.info.offset === 0 && lastContext !== null) {
             return null;
         }
         

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -209,7 +209,7 @@ define(function (require, exports, module) {
             selectInitial = false;
             
         
-        if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
+        if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1 || implicitChar === null) {
             selectInitial = true;
         }
         


### PR DESCRIPTION
**Select the initial hint on backspace key press**

Problem: When you input "col", the code hint plugin will present hints like "color","column-count",etc, with the initial item "color" selected. But, after you press backspace key once, nothing is selected on the hints list.

This patch set the `selectInitial = true` on `implicitChar === null`, making the first hint selected on backspace key press.

**Clear hints when nothing's left**

Problem: When you input "co", then press backspace twice to delete the CSS property, the code hints list remains open with hints like "align-content","align-items",etc.

This patch fixed the problem by returning `null` for the hints list when `this.info.offset === 0`.
