### PR TITLE
Prevent modal dialog from exceeding window height

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -224,7 +224,26 @@ define(function (require, exports, module) {
         this._promise.done(callback);
     };
     
-    
+
+    /**
+     * Don't allow dialog to exceed viewport size
+     */
+    function setDialogMaxSize() {
+        var maxWidth, maxHeight,
+            $dlgs = $(".modal-inner-wrapper > .instance");
+
+        // Verify 1 or more modal dialogs are showing
+        if ($dlgs.length > 0) {
+            maxWidth  = $("body").width();
+            maxHeight = $("body").height();
+
+            $dlgs.css({
+                "max-width":  maxWidth,
+                "max-height": maxHeight,
+                "overflow":   "auto"
+            });
+        }
+    }
     
     /**
      * Creates a new modal dialog from a given template.
@@ -245,16 +264,12 @@ define(function (require, exports, module) {
 
         var result    = $.Deferred(),
             promise   = result.promise(),
-            maxHeight = $(".main-view > .content").height(),
             $dlg      = $(template)
                 .addClass("instance")
                 .appendTo(".modal-inner-wrapper:last");
 
-        // Don't allow dialog to exceed viewport height
-        $(".modal-inner-wrapper:last > .instance").css({
-            "max-height": maxHeight,
-            "overflow": "auto"
-        });
+        // Don't allow dialog to exceed viewport size
+        setDialogMaxSize();
         
         // Save the dialog promise for unit tests
         $dlg.data("promise", promise);
@@ -366,6 +381,7 @@ define(function (require, exports, module) {
         });
     }
     
+    window.addEventListener("resize", setDialogMaxSize);
     
     exports.DIALOG_BTN_CANCEL            = DIALOG_BTN_CANCEL;
     exports.DIALOG_BTN_OK                = DIALOG_BTN_OK;

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -242,12 +242,19 @@ define(function (require, exports, module) {
         }
         
         $("body").append("<div class='modal-wrapper'><div class='modal-inner-wrapper'></div></div>");
-        
-        var result  = $.Deferred(),
-            promise = result.promise(),
-            $dlg    = $(template)
+
+        var result    = $.Deferred(),
+            promise   = result.promise(),
+            maxHeight = $(".main-view > .content").height(),
+            $dlg      = $(template)
                 .addClass("instance")
                 .appendTo(".modal-inner-wrapper:last");
+
+        // Don't allow dialog to exceed viewport height
+        $(".modal-inner-wrapper:last > .instance").css({
+            "max-height": maxHeight,
+            "overflow": "auto"
+        });
         
         // Save the dialog promise for unit tests
         $dlg.data("promise", promise);


### PR DESCRIPTION
This is for #6395.

I've seen this when I don't remember a modal dialog exceeding window height, so there may be other causes.

The problem is that sidebar gets stretched out-of-shape but doesn't get refreshed properly. This fix prevents modal dialogs from stretching window out-of-shape.

I think problem with sidebar not getting refreshed properly is because its layout is not pure CSS (i.e. uses JS). For some reason modal dialog exceeding window height does not trigger resize events. This is probably because modal dialog is inside a display:table and/or position:relative/absolute container.
