### PR TITLE
Fix bug #6462 (Go to First Error/Warning command broken)

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
                     _$dirtydot.css("visibility", (currentDoc.isDirty) ? "visible" : "hidden");
                 } else {
                     // hide dirty dot if there is no document
-                    _$dirtydot.css("visibility", "hidden");                    
+                    _$dirtydot.css("visibility", "hidden");
                 }
             } else {
                 _$title.text("");
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
             windowTitle = (currentDoc.isDirty) ? "• " + windowTitle : windowTitle;
         } else {
             // hide dirty dot if there is no document
-            _$dirtydot.css("visibility", "hidden");                    
+            _$dirtydot.css("visibility", "hidden");
         }
 
         // update shell/browser window title

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -464,7 +464,7 @@ define(function (require, exports, module) {
     function handleGotoFirstProblem() {
         run();
         if (_gotoEnabled) {
-            $problemsPanel.find("tr:first-child").trigger("click");
+            $problemsPanel.find("tr:not(.inspector-section)").first().trigger("click");
         }
     }
 


### PR DESCRIPTION
Fix bug #6462 - Screen out header sections (even invisible ones) when looking for first clickable row in results table.
With unit tests.

Speaking of linting, also fixes two whitespace errors in DocumentCommandHandlers.
