### PR TITLE
#5059 chmod all sub files and folders in temp directory

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -240,35 +240,54 @@ define(function (require, exports, module) {
     }
     
     function _resetPermissionsOnSpecialTempFolders() {
-        var i,
-            folders = [],
-            baseDir = getTempDirectory(),
-            promise;
-        
-        folders.push(baseDir + "/cant_read_here");
-        folders.push(baseDir + "/cant_write_here");
-        
-        promise = Async.doSequentially(folders, function (folder) {
-            var deferred = new $.Deferred();
-            
-            FileSystem.resolve(folder, function (err, entry) {
-                if (!err) {
-                    // Change permissions if the directory exists
-                    chmod(folder, "777").then(deferred.resolve, deferred.reject);
+        var entries = [],
+            result = new $.Deferred(),
+            promise,
+            entryPromise = new $.Deferred(),
+            tempDir;
+
+        function visitor(entry) {
+            entries.push(entry.fullPath);
+            return true;
+        }
+        tempDir = FileSystem.getDirectoryForPath(getTempDirectory());
+        tempDir.visit(visitor, function(err){
+            if (!err) {
+                entryPromise.resolve(entries);
+            } else {
+                if (err === FileSystemError.NOT_FOUND) {
+                    entryPromise.resolve(entries);
                 } else {
-                    if (err === FileSystemError.NOT_FOUND) {
-                        // Resolve the promise since the folder to reset doesn't exist
-                        deferred.resolve();
-                    } else {
-                        deferred.reject();
-                    }
+                    entryPromise.reject();
                 }
-            });
-            
-            return deferred.promise();
-        }, true);
+            }
+        });
+        entryPromise.done(function(entries){
+            promise = Async.doSequentially(entries, function (entry) {
+                var deferred = new $.Deferred();
+
+                FileSystem.resolve(entry, function (err, item) {
+                    if (!err) {
+                        // Change permissions if the directory exists
+                        chmod(entry, "777").then(deferred.resolve, deferred.reject);
+                    } else {
+                        if (err === FileSystemError.NOT_FOUND) {
+                            // Resolve the promise since the folder to reset doesn't exist
+                            deferred.resolve();
+                        } else {
+                            deferred.reject();
+                        }
+                    }
+                });
+
+                return deferred.promise();
+            }, true);
+            promise.then(result.resolve, result.reject);
+        }).fail(function() {
+            result.reject();
+        });
         
-        return promise;
+        return result.promise();
     }
     
     /**


### PR DESCRIPTION
Programatically set permission to all sub files and folders of temp directory.

Passed Unit test and JsLint
