### PR TITLE
Fix for #5535: default JSLint to the editor's indentation

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -4,7 +4,6 @@
         "plusplus": true,
         "devel": true,
         "nomen": true,
-        "indent": 4,
         "maxerr": 50
     },
     "defaultExtension": "js",

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
     // Load dependent modules
     var CodeInspection     = brackets.getModule("language/CodeInspection"),
         PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
-        Strings            = brackets.getModule("strings");
+        Strings            = brackets.getModule("strings"),
+        _                  = brackets.getModule("thirdparty/lodash");
     
     var prefs = PreferencesManager.getExtensionPrefs("jslint");
     
@@ -63,6 +64,17 @@ define(function (require, exports, module) {
         text = arr.join("\n");
         
         var options = prefs.get("options");
+        if (!options) {
+            options = {};
+        } else {
+            options = _.clone(options);
+        }
+        
+        if (!options.indent) {
+            // default to using the same indentation value that the editor is using
+            options.indent = PreferencesManager.get("spaceUnits");
+        }
+        
         var jslintResult = JSLINT(text, options);
         
         if (!jslintResult) {

--- a/src/extensions/default/JSLint/unittest-files/.brackets.json
+++ b/src/extensions/default/JSLint/unittest-files/.brackets.json
@@ -1,0 +1,10 @@
+{
+    "jslint.options": {
+    },
+    "path": {
+        "different-indent.js": {
+            "spaceUnits": 2,
+            "linting.collapsed": false
+        }
+    }
+}

--- a/src/extensions/default/JSLint/unittest-files/different-indent.js
+++ b/src/extensions/default/JSLint/unittest-files/different-indent.js
@@ -1,0 +1,3 @@
+function notAnError() {
+  "use strict";
+}

--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -99,5 +99,13 @@ define(function (require, exports, module) {
             });
         });
         
+        it("should default to the editor's indent", function () {
+            waitsForDone(SpecRunnerUtils.openProjectFiles(["different-indent.js"]), "open test file");
+            
+            runs(function () {
+                toggleJSLintResults(false);
+                toggleJSLintResults(false);
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes #5535 by defaulting JSLint's indentation to the same setting the editor uses.
