### PR TITLE
Avoid showing the keep changes/overwrite dialogs when unnecessary.

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -614,9 +614,7 @@ define(function (require, exports, module) {
                 });
         }
             
-        if (docToSave.isDirty) {
-            var writeError = false;
-            
+        function trySave() {
             // We don't want normalized line endings, so it's important to pass true to getText()
             FileUtils.writeText(file, docToSave.getText(true), force)
                 .done(function () {
@@ -630,6 +628,25 @@ define(function (require, exports, module) {
                         handleError(err);
                     }
                 });
+        }
+
+        if (docToSave.isDirty) {
+            var writeError = false;
+            
+            if (docToSave.keepChangesTime) {
+                // The user has decided to keep conflicting changes in the editor. Check to make sure
+                // the file hasn't changed since they last decided to do that.
+                docToSave.file.stat(function (err, stat) {
+                    if (!err && docToSave.keepChangesTime === stat.mtime.getTime()) {
+                        // OK, it's safe to overwrite the file even though we never reloaded the latest version,
+                        // since the user already said s/he wanted to ignore the disk version.
+                        force = true;
+                    }
+                    trySave();
+                });
+            } else {
+                trySave();
+            }
         } else {
             result.resolve(file);
         }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -637,6 +637,9 @@ define(function (require, exports, module) {
                 // The user has decided to keep conflicting changes in the editor. Check to make sure
                 // the file hasn't changed since they last decided to do that.
                 docToSave.file.stat(function (err, stat) {
+                    // If the file has been deleted on disk, the stat will return an error, but that's fine since 
+                    // that means there's no file to overwrite anyway, so the save will succeed without us having
+                    // to set force = true.
                     if (!err && docToSave.keepChangesTime === stat.mtime.getTime()) {
                         // OK, it's safe to overwrite the file even though we never reloaded the latest version,
                         // since the user already said s/he wanted to ignore the disk version.

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -71,9 +71,9 @@ define(function (require, exports, module) {
     var toReload;
     /** @type {Array.<Document>} */
     var toClose;
-    /** @type {Array.<Document>} */
+    /** @type {Array.<{doc: Document, fileTime: number}>} */
     var editConflicts;
-    /** @type {Array.<Document>} */
+    /** @type {Array.<{doc: Document, fileTime: number}>} */
     var deleteConflicts;
     
     
@@ -109,33 +109,39 @@ define(function (require, exports, module) {
                         // Does file's timestamp differ from last sync time on the Document?
                         var fileTime = stat.mtime.getTime();
                         if (fileTime !== doc.diskTimestamp.getTime()) {
-                            if (doc.isDirty) {
-                                // If the file has changed since the last time the user chose to
-                                // keep conflicting changes (if any), then this is a conflict. If
-                                // it hasn't changed, then we don't need to do anything.
-                                if (doc.keepChangesTime !== fileTime) {
+                            // If the user has chosen to keep changes that conflict with the
+                            // current state of the file on disk, then do nothing. This means
+                            // that even if the user later undoes back to clean, we won't
+                            // automatically reload the file on window reactivation. We could
+                            // make it do that, but it seems better to be consistent with the
+                            // deletion case below, where it seems clear that you don't want
+                            // to auto-delete the file on window reactivation just because you
+                            // undid back to clean.
+                            if (doc.keepChangesTime !== fileTime) {
+                                if (doc.isDirty) {
                                     editConflicts.push({doc: doc, fileTime: fileTime});
+                                } else {
+                                    toReload.push(doc);
                                 }
-                            } else {
-                                toReload.push(doc);
                             }
                         }
                         result.resolve();
                     } else {
                         // File has been deleted externally
                         if (err === FileSystemError.NOT_FOUND) {
-                            if (doc.isDirty) {
-                                // If the file existed the last time the user chose to keep
-                                // conflicting changes (if any), then this is a conflict. If it
-                                // didn't exist, then we don't need to do anything.
-                                // (We use -1 as the "mod time" to indicate that the file didn't
-                                // exist, since there's no actual modification time to keep track of
-                                // and -1 isn't a valid mod time for a real file.)
-                                if (doc.keepChangesTime !== -1) {
+                            // If the user has chosen to keep changes previously, and the file
+                            // has been deleted, then do nothing. Like the case above, this
+                            // means that even if the user later undoes back to clean, we won't
+                            // then automatically delete the file on window reactivation.
+                            // (We use -1 as the "mod time" to indicate that the file didn't
+                            // exist, since there's no actual modification time to keep track of
+                            // and -1 isn't a valid mod time for a real file.)
+                            if (doc.keepChangesTime !== -1) {
+                                if (doc.isDirty) {
                                     deleteConflicts.push({doc: doc, fileTime: -1});
+                                } else {
+                                    toClose.push(doc);
                                 }
-                            } else {
-                                toClose.push(doc);
                             }
                             result.resolve();
                         } else {


### PR DESCRIPTION
For #6525 and the issue mentioned in #5614. Essentially, the changes here should make it so that once you've clicked "Keep Changes in Editor" (when the underlying file is externally modified or deleted), you don't get prompted with that dialog again (or with the "Overwrite" dialog on save) unless the file changes on disk again.

@peterflynn - might be good for you to review this one.

I tested all the cases I can think of, but this seems like it would be good to unit test - though I wasn't able to find any existing unit tests for the file sync stuff. Is it worth starting up a new suite?
