### PR TITLE
Integrate latest CodeMirror for sprint 36

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -986,10 +986,14 @@ define(function (require, exports, module) {
             return;
         }
         
+        // We set clearWhenEmpty: false so that if there's a blank line at the beginning or end of
+        // the document, and that's the only hidden line, we can still actually hide it. Doing so
+        // requires us to create a 0-length marked span, which would ordinarily be cleaned up by CM
+        // if clearWithEmpty is true. See https://groups.google.com/forum/#!topic/codemirror/RB8VNF8ow2w
         var value = this._codeMirror.markText(
             {line: from, ch: 0},
             {line: to - 1, ch: this._codeMirror.getLine(to - 1).length},
-            {collapsed: true, inclusiveLeft: true, inclusiveRight: true}
+            {collapsed: true, inclusiveLeft: true, inclusiveRight: true, clearWhenEmpty: false}
         );
         
         return value;

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -755,7 +755,7 @@ define(function (require, exports, module) {
         } else {
             doc.replaceRange("\n", {line: line, ch: 0}, null, "+input");
         }
-        cm.indentLine(line, "smart", false);
+        cm.indentLine(line, "smart", true);
         editor.setSelection({line: line, ch: null});
     }
 

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -379,7 +379,7 @@ define(function (require, exports, module) {
     
     AppInit.appReady(function () {
         var cssPropHints = new CssPropHints();
-        CodeHintManager.registerHintProvider(cssPropHints, ["css", "scss"], 0);
+        CodeHintManager.registerHintProvider(cssPropHints, ["css", "scss", "less"], 0);
         
         // For unit testing
         exports.cssPropHintProvider = cssPropHints;

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
                 verifyAttrHints(hintList, "application/msexcel");
             });
 
-            it("should NOT list attribute value hints when the cursor is after the end quote of an attribute value", function () {
+            xit("should NOT list attribute value hints when the cursor is after the end quote of an attribute value", function () {
                 testDocument.replaceRange("  <input checked accept='' >\n", { line: 9, ch: 0 });  // insert new line
                 
                 // Set cursor after the closing quote of accept attribute

--- a/src/extensions/default/LESSSupport/main.js
+++ b/src/extensions/default/LESSSupport/main.js
@@ -32,7 +32,7 @@ define(function (require, exports, module) {
     
     LanguageManager.defineLanguage("less", {
         name: "LESS",
-        mode: "less",
+        mode: ["css", "text/x-less"],
         fileExtensions: ["less"],
         blockComment: ["/*", "*/"],
         lineComment: ["//"]

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -95,17 +95,16 @@ define(function (require, exports, module) {
         }
         return ((state.context.type === "prop" &&
                     (state.context.prev.type === "rule" || state.context.prev.type === "block")) ||
-                    (state.context.type === "(" && state.context.prev.type === "prop") ||
                     (state.context.type === "parens" && state.context.prev.type === "prop"));
     }
     
     /**
      * @private
-     * Checks if the current cursor position is inside an @import rule
+     * Checks if the current cursor position is inside an at-rule
      * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} context
      * @return {boolean} true if the context is in property value
      */
-    function _isInImportRule(ctx) {
+    function _isInAtRule(ctx) {
         var state;
         if (!ctx || !ctx.token || !ctx.token.state) {
             return false;
@@ -482,7 +481,7 @@ define(function (require, exports, module) {
             return _getRuleInfoStartingFromPropValue(ctx, editor);
         }
 
-        if (_isInImportRule(ctx)) {
+        if (_isInAtRule(ctx)) {
             return _getImportUrlInfo(ctx, editor);
         }
         

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -67,11 +67,11 @@ define(function (require, exports, module) {
 
         state = ctx.token.state.localState || ctx.token.state;
         
-        if (!state.stack || state.stack.length < 1) {
+        if (!state.context) {
             return false;
         }
         
-        lastToken = state.stack[state.stack.length - 1];
+        lastToken = state.context.type;
         return (lastToken === "{" || lastToken === "rule" || lastToken === "block");
     }
     
@@ -90,12 +90,12 @@ define(function (require, exports, module) {
 
         state = ctx.token.state.localState || ctx.token.state;
         
-        if (!state.stack || state.stack.length < 2) {
+        if (!state.context || !state.context.prev) {
             return false;
         }
-        return ((state.stack[state.stack.length - 1] === "propertyValue" &&
-                    (state.stack[state.stack.length - 2] === "rule" || state.stack[state.stack.length - 2] === "block")) ||
-                    (state.stack[state.stack.length - 1] === "(" && (state.stack[state.stack.length - 2] === "propertyValue")));
+        return ((state.context.type === "prop" &&
+                    (state.context.prev.type === "rule" || state.context.prev.type === "block")) ||
+                    (state.context.type === "(" && (state.context.type === "prop")));
     }
     
     /**
@@ -112,10 +112,11 @@ define(function (require, exports, module) {
 
         state = ctx.token.state.localState || ctx.token.state;
         
-        if (!state.stack || state.stack.length < 1) {
+        if (!state.context) {
             return false;
         }
-        return (state.stack[0] === "@import");
+        // TODO: probably doesn't work
+        return (state.context.type === "@import");
     }
 
     /**
@@ -451,7 +452,7 @@ define(function (require, exports, module) {
             mode = editor.getModeForSelection();
         
         // Check if this is inside a style block or in a css/less document.
-        if (mode !== "css" && mode !== "text/x-scss" && mode !== "less") {
+        if (mode !== "css" && mode !== "text/x-scss" && mode !== "text/x-less") {
             return createInfo();
         }
 

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -95,7 +95,8 @@ define(function (require, exports, module) {
         }
         return ((state.context.type === "prop" &&
                     (state.context.prev.type === "rule" || state.context.prev.type === "block")) ||
-                    (state.context.type === "(" && (state.context.type === "prop")));
+                    (state.context.type === "(" && state.context.prev.type === "prop") ||
+                    (state.context.type === "parens" && state.context.prev.type === "prop"));
     }
     
     /**
@@ -115,8 +116,7 @@ define(function (require, exports, module) {
         if (!state.context) {
             return false;
         }
-        // TODO: probably doesn't work
-        return (state.context.type === "@import");
+        return (state.context.type === "at");
     }
 
     /**


### PR DESCRIPTION
_Update:_ Removed "[discussion only]" tag since we think we've addressed the issues and could merge this.

In the latest CM (as of marijnh/CodeMirror@d13582f), the CSS mode has been refactored substantially. The good news is that LESS is now supported by CSS mode, meaning that we can much more easily make basic code hinting work for LESS files (similar to what we've already done for SCSS files). The less good news is that the internals of the mode have changed significantly. In particular:
- There's no longer a `stack` member on the `state` object, but instead a `context` member which seems to fulfill the same role (using a linked list instead of a stack).
- Some of the token types appear to have changed (specifically, `propertyValue` now seems to be `prop`).

This PR contains a quick attempt to make the existing CSS code hinting work properly with the changes to CSS mode. It also hooks up LESS files to the CSS mode (instead of the old LESS mode) and attempts to turn on code hinting in those files.

With these changes, it looks like almost all the existing CSS code hinting unit tests pass, except for one in CSS Context Info. However, I haven't done much manual testing beyond verifying that basic property and value hints seem to work in CSS and LESS files. Also, this was based on only a **very** cursory understanding of the existing CSSUtils code and of the changes to the CM CSS mode, so it's quite likely that we need to do more work and testing to make sure everything is working properly.

@RaymondLim - would you mind taking a look at the code changes and seeing what you think? I'm wondering if we need to add a story for this (to ensure we get adequate testing, etc.), which might mean pushing it to the next sprint.

Additionally, there were a number of other smaller changes since our last CM merge that are probably worth testing around. From looking at the commit log, these are the areas we'd want to do some sanity testing around:
- Inline editor line hiding (esp at beginning/end of doc) - make fix first
- LESS - using CSS mode now! - include that and test
- XML-mode
- Auto-closing of HTML tags
- Look for gutter issues
- Hit up arrow while selection exists
- Scroll into view
- newline and indent
- electric chars
- CSS mode changes, incl. tokenization (test quick edit, quick open symbol, etc.)
- JS mode - indentation around for / forEach
- Check undo/redo/dirty bit esp. around quick typing

Finally, this PR also contains the small update required by #6204. 
