### PR TITLE
Remove lineComment from JSON

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -79,8 +79,7 @@
     "json": {
         "name": "JSON",
         "mode": ["javascript", "application/json"],
-        "fileExtensions": ["json"],
-        "lineComment": ["//"]
+        "fileExtensions": ["json"]
     },
 
     "xml": {


### PR DESCRIPTION
According to multiple sources (https://plus.google.com/+DouglasCrockfordEsq/posts/RK8qyGVaGSr, http://stackoverflow.com/questions/244777/can-i-comment-a-json-file, http://fadefade.com/json-comments.html and http://zehfernando.com/2013/commenting-json-files/), there is no possibility to add (line) comments to a json file.
So we should consider removing the lineComment `//` from JSON.
