### PR TITLE
[cmv4] Move CM global includes to use require

### DIFF
--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -36,11 +36,6 @@
   <!-- Pre-load third party scripts that cannot be async loaded. -->
   <!-- Keep in sync with Gruntfile.js jasmine vendor dependencies -->
   <script src="../src/thirdparty/jquery-2.0.1.min.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/lib/codemirror.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/addon/search/searchcursor.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/addon/edit/closetag.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/addon/edit/closebrackets.js"></script>
-  <script src="../src/thirdparty/CodeMirror2/addon/selection/active-line.js"></script>
   <script src="../src/thirdparty/mustache/mustache.js"></script>
   <script src="../src/thirdparty/path-utils/path-utils.js"></script>
   <script src="../src/thirdparty/less-1.4.2.min.js"></script>

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -79,6 +79,18 @@ define(function (require, exports, module) {
     // Load JUnitXMLReporter
     require("test/thirdparty/jasmine-reporters/jasmine.junit_reporter");
     
+    // Load CodeMirror add-ons--these attach themselves to the CodeMirror module    
+    require("thirdparty/CodeMirror2/addon/fold/xml-fold");
+    require("thirdparty/CodeMirror2/addon/edit/matchtags");
+    require("thirdparty/CodeMirror2/addon/edit/matchbrackets");
+    require("thirdparty/CodeMirror2/addon/edit/closebrackets");
+    require("thirdparty/CodeMirror2/addon/edit/closetag");
+    require("thirdparty/CodeMirror2/addon/selection/active-line");
+    require("thirdparty/CodeMirror2/addon/mode/multiplex");
+    require("thirdparty/CodeMirror2/addon/mode/overlay");
+    require("thirdparty/CodeMirror2/addon/search/searchcursor");
+    require("thirdparty/CodeMirror2/keymap/multiselect");
+
     var selectedSuites,
         params                  = new UrlParams(),
         reporter,

--- a/test/perf/OpenFile-perf-files/InlineWidget.js
+++ b/test/perf/OpenFile-perf-files/InlineWidget.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, CodeMirror, window */
+/*global define, $, window */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, xdescribe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, CodeMirror, beforeFirst, afterLast */
+/*global define, describe, xdescribe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, beforeEach: false, afterEach: false, it: false, runs: false, waitsFor: false, expect: false, $: false, CodeMirror: false  */
+/*global define: false, describe: false, beforeEach: false, afterEach: false, it: false, runs: false, waitsFor: false, expect: false, $: false */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false, CodeMirror: false */
+/*global define: false, describe: false, it: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, runs: false, $: false */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/EditorManager-test.js
+++ b/test/spec/EditorManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, spyOn, expect, beforeEach, afterEach, waitsFor, runs, $, CodeMirror */
+/*global define, describe, it, spyOn, expect, beforeEach, afterEach, waitsFor, runs, $ */
 
 define(function (require, exports, module) {
     'use strict';


### PR DESCRIPTION
Also cleans up CodeMirror globals in various jslint directives

To @redmunds.
