### PR TITLE
Keep 'change extensions' dialog up while processing changes before quitting

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -39,7 +39,8 @@ define(function (require, exports, module) {
         Async                       = require("utils/Async"),
         ExtensionManager            = require("extensibility/ExtensionManager"),
         ExtensionManagerView        = require("extensibility/ExtensionManagerView").ExtensionManagerView,
-        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel");
+        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel"),
+        KeyEvent                    = require("utils/KeyEvent");
     
     var dialogTemplate    = require("text!htmlContent/extension-manager-dialog.html");
     
@@ -53,88 +54,107 @@ define(function (require, exports, module) {
      * Triggers changes requested by the dialog UI.
      */
     function _performChanges() {
+        // If an extension was removed or updated, prompt the user to quit Brackets.
         var hasRemovedExtensions = ExtensionManager.hasExtensionsToRemove(),
             hasUpdatedExtensions = ExtensionManager.hasExtensionsToUpdate();
-        // If an extension was removed or updated, prompt the user to quit Brackets.
-        if (hasRemovedExtensions || hasUpdatedExtensions) {
-            var buttonLabel = Strings.CHANGE_AND_QUIT;
-            if (hasRemovedExtensions && !hasUpdatedExtensions) {
-                buttonLabel = Strings.REMOVE_AND_QUIT;
-            } else if (hasUpdatedExtensions && !hasRemovedExtensions) {
-                buttonLabel = Strings.UPDATE_AND_QUIT;
-            }
-            Dialogs.showModalDialog(
-                DefaultDialogs.DIALOG_ID_CHANGE_EXTENSIONS,
-                Strings.CHANGE_AND_QUIT_TITLE,
-                Strings.CHANGE_AND_QUIT_MESSAGE,
-                [
-                    {
-                        className : Dialogs.DIALOG_BTN_CLASS_NORMAL,
-                        id        : Dialogs.DIALOG_BTN_CANCEL,
-                        text      : Strings.CANCEL
-                    },
-                    {
-                        className : Dialogs.DIALOG_BTN_CLASS_PRIMARY,
-                        id        : Dialogs.DIALOG_BTN_OK,
-                        text      : buttonLabel
-                    }
-                ]
-            )
-                .done(function (buttonId) {
-                    if (buttonId === "ok") {
-                        ExtensionManager.removeMarkedExtensions()
+        if (!hasRemovedExtensions && !hasUpdatedExtensions) {
+            return;
+        }
+        
+        var buttonLabel = Strings.CHANGE_AND_QUIT;
+        if (hasRemovedExtensions && !hasUpdatedExtensions) {
+            buttonLabel = Strings.REMOVE_AND_QUIT;
+        } else if (hasUpdatedExtensions && !hasRemovedExtensions) {
+            buttonLabel = Strings.UPDATE_AND_QUIT;
+        }
+        
+        var dlg = Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_CHANGE_EXTENSIONS,
+            Strings.CHANGE_AND_QUIT_TITLE,
+            Strings.CHANGE_AND_QUIT_MESSAGE,
+            [
+                {
+                    className : Dialogs.DIALOG_BTN_CLASS_NORMAL,
+                    id        : Dialogs.DIALOG_BTN_CANCEL,
+                    text      : Strings.CANCEL
+                },
+                {
+                    className : Dialogs.DIALOG_BTN_CLASS_PRIMARY,
+                    id        : Dialogs.DIALOG_BTN_OK,
+                    text      : buttonLabel
+                }
+            ],
+            false
+        ),
+            $dlg = dlg.getElement();
+        
+        $dlg.one("buttonClick", function (e, buttonId) {
+            if (buttonId === Dialogs.DIALOG_BTN_OK) {
+                // Disable the dialog buttons so the user can't dismiss it,
+                // and show a message indicating that we're doing the updates,
+                // in case it takes a long time.
+                $dlg.find(".dialog-button").prop("disabled", true);
+                $dlg.find(".close").hide();
+                $dlg.find(".dialog-message")
+                    .text(Strings.PROCESSING_EXTENSIONS)
+                    .append("<span class='spinner spin'/>");
+                
+                ExtensionManager.removeMarkedExtensions()
+                    .done(function () {
+                        ExtensionManager.updateExtensions()
                             .done(function () {
-                                ExtensionManager.updateExtensions()
-                                    .done(function () {
-                                        CommandManager.execute(Commands.FILE_QUIT);
-                                    })
-                                    .fail(function (errorArray) {
-                                        
-                                        // This error case should be very uncommon.
-                                        // Just let the user know that we couldn't update
-                                        // this extension and log the errors to the console.
-                                        var ids = [];
-                                        errorArray.forEach(function (errorObj) {
-                                            ids.push(errorObj.item);
-                                            if (errorObj.error && errorObj.error.forEach) {
-                                                console.error("Errors for ", errorObj.item);
-                                                errorObj.error.forEach(function (error) {
-                                                    console.error(Package.formatError(error));
-                                                });
-                                            }
-                                        });
-                                        Dialogs.showModalDialog(
-                                            DefaultDialogs.DIALOG_ID_ERROR,
-                                            Strings.EXTENSION_MANAGER_UPDATE,
-                                            StringUtils.format(Strings.EXTENSION_MANAGER_UPDATE_ERROR, ids.join(", "))
-                                        ).done(function () {
-                                            // We still have to quit even if some of the removals failed.
-                                            CommandManager.execute(Commands.FILE_QUIT);
-                                        });
-                                    });
+                                dlg.close();
+                                CommandManager.execute(Commands.FILE_QUIT);
                             })
                             .fail(function (errorArray) {
-                                ExtensionManager.cleanupUpdates();
+                                dlg.close();
                                 
+                                // This error case should be very uncommon.
+                                // Just let the user know that we couldn't update
+                                // this extension and log the errors to the console.
                                 var ids = [];
                                 errorArray.forEach(function (errorObj) {
                                     ids.push(errorObj.item);
+                                    if (errorObj.error && errorObj.error.forEach) {
+                                        console.error("Errors for ", errorObj.item);
+                                        errorObj.error.forEach(function (error) {
+                                            console.error(Package.formatError(error));
+                                        });
+                                    }
                                 });
                                 Dialogs.showModalDialog(
                                     DefaultDialogs.DIALOG_ID_ERROR,
-                                    Strings.EXTENSION_MANAGER_REMOVE,
-                                    StringUtils.format(Strings.EXTENSION_MANAGER_REMOVE_ERROR, ids.join(", "))
+                                    Strings.EXTENSION_MANAGER_UPDATE,
+                                    StringUtils.format(Strings.EXTENSION_MANAGER_UPDATE_ERROR, ids.join(", "))
                                 ).done(function () {
                                     // We still have to quit even if some of the removals failed.
                                     CommandManager.execute(Commands.FILE_QUIT);
                                 });
                             });
-                    } else {
+                    })
+                    .fail(function (errorArray) {
+                        dlg.close();
                         ExtensionManager.cleanupUpdates();
-                        ExtensionManager.unmarkAllForRemoval();
-                    }
-                });
-        }
+                        
+                        var ids = [];
+                        errorArray.forEach(function (errorObj) {
+                            ids.push(errorObj.item);
+                        });
+                        Dialogs.showModalDialog(
+                            DefaultDialogs.DIALOG_ID_ERROR,
+                            Strings.EXTENSION_MANAGER_REMOVE,
+                            StringUtils.format(Strings.EXTENSION_MANAGER_REMOVE_ERROR, ids.join(", "))
+                        ).done(function () {
+                            // We still have to quit even if some of the removals failed.
+                            CommandManager.execute(Commands.FILE_QUIT);
+                        });
+                    });
+            } else {
+                dlg.close();
+                ExtensionManager.cleanupUpdates();
+                ExtensionManager.unmarkAllForRemoval();
+            }
+        });
     }
     
     /**

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -39,8 +39,7 @@ define(function (require, exports, module) {
         Async                       = require("utils/Async"),
         ExtensionManager            = require("extensibility/ExtensionManager"),
         ExtensionManagerView        = require("extensibility/ExtensionManagerView").ExtensionManagerView,
-        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel"),
-        KeyEvent                    = require("utils/KeyEvent");
+        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel");
     
     var dialogTemplate    = require("text!htmlContent/extension-manager-dialog.html");
     

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -414,6 +414,7 @@ define({
     "REMOVE_AND_QUIT"                      : "Remove Extensions and Quit",
     "CHANGE_AND_QUIT"                      : "Change Extensions and Quit",
     "UPDATE_AND_QUIT"                      : "Update Extensions and Quit",
+    "PROCESSING_EXTENSIONS"                : "Processing extension changes\u2026",
     "EXTENSION_NOT_INSTALLED"              : "Couldn't remove extension {0} because it wasn't installed.",
     "NO_EXTENSIONS"                        : "No extensions installed yet.<br>Click on the Available tab above to get started.",
     "NO_EXTENSION_MATCHES"                 : "No extensions match your search.",

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -70,6 +70,22 @@ define(function (require, exports, module) {
         $dlg.data("buttonId", buttonId);
         $dlg.modal("hide");
     }
+    
+    /**
+     * @private
+     * If autoDismiss is true, then dismisses the dialog. Otherwise just raises an event that the
+     * given button was clicked.
+     * @param {$.Element} $dlg The dialog element to be dismissed.
+     * @param {string} buttonId The ID of the button that was clicked.
+     * @param {boolean} autoDismiss Whether to autodismiss the dialog on a button click.
+     */
+    function _processButton($dlg, buttonId, autoDismiss) {
+        if (autoDismiss) {
+            _dismissDialog($dlg, buttonId);
+        } else {
+            $dlg.triggerHandler("buttonClick", buttonId);
+        }
+    }
 
     /**
      * @private
@@ -157,8 +173,8 @@ define(function (require, exports, module) {
             }
         }
         
-        if (autoDismiss && buttonId) {
-            _dismissDialog(this, buttonId);
+        if (buttonId) {
+            _processButton(this, buttonId, autoDismiss);
         }
         
         // Stop any other global hooks from processing the event (but
@@ -216,7 +232,7 @@ define(function (require, exports, module) {
      * @param {string} template A string template or jQuery object to use as the dialog HTML.
      * @param {boolean=} autoDismiss Whether to automatically dismiss the dialog when one of the buttons
      *      is clicked. Default true. If false, you'll need to manually handle button clicks and the Esc
-     *      key, and dismiss the dialog yourself when ready with `cancelModalDialogIfOpen()`.
+     *      key, and dismiss the dialog yourself when ready by calling `close()` on the returned dialog.
      * @return {Dialog}
      */
     function showModalDialogUsingTemplate(template, autoDismiss) {
@@ -275,11 +291,9 @@ define(function (require, exports, module) {
         });
         
         // Click handler for buttons
-        if (autoDismiss) {
-            $dlg.one("click", ".dialog-button", function (e) {
-                _dismissDialog($dlg, $(this).attr("data-button-id"));
-            });
-        }
+        $dlg.one("click", ".dialog-button", function (e) {
+            _processButton($dlg, $(this).attr("data-button-id"), autoDismiss);
+        });
         
         $(".last-backdrop").removeClass("last-backdrop");
         
@@ -313,9 +327,12 @@ define(function (require, exports, module) {
      * @param {Array.<{className: string, id: string, text: string}>=} buttons An array of buttons where each button
      *      has a class, id and text property. The id is used in "data-button-id". Defaults to a single Ok button.
      *      Typically className is one of DIALOG_BTN_CLASS_*, id is one of DIALOG_BTN_*
+     * @param {boolean=} autoDismiss Whether to automatically dismiss the dialog when one of the buttons
+     *      is clicked. Default true. If false, you'll need to manually handle button clicks and the Esc
+     *      key, and dismiss the dialog yourself when ready by calling `close()` on the returned dialog.
      * @return {Dialog}
      */
-    function showModalDialog(dlgClass, title, message, buttons) {
+    function showModalDialog(dlgClass, title, message, buttons, autoDismiss) {
         var templateVars = {
             dlgClass: dlgClass,
             title:    title   || "",
@@ -324,7 +341,7 @@ define(function (require, exports, module) {
         };
         var template = Mustache.render(DialogTemplate, templateVars);
         
-        return showModalDialogUsingTemplate(template);
+        return showModalDialogUsingTemplate(template, autoDismiss);
     }
     
     /**

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -1291,18 +1291,22 @@ define(function (require, exports, module) {
             
             
             describe("ExtensionManagerDialog", function () {
-                var dialogClassShown, dialogDeferred, didQuit;
+                var dialogClassShown, didQuit, didClose, $mockDlg;
                 
                 describe("_performChanges", function () {
                 
                     beforeEach(function () {
                         // Mock popping up dialogs
                         dialogClassShown = null;
-                        dialogDeferred = new $.Deferred();
+                        didClose = false;
                         spyOn(Dialogs, "showModalDialog").andCallFake(function (dlgClass, title, message) {
                             dialogClassShown = dlgClass;
+                            $mockDlg = $("<div/>").addClass(dlgClass);
                             // The test will resolve the promise.
-                            return dialogDeferred.promise();
+                            return {
+                                getElement: function () { return $mockDlg; },
+                                close: function () { didClose = true; }
+                            };
                         });
                         
                         // Mock quitting the app so we don't actually quit :)
@@ -1352,7 +1356,7 @@ define(function (require, exports, module) {
                             // Don't expect the model to be disposed until after the dialog is dismissed.
                             ExtensionManagerDialog._performChanges();
                             expect(dialogClassShown).toBe("change-marked-extensions");
-                            dialogDeferred.resolve("cancel");
+                            $mockDlg.triggerHandler("buttonClick", Dialogs.DIALOG_BTN_CANCEL);
                         });
                     });
                     
@@ -1366,12 +1370,13 @@ define(function (require, exports, module) {
                         runs(function () {
                             // Don't expect the model to be disposed until after the dialog is dismissed.
                             ExtensionManagerDialog._performChanges();
-                            dialogDeferred.resolve("ok");
+                            $mockDlg.triggerHandler("buttonClick", Dialogs.DIALOG_BTN_OK);
                         });
                         waitsFor(function () { return didQuit; }, "mock quit");
                         runs(function () {
                             var mockPath = SpecRunnerUtils.getTestPath("/spec/ExtensionManager-test-files");
                             expect(removedPath).toBe(mockPath + "/user/mock-extension-3");
+                            expect(didClose).toBe(true);
                             expect(didQuit).toBe(true);
                         });
                     });
@@ -1386,9 +1391,10 @@ define(function (require, exports, module) {
                         runs(function () {
                             // Don't expect the model to be disposed until after the dialog is dismissed.
                             ExtensionManagerDialog._performChanges();
-                            dialogDeferred.resolve("cancel");
+                            $mockDlg.triggerHandler("buttonClick", Dialogs.DIALOG_BTN_CANCEL);
                             expect(removedPath).toBeFalsy();
                             expect(ExtensionManager.isMarkedForRemoval("mock-extension-3")).toBe(false);
+                            expect(didClose).toBe(true);
                             expect(didQuit).toBe(false);
                         });
                     });
@@ -1408,7 +1414,7 @@ define(function (require, exports, module) {
                             });
                             // Don't expect the model to be disposed until after the dialog is dismissed.
                             ExtensionManagerDialog._performChanges();
-                            dialogDeferred.resolve("ok");
+                            $mockDlg.triggerHandler("buttonClick", Dialogs.DIALOG_BTN_OK);
                             installDeferred.resolve({
                                 installationStatus: "INSTALLED"
                             });
@@ -1416,6 +1422,7 @@ define(function (require, exports, module) {
                         waitsFor(function () { return didQuit; }, "mock quit");
                         runs(function () {
                             expect(Package.installUpdate).toHaveBeenCalledWith(filename, id);
+                            expect(didClose).toBe(true);
                             expect(didQuit).toBe(true);
                         });
                     });
@@ -1436,9 +1443,10 @@ define(function (require, exports, module) {
                             spyOn(file, "unlink");
                             // Don't expect the model to be disposed until after the dialog is dismissed.
                             ExtensionManagerDialog._performChanges();
-                            dialogDeferred.resolve("cancel");
+                            $mockDlg.triggerHandler("buttonClick", Dialogs.DIALOG_BTN_CANCEL);
                             expect(removedPath).toBeFalsy();
                             expect(ExtensionManager.isMarkedForUpdate("mock-extension-3")).toBe(false);
+                            expect(didClose).toBe(true);
                             expect(didQuit).toBe(false);
                             expect(file.unlink).toHaveBeenCalled();
                         });


### PR DESCRIPTION
For #6257. @dangoor - maybe this would be good for you to look at since I think you did the original update flow on quit.

The main change is just to make it so the dialog doesn't autodismiss when buttons are clicked, so we can keep it open and just disable the buttons/change the message while the changes are being applied.

Worth looking at the diffs with `?w=1` in ExtensionManagerDialog.js since that makes the actual changes more obvious.
