### PR TITLE
expose server baseUrl in LiveDevelopment

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1347,6 +1347,10 @@ define(function LiveDevelopment(require, exports, module) {
         return _server;
     }
 
+    function getServerBaseUrl() {
+        return _server.getBaseUrl();
+    }
+
     // For unit testing
     exports.launcherUrl               = launcherUrl;
     exports._getServer                = _getServer;
@@ -1365,4 +1369,5 @@ define(function LiveDevelopment(require, exports, module) {
     exports.redrawHighlight     = redrawHighlight;
     exports.init                = init;
     exports.getCurrentProjectServerConfig = getCurrentProjectServerConfig;
+    exports.getServerBaseUrl    = getServerBaseUrl;
 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1348,7 +1348,7 @@ define(function LiveDevelopment(require, exports, module) {
     }
 
     function getServerBaseUrl() {
-        return _server.getBaseUrl();
+        return _server && _server.getBaseUrl();
     }
 
     // For unit testing


### PR DESCRIPTION
No use case at this time to expose the whole server.
