### PR TITLE
Add proxy support for extension installation.

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -37,7 +37,10 @@ define(function (require, exports, module) {
         StringUtils          = require("utils/StringUtils"),
         Strings              = require("strings"),
         ExtensionLoader      = require("utils/ExtensionLoader"),
-        NodeConnection       = require("utils/NodeConnection");
+        NodeConnection       = require("utils/NodeConnection"),
+        PreferencesManager   = require("preferences/PreferencesManager");
+    
+    PreferencesManager.definePreference("proxy", "string");
     
     var Errors = {
         ERROR_LOADING: "ERROR_LOADING",
@@ -246,7 +249,7 @@ define(function (require, exports, module) {
             }
             
             // Download the bits (using Node since brackets-shell doesn't support binary file IO)
-            var r = extensionManager.downloadFile(downloadId, urlInfo.url);
+            var r = extensionManager.downloadFile(downloadId, urlInfo.url, PreferencesManager.get("proxy"));
             r.done(function (result) {
                 d.resolve({ localPath: result, filenameHint: urlInfo.filenameHint });
             }).fail(function (err) {

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -379,7 +379,13 @@ function _endDownload(downloadId, error) {
 /**
  * Implements "downloadFile" command, asynchronously.
  */
-function _cmdDownloadFile(downloadId, url, callback) {
+function _cmdDownloadFile(downloadId, url, proxy, callback) {
+    // Backwards compatibility check, added in 0.37
+    if (typeof proxy === "function") {
+        callback = proxy;
+        proxy = undefined;
+    }
+    
     if (pendingDownloads[downloadId]) {
         callback(Errors.DOWNLOAD_ID_IN_USE, null);
         return;
@@ -387,7 +393,8 @@ function _cmdDownloadFile(downloadId, url, callback) {
     
     var req = request.get({
         url: url,
-        encoding: null
+        encoding: null,
+        proxy: proxy
     },
         // Note: we could use the traditional "response"/"data"/"end" events too if we wanted to stream data
         // incrementally, limit download size, etc. - but the simple callback is good enough for our needs.
@@ -593,6 +600,10 @@ function init(domainManager) {
             name: "url",
             type: "string",
             description: "URL to download from"
+        }, {
+            name: "proxy",
+            type: "string",
+            description: "optional proxy URL"
         }],
         {
             type: "string",


### PR DESCRIPTION
Configurable via a "proxy" preference (which could be used for other parts of
Brackets that should use HTTP proxy).

This fixes #6241, #5958 and [this backlog item](https://trello.com/c/SEV95fdK/902-support-for-a-proxy-in-extensions-installation)
