### PR TITLE
adds getLanguages() for accessing the language map

### DIFF
--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -186,6 +186,14 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Retrieves the Language Map for further use in extensions.
+     * @return {Languages} The languages map as currently defined.
+     */
+    function getLanguages() {
+        return _languages;
+    }
+
+    /**
      * Resolves a language ID to a Language object.
      * File names have a higher priority than file extensions. 
      * @param {!string} id Identifier for this language: lowercase letters, digits, and _ separators (e.g. "cpp", "foo_bar", "c99")


### PR DESCRIPTION
Mostly geared toward extensions that need to
know the current state of the language map
before they provide further features.

@redmunds I blame you for this. :wink: 
