### PR TITLE
Add test to highlight where CSSUtils.getInfoAtPos() returns invalid context on functional notation values

### DIFF
--- a/test/spec/CSSUtils-test-files/contexts.css
+++ b/test/spec/CSSUtils-test-files/contexts.css
@@ -55,6 +55,14 @@
     color: {{75}}rgba(50, {{76}}100, 200, 0.3);
 }
 
+.functional-notation-simple {
+    shape-inside: polygon(0{{107}} 0);
+}
+
+.functional-notation-modifier {
+    shape-inside: polygon(n{{108}}onzero, 0 0);
+}
+
 .single-quotes {
     font-family: {{50}}'{{51}}Helvetica {{52}}Neue{{53}}'{{54}}, Arial;
 }

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -2036,6 +2036,31 @@ define(function (require, exports, module) {
                     });
                 }
             });
+            
+            it("should return PROP_VALUE when inside functional value notation - simple", function () {
+                result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[107]);
+                expect(result).toEqual({
+                    context: CSSUtils.PROP_VALUE,
+                    name: "shape-inside",
+                    offset: 1,
+                    index: 1,
+                    values: ["polygon(", "0 ", "0)"],
+                    isNewItem: false
+                });
+            });
+            
+            it("should return PROP_VALUE when inside functional value notation with modifier", function () {
+                result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[108]);
+                expect(result).toEqual({
+                    context: CSSUtils.PROP_VALUE,
+                    name: "shape-inside",
+                    offset: 1,
+                    index: 1,
+                    values: ["polygon(", "nonzero, ", "0 ", "0)"],
+                    isNewItem: false
+                });
+            });
+            
         });
         
         describe("quoting", function () {


### PR DESCRIPTION
A recent change to CodeMirror (I assume) causes `CSSUtils.getInfoAtPos()` to return invalid context when putting the cursor inside the parentheses of CSS functional notation values. Two tests added; one works, one fails.

Example:
This works: polygon(0 0, 100px 100px);
This fails: polygon(nonzero, 0 0, 100px, 100px);

`CSSUtils.getInfoAtPos()` used to work on both cases a few weeks ago. [A recent change to CSSUtils.js](https://github.com/adobe/brackets/commit/d6eacd631f0b1385d38fcdf9775927757cca46b8) brought updates to the internal methods used for `getInfoAtPos()`, perhaps to sync with CodeMirror API updates. 

I tracked down the issue to a undefined context got from CodeMirror when focusing the cursor inside the functional value notation **only when** the value contains a modifier, for example: polygon(**n|onzero**, 0 0)

```
function getInfoAtPos(editor, constPos) {
    ...
    ctx = TokenUtils.getInitialContext(editor._codeMirror, pos) // undefined
```

I have tried debugging CodeMirror for a few hours, but it has proved beyond my understanding. 
Can someone please help me look into this issue? 

The result I'm looking for is a correct CSS info object from `CSSUtils.getInfoAtPos()` when querying the functional notation value both with and without the modifier. I suspect this issue may also affect gradients - linear and radial - which can use modifiers such as "top", "left", "right" and so forth.
