### PR TITLE
Don't clear cache if it's a pending deferred

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
 
         Data                = require("text!data.json"),
 
+        urlHints,
         data,
         htmlAttrs;
     
@@ -766,19 +767,24 @@ define(function (require, exports, module) {
         return false;
     };
 
-    AppInit.appReady(function () {
-        data            = JSON.parse(Data);
-        htmlAttrs       = data.htmlAttrs;
+    function _clearCachedHints() {
+        // Verify cache exists and is not deferred
+        if (urlHints && urlHints.cachedHints && urlHints.cachedHints.deferred &&
+                urlHints.cachedHints.deferred.state() !== "pending") {
 
-        var urlHints = new UrlCodeHints();
-        CodeHintManager.registerHintProvider(urlHints, ["css", "html"], 5);
-        
-        function _clearCachedHints() {
             // Cache may or may not be stale. Main benefit of cache is to limit async lookups
             // during typing. File tree updates cannot happen during typing, so it's probably
             // not worth determining whether cache may still be valid. Just delete it.
             urlHints.cachedHints = null;
         }
+    }
+        
+    AppInit.appReady(function () {
+        data            = JSON.parse(Data);
+        htmlAttrs       = data.htmlAttrs;
+
+        urlHints        = new UrlCodeHints();
+        CodeHintManager.registerHintProvider(urlHints, ["css", "html"], 5);
         
         FileSystem.on("change", _clearCachedHints);
         FileSystem.on("rename", _clearCachedHints);


### PR DESCRIPTION
We were blindly clearing hints cache object. We now prevent cache object from being cleared if it's a pending deferred.

I think this problem was introduced by new file system or watchers which fire the "change" event more often, which causes cache to clear. The PreferencesModel code must have changed something that exposed this problem.
