### PR TITLE
Merge "blind writes" workaround from release into master

### DIFF
--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -422,8 +422,12 @@ define(function (require, exports, module) {
             
             if (options.hasOwnProperty("expectedHash") && options.expectedHash !== stats._hash) {
                 console.error("Blind write attempted: ", path, stats._hash, options.expectedHash);
-                callback(FileSystemError.CONTENTS_MODIFIED);
-                return;
+                
+                // Temporary change for release 36: allow the blind write anyway. We're getting
+                // spurious cases where file modification times are being changed without actually
+                // changing the content and without sending us a file change notification.
+                // callback(FileSystemError.CONTENTS_MODIFIED);
+                // return;
             }
             
             _finishWrite(false);


### PR DESCRIPTION
We're going to turn around and revert this in master right away, but we need the commit merged back into master first so future merges back from release don't cause confusion.
