### PR TITLE
Fix #6828. Bracketize Win paths returned by node.

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -248,7 +248,7 @@ define(function (require, exports, module) {
             // Download the bits (using Node since brackets-shell doesn't support binary file IO)
             var r = extensionManager.downloadFile(downloadId, urlInfo.url);
             r.done(function (result) {
-                d.resolve({ localPath: result, filenameHint: urlInfo.filenameHint });
+                d.resolve({ localPath: FileUtils.convertWindowsPathToUnixPath(result), filenameHint: urlInfo.filenameHint });
             }).fail(function (err) {
                 d.reject(err);
             });


### PR DESCRIPTION
This fixes #6828 the issue with node returning native windows path and Brackets treating them as "native". IMO, it makes sense to do so on editor side using routines designed for that instead of trying it on the node.
