### PR TITLE
Start loading project preferences as soon as possible.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1055,6 +1055,7 @@ define(function (require, exports, module) {
             var rootEntry = FileSystem.getDirectoryForPath(rootPath);
             rootEntry.exists(function (err, exists) {
                 if (exists) {
+                    PreferencesManager._setCurrentEditingFile(rootPath);
                     var projectRootChanged = (!_projectRoot || !rootEntry) ||
                         _projectRoot.fullPath !== rootEntry.fullPath;
                     var i;


### PR DESCRIPTION
This is not a 100% fix for #6555 but it does eliminate the flash of JSLint
Errors in my testing.
