### PR TITLE
Fix bug #6609 (Fast file replacement operations can be missed)

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -45,8 +45,8 @@ define(function (require, exports, module) {
      * Asynchronously reads a file as UTF-8 encoded text.
      * @param {!File} file File to read
      * @return {$.Promise} a jQuery promise that will be resolved with the 
-     *  file's text content plus its timestamp, or rejected with a FileSystemError if
-     *  the file can not be read.
+     *  file's text content plus its timestamp, or rejected with a FileSystemError string
+     *  constant if the file can not be read.
      */
     function readAsText(file) {
         var result = new $.Deferred();
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
      *      errors---which can be triggered if the actual file contents differ from 
      *      the FileSystem's last-known contents---should be ignored.
      * @return {$.Promise} a jQuery promise that will be resolved when
-     * file writing completes, or rejected with a FileSystemError.
+     * file writing completes, or rejected with a FileSystemError string constant.
      */
     function writeText(file, text, allowBlindWrite) {
         var result = new $.Deferred(),

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -783,7 +783,7 @@ define(function (require, exports, module) {
                 this._handleDirectoryChange(entry, function (added, removed) {
                     entry._stat = stat;
                     
-                    // We send a change even if added & removed are both length zero-length. Something may still have changed,
+                    // We send a change even if added & removed are both zero-length. Something may still have changed,
                     // e.g. a file may have been quickly removed & re-added before we got a chance to reread the directory
                     // listing.
                     this._fireChangeEvent(entry, added, removed);

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -1311,6 +1311,8 @@ define(function (require, exports, module) {
                 });
             });
         });
+        
+        
         describe("External change events", function () {
             var _model,
                 changedEntry,
@@ -1452,6 +1454,44 @@ define(function (require, exports, module) {
                     expect(removedEntries.length).toBe(1);
                     expect(addedEntries[0]).toBe(newfile);
                     expect(removedEntries[0]).toBe(oldfile);
+                });
+            });
+            
+            it("should fire change event after rapid delete-add pair", function () {
+                var dirname = "/subdir/",
+                    filename = "/subdir/file3.txt",
+                    dir,
+                    newfile;
+                
+                runs(function () {
+                    // Delay watcher change notifications so that the FS doesn't get a chance to
+                    // read the directory contents in between the deletion and the re-creation
+                    MockFileSystemImpl.when("change", "/subdir/", delay(100));
+                    
+                    dir = fileSystem.getDirectoryForPath(dirname);
+                    
+                    dir.getContents(function () {
+                        _model.unlink(filename);
+                    });
+                    
+                    // Normally we'd get a change event here, but due to our delay the FS doesn't
+                    // know of the change yet and thus has no reason to trigger an event
+                    expect(changeDone).toBe(false);
+                    
+                    dir.getContents(function () {
+                        _model.writeFile(filename, "new file content");
+                    });
+                });
+                
+                waitsFor(function () { return changeDone; }, "external change event");
+                
+                runs(function () {
+                    // We should still receive a change event, but the dir-contents diff shows no changes
+                    // since it didn't happen in between the delete and the create - so we expect the added
+                    // & removed lists to both be empty.
+                    expect(changedEntry).toBe(dir);
+                    expect(addedEntries.length).toBe(0);
+                    expect(removedEntries.length).toBe(0);
                 });
             });
         });

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -229,7 +229,8 @@ define(function (require, exports, module) {
 
         $(_model).on("change", function (event, path) {
             if (_changeCallback) {
-                _changeCallback(path, _model.stat(path));
+                var cb = _getCallback("change", path, _changeCallback);
+                cb(path, _model.stat(path));
             }
         });
         
@@ -252,7 +253,8 @@ define(function (require, exports, module) {
      * Add callback hooks to be used when specific methods are called with a
      * specific path.
      *
-     * @param {string} method The name of the method
+     * @param {string} method The name of the method. The special name "change"
+     *          may be used to hook the "change" event handler as well.
      * @param {string} path The path that must be matched
      * @param {function} getCallback A function that has one parameter and
      *           must return a callback function.


### PR DESCRIPTION
Fix bug #6609 --

Dispatch a FileSystem "change" event even when a dir change yields empty added/removed lists - because there's a delay between the change occurring and the time we re-read the dir contents in response, we might see back-to-back changes (e.g. a delete-recreate pair) as a no-op even though something definitely changed. See #6609 for an example bug.

Updated docs to clarify the two different special cases of directory change events. (Also contains an unrelated small docs improvement in FileUtils).

ProjectManager already responds to this special case the way we'd want - it calls FileSyncManager and then does nothing else - so no code changes needed there.
