### PR TITLE
Fixed status bar so it can add indicators to itself again

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -404,8 +404,7 @@ define(function (require, exports, module) {
         
         // Status bar indicator - icon & tooltip updated by run()
         var statusIconHtml = Mustache.render("<div id=\"status-inspection\">&nbsp;</div>", Strings);
-        $(statusIconHtml).insertBefore("#status-language");
-        StatusBar.addIndicator(INDICATOR_ID, $("#status-inspection"));
+        StatusBar.addIndicator(INDICATOR_ID, $(statusIconHtml), true, "", "", "status-language");
         
         $("#status-inspection").click(function () {
             // Clicking indicator toggles error panel, if any errors in current file

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -404,7 +404,7 @@ define(function (require, exports, module) {
         
         // Status bar indicator - icon & tooltip updated by run()
         var statusIconHtml = Mustache.render("<div id=\"status-inspection\">&nbsp;</div>", Strings);
-        StatusBar.addIndicator(INDICATOR_ID, $(statusIconHtml), true, "", "", "status-language");
+        StatusBar.addIndicator(INDICATOR_ID, $(statusIconHtml), true, "", "", "status-indent");
         
         $("#status-inspection").click(function () {
             // Clicking indicator toggles error panel, if any errors in current file

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -130,7 +130,8 @@ define(function (require, exports, module) {
         if (insertBefore && $("#" + insertBefore).length > 0) {
             $indicator.insertAfter("#" + insertBefore);
         } else {
-            // No positioning is provided, put after "busy" indicator
+            // No positioning is provided, put on left end of indicators, but
+            // to right of "busy" indicator (which is usually hidden).
             var $busyIndicator = $("#status-bar .spinner");
             $indicator.insertBefore($busyIndicator);
         }

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -122,7 +122,7 @@ define(function (require, exports, module) {
             $indicator.hide();
         }
         
-        if (_beforeID) {
+        if (_beforeID && $("#" + _beforeID).length > 0) {
             $indicator.insertBefore("#" + _beforeID);
         } else {
             // The "busy" spinner should always be leftmost

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -98,13 +98,14 @@ define(function (require, exports, module) {
      * @param {boolean=} visible Shows or hides the indicator over the statusbar.
      * @param {string=} style Sets the attribute "class" of the indicator.
      * @param {string=} tooltip Sets the attribute "title" of the indicator.
+     * @param {string=} _beforeID For internal use by CodeInspection module.
      */
-    function addIndicator(id, indicator, visible, style, tooltip) {
+    function addIndicator(id, indicator, visible, style, tooltip, _beforeID) {
         if (!_init) {
             console.error("StatusBar API invoked before status bar created");
             return;
         }
-
+        
         indicator = indicator || document.createElement("div");
         tooltip = tooltip || "";
         style = style || "";
@@ -121,6 +122,13 @@ define(function (require, exports, module) {
             $indicator.hide();
         }
         
+        if (_beforeID) {
+            $("#" + _beforeID).before($indicator);
+        } else {
+            // The "busy" spinner should always be leftmost
+            var $busyIndicator = $("#status-bar .spinner");
+            $indicator.insertBefore($busyIndicator);
+        }
     }
     
     /**

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
         }
         
         if (_beforeID) {
-            $("#" + _beforeID).before($indicator);
+            $indicator.insertBefore("#" + _beforeID);
         } else {
             // The "busy" spinner should always be leftmost
             var $busyIndicator = $("#status-bar .spinner");

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -98,9 +98,11 @@ define(function (require, exports, module) {
      * @param {boolean=} visible Shows or hides the indicator over the statusbar.
      * @param {string=} style Sets the attribute "class" of the indicator.
      * @param {string=} tooltip Sets the attribute "title" of the indicator.
-     * @param {string=} _beforeID For internal use by CodeInspection module.
+     * @param {string=} insertBefore An id of an existing status bar indicator.
+     *          The new indicator will be inserted before (i.e. to the left of)
+     *          the indicator specified by this parameter.
      */
-    function addIndicator(id, indicator, visible, style, tooltip, _beforeID) {
+    function addIndicator(id, indicator, visible, style, tooltip, insertBefore) {
         if (!_init) {
             console.error("StatusBar API invoked before status bar created");
             return;
@@ -122,10 +124,13 @@ define(function (require, exports, module) {
             $indicator.hide();
         }
         
-        if (_beforeID && $("#" + _beforeID).length > 0) {
-            $indicator.insertBefore("#" + _beforeID);
+        // This code looks backwards because the DOM model is ordered
+        // top-to-bottom but the UI view is ordered right-to-left. The concept
+        // of "before" in the model is "after" in the view, and vice versa.
+        if (insertBefore && $("#" + insertBefore).length > 0) {
+            $indicator.insertAfter("#" + insertBefore);
         } else {
-            // The "busy" spinner should always be leftmost
+            // No positioning is provided, put after "busy" indicator
             var $busyIndicator = $("#status-bar .spinner");
             $indicator.insertBefore($busyIndicator);
         }


### PR DESCRIPTION
This fix addresses issue #5682.  StatusBar.addIndicator() now adds the indicators to the DOM correctly.
