### PR TITLE
Batch delete/create nodes in ProjectManager

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -478,7 +478,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * A memozied function that returns a sortable name for a given DOM node.
+     * A memoized function that returns a sortable name for a given DOM node.
      * @private
      * @param {Node} A DOM node with a nodeN id
      * @return {string}

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1404,18 +1404,17 @@ define(function (require, exports, module) {
             arr = [arr];
         }
         
-        // Convert strings to json
-        arr = arr.map(function (node) {
-            return (typeof node === "string") ? { data: node } : node;
-        });
+        position = position || 0;
         
-        // remove null nodes
-        arr = arr.filter(function (node) {
-            return !!node;
-        });
-        
-        arr.forEach(function (data) {
-            _projectTree.jstree("create", $target, position || 0, data, null, skipRename);
+        arr.forEach(function (node) {
+            // Convert strings to objects
+            if (typeof node === "string") {
+                node = { data: node };
+            }
+            
+            if (node) {
+                _projectTree.jstree("create", $target, position, node, null, skipRename);
+            }
         });
         
         if (!skipRedraw) {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1096,11 +1096,16 @@ define(function (require, exports, module) {
      * outside the project, or if it doesn't exist).
      *
      * @param {!(File|Directory)} entry File or Directory to find
-     * @param {boolean} shallowSearch Flag to return no result if the node is not loaded
      * @return {$.Promise} Resolved with jQ obj for the jsTree tree node; or rejected if not found
      */
-    function _findTreeNode(entry, shallowSearch) {
-        var result = new $.Deferred();
+    function _findTreeNode(entry) {
+        var result = new $.Deferred(),
+            $renderedNode = _getTreeNode(entry);
+        
+        // Check if tree node was already rendered
+        if ($renderedNode) {
+            return result.resolve($renderedNode).promise();
+        }
         
         var projRelativePath = makeProjectRelativeIfPossible(entry.fullPath);
 
@@ -1140,7 +1145,7 @@ define(function (require, exports, module) {
                     var subChildren = treeAPI._get_children($node);
                     if (subChildren.length > 0) {
                         findInSubtree(subChildren, segmentI + 1);
-                    } else if (!shallowSearch) {
+                    } else {
                         // Subtree not loaded yet: force async load & try again
                         treeAPI.load_node($node, function (data) {
                             subChildren = treeAPI._get_children($node);
@@ -1148,9 +1153,6 @@ define(function (require, exports, module) {
                         }, function (err) {
                             result.reject();  // includes case where folder is empty
                         });
-                    } else {
-                        // Stop searching
-                        result.resolve(null);
                     }
                 }
             }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -484,11 +484,11 @@ define(function (require, exports, module) {
      * @return {string}
      */
     var _getComparableName = _.memoize(function (a) {
-        var $a = $(a),
-            a1 = $a.text();
+        var entry   = $(a).data("entry"),
+            a1      = entry.name;
         
         if (brackets.platform !== "mac") {
-            a1 = ($a.hasClass("jstree-leaf") ? "1" : "0") + a1;
+            a1 = (entry.isFile ? "1" : "0") + a1;
         }
         
         return a1;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1954,21 +1954,13 @@ define(function (require, exports, module) {
 
         // Directory contents added
         if (added.length > 0) {
-            var addedJSON = [];
-
-            added.forEach(function (addedEntry) {
-                // Before creating a new node, make sure it doesn't already exist
-                if (_getTreeNode(addedEntry)) {
-                    return;
-                }
-
-                // _entryToJSON returns null if the added file is filtered from view
-                var json = _entryToJSON(addedEntry);
-
-                if (json) {
-                    addedJSON.push(json);
-                }
+            // Before creating a new node, make sure it doesn't already exist
+            var addedJSON = added.filter(function (addedEntry) {
+                return !_getTreeNode(addedEntry);
             });
+            
+            // Convert entries to JSON objects for jstree
+            addedJSON = addedJSON.map(_entryToJSON);
 
             // create all new nodes in a batch
             _createNode($directoryNode, null, addedJSON, true, true);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1409,6 +1409,11 @@ define(function (require, exports, module) {
             return (typeof node === "string") ? { data: node } : node;
         });
         
+        // remove null nodes
+        arr = arr.filter(function (node) {
+            return !!node;
+        });
+        
         arr.forEach(function (data) {
             _projectTree.jstree("create", $target, position || 0, data, null, skipRename);
         });
@@ -1977,16 +1982,16 @@ define(function (require, exports, module) {
             doRedraw = true;
         }
 
-        // Directory contents added
-        if (added.length > 0) {
-            // Before creating a new node, make sure it doesn't already exist
-            var addedJSON = added.filter(function (addedEntry) {
-                return !_getTreeNode(addedEntry);
-            });
-            
-            // Convert entries to JSON objects for jstree
-            addedJSON = addedJSON.map(_entryToJSON);
+        // Before creating new nodes, make sure it doesn't already exist
+        var addedJSON = added.filter(function (addedEntry) {
+            return !_getTreeNode(addedEntry);
+        });
 
+        // Convert entries to JSON objects for jstree
+        addedJSON = addedJSON.map(_entryToJSON);
+
+        // Directory contents added
+        if (addedJSON.length > 0) {
             // create all new nodes in a batch
             _createNode($directoryNode, null, addedJSON, true, true);
             doRedraw = true;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1083,6 +1083,11 @@ define(function (require, exports, module) {
      * @return {?jQuery} The jQuery node for this entry or null if not found
      */
     function _getTreeNode(entry) {
+        // Special case if the entry matches the project root
+        if (entry === getProjectRoot()) {
+            return $projectTreeList;
+        }
+        
         var id = _projectInitialLoad.fullPathToIdMap[entry.fullPath],
             node = null;
         


### PR DESCRIPTION
@iwehrman 
- delete/create tree node methods are now synchronous
- batch delete/create nodes to avoid excessive calls to `_redraw`
