### PR TITLE
Always select first css value in code hint list

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -209,14 +209,14 @@ define(function (require, exports, module) {
             selectInitial = false;
             
         
-        if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
-            selectInitial = true;
-        }
-        
         // Clear the exclusion if the user moves the cursor with left/right arrow key.
         this.updateExclusion(true);
 
         if (context === CSSUtils.PROP_VALUE) {
+            
+            // Always select initial value
+            selectInitial = true;
+            
             // When switching from a NAME to a VALUE context, restart the session
             // to give other more specialized providers a chance to intervene.
             if (lastContext === CSSUtils.PROP_NAME) {
@@ -260,6 +260,12 @@ define(function (require, exports, module) {
                 selectInitial: selectInitial
             };
         } else if (context === CSSUtils.PROP_NAME) {
+            
+            // Select initial property if anything has been typed
+            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
+                selectInitial = true;
+            }
+            
             lastContext = CSSUtils.PROP_NAME;
             needle = needle.substr(0, this.info.offset);
             result = $.map(properties, function (pvalues, pname) {

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -260,14 +260,15 @@ define(function (require, exports, module) {
                 selectInitial: selectInitial
             };
         } else if (context === CSSUtils.PROP_NAME) {
+            lastContext = CSSUtils.PROP_NAME;
+            needle = needle.substr(0, this.info.offset);
             
             // Select initial property if anything has been typed
-            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
+            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1 ||
+                    needle !== "") {
                 selectInitial = true;
             }
             
-            lastContext = CSSUtils.PROP_NAME;
-            needle = needle.substr(0, this.info.offset);
             result = $.map(properties, function (pvalues, pname) {
                 if (pname.indexOf(needle) === 0) {
                     return pname;

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -260,15 +260,14 @@ define(function (require, exports, module) {
                 selectInitial: selectInitial
             };
         } else if (context === CSSUtils.PROP_NAME) {
-            lastContext = CSSUtils.PROP_NAME;
-            needle = needle.substr(0, this.info.offset);
             
             // Select initial property if anything has been typed
-            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1 ||
-                    needle !== "") {
+            if (this.primaryTriggerKeys.indexOf(implicitChar) !== -1) {
                 selectInitial = true;
             }
             
+            lastContext = CSSUtils.PROP_NAME;
+            needle = needle.substr(0, this.info.offset);
             result = $.map(properties, function (pvalues, pname) {
                 if (pname.indexOf(needle) === 0) {
                     return pname;

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -491,8 +491,14 @@ define(function (require, exports, module) {
             // Deferred hints were returned
             var deferred = $.Deferred();
             hints.done(function (asyncHints) {
+                result = $.map(asyncHints, function (item) {
+                    if (item.indexOf(filter) === 0) {
+                        return item;
+                    }
+                }).sort(sortFunc);
+
                 deferred.resolveWith(this, [{
-                    hints: asyncHints,
+                    hints: result,
                     match: query.queryStr,
                     selectInitial: true,
                     handleWideResults: false

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -137,7 +137,10 @@ define(function (require, exports, module) {
                     contents.forEach(function (entry) {
                         if (ProjectManager.shouldShow(entry)) {
                             // convert to doc relative path
-                            var entryStr = entry.fullPath.replace(docDir, "");
+                            var entryStr = queryDir + entry._name;
+                            if (entry._isDirectory) {
+                                entryStr += "/";
+                            }
 
                             // code hints show the unencoded string so the
                             // choices are easier to read.  The encoded string

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -58,11 +58,6 @@ define(function (require, exports, module) {
     UrlCodeHints.prototype._getUrlList = function (query) {
         var doc,
             result = [];
-        
-        // site-root relative links are not yet supported, so filter them out
-        if (query.queryStr.length > 0 && query.queryStr[0] === "/") {
-            return result;
-        }
 
         // get path to current document
         doc = DocumentManager.getCurrentDocument();
@@ -81,7 +76,15 @@ define(function (require, exports, module) {
         }
 
         // build target folder path
-        var targetDir = docDir + decodeURI(queryDir);
+        var targetDir;
+        if (queryDir.length > 0 && queryDir[0] === "/") {
+            // site-root relative path
+            targetDir = ProjectManager.getProjectRoot().fullPath +
+                        decodeURI(queryDir).substring(1);
+        } else {
+            // page relative path
+            targetDir = docDir + decodeURI(queryDir);
+        }
 
         // get list of files from target folder
         var unfiltered = [];

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -56,8 +56,15 @@ define(function (require, exports, module) {
      * @return {Array.<string>|$.Deferred} The (possibly deferred) hints.
      */
     UrlCodeHints.prototype._getUrlList = function (query) {
-        var doc,
-            result = [];
+        var directory,
+            doc,
+            docDir,
+            queryDir = "",
+            queryUrl,
+            result = [],
+            self,
+            targetDir,
+            unfiltered = [];
 
         // get path to current document
         doc = DocumentManager.getCurrentDocument();
@@ -65,18 +72,16 @@ define(function (require, exports, module) {
             return result;
         }
 
-        var docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
+        docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
         
         // get relative path from query string
         // TODO: handle site-root relative
-        var queryDir = "";
-        var queryUrl = window.PathUtils.parseUrl(query.queryStr);
+        queryUrl = window.PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;
         }
 
         // build target folder path
-        var targetDir;
         if (queryDir.length > 0 && queryDir[0] === "/") {
             // site-root relative path
             targetDir = ProjectManager.getProjectRoot().fullPath +
@@ -86,10 +91,8 @@ define(function (require, exports, module) {
             targetDir = docDir + decodeURI(queryDir);
         }
 
-        // get list of files from target folder
-        var unfiltered = [];
-
-        // Getting the file/folder info is an asynch operation, so it works like this:
+        // Get list of files from target folder. Getting the file/folder info is an
+        // asynch operation, so it works like this:
         //
         // The initial pass initiates the asynchronous retrieval of data and returns an
         // empty list, so no code hints are displayed. In the async callback, the code
@@ -124,8 +127,8 @@ define(function (require, exports, module) {
             unfiltered = this.cachedHints.unfiltered;
 
         } else {
-            var directory = FileSystem.getDirectoryForPath(targetDir),
-                self = this;
+            directory = FileSystem.getDirectoryForPath(targetDir);
+            self = this;
 
             if (self.cachedHints && self.cachedHints.deferred) {
                 self.cachedHints.deferred.reject();
@@ -136,11 +139,13 @@ define(function (require, exports, module) {
             self.cachedHints.unfiltered = [];
 
             directory.getContents(function (err, contents) {
+                var currentDeferred, entryStr, syncResults;
+
                 if (!err) {
                     contents.forEach(function (entry) {
                         if (ProjectManager.shouldShow(entry)) {
                             // convert to doc relative path
-                            var entryStr = queryDir + entry._name;
+                            entryStr = queryDir + entry._name;
                             if (entry._isDirectory) {
                                 entryStr += "/";
                             }
@@ -158,11 +163,12 @@ define(function (require, exports, module) {
                     self.cachedHints.docDir     = docDir;
                     
                     if (self.cachedHints.deferred.state() !== "rejected") {
-                        var currentDeferred = self.cachedHints.deferred;
+                        currentDeferred = self.cachedHints.deferred;
+
                         // Since we've cached the results, the next call to _getUrlList should be synchronous.
                         // If it isn't, we've got a problem and should reject both the current deferred
                         // and any new deferred that got created on the call.
-                        var syncResults = self._getUrlList(query);
+                        syncResults = self._getUrlList(query);
                         if (syncResults instanceof Array) {
                             currentDeferred.resolveWith(self, [syncResults]);
                         } else {

--- a/src/extensions/default/UrlCodeHints/testfiles/test.html
+++ b/src/extensions/default/UrlCodeHints/testfiles/test.html
@@ -17,5 +17,7 @@ body {
   <img src=''>
   <img src='subfolder/'>
   <a href='results.html?id=1003'>Results</a>
+  <a href='../'>Page relative: up 1 folder</a>
+  <a href='/'>Site-root relative: root folder</a>
 </body>
 </html>


### PR DESCRIPTION
This is for #6231 

Always select the first value hint. The list of values is usually a relatively short, finite list, so if user happens to want first item in list, this saves them a keystroke.
