### PR TITLE
Fix removing menu dividers

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -497,7 +497,7 @@ define(function (require, exports, module) {
                 return;
             }
         } else {
-            brackets.app.removeMenuItem(menuItemID, function (err) {
+            brackets.app.removeMenuItem(menuItem.dividerId, function (err) {
                 if (err) {
                     console.error("removeMenuDivider() -- divider not found: %s (error: %s)", menuItemID, err);
                 }
@@ -643,7 +643,9 @@ define(function (require, exports, module) {
         }
 
         // Initialize MenuItem state
-        if (!menuItem.isDivider) {
+        if (menuItem.isDivider) {
+            menuItem.dividerId = commandID;
+        } else {
             if (keyBindings) {
                 // Add key bindings. The MenuItem listens to the Command object to update MenuItem DOM with shortcuts.
                 if (!Array.isArray(keyBindings)) {


### PR DESCRIPTION
Menu dividers don't have commands (for retrieving id), so store divider id for later reference.

This is for https://github.com/adobe/brackets/issues/6300. Pull request https://github.com/adobe/brackets-shell/pull/405 is related to, but not required for, this one.
