### PR TITLE
Monkeypatch CodeMirror for sprint 36 to include latest xml mode

### DIFF
--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
                 verifyAttrHints(hintList, "application/msexcel");
             });
 
-            xit("should NOT list attribute value hints when the cursor is after the end quote of an attribute value", function () {
+            it("should NOT list attribute value hints when the cursor is after the end quote of an attribute value", function () {
                 testDocument.replaceRange("  <input checked accept='' >\n", { line: 9, ch: 0 });  // insert new line
                 
                 // Set cursor after the closing quote of accept attribute


### PR DESCRIPTION
@RaymondLim 

This points the Brackets CM submodule SHA at the `monkeypatch-sprint36` branch in the adobe/CodeMirror2 repo: https://github.com/adobe/CodeMirror2/tree/monkeypatch-sprint36. The only change in that branch from the SHA we'd previously merged (in #6268) is a commit that pulls in the latest xml mode from CodeMirror master. In addition to the fix for #6400, the latest xml mode fixes a bug in indentation after open tags that span multiple lines, and the changes looked reasonably harmless, so I thought it made sense to go ahead and just pull it in instead of monkeypatching just the fix for #6400.

This also re-enables the HTML code hints unit test that was failing. I ran all the unit tests (including this one) and they passed.
