### PR TITLE
Amend fix #6647

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -1109,7 +1109,10 @@ define(function (require, exports, module) {
                     // It is not valid to have an unparseable file.
                     if (err instanceof ParsingError) {
                         console.error(err);
+                        deferred.reject(err);
+                        return;
                     }
+                    deferred.resolve(id, scope);
                 });
             
             return deferred.promise();

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -231,7 +231,7 @@ define(function (require, exports, module) {
     
     // Set up the .brackets.json file handling
     userScope
-        .done(function () {
+        .always(function () {
             preferencesManager.addPathScopes(".brackets.json", {
                 before: "user",
                 checkExists: function (filename) {
@@ -246,7 +246,7 @@ define(function (require, exports, module) {
                     return new PreferencesBase.Scope(new PreferencesBase.FileStorage(filename));
                 }
             })
-                .done(function () {
+                .always(function () {
                     // Session Scope is for storing prefs in memory only but with the highest precedence.
                     preferencesManager.addScope("session", new PreferencesBase.MemoryStorage());
                 });


### PR DESCRIPTION
Load preferences always instead on positive cases only.
Also, resolve and reject deferred on negative flows in addScope.

@dangoor, this is to relax a little bit adding of the scopes. note that path scope is still dependent on "user" scope to be loaded as it explicitly specifies its position.
