### PR TITLE
fix for the issue #6238

### DIFF
--- a/src/htmlContent/findinfiles-bar.html
+++ b/src/htmlContent/findinfiles-bar.html
@@ -1,9 +1,11 @@
-{{CMD_FIND}}: 
-<div class="search-input-container"><input type="text" id="find-what" value="{{value}}" /><div class="error"></div><!--
---><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
---><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button>
-
-<div class="no-results-message">{{FIND_NO_RESULTS}}</div></div>
-<div class="message">
-    <span id="searchlabel">{{{label}}}</span>
+<div id="find-in-files-bar">
+    {{CMD_FIND}}: 
+    <div class="search-input-container"><input type="text" id="find-what" value="{{value}}" /><div class="error"></div><!--
+    --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
+    --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button>
+    
+    <div class="no-results-message">{{FIND_NO_RESULTS}}</div></div>
+    <div class="message">
+        <span id="searchlabel">{{{label}}}</span>
+    </div>
 </div>

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1085,7 +1085,7 @@ a, img {
         }
     }
     
-    #find-group, #replace-group {
+    #find-group, #replace-group, #find-in-files-bar {
         display: inline-block;
         white-space: nowrap;
     }
@@ -1144,6 +1144,7 @@ a, img {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
     }
+    
     #find-case-sensitive, #replace-yes {
         border-left: none;
         margin-left: 0px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -142,6 +142,8 @@ a:focus {
     background: @main-toolbar-background-color;
     padding: 7px 0px;
 
+    z-index: @z-index-brackets-main-toolbar;
+
     // Ensure icons are vertically stacked & horizontally centered
     .vbox;
     .box-flex(1);

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -50,6 +50,7 @@
 @z-index-brackets-toolbar: (@z-index-brackets-ui + 1);
 @z-index-brackets-max: @z-index-brackets-toolbar;
 @z-index-brackets-modalbar: (@z-index-brackets-toolbar - 1);
+@z-index-brackets-main-toolbar: (@z-index-brackets-toolbar + 1);
 
 @z-index-brackets-sidebar-resizer: (@z-index-brackets-ui + 2);
 @z-index-brackets-resizer-div: (@z-index-brackets-sidebar-resizer + 1);


### PR DESCRIPTION
This PR addresses issue #6238.
All the elements of "Find in Files" ( Ctrl-Shift-F ) (i.e. label text input and buttons), are in one line.
![find-in-files fixed](https://f.cloud.github.com/assets/2771653/1839057/aba3bf5a-746f-11e3-8d80-9f8239eb60c0.png)

I left the "Find and Replace" ( Ctrl-H ) as it was instead of forcing the "find-group" and "replace-group" into one line, as it seems more fit to me than forcing them in one line.
![find-replace untouched](https://f.cloud.github.com/assets/2771653/1839059/c5f55f1c-746f-11e3-9ae1-039472c8498e.png)

It seems more fit because the elements (i.e. label text input and buttons) of "find-group" and "replace-group" do not get broken down to many lines; they separately stay in one line only. Leaving the situation as it is will ease the "Replace" feature, when he/she is working in "Live Preview".
