### PR TITLE
Unit Tests: CSSUtils.getInfoAtPos() ignores prefixes

### DIFF
--- a/test/spec/CSSUtils-test-files/contexts.css
+++ b/test/spec/CSSUtils-test-files/contexts.css
@@ -63,6 +63,11 @@
     shape-inside: polygon(n{{108}}onzero, 0 0);
 }
 
+.prefixed{
+    -{{110}}webkit-transform: ;
+    t{{111}}ransform: ;
+}
+
 .nested-functional-notation {
     background: linear-gradient(to r{{109}}ight, rgba(255,255,0), #fff);
 }

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -2100,6 +2100,29 @@ define(function (require, exports, module) {
                 });
             });
             
+            it("should return unprefixed PROP_NAME", function () {
+                result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[111]);
+                expect(result).toEqual({
+                    context: CSSUtils.PROP_NAME,
+                    name: "transform",
+                    offset: 1,
+                    index: -1,
+                    values: [],
+                    isNewItem: false
+                });
+            });
+
+            it("should return prefixed PROP_NAME when inside a prefixed property name", function () {
+                result = CSSUtils.getInfoAtPos(testEditor, contextTest.offsets[110]);
+                expect(result).toEqual({
+                    context: CSSUtils.PROP_NAME,
+                    name: "-webkit-transform",
+                    offset: 1,
+                    index: -1,
+                    values: [],
+                    isNewItem: false
+                });
+            });
         });
         
         describe("quoting", function () {


### PR DESCRIPTION
Is there any reason to ignore prefixes in CSS properties? 

Any prefix-like notation is dropped (-webkit- or -xxx-) and the remainder is served as PROP_NAME. This yields false-positives for things like `-xxx-transform: value`. 

Attached test to highlight the issue.

This is for #6861
