### PR TITLE
Full width inputs in the Search/Replace modal bars

### DIFF
--- a/src/htmlContent/findinfiles-bar.html
+++ b/src/htmlContent/findinfiles-bar.html
@@ -1,4 +1,4 @@
-<div id="find-group">
+<div id="findinfiles-group">
     <div class="search-input-container"><input type="text" id="find-what" placeholder="{{CMD_FIND_IN_SUBTREE}}" value="{{value}}" /><div class="error"></div><!--
     --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
     --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button>

--- a/src/htmlContent/findreplace-bar.html
+++ b/src/htmlContent/findreplace-bar.html
@@ -1,17 +1,21 @@
 <div id="find-group"><!--
-    --><div class="search-input-container"><input type="text" id="find-what" placeholder="{{CMD_FIND_FIELD_PLACEHOLDER}}" /><div class="error"></div><span id="find-counter"></span></div><!--
-    --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
-    --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button><!--
-    --><div class="navigator"><!--
-        --><button id="find-prev" class="btn no-focus" tabindex="-1" title="{{BUTTON_PREV_HINT}}">{{BUTTON_PREV}}</button><!--
-        --><button id="find-next" class="btn no-focus" tabindex="-1" title="{{BUTTON_NEXT_HINT}}">{{BUTTON_NEXT}}</button><!--
+    --><div class="search-input"><div class="search-input-container"><input type="text" id="find-what" placeholder="{{CMD_FIND_FIELD_PLACEHOLDER}}" /><div class="error"></div><span id="find-counter"></span></div></div><!--
+    --><div class="search-buttons"><!--
+        --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
+        --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button><!--
+        --><div class="navigator"><!--
+            --><button id="find-prev" class="btn no-focus" tabindex="-1" title="{{BUTTON_PREV_HINT}}">{{BUTTON_PREV}}</button><!--
+            --><button id="find-next" class="btn no-focus" tabindex="-1" title="{{BUTTON_NEXT_HINT}}">{{BUTTON_NEXT}}</button><!--
+        --></div><!--
     --></div><!--
 --></div><!--
 
 {{#replace}}
 --><div id="replace-group"><!--
-    --><input type="text" id="replace-with" placeholder="{{REPLACE_PLACEHOLDER}}"/><!--
-    --><button id="replace-yes" class="btn no-focus" tabindex="-1">{{BUTTON_REPLACE}}</button><!--
-    --><button id="replace-all" class="btn no-focus" tabindex="-1">{{BUTTON_REPLACE_ALL}}</button><!--
+    --><div class="search-input"><input type="text" id="replace-with" placeholder="{{REPLACE_PLACEHOLDER}}"/></div><!--
+    --><div class="search-buttons"><!--
+        --><button id="replace-yes" class="btn no-focus" tabindex="-1">{{BUTTON_REPLACE}}</button><!--
+        --><button id="replace-all" class="btn no-focus" tabindex="-1">{{BUTTON_REPLACE_ALL}}</button><!--
+    --></div><!--
 --></div>
 {{/replace}}

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1012,7 +1012,18 @@ a, img {
     -webkit-transform: translate(0, 0); // Prefix still required.
     transition: -webkit-transform 66ms cubic-bezier(0, 0.62, 0.04, 0.99);
     z-index: @z-index-brackets-modalbar;
-
+    
+    .flex-box;
+    
+    #find-group, #replace-group {
+        .flex-box;
+        width: 50%;
+    }
+    #findinfiles-group {
+        display: inline-block;
+        white-space: nowrap;
+    }
+    
     body.in-browser &,
     body:not(.has-appshell-menus) & {
         // Separator line between us and the HTML menu/titlebar above
@@ -1050,10 +1061,13 @@ a, img {
         }
     }
     
-    #find-what, #replace-with {
-        width: 295px;
+    .search-input {
+        .flex-item(1, 1, 0%);
     }
-
+    #find-what, #replace-with {
+        width: calc(~"100% - 19px");
+    }
+    
     .search-input-container {
         position: relative;
         display: inline;
@@ -1074,7 +1088,7 @@ a, img {
         
         #find-what {
             padding-right: 62px;  // room for #find-counter overlay
-            width: 295px - (62px - 6px);  // maintain width, accounting for differing padding
+            width: calc(~"100% - 62px - 12px");  // maintain width, accounting for differing padding
         }
         #find-counter {
             position: absolute;
@@ -1085,9 +1099,10 @@ a, img {
         }
     }
     
-    #find-group, #replace-group {
+    .search-buttons {
         display: inline-block;
         white-space: nowrap;
+        .flex-item(0, 1);
     }
     
     .message, .no-results-message {


### PR DESCRIPTION
I used flexbox to make the Search and Replace inputs fill the remaining space of the modal bar and shrink/stretch when required.

To @larz to check the final result.

@SAPlayer This time it does works with other languages since it doesn't implies the widths of the buttons. It still doesn't split into multiple lines. I guess it might be possible adding an additional class in JavaScript. I don't think it could be achieved in CSS only.
