### PR TITLE
Handle exceptions thrown in done handles attached to ProjectManager.getAllFiles

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1810,12 +1810,12 @@ define(function (require, exports, module) {
             
             // If a done handler attached to the returned filtered files promise
             // throws an exception that isn't handled here then it will leave
-            // _allFilesPromise in an inconsistent state such that no additional
-            // done handlers will ever be called!
+            // _allFilesCachePromise in an inconsistent state such that no
+            // additional done handlers will ever be called!
             try {
                 filteredFilesDeferred.resolve(result);
             } catch (e) {
-                filteredFilesDeferred.reject(e);
+                console.warn("Unhandled exception in getAllFiles handler: ", e);
             }
         });
         


### PR DESCRIPTION
`ProjectManager.getAllFiles` currently returns a new promise to each caller, but if one of the callers attaches a done handler to its promise that throws an exception then no further done handlers attached to later promises returned from `getAllFiles` are executed. This is because jQuery promises are dumb.

Addresses #6401.

CC @redmunds 
