### PR TITLE
[Initial review only] Editor APIs and edit ops for multiselection

### DIFF
--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -37,7 +37,8 @@ define(function HighlightAgent(require, exports, module) {
     var DOMAgent        = require("LiveDevelopment/Agents/DOMAgent"),
         Inspector       = require("LiveDevelopment/Inspector/Inspector"),
         LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
-        RemoteAgent     = require("LiveDevelopment/Agents/RemoteAgent");
+        RemoteAgent     = require("LiveDevelopment/Agents/RemoteAgent"),
+        _               = require("thirdparty/lodash");
 
     var _highlight = {}; // active highlight
 
@@ -108,11 +109,22 @@ define(function HighlightAgent(require, exports, module) {
     }
     
     /** Highlight all nodes with 'data-brackets-id' value
-     * that matches id.
-     * @param {string} value of the 'data-brackets-id' to match
+     * that matches id, or if id is an array, matches any of the given ids.
+     * @param {string|Array<string>} value of the 'data-brackets-id' to match,
+     * or an array of such.
      */
-    function domElement(id) {
-        rule("[data-brackets-id='" + id + "']");
+    function domElement(ids) {
+        var selector = "";
+        if (!Array.isArray(ids)) {
+            ids = [ids];
+        }
+        _.each(ids, function (id) {
+            if (selector !== "") {
+                selector += ",";
+            }
+            selector += "[data-brackets-id='" + id + "']";
+        });
+        rule(selector);
     }
     
     /**

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -52,7 +52,8 @@ define(function CSSDocumentModule(require, exports, module) {
         CSSUtils        = require("language/CSSUtils"),
         EditorManager   = require("editor/EditorManager"),
         HighlightAgent  = require("LiveDevelopment/Agents/HighlightAgent"),
-        Inspector       = require("LiveDevelopment/Inspector/Inspector");
+        Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        _               = require("thirdparty/lodash");
 
     /** Constructor
      *
@@ -154,10 +155,17 @@ define(function CSSDocumentModule(require, exports, module) {
 
     CSSDocument.prototype.updateHighlight = function () {
         if (Inspector.config.highlight && this.editor) {
-            var codeMirror = this.editor._codeMirror;
-            var selector = CSSUtils.findSelectorAtDocumentPos(this.editor, this.editor.getCursorPos());
-            if (selector) {
-                HighlightAgent.rule(selector);
+            var editor = this.editor,
+                codeMirror = editor._codeMirror,
+                selectors = [];
+            _.each(this.editor.getSelections(), function (sel) {
+                var selector = CSSUtils.findSelectorAtDocumentPos(editor, (sel.reversed ? sel.end : sel.start));
+                if (selector) {
+                    selectors.push(selector);
+                }
+            });
+            if (selectors.length) {
+                HighlightAgent.rule(selectors.join(","));
             } else {
                 HighlightAgent.hide();
             }

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -52,7 +52,8 @@ define(function HTMLDocumentModule(require, exports, module) {
         LiveDevelopment     = require("LiveDevelopment/LiveDevelopment"),
         PerfUtils           = require("utils/PerfUtils"),
         RemoteAgent         = require("LiveDevelopment/Agents/RemoteAgent"),
-        StringUtils         = require("utils/StringUtils");
+        StringUtils         = require("utils/StringUtils"),
+        _                   = require("thirdparty/lodash");
 
     /**
      * Constructor
@@ -140,17 +141,24 @@ define(function HTMLDocumentModule(require, exports, module) {
     
     /** Update the highlight */
     HTMLDocument.prototype.updateHighlight = function () {
-        var codeMirror = this.editor._codeMirror;
+        var editor = this.editor,
+            codeMirror = editor._codeMirror,
+            ids = [];
         if (Inspector.config.highlight) {
-            var tagID = HTMLInstrumentation._getTagIDAtDocumentPos(
-                this.editor,
-                this.editor.getCursorPos()
-            );
+            _.each(this.editor.getSelections(), function (sel) {
+                var tagID = HTMLInstrumentation._getTagIDAtDocumentPos(
+                    editor,
+                    sel.reversed ? sel.end : sel.start
+                );
+                if (tagID !== -1) {
+                    ids.push(tagID);
+                }
+            });
             
-            if (tagID === -1) {
+            if (!ids.length) {
                 HighlightAgent.hide();
             } else {
-                HighlightAgent.domElement(tagID);
+                HighlightAgent.domElement(ids);
             }
         }
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1118,18 +1118,21 @@ define(function (require, exports, module) {
             return CodeMirror.cmpPos(range2.start, range1.start);
         });
         
-        // Preflight the edits to make sure they don't overlap. (We don't want to do it during the
-        // actual edits, since we don't want to apply some of the edits before we find out.)
+        // Preflight the edits to specify "end" if unspecified and make sure they don't overlap. 
+        // (We don't want to do it during the actual edits, since we don't want to apply some of
+        // the edits before we find out.)
         _.each(edits, function (edit, index) {
-            // Check to make sure none of the edits overlap.
+            if (!edit.end) {
+                edit.end = edit.start;
+            }
             if (index > 0) {
                 var prevEdit = edits[index - 1];
-                // The edits are in reverse order, so we want to make sure this edit is
-                // before the previous one.
+                // The edits are in reverse order, so we want to make sure this edit ends
+                // before the previous one starts.
                 if (CodeMirror.cmpPos(edit.end, prevEdit.start) > 0) {
                     throw new Error("Editor.doMultipleEdits(): Overlapping edits specified");
                 }
-            }            
+            }
         });
         
         // Perform the edits.

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -399,8 +399,8 @@ define(function (require, exports, module) {
         //    insertion point, insert a tab character or the appropriate number
         //    of spaces to pad to the nearest tab boundary.
         var instance = this._codeMirror,
-            from = this.getCursorPos(false, "from"),
-            to = this.getCursorPos(false, "to"),
+            from = this.getCursorPos(false, "start"),
+            to = this.getCursorPos(false, "end"),
             line = instance.getLine(from.line),
             indentAuto = false,
             insertTab = false;
@@ -419,8 +419,8 @@ define(function (require, exports, module) {
             // already been at the correct indentation level as far as CM is concerned, so insert 
             // another tab.
             if (instance.getLine(from.line).length === currentLength) {
-                var newFrom = this.getCursorPos(false, "from"),
-                    newTo = this.getCursorPos(false, "to");
+                var newFrom = this.getCursorPos(false, "start"),
+                    newTo = this.getCursorPos(false, "end");
                 if (newFrom.line === from.line && newFrom.ch === from.ch &&
                         newTo.line === to.line && newTo.ch === to.ch) {
                     insertTab = true;
@@ -770,15 +770,23 @@ define(function (require, exports, module) {
      * Gets the current cursor position within the editor.
      * @param {boolean} expandTabs  If true, return the actual visual column number instead of the character offset in
      *      the "ch" property.
-     * @param {?string} start Optional string indicating which end of the
-     *  selection to return. It may be "from", "to", "head" (the side of the
+     * @param {?string} which Optional string indicating which end of the
+     *  selection to return. It may be "start", "end", "head" (the side of the
      *  selection that moves when you press shift+arrow), or "anchor" (the
      *  fixed side of the selection). Omitting the argument is the same as
      *  passing "head". A {line, ch} object will be returned.)
      * @return !{line:number, ch:number}
      */
-    Editor.prototype.getCursorPos = function (expandTabs, start) {
-        var cursor = _copyPos(this._codeMirror.getCursor(start));
+    Editor.prototype.getCursorPos = function (expandTabs, which) {
+        // Translate "start" and "end" to the official CM names (it actually
+        // supports them as-is, but that isn't documented and we don't want to
+        // rely on it).
+        if (which === "start") {
+            which = "from";
+        } else if (which === "end") {
+            which = "to";
+        }
+        var cursor = _copyPos(this._codeMirror.getCursor(which));
         
         if (expandTabs) {
             cursor.ch = this.getColOffset(cursor);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1083,12 +1083,13 @@ define(function (require, exports, module) {
      *     If any of the edits overlap, an error will be thrown.
      * @param {Array<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean}>} selections
      *     Optional set of selections to track through all the performed edits. Will not be modified.
+     * @param {?string} origin An optional edit origin that's passed through to each replaceRange().
      * @return {Array<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean}>}
      *     The selections array adjusted for the performed edits, or null if no selections array was specified.
      *     Note that if an input selection was inside any edited range, it will be pushed to the end of
      *     that range (in the post-edit document).     
      */
-    Editor.prototype.doMultipleEdits = function (edits, selections) {
+    Editor.prototype.doMultipleEdits = function (edits, selections, origin) {
         var result = (selections ? _.cloneDeep(selections) : null),
             self = this;
         
@@ -1141,7 +1142,7 @@ define(function (require, exports, module) {
                 // Perform this edit. The edit positions are guaranteed to be okay since all the previous
                 // edits we've done have been later in the document. However, we have to fix up any
                 // selections that overlap or come after the edit.
-                self._codeMirror.replaceRange(edit.text, edit.start, edit.end);
+                self._codeMirror.replaceRange(edit.text, edit.start, edit.end, origin);
                 
                 var textLines = edit.text.split("\n");
                 _.each(result, function (sel, index) {

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -785,8 +785,8 @@ define(function (require, exports, module) {
         doc.batchOperation(function () {
             _.each(selections, function (sel, index) {
                 if (index === 0 ||
-                        (direction === DIRECTION_UP && sel.start.line >= selections[index - 1].start.line) ||
-                        (direction === DIRECTION_DOWN && sel.end.line >= selections[index - 1].end.line)) {
+                        (direction === DIRECTION_UP && sel.start.line > selections[index - 1].start.line) ||
+                        (direction === DIRECTION_DOWN && sel.end.line > selections[index - 1].end.line)) {
                     // Insert the new line
                     switch (direction) {
                     case DIRECTION_UP:

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -94,18 +94,23 @@ define(function (require, exports, module) {
         var cursorStr = StringUtils.format(Strings.STATUSBAR_CURSOR_POSITION, cursor.line + 1, cursor.ch + 1);
         if (editor.hasSelection()) {
             // Show info about selection size when one exists
-            var sel = editor.getSelection(),
+            var sels = editor.getSelections(),
                 selStr;
             
-            if (sel.start.line !== sel.end.line) {
-                var lines = sel.end.line - sel.start.line + 1;
-                if (sel.end.ch === 0) {
-                    lines--;  // end line is exclusive if ch is 0, inclusive otherwise
-                }
-                selStr = _formatCountable(lines, Strings.STATUSBAR_SELECTION_LINE_SINGULAR, Strings.STATUSBAR_SELECTION_LINE_PLURAL);
+            if (sels.length > 1) {
+                selStr = StringUtils.format(Strings.STATUSBAR_SELECTION_MULTIPLE, sels.length);
             } else {
-                var cols = editor.getColOffset(sel.end) - editor.getColOffset(sel.start);  // end ch is exclusive always
-                selStr = _formatCountable(cols, Strings.STATUSBAR_SELECTION_CH_SINGULAR, Strings.STATUSBAR_SELECTION_CH_PLURAL);
+                var sel = sels[0];
+                if (sel.start.line !== sel.end.line) {
+                    var lines = sel.end.line - sel.start.line + 1;
+                    if (sel.end.ch === 0) {
+                        lines--;  // end line is exclusive if ch is 0, inclusive otherwise
+                    }
+                    selStr = _formatCountable(lines, Strings.STATUSBAR_SELECTION_LINE_SINGULAR, Strings.STATUSBAR_SELECTION_LINE_PLURAL);
+                } else {
+                    var cols = editor.getColOffset(sel.end) - editor.getColOffset(sel.start);  // end ch is exclusive always
+                    selStr = _formatCountable(cols, Strings.STATUSBAR_SELECTION_CH_SINGULAR, Strings.STATUSBAR_SELECTION_CH_PLURAL);
+                }
             }
             $cursorInfo.text(cursorStr + selStr);
         } else {

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -92,30 +92,26 @@ define(function (require, exports, module) {
         var cursor = editor.getCursorPos(true);
         
         var cursorStr = StringUtils.format(Strings.STATUSBAR_CURSOR_POSITION, cursor.line + 1, cursor.ch + 1);
-        if (editor.hasSelection()) {
-            // Show info about selection size when one exists
-            var sels = editor.getSelections(),
-                selStr;
-            
-            if (sels.length > 1) {
-                selStr = StringUtils.format(Strings.STATUSBAR_SELECTION_MULTIPLE, sels.length);
-            } else {
-                var sel = sels[0];
-                if (sel.start.line !== sel.end.line) {
-                    var lines = sel.end.line - sel.start.line + 1;
-                    if (sel.end.ch === 0) {
-                        lines--;  // end line is exclusive if ch is 0, inclusive otherwise
-                    }
-                    selStr = _formatCountable(lines, Strings.STATUSBAR_SELECTION_LINE_SINGULAR, Strings.STATUSBAR_SELECTION_LINE_PLURAL);
-                } else {
-                    var cols = editor.getColOffset(sel.end) - editor.getColOffset(sel.start);  // end ch is exclusive always
-                    selStr = _formatCountable(cols, Strings.STATUSBAR_SELECTION_CH_SINGULAR, Strings.STATUSBAR_SELECTION_CH_PLURAL);
+        
+        var sels = editor.getSelections(),
+            selStr = "";
+
+        if (sels.length > 1) {
+            selStr = StringUtils.format(Strings.STATUSBAR_SELECTION_MULTIPLE, sels.length);
+        } else if (editor.hasSelection()) {
+            var sel = sels[0];
+            if (sel.start.line !== sel.end.line) {
+                var lines = sel.end.line - sel.start.line + 1;
+                if (sel.end.ch === 0) {
+                    lines--;  // end line is exclusive if ch is 0, inclusive otherwise
                 }
+                selStr = _formatCountable(lines, Strings.STATUSBAR_SELECTION_LINE_SINGULAR, Strings.STATUSBAR_SELECTION_LINE_PLURAL);
+            } else {
+                var cols = editor.getColOffset(sel.end) - editor.getColOffset(sel.start);  // end ch is exclusive always
+                selStr = _formatCountable(cols, Strings.STATUSBAR_SELECTION_CH_SINGULAR, Strings.STATUSBAR_SELECTION_CH_PLURAL);
             }
-            $cursorInfo.text(cursorStr + selStr);
-        } else {
-            $cursorInfo.text(cursorStr);
         }
+        $cursorInfo.text(cursorStr + selStr);
     }
     
     function _changeIndentWidth(value) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -189,6 +189,7 @@ define({
     "STATUSBAR_SELECTION_CH_PLURAL"         : " \u2014 Selected {0} columns",
     "STATUSBAR_SELECTION_LINE_SINGULAR"     : " \u2014 Selected {0} line",
     "STATUSBAR_SELECTION_LINE_PLURAL"       : " \u2014 Selected {0} lines",
+    "STATUSBAR_SELECTION_MULTIPLE"          : " \u2014 {0} selections",
     "STATUSBAR_INDENT_TOOLTIP_SPACES"       : "Click to switch indentation to spaces",
     "STATUSBAR_INDENT_TOOLTIP_TABS"         : "Click to switch indentation to tabs",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_SPACES"  : "Click to change number of spaces used when indenting",

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -435,8 +435,9 @@ define(function (require, exports, module) {
 
         // Prepopulate the search field
         if (!initialQuery) {
-            // Prepopulate with the current selection, if any
-            initialQuery = cm.getSelection();
+            // Prepopulate with the current primary selection, if any
+            var sel = editor.getSelection();
+            initialQuery = cm.getRange(sel.start, sel.end);
             
             // Eliminate newlines since we don't generally support searching across line boundaries (#2960)
             var newline = initialQuery.indexOf("\n");

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -340,18 +340,18 @@ define(function (require, exports, module) {
                 it("should return a single cursor", function () {
                     myEditor._codeMirror.setCursor(0, 2);
                     expect(myEditor.getCursorPos()).toEqual({line: 0, ch: 2});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 0, ch: 2});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 0, ch: 2});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 0, ch: 2});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 0, ch: 2});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 0, ch: 2});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 0, ch: 2});
                 });
                 
                 it("should return the correct ends of a single selection", function () {
                     myEditor._codeMirror.setSelection({line: 0, ch: 1}, {line: 0, ch: 5});
                     expect(myEditor.getCursorPos()).toEqual({line: 0, ch: 5});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 0, ch: 1});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 0, ch: 1});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 0, ch: 1});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 0, ch: 5});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 0, ch: 5});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 0, ch: 5});
                 });
                 
@@ -361,9 +361,9 @@ define(function (require, exports, module) {
                                                         {anchor: {line: 2, ch: 1}, head: {line: 2, ch: 1}}
                                                        ]);
                     expect(myEditor.getCursorPos()).toEqual({line: 2, ch: 1});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 2, ch: 1});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 2, ch: 1});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 2, ch: 1});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 2, ch: 1});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 2, ch: 1});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 2, ch: 1});
                 });
                 
@@ -373,9 +373,9 @@ define(function (require, exports, module) {
                                                         {anchor: {line: 2, ch: 1}, head: {line: 2, ch: 1}}
                                                        ], 1);
                     expect(myEditor.getCursorPos()).toEqual({line: 1, ch: 1});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 1, ch: 1});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 1, ch: 1});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 1, ch: 1});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 1, ch: 1});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 1, ch: 1});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 1, ch: 1});
                 });
                 
@@ -385,9 +385,9 @@ define(function (require, exports, module) {
                                                         {anchor: {line: 2, ch: 1}, head: {line: 2, ch: 4}}
                                                        ]);
                     expect(myEditor.getCursorPos()).toEqual({line: 2, ch: 4});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 2, ch: 1});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 2, ch: 1});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 2, ch: 1});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 2, ch: 4});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 2, ch: 4});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 2, ch: 4});
                 });
                 
@@ -397,9 +397,9 @@ define(function (require, exports, module) {
                                                         {anchor: {line: 2, ch: 1}, head: {line: 2, ch: 4}}
                                                        ], 1);
                     expect(myEditor.getCursorPos()).toEqual({line: 1, ch: 4});
-                    expect(myEditor.getCursorPos(false, "from")).toEqual({line: 1, ch: 1});
+                    expect(myEditor.getCursorPos(false, "start")).toEqual({line: 1, ch: 1});
                     expect(myEditor.getCursorPos(false, "anchor")).toEqual({line: 1, ch: 1});
-                    expect(myEditor.getCursorPos(false, "to")).toEqual({line: 1, ch: 4});
+                    expect(myEditor.getCursorPos(false, "end")).toEqual({line: 1, ch: 4});
                     expect(myEditor.getCursorPos(false, "head")).toEqual({line: 1, ch: 4});
                 });
             });

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -1825,6 +1825,87 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual(expectedText);
                 expectSelection({start: {line: 7, ch: 1}, end: {line: 14, ch: 1}});
             });
+            
+            describe("with multiple selections", function () {
+                it("should duplicate multiple lines containing cursors", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
+                                            {start: {line: 3, ch: 3}, end: {line: 3, ch: 3}}]);
+                    
+                    CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(4, 0, lines[3]);
+                    lines.splice(2, 0, lines[1]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 3}, end: {line: 2, ch: 3}, primary: false, reversed: false},
+                                      {start: {line: 5, ch: 3}, end: {line: 5, ch: 3}, primary: true, reversed: false}]);
+                });
+                
+                it("should not duplicate the same line multiple times", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
+                                            {start: {line: 1, ch: 6}, end: {line: 1, ch: 6}},
+                                            {start: {line: 3, ch: 3}, end: {line: 3, ch: 3}}]);
+                    
+                    CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(4, 0, lines[3]);
+                    lines.splice(2, 0, lines[1]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 3}, end: {line: 2, ch: 3}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 6}, end: {line: 2, ch: 6}, primary: false, reversed: false},
+                                      {start: {line: 5, ch: 3}, end: {line: 5, ch: 3}, primary: true, reversed: false}]);
+                });
+                
+                it("should duplicate multiple range selections", function () {
+                    // select "bar" on line 1, cursor on line 2, and "a()" on line 3
+                    myEditor.setSelections([{start: {line: 1, ch: 13}, end: {line: 1, ch: 16}},
+                                            {start: {line: 3, ch: 8}, end: {line: 3, ch: 11}}]);
+
+                    CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+
+                    var lines = defaultContent.split("\n");
+                    lines[1] = "    function barbar() {";
+                    lines[3] = "        a()a();";
+                    var expectedText = lines.join("\n");
+
+                    expect(myDocument.getText()).toEqual(expectedText);
+                    expectSelections([{start: {line: 1, ch: 16}, end: {line: 1, ch: 19}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 11}, end: {line: 3, ch: 14}, primary: true, reversed: false}]);
+                });
+                
+                it("should duplicate a mix of cursors and ranges", function () {
+                    // select "bar" on line 1, cursor on line 2, and "a()" on line 3
+                    myEditor.setSelections([{start: {line: 1, ch: 13}, end: {line: 1, ch: 16}},
+                                            {start: {line: 2, ch: 3}, end: {line: 2, ch: 3}},
+                                            {start: {line: 3, ch: 8}, end: {line: 3, ch: 11}}]);
+
+                    CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+
+                    var lines = defaultContent.split("\n");
+                    lines[1] = "    function barbar() {";
+                    lines[3] = "        a()a();";
+                    lines.splice(3, 0, lines[2]);
+                    var expectedText = lines.join("\n");
+
+                    expect(myDocument.getText()).toEqual(expectedText);
+                    expectSelections([{start: {line: 1, ch: 16}, end: {line: 1, ch: 19}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 3}, end: {line: 3, ch: 3}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 11}, end: {line: 4, ch: 14}, primary: true, reversed: false}]);
+                });
+                
+                it("should duplicate line first, then range, if both a cursor and range are on the same line", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
+                                            {start: {line: 1, ch: 13}, end: {line: 1, ch: 16}}]);
+                    CommandManager.execute(Commands.EDIT_DUPLICATE, myEditor);
+
+                    var lines = defaultContent.split("\n");
+                    lines.splice(2, 0, "    function barbar() {");
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 3}, end: {line: 2, ch: 3}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 16}, end: {line: 2, ch: 19}, primary: true, reversed: false}]);
+                });
+            });
         });
         
         
@@ -2213,73 +2294,75 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual("");
             });
             
-            it("should delete lines containing any cursor in a multiple selection", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
-                                        {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}},
-                                        {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+            describe("with multiple selections", function () {
+                it("should delete lines containing any cursor in a multiple selection", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
+                                            {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}},
+                                            {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
-            });
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
+                });
 
-            it("should delete lines containing any range in a multiple selection", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 3}, end: {line: 0, ch: 5}},
-                                        {start: {line: 2, ch: 2}, end: {line: 2, ch: 5}},
-                                        {start: {line: 6, ch: 0}, end: {line: 6, ch: 1}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                it("should delete lines containing any range in a multiple selection", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 3}, end: {line: 0, ch: 5}},
+                                            {start: {line: 2, ch: 2}, end: {line: 2, ch: 5}},
+                                            {start: {line: 6, ch: 0}, end: {line: 6, ch: 1}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
-            });
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
+                });
 
-            it("should handle multiple cursors/selections on the same line (only deleting the line once)", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
-                                        {start: {line: 2, ch: 3}, end: {line: 2, ch: 5}},
-                                        {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}},
-                                        {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                it("should handle multiple cursors/selections on the same line (only deleting the line once)", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
+                                            {start: {line: 2, ch: 3}, end: {line: 2, ch: 5}},
+                                            {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}},
+                                            {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
-            });
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
+                });
 
-            it("should handle multiple selections that span multiple lines", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 5}},
-                                        {start: {line: 3, ch: 4}, end: {line: 4, ch: 5}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                it("should handle multiple selections that span multiple lines", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 5}},
+                                            {start: {line: 3, ch: 4}, end: {line: 4, ch: 5}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 3, 4]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: true, reversed: false}]);
-            });
-            
-            it("should delete the rest of a selection that starts on a line previously deleted", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 3}},
-                                        {start: {line: 1, ch: 5}, end: {line: 3, ch: 5}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 3, 4]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: true, reversed: false}]);
+                });
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 2, 3]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: true, reversed: false}]);
-            });
-            
-            it("should merge the primary selection into another selection on the same line", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
-                                        {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}},
-                                        {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}, primary: true},
-                                        {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                it("should delete the rest of a selection that starts on a line previously deleted", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 3}},
+                                            {start: {line: 1, ch: 5}, end: {line: 3, ch: 5}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
 
-                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
-                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
-                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: true, reversed: false},
-                                                         {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: false, reversed: false}]);
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 2, 3]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: true, reversed: false}]);
+                });
+
+                it("should merge the primary selection into another selection on the same line", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
+                                            {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}},
+                                            {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}, primary: true},
+                                            {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+
+                    expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
+                    expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                             {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: true, reversed: false},
+                                                             {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: false, reversed: false}]);
+                });
             });
         });
         
@@ -2402,85 +2485,87 @@ define(function (require, exports, module) {
                 expectSelection({start: {line: 1, ch: 0}, end: {line: 5, ch: 0}});
             });
             
-            it("should extend multiple cursors to multiple lines", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
-                                        {start: {line: 3, ch: 9}, end: {line: 3, ch: 9}},
-                                        {start: {line: 7, ch: 0}, end: {line: 7, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
-            });
-            
-            it("should extend multiple selections to multiple lines", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 0, ch: 5}},
-                                        {start: {line: 3, ch: 0}, end: {line: 3, ch: 9}},
-                                        {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
-            });
-            
-            it("should extend multiple multi-line selections to whole lines, and handle end properly", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 2}, end: {line: 1, ch: 3}},
-                                        {start: {line: 3, ch: 2}, end: {line: 4, ch: 3}},
-                                        {start: {line: 6, ch: 2}, end: {line: 7, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 6, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
-            });
-            
-            it("should extend whole lines in multiple selection to next line, except at end", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
-                                        {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}},
-                                        {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
-            });
-            
-            it("should extend multiple lines in multiple selection to additional line, and handle end properly", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}},
-                                        {start: {line: 4, ch: 0}, end: {line: 7, ch: 0}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 3, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 4, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
-            });
-            
-            it("should merge selections that collide", function () {
-                myEditor.setSelections([{start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
-                                        {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 1, ch: 0}, end: {line: 3, ch: 0}, reversed: false, primary: true}]);
-            });
-            
-            it("should track a non-default primary selection", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
-                                        {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, primary: true},
-                                        {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelection({start: {line: 3, ch: 0}, end: {line: 5, ch: 0}});
-            });
-            
-            it("should track a reversed selection", function () {
-                myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
-                                        {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: true},
-                                        {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
-                CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
-                
-                expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
-                                  {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: true, primary: false},
-                                  {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+            describe("with multiple selections", function () {
+                it("should extend multiple cursors to multiple lines", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
+                                            {start: {line: 3, ch: 9}, end: {line: 3, ch: 9}},
+                                            {start: {line: 7, ch: 0}, end: {line: 7, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
+
+                it("should extend multiple selections to multiple lines", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 0, ch: 5}},
+                                            {start: {line: 3, ch: 0}, end: {line: 3, ch: 9}},
+                                            {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
+
+                it("should extend multiple multi-line selections to whole lines, and handle end properly", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 2}, end: {line: 1, ch: 3}},
+                                            {start: {line: 3, ch: 2}, end: {line: 4, ch: 3}},
+                                            {start: {line: 6, ch: 2}, end: {line: 7, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 6, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
+
+                it("should extend whole lines in multiple selection to next line, except at end", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
+                                            {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}},
+                                            {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
+
+                it("should extend multiple lines in multiple selection to additional line, and handle end properly", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}},
+                                            {start: {line: 4, ch: 0}, end: {line: 7, ch: 0}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 3, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 4, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
+
+                it("should merge selections that collide", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 1, ch: 0}, end: {line: 3, ch: 0}, reversed: false, primary: true}]);
+                });
+
+                it("should track a non-default primary selection", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
+                                            {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, primary: true},
+                                            {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelection({start: {line: 3, ch: 0}, end: {line: 5, ch: 0}});
+                });
+
+                it("should track a reversed selection", function () {
+                    myEditor.setSelections([{start: {line: 0, ch: 0}, end: {line: 1, ch: 0}},
+                                            {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: true},
+                                            {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}}]);
+                    CommandManager.execute(Commands.EDIT_SELECT_LINE, myEditor);
+
+                    expectSelections([{start: {line: 0, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 5, ch: 0}, reversed: true, primary: false},
+                                      {start: {line: 7, ch: 0}, end: {line: 7, ch: 1}, reversed: false, primary: true}]);
+                });
             });
         });
         

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2225,9 +2225,21 @@ define(function (require, exports, module) {
                                                          {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
             });
 
-            it("should handle multiple selections on the same line (only deleting the line once)", function () {
+            it("should delete lines containing any range in a multiple selection", function () {
+                myEditor.setSelections([{start: {line: 0, ch: 3}, end: {line: 0, ch: 5}},
+                                        {start: {line: 2, ch: 2}, end: {line: 2, ch: 5}},
+                                        {start: {line: 6, ch: 0}, end: {line: 6, ch: 1}}]);
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+
+                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 2, 6]));
+                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
+                                                         {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
+            });
+
+            it("should handle multiple cursors/selections on the same line (only deleting the line once)", function () {
                 myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}},
-                                        {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}},
+                                        {start: {line: 2, ch: 3}, end: {line: 2, ch: 5}},
                                         {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}},
                                         {start: {line: 6, ch: 0}, end: {line: 6, ch: 0}}]);
                 CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
@@ -2236,6 +2248,25 @@ define(function (require, exports, module) {
                 expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
                                                          {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: false, reversed: false},
                                                          {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, primary: true, reversed: false}]);
+            });
+
+            it("should handle multiple selections that span multiple lines", function () {
+                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 5}},
+                                        {start: {line: 3, ch: 4}, end: {line: 4, ch: 5}}]);
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+
+                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 3, 4]));
+                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: false, reversed: false},
+                                                         {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}, primary: true, reversed: false}]);
+            });
+            
+            it("should delete the rest of a selection that starts on a line previously deleted", function () {
+                myEditor.setSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 3}},
+                                        {start: {line: 1, ch: 5}, end: {line: 3, ch: 5}}]);
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+
+                expect(myDocument.getText()).toEqual(contentWithDeletedLines([0, 1, 2, 3]));
+                expect(myEditor.getSelections()).toEqual([{start: {line: 0, ch: 0}, end: {line: 0, ch: 0}, primary: true, reversed: false}]);
             });
             
             it("should merge the primary selection into another selection on the same line", function () {

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2815,6 +2815,41 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual(expectedText);
                 expectCursorAt({line: 5, ch: indentUnit * 2});
             });
+            
+            describe("with multiple selections", function () {
+                it("should insert new line above each selection cursor/range", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 4, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(4, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    lines.splice(1, 0, indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 6, ch: 8}, end: {line: 6, ch: 8}, primary: true, reversed: false}]);
+                });
+                
+                it("should insert new line below each selection cursor/range", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 4, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(6, 0, indentation);
+                    lines.splice(3, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 8}, end: {line: 4, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 8, ch: 4}, end: {line: 8, ch: 4}, primary: true, reversed: false}]);
+                });
+
+            });
         });
 
         

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2832,7 +2832,42 @@ define(function (require, exports, module) {
                                       {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: false, reversed: false},
                                       {start: {line: 6, ch: 8}, end: {line: 6, ch: 8}, primary: true, reversed: false}]);
                 });
-                
+
+                it("should ignore multiple selections on same line when inserting above", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}},
+                                            {start: {line: 4, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(4, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    lines.splice(1, 0, indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 6, ch: 8}, end: {line: 6, ch: 8}, primary: true, reversed: false}]);
+                });
+
+                it("should not ignore multiple selections that end on the same line if the second one starts on a different line when inserting above", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 4, ch: 2}},
+                                            {start: {line: 4, ch: 6}, end: {line: 4, ch: 6}},
+                                            {start: {line: 5, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_ABOVE, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(5, 0, indentation + indentation);
+                    lines.splice(4, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    lines.splice(1, 0, indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 6, ch: 8}, end: {line: 6, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 8, ch: 8}, end: {line: 8, ch: 8}, primary: true, reversed: false}]);
+                });
                 it("should insert new line below each selection cursor/range", function () {
                     myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
                                             {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
@@ -2849,6 +2884,41 @@ define(function (require, exports, module) {
                                       {start: {line: 8, ch: 4}, end: {line: 8, ch: 4}, primary: true, reversed: false}]);
                 });
 
+                it("should ignore multiple selections on same line when inserting below", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 2, ch: 7}, end: {line: 2, ch: 7}},
+                                            {start: {line: 4, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(6, 0, indentation);
+                    lines.splice(3, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 8}, end: {line: 4, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 8, ch: 4}, end: {line: 8, ch: 4}, primary: true, reversed: false}]);
+                });
+
+                it("should not ignore multiple selections that start on the same line if the second one ends on a different line when inserting below", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 4, ch: 2}, end: {line: 4, ch: 2}},
+                                            {start: {line: 4, ch: 5}, end: {line: 5, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_OPEN_LINE_BELOW, myEditor);
+                    
+                    var lines = defaultContent.split("\n");
+                    lines.splice(6, 0, indentation);
+                    lines.splice(5, 0, indentation + indentation);
+                    lines.splice(3, 0, indentation + indentation);
+                    lines.splice(2, 0, indentation + indentation);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 8}, end: {line: 4, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 7, ch: 8}, end: {line: 7, ch: 8}, primary: false, reversed: false},
+                                      {start: {line: 9, ch: 4}, end: {line: 9, ch: 4}, primary: true, reversed: false}]);
+                });
             });
         });
 

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -78,6 +78,9 @@ define(function (require, exports, module) {
         // Helper functions for testing cursor position / selection range
         // TODO: duplicated from EditorCommandHandlers-test
         function expectSelection(sel) {
+            if (!sel.reversed) {
+                sel.reversed = false;
+            }
             expect(myEditor.getSelection()).toEqual(sel);
         }
         function expectHighlightedMatches(selections, expectedDOMHighlightCount) {
@@ -509,6 +512,13 @@ define(function (require, exports, module) {
                 
                 enterSearchText("bar");
                 expectSelection(barExpectedMatches[0]);
+            });
+            
+            it("should get primary selection as initial query", function () {
+                myEditor.setSelections([{start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}, primary: true},
+                                        {start: {line: 1, ch: 0}, end: {line: 1, ch: 1}}]);
+                twCommandManager.execute(Commands.EDIT_FIND);
+                expect(getSearchField().val()).toEqual("require");
             });
             
             it("should extend original selection when appending to prepopulated text", function () {


### PR DESCRIPTION
Putting this up so others can take a look at it as I go along. The main multiselect editor APIs and unit tests are done. I also tweaked the status bar so it shows "n selections" instead of "n columns/lines selected" if there are multiple selections.

Note that the existing Editor APIs didn't have to change at all in most cases, since they call CM APIs that already just look at the primary selection. I did add unit tests for all of them however.

We might want to go ahead and review and pull this into `cmv4` so that we can unblock the keyboard selection work in https://trello.com/c/oRlwWPcw.

Note on the API style: We handle selection ranges differently than in CodeMirror in a way that seems more straightforward for edit operations. Rather than having "anchor" and "head", either of which could be earlier in the document, each range has a "start" and an "end", with the start guaranteed to be <= the end. If the anchor of the range is the end, then "reversed" is set on the range. Also, rather than specifying the primary selection by index in `setSelections()`, we set an attribute on the range. `getSelections()` works symmetrically, so this makes it a lot easier for edit ops to easily track primary and reversed selections through an edit without a lot of work.

Also note that I augmented the existing `getSelection()` API to also add the `reversed` property (we don't add `primary` since `getSelection()` always returns the primary selection by definition). This shouldn't break normal callers of the API since it's just an added property, but it did break some unit tests that were using `toEqual()` to test the return value (since they now have to account for the additional property). I think that's ok, but let me know if you disagree.

Update: started implementing a number of edit ops as well. Added some helper APIs to make writing multiselect-aware edit ops easier.
