### PR TITLE
Temporary fix of issue #6781 hiding crucial files starting with a dot.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -95,9 +95,11 @@ define(function (require, exports, module) {
      * File and folder names which are not displayed or searched
      * TODO: We should add the rest of the file names that TAR excludes:
      *    http://www.gnu.org/software/tar/manual/html_section/exclude.html
+     * TODO: This should be user configurable
+     *    https://github.com/adobe/brackets/issues/6781
      * @type {RegExp}
      */
-    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitignore$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.cvsignore$|^\.gitattributes$|^\.hgtags$|^\.c9revisions|^\.SyncArchive|^\.SyncID|^\.SyncIgnore|^\.hgignore$|\~$/;
+    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.hgtags$|^\.c9revisions|^\.SyncArchive|^\.SyncID|^\.SyncIgnore|\~$/;
 
     /**
      * @private


### PR DESCRIPTION
Fix for #6781 

Followed the advise of njx and removed .gitignore, .gitattributes, .cvsignore, and .hgignore from the _exclusionListRegEx as a temporary fix until this becomes a user configurable feature.

Also added an extra TODO in the comments so  this will not be forgotten.
