### PR TITLE
Fix cursor in nested editor

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -187,10 +187,10 @@
         color: @accent-bracket !important;
     }
 
-    .CodeMirror .CodeMirror-cursor {
+    .CodeMirror .CodeMirror-cursors {
         visibility: hidden;
     }
-    .CodeMirror.CodeMirror-focused .CodeMirror-cursor {
+    .CodeMirror.CodeMirror-focused .CodeMirror-cursors {
         visibility: visible;
     }
     


### PR DESCRIPTION
This is for #6755. A new `CodeMirror-cursors` class was added.

cc @njx 
