### PR TITLE
Restore focus after altering inline widget

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1543,7 +1543,16 @@ define(function (require, exports, module) {
         function updateHeight() {
             // Notify CodeMirror for the height change.
             if (isAttached) {
+                var focused = window.document.activeElement;
+
                 inlineWidget.info.changed();
+
+                // From CodeMirror function updateDisplayInner():
+                // There might have been a widget with a focused element
+                // in the hidden nodes, if so re-focus it.
+                if (focused && window.document.activeElement !== focused && focused.offsetHeight) {
+                    focused.focus();
+                }
             }
         }
         


### PR DESCRIPTION
cc @njx - this is for #6767.

**Note** that we may not want to take this fix in this form, but it illustrates problem.

I trapped this issue by changing this code (InlineTextEditor.js line 182):

```
        if (this.editor) {
            this.editor.focus();
        }
```

to:

```
        if (this.editor) {
            this.editor._codeMirror.on("blur", function () {
                console.log("blurred...");   // put BREAKPOINT HERE
            });
            this.editor.focus();
        }
```

When you hit that breakpoint and look at the callstack at CodeMirror function updateDisplayInner(), you can see it's doing something similar, so this seems to be a known issue. Maybe that code needs to be fixed?
