### PR TITLE
prefix functions with underscore

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -247,7 +247,7 @@ define(function (require, exports, module) {
                 var file = FileSystem.getFileForPath(fullPath);
                 file.exists(function (fileError, fileExists) {
                     if (fileExists) {
-                        EditorManager.showCustomViewer(viewProvider, fullPath);
+                        EditorManager._showCustomViewer(viewProvider, fullPath);
                         result.resolve();
                     } else {
                         fileError = fileError || FileSystemError.NOT_FOUND;
@@ -953,7 +953,7 @@ define(function (require, exports, module) {
                         result.resolve();
                     });
                 } else {
-                    EditorManager.closeCustomViewer();
+                    EditorManager._closeCustomViewer();
                     result.resolve();
                 }
             }
@@ -1164,7 +1164,7 @@ define(function (require, exports, module) {
         return _closeList(DocumentManager.getWorkingSet(),
                                     (commandData && commandData.promptOnly), true).done(function () {
             if (!DocumentManager.getCurrentDocument()) {
-                EditorManager.closeCustomViewer();
+                EditorManager._closeCustomViewer();
             }
         });
     }
@@ -1172,7 +1172,7 @@ define(function (require, exports, module) {
     function handleFileCloseList(commandData) {
         return _closeList(commandData.fileList, false, false).done(function () {
             if (!DocumentManager.getCurrentDocument()) {
-                EditorManager.closeCustomViewer();
+                EditorManager._closeCustomViewer();
             }
         });
     }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -641,7 +641,7 @@ define(function (require, exports, module) {
      * Closes the customViewer currently displayed, shows the NoEditor view
      * and notifies the ProjectManager to update the file selection
      */
-    function closeCustomViewer() {
+    function _closeCustomViewer() {
         _removeCustomViewer();
         _setCurrentlyViewedPath();
         _showNoEditor();
@@ -652,7 +652,7 @@ define(function (require, exports, module) {
      * @param {!Object} provider  custom view provider
      * @param {!string} fullPath  path to the file displayed in the custom view
      */
-    function showCustomViewer(provider, fullPath) {
+    function _showCustomViewer(provider, fullPath) {
         // Don't show the same custom view again if file path
         // and view provider are still the same.
         if (_currentlyViewedPath === fullPath &&
@@ -1037,10 +1037,10 @@ define(function (require, exports, module) {
     exports.registerJumpToDefProvider     = registerJumpToDefProvider;
     exports.getInlineEditors              = getInlineEditors;
     exports.closeInlineWidget             = closeInlineWidget;
-    exports.showCustomViewer              = showCustomViewer;
+    exports._showCustomViewer              = _showCustomViewer;
     exports.registerCustomViewer          = registerCustomViewer;
     exports.getCustomViewerForPath        = getCustomViewerForPath;
     exports.notifyPathDeleted             = notifyPathDeleted;
-    exports.closeCustomViewer             = closeCustomViewer;
+    exports._closeCustomViewer             = _closeCustomViewer;
     exports.showingCustomViewerForPath    = showingCustomViewerForPath;
 });

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -1018,6 +1018,10 @@ define(function (require, exports, module) {
     exports._resetViewStates              = _resetViewStates;
     exports._doShow                       = _doShow;
     exports._notifyActiveEditorChanged    = _notifyActiveEditorChanged;
+    exports._showCustomViewer             = _showCustomViewer;
+    exports._closeCustomViewer            = _closeCustomViewer;
+    
+    
     
     exports.REFRESH_FORCE = REFRESH_FORCE;
     exports.REFRESH_SKIP  = REFRESH_SKIP;
@@ -1037,10 +1041,8 @@ define(function (require, exports, module) {
     exports.registerJumpToDefProvider     = registerJumpToDefProvider;
     exports.getInlineEditors              = getInlineEditors;
     exports.closeInlineWidget             = closeInlineWidget;
-    exports._showCustomViewer              = _showCustomViewer;
     exports.registerCustomViewer          = registerCustomViewer;
     exports.getCustomViewerForPath        = getCustomViewerForPath;
     exports.notifyPathDeleted             = notifyPathDeleted;
-    exports._closeCustomViewer             = _closeCustomViewer;
     exports.showingCustomViewerForPath    = showingCustomViewerForPath;
 });


### PR DESCRIPTION
to make the customViewer API easier to use, prefixing functions with underscore that are not intended to be used by extension developers.
