### PR TITLE
[cmv4] Fix code hint unit tests

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -691,16 +691,6 @@ define(function (require, exports, module) {
     Editor.prototype._installEditorListeners = function () {
         var self = this;
         
-        // onKeyEvent is an option in CodeMirror rather than an event--it's a
-        // low-level hook for all keyboard events rather than a specific event. For
-        // our purposes, though, it's convenient to treat it as an event internally,
-        // so we bridge it to jQuery events the same way we do ordinary CodeMirror
-        // events.
-        this._codeMirror.setOption("onKeyEvent", function (instance, event) {
-            $(self).triggerHandler("keyEvent", [self, event]);
-            return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
-        });
-        
         // FUTURE: if this list grows longer, consider making this a more generic mapping
         // NOTE: change is a "private" event--others shouldn't listen to it on Editor, only on
         // Document

--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -393,8 +393,8 @@ define(function (require, exports, module) {
      */
     function installListeners(editor) {
 
-        $(editor).on("keyEvent", function (jqEvent, editor, event) {
-            if (event.type === "keydown" && event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+        $(editor.getRootElement()).on("keydown", function (event) {
+            if (event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
                 dismissHint();
             }
         }).on("scroll", function () {

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -383,7 +383,7 @@ define(function (require, exports, module) {
             testToken = editor._codeMirror.getTokenAt(testPos, true);
 
         // Currently only support url. May be null if starting to type
-        if (ctx.token.className && ctx.token.className !== "string") {
+        if (ctx.token.type && ctx.token.type !== "string") {
             return createInfo();
         }
 
@@ -393,11 +393,11 @@ define(function (require, exports, module) {
         propValues[0] = backwardCtx.token.string;
 
         while (TokenUtils.movePrevToken(backwardCtx)) {
-            if (backwardCtx.token.className === "def" && backwardCtx.token.string === "@import") {
+            if (backwardCtx.token.type === "def" && backwardCtx.token.string === "@import") {
                 break;
             }
             
-            if (backwardCtx.token.className && backwardCtx.token.className !== "tag" && backwardCtx.token.string !== "url") {
+            if (backwardCtx.token.type && backwardCtx.token.type !== "tag" && backwardCtx.token.string !== "url") {
                 // Previous token may be white-space
                 // Otherwise, previous token may only be "url("
                 break;
@@ -407,7 +407,7 @@ define(function (require, exports, module) {
             offset += backwardCtx.token.string.length;
         }
         
-        if (backwardCtx.token.className !== "def" || backwardCtx.token.string !== "@import") {
+        if (backwardCtx.token.type !== "def" || backwardCtx.token.string !== "@import") {
             // Not in url
             return createInfo();
         }


### PR DESCRIPTION
This is for #6042 and unit tests for url hints and js parameter code hints.

Changes:
- `token.className` has been replaced with `token.type`.
- CodeMirror "onKeyEvent" is no longer supported.

This fixes unit tests and I did some basic testing of code hints, but this has not been stress tested.

Note: use [?w=1](https://github.com/adobe/brackets/pull/6779/files?w=1) for Editor.js changes
cc @njx  
