### PR TITLE
Receive binary Brackets-Node command responses 

### DIFF
--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -24,7 +24,7 @@
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
 maxerr: 50, browser: true */
-/*global $, define, brackets, WebSocket */
+/*global $, define, brackets, WebSocket, ArrayBuffer, Uint32Array */
 
 define(function (require, exports, module) {
     "use strict";
@@ -46,6 +46,9 @@ define(function (require, exports, module) {
     /** @define{number} Milliseconds to wait before retrying connecting */
     var RETRY_DELAY         = 500;   // 1/2 second
 
+    /** @define {number} Maximum value of the command ID counter */
+    var MAX_COUNTER_VALUE = 4294967295; // 2^32 - 1
+    
     /**
      * @private
      * Helper function to auto-reject a deferred after a given amount of time.
@@ -73,6 +76,10 @@ define(function (require, exports, module) {
             if (!err && nodePort && deferred.state() !== "rejected") {
                 port = nodePort;
                 ws = new WebSocket("ws://localhost:" + port);
+                
+                // Expect ArrayBuffer objects from Node when receiving binary
+                // data instead of DOM Blobs, which are the default.
+                ws.binaryType = "arraybuffer";
                 
                 // If the server port isn't open, we get a close event
                 // at some point in the future (and will not get an onopen 
@@ -173,6 +180,23 @@ define(function (require, exports, module) {
      * resolved/rejected with the response of commands.
      */
     NodeConnection.prototype._pendingCommandDeferreds = null;
+    
+    /**
+     * @private
+     * @return {number} The next command ID to use. Always representable as an
+     * unsigned 32-bit integer.
+     */
+    NodeConnection.prototype._getNextCommandID = function () {
+        var nextID;
+        
+        if (this._commandCount > MAX_COUNTER_VALUE) {
+            nextID = this._commandCount = 0;
+        } else {
+            nextID = this._commandCount++;
+        }
+        
+        return nextID;
+    };
     
     /**
      * @private
@@ -402,12 +426,36 @@ define(function (require, exports, module) {
      */
     NodeConnection.prototype._receive = function (message) {
         var responseDeferred = null;
+        var data = message.data;
         var m;
-        try {
-            m = JSON.parse(message.data);
-        } catch (e) {
-            console.error("[NodeConnection] received malformed message", message, e.message);
-            return;
+        
+        if (message.data instanceof ArrayBuffer) {
+            // The first four bytes encode the command ID as an unsigned 32-bit integer
+            if (data.byteLength < 4) {
+                console.error("[NodeConnection] received malformed binary message");
+                return;
+            }
+            
+            var header = data.slice(0, 4),
+                body = data.slice(4),
+                headerView = new Uint32Array(header),
+                id = headerView[0];
+            
+            // Unpack the binary message into a commandResponse
+            m = {
+                type: "commandResponse",
+                message: {
+                    id: id,
+                    response: body
+                }
+            };
+        } else {
+            try {
+                m = JSON.parse(data);
+            } catch (e) {
+                console.error("[NodeConnection] received malformed message", message, e.message);
+                return;
+            }
         }
         
         switch (m.type) {
@@ -467,7 +515,7 @@ define(function (require, exports, module) {
                 return function () {
                     var deferred = $.Deferred();
                     var parameters = Array.prototype.slice.call(arguments, 0);
-                    var id = self._commandCount++;
+                    var id = self._getNextCommandID();
                     self._pendingCommandDeferreds[id] = deferred;
                     self._send({id: id,
                                domain: domainName,

--- a/test/spec/NodeConnection-test-files/BinaryTestCommands.js
+++ b/test/spec/NodeConnection-test-files/BinaryTestCommands.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, node: true */
+/*global */
+
+(function () {
+    "use strict";
+
+    /**
+     * @private
+     * @type {DomainManager}
+     * The DomainManager passed in at init.
+     */
+    var _domainManager = null;
+
+
+    /**
+     * @private
+     * @type {Buffer}
+     */
+    var _buffer = new Buffer(18);
+    
+    // write some bytes into the buffer with varied alignments
+    _buffer.writeUInt8(1, 0);
+    _buffer.writeUInt32LE(Math.pow(2, 32) - 1, 1);
+    _buffer.writeFloatBE(3.141592, 5);
+    _buffer.writeDoubleLE(Number.MAX_VALUE, 9);
+    _buffer.writeInt8(-128, 17);
+        
+    /**
+     * @private
+     * @return {Buffer}
+     */
+    function _getBufferSync() {
+        return _buffer;
+    }
+    
+    /**
+     * @private
+     * @param {function(?string, Buffer=)} callback
+     */
+    function _getBufferAsync(callback) {
+        process.nextTick(function () {
+            callback(null, _buffer);
+        });
+    }
+    
+    /**
+     * @param {DomainManager} DomainManager The DomainManager for the server
+     */
+    function init(DomainManager) {
+        _domainManager = DomainManager;
+        if (!_domainManager.hasDomain("test")) {
+            _domainManager.registerDomain("test", {major: 0, minor: 1});
+        }
+        _domainManager.registerCommand(
+            "binaryTest",
+            "getBufferSync",
+            _getBufferSync,
+            false,
+            "Get a byte array synchronously",
+            [],
+            {name: "bytes", type: "Buffer"}
+        );
+        _domainManager.registerCommand(
+            "binaryTest",
+            "getBufferAsync",
+            _getBufferAsync,
+            true,
+            "Get a byte array asynchronously",
+            [],
+            {name: "bytes", type: "Buffer"}
+        );
+    }
+    
+    exports.init = init;
+    
+}());


### PR DESCRIPTION
This pull request updates `NodeConnection` so that it can receive binary responses to commands in Node domains. When a binary message --- i.e., an `ArrayBuffer` instance; i.e., an array of bytes; i.e., _not_ a string to be interpreted as JSON --- is received via the WebSocket, the first four bytes are assumed to be a header and are interpreted as a (32-bit unsigned integer) command ID. The header is then stripped off and the pending deferred of the corresponding command is resolved with the remaining bytes. Clients can then interpret or process the bytes arbitrarily. 

To ensure that the command ID can always be encoded as a 32-bit unsigned integer, IDs are now restricted to the range `0 <= id < 2^32`. When the maximum value is eclipsed, the counter just rolls back to 0. (This could be improved, but the bugs in this PR already exist in the current implementation, so I'm not too worried about it.)

This should be reviewed in tandem with a companion brackets-shell pull request, adobe/brackets-shell#406, which allows domain commands to return binary responses.
