### PR TITLE
Keep 'change extensions' dialog up with different message/disabled buttons while processing changes before quitting

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -39,7 +39,8 @@ define(function (require, exports, module) {
         Async                       = require("utils/Async"),
         ExtensionManager            = require("extensibility/ExtensionManager"),
         ExtensionManagerView        = require("extensibility/ExtensionManagerView").ExtensionManagerView,
-        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel");
+        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel"),
+        KeyEvent                    = require("utils/KeyEvent");
     
     var dialogTemplate    = require("text!htmlContent/extension-manager-dialog.html");
     
@@ -53,17 +54,21 @@ define(function (require, exports, module) {
      * Triggers changes requested by the dialog UI.
      */
     function _performChanges() {
+        // If an extension was removed or updated, prompt the user to quit Brackets.
         var hasRemovedExtensions = ExtensionManager.hasExtensionsToRemove(),
             hasUpdatedExtensions = ExtensionManager.hasExtensionsToUpdate();
-        // If an extension was removed or updated, prompt the user to quit Brackets.
-        if (hasRemovedExtensions || hasUpdatedExtensions) {
-            var buttonLabel = Strings.CHANGE_AND_QUIT;
-            if (hasRemovedExtensions && !hasUpdatedExtensions) {
-                buttonLabel = Strings.REMOVE_AND_QUIT;
-            } else if (hasUpdatedExtensions && !hasRemovedExtensions) {
-                buttonLabel = Strings.UPDATE_AND_QUIT;
-            }
-            Dialogs.showModalDialog(
+        if (!hasRemovedExtensions && !hasUpdatedExtensions) {
+            return;
+        }
+        
+        var buttonLabel = Strings.CHANGE_AND_QUIT;
+        if (hasRemovedExtensions && !hasUpdatedExtensions) {
+            buttonLabel = Strings.REMOVE_AND_QUIT;
+        } else if (hasUpdatedExtensions && !hasRemovedExtensions) {
+            buttonLabel = Strings.UPDATE_AND_QUIT;
+        }
+        
+        var dlg = Dialogs.showModalDialog(
                 DefaultDialogs.DIALOG_ID_CHANGE_EXTENSIONS,
                 Strings.CHANGE_AND_QUIT_TITLE,
                 Strings.CHANGE_AND_QUIT_MESSAGE,
@@ -78,63 +83,102 @@ define(function (require, exports, module) {
                         id        : Dialogs.DIALOG_BTN_OK,
                         text      : buttonLabel
                     }
-                ]
-            )
-                .done(function (buttonId) {
-                    if (buttonId === "ok") {
-                        ExtensionManager.removeMarkedExtensions()
-                            .done(function () {
-                                ExtensionManager.updateExtensions()
-                                    .done(function () {
-                                        CommandManager.execute(Commands.FILE_QUIT);
-                                    })
-                                    .fail(function (errorArray) {
-                                        
-                                        // This error case should be very uncommon.
-                                        // Just let the user know that we couldn't update
-                                        // this extension and log the errors to the console.
-                                        var ids = [];
-                                        errorArray.forEach(function (errorObj) {
-                                            ids.push(errorObj.item);
-                                            if (errorObj.error && errorObj.error.forEach) {
-                                                console.error("Errors for ", errorObj.item);
-                                                errorObj.error.forEach(function (error) {
-                                                    console.error(Package.formatError(error));
-                                                });
-                                            }
-                                        });
-                                        Dialogs.showModalDialog(
-                                            DefaultDialogs.DIALOG_ID_ERROR,
-                                            Strings.EXTENSION_MANAGER_UPDATE,
-                                            StringUtils.format(Strings.EXTENSION_MANAGER_UPDATE_ERROR, ids.join(", "))
-                                        ).done(function () {
-                                            // We still have to quit even if some of the removals failed.
-                                            CommandManager.execute(Commands.FILE_QUIT);
-                                        });
+                ],
+                false
+            ),
+            $dlg = dlg.getElement(),
+            disabled = false;
+        
+        function ok() {
+            // Disable the dialog buttons so the user can't dismiss it,
+            // and show a message indicating that we're doing the updates,
+            // in case it takes a long time.
+            disabled = true;
+            $dlg.find(".dialog-button").prop("disabled", true);
+            $dlg.find(".close").hide();
+            $dlg.find(".dialog-message")
+                .text(Strings.PROCESSING_EXTENSIONS)
+                .append("<span class='spinner spin'/>");
+            
+            // Process the changes.
+            ExtensionManager.removeMarkedExtensions()
+                .done(function () {
+                    ExtensionManager.updateExtensions()
+                        .done(function () {
+                            dlg.close();
+                            CommandManager.execute(Commands.FILE_QUIT);
+                        })
+                        .fail(function (errorArray) {
+                            dlg.close();
+                            
+                            // This error case should be very uncommon.
+                            // Just let the user know that we couldn't update
+                            // this extension and log the errors to the console.
+                            var ids = [];
+                            errorArray.forEach(function (errorObj) {
+                                ids.push(errorObj.item);
+                                if (errorObj.error && errorObj.error.forEach) {
+                                    console.error("Errors for ", errorObj.item);
+                                    errorObj.error.forEach(function (error) {
+                                        console.error(Package.formatError(error));
                                     });
-                            })
-                            .fail(function (errorArray) {
-                                ExtensionManager.cleanupUpdates();
-                                
-                                var ids = [];
-                                errorArray.forEach(function (errorObj) {
-                                    ids.push(errorObj.item);
-                                });
-                                Dialogs.showModalDialog(
-                                    DefaultDialogs.DIALOG_ID_ERROR,
-                                    Strings.EXTENSION_MANAGER_REMOVE,
-                                    StringUtils.format(Strings.EXTENSION_MANAGER_REMOVE_ERROR, ids.join(", "))
-                                ).done(function () {
-                                    // We still have to quit even if some of the removals failed.
-                                    CommandManager.execute(Commands.FILE_QUIT);
-                                });
+                                }
                             });
-                    } else {
-                        ExtensionManager.cleanupUpdates();
-                        ExtensionManager.unmarkAllForRemoval();
-                    }
+                            Dialogs.showModalDialog(
+                                DefaultDialogs.DIALOG_ID_ERROR,
+                                Strings.EXTENSION_MANAGER_UPDATE,
+                                StringUtils.format(Strings.EXTENSION_MANAGER_UPDATE_ERROR, ids.join(", "))
+                            ).done(function () {
+                                // We still have to quit even if some of the removals failed.
+                                CommandManager.execute(Commands.FILE_QUIT);
+                            });
+                        });
+                })
+                .fail(function (errorArray) {
+                    dlg.close();
+                    ExtensionManager.cleanupUpdates();
+                    
+                    var ids = [];
+                    errorArray.forEach(function (errorObj) {
+                        ids.push(errorObj.item);
+                    });
+                    Dialogs.showModalDialog(
+                        DefaultDialogs.DIALOG_ID_ERROR,
+                        Strings.EXTENSION_MANAGER_REMOVE,
+                        StringUtils.format(Strings.EXTENSION_MANAGER_REMOVE_ERROR, ids.join(", "))
+                    ).done(function () {
+                        // We still have to quit even if some of the removals failed.
+                        CommandManager.execute(Commands.FILE_QUIT);
+                    });
                 });
         }
+        
+        function cancel() {
+            ExtensionManager.cleanupUpdates();
+            ExtensionManager.unmarkAllForRemoval();
+            dlg.close();
+        }
+        
+        function escHandler(e) {
+            if (!disabled && e.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+                cancel();
+            }
+        }
+        
+        // We have to explicitly handle button clicks and the Esc key when autoDismiss is false.
+        $dlg.one("click", ".dialog-button", function (e) {
+            var id = $(this).attr("data-button-id");
+            if (id === Dialogs.DIALOG_BTN_CANCEL) {
+                cancel();
+            } else {
+                ok();
+            }
+        });
+        
+        $(window.document.body).on("keyup", escHandler);
+        $dlg.done(function () {
+            $(window.document.body).off("keyup", escHandler);
+        });
     }
     
     /**

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -414,6 +414,7 @@ define({
     "REMOVE_AND_QUIT"                      : "Remove Extensions and Quit",
     "CHANGE_AND_QUIT"                      : "Change Extensions and Quit",
     "UPDATE_AND_QUIT"                      : "Update Extensions and Quit",
+    "PROCESSING_EXTENSIONS"                : "Processing extension changes\u2026",
     "EXTENSION_NOT_INSTALLED"              : "Couldn't remove extension {0} because it wasn't installed.",
     "NO_EXTENSIONS"                        : "No extensions installed yet.<br>Click on the Available tab above to get started.",
     "NO_EXTENSION_MATCHES"                 : "No extensions match your search.",

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
      * @param {string} template A string template or jQuery object to use as the dialog HTML.
      * @param {boolean=} autoDismiss Whether to automatically dismiss the dialog when one of the buttons
      *      is clicked. Default true. If false, you'll need to manually handle button clicks and the Esc
-     *      key, and dismiss the dialog yourself when ready with `cancelModalDialogIfOpen()`.
+     *      key, and dismiss the dialog yourself when ready by calling `close()` on the returned dialog.
      * @return {Dialog}
      */
     function showModalDialogUsingTemplate(template, autoDismiss) {
@@ -313,9 +313,12 @@ define(function (require, exports, module) {
      * @param {Array.<{className: string, id: string, text: string}>=} buttons An array of buttons where each button
      *      has a class, id and text property. The id is used in "data-button-id". Defaults to a single Ok button.
      *      Typically className is one of DIALOG_BTN_CLASS_*, id is one of DIALOG_BTN_*
+     * @param {boolean=} autoDismiss Whether to automatically dismiss the dialog when one of the buttons
+     *      is clicked. Default true. If false, you'll need to manually handle button clicks and the Esc
+     *      key, and dismiss the dialog yourself when ready by calling `close()` on the returned dialog.
      * @return {Dialog}
      */
-    function showModalDialog(dlgClass, title, message, buttons) {
+    function showModalDialog(dlgClass, title, message, buttons, autoDismiss) {
         var templateVars = {
             dlgClass: dlgClass,
             title:    title   || "",
@@ -324,7 +327,7 @@ define(function (require, exports, module) {
         };
         var template = Mustache.render(DialogTemplate, templateVars);
         
-        return showModalDialogUsingTemplate(template);
+        return showModalDialogUsingTemplate(template, autoDismiss);
     }
     
     /**


### PR DESCRIPTION
For #6257. @dangoor - maybe this would be good for you to look at since I think you did the original update flow on quit.

The main change is just to make it so the dialog doesn't autodismiss when buttons are clicked, so we can keep it open and just disable the buttons/change the message while the changes are being applied.

The diffs are unfortunately a bit hard to look at because I moved some stuff into functions, but the only real change within the code that runs after ExtensionManager has applied the changes is to make it so we explicitly close the dialog before quitting.
