### PR TITLE
Url Hinting bug fixes

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -75,7 +75,6 @@ define(function (require, exports, module) {
         docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
         
         // get relative path from query string
-        // TODO: handle site-root relative
         queryUrl = window.PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -56,13 +56,15 @@ define(function (require, exports, module) {
      * @return {Array.<string>|$.Deferred} The (possibly deferred) hints.
      */
     UrlCodeHints.prototype._getUrlList = function (query) {
-        var doc,
-            result = [];
-        
-        // site-root relative links are not yet supported, so filter them out
-        if (query.queryStr.length > 0 && query.queryStr[0] === "/") {
-            return result;
-        }
+        var directory,
+            doc,
+            docDir,
+            queryDir = "",
+            queryUrl,
+            result = [],
+            self,
+            targetDir,
+            unfiltered = [];
 
         // get path to current document
         doc = DocumentManager.getCurrentDocument();
@@ -70,23 +72,27 @@ define(function (require, exports, module) {
             return result;
         }
 
-        var docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
+        docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
         
         // get relative path from query string
         // TODO: handle site-root relative
-        var queryDir = "";
-        var queryUrl = window.PathUtils.parseUrl(query.queryStr);
+        queryUrl = window.PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;
         }
 
         // build target folder path
-        var targetDir = docDir + decodeURI(queryDir);
+        if (queryDir.length > 0 && queryDir[0] === "/") {
+            // site-root relative path
+            targetDir = ProjectManager.getProjectRoot().fullPath +
+                        decodeURI(queryDir).substring(1);
+        } else {
+            // page relative path
+            targetDir = docDir + decodeURI(queryDir);
+        }
 
-        // get list of files from target folder
-        var unfiltered = [];
-
-        // Getting the file/folder info is an asynch operation, so it works like this:
+        // Get list of files from target folder. Getting the file/folder info is an
+        // asynch operation, so it works like this:
         //
         // The initial pass initiates the asynchronous retrieval of data and returns an
         // empty list, so no code hints are displayed. In the async callback, the code
@@ -121,8 +127,8 @@ define(function (require, exports, module) {
             unfiltered = this.cachedHints.unfiltered;
 
         } else {
-            var directory = FileSystem.getDirectoryForPath(targetDir),
-                self = this;
+            directory = FileSystem.getDirectoryForPath(targetDir);
+            self = this;
 
             if (self.cachedHints && self.cachedHints.deferred) {
                 self.cachedHints.deferred.reject();
@@ -133,11 +139,16 @@ define(function (require, exports, module) {
             self.cachedHints.unfiltered = [];
 
             directory.getContents(function (err, contents) {
+                var currentDeferred, entryStr, syncResults;
+
                 if (!err) {
                     contents.forEach(function (entry) {
                         if (ProjectManager.shouldShow(entry)) {
                             // convert to doc relative path
-                            var entryStr = entry.fullPath.replace(docDir, "");
+                            entryStr = queryDir + entry._name;
+                            if (entry._isDirectory) {
+                                entryStr += "/";
+                            }
 
                             // code hints show the unencoded string so the
                             // choices are easier to read.  The encoded string
@@ -152,11 +163,12 @@ define(function (require, exports, module) {
                     self.cachedHints.docDir     = docDir;
                     
                     if (self.cachedHints.deferred.state() !== "rejected") {
-                        var currentDeferred = self.cachedHints.deferred;
+                        currentDeferred = self.cachedHints.deferred;
+
                         // Since we've cached the results, the next call to _getUrlList should be synchronous.
                         // If it isn't, we've got a problem and should reject both the current deferred
                         // and any new deferred that got created on the call.
-                        var syncResults = self._getUrlList(query);
+                        syncResults = self._getUrlList(query);
                         if (syncResults instanceof Array) {
                             currentDeferred.resolveWith(self, [syncResults]);
                         } else {
@@ -479,8 +491,14 @@ define(function (require, exports, module) {
             // Deferred hints were returned
             var deferred = $.Deferred();
             hints.done(function (asyncHints) {
+                result = $.map(asyncHints, function (item) {
+                    if (item.indexOf(filter) === 0) {
+                        return item;
+                    }
+                }).sort(sortFunc);
+
                 deferred.resolveWith(this, [{
-                    hints: asyncHints,
+                    hints: result,
                     match: query.queryStr,
                     selectInitial: true,
                     handleWideResults: false

--- a/src/extensions/default/UrlCodeHints/testfiles/test.html
+++ b/src/extensions/default/UrlCodeHints/testfiles/test.html
@@ -17,5 +17,7 @@ body {
   <img src=''>
   <img src='subfolder/'>
   <a href='results.html?id=1003'>Results</a>
+  <a href='../'>Page relative: up 1 folder</a>
+  <a href='/'>Site-root relative: root folder</a>
 </body>
 </html>


### PR DESCRIPTION
This is for #6239 to fix hinting for '../' which was exposed by recent file system changes. Added a unit test for this.

---

This also adds site-root relative path support (i.e. path that start with '/'). Added a unit test for this.

---

I also fixed a bug I noticed where list was not filtered for initial list. Recipe:
1. Shutdown and restart Brackets to clear Url Hinting cache
2. Open a .css file in a folder with other files and folders
3. Add this declaration in a rule: `background-image: url("");`
4. Put cursor between quotes and type a single letter

Results:
Hints list shows all files and folders in the current folder

Expected:
Only files and folders that start with letter typed are listed (which may be none).

Workaround:
Hit Esc key and then Ctrl-space. This works because it uses cached list, which is filtered.
