### PR TITLE
Fix issue #5507- "[Core][layout issue]: The layout of bottom panel and selected file seem strange when drag the left sidebar."

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -105,6 +105,7 @@ a, img {
         top: 0;
         left: @sidebar-width;  // changed dynamically via Resizer
         right: @main-toolbar-width;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
Fix issue #5507- "[Core][layout issue]: The layout of bottom panel and selected file seem strange when drag the left sidebar."

per suggestion from @peterflynn, add the 'overlap' style to properly hide the panel adornments when the content is shrunk too small.
