### PR TITLE
[REVIEW ONLY] Bare async provider implementation.

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -170,29 +170,48 @@ define(function (require, exports, module) {
             response.resolve(null);
             return response.promise();
         }
-
+        
         DocumentManager.getDocumentText(file)
             .done(function (fileText) {
-                var perfTimerInspector = PerfUtils.markStart("CodeInspection:\t" + file.fullPath);
+                var perfTimerInspector = PerfUtils.markStart("CodeInspection:\t" + file.fullPath),
+                    masterPromise;
 
-                providerList.forEach(function (provider) {
-                    var perfTimerProvider = PerfUtils.markStart("CodeInspection '" + provider.name + "':\t" + file.fullPath);
-
-                    try {
-                        var scanResult = provider.scanFile(fileText, file.fullPath);
-                        results.push({provider: provider, result: scanResult});
-                    } catch (err) {
-                        console.error("[CodeInspection] Provider " + provider.name + " threw an error: " + err);
-                        response.reject(err);
-                        return;
+                masterPromise = Async.doInParallel(providerList, function (provider) {
+                    var perfTimerProvider = PerfUtils.markStart("CodeInspection '" + provider.name + "':\t" + file.fullPath),
+                        runPromise = new $.Deferred();
+                    
+                    if (provider.scanFileAsync) {
+                        provider.scanFileAsync(fileText, file.fullPath)
+                            .then(function (scanResult) {
+                                results.push({provider: provider, result: scanResult});
+                                PerfUtils.addMeasurement(perfTimerProvider);
+                                runPromise.resolve();
+                            })
+                            .fail(function (err) {
+                                console.error("[CodeInpsection] Provider " + provider.name + " (async) failed: " + err);
+                                runPromise.reject(err);
+                            });
+                    } else {
+                        try {
+                            var scanResult = provider.scanFile(fileText, file.fullPath);
+                            results.push({provider: provider, result: scanResult});
+                            PerfUtils.addMeasurement(perfTimerProvider);
+                            runPromise.resolve();
+                        } catch (err) {
+                            console.error("[CodeInspection] Provider " + provider.name + " (sync) threw an error: " + err);
+                            runPromise.reject(err);
+                            return;
+                        }
                     }
+                    return runPromise.promise();
 
-                    PerfUtils.addMeasurement(perfTimerProvider);
+                }, false);
+                
+                masterPromise.then(function () {
+                    PerfUtils.addMeasurement(perfTimerInspector);
+                    response.resolve(results);
                 });
 
-                PerfUtils.addMeasurement(perfTimerInspector);
-
-                response.resolve(results);
             })
             .fail(function (err) {
                 console.error("[CodeInspection] Could not read file for inspection: " + file.fullPath);
@@ -328,7 +347,7 @@ define(function (require, exports, module) {
                 
                 html = Mustache.render(ResultsTemplate, {reportList: allErrors});
             });
-
+            
             // Update results table
             var perfTimerDOM = PerfUtils.markStart("ProblemsPanel render:\t" + currentDoc.file.fullPath);
 
@@ -377,7 +396,7 @@ define(function (require, exports, module) {
         if (!_providers[languageId]) {
             _providers[languageId] = [];
         }
-
+        
         if (languageId === "javascript") {
             // This is a special case to enable extension provider to replace the JSLint provider
             // in favor of their own implementation
@@ -385,7 +404,7 @@ define(function (require, exports, module) {
                 return registeredProvider.name === "JSLint";
             });
         }
-
+        
         _providers[languageId].push(provider);
         
         run();


### PR DESCRIPTION
@peterflynn, @ingorichter, @fdecampredon please take at this implementation draft. It introduces an optional `scanFileAsync` function in the provider interface which when implemented will be used instead of sync `scanFile` to get the code inspection results. I chose to introduce a separate function since I, personally, don't like multi-semantic functions (e.g. the same `scanFile` which may return an array or a promise). If there's a compelling argument to overload semantics of `scanFile`, let me know.

Not working due to an issue in code inspection implementation (html template is displayed before it's rendered). See [this comment to #5935](https://github.com/adobe/brackets/pull/5935?source=cc#discussion_r8590449). If you want to try it out, just move rendering into the same block where `html` is prepared (into `.then` handler).

This is just to get a general agreement on the proposal/approach, a lot of work is missing on the documentation etc. A mergeable PR will be prepared when #5935 is landed in master.
