### PR TITLE
Display current project title in main window

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
 
         // build shell/browser window title, e.g. "• file.html — Brackets"
         if (currentlyViewedPath) {
-            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath, windowTitle);
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath + " (" + _.escape(ProjectManager.getProjectRoot().name + ")"), windowTitle);
         }
         
         if (currentDoc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -71,11 +71,11 @@ define(function (require, exports, module) {
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     /** @type {string} The current project name; displayed in window title. Set to app_title to avoid split-second display of null */
-    var _projectName = brackets.config.app_title;
+    var _projectName = null;
     /** @type {string} String template for window title when no file is open. Use emdash on mac only. */
-    var WINDOW_TITLE_STRING_INIT = (brackets.platform !== "mac") ? "({0}) - {1}" : "({0}) \u2014 {1}";
+    var WINDOW_TITLE_STRING_NO_DOC = (brackets.platform !== "mac") ? "{0} - {1}" : "{0} \u2014 {1}";
     /** @type {string} String template for window title. */
-    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} ({1}) - {2}" : "{0} \u2014 {2}";
+    var WINDOW_TITLE_STRING_DOC = (brackets.platform !== "mac") ? "{0} ({1}) - {2}" : "{0} \u2014 {2}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -96,14 +96,6 @@ define(function (require, exports, module) {
     /** @type {function} JSLint workaround for circular dependency */
     var handleFileSaveAs;
 
-    /**
-     * @private
-     * Get the project root and insert into the global name space.
-     */
-    function _getProjectName() {
-       _projectName = ProjectManager.getProjectRoot().name;
-    }
-
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument(),
             currentlyViewedPath = EditorManager.getCurrentlyViewedPath(),
@@ -1600,7 +1592,9 @@ define(function (require, exports, module) {
     CommandManager.registerInternal(Commands.APP_RELOAD_WITHOUT_EXTS,   handleReloadWithoutExts);
     
     // Listen for changes that require updating the editor titlebar
-    $(ProjectManager).on("projectOpen", _getProjectName);
+    $(ProjectManager).on("projectOpen", function () {
+        _projectName = ProjectManager.getProjectRoot().name;
+    });
     $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
     $(DocumentManager).on("fileNameChange", updateDocumentTitle);
     $(EditorManager).on("currentlyViewedFileChange", updateDocumentTitle);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -72,6 +72,8 @@ define(function (require, exports, module) {
     var _currentTitlePath = null;
     /** @type {string} String template for window title. Use emdash on mac only. */
     var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} ({1}) - {2}" : "{0} \u2014 {2}";
+    /** @type {string} String template for window title when no file is open. Use emdash on mac only. */
+    var WINDOW_TITLE_STRING_INIT = (brackets.platform !== "mac") ? "({0}) - {1}" : "({0}) \u2014 {1}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;
@@ -95,7 +97,7 @@ define(function (require, exports, module) {
     function updateTitle() {
         var currentDoc = DocumentManager.getCurrentDocument(),
             currentlyViewedPath = EditorManager.getCurrentlyViewedPath(),
-            windowTitle = brackets.config.app_title;
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING_INIT, ProjectManager.getProjectRoot().name, brackets.config.app_title);
 
         if (!brackets.nativeMenus) {
             if (currentlyViewedPath) {
@@ -132,7 +134,7 @@ define(function (require, exports, module) {
 
         // build shell/browser window title, e.g. "• file.html (myProject) — Brackets"
         if (currentlyViewedPath) {
-            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath, ProjectManager.getProjectRoot().name, windowTitle);
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath, ProjectManager.getProjectRoot().name, brackets.config.app_title);
         }
         
         if (currentDoc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
                 _$dirtydot.css("visibility", "hidden");
             }
         
-            // Set _$titleWrapper to a fixed width just large enough to accomodate _$title. This seems equivalent to what
+            // Set _$titleWrapper to a fixed width just large enough to accommodate _$title. This seems equivalent to what
             // the browser would do automatically, but the CSS trick we use for layout requires _$titleWrapper to have a
             // fixed width set on it (see the "#titlebar" CSS rule for details).
             _$titleWrapper.css("width", "");
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
     function updateDocumentTitle() {
         var newDocument = DocumentManager.getCurrentDocument();
 
-        // TODO: This timer is causing a "Recursive tests with the same name are not supporte"
+        // TODO: This timer is causing a "Recursive tests with the same name are not supported"
         // exception. This code should be removed (if not needed), or updated with a unique
         // timer name (if needed).
         // var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
@@ -227,7 +227,7 @@ define(function (require, exports, module) {
                 // occurs on Mac since opening a non-text file always fails on Mac and triggers an error
                 // message that in turn calls _cleanup() after the user clicks OK in the message box.
                 // So we need to explicitly close the currently viewing image file whose filename is  
-                // no longer valid. Calling notifyPathDeleted will close the image vieer and then select 
+                // no longer valid. Calling notifyPathDeleted will close the image viewer and then select 
                 // the previously opened text file or show no-editor if none exists.
                 EditorManager.notifyPathDeleted(fullFilePath);
             } else {
@@ -431,7 +431,7 @@ define(function (require, exports, module) {
      * @private
      * Ensures the suggested file name doesn't already exit.
      * @param {Directory} dir  The directory to use
-     * @param {string} baseFileName  The base to start with, "-n" will get appened to make unique
+     * @param {string} baseFileName  The base to start with, "-n" will get appended to make unique
      * @param {boolean} isFolder True if the suggestion is for a folder name
      * @return {$.Promise} a jQuery promise that will be resolved with a unique name starting with
      *   the given base name
@@ -755,7 +755,7 @@ define(function (require, exports, module) {
             newFile = FileSystem.getFileForPath(path);
             
             // Save as warns you when you're about to overwrite a file, so we
-            // explictly allow "blind" writes to the filesystem in this case,
+            // explicitly allow "blind" writes to the filesystem in this case,
             // ignoring warnings about the contents being modified outside of
             // the editor.
             FileUtils.writeText(newFile, doc.getText(), true).done(function () {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
     /** @type {string} String template for window title. Use emdash on mac only. */
-    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} - {1}" : "{0} \u2014 {1}";
+    var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} ({1}) - {2}" : "{0} \u2014 {2}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;
@@ -130,9 +130,9 @@ define(function (require, exports, module) {
             }
         }
 
-        // build shell/browser window title, e.g. "• file.html — Brackets"
+        // build shell/browser window title, e.g. "• file.html (myProject) — Brackets"
         if (currentlyViewedPath) {
-            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath + " (" + ProjectManager.getProjectRoot().name + ")", windowTitle);
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath, ProjectManager.getProjectRoot().name, windowTitle);
         }
         
         if (currentDoc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
 
         // build shell/browser window title, e.g. "• file.html — Brackets"
         if (currentlyViewedPath) {
-            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath + " (" + _.escape(ProjectManager.getProjectRoot().name + ")"), windowTitle);
+            windowTitle = StringUtils.format(WINDOW_TITLE_STRING, _currentTitlePath + " (" + ProjectManager.getProjectRoot().name + ")", windowTitle);
         }
         
         if (currentDoc) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -70,10 +70,10 @@ define(function (require, exports, module) {
     var _$titleWrapper = null;
     /** @type {string} Label shown above editor for current document: filename and potentially some of its path */
     var _currentTitlePath = null;
+    /** @type {string} String template for window title when no file is open. */
+    var WINDOW_TITLE_STRING_INIT = (brackets.platform !== "mac") ? "({0}) - {1}" : "({0}) \u2014 {1}";
     /** @type {string} String template for window title. Use emdash on mac only. */
     var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} ({1}) - {2}" : "{0} \u2014 {2}";
-    /** @type {string} String template for window title when no file is open. Use emdash on mac only. */
-    var WINDOW_TITLE_STRING_INIT = (brackets.platform !== "mac") ? "({0}) - {1}" : "({0}) \u2014 {1}";
     
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -609,7 +609,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.document.title).toBe(brackets.config.app_title);
+                    expect(testWindow.document.title).toBe("({0}) - " + brackets.config.app_title);
                 });
             });
 
@@ -625,7 +625,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.document.title).toBe(brackets.config.app_title);
+                    expect(testWindow.document.title).toBe("({0}) - " + brackets.config.app_title);
                 });
             });
         });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -40,8 +40,7 @@ define(function (require, exports, module) {
         SpecRunnerUtils          = require("spec/SpecRunnerUtils"),
         FileUtils                = require("file/FileUtils"),
         StringUtils              = require("utils/StringUtils"),
-        Editor                   = require("editor/Editor"),
-        ProjectManager           = require("project/ProjectManager");
+        Editor                   = require("editor/Editor");
                     
     
     describe("DocumentCommandHandlers", function () {
@@ -609,7 +608,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.document.title).toBe("({0}) - " + brackets.config.app_title);
+                    expect(testWindow.document.title).toBe("DocumentCommandHandlers-test-files - " + brackets.config.app_title);
                 });
             });
 
@@ -625,7 +624,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "FILE_CLOSE");
                 });
                 runs(function () {
-                    expect(testWindow.document.title).toBe("({0}) - " + brackets.config.app_title);
+                    expect(testWindow.document.title).toBe("(DocumentCommandHandlers-test-files) - " + brackets.config.app_title);
                 });
             });
         });
@@ -931,8 +930,8 @@ define(function (require, exports, module) {
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
                     
                     // verify no dot in titlebar
-                    var expectedTitleClean = (brackets.platform !== "mac" ? ("test.js — ({0}) - {1}") : ("test.js - ({0}) - {1}"));
-                    var expectedTitle = StringUtils.format(expectedTitleClean, ProjectManager.getProjectRoot().name, brackets.config.app_title);
+                    var expectedTitleClean = (brackets.platform !== "mac" ? ("test.js — (DocumentCommandHandlers-test-files) - {0}") : ("test.js - (DocumentCommandHandlers-test-files) - {0}"));
+                    var expectedTitle = StringUtils.format(expectedTitleClean, brackets.config.app_title);
                     expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });
@@ -948,8 +947,8 @@ define(function (require, exports, module) {
                     expect(doc.isDirty).toBe(true);
                     
                     // verify dot in titlebar
-                    var expectedTitleDirty = (brackets.platform !== "mac" ? ("• test.js — ({0}) - {1}") : ("• test.js - ({0}) - {1}"));
-                    var expectedTitle = StringUtils.format(expectedTitleDirty, ProjectManager.getProjectRoot().name, brackets.config.app_title);
+                    var expectedTitleDirty = (brackets.platform !== "mac" ? ("• test.js — (DocumentCommandHandlers-test-files) - {0}") : ("• test.js - (DocumentCommandHandlers-test-files) - {0}"));
+                    var expectedTitle = StringUtils.format(expectedTitleDirty, brackets.config.app_title);
                     expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
         SpecRunnerUtils          = require("spec/SpecRunnerUtils"),
         FileUtils                = require("file/FileUtils"),
         StringUtils              = require("utils/StringUtils"),
-        Editor                   = require("editor/Editor");
+        Editor                   = require("editor/Editor"),
+        ProjectManager           = require("project/ProjectManager");
                     
     
     describe("DocumentCommandHandlers", function () {
@@ -930,7 +931,8 @@ define(function (require, exports, module) {
                     expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
                     
                     // verify no dot in titlebar
-                    var expectedTitle = (brackets.platform === "mac" ? ("test.js — " + brackets.config.app_title) : ("test.js - " + brackets.config.app_title));
+                    var expectedTitleClean = (brackets.platform !== "mac" ? ("test.js — ({0}) - {1}") : ("test.js - ({0}) - {1}"));
+                    var expectedTitle = StringUtils.format(expectedTitleClean, ProjectManager.getProjectRoot().name, brackets.config.app_title);
                     expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });
@@ -946,7 +948,8 @@ define(function (require, exports, module) {
                     expect(doc.isDirty).toBe(true);
                     
                     // verify dot in titlebar
-                    var expectedTitle = (brackets.platform === "mac" ? ("• test.js — " + brackets.config.app_title) : ("• test.js - " + brackets.config.app_title));
+                    var expectedTitleDirty = (brackets.platform !== "mac" ? ("• test.js — ({0}) - {1}") : ("• test.js - ({0}) - {1}"));
+                    var expectedTitle = StringUtils.format(expectedTitleDirty, ProjectManager.getProjectRoot().name, brackets.config.app_title);
                     expect(testWindow.document.title).toBe(expectedTitle);
                 });
             });


### PR DESCRIPTION
I was feeling adventurous, so I grabbed a copy of the Brackets source and worked on #2281. Jasmine tests are currently running but _appear_ to be all good. For some reason, comma separating the code always broke the window title completely, so I had to 
concentrate it to `_currentTitlePath`.
