### PR TITLE
Stale image preview - refresh image  when the timestamp of image file changes on disk

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -831,7 +831,7 @@ define(function (require, exports, module) {
         if (!fullPath || _currentlyViewedPath === fullPath) {
             openAlternateFile();
         }
-    }
+    };
     
     /** Handles changes to DocumentManager.getCurrentDocument() */
     function _onCurrentDocumentChange() {

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -358,12 +358,34 @@ define(function (require, exports, module) {
         });
         return $customViewer;
     }
-    
+
+    /*
+     * Updates the URL with an ID tag at the end to force the file to be reloaded.
+     *
+     * This will is called by EditorManager when an file displayed by image viewer changes 
+     * on disk, to force a reload of a file.  
+     * CEF caches files loaded via the file-protocol and doesn't honor the 
+     * files modification date to determin wether it is stale.
+     */
+    function refresh() {
+        var noCacheUrl = $("#img-preview").attr("src"),
+            now = new Date().valueOf();
+
+        if (noCacheUrl.indexOf("#") > 0) {
+            noCacheUrl = noCacheUrl.replace(/#\d+/, "#" + now);
+        } else {
+            noCacheUrl = noCacheUrl + "#" + now;
+        }
+        $("#img-preview").attr("src", noCacheUrl);
+    }
+
     EditorManager.registerCustomViewer("image", {
         render: render,
-        onRemove: onRemove
+        onRemove: onRemove,
+        refresh: refresh
     });
-    
+
     exports.render              = render;
     exports.onRemove            = onRemove;
+    exports.refresh             = refresh;
 });

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils"),
         FileUtils           = require("file/FileUtils"),
+        FileSystem          = require("filesystem/FileSystem"),
         FileSystemError     = require("filesystem/FileSystemError");
 
     
@@ -390,10 +391,11 @@ define(function (require, exports, module) {
         //  3) Refresh all Documents that are clean (if file changed on disk)
         //  4) Close all Documents that are clean (if file deleted on disk)
         //  5) Prompt about any Documents that are dirty (if file changed/deleted on disk)
+        //  6) Handle custom viewer files: If a custom viewer is currently displaying a file, check if it has been updated or deleted
         // Each phase fully completes (asynchronously) before the next one begins.
-        
-        
-        // 1) Check for external modifications
+
+
+        // 1) Check for external modifications for open documents
         var allDocs = DocumentManager.getAllOpenDocuments();
         
         findExternalChanges(allDocs)
@@ -447,7 +449,33 @@ define(function (require, exports, module) {
                 // We can't go on without knowing which files are dirty, so bail now
                 _alreadyChecking = false;
             });
-        
+
+        // 6) Handle custom viewer files: If a custom viewer is currently displaying a file, check if it has been updated or deleted
+        var fullPath = EditorManager.getCurrentlyViewedPath();
+        if (!DocumentManager.getCurrentDocument() && fullPath) {
+            var file = FileSystem.getFileForPath(fullPath);
+            //
+            file.stat(function (err, stat) {
+                if (!err) {
+                    // Does file's timestamp differ from last sync time on the Document?
+                    if (stat.mtime.getTime() !== EditorManager.getCurrentlyViewedFileMTime()) {
+                        // Then close and reopen.
+                        CommandManager.execute(Commands.FILE_CLOSE).done(function () {
+                            CommandManager.execute(Commands.FILE_OPEN, {fullPath: fullPath}).done(function () {
+                                // CEF caches files loaded via the file-protocol but doesn't honor
+                                // its timestamp to purge the cache. 
+                                // Hence tell the custom viewer to refresh
+                                EditorManager.refreshCustomViewer(fullPath);
+                            });
+                        });
+
+                    }
+                } else {
+                    // if we cannot stat the file we better close it.
+                    EditorManager.notifyPathDeleted(fullPath);
+                }
+            });
+        }
     }
     
     


### PR DESCRIPTION
fix #6356 - forcing CEF to reload a cached image when its timestamp on disk changes. 

This pull does two things: 
a) it enables file sync manager to detect if an image file viewed by a custom viewer  changes
b) it enables a work around for CEFs failure to reload files that changed on disk. 

Ideally none of this code would not be necessary if CEF automatically purged its cache of files loaded via the file protocol based on their timestamp on disk.
