### PR TITLE
[cmv4] Fix LanguageManager unit test

### DIFF
--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -23,13 +23,14 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, CodeMirror, jasmine, beforeEach, afterEach, it, runs, waitsFor, expect, waitsForDone, waitsForFail, spyOn */
+/*global define, $, describe, jasmine, beforeEach, afterEach, it, runs, waitsFor, expect, waitsForDone, waitsForFail, spyOn */
 
 define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var LanguageManager = require("language/LanguageManager"),
+    var CodeMirror      = require("thirdparty/CodeMirror2/lib/codemirror"),
+        LanguageManager = require("language/LanguageManager"),
         DocumentManager = require("document/DocumentManager"),
         PathUtils       = require("thirdparty/path-utils/path-utils.min"),
         SpecRunnerUtils = require("spec/SpecRunnerUtils"),


### PR DESCRIPTION
CodeMirror is now loaded with require.

All test in "Unit" category now pass.

cc @njx 
