### PR TITLE
Add default (blank) options parameter for File.write

### DIFF
--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -103,6 +103,7 @@ define(function (require, exports, module) {
             options = {};
         }
         
+        options = options || {};
         callback = callback || function () {};
         
         this._fileSystem._beginWrite();


### PR DESCRIPTION
Add a default `options` parameter to `File.write` similar to what was already done with `callback`. This gets rid of the encoding error message when calling `File.write` without the options parameter.

The error message displayed in the console: `TypeError: Cannot read property 'encoding' of undefined`

Addresses issue #6331
