### PR TITLE
Removing space character from secondary trigger keys for CSS code hints.

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
      */
     function CssPropHints() {
         this.primaryTriggerKeys = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-()";
-        this.secondaryTriggerKeys = ": ";
+        this.secondaryTriggerKeys = ":";
         this.exclusion = null;
     }
 


### PR DESCRIPTION
This reverts an incorrect change in pull request #6317 and fixes issues #6867 and #6675.
