### PR TITLE
Refactor Getting Started main.css

### DIFF
--- a/samples/root/Getting Started/main.css
+++ b/samples/root/Getting Started/main.css
@@ -1,25 +1,25 @@
 html {
     background-color: #e6e9e9;
-    background-image: linear-gradient(270deg,rgb(230,233,233) 0%,rgb(216,221,221) 100%);
-    background-image: -o-linear-gradient(270deg,rgb(230,233,233) 0%,rgb(216,221,221) 100%);
-    background-image: -moz-linear-gradient(270deg,rgb(230,233,233) 0%,rgb(216,221,221) 100%);
-    background-image: -webkit-linear-gradient(270deg,rgb(230,233,233) 0%,rgb(216,221,221) 100%);
-    background-image: -ms-linear-gradient(270deg,rgb(230,233,233) 0%,rgb(216,221,221) 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, rgb(230,233,233)), color-stop(100%, rgb(216,221,221)));
+    background-image: -webkit-linear-gradient(top, rgb(230,233,233) 0%, rgb(216,221,221) 100%);
+    background-image: -moz-linear-gradient(top, rgb(230,233,233) 0%, rgb(216,221,221) 100%);
+    background-image: -ms-linear-gradient(top, rgb(230,233,233) 0%, rgb(216,221,221) 100%);
+    background-image: -o-linear-gradient(top, rgb(230,233,233) 0%, rgb(216,221,221) 100%);
+    background-image: linear-gradient(to bottom, rgb(230,233,233) 0%, rgb(216,221,221) 100%);
 }
 
 body {
-    margin: 0 auto;
-    padding: 2em 2em 4em;
-    max-width: 800px;
-    font-family: source-sans-pro, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 16px;
-    line-height: 1.5em;
-    color: #545454;
     background-color: #ffffff;
     -webkit-box-shadow: 0 0 2px rgba(0, 0, 0, 0.06);
     -moz-box-shadow: 0 0 2px rgba(0, 0, 0, 0.06);
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.06);
-    -webkit-font-smoothing: antialiased;
+    color: #545454;
+    font-family: source-sans-pro, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5em;
+    margin: 0 auto;
+    max-width: 800px;
+    padding: 2em 2em 4em;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -46,22 +46,14 @@ samp {
 }
 
 img {
+    -webkit-animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
+    animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
     background: transparent;
     border: 10px solid rgba(0, 0, 0, 0.12);
     border-radius: 4px;
     display: block;
     margin: 1.3em auto;
     max-width: 95%;
-    -webkit-animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
-}
-
-@keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
 }
 
 @-webkit-keyframes colorize {
@@ -70,5 +62,16 @@ img {
     }
     100% {
         -webkit-filter: grayscale(0%);
+    }
+}
+
+@keyframes colorize {
+    0% {
+        -webkit-filter: grayscale(100%);
+        filter: grayscale(100%);
+    }
+    100% {
+        -webkit-filter: grayscale(0%);
+        filter: grayscale(0%);
     }
 }


### PR DESCRIPTION
This was suggested in issue #6320
- Standard properties preferred over vendor prefixes.
- Properties sorted alphabetically.
- Vendor prefixes sorted by length from oldest to newest and longest to shortest to improve readability.
- Added older WebKit gradient syntax to match the age of vendor prefixed box-shadow.
- Fix gradient vendor syntaxes to match their implementation: https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient
