### PR TITLE
Change FileWatcherDomain unwatchPath to handle directories and descendants

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -74,6 +74,7 @@ define(function (require, exports, module) {
     var Directory       = require("filesystem/Directory"),
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
+        FileSystemError = require("filesystem/FileSystemError"),
         WatchedRoot     = require("filesystem/WatchedRoot");
     
     /**
@@ -273,8 +274,15 @@ define(function (require, exports, module) {
                 
                 entry.visit(visitor, function (err) {
                     if (err) {
-                        requestCb(err);
-                        return;
+                        // Unwatching a file/folder that doesn't exist will 
+                        // trigger an expected error
+                        if (!shouldWatch && (err === FileSystemError.NOT_FOUND)) {
+                            visitor(entry);
+                        } else {
+                            // Unexpected error
+                            requestCb(err);
+                            return;
+                        }
                     }
                     
                     // Then watch or unwatched all these entries
@@ -714,6 +722,10 @@ define(function (require, exports, module) {
             }
             
             var watchOrUnwatchCallback = function (err) {
+                if (err) {
+                    console.error("FileSystem error in _handleDirectoryChange after watch/unwatch entries: " + err);
+                }
+                
                 if (--counter === 0) {
                     callback(addedEntries, removedEntries);
                 }

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -276,8 +276,10 @@ define(function (require, exports, module) {
                     if (err) {
                         // Unwatching a file/folder that doesn't exist will 
                         // trigger an expected error
-                        if (!shouldWatch && (err === FileSystemError.NOT_FOUND)) {
-                            visitor(entry);
+                        if (!shouldWatch && (err === FileSystemError.NOT_FOUND) &&
+                                (entriesToWatchOrUnwatch.length === 0)) {
+                            impl.unwatchPathsWithPrefix(entry.fullPath, requestCb);
+                            return;
                         } else {
                             // Unexpected error
                             requestCb(err);

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -74,7 +74,6 @@ define(function (require, exports, module) {
     var Directory       = require("filesystem/Directory"),
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
-        FileSystemError = require("filesystem/FileSystemError"),
         WatchedRoot     = require("filesystem/WatchedRoot");
     
     /**
@@ -296,13 +295,7 @@ define(function (require, exports, module) {
                     });
                 });
             }, callback);
-        } else if (entry.isDirectory) {
-            // Unwatch a directory and all it's descendants
-            this._enqueueWatchRequest(function (requestCb) {
-                impl.unwatchPathsWithPrefix(entry.fullPath, requestCb);
-            }, callback);
         } else {
-            // Unwatch a single file
             this._enqueueWatchRequest(function (requestCb) {
                 impl.unwatchPath(entry.fullPath, requestCb);
             }, callback);

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -517,6 +517,19 @@ define(function (require, exports, module) {
     
     /**
      * Stop providing change notifications for all previously watched files and
+     * directories that start with a path prefix, optionally calling back
+     * asynchronously with a possibly null FileSystemError string when the \
+     * operation is complete.
+     *
+     * @param {function(?string)=} callback
+     */
+    function unwatchPathsWithPrefix(callback) {
+        _nodeDomain.exec("unwatchPathsWithPrefix")
+            .then(callback, callback);
+    }
+    
+    /**
+     * Stop providing change notifications for all previously watched files and
      * directories, optionally calling back asynchronously with a possibly null
      * FileSystemError string when the operation is complete.
      *
@@ -528,21 +541,22 @@ define(function (require, exports, module) {
     }
     
     // Export public API
-    exports.showOpenDialog  = showOpenDialog;
-    exports.showSaveDialog  = showSaveDialog;
-    exports.exists          = exists;
-    exports.readdir         = readdir;
-    exports.mkdir           = mkdir;
-    exports.rename          = rename;
-    exports.stat            = stat;
-    exports.readFile        = readFile;
-    exports.writeFile       = writeFile;
-    exports.unlink          = unlink;
-    exports.moveToTrash     = moveToTrash;
-    exports.initWatchers    = initWatchers;
-    exports.watchPath       = watchPath;
-    exports.unwatchPath     = unwatchPath;
-    exports.unwatchAll      = unwatchAll;
+    exports.showOpenDialog          = showOpenDialog;
+    exports.showSaveDialog          = showSaveDialog;
+    exports.exists                  = exists;
+    exports.readdir                 = readdir;
+    exports.mkdir                   = mkdir;
+    exports.rename                  = rename;
+    exports.stat                    = stat;
+    exports.readFile                = readFile;
+    exports.writeFile               = writeFile;
+    exports.unlink                  = unlink;
+    exports.moveToTrash             = moveToTrash;
+    exports.initWatchers            = initWatchers;
+    exports.watchPath               = watchPath;
+    exports.unwatchPath             = unwatchPath;
+    exports.unwatchPathsWithPrefix  = unwatchPathsWithPrefix
+    exports.unwatchAll              = unwatchAll;
     
     /**
      * Indicates whether or not recursive watching notifications are supported

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -556,7 +556,7 @@ define(function (require, exports, module) {
     exports.initWatchers            = initWatchers;
     exports.watchPath               = watchPath;
     exports.unwatchPath             = unwatchPath;
-    exports.unwatchPathsWithPrefix  = unwatchPathsWithPrefix
+    exports.unwatchPathsWithPrefix  = unwatchPathsWithPrefix;
     exports.unwatchAll              = unwatchAll;
     
     /**

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -521,10 +521,11 @@ define(function (require, exports, module) {
      * asynchronously with a possibly null FileSystemError string when the \
      * operation is complete.
      *
+     * @param {string} path
      * @param {function(?string)=} callback
      */
-    function unwatchPathsWithPrefix(callback) {
-        _nodeDomain.exec("unwatchPathsWithPrefix")
+    function unwatchPathsWithPrefix(path, callback) {
+        _nodeDomain.exec("unwatchPathsWithPrefix", path)
             .then(callback, callback);
     }
     

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -517,20 +517,6 @@ define(function (require, exports, module) {
     
     /**
      * Stop providing change notifications for all previously watched files and
-     * directories that start with a path prefix, optionally calling back
-     * asynchronously with a possibly null FileSystemError string when the \
-     * operation is complete.
-     *
-     * @param {string} path
-     * @param {function(?string)=} callback
-     */
-    function unwatchPathsWithPrefix(path, callback) {
-        _nodeDomain.exec("unwatchPathsWithPrefix", path)
-            .then(callback, callback);
-    }
-    
-    /**
-     * Stop providing change notifications for all previously watched files and
      * directories, optionally calling back asynchronously with a possibly null
      * FileSystemError string when the operation is complete.
      *
@@ -542,22 +528,21 @@ define(function (require, exports, module) {
     }
     
     // Export public API
-    exports.showOpenDialog          = showOpenDialog;
-    exports.showSaveDialog          = showSaveDialog;
-    exports.exists                  = exists;
-    exports.readdir                 = readdir;
-    exports.mkdir                   = mkdir;
-    exports.rename                  = rename;
-    exports.stat                    = stat;
-    exports.readFile                = readFile;
-    exports.writeFile               = writeFile;
-    exports.unlink                  = unlink;
-    exports.moveToTrash             = moveToTrash;
-    exports.initWatchers            = initWatchers;
-    exports.watchPath               = watchPath;
-    exports.unwatchPath             = unwatchPath;
-    exports.unwatchPathsWithPrefix  = unwatchPathsWithPrefix;
-    exports.unwatchAll              = unwatchAll;
+    exports.showOpenDialog  = showOpenDialog;
+    exports.showSaveDialog  = showSaveDialog;
+    exports.exists          = exists;
+    exports.readdir         = readdir;
+    exports.mkdir           = mkdir;
+    exports.rename          = rename;
+    exports.stat            = stat;
+    exports.readFile        = readFile;
+    exports.writeFile       = writeFile;
+    exports.unlink          = unlink;
+    exports.moveToTrash     = moveToTrash;
+    exports.initWatchers    = initWatchers;
+    exports.watchPath       = watchPath;
+    exports.unwatchPath     = unwatchPath;
+    exports.unwatchAll      = unwatchAll;
     
     /**
      * Indicates whether or not recursive watching notifications are supported

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -85,11 +85,24 @@ function unwatchPath(path) {
 }
 
 /**
+ * Un-watch a directory and all paths below it.
+ * @param {string} path Directory to unwatch.
+ */
+function unwatchPathsWithPrefix(path) {
+    Object.keys(_watcherMap).forEach(function (keyPath) {
+        if (keyPath.indexOf(keyPath) === 0) {
+            unwatchPath(keyPath);
+        }
+    });
+}
+
+/**
  * Watch a file or directory.
  * @param {string} path File or directory to watch.
  */
 function watchPath(path) {
     if (_watcherMap.hasOwnProperty(path)) {
+        console.log("FileWatcher.watchPath already watched " + path);
         return;
     }
         
@@ -115,6 +128,7 @@ function watchPath(path) {
                 _domainManager.emitEvent("fileWatcher", "change", [parent, type, name]);
             });
         } else {
+            console.log("FileWatcherDomain.watchPath: " + path);
             watcher = fs.watch(path, {persistent: false}, function (event, filename) {
                 // File/directory changes are emitted as "change" events on the fileWatcher domain.
                 _domainManager.emitEvent("fileWatcher", "change", [path, event, filename]);
@@ -176,6 +190,18 @@ function init(domainManager) {
             name: "path",
             type: "string",
             description: "absolute filesystem path of the file or directory to unwatch"
+        }]
+    );
+    domainManager.registerCommand(
+        "fileWatcher",
+        "unwatchPathsWithPrefix",
+        unwatchPath,
+        false,
+        "Stop watching a directory and it's descendants",
+        [{
+            name: "path",
+            type: "string",
+            description: "absolute filesystem path of the directory to unwatch"
         }]
     );
     domainManager.registerCommand(

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -102,7 +102,6 @@ function unwatchPathsWithPrefix(path) {
  */
 function watchPath(path) {
     if (_watcherMap.hasOwnProperty(path)) {
-        console.log("FileWatcher.watchPath already watched " + path);
         return;
     }
         
@@ -128,7 +127,6 @@ function watchPath(path) {
                 _domainManager.emitEvent("fileWatcher", "change", [parent, type, name]);
             });
         } else {
-            console.log("FileWatcherDomain.watchPath: " + path);
             watcher = fs.watch(path, {persistent: false}, function (event, filename) {
                 // File/directory changes are emitted as "change" events on the fileWatcher domain.
                 _domainManager.emitEvent("fileWatcher", "change", [path, event, filename]);
@@ -195,7 +193,7 @@ function init(domainManager) {
     domainManager.registerCommand(
         "fileWatcher",
         "unwatchPathsWithPrefix",
-        unwatchPath,
+        unwatchPathsWithPrefix,
         false,
         "Stop watching a directory and it's descendants",
         [{

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -63,10 +63,11 @@ var _domainManager,
     _watcherMap = {};
 
 /**
+ * @private
  * Un-watch a file or directory.
  * @param {string} path File or directory to unwatch.
  */
-function unwatchPath(path) {
+function _unwatchPath(path) {
     var watcher = _watcherMap[path];
         
     if (watcher) {
@@ -85,13 +86,13 @@ function unwatchPath(path) {
 }
 
 /**
- * Un-watch a directory and all paths below it.
- * @param {string} path Directory to unwatch.
+ * Un-watch a file or directory. For directories, unwatch all descendants.
+ * @param {string} path File or directory to unwatch.
  */
-function unwatchPathsWithPrefix(path) {
+function unwatchPath(path) {
     Object.keys(_watcherMap).forEach(function (keyPath) {
         if (keyPath.indexOf(path) === 0) {
-            unwatchPath(keyPath);
+            _unwatchPath(keyPath);
         }
     });
 }
@@ -183,23 +184,11 @@ function init(domainManager) {
         "unwatchPath",
         unwatchPath,
         false,
-        "Stop watching a file or directory",
+        "Stop watching a single file or a directory and it's descendants",
         [{
             name: "path",
             type: "string",
             description: "absolute filesystem path of the file or directory to unwatch"
-        }]
-    );
-    domainManager.registerCommand(
-        "fileWatcher",
-        "unwatchPathsWithPrefix",
-        unwatchPathsWithPrefix,
-        false,
-        "Stop watching a directory and it's descendants",
-        [{
-            name: "path",
-            type: "string",
-            description: "absolute filesystem path of the directory to unwatch"
         }]
     );
     domainManager.registerCommand(

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -90,7 +90,7 @@ function unwatchPath(path) {
  */
 function unwatchPathsWithPrefix(path) {
     Object.keys(_watcherMap).forEach(function (keyPath) {
-        if (keyPath.indexOf(keyPath) === 0) {
+        if (keyPath.indexOf(path) === 0) {
             unwatchPath(keyPath);
         }
     });


### PR DESCRIPTION
Allows deleted paths to be unwatched on windows. See #6554.
