### PR TITLE
Fix for issue #6452: Prevent reload commands from being repeated too quickly

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -81,6 +81,9 @@ define(function (require, exports, module) {
     /** @type {Number} index to use for next, new Untitled document */
     var _nextUntitledIndexToUse = 1;
     
+    /** @type {boolean} prevents reentrancy of browserReload() */
+    var _isReloading = false;
+    
     /** Unique token used to indicate user-driven cancellation of Save As (as opposed to file IO error) */
     var USER_CANCELED = { userCanceled: true };
     
@@ -1439,19 +1442,16 @@ define(function (require, exports, module) {
         return result.promise();
     }
     
-    /** @type {boolean} prevents reentrancy of browserReload() */
-    var isReloading = false;
-    
     /**
     * Does a full reload of the browser window
     * @param {string} href The url to reload into the window
     */
     function browserReload(href) {
-        if (isReloading) {
+        if (_isReloading) {
             return;
         }
         
-        isReloading = true;
+        _isReloading = true;
         
         return CommandManager.execute(Commands.FILE_CLOSE_ALL, { promptOnly: true }).done(function () {
             // Give everyone a chance to save their state - but don't let any problems block
@@ -1472,7 +1472,7 @@ define(function (require, exports, module) {
                 window.location.href = href;
             });
         }).fail(function () {
-            isReloading = false;
+            _isReloading = false;
         });
     }
     

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1438,12 +1438,21 @@ define(function (require, exports, module) {
          
         return result.promise();
     }
-        
+    
+    /** @type {boolean} prevents reentrancy of browserReload() */
+    var isReloading = false;
+    
     /**
     * Does a full reload of the browser window
     * @param {string} href The url to reload into the window
     */
     function browserReload(href) {
+        if (isReloading) {
+            return;
+        }
+        
+        isReloading = true;
+        
         return CommandManager.execute(Commands.FILE_CLOSE_ALL, { promptOnly: true }).done(function () {
             // Give everyone a chance to save their state - but don't let any problems block
             // us from quitting
@@ -1452,7 +1461,7 @@ define(function (require, exports, module) {
             } catch (ex) {
                 console.error(ex);
             }
-           
+            
             // Disable the cache to make reloads work
             _disableCache().always(function () {
                 // Remove all menus to assure every part of Brackets is reloaded
@@ -1462,6 +1471,8 @@ define(function (require, exports, module) {
                 
                 window.location.href = href;
             });
+        }).fail(function () {
+            isReloading = false;
         });
     }
     


### PR DESCRIPTION
Fix for issue #6452: Prevent reload commands from being repeated too quickly.
