### PR TITLE
Clicking an Image file in the project tree calls FileOpen command twice

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -197,15 +197,6 @@ define(function (require, exports, module) {
     function doOpen(fullPath, silent) {
         var result = new $.Deferred();
         
-        // workaround for https://github.com/adobe/brackets/issues/6001
-        // TODO should be removed once bug is closed.
-        // if we are already displaying a file do nothing but resolve immediately.
-        // this fixes timing issues in test cases.
-        if (EditorManager.getCurrentlyViewedPath() === fullPath) {
-            result.resolve(DocumentManager.getCurrentDocument());
-            return result.promise();
-        }
-        
         function _cleanup(fullFilePath) {
             if (!fullFilePath || EditorManager.showingCustomViewerForPath(fullFilePath)) {
                 // We get here only after the user renames a file that makes it no longer belong to a

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -567,7 +567,6 @@ define(function (require, exports, module) {
                             } else {
                                 redraw();
                             }
-                           
                         } else {
                             FileViewController.setFileViewFocus(FileViewController.PROJECT_MANAGER);
                             // show selection marker on folders

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -542,23 +542,32 @@ define(function (require, exports, module) {
                 "select_node.jstree",
                 function (event, data) {
                     var entry = data.rslt.obj.data("entry");
+                    function redraw() {
+                        // update when tree display state changes
+                        _redraw(true);
+                        _lastSelected = data.rslt.obj;
+                    }
                     if (entry) {
                         if (entry.isFile) {
-                            var openResult = FileViewController.openAndSelectDocument(entry.fullPath, FileViewController.PROJECT_MANAGER);
-                        
-                            openResult.done(function () {
-                                // update when tree display state changes
-                                _redraw(true);
-                                _lastSelected = data.rslt.obj;
-                            }).fail(function () {
-                                if (_lastSelected) {
-                                    // revert this new selection and restore previous selection
-                                    _forceSelection(data.rslt.obj, _lastSelected);
-                                } else {
-                                    _projectTree.jstree("deselect_all");
-                                    _lastSelected = null;
-                                }
-                            });
+                            if (EditorManager.getCurrentlyViewedPath() !== entry.fullPath) {
+                                // avoid dupe open /bug #6001
+                                // if the entry points to a file that is already in view
+                                // we don't want to send the open command again.
+                                var openResult = FileViewController.openAndSelectDocument(entry.fullPath, FileViewController.PROJECT_MANAGER);
+                                openResult.done(redraw())
+                                    .fail(function () {
+                                        if (_lastSelected) {
+                                            // revert this new selection and restore previous selection
+                                            _forceSelection(data.rslt.obj, _lastSelected);
+                                        } else {
+                                            _projectTree.jstree("deselect_all");
+                                            _lastSelected = null;
+                                        }
+                                    });
+                            } else {
+                                redraw();
+                            }
+                           
                         } else {
                             FileViewController.setFileViewFocus(FileViewController.PROJECT_MANAGER);
                             // show selection marker on folders


### PR DESCRIPTION
Fixes https://github.com/adobe/brackets/issues/6001

Enable project manager to differentiate on documentSelectionFocusChange between 
a) the case where it needs to open the file before redrawing the tree or
b) go ahead and redraw because the custom viewer for the file entry is already open.

Essentially the fix does the same as the work around in DCHs did, that is check if we already display the file before calling the FILE_OPEN cmd.
