### PR TITLE
Add support for proxy in extension manager, via config.json

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -30,7 +30,7 @@ indent: 4, maxerr: 50 */
 
 define(function (require, exports, module) {
     "use strict";
-    
+
     var AppInit              = require("utils/AppInit"),
         FileSystem           = require("filesystem/FileSystem"),
         FileUtils            = require("file/FileUtils"),
@@ -38,13 +38,13 @@ define(function (require, exports, module) {
         Strings              = require("strings"),
         ExtensionLoader      = require("utils/ExtensionLoader"),
         NodeConnection       = require("utils/NodeConnection");
-    
+
     var Errors = {
         ERROR_LOADING: "ERROR_LOADING",
         MALFORMED_URL: "MALFORMED_URL",
         UNSUPPORTED_PROTOCOL: "UNSUPPORTED_PROTOCOL"
     };
-    
+
     var InstallationStatuses = {
         FAILED: "FAILED",
         INSTALLED: "INSTALLED",
@@ -61,7 +61,7 @@ define(function (require, exports, module) {
      * Connects to ExtensionManagerDomain
      */
     var _nodeConnection;
-    
+
     /**
      * @private
      * @type{jQuery.Deferred.<NodeConnection>}
@@ -69,12 +69,12 @@ define(function (require, exports, module) {
      * we are unable to connect to Node.
      */
     var _nodeConnectionDeferred = $.Deferred();
-    
+
     /**
      * @type {number} Used to generate unique download ids
      */
     var _uniqueId = 0;
-    
+
     function _extensionManagerCall(callback) {
         if (_nodeConnection.domains.extensionManager) {
             return callback(_nodeConnection.domains.extensionManager);
@@ -85,10 +85,10 @@ define(function (require, exports, module) {
 
     /**
      * TODO: can this go away now that we never call it directly?
-     * 
+     *
      * Validates the package at the given path. The actual validation is
      * handled by the Node server.
-     * 
+     *
      * The promise is resolved with an object:
      * { errors: Array.<{string}>, metadata: { name:string, version:string, ... } }
      * metadata is pulled straight from package.json and will be undefined
@@ -101,7 +101,7 @@ define(function (require, exports, module) {
     function validate(path, options) {
         return _extensionManagerCall(function (extensionManager) {
             var d = new $.Deferred();
-            
+
             extensionManager.validate(path, options)
                 .done(function (result) {
                     d.resolve({
@@ -112,11 +112,11 @@ define(function (require, exports, module) {
                 .fail(function (error) {
                     d.reject(error);
                 });
-    
+
             return d.promise();
         });
     }
-    
+
     /**
      * Validates and installs the package at the given path. Validation and
      * installation is handled by the Node process.
@@ -124,13 +124,13 @@ define(function (require, exports, module) {
      * The extension will be installed into the user's extensions directory.
      * If the user already has the extension installed, it will instead go
      * into their disabled extensions directory.
-     * 
+     *
      * The promise is resolved with an object:
      * { errors: Array.<{string}>, metadata: { name:string, version:string, ... },
      * disabledReason:string, installedTo:string, commonPrefix:string }
      * metadata is pulled straight from package.json and is likely to be undefined
      * if there are errors. It is null if there was no package.json.
-     * 
+     *
      * disabledReason is either null or the reason the extension was installed disabled.
      *
      * @param {string} path Absolute path to the package zip file
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
                 destinationDirectory    = ExtensionLoader.getUserExtensionPath(),
                 disabledDirectory       = destinationDirectory.replace(/\/user$/, "/disabled"),
                 systemDirectory         = FileUtils.getNativeBracketsDirectoryPath() + "/extensions/default/";
-            
+
             var operation = _doUpdate ? "update" : "install";
             extensionManager[operation](path, destinationDirectory, {
                 disabledDirectory: disabledDirectory,
@@ -175,18 +175,18 @@ define(function (require, exports, module) {
                 .fail(function (error) {
                     d.reject(error);
                 });
-            
+
             return d.promise();
         });
     }
-    
-    
-    
+
+
+
     /**
      * Special case handling to make the common case of downloading from GitHub easier; modifies 'urlInfo' as
      * needed. Converts a bare GitHub repo URL to the corresponding master ZIP URL; or if given a direct
      * master ZIP URL already, sets a nicer download filename (both cases use the repo name).
-     * 
+     *
      * @param {{url:string, parsed:Array.<string>, filenameHint:string}} urlInfo
      */
     function githubURLFilter(urlInfo) {
@@ -199,7 +199,7 @@ define(function (require, exports, module) {
                 }
                 urlInfo.url += "archive/master.zip";
                 urlInfo.filenameHint = match[1] + ".zip";
-                
+
             } else {
                 // Is it a URL directly to the repo's 'master.zip'? (/user/repo/archive/master.zip)
                 match = /^\/[^\/?]+\/([^\/?]+)\/archive\/master.zip$/.exec(urlInfo.parsed.pathname);
@@ -209,12 +209,12 @@ define(function (require, exports, module) {
             }
         }
     }
-    
+
     /**
      * Downloads from the given URL to a temporary location. On success, resolves with the path of the
      * downloaded file (typically in a temp folder) and a hint for the real filename. On failure, rejects
      * with an error object.
-     * 
+     *
      * @param {string} url URL of the file to be downloaded
      * @param {number} downloadId Unique number to identify this request
      * @return {$.Promise}
@@ -222,7 +222,7 @@ define(function (require, exports, module) {
     function download(url, downloadId) {
         return _extensionManagerCall(function (extensionManager) {
             var d = new $.Deferred();
-            
+
             // Validate URL
             // TODO: PathUtils fails to parse URLs that are missing the protocol part (e.g. starts immediately with "www...")
             var parsed = PathUtils.parseUrl(url);
@@ -234,33 +234,33 @@ define(function (require, exports, module) {
                 d.reject(Errors.UNSUPPORTED_PROTOCOL);
                 return d.promise();
             }
-            
+
             var urlInfo = { url: url, parsed: parsed, filenameHint: parsed.filename };
             githubURLFilter(urlInfo);
-            
+
             // Decide download destination
             var filename = urlInfo.filenameHint;
             filename = filename.replace(/[^a-zA-Z0-9_\- \(\)\.]/g, "_"); // make sure it's a valid filename
             if (!filename) {  // in case of URL ending in "/"
                 filename = "extension.zip";
             }
-            
+
             // Download the bits (using Node since brackets-shell doesn't support binary file IO)
-            var r = extensionManager.downloadFile(downloadId, urlInfo.url);
+            var r = extensionManager.downloadFile(downloadId, urlInfo.url, brackets.config.proxy);
             r.done(function (result) {
                 d.resolve({ localPath: result, filenameHint: urlInfo.filenameHint });
             }).fail(function (err) {
                 d.reject(err);
             });
-            
+
             return d.promise();
         });
     }
-    
+
     /**
      * Attempts to synchronously cancel the given pending download. This may not be possible, e.g.
      * if the download has already finished.
-     * 
+     *
      * @param {number} downloadId Identifier previously passed to download()
      */
     function cancelDownload(downloadId) {
@@ -268,21 +268,21 @@ define(function (require, exports, module) {
             return extensionManager.abortDownload(downloadId);
         });
     }
-    
-    
+
+
     /**
      * On success, resolves with an extension metadata object; at that point, the extension has already
      * started running in Brackets. On failure (including validation errors), rejects with an error object.
-     * 
+     *
      * An error object consists of either a string error code OR an array where the first entry is the error
      * code and the remaining entries are further info. The error code string is one of either
      * ExtensionsDomain.Errors or Package.Errors. Use formatError() to convert an error object to a friendly,
      * localized error message.
-     * 
+     *
      * The returned cancel() function will *attempt* to cancel installation, but it is not guaranteed to
      * succeed. If cancel() succeeds, the Promise is rejected with a CANCELED error code. If we're unable
      * to cancel, the Promise is resolved or rejected normally, as if cancel() had never been called.
-     * 
+     *
      * @return {{promise: $.Promise, cancel: function():boolean}}
      */
     function installFromURL(url) {
@@ -290,15 +290,15 @@ define(function (require, exports, module) {
             STATE_INSTALLING = 2,
             STATE_SUCCEEDED = 3,
             STATE_FAILED = 4;
-        
+
         var d = new $.Deferred();
         var state = STATE_DOWNLOADING;
-        
+
         var downloadId = (_uniqueId++);
         download(url, downloadId)
             .done(function (downloadResult) {
                 state = STATE_INSTALLING;
-                
+
                 install(downloadResult.localPath, downloadResult.filenameHint)
                     .done(function (result) {
                         var installationStatus = result.installationStatus;
@@ -340,7 +340,7 @@ define(function (require, exports, module) {
                 state = STATE_FAILED;
                 d.reject(err);
             });
-        
+
         return {
             promise: d.promise(),
             cancel: function () {
@@ -353,7 +353,7 @@ define(function (require, exports, module) {
             }
         };
     }
-    
+
     /**
      * Converts an error object as returned by install() or installFromURL() into a flattened, localized string.
      * @param {string|Array.<string>} error
@@ -367,7 +367,7 @@ define(function (require, exports, module) {
             console.log("Unknown installation error", key);
             return Strings.UNKNOWN_ERROR;
         }
-        
+
         if (Array.isArray(error)) {
             error[0] = localize(error[0]);
             return StringUtils.format.apply(window, error);
@@ -375,7 +375,7 @@ define(function (require, exports, module) {
             return localize(error);
         }
     }
-    
+
     /**
      * Removes the extension at the given path.
      *
@@ -388,7 +388,7 @@ define(function (require, exports, module) {
             return extensionManager.remove(path);
         });
     }
-    
+
     /**
      * Install an extension update located at path.
      * This assumes that the installation was previously attempted
@@ -423,7 +423,7 @@ define(function (require, exports, module) {
             });
         return d.promise();
     }
-        
+
     /**
      * Allows access to the deferred that manages the node connection. This
      * is *only* for unit tests. Messing with this not in testing will
@@ -435,7 +435,7 @@ define(function (require, exports, module) {
     function _getNodeConnectionDeferred() {
         return _nodeConnectionDeferred;
     }
-    
+
     // Initializes node connection
     // TODO: duplicates code from StaticServer
     // TODO: can this be done lazily?
@@ -443,7 +443,7 @@ define(function (require, exports, module) {
         _nodeConnection = new NodeConnection();
         _nodeConnection.connect(true).then(function () {
             var domainPath = FileUtils.getNativeBracketsDirectoryPath() + "/" + FileUtils.getNativeModuleDirectoryPath(module) + "/node/ExtensionManagerDomain";
-            
+
             _nodeConnection.loadDomains(domainPath, true)
                 .then(
                     function () {

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -92,16 +92,16 @@ function _removeFailedInstallation(installDirectory) {
  */
 function _performInstall(packagePath, installDirectory, validationResult, callback) {
     validationResult.installedTo = installDirectory;
-    
+
     var callbackCalled = false;
-    
+
     fs.mkdirs(installDirectory, function (err) {
         if (err) {
             callback(err);
             return;
         }
         var sourceDir = path.join(validationResult.extractDir, validationResult.commonPrefix);
-        
+
         fs.copy(sourceDir, installDirectory, function (err) {
             if (err) {
                 _removeFailedInstallation(installDirectory);
@@ -120,7 +120,7 @@ function _performInstall(packagePath, installDirectory, validationResult, callba
 
 /**
  * Private function to remove the target directory and then install.
- * 
+ *
  * @param {string} Absolute path to the package zip file
  * @param {string} Absolute path to the destination directory for unzipping
  * @param {Object} the return value with the useful information for the client
@@ -147,7 +147,7 @@ function _checkExistingInstallation(validationResult, installDirectory, systemIn
         callback(null, validationResult);
         return;
     }
-    
+
     fs.readJson(path.join(installDirectory, "package.json"), function (err, packageObj) {
         // if the package.json is unreadable, we assume that the new package is an update
         // that is the first to include a package.json.
@@ -175,7 +175,7 @@ function _checkExistingInstallation(validationResult, installDirectory, systemIn
 /**
  * A "legacy package" is an extension that was installed based on the GitHub name without
  * a package.json file. Checking for the presence of these legacy extensions will help
- * users upgrade if the extension developer puts a different name in package.json than 
+ * users upgrade if the extension developer puts a different name in package.json than
  * the name of the GitHub project.
  *
  * @param {string} legacyDirectory directory to check for old-style extension.
@@ -203,10 +203,10 @@ function legacyPackageCheck(legacyDirectory) {
  * or the name of the zip file).
  *
  * The destinationDirectory will be created if it does not exist.
- * 
+ *
  * @param {string} Absolute path to the package zip file
  * @param {string} the destination directory
- * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, 
+ * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string,
  *      systemExtensionDirectory: !string}} additional settings to control the installation
  * @param {function} callback (err, result)
  * @param {boolean} _doUpdate  private argument to signal that an update should be performed
@@ -216,10 +216,10 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
         callback(new Error(Errors.MISSING_REQUIRED_OPTIONS), null);
         return;
     }
-    
+
     var validateCallback = function (err, validationResult) {
         validationResult.localPath = packagePath;
-        
+
         // This is a wrapper for the callback that will delete the temporary
         // directory to which the package was unzipped.
         function deleteTempAndCallback(err) {
@@ -229,14 +229,14 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
             }
             callback(err, validationResult);
         }
-        
+
         // If there was trouble at the validation stage, we stop right away.
         if (err || validationResult.errors.length > 0) {
             validationResult.installationStatus = Statuses.FAILED;
             deleteTempAndCallback(err, validationResult);
             return;
         }
-        
+
         // Prefers the package.json name field, but will take the zip
         // file's name if that's all that's available.
         var extensionName, guessedName;
@@ -250,12 +250,12 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
         } else {
             extensionName = guessedName;
         }
-        
+
         validationResult.name = extensionName;
         var installDirectory = path.join(destinationDirectory, extensionName),
             legacyDirectory = path.join(destinationDirectory, guessedName),
             systemInstallDirectory = path.join(options.systemExtensionDirectory, extensionName);
-        
+
         if (validationResult.metadata && validationResult.metadata.engines &&
                 validationResult.metadata.engines.brackets) {
             var compatible = semver.satisfies(options.apiVersion,
@@ -268,11 +268,11 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
                 return;
             }
         }
-        
+
         // The "legacy" stuff should go away after all of the commonly used extensions
         // have been upgraded with package.json files.
         var hasLegacyPackage = validationResult.metadata && legacyPackageCheck(legacyDirectory);
-        
+
         // If the extension is already there, we signal to the front end that it's already installed
         // unless the front end has signaled an intent to update.
         if (hasLegacyPackage || fs.existsSync(installDirectory) || fs.existsSync(systemInstallDirectory)) {
@@ -305,7 +305,7 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
             _performInstall(packagePath, installDirectory, validationResult, deleteTempAndCallback);
         }
     };
-    
+
     validate(packagePath, {}, validateCallback);
 }
 
@@ -331,10 +331,10 @@ function _cmdInstall(packagePath, destinationDirectory, options, callback, _doUp
  * or the name of the zip file).
  *
  * The destinationDirectory will be created if it does not exist.
- * 
+ *
  * @param {string} Absolute path to the package zip file
  * @param {string} the destination directory
- * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string, 
+ * @param {{disabledDirectory: !string, apiVersion: !string, nameHint: ?string,
  *      systemExtensionDirectory: !string}} additional settings to control the installation
  * @param {function} callback (err, result)
  */
@@ -345,19 +345,19 @@ function _cmdUpdate(packagePath, destinationDirectory, options, callback) {
 /**
  * Wrap up after the given download has terminated (successfully or not). Closes connections, calls back the
  * client's callback, and IF there was an error, delete any partially-downloaded file.
- * 
+ *
  * @param {string} downloadId Unique id originally passed to _cmdDownloadFile()
  * @param {?string} error If null, download was treated as successful
  */
 function _endDownload(downloadId, error) {
     var downloadInfo = pendingDownloads[downloadId];
     delete pendingDownloads[downloadId];
-    
+
     if (error) {
         // Abort the download if still pending
         // Note that this will trigger response's "end" event
         downloadInfo.request.abort();
-        
+
         // Clean up any partially-downloaded file
         // (if no outStream, then we never got a response back yet and never created any file)
         if (downloadInfo.outStream) {
@@ -365,9 +365,9 @@ function _endDownload(downloadId, error) {
                 fs.unlink(downloadInfo.localPath);
             });
         }
-        
+
         downloadInfo.callback(error, null);
-        
+
     } else {
         // Download completed successfully. Flush stream to disk and THEN signal completion
         downloadInfo.outStream.end(function () {
@@ -379,16 +379,22 @@ function _endDownload(downloadId, error) {
 /**
  * Implements "downloadFile" command, asynchronously.
  */
-function _cmdDownloadFile(downloadId, url, callback) {
+function _cmdDownloadFile(downloadId, url, proxy, callback) {
+    var requestOption = {
+        url: url,
+        encoding: null,
+    };
+
+    if (proxy && typeof proxy === "string") {
+        requestOption.proxy = proxy;
+    }
+
     if (pendingDownloads[downloadId]) {
         callback(Errors.DOWNLOAD_ID_IN_USE, null);
         return;
     }
-    
-    var req = request.get({
-        url: url,
-        encoding: null
-    },
+
+    var req = request.get(requestOption,
         // Note: we could use the traditional "response"/"data"/"end" events too if we wanted to stream data
         // incrementally, limit download size, etc. - but the simple callback is good enough for our needs.
         function (error, response, body) {
@@ -401,7 +407,7 @@ function _cmdDownloadFile(downloadId, url, callback) {
                 _endDownload(downloadId, [Errors.BAD_HTTP_STATUS, response.statusCode]);
                 return;
             }
-            
+
             var stream = temp.createWriteStream("brackets");
             if (!stream) {
                 _endDownload(downloadId, Errors.CANNOT_WRITE_TEMP);
@@ -409,11 +415,11 @@ function _cmdDownloadFile(downloadId, url, callback) {
             }
             pendingDownloads[downloadId].localPath = stream.path;
             pendingDownloads[downloadId].outStream = stream;
-            
+
             stream.write(body);
             _endDownload(downloadId);
         });
-    
+
     pendingDownloads[downloadId] = { request: req, callback: callback };
 }
 
@@ -593,6 +599,10 @@ function init(domainManager) {
             name: "url",
             type: "string",
             description: "URL to download from"
+        }, {
+            name: "proxy",
+            type: "string",
+            description: "Http proxy connection string (or null)"
         }],
         {
             type: "string",


### PR DESCRIPTION
This PR refer to #6241. It allows to add a proxy connection string
in config.json wich will beused by the extension manager when
downloading package file.

To use, add a line to `config.json`, in the `config` section
named `proxy`:
`config: { ... , proxy: "http://user:password@addres: port" }`.

This feature is tracked by trello card [902](https://trello.com/c/SEV95fdK/902-support-for-a-proxy-in-extensions-installation)
