### PR TITLE
[XD] Add Extensions Menu

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -55,8 +55,6 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW);
         menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
         
         // suppress redundant quit menu item on mac
         if (brackets.platform !== "mac" || !brackets.nativeMenus) {
@@ -140,6 +138,12 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.CSS_QUICK_EDIT_NEW_RULE);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_QUICK_DOCS);
+        
+        /*
+         * Extensions menu
+         */
+        menu = Menus.addMenu(Strings.EXTENSIONS_MENU, Menus.AppMenuBar.EXTENSION_MENU);
+        menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
 
         /*
          * Help menu

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
         /*
          * Extensions menu
          */
-        menu = Menus.addMenu(Strings.EXTENSIONS_MENU, Menus.AppMenuBar.EXTENSION_MENU);
+        menu = Menus.addMenu(Strings.EXTENSIONS_MENU, Menus.AppMenuBar.EXTENSIONS_MENU);
         menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
 
         /*

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
         EDIT_MENU       : "edit-menu",
         VIEW_MENU       : "view-menu",
         NAVIGATE_MENU   : "navigate-menu",
-        EXTENSION_MENU  : "extension-menu",
+        EXTENSIONS_MENU  : "extensions-menu",
         HELP_MENU       : "help-menu"
     };
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
         EDIT_MENU       : "edit-menu",
         VIEW_MENU       : "view-menu",
         NAVIGATE_MENU   : "navigate-menu",
+        EXTENSION_MENU  : "extension-menu",
         HELP_MENU       : "help-menu"
     };
 

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -232,7 +232,6 @@ define({
     "CMD_FILE_RENAME"                     : "Renombrar",
     "CMD_FILE_DELETE"                     : "Eliminar",
     "CMD_INSTALL_EXTENSION"               : "Instalar extensión\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Gestionar extensiones\u2026",
     "CMD_FILE_REFRESH"                    : "Actualizar árbol de archivos",
     "CMD_QUIT"                            : "Salir",
     // Used in native File menu on Windows
@@ -300,6 +299,10 @@ define({
     "CMD_PREV_DOC"                        : "Documento anterior",
     "CMD_SHOW_IN_TREE"                    : "Mostrar en el árbol de directorios",
     "CMD_SHOW_IN_OS"                      : "Mostrar en el Sistema Operativo",
+
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensiones",
+    "CMD_EXTENSION_MANAGER"               : "Gestionar extensiones\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "Ayuda",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -218,7 +218,6 @@ define({
     "CMD_FILE_RENAME"                     : "Renomear",
     "CMD_FILE_DELETE"                     : "Excluir",
     "CMD_INSTALL_EXTENSION"               : "Instalar extensão\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Gerenciador de extensões\u2026",
     "CMD_FILE_REFRESH"                    : "Recarregar árvore de arquivos",
     "CMD_QUIT"                            : "Sair",
     // Used in native File menu on Windows
@@ -285,6 +284,10 @@ define({
     "CMD_PREV_DOC"                        : "Documento anterior",
     "CMD_SHOW_IN_TREE"                    : "Mostrar na árvore de arquivos",
     "CMD_SHOW_IN_OS"                      : "Mostrar no sistema operacional",
+
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensões",
+    "CMD_EXTENSION_MANAGER"               : "Gerenciador de extensões\u2026",
 
     // Help menu commands
     "HELP_MENU"                           : "Ajuda",

--- a/src/nls/pt-pt/strings.js
+++ b/src/nls/pt-pt/strings.js
@@ -209,6 +209,9 @@ define({
     "CMD_PREV_DOC"                        : "Ficheiro anterior",
     "CMD_SHOW_IN_TREE"                    : "Mostrar na lista de pastas",
 
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extenções",
+
     // Help menu commands
     "HELP_MENU"                           : "Ajuda",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Mostrar pasta de extensões",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -232,7 +232,6 @@ define({
     "CMD_FILE_RENAME"                     : "Rename",
     "CMD_FILE_DELETE"                     : "Delete",
     "CMD_INSTALL_EXTENSION"               : "Install Extension\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Extension Manager\u2026",
     "CMD_FILE_REFRESH"                    : "Refresh File Tree",
     "CMD_QUIT"                            : "Quit",
     // Used in native File menu on Windows
@@ -300,6 +299,10 @@ define({
     "CMD_PREV_DOC"                        : "Previous Document",
     "CMD_SHOW_IN_TREE"                    : "Show in File Tree",
     "CMD_SHOW_IN_OS"                      : "Show in OS",
+    
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensions",
+    "CMD_EXTENSION_MANAGER"               : "Extension Manager\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "Help",

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -211,6 +211,9 @@ define({
     "CMD_NEXT_DOC"                        : "Следующий документ",
     "CMD_PREV_DOC"                        : "Предыдущий документ",
     "CMD_SHOW_IN_TREE"                    : "Показать в дереве файлов",
+
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensions",
     
     // Help menu commands
     "HELP_MENU"                           : "Помощь",

--- a/src/nls/sk/strings.js
+++ b/src/nls/sk/strings.js
@@ -200,7 +200,6 @@ define({
     "CMD_FILE_RENAME"                     : "Premenovať",
     "CMD_FILE_DELETE"                     : "Zmazať",
     "CMD_INSTALL_EXTENSION"               : "Inštalovať rozšírenia\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Správca rozšírení\u2026",
     "CMD_FILE_REFRESH"                    : "Obnoviť strom súborov",
     "CMD_QUIT"                            : "Koniec",
     // Použité v natívnom menu Súborov na Windows 
@@ -264,6 +263,10 @@ define({
     "CMD_PREV_DOC"                        : "Predchádzajúci dokument",
     "CMD_SHOW_IN_TREE"                    : "Zobraziť stromovú štruktúru",
     "CMD_SHOW_IN_OS"                      : "Zobraziť v OS",
+
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensions",
+    "CMD_EXTENSION_MANAGER"               : "Správca rozšírení\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "Nápoveda",

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -217,7 +217,6 @@ define({
     "CMD_FILE_RENAME"                     : "Преименуј",
     "CMD_FILE_DELETE"                     : "Обриши",
     "CMD_INSTALL_EXTENSION"               : "Инсталирај екстензију\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Менаџер екстензија\u2026",
     "CMD_FILE_REFRESH"                    : "Освежи стабло датотека",
     "CMD_QUIT"                            : "Прекини",
     // Used in native File menu on Windows
@@ -284,6 +283,10 @@ define({
     "CMD_PREV_DOC"                        : "Претходни документ",
     "CMD_SHOW_IN_TREE"                    : "Прикажи у стаблу датотека",
     "CMD_SHOW_IN_OS"                      : "Прикажи у оперативном систему",
+    
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Extensions",
+    "CMD_EXTENSION_MANAGER"               : "Менаџер екстензија\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "Помоћ",

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -232,7 +232,6 @@ define({
     "CMD_FILE_RENAME"                     : "Byt namn",
     "CMD_FILE_DELETE"                     : "Radera",
     "CMD_INSTALL_EXTENSION"               : "Installera tillägg\u2026",
-    "CMD_EXTENSION_MANAGER"               : "Tilläggshanteraren\u2026",
     "CMD_FILE_REFRESH"                    : "Uppdatera filträd",
     "CMD_QUIT"                            : "Avsluta",
     // Used in native File menu on Windows
@@ -300,6 +299,10 @@ define({
     "CMD_PREV_DOC"                        : "Föregående dokument",
     "CMD_SHOW_IN_TREE"                    : "Visa i filträdet",
     "CMD_SHOW_IN_OS"                      : "Visa i operativsystemet",
+    
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Tilläggshanterarens",
+    "CMD_EXTENSION_MANAGER"               : "Tilläggshanteraren\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "Hjälp",

--- a/src/nls/tr/strings.js
+++ b/src/nls/tr/strings.js
@@ -213,6 +213,9 @@ define({
     "CMD_SHOW_IN_TREE"                    : "Dosya Listesinde Göster",
     "CMD_SHOW_IN_OS"                      : "Bulunduğu Konumu Aç",
     
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "Uzantıları",
+    
     // Help menu commands
     "HELP_MENU"                           : "Yardım",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Eklentiler Klasörünü Göster",

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -232,7 +232,6 @@ define({
     "CMD_FILE_RENAME"                     : "重命名",
     "CMD_FILE_DELETE"                     : "删除",
     "CMD_INSTALL_EXTENSION"               : "安装扩展\u2026",
-    "CMD_EXTENSION_MANAGER"               : "扩展管理器\u2026",
     "CMD_FILE_REFRESH"                    : "刷新文件列表",
     "CMD_QUIT"                            : "退出",
     // Used in native File menu on Windows
@@ -300,6 +299,10 @@ define({
     "CMD_PREV_DOC"                        : "上一个文件",
     "CMD_SHOW_IN_TREE"                    : "在侧边栏显示",
     "CMD_SHOW_IN_OS"                      : "打开文件所在目录",
+    
+    // Extensions menu commands
+    "EXTENSIONS_MENU"                     : "扩展",
+    "CMD_EXTENSION_MANAGER"               : "扩展管理器\u2026",
     
     // Help menu commands
     "HELP_MENU"                           : "帮助",


### PR DESCRIPTION
Add Extensions Menu to organize extension commands

Why? When you add extensions, the edit menu grows and becomes very messy

The extensions need to change the following code to use this feature:

```
    var menu = Menus.getMenu(Menus.AppMenuBar.HELP_MENU);
```

To:

```
    var menu = Menus.getMenu(Menus.AppMenuBar.EXTENSIONS_MENU);
    if(!menu) //fallback to old sprints
        menu = Menus.getMenu(Menus.AppMenuBar.HELP_MENU);
```
