### PR TITLE
CSSUtils.findSelectorAtDocumentPos() matching in embedded stylesheet

### DIFF
--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -569,6 +569,33 @@ define(function (require, exports, module) {
                 expect(result).toEqual(expected);
             });
         });
+        
+        describe("findSelectorAtDocumentPos in embedded <style> blocks", function () {
+            var editor;
+            
+            beforeEach(function () {
+                init(this, embeddedHtmlFileEntry);
+                runs(function () {
+                    editor = SpecRunnerUtils.createMockEditor(this.fileContent, "html").editor;
+                });
+            });
+            
+            afterEach(function () {
+                SpecRunnerUtils.destroyMockEditor(editor.document);
+                editor = null;
+            });
+            
+            // Indexes of external UI are 1-based. Internal indexes are 0-based.
+            it("should find the first selector when pos is at beginning of selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 6, ch: 0});
+                expect(selector).toEqual("div");
+            });
+
+            it("should find the second selector when pos is at beginning of selector name", function () {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, {line: 11, ch: 0});
+                expect(selector).toEqual(".foo");
+            });
+        });
     }); // describe("CSSUtils")
 
     


### PR DESCRIPTION
`CSSUtils.findSelectorAtDocumentPos()` does not correctly match _the first selector_ in an embedded stylesheet. It spills out of the `<style>` tag and incorrectly matches everything up to the start of the document.

This PR includes a test to demonstrate this behavior.

I want to fix this problem. My idea is to check for the mode (css | text/x-scss | text/x-less) while looping tokens at: https://github.com/adobe/brackets/blob/master/src/language/CSSUtils.js#L1087

Is this a correct approach? Do you have another suggestion?
