### PR TITLE
Fix bug #6403 - Restore a reference to CollectionUtils

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -103,6 +103,8 @@ define(function (require, exports, module) {
     require("extensibility/ExtensionManagerDialog");
     require("editor/ImageViewer");
     
+    // Deprecated modules loaded just so extensions can still use them for now
+    require("utils/CollectionUtils");
     // Compatibility shims for filesystem API migration
     require("project/FileIndexManager");
     require("file/NativeFileSystem");


### PR DESCRIPTION
Fix bug #6403 - Restore a reference to CollectionUtils so it's still usable by extensions until its deprecation cycle ends
