### PR TITLE
Enable Quick Docs for LESS

### DIFF
--- a/src/extensions/default/WebPlatformDocs/main.js
+++ b/src/extensions/default/WebPlatformDocs/main.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
     function inlineProvider(hostEditor, pos) {
         var langId = hostEditor.getLanguageForSelection().getId();
         // Only provide docs when cursor is in CSS content
-        if (langId !== "css" && langId !== "scss") {
+        if (langId !== "css" && langId !== "scss" && langId !== "less") {
             return null;
         }
         


### PR DESCRIPTION
Now that LESS uses the same tokenizer as CSS, we've turned on code hints for LESS and it seems to work. This just does the same thing for Quick Docs. I tested it on brackets.less and it seems to work fine, even in nested rules.
