### PR TITLE
[cmv4] Fix code hint unit tests - take 3

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -517,7 +517,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Handles keys related to displaying, searching, and navigating the hint list.
+     * Handle keys related to displaying, searching, and navigating the hint list.
      * This gets called before handleChange.
      *
      * TODO: Ideally, we'd get a more semantic event from the editor that told us
@@ -529,24 +529,29 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      * @param {KeyboardEvent} event
      */
-    function _handleKeyEvent(jqEvent, editor, event) {
+    function _handleKeydownEvent(jqEvent, editor, event) {
         keyDownEditor = editor;
-        if (event.type === "keydown") {
-            if (!(event.ctrlKey || event.altKey || event.metaKey) &&
-                    (event.keyCode === KeyEvent.DOM_VK_ENTER ||
-                     event.keyCode === KeyEvent.DOM_VK_RETURN ||
-                     event.keyCode === KeyEvent.DOM_VK_TAB)) {
-                lastChar = String.fromCharCode(event.keyCode);
-            }
-        } else if (event.type === "keypress") {
-            // Last inserted character, used later by handleChange
-            lastChar = String.fromCharCode(event.charCode);
-            
-            // Pending Text is used in hintList._keydownHook()
-            if (hintList) {
-                hintList.addPendingText(lastChar);
-            }
-        } else if (event.type === "keyup" && _inSession(editor)) {
+        if (!(event.ctrlKey || event.altKey || event.metaKey) &&
+                (event.keyCode === KeyEvent.DOM_VK_ENTER ||
+                 event.keyCode === KeyEvent.DOM_VK_RETURN ||
+                 event.keyCode === KeyEvent.DOM_VK_TAB)) {
+            lastChar = String.fromCharCode(event.keyCode);
+        }
+    }
+    function _handleKeypressEvent(jqEvent, editor, event) {
+        keyDownEditor = editor;
+
+        // Last inserted character, used later by handleChange
+        lastChar = String.fromCharCode(event.charCode);
+
+        // Pending Text is used in hintList._keydownHook()
+        if (hintList) {
+            hintList.addPendingText(lastChar);
+        }
+    }
+    function _handleKeyupEvent(jqEvent, editor, event) {
+        keyDownEditor = editor;
+        if (_inSession(editor)) {
             if (event.keyCode === KeyEvent.DOM_VK_HOME || event.keyCode === KeyEvent.DOM_VK_END) {
                 _endSession();
             } else if (event.keyCode === KeyEvent.DOM_VK_LEFT ||
@@ -626,13 +631,17 @@ define(function (require, exports, module) {
     function activeEditorChangeHandler(event, current, previous) {
         if (current) {
             $(current).on("editorChange", _handleChange);
-            $(current).on("keyEvent", _handleKeyEvent);
+            $(current).on("keydown",  _handleKeydownEvent);
+            $(current).on("keypress", _handleKeypressEvent);
+            $(current).on("keyup",    _handleKeyupEvent);
         }
         
         if (previous) {
             //Removing all old Handlers
             $(previous).off("editorChange", _handleChange);
-            $(previous).off("keyEvent", _handleKeyEvent);
+            $(previous).off("keydown",  _handleKeydownEvent);
+            $(previous).off("keypress", _handleKeypressEvent);
+            $(previous).off("keyup",    _handleKeyupEvent);
         }
     }
     

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -517,7 +517,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Handle keys related to displaying, searching, and navigating the hint list.
+     * Handles keys related to displaying, searching, and navigating the hint list.
      * This gets called before handleChange.
      *
      * TODO: Ideally, we'd get a more semantic event from the editor that told us

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -254,10 +254,10 @@ define(function (require, exports, module) {
         
         this._installEditorListeners();
         
-        $(this).on("cursorActivity", function (jqEvent, cmEvent) {
-            self._handleCursorActivity(cmEvent);
+        $(this).on("cursorActivity", function (jqEvent, editor) {
+            self._handleCursorActivity(jqEvent);
         });
-        $(this).on("keyEvent", function (jqEvent, cmEvent) {
+        $(this).on("keyEvent", function (jqEvent, editor, cmEvent) {
             self._handleKeyEvents(cmEvent);
         });
         $(this).on("change", function (jqEvent, editor, changeList) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -691,15 +691,14 @@ define(function (require, exports, module) {
     Editor.prototype._installEditorListeners = function () {
         var self = this;
         
-        // onKeyEvent is an option in CodeMirror rather than an event--it's a
-        // low-level hook for all keyboard events rather than a specific event. For
-        // our purposes, though, it's convenient to treat it as an event internally,
-        // so we bridge it to jQuery events the same way we do ordinary CodeMirror
-        // events.
-        this._codeMirror.setOption("onKeyEvent", function (instance, event) {
+        // Redispatch these CodeMirror key events as jQuery events
+        function _onKeyEvent(instance, event) {
             $(self).triggerHandler("keyEvent", [self, event]);
             return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
-        });
+        }
+        this._codeMirror.on("keydown",  _onKeyEvent);
+        this._codeMirror.on("keypress", _onKeyEvent);
+        this._codeMirror.on("keyup",    _onKeyEvent);
         
         // FUTURE: if this list grows longer, consider making this a more generic mapping
         // NOTE: change is a "private" event--others shouldn't listen to it on Editor, only on

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -257,8 +257,8 @@ define(function (require, exports, module) {
         $(this).on("cursorActivity", function (jqEvent, editor) {
             self._handleCursorActivity(jqEvent);
         });
-        $(this).on("keyEvent", function (jqEvent, editor, cmEvent) {
-            self._handleKeyEvents(cmEvent);
+        $(this).on("keypress", function (jqEvent, editor, cmEvent) {
+            self._handleKeypressEvents(cmEvent);
         });
         $(this).on("change", function (jqEvent, editor, changeList) {
             self._handleEditorChange(changeList);
@@ -332,24 +332,23 @@ define(function (require, exports, module) {
      * back-indenting it if so.
      */
     Editor.prototype._checkElectricChars = function (event) {
-        var instance = this._codeMirror;
-        if (event.type === "keypress") {
-            var keyStr = String.fromCharCode(event.which || event.keyCode);
-            if (/[\]\{\}\)]/.test(keyStr)) {
-                // If all text before the cursor is whitespace, auto-indent it
-                var cursor = this.getCursorPos();
-                var lineStr = instance.getLine(cursor.line);
-                var nonWS = lineStr.search(/\S/);
-                
-                if (nonWS === -1 || nonWS >= cursor.ch) {
-                    // Need to do the auto-indent on a timeout to ensure
-                    // the keypress is handled before auto-indenting.
-                    // This is the same timeout value used by the
-                    // electricChars feature in CodeMirror.
-                    window.setTimeout(function () {
-                        instance.indentLine(cursor.line);
-                    }, 75);
-                }
+        var instance = this._codeMirror,
+            keyStr = String.fromCharCode(event.which || event.keyCode);
+
+        if (/[\]\{\}\)]/.test(keyStr)) {
+            // If all text before the cursor is whitespace, auto-indent it
+            var cursor = this.getCursorPos();
+            var lineStr = instance.getLine(cursor.line);
+            var nonWS = lineStr.search(/\S/);
+
+            if (nonWS === -1 || nonWS >= cursor.ch) {
+                // Need to do the auto-indent on a timeout to ensure
+                // the keypress is handled before auto-indenting.
+                // This is the same timeout value used by the
+                // electricChars feature in CodeMirror.
+                window.setTimeout(function () {
+                    instance.indentLine(cursor.line);
+                }, 75);
             }
         }
     };
@@ -379,7 +378,7 @@ define(function (require, exports, module) {
      * Handle CodeMirror key events.
      * @param {!Event} event
      */
-    Editor.prototype._handleKeyEvents = function (event) {
+    Editor.prototype._handleKeypressEvents = function (event) {
         this._checkElectricChars(event);
     };
 
@@ -693,7 +692,8 @@ define(function (require, exports, module) {
         
         // Redispatch these CodeMirror key events as jQuery events
         function _onKeyEvent(instance, event) {
-            $(self).triggerHandler("keyEvent", [self, event]);
+            $(self).triggerHandler("keyEvent", [self, event]);  // deprecated
+            $(self).triggerHandler(event.type, [self, event]);
             return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
         }
         this._codeMirror.on("keydown",  _onKeyEvent);

--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -393,8 +393,8 @@ define(function (require, exports, module) {
      */
     function installListeners(editor) {
 
-        $(editor).on("keyEvent", function (jqEvent, editor, event) {
-            if (event.type === "keydown" && event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+        $(editor).on("keydown", function (jqEvent, editor, event) {
+            if (event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
                 dismissHint();
             }
         }).on("scroll", function () {

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -383,7 +383,7 @@ define(function (require, exports, module) {
             testToken = editor._codeMirror.getTokenAt(testPos, true);
 
         // Currently only support url. May be null if starting to type
-        if (ctx.token.className && ctx.token.className !== "string") {
+        if (ctx.token.type && ctx.token.type !== "string") {
             return createInfo();
         }
 
@@ -393,11 +393,11 @@ define(function (require, exports, module) {
         propValues[0] = backwardCtx.token.string;
 
         while (TokenUtils.movePrevToken(backwardCtx)) {
-            if (backwardCtx.token.className === "def" && backwardCtx.token.string === "@import") {
+            if (backwardCtx.token.type === "def" && backwardCtx.token.string === "@import") {
                 break;
             }
             
-            if (backwardCtx.token.className && backwardCtx.token.className !== "tag" && backwardCtx.token.string !== "url") {
+            if (backwardCtx.token.type && backwardCtx.token.type !== "tag" && backwardCtx.token.string !== "url") {
                 // Previous token may be white-space
                 // Otherwise, previous token may only be "url("
                 break;
@@ -407,7 +407,7 @@ define(function (require, exports, module) {
             offset += backwardCtx.token.string.length;
         }
         
-        if (backwardCtx.token.className !== "def" || backwardCtx.token.string !== "@import") {
+        if (backwardCtx.token.type !== "def" || backwardCtx.token.string !== "@import") {
             // Not in url
             return createInfo();
         }


### PR DESCRIPTION
This is for #6042, #6704 and unit tests for url hints and js parameter code hints.

Changes:
- `token.className` has been replaced with `token.type`.
- CodeMirror "onKeyEvent" option is no longer supported, so use separate key events.

cc @njx 
