### PR TITLE
Fix remaining cmv4 FindReplace unit tests

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -376,7 +376,7 @@ define(function (require, exports, module) {
         // start with a pre-populated search and enter an additional character,
         // it will extend the initial selection instead of jumping to the next
         // occurrence.
-        state.searchStartPos = editor.getCursorPos(true);
+        state.searchStartPos = editor.getCursorPos(false, "start");
         
         // If a previous search/replace bar was open, capture its query text for use below
         var initialQuery;

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
             
             // Verify that editor UI doesn't have extra ranges left highlighted from earlier
             // (note: this only works for text that's short enough to not get virtualized)
-            var lineDiv = tw$(".CodeMirror-lines > div", myEditor.getRootElement()).children()[2];
+            var lineDiv = tw$(".CodeMirror-lines .CodeMirror-code", myEditor.getRootElement());
             var actualHighlights = tw$(".CodeMirror-searching", lineDiv);
             if (expectedDOMHighlightCount === undefined) {
                 expectedDOMHighlightCount = selections.length;


### PR DESCRIPTION
Fixed 2 issues:
1. DOM structure changed slightly, so test was not building matching array correctly. Used a safer search.
2. Another case where call to `Editor.getCursorPos()` was missing first param.

cc @njx 
