### PR TITLE
Fix #6661: linting option to not remove JSLint.

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -7,6 +7,7 @@
         "indent": 4,
         "maxerr": 50
     },
+    "linting.overrideJSLint": false,
     "defaultExtension": "js",
     "path": {
         "src/thirdparty/CodeMirror2/**/*.js": {


### PR DESCRIPTION
This pull request introduces an option to keep JSLint active. By default it will not be enabled when there's another linter for JavaScript.

Please, please @peterflynn, @ingorichter take a look at this. It will make life so easier for working on projects which uses different linting requirements!
