### PR TITLE
Backout change for dismissing hint list

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -211,10 +211,6 @@ define(function (require, exports, module) {
         
         // Clear the exclusion if the user moves the cursor with left/right arrow key.
         this.updateExclusion(true);
-
-        if (this.info.offset === 0 && lastContext !== null) {
-            return null;
-        }
         
         if (context === CSSUtils.PROP_VALUE) {
             


### PR DESCRIPTION
This is for #6392 .

@YuAo This backs out part of your fix for https://github.com/adobe/brackets/pull/6242 because it introduces issue #6392 which is worse. I tried to find a way to fix both, but haven't been able to find anything reasonable, so I want to make this change for now. You're welcome to take another look at this. 
