### PR TITLE
Handle code completion correctly with auto close braces on.

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -169,13 +169,6 @@ define(function (require, exports, module) {
     CodeHintList.prototype.removePendingText = function (text) {
         if (this.pendingText.indexOf(text) === 0) {
             this.pendingText = this.pendingText.slice(text.length);
-        } else if (text.indexOf(this.pendingText) === 0) {
-            // We get here if this.pendingText is a substring of text.
-            // This can happen when some extra characters are auto appended 
-            // by some features like auto close braces. 
-            // See https://github.com/adobe/brackets/issues/6345#issuecomment-32548064
-            // as an example of this scenario.
-            this.pendingText = "";
         }
     };
 

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -169,6 +169,13 @@ define(function (require, exports, module) {
     CodeHintList.prototype.removePendingText = function (text) {
         if (this.pendingText.indexOf(text) === 0) {
             this.pendingText = this.pendingText.slice(text.length);
+        } else if (text.indexOf(this.pendingText) === 0) {
+            // We get here if this.pendingText is a substring of text.
+            // This can happen when some extra characters are auto appended 
+            // by some features like auto close braces. 
+            // See https://github.com/adobe/brackets/issues/6345#issuecomment-32548064
+            // as an example of this scenario.
+            this.pendingText = "";
         }
     };
 

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -590,11 +590,21 @@ define(function (require, exports, module) {
 
             // Pending Text is used in hintList._keydownHook()
             if (hintList && changeList.text.length && changeList.text[0].length) {
-                hintList.removePendingText(changeList.text[0]);
+                var expectedLength = editor.getCursorPos().ch - changeList.from.ch,
+                    newText = changeList.text[0];
+                // We may get extra text in newText since some features like auto 
+                // close braces can append some text automatically.
+                // See https://github.com/adobe/brackets/issues/6345#issuecomment-32548064
+                // as an example of this scenario.
+                if (newText.length > expectedLength) {
+                    // Strip off the extra text before calling removePendingText.
+                    newText = newText.substr(0, expectedLength);
+                }
+                hintList.removePendingText(newText);
             }
         }
     }
-
+    
     /**
      * Test whether the provider has an exclusion that is still the same as text after the cursor.
      *


### PR DESCRIPTION
This fixes the scenario described in @TomMalbran's [comment](https://github.com/adobe/brackets/issues/6345#issuecomment-32548064) in issue #6345.

@redmunds Can you review this?
