### PR TITLE
Resize QuickOpen results if the window size is changed, and add scroll bars

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -70,6 +70,11 @@ define(function (require, exports, module) {
      * The currently open quick open dialog.
      */
     var _curDialog;
+    
+    /**
+     * The width of the window.
+     */
+    var _windowWidth;
 
     /**
      * Defines API for new QuickOpen plug-ins
@@ -848,6 +853,13 @@ define(function (require, exports, module) {
 
         this.setSearchFieldValue(prefix, initialString);
         
+        // Set the smart_autocomplete_container's max-height for scroll bars
+        // and margin-left to keep it aligned with the QuickOpen input area
+        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
+        $(".smart_autocomplete_container").css({"height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
+        // Set the initial window width every time QuickOpen is opened. Used to calculate the change in width of the window
+        _windowWidth = window.document.width;
+        
         // Start fetching the file list, which will be needed the first time the user enters an un-prefixed query. If file index
         // caches are out of date, this list might take some time to asynchronously build. See searchFileList() for how this is handled.
         fileListPromise = ProjectManager.getAllFiles(true)
@@ -914,6 +926,15 @@ define(function (require, exports, module) {
     // Listen for a change of project to invalidate our file list
     $(ProjectManager).on("projectOpen", function () {
         fileList = null;
+    });
+    
+    // Listen for the resizing of window to resize and move the smart_autocomplete_container accordingly
+    $(window).resize(function() {
+        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
+        $(".smart_autocomplete_container").css({"height": _smartAutocompleteContainerHeight});
+        // move the smart_autocomplete_container according to change in the width of the window
+        var _widthChange = window.document.width - _windowWidth;
+        $(".smart_autocomplete_container").css({"margin-left": _widthChange});
     });
 
     // TODO: allow QuickOpenJS to register it's own commands and key bindings

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -162,6 +162,7 @@ define(function (require, exports, module) {
         // Bind event handlers
         this._handleItemSelect         = this._handleItemSelect.bind(this);
         this._handleItemFocus          = this._handleItemFocus.bind(this);
+        this._handleItemFocus          = this._handleItemFocus.bind(this);
         this._handleKeyUp              = this._handleKeyUp.bind(this);
         this._handleResultsReady       = this._handleResultsReady.bind(this);
         this._handleShowResults        = this._handleShowResults.bind(this);
@@ -856,7 +857,7 @@ define(function (require, exports, module) {
         // Set the smart_autocomplete_container's max-height for scroll bars
         // and margin-left to keep it aligned with the QuickOpen input area
         var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
-        $(".smart_autocomplete_container").css({"height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
+        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
         // Set the initial window width every time QuickOpen is opened. Used to calculate the change in width of the window
         _windowWidth = window.document.width;
         
@@ -929,9 +930,9 @@ define(function (require, exports, module) {
     });
     
     // Listen for the resizing of window to resize and move the smart_autocomplete_container accordingly
-    $(window).resize(function() {
+    $(window).resize(function () {
         var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
-        $(".smart_autocomplete_container").css({"height": _smartAutocompleteContainerHeight});
+        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight});
         // move the smart_autocomplete_container according to change in the width of the window
         var _widthChange = window.document.width - _windowWidth;
         $(".smart_autocomplete_container").css({"margin-left": _widthChange});

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -447,6 +447,10 @@ define(function (require, exports, module) {
         ViewUtils.toggleClass(this.$searchField, "no-results", hasNoResults);
     };
     
+    function _smartAutocompleteContainerMaxHeight() {
+        return parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
+    }
+    
     /**
      * Called synchronously after all other processing is done (_handleFilter(), updating cached "last result" and
      * re-rendering DOM list items). NOT called if the last filter action had 0 results.
@@ -459,8 +463,7 @@ define(function (require, exports, module) {
         
         // Set the smart_autocomplete_container's max-height for scroll bars
         // and margin-left to keep it aligned with the QuickOpen input area
-        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
-        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
+        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerMaxHeight(), "margin-left": "0px"});
         // Set the initial window width every time QuickOpen is opened. Used to calculate the change in width of the window
         _windowWidth = window.document.width;
     };
@@ -931,8 +934,7 @@ define(function (require, exports, module) {
     
     // Listen for the resizing of window to resize and move the smart_autocomplete_container accordingly
     $(window).resize(function () {
-        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
-        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight});
+        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerMaxHeight()});
         // move the smart_autocomplete_container according to change in the width of the window
         var _widthChange = window.document.width - _windowWidth;
         $(".smart_autocomplete_container").css({"margin-left": _widthChange});

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -456,6 +456,13 @@ define(function (require, exports, module) {
         if ($(".smart_autocomplete_highlight").length === 0) {
             this._handleItemFocus(null, $(".smart_autocomplete_container > li:first-child").get(0));
         }
+        
+        // Set the smart_autocomplete_container's max-height for scroll bars
+        // and margin-left to keep it aligned with the QuickOpen input area
+        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
+        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
+        // Set the initial window width every time QuickOpen is opened. Used to calculate the change in width of the window
+        _windowWidth = window.document.width;
     };
 
     /**
@@ -853,13 +860,6 @@ define(function (require, exports, module) {
         });
 
         this.setSearchFieldValue(prefix, initialString);
-        
-        // Set the smart_autocomplete_container's max-height for scroll bars
-        // and margin-left to keep it aligned with the QuickOpen input area
-        var _smartAutocompleteContainerHeight = parseInt($(".main-view").css("height"), 10) - parseInt($("#status-bar").css("height"), 10) - 10;
-        $(".smart_autocomplete_container").css({"max-height": _smartAutocompleteContainerHeight, "margin-left": "0px"});
-        // Set the initial window width every time QuickOpen is opened. Used to calculate the change in width of the window
-        _windowWidth = window.document.width;
         
         // Start fetching the file list, which will be needed the first time the user enters an un-prefixed query. If file index
         // caches are out of date, this list might take some time to asynchronously build. See searchFileList() for how this is handled.

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1219,7 +1219,11 @@ a, img {
     /* smart auto complete doesn't correctly position the container
      * so these specific padding and margin values are necessary*/
     padding: 0px;
-    margin: 9px 0 0;
+    margin-top: 9px;
+    
+    /* smart auto complete doesn't provide any scroll bars
+     * so an overflow is necessary*/
+    overflow-y: auto;
 
     .quick-open-path {
         color: #666;


### PR DESCRIPTION
These changes add a scroll-bar to the results of QuickOpen when there are more results that can fit in the screen.
It also moves the results horizontally with the QuickOpen input area.

This addresses issues #1156 and #1157

Result :
![15a2214](https://f.cloud.github.com/assets/2771653/1814639/cdd6258c-6efb-11e3-93d7-00f1d9bbf928.png)
