### PR TITLE
Avoid showing the 'overwrite changes' dialog as a temporary workaround for #6437

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -560,7 +560,8 @@ define(function (require, exports, module) {
     /**
      * Saves a document to its existing path. Does NOT support untitled documents.
      * @param {!Document} docToSave
-     * @param {boolean=} force Ignore CONTENTS_MODIFIED errors from the FileSystem
+     * @param {boolean=} force Ignore CONTENTS_MODIFIED errors from the FileSystem.
+     *     Note: for release 36, we always ignore these errors regardless of this flag.
      * @return {$.Promise} a promise that is resolved with the File of docToSave (to mirror
      *   the API of _doSaveAs()). Rejected in case of IO error (after error dialog dismissed).
      */
@@ -618,7 +619,12 @@ define(function (require, exports, module) {
             var writeError = false;
             
             // We don't want normalized line endings, so it's important to pass true to getText()
-            FileUtils.writeText(file, docToSave.getText(true), force)
+            // For release 36, always allow "blind writes" as we did before file watchers, to avoid
+            // spurious overwrite dialogs (see #6437). This is the same as the pre-36 behavior,
+            // and in almost all cases we would have gotten a prior file watcher notification in
+            // any case; in the only cases we know about where the user would have hit this, the
+            // file hasn't actually changed on disk.
+            FileUtils.writeText(file, docToSave.getText(true), true)
                 .done(function () {
                     docToSave.notifySaved();
                     result.resolve(file);


### PR DESCRIPTION
The "overwrite changes" dialog that was introduced as part of the file watchers feature is not fully reliable on Mac, and is showing up occasionally when there appears to have actually been no change on disk. For now, we're simply disabling this dialog; in most cases we will still have warned the user (via the "external changes" dialog) that the file has been updated on disk, and in the small number of cases where they would have gotten the "overwrite changes" dialog, the behavior is no worse than it was before the file watchers feature.

Note that this is targeting the release branch.
