### PR TITLE
Fix for #5923: Maintain scroll position for each ExtensionManager tab

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -207,7 +207,11 @@ define(function (require, exports, module) {
         // Dialog tabs
         $dlg.find(".nav-tabs a")
             .on("click", function (event) {
+                models[_activeTabIndex].scrollPos = $(".modal-body", $dlg).scrollTop();
+                
                 $(this).tab("show");
+                
+                $(".modal-body", $dlg).scrollTop(models[_activeTabIndex].scrollPos || 0);
             });
         
         // Update & hide/show the notification overlay on a tab's icon, based on its model's notifyCount

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -208,9 +208,7 @@ define(function (require, exports, module) {
         $dlg.find(".nav-tabs a")
             .on("click", function (event) {
                 models[_activeTabIndex].scrollPos = $(".modal-body", $dlg).scrollTop();
-                
                 $(this).tab("show");
-                
                 $(".modal-body", $dlg).scrollTop(models[_activeTabIndex].scrollPos || 0);
             });
         


### PR DESCRIPTION
#5923 @lkcampbell @couzteau

This fixes #5923 where the scroll position of the ExtensionManager tabs was not maintained.

Is this a good approach? Should I (try to) add an unit test?
