### PR TITLE
Show image path in window title 

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -90,6 +90,9 @@ define(function (require, exports, module) {
                 if (currentDoc) {
                     // dirty dot is always in DOM so layout doesn't change, and visibility is toggled
                     _$dirtydot.css("visibility", (currentDoc.isDirty) ? "visible" : "hidden");
+                } else {
+                    // hide dirty dot if there is no document
+                    _$dirtydot.css("visibility", "hidden");                    
                 }
             } else {
                 _$title.text("");
@@ -120,6 +123,9 @@ define(function (require, exports, module) {
         
         if (currentDoc) {
             windowTitle = (currentDoc.isDirty) ? "• " + windowTitle : windowTitle;
+        } else {
+            // hide dirty dot if there is no document
+            _$dirtydot.css("visibility", "hidden");                    
         }
 
         // update shell/browser window title


### PR DESCRIPTION
Update window title with the path and file name for image files or other files handled by a custom viewer. 

This pull request changes DocumentCommandHandlers to update the title when a `currentlyViewedFileChange` event is emitted by EditorManager. 

This event is by definition emitted in all cases a currentDocumentChange but also when CustomViewers are used to display non text files. 
