### PR TITLE
Fix for 6595: Set preferences are, by default, set in the context in which they are defined

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -14,5 +14,6 @@
             "linting.enabled": false
         }
     },
-    "spaceUnits": 4
+    "spaceUnits": 4,
+    "useTabChar": false
 }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1552,7 +1552,7 @@ define(function (require, exports, module) {
     function _setEditorOptionAndPref(value, cmOption, prefName, _editorOnly) {
         _setEditorOption(value, cmOption);
         if (!_editorOnly) {
-            PreferencesManager.setValueAndSave("user", prefName, value);
+            PreferencesManager.setValueAndSave(prefName, value);
         }
     }
     

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -690,7 +690,7 @@ define(function (require, exports, module) {
                 hidePreview();
             }
             if (!doNotSave) {
-                prefs.set("user", "enabled", enabled);
+                prefs.set("enabled", enabled);
                 prefs.save();
             }
         }

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -317,7 +317,7 @@ define(function (require, exports, module) {
                                     (error.codeSnippet = currentDoc.getLine(error.pos.line)) !== undefined) {
                                 error.friendlyLine = error.pos.line + 1;
                                 error.codeSnippet = error.codeSnippet.substr(0, Math.min(175, error.codeSnippet.length));  // limit snippet width
-                            } 
+                            }
                             
                             if (error.type !== Type.META) {
                                 numProblems++;
@@ -439,7 +439,7 @@ define(function (require, exports, module) {
         CommandManager.get(Commands.VIEW_TOGGLE_INSPECTION).setChecked(_enabled);
         updateListeners();
         if (!doNotSave) {
-            prefs.set("user", PREF_ENABLED, _enabled);
+            prefs.set(PREF_ENABLED, _enabled);
             prefs.save();
         }
     
@@ -462,7 +462,7 @@ define(function (require, exports, module) {
 
         _collapsed = collapsed;
         if (!doNotSave) {
-            prefs.set("user", PREF_COLLAPSED, _collapsed);
+            prefs.set(PREF_COLLAPSED, _collapsed);
             prefs.save();
         }
         

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -211,7 +211,7 @@ define(function (require, exports, module) {
                 var parts = rule.split(" ");
                 if (parts[0] === "user") {
                     var newKey = parts.length > 1 ? parts[1] : key;
-                    PreferencesManager.set("user", newKey, prefs[key]);
+                    PreferencesManager.set(newKey, prefs[key]);
                     convertedKeys.push(key);
                 }
             } else {

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -307,7 +307,7 @@ define(function (require, exports, module) {
          * 
          * @param {string} id Key to set
          * @param {*} value Value for this key
-         * @param {Object} context Optional additional information about the request (typically used for layers)
+         * @param {Object=} context Optional additional information about the request (typically used for layers)
          * @param {{layer: ?string, layerID: ?Object}=} location Optional location in which to set the value.
          *                                                      If the object is empty, the value will be
          *                                                      set at the Scope's base level.
@@ -317,18 +317,14 @@ define(function (require, exports, module) {
             if (!location) {
                 location = this.getPreferenceLocation(id, context);
             }
-            if (location) {
-                if (location.layer) {
-                    var layer = this._layerMap[location.layer];
-                    if (layer) {
-                        var wasSet = layer.set(this.data[layer.key], id, value, context, location.layerID);
-                        this._dirty = this._dirty || wasSet;
-                        return wasSet;
-                    } else {
-                        return false;
-                    }
+            if (location && location.layer) {
+                var layer = this._layerMap[location.layer];
+                if (layer) {
+                    var wasSet = layer.set(this.data[layer.key], id, value, context, location.layerID);
+                    this._dirty = this._dirty || wasSet;
+                    return wasSet;
                 } else {
-                    return this._performSet(id, value);
+                    return false;
                 }
             } else {
                 return this._performSet(id, value);
@@ -416,8 +412,14 @@ define(function (require, exports, module) {
             }
             
             if (this._exclusions.indexOf(id) === -1 && data[id] !== undefined) {
+                // The value is defined in this Scope, which means we need to return an
+                // empty object as a signal to the PreferencesSystem that this pref
+                // is defined in this Scope (in the base data)
                 return {};
             }
+            
+            // return undefined when this Scope does not have the requested pref
+            return undefined;
         },
         
         /**

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -387,9 +387,10 @@ define(function (require, exports, module) {
          * 
          * @param {string} id Name of the preference for which the value should be retrieved
          * @param {Object=} context Optional context object to change the preference lookup
-         * @return {?{layer: ?string, layerID: ?object}} Object describing where the preferences came from. 
+         * @return {{layer: ?string, layerID: ?object}|undefined} Object describing where the preferences came from. 
          *                                              An empty object means that it was defined in the Scope's
-         *                                              base data.
+         *                                              base data. Undefined means the pref is not
+         *                                              defined in this Scope.
          */
         getPreferenceLocation: function (id, context) {
             var layerCounter,


### PR DESCRIPTION
For example, if a preference is set at the "user" level and the user changes
the value via UI, the preference will be changed at the "user" level. If it's
set in a .brackets.json file, the preference will be changed there.
If the preference is defined only at the "default" level, it will be set
at the next higher level of precedence ("user" level in our setup).

This is a fix for #6595.
