### PR TITLE
JSLint assumes browser unless otherwise configured

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -46,6 +46,9 @@ define(function (require, exports, module) {
             CodeInspection.requestRun(Strings.JSLINT_NAME);
         });
     
+    // Predefined environments understood by JSLint.
+    var ENVIRONMENTS = ["browser", "node", "couch", "rhino"];
+    
     /**
      * Run JSLint on the current document. Reports results to the main UI. Displays
      * a gold star when no errors are found.
@@ -73,6 +76,15 @@ define(function (require, exports, module) {
         if (!options.indent) {
             // default to using the same indentation value that the editor is using
             options.indent = PreferencesManager.get("spaceUnits");
+        }
+        
+        // If the user has not defined the environment, we use browser by default.
+        var hasEnvironment = _.some(ENVIRONMENTS, function (env) {
+            return options[env] !== undefined;
+        });
+        
+        if (!hasEnvironment) {
+            options.browser = true;
         }
         
         var jslintResult = JSLINT(text, options);

--- a/src/extensions/default/JSLint/unittest-files/no-errors.js
+++ b/src/extensions/default/JSLint/unittest-files/no-errors.js
@@ -1,3 +1,4 @@
 function foo() {
     "use strict";
+    var body = document.body;
 }


### PR DESCRIPTION
This is a fix for #3269 which assumes the browser environment for JSLint unless JSLint is configured otherwise.
