### PR TITLE
disable defaultExtension pref

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -511,10 +511,11 @@ define(function (require, exports, module) {
      * Promise is resolved (synchronously) with the newly-created Document.
      */
     function handleFileNew() {
-        var defaultExtension = PreferencesManager.get("defaultExtension");
-        if (defaultExtension) {
-            defaultExtension = "." + defaultExtension;
-        }
+        //var defaultExtension = PreferencesManager.get("defaultExtension");
+        //if (defaultExtension) {
+        //    defaultExtension = "." + defaultExtension;
+        //}
+        var defaultExtension = "";  // disable preference setting for now 
         
         var doc = DocumentManager.createUntitledDocument(_nextUntitledIndexToUse++, defaultExtension);
         DocumentManager.setCurrentDocument(doc);


### PR DESCRIPTION
Revealed as an issue when testing the new Preferences model, comment out use of defaultExtension pref to avoid problems with ScopeManager.
