### PR TITLE
Removes the Browse Extensions button in the default configuration.

### DIFF
--- a/src/brackets.config.json
+++ b/src/brackets.config.json
@@ -13,7 +13,7 @@
         "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
         "twitter_name"      : "@brackets",
         "contributors_url"  : "https://api.github.com/repos/adobe/brackets/contributors",
-        "extension_wiki_url": "https://github.com/adobe/brackets/wiki/Brackets-Extensions",
+        "extension_wiki_url": "",
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url"     : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default" : true

--- a/src/brackets.config.json
+++ b/src/brackets.config.json
@@ -1,21 +1,21 @@
 {
     "config"                :
     {
-        "app_title"         : "Brackets",
-        "app_name_about"    : "Brackets",
-        "about_icon"        : "styles/images/brackets_icon.svg",
-        "update_info_url"   : "http://dev.brackets.io/updates/stable/",
-        "how_to_use_url"    : "https://github.com/adobe/brackets/wiki/How-to-Use-Brackets",
-        "forum_url"         : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev",
-        "release_notes_url" : "https://github.com/adobe/brackets/wiki/Release-Notes",
-        "report_issue_url"  : "https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue",
-        "twitter_url"       : "https://twitter.com/brackets",
-        "troubleshoot_url"  : "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
-        "twitter_name"      : "@brackets",
-        "contributors_url"  : "https://api.github.com/repos/adobe/brackets/contributors",
-        "extension_wiki_url": "",
-        "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
-        "extension_url"     : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
+        "app_title"                  : "Brackets",
+        "app_name_about"             : "Brackets",
+        "about_icon"                 : "styles/images/brackets_icon.svg",
+        "update_info_url"            : "http://dev.brackets.io/updates/stable/",
+        "how_to_use_url"             : "https://github.com/adobe/brackets/wiki/How-to-Use-Brackets",
+        "forum_url"                  : "https://groups.google.com/forum/?fromgroups#!forum/brackets-dev",
+        "release_notes_url"          : "https://github.com/adobe/brackets/wiki/Release-Notes",
+        "report_issue_url"           : "https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue",
+        "twitter_url"                : "https://twitter.com/brackets",
+        "troubleshoot_url"           : "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
+        "twitter_name"               : "@brackets",
+        "contributors_url"           : "https://api.github.com/repos/adobe/brackets/contributors",
+        "extension_listing_url"      : "",
+        "extension_registry"         : "https://s3.amazonaws.com/extend.brackets/registry.json",
+        "extension_url"              : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default" : true
     }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -12,7 +12,7 @@
         "troubleshoot_url": "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
         "twitter_name": "@brackets",
         "contributors_url": "https://api.github.com/repos/adobe/brackets/contributors",
-        "extension_wiki_url": "",
+        "extension_listing_url": "",
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true

--- a/src/config.json
+++ b/src/config.json
@@ -12,7 +12,7 @@
         "troubleshoot_url": "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
         "twitter_name": "@brackets",
         "contributors_url": "https://api.github.com/repos/adobe/brackets/contributors",
-        "extension_wiki_url": "https://github.com/adobe/brackets/wiki/Brackets-Extensions",
+        "extension_wiki_url": "",
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -332,7 +332,8 @@ define(function (require, exports, module) {
 
         var context = {
             Strings: Strings,
-            isUpdate: this._isUpdate
+            isUpdate: this._isUpdate,
+            includeBrowseExtensions: !!brackets.config.extension_wiki_url
         };
         
         // We ignore the promise returned by showModalDialogUsingTemplate, since we're managing the 

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -333,7 +333,7 @@ define(function (require, exports, module) {
         var context = {
             Strings: Strings,
             isUpdate: this._isUpdate,
-            includeBrowseExtensions: !!brackets.config.extension_wiki_url
+            includeBrowseExtensions: !!brackets.config.extension_listing_url
         };
         
         // We ignore the promise returned by showModalDialogUsingTemplate, since we're managing the 
@@ -353,7 +353,7 @@ define(function (require, exports, module) {
         this.$cancelButton.on("click", this._handleCancel.bind(this));
         this.$url.on("input", this._handleUrlInput.bind(this));
         this.$browseExtensionsButton.on("click", function () {
-            NativeApp.openURLInDefaultBrowser(brackets.config.extension_wiki_url);
+            NativeApp.openURLInDefaultBrowser(brackets.config.extension_listing_url);
         });
         $(document.body).on("keyup.installDialog", this._handleKeyUp.bind(this));
         

--- a/src/htmlContent/install-extension-dialog.html
+++ b/src/htmlContent/install-extension-dialog.html
@@ -14,7 +14,7 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button class="btn left browse-extensions">{{Strings.BROWSE_EXTENSIONS}}</button>
+        {{#includeBrowseExtensions}}<button class="btn left browse-extensions">{{Strings.BROWSE_EXTENSIONS}}</button>{{/includeBrowseExtensions}}
         <button class="dialog-button btn" data-button-id="cancel">{{Strings.CANCEL}}</button>
         <button class="dialog-button btn primary" data-button-id="ok" disabled>{{Strings.INSTALL}}</button>
     </div>

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -36,8 +36,7 @@ define(function (require, exports, module) {
 
     describe("Install Extension Dialog", function () {
         var testWindow, dialog, fields, goodInstaller, badInstaller, closed,
-            url = "http://brackets.io/extensions/myextension.zip",
-            oldExtensionWikiURL = brackets.config.extension_wiki_url;
+            url = "http://brackets.io/extensions/myextension.zip";
         
         this.category = "integration";
         
@@ -55,7 +54,7 @@ define(function (require, exports, module) {
         });
 
         afterEach(function () {
-            testWindow.brackets.config.extension_wiki_url = oldExtensionWikiURL;
+            testWindow.brackets.config.extension_listing_url = brackets.config.extension_listing_url;
             runs(function () {
                 if (dialog) {
                     dialog._close();
@@ -99,8 +98,10 @@ define(function (require, exports, module) {
         
         describe("with Browse Extensions enabled", function () {
             it("should open the extension list wiki page when the user clicks on the Browse Extensions button", function () {
-                var extensionWikiURL = "https://github.com/adobe/brackets/wiki/Brackets-Extensions";
-                testWindow.brackets.config.extension_wiki_url = extensionWikiURL;
+                // Set the extension_listing_url in the configuration so that the button will
+                // show up.
+                var extensionListingURL = "https://github.com/adobe/brackets/wiki/Brackets-Extensions";
+                testWindow.brackets.config.extension_listing_url = extensionListingURL;
                 
                 dialog = new testWindow.brackets.test.InstallExtensionDialog._Dialog();
                 dialog.show()
@@ -115,7 +116,7 @@ define(function (require, exports, module) {
                 var NativeApp = testWindow.brackets.getModule("utils/NativeApp");
                 spyOn(NativeApp, "openURLInDefaultBrowser");
                 fields.$browseExtensionsButton.click();
-                expect(NativeApp.openURLInDefaultBrowser).toHaveBeenCalledWith(extensionWikiURL);
+                expect(NativeApp.openURLInDefaultBrowser).toHaveBeenCalledWith(extensionListingURL);
             });
         });
         


### PR DESCRIPTION
This is a fix for #6800. If the extension_wiki_url configuration option is not
set, the Browse Extensions button will not be displayed. In the default Brackets
configuration, this value is no longer set.
