### PR TITLE
Fail fast on paths with Windows-style separators

### DIFF
--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -264,6 +264,21 @@ define(function (require, exports, module) {
                     expectInvalidFile("/foo/../bar/../..");
                 });
             });
+            
+            it("should detect mistaken/invalid paths", function () {
+                // Not a full path
+                expectInvalidFile("");
+                expectInvalidFile("c:");
+                
+                // Windows-style \ path separators aren't permitted
+                expectInvalidFile("c:\\");
+                expectInvalidFile("c:\\foo");
+                expectInvalidFile("c:\\foo\\bar");
+                
+                // But proper paths ARE allowed to contain a \ (at least on Mac/Linux)
+                expectNormFile("/foo/one\\two", "/foo/one\\two");
+                expectNormDir("/foo/one\\two", "/foo/one\\two/");
+            });
         });
         
         describe("parent and name properties", function () {
@@ -283,7 +298,7 @@ define(function (require, exports, module) {
             });
             it("should not have a parentPath property if it is a root directory", function () {
                 var unixRootDir = fileSystem.getDirectoryForPath("/"),
-                    winRootDir = fileSystem.getDirectoryForPath("B:");
+                    winRootDir = fileSystem.getDirectoryForPath("B:/");
                 
                 expect(unixRootDir.parentPath).toBeNull();
                 expect(winRootDir.parentPath).toBeNull();


### PR DESCRIPTION
Add a check in FileSystem to ensure paths with Windows-style separators aren't used. This won't detect mixed separators (e.g. from concatenating two paths with different separators), but it will detect the more common case of someone passing a complete Windows-style path. Such paths have never been officially supported, and have always been partially broken in the new FileSystem. This simply makes them fail fast(er).

Note: we can't simply automatically convert slashes because Mac/Linux paths allow "\" as a normal character within a file/dir name.

This also improves the docs to explain path formats more clearly, and updates older docs on how FileSystem is initialized.

@ingorichter Do you want to review?
(CC @gruehle)
