### PR TITLE
added testcase for https://github.com/adobe/brackets/issues/6441

### DIFF
--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -546,20 +546,31 @@ define(function (require, exports, module) {
                         }
                     ]
                 });
+
+                var codeInspector2 = createCodeInspector("NoLineNumberLinter2", {
+                    errors: [
+                        {
+                            pos: { line: "all", ch: 0 },
+                            message: "Some errors here and there",
+                            type: CodeInspection.Type.WARNING
+                        }
+                    ]
+                });
                 CodeInspection.register("javascript", codeInspector1);
+                CodeInspection.register("javascript", codeInspector2);
 
                 waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
 
                 runs(function () {
                     var $problemPanelTitle = $("#problems-panel .title").text();
-                    expect($problemPanelTitle).toBe("1 NoLineNumberLinter Problem");
+                    expect($problemPanelTitle).toBe("2 Problems");
 
                     var $statusBar = $("#status-inspection");
                     expect($statusBar.is(":visible")).toBe(true);
 
                     var tooltip = $statusBar.attr("title");
                     // tooltip will contain + in the title if the inspection was aborted
-                    expect(tooltip).toBe("1 NoLineNumberLinter Problem");
+                    expect(tooltip).toBe("2 Problems");
                 });
             });
         });

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -536,6 +536,32 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should handle missing or negative line numbers gracefully (https://github.com/adobe/brackets/issues/6441)", function () {
+                var codeInspector1 = createCodeInspector("NoLineNumberLinter", {
+                    errors: [
+                        {
+                            pos: { line: -1, ch: 0 },
+                            message: "Some errors here and there",
+                            type: CodeInspection.Type.WARNING
+                        }
+                    ]
+                });
+                CodeInspection.register("javascript", codeInspector1);
+
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+
+                runs(function () {
+                    var $problemPanelTitle = $("#problems-panel .title").text();
+                    expect($problemPanelTitle).toBe("1 NoLineNumberLinter Problem");
+
+                    var $statusBar = $("#status-inspection");
+                    expect($statusBar.is(":visible")).toBe(true);
+
+                    var tooltip = $statusBar.attr("title");
+                    // tooltip will contain + in the title if the inspection was aborted
+                    expect(tooltip).toBe("1 NoLineNumberLinter Problem");
+                });
+            });
         });
         
         describe("Code Inspector Registration", function () {

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -569,7 +569,6 @@ define(function (require, exports, module) {
                     expect($statusBar.is(":visible")).toBe(true);
 
                     var tooltip = $statusBar.attr("title");
-                    // tooltip will contain + in the title if the inspection was aborted
                     expect(tooltip).toBe("2 Problems");
                 });
             });


### PR DESCRIPTION
Testcase to check if the CodeInspection handles negative/NaN line number information returned from the linter
