### PR TITLE
Avoid re-running linting when there are no changes to prefs

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -36,13 +36,25 @@ define(function (require, exports, module) {
     // Load dependent modules
     var CodeInspection     = brackets.getModule("language/CodeInspection"),
         PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
-        Strings            = brackets.getModule("strings");
+        Strings            = brackets.getModule("strings"),
+        _                  = brackets.getModule("thirdparty/lodash");
     
     var prefs = PreferencesManager.getExtensionPrefs("jslint");
     
+    /**
+     * @private
+     * 
+     * Used to keep track of the last options JSLint was run with to avoid running
+     * again when there were no changes.
+     */
+    var _lastRunOptions;
+    
     prefs.definePreference("options", "object")
         .on("change", function (e, data) {
-            CodeInspection.requestRun(Strings.JSLINT_NAME);
+            var options = prefs.get("options");
+            if (!_.isEqual(options, _lastRunOptions)) {
+                CodeInspection.requestRun(Strings.JSLINT_NAME);
+            }
         });
     
     /**
@@ -50,7 +62,6 @@ define(function (require, exports, module) {
      * a gold star when no errors are found.
      */
     function lintOneFile(text, fullPath) {
-        
         // If a line contains only whitespace, remove the whitespace
         // This should be doable with a regexp: text.replace(/\r[\x20|\t]+\r/g, "\r\r");,
         // but that doesn't work.
@@ -63,6 +74,8 @@ define(function (require, exports, module) {
         text = arr.join("\n");
         
         var options = prefs.get("options");
+        _lastRunOptions = _.clone(options);
+        
         var jslintResult = JSLINT(text, options);
         
         if (!jslintResult) {

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
      * @private
      * @type {boolean}
      */
-    var _enabled = true;
+    var _enabled = false;
 
     /**
      * When collapsed, the errors panel is closed but the status bar icon is kept up to date.
@@ -434,6 +434,12 @@ define(function (require, exports, module) {
         if (enabled === undefined) {
             enabled = !_enabled;
         }
+        
+        // Take no action when there is no change.
+        if (enabled === _enabled) {
+            return;
+        }
+        
         _enabled = enabled;
 
         CommandManager.get(Commands.VIEW_TOGGLE_INSPECTION).setChecked(_enabled);
@@ -458,6 +464,10 @@ define(function (require, exports, module) {
     function toggleCollapsed(collapsed, doNotSave) {
         if (collapsed === undefined) {
             collapsed = !_collapsed;
+        }
+        
+        if (collapsed === _collapsed) {
+            return;
         }
 
         _collapsed = collapsed;


### PR DESCRIPTION
In #6676, @peterflynn reported that CodeInspection would keep adding listeners and re-run many times as you switch between files (exacerbated by the fact that the JSLint extension would also re-run as it detected changes).

This change corrects that behavior by confirming that there was an actual change between the new value and old. Note that the first time this runs in the Brackets project, you might see JSLint run twice (once when CodeInspection turns on and again when the JSLint preferences are set)... but this is legitimate because both of those changes could result in different lint results. As you switch around between files within Brackets, you'll see just a single linting event.

cc @redmunds 
