### PR TITLE
Collect all parameter values from a css property in functional notation

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -252,7 +252,11 @@ define(function (require, exports, module) {
                     lastValue += ctx.token.string;
                 } else if (lastValue && lastValue.match(/,$/)) {
                     propValues.push(lastValue);
-                    lastValue = "";
+                    if (ctx.token.string.length > 0) {
+                        lastValue = ctx.token.string;
+                    } else {
+                        lastValue = "";
+                    }
                 } else {
                     // e.g. "rgba(50" gets broken into 2 tokens
                     lastValue += ctx.token.string;

--- a/test/spec/CSSUtils-test-files/contexts.css
+++ b/test/spec/CSSUtils-test-files/contexts.css
@@ -63,6 +63,10 @@
     shape-inside: polygon(n{{108}}onzero, 0 0);
 }
 
+.nested-functional-notation {
+    background: linear-gradient(to r{{109}}ight, rgba(255,255,0), #fff);
+}
+
 .single-quotes {
     font-family: {{50}}'{{51}}Helvetica {{52}}Neue{{53}}'{{54}}, Arial;
 }

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -2037,6 +2037,18 @@ define(function (require, exports, module) {
                 }
             });
             
+            it("should return a separate token for each param in a functional value notation", function () {
+                result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[109]);
+                expect(result).toEqual({
+                    context: CSSUtils.PROP_VALUE,
+                    name: "background",
+                    offset: 1,
+                    index: 1,
+                    values: ["linear-gradient(to ", "right, ", "rgba(255,", "255,", "0), ", "#fff)"],
+                    isNewItem: false
+                });
+            });
+            
             it("should return PROP_VALUE when inside functional value notation - simple", function () {
                 result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[107]);
                 expect(result).toEqual({


### PR DESCRIPTION
Fix an issue in collecting css property value that misses to collect a parameter if it immediately follows a comma (no whitespaces in between).

For example, when collecting the property value for `background: linear-gradient(to right, rgba(255,255,0), #fff);`,  we missed to collect `255` and `0` from `rgba(255,255,0)`. So the returned array has an entry for `,` and another for `),` instead of `255,` and `0),`.

@redmunds Can you review this?
