### PR TITLE
Add session scope

### DIFF
--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -245,6 +245,9 @@ define(function (require, exports, module) {
         }
     });
     
+    // Session Scope is for storing prefs in memory only but with the highest precedence.
+    preferencesManager.addScope("session", new PreferencesBase.MemoryStorage());
+    
     /**
      * Creates an extension-specific preferences manager using the prefix given.
      * A `.` character will be appended to the prefix. So, a preference named `foo`


### PR DESCRIPTION
When I first built it, the PreferencesManager had a "session" scope that was used to hold transient preference values with a priority above all of the scopes. We got rid of it because it had no concrete use case. @busykai is already working on an extension that needs an in-memory scope (it auto-detects indentation and then sets the value for the session).

Having an official "session" scope is better than having multiple extensions that add their own in-memory scope.

This change should not affect any user-facing behavior because nothing is actually set in the session scope.
