### PR TITLE
Temporary workaround for #6437: always allow blind writes (but log the issue)

### DIFF
--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -422,8 +422,12 @@ define(function (require, exports, module) {
             
             if (options.hasOwnProperty("expectedHash") && options.expectedHash !== stats._hash) {
                 console.error("Blind write attempted: ", path, stats._hash, options.expectedHash);
-                callback(FileSystemError.CONTENTS_MODIFIED);
-                return;
+                
+                // Temporary change for release 36: allow the blind write anyway. We're getting
+                // spurious cases where file modification times are being changed without actually
+                // changing the content and without sending us a file change notification.
+                // callback(FileSystemError.CONTENTS_MODIFIED);
+                // return;
             }
             
             _finishWrite(false);


### PR DESCRIPTION
For #6437, allow a file write to succeed even if we think the timestamp is newer. In general, we get reliable notifications from file watchers when files change. However, in rare cases on Mac we appear to see a change in modtime even when the contents of files haven't changed, and that isn't accompanied by a file watcher notification. For now, we're simply disabling the check.

/cc @peterflynn 
