### PR TITLE
Fix for remainder of #6676 (JSLint runs twice).

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -78,6 +78,8 @@ define(function (require, exports, module) {
         
         var options = prefs.get("options");
 
+        _lastRunOptions = _.clone(options);
+        
         if (!options) {
             options = {};
         } else {
@@ -98,8 +100,6 @@ define(function (require, exports, module) {
             options.browser = true;
         }
 
-        _lastRunOptions = _.clone(options);
-        
         var jslintResult = JSLINT(text, options);
         
         if (!jslintResult) {


### PR DESCRIPTION
This turned out to be caused by the addition of automatic indentation and browser
settings which were implicitly added to the options. When comparing the JSLint options,
we really want to look at what the user has set in their configuration file.

This is a fix for #6676.
