### PR TITLE
Fix duplicate tree nodes when creating a file externally in a folder that was not loaded

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
     var Directory       = require("filesystem/Directory"),
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
+        FileSystemError = require("filesystem/FileSystemError"),
         WatchedRoot     = require("filesystem/WatchedRoot");
     
     /**
@@ -273,8 +274,15 @@ define(function (require, exports, module) {
                 
                 entry.visit(visitor, function (err) {
                     if (err) {
-                        requestCb(err);
-                        return;
+                        // Unwatching a file/folder that doesn't exist will 
+                        // trigger an expected error
+                        if (!shouldWatch && (err === FileSystemError.NOT_FOUND)) {
+                            visitor(entry);
+                        } else {
+                            // Unexpected error
+                            requestCb(err);
+                            return;
+                        }
                     }
                     
                     // Then watch or unwatched all these entries

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -722,7 +722,10 @@ define(function (require, exports, module) {
             }
             
             var watchOrUnwatchCallback = function (err) {
-                console.error("FileSystem error in _handleDirectoryChange after watch/unwatch entries: " + err);
+                if (err) {
+                    console.error("FileSystem error in _handleDirectoryChange after watch/unwatch entries: " + err);
+                }
+                
                 if (--counter === 0) {
                     callback(addedEntries, removedEntries);
                 }

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -722,6 +722,7 @@ define(function (require, exports, module) {
             }
             
             var watchOrUnwatchCallback = function (err) {
+                console.error("FileSystem error in _handleDirectoryChange after watch/unwatch entries: " + err);
                 if (--counter === 0) {
                     callback(addedEntries, removedEntries);
                 }


### PR DESCRIPTION
- fix bug where unwatch was not called after file/folder was removed/renamed
- skip incremental update to jstree if directory was not loaded
