### PR TITLE
Style Extension Update buttons to the match the green notification "badge"

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1077,7 +1077,7 @@ input[type="color"],
         border-color: #65a015;
         box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.27);
         color: #fff;
-		font-weight: @font-weight-semibold;
+        font-weight: @font-weight-semibold;
         text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.24) ;
         
         &:active {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1074,15 +1074,16 @@ input[type="color"],
     // Update Button Type
     &.update {
         background-color: #91cc41;
-        border-color: #658e2d;
-        box-shadow: inset 0 1px 0 #d9edbd;
+        border-color: #65a015;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.27);
         color: #fff;
-        text-shadow: 0 1px 0 #333;
+		font-weight: @font-weight-semibold;
+        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.24) ;
         
         &:active {
             background-color: #82b839;
             border-color: #5b8028;
-            box-shadow: inset 0 1px 0 #d3e6ba;
+            box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.06);
             color: #fff;
         }
     }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1070,6 +1070,22 @@ input[type="color"],
             outline: none;
         }
     }
+    
+    // Update Button Type
+    &.update {
+        background-color: #91cc41;
+        border-color: #658e2d;
+        box-shadow: inset 0 1px 0 #d9edbd;
+        color: #fff;
+        text-shadow: 0 1px 0 #333;
+        
+        &:active {
+            background-color: #82b839;
+            border-color: #5b8028;
+            box-shadow: inset 0 1px 0 #d3e6ba;
+            color: #fff;
+        }
+    }
 
     // Button Sizes
     &.large {


### PR DESCRIPTION
When an extension has an update, it would be a much better user experience for the Update button to be clearly differentiated in the list (and especially from the Remove button).

Thus, this pull request changes .btn.update to match the green of the notification badge.
