### PR TITLE
Prevent duplicate tree nodes when renaming the only file in a directory

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1933,6 +1933,7 @@ define(function (require, exports, module) {
         }
         
         var $directoryNode = _getTreeNode(entry),
+            wasOpen = $directoryNode.hasClass("jstree-open"),
             doRedraw = false;
         
         // Ignore change event when: the entry is not a directory, the directory
@@ -1968,9 +1969,27 @@ define(function (require, exports, module) {
 
         // Directory contents added
         if (addedJSON.length > 0) {
-            // create all new nodes in a batch
-            _createNode($directoryNode, null, addedJSON, true, true);
-            doRedraw = true;
+            var isClosed = $directoryNode.hasClass("jstree-closed");
+
+            // Manually force the directory to open in case it was auto-closed
+            // when deleting the files in the removed file set for this event.
+            // This starts an async call to load_node/Directory.getContents().
+            // We do this to avoid a race condition in jstree create_node where
+            // jstree attempts to load empty nodes during the create workflow,
+            // resulting in duplicate nodes for the same entry, see
+            // https://github.com/adobe/brackets/issues/6474.
+            if (wasOpen && isClosed) {
+                _projectTree.one("open_node.jstree", function () {
+                    _redraw(true);
+                });
+        
+                // Open the node before creating the new child
+                _projectTree.jstree("open_node", $directoryNode);
+            } else {
+                // Create all new nodes in a batch
+                _createNode($directoryNode, null, addedJSON, true, true);
+                doRedraw = true;
+            }
         }
         
         if (doRedraw) {


### PR DESCRIPTION
Use jstree open_node in corner case #6474 where renaming the only file in a directory caused duplicate tree nodes to appear
