### PR TITLE
Fix several visual issues with find result highlighting:

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -313,7 +313,8 @@ define(function (require, exports, module) {
                     toggleHighlighting(editor, true);
                     
                     resultSet.forEach(function (result) {
-                        state.marked.push(cm.markText(result.from, result.to, { className: "CodeMirror-searching" }));
+                        state.marked.push(cm.markText(result.from, result.to,
+                             { className: "CodeMirror-searching", startStyle: "searching-first", endStyle: "searching-last" }));
                     });
                     var scrollTrackPositions = resultSet.map(function (result) {
                         return result.from;

--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
     var _ = require("thirdparty/lodash");
     
     var Editor              = require("editor/Editor"),
-        EditorManager       = require("editor/EditorManager");
+        EditorManager       = require("editor/EditorManager"),
+        PanelManager        = require("view/PanelManager");
     
     
     /** @const @type {number} Height (and width) or scrollbar up/down arrow button on Win */
@@ -129,8 +130,8 @@ define(function (require, exports, module) {
             
             _calcScaling();
             
-            // Update tickmarks during window resize (whenever resizing has paused/stopped for > 1/3 sec)
-            $(window).on("resize.ScrollTrackMarkers", _.debounce(function () {
+            // Update tickmarks during editor resize (whenever resizing has paused/stopped for > 1/3 sec)
+            $(PanelManager).on("editorAreaResize.ScrollTrackMarkers", _.debounce(function () {
                 if (marks.length) {
                     _calcScaling();
                     $(".tickmark-track", editor.getRootElement()).empty();
@@ -143,7 +144,7 @@ define(function (require, exports, module) {
             $(".tickmark-track", curEditor.getRootElement()).remove();
             editor = null;
             marks = [];
-            $(window).off("resize.ScrollTrackMarkers");
+            $(PanelManager).off("editorAreaResize.ScrollTrackMarkers");
         }
     }
     

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1158,9 +1158,16 @@ a, img {
 .CodeMirror-searching {
     // Highlight color, overlaid on top of the .find-highlighting color
     background-color: @cm-match-highlight;
-    border-radius: @tc-inline-border-radius;
     box-shadow: @tc-small-shadow-bottom;
     color: @match-text !important;
+    &.searching-first {
+        border-top-left-radius: @tc-inline-border-radius;
+        border-bottom-left-radius: @tc-inline-border-radius;
+    }
+    &.searching-last {
+        border-top-right-radius: @tc-inline-border-radius;
+        border-bottom-right-radius: @tc-inline-border-radius;
+    }
 }
 .CodeMirror.find-highlighting div.CodeMirror-selected,
 .CodeMirror .CodeMirror.find-highlighting div.CodeMirror-selected {
@@ -1181,14 +1188,13 @@ a, img {
     bottom: 0;
     top: 0;
     right: 0;
-    width: 16px;
+    width: 12px;
     z-index: @z-index-cm-max;
     pointer-events: none;
     
     .tickmark {
         position: absolute;
-        width: 16px;
-        body.platform-mac & { width: 15px; }
+        width: 12px;
         
         height: 1px;
         background-color: #eddd23;


### PR DESCRIPTION
- Reduce width of scrollbar tickmarks to match new, narrower custom-themed scrollbars from #6305 (should also look better on Mac, where the tickmarks were already too wide)
- Fix bug where showing/hiding a bottom panel didn't update the positioning of scrollbar tickmarks
- Results that span multiple tokens showed little orange dots in the text highlight between tokens (due to repeated corner rounding). There are still faint lines between tokens (due to box-shadow), but they're much fainter.
