### PR TITLE
[cmv4] Make more edit ops work with multiple selections

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1074,51 +1074,6 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Utility function that takes a list of selection ranges as returned by `setSelections()` and
-     * expands them to encompass whole lines, merging selections as necessary and preserving the
-     * primary selection.
-     * @param {!Array<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean}>} selections
-     *     A list of selections as returned by `setSelections()`. Expected to be sorted and non-overlapping.
-     * @return {Array<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean}>}}
-     *     The expanded selections. Also guaranteed to be sorted and non-overlapping.
-     */
-    Editor.prototype.expandSelectionsToLines = function (selections) {
-        var self = this, result = [], last;
-        _.each(selections, function (sel) {
-            var from = {line: sel.start.line, ch: 0};
-            var to   = {line: sel.end.line + 1, ch: 0};
-
-            if (to.line === self.getLastVisibleLine() + 1) {
-                // Last line: select to end of line instead of start of (hidden/nonexistent) following line,
-                // which due to how CM clips coords would only work some of the time
-                to.line -= 1;
-                to.ch = self.document.getLine(to.line).length;
-            }
-            
-            var newSel = {start: from, end: to, primary: sel.primary, reversed: sel.reversed};
-            if (last) {
-                if (self.posWithinRange(newSel.start, last.start, last.end, true)) {
-                    if (!self.posWithinRange(newSel.end, last.start, last.end, true)) {
-                        // Extend the last selection to include this one.
-                        last.end = newSel.end;
-                    }
-                    // If this was primary, make the selection it was merged into primary.
-                    if (newSel.primary) {
-                        last.primary = true;
-                    }
-                    // We can throw away this selection now since it was merged (partially or fully) into the last one.
-                    newSel = null;
-                }
-            }
-            if (newSel) {
-                result.push(newSel);
-                last = newSel;
-            }
-        });
-        return result;
-    };
-    
-    /**
      * Adjusts a given position taking a given replaceRange-type edit into account. 
      * If the position is within the edit range (start exclusive, end inclusive),
      * it gets pushed to the end. Otherwise, if it's after the edit, it gets adjusted

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -120,8 +120,10 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Add or remove line-comment tokens to all the lines in the selected range, preserving selection
-     * and cursor position. Applies to currently focused Editor.
+     * @private
+     * Generates an edit that adds or remove line-comment tokens to all the lines in the selected range,
+     * preserving selection and cursor position. Applies to currently focused Editor. The given selection
+     * must already be a line selection in the form returned by `Editor.convertToLineSelections()`.
      * 
      * If all non-whitespace lines are already commented out, then we uncomment; otherwise we comment
      * out. Commenting out adds the prefix at column 0 of every line. Uncommenting removes the first prefix
@@ -129,74 +131,72 @@ define(function (require, exports, module) {
      *
      * @param {!Editor} editor
      * @param {!Array.<string>} prefixes, e.g. ["//"]
+     * @param {!Editor} editor The editor to edit within.
+     * @param {!{selectionForEdit: {start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}, 
+     *           selectionsToTrack: Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}>}}
+     *      lineSel A line selection as returned from `Editor.convertToLineSelections()`. `selectionForEdit` is the selection to perform
+     *      the line comment operation on, and `selectionsToTrack` are a set of selections associated with this line that need to be
+     *      tracked through the edit.
+     * @return {{edit: {text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}|Array.<{text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}>,
+     *                  selection: {start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}|Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}}
+     *      An edit description suitable for including in the edits array passed to `Editor.doMultipleEdits()`.
      */
-    function lineCommentPrefix(editor, prefixes) {
-        var doc            = editor.document,
-            // Don't merge adjacent line selections - we want to toggle separate cursors independently
-            lineSelections = editor.convertToLineSelections(editor.getSelections(), { mergeAdjacent: false }),
-            lineExp        = _createLineExpressions(prefixes),
-            edits          = [];
-        
-        _.each(lineSelections, function (lineSel) {
-            var sel         = lineSel.selectionForEdit,
-                trackedSels = lineSel.selectionsToTrack,
-                startLine   = sel.start.line,
-                endLine     = sel.end.line,
-                editGroup   = [];
+    function _getLineCommentPrefixEdit(editor, prefixes, lineSel) {
+        var doc         = editor.document,
+            sel         = lineSel.selectionForEdit,
+            trackedSels = lineSel.selectionsToTrack,
+            lineExp     = _createLineExpressions(prefixes),
+            startLine   = sel.start.line,
+            endLine     = sel.end.line,
+            editGroup   = [];
 
-            // Is a range of text selected? (vs just an insertion pt)
-            var hasSelection = (startLine !== endLine) || (sel.start.ch !== sel.end.ch);
+        // In full-line selection, cursor pos is start of next line - but don't want to modify that line
+        if (sel.end.ch === 0) {
+            endLine--;
+        }
 
-            // In full-line selection, cursor pos is start of next line - but don't want to modify that line
-            if (sel.end.ch === 0 && hasSelection) {
-                endLine--;
+        // Decide if we're commenting vs. un-commenting
+        // Are there any non-blank lines that aren't commented out? (We ignore blank lines because
+        // some editors like Sublime don't comment them out)
+        var containsUncommented = _containsUncommented(editor, startLine, endLine, lineExp);
+        var i;
+        var line;
+        var prefix;
+        var commentI;
+        var updateSelection = false;
+
+        if (containsUncommented) {
+            // Comment out - prepend the first prefix to each line
+            for (i = startLine; i <= endLine; i++) {
+                editGroup.push({text: prefixes[0], start: {line: i, ch: 0}});
             }
 
-            // Decide if we're commenting vs. un-commenting
-            // Are there any non-blank lines that aren't commented out? (We ignore blank lines because
-            // some editors like Sublime don't comment them out)
-            var containsUncommented = _containsUncommented(editor, startLine, endLine, lineExp);
-            var i;
-            var line;
-            var prefix;
-            var commentI;
-            var updateSelection = false;
-
-            if (containsUncommented) {
-                // Comment out - prepend the first prefix to each line
-                for (i = startLine; i <= endLine; i++) {
-                    editGroup.push({text: prefixes[0], start: {line: i, ch: 0}});
-                }
-                
-                // Make sure tracked selections include the prefix that was added at start of range
-                _.each(trackedSels, function (trackedSel) {
-                    if (trackedSel.start.ch === 0 && CodeMirror.cmpPos(trackedSel.start, trackedSel.end) !== 0) {
-                        trackedSel.start = {line: trackedSel.start.line, ch: 0};
-                        trackedSel.end = {line: trackedSel.end.line, ch: (trackedSel.end.line === endLine ? trackedSel.end.ch + prefixes[0].length : 0)};
-                    } else {
-                        trackedSel.isBeforeEdit = true;
-                    }
-                });
-            } else {
-                // Uncomment - remove the prefix on each line (if any)
-                for (i = startLine; i <= endLine; i++) {
-                    line   = doc.getLine(i);
-                    prefix = _getLinePrefix(line, lineExp, prefixes);
-
-                    if (prefix) {
-                        commentI = line.indexOf(prefix);
-                        editGroup.push({text: "", start: {line: i, ch: commentI}, end: {line: i, ch: commentI + prefix.length}});
-                    }
-                }
-                _.each(trackedSels, function (trackedSel) {
+            // Make sure tracked selections include the prefix that was added at start of range
+            _.each(trackedSels, function (trackedSel) {
+                if (trackedSel.start.ch === 0 && CodeMirror.cmpPos(trackedSel.start, trackedSel.end) !== 0) {
+                    trackedSel.start = {line: trackedSel.start.line, ch: 0};
+                    trackedSel.end = {line: trackedSel.end.line, ch: (trackedSel.end.line === endLine ? trackedSel.end.ch + prefixes[0].length : 0)};
+                } else {
                     trackedSel.isBeforeEdit = true;
-                });
+                }
+            });
+        } else {
+            // Uncomment - remove the prefix on each line (if any)
+            for (i = startLine; i <= endLine; i++) {
+                line   = doc.getLine(i);
+                prefix = _getLinePrefix(line, lineExp, prefixes);
+
+                if (prefix) {
+                    commentI = line.indexOf(prefix);
+                    editGroup.push({text: "", start: {line: i, ch: commentI}, end: {line: i, ch: commentI + prefix.length}});
+                }
             }
-            edits.push({edit: editGroup, selection: trackedSels});
-        });
-        editor.setSelections(editor.doMultipleEdits(edits));
+            _.each(trackedSels, function (trackedSel) {
+                trackedSel.isBeforeEdit = true;
+            });
+        }
+        return {edit: editGroup, selection: trackedSels};
     }
-    
     
     /**
      * @private
@@ -254,7 +254,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Add or remove block-comment tokens to the selection, preserving selection
+     * Generates an edit that adds or removes block-comment tokens to the selection, preserving selection
      * and cursor position. Applies to the currently focused Editor.
      * 
      * If the selection is inside a block-comment or one block-comment is inside or partially
@@ -262,19 +262,25 @@ define(function (require, exports, module) {
      * Commenting out adds the prefix before the selection and the suffix after.
      * Uncommenting removes them.
      * 
-     * If slashComment is true and the start or end of the selection is inside a line-comment it 
-     * will try to do a line uncomment if is not actually inside a bigger block comment and all
-     * the lines in the selection are line-commented.
+     * As a special case, if slashComment is true and the start or end of the selection is inside a 
+     * line-comment it needs to do a line uncomment if is not actually inside a bigger block comment and all
+     * the lines in the selection are line-commented. In this case, we return null to indicate to the caller
+     * that it needs to handle this selection as a line comment.
      *
      * @param {!Editor} editor
      * @param {!string} prefix, e.g. "<!--"
      * @param {!string} suffix, e.g. "-->"
      * @param {!Array.<string>} linePrefixes, e.g. ["//"]
+     * @param {!{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}} sel
+     *      The selection to block comment/uncomment.
+     * @param {?Array.<{!{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}}>} selectionsToTrack
+     *      An array of selections that should be tracked through this edit.
+     * @return {{edit: {text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}|Array.<{text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}>,
+     *                  selection: {start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}|Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}}
+     *      An edit description suitable for including in the edits array passed to `Editor.doMultipleEdits()`.
      */
-    function blockCommentPrefixSuffix(editor, prefix, suffix, linePrefixes) {
-        
+    function _getBlockCommentPrefixSuffixEdit(editor, prefix, suffix, linePrefixes, sel, selectionsToTrack) {
         var doc            = editor.document,
-            sel            = editor.getSelection(),
             ctx            = TokenUtils.getInitialContext(editor._codeMirror, {line: sel.start.line, ch: sel.start.ch}),
             startCtx       = TokenUtils.getInitialContext(editor._codeMirror, {line: sel.start.line, ch: sel.start.ch}),
             endCtx         = TokenUtils.getInitialContext(editor._codeMirror, {line: sel.end.line, ch: sel.end.ch}),
@@ -286,41 +292,47 @@ define(function (require, exports, module) {
             canComment     = false,
             invalidComment = false,
             lineUncomment  = false,
-            newSelection;
+            editGroup      = [],
+            edit;
         
+        if (!selectionsToTrack) {
+            // Track the original selection.
+            selectionsToTrack = [_.cloneDeep(sel)];
+        }
+
         var result, text, line;
-        
+
         // Move the context to the first non-empty token.
         if (!ctx.token.type && ctx.token.string.trim().length === 0) {
             result = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx);
         }
-        
+
         // Check if we should just do a line uncomment (if all lines in the selection are commented).
         if (lineExp.length && (_matchExpressions(ctx.token.string, lineExp) || _matchExpressions(endCtx.token.string, lineExp))) {
             var startCtxIndex = editor.indexFromPos({line: ctx.pos.line, ch: ctx.token.start});
             var endCtxIndex   = editor.indexFromPos({line: endCtx.pos.line, ch: endCtx.token.start + endCtx.token.string.length});
-            
+
             // Find if we aren't actually inside a block-comment
             result = true;
             while (result && _matchExpressions(ctx.token.string, lineExp)) {
                 result = TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, ctx);
             }
-            
+
             // If we aren't in a block-comment.
             if (!result || ctx.token.type !== "comment" || ctx.token.string.match(suffixExp)) {
                 // Is a range of text selected? (vs just an insertion pt)
                 var hasSelection = (sel.start.line !== sel.end.line) || (sel.start.ch !== sel.end.ch);
-                
+
                 // In full-line selection, cursor pos is start of next line - but don't want to modify that line
                 var endLine = sel.end.line;
                 if (sel.end.ch === 0 && hasSelection) {
                     endLine--;
                 }
-                
+
                 // Find if all the lines are line-commented.
                 if (!_containsUncommented(editor, sel.start.line, endLine, lineExp)) {
                     lineUncomment = true;
-                
+
                 // Block-comment in all the other cases
                 } else {
                     canComment = true;
@@ -329,34 +341,34 @@ define(function (require, exports, module) {
                 prefixPos = _findCommentStart(startCtx, prefixExp);
                 suffixPos = _findCommentEnd(startCtx, suffixExp, suffix.length);
             }
-            
+
         // If we are in a selection starting and ending in invalid tokens and with no content (not considering spaces),
         // find if we are inside a block-comment.
         } else if (startCtx.token.type === null && endCtx.token.type === null &&
                 !editor.posWithinRange(ctx.pos, startCtx.pos, endCtx.pos, true)) {
             result = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, startCtx);
-            
+
             // We found a comment, find the start and end and check if the selection is inside the block-comment.
             if (startCtx.token.type === "comment") {
                 prefixPos = _findCommentStart(startCtx, prefixExp);
                 suffixPos = _findCommentEnd(startCtx, suffixExp, suffix.length);
-                
+
                 if (prefixPos !== null && suffix !== null && !editor.posWithinRange(sel.start, prefixPos, suffixPos, true)) {
                     canComment = true;
                 }
             } else {
                 canComment = true;
             }
-        
+
         // If the start is inside a comment, find the prefix and suffix positions.
         } else if (ctx.token.type === "comment") {
             prefixPos = _findCommentStart(ctx, prefixExp);
             suffixPos = _findCommentEnd(ctx, suffixExp, suffix.length);
-            
+
         // If not try to find the first comment inside the selection.
         } else {
             result = _findNextBlockComment(ctx, sel.end, prefixExp);
-            
+
             // If nothing was found is ok to comment.
             if (!result) {
                 canComment = true;
@@ -369,7 +381,7 @@ define(function (require, exports, module) {
                 suffixPos = _findCommentEnd(ctx, suffixExp, suffix.length);
             }
         }
-        
+
         // Search if there is another comment in the selection. Do nothing if there is one.
         if (!canComment && !invalidComment && !lineUncomment && suffixPos) {
             var start = {line: suffixPos.line, ch: suffixPos.ch + suffix.length + 1};
@@ -377,90 +389,116 @@ define(function (require, exports, module) {
                 // Start searching at the next token, if there is one.
                 result = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx) &&
                          _findNextBlockComment(ctx, sel.end, prefixExp);
-                
+
                 if (result) {
                     invalidComment = true;
                 }
             }
         }
-        
-        
+
+
         // Make the edit
         if (invalidComment) {
-            return;
-        
+            // We don't want to do an edit, but we still want to track selections associated with it.
+            edit = {edit: [], selection: selectionsToTrack};
+
         } else if (lineUncomment) {
-            lineCommentPrefix(editor, linePrefixes);
-        
+            // Return a null edit. This is a signal to the caller that we should delegate to the
+            // line commenting code. We don't want to just generate the edit here, because the edit
+            // might need to be coalesced with other line-uncomment edits generated by cursors on the
+            // same line.
+            edit = null;
+
         } else {
-            doc.batchOperation(function () {
-                
-                if (canComment) {
-                    // Comment out - add the suffix to the start and the prefix to the end.
-                    var completeLineSel = sel.start.ch === 0 && sel.end.ch === 0 && sel.start.line < sel.end.line;
-                    if (completeLineSel) {
-                        doc.replaceRange(suffix + "\n", sel.end);
-                        doc.replaceRange(prefix + "\n", sel.start);
-                    } else {
-                        doc.replaceRange(suffix, sel.end);
-                        doc.replaceRange(prefix, sel.start);
-                    }
-                    
-                    // Correct the selection.
-                    if (completeLineSel) {
-                        newSelection = {start: {line: sel.start.line + 1, ch: 0}, end: {line: sel.end.line + 1, ch: 0}};
-                    } else {
-                        var newSelStart = {line: sel.start.line, ch: sel.start.ch + prefix.length};
-                        if (sel.start.line === sel.end.line) {
-                            newSelection = {start: newSelStart, end: {line: sel.end.line, ch: sel.end.ch + prefix.length}};
-                        } else {
-                            newSelection = {start: newSelStart, end: {line: sel.end.line, ch: sel.end.ch}};
-                        }
-                    }
-                
-                // Uncomment - remove prefix and suffix.
+            if (canComment) {
+                // Comment out - add the suffix to the start and the prefix to the end.
+                var completeLineSel = sel.start.ch === 0 && sel.end.ch === 0 && sel.start.line < sel.end.line;
+                if (completeLineSel) {
+                    editGroup.push({text: suffix + "\n", start: sel.end});
+                    editGroup.push({text: prefix + "\n", start: sel.start});
                 } else {
-                    // Find if the prefix and suffix are at the ch 0 and if they are the only thing in the line.
-                    // If both are found we assume that a complete line selection comment added new lines, so we remove them.
-                    var prefixAtStart = false, suffixAtStart = false;
-                    
-                    line = doc.getLine(prefixPos.line).trim();
-                    prefixAtStart = prefixPos.ch === 0 && prefix.length === line.length;
-                    if (suffixPos) {
-                        line = doc.getLine(suffixPos.line).trim();
-                        suffixAtStart = suffixPos.ch === 0 && suffix.length === line.length;
-                    }
-                    
-                    // Remove the suffix if there is one
-                    if (suffixPos) {
-                        if (prefixAtStart && suffixAtStart) {
-                            doc.replaceRange("", suffixPos, {line: suffixPos.line + 1, ch: 0});
-                        } else {
-                            doc.replaceRange("", suffixPos, {line: suffixPos.line, ch: suffixPos.ch + suffix.length});
+                    editGroup.push({text: suffix, start: sel.end});
+                    editGroup.push({text: prefix, start: sel.start});
+                }
+
+                // Correct the tracked selections. We can't just use the default selection fixup,
+                // because it will push the end of the selection past the inserted content. Also,
+                // it's possible that we have to deal with tracked selections that might be outside
+                // the bounds of the edit.
+                _.each(selectionsToTrack, function (trackedSel) {
+                    function updatePosForEdit(pos) {
+                        // First adjust for the suffix insertion. Don't adjust
+                        // positions that are exactly at the suffix insertion point.
+                        if (CodeMirror.cmpPos(pos, sel.end) > 0) {
+                            if (completeLineSel) {
+                                pos.line++;
+                            } else if (pos.line === sel.end.line) {
+                                pos.ch += suffix.length;
+                            }
+                        }
+                        // Now adjust for the prefix insertion. In this case, we do
+                        // want to adjust positions that are exactly at the insertion 
+                        // point.
+                        if (CodeMirror.cmpPos(pos, sel.start) >= 0) {
+                            if (completeLineSel) {
+                                // Just move the line down.
+                                pos.line++;
+                            } else if (pos.line === sel.start.line) {
+                                pos.ch += prefix.length;
+                            }
                         }
                     }
                     
-                    // Remove the prefix
+                    updatePosForEdit(trackedSel.start);
+                    updatePosForEdit(trackedSel.end);
+                });
+
+            // Uncomment - remove prefix and suffix.
+            } else {
+                // Find if the prefix and suffix are at the ch 0 and if they are the only thing in the line.
+                // If both are found we assume that a complete line selection comment added new lines, so we remove them.
+                var prefixAtStart = false, suffixAtStart = false;
+
+                line = doc.getLine(prefixPos.line).trim();
+                prefixAtStart = prefixPos.ch === 0 && prefix.length === line.length;
+                if (suffixPos) {
+                    line = doc.getLine(suffixPos.line).trim();
+                    suffixAtStart = suffixPos.ch === 0 && suffix.length === line.length;
+                }
+
+                // Remove the suffix if there is one
+                if (suffixPos) {
                     if (prefixAtStart && suffixAtStart) {
-                        doc.replaceRange("", prefixPos, {line: prefixPos.line + 1, ch: 0});
+                        editGroup.push({text: "", start: suffixPos, end: {line: suffixPos.line + 1, ch: 0}});
                     } else {
-                        doc.replaceRange("", prefixPos, {line: prefixPos.line, ch: prefixPos.ch + prefix.length});
+                        editGroup.push({text: "", start: suffixPos, end: {line: suffixPos.line, ch: suffixPos.ch + suffix.length}});
                     }
                 }
-            });
-            
-            // Update the selection after the document batch so it's not blown away on resynchronization
-            // if this editor is not the master editor.
-            if (newSelection) {
-                editor.setSelection(newSelection.start, newSelection.end);
+
+                // Remove the prefix
+                if (prefixAtStart && suffixAtStart) {
+                    editGroup.push({text: "", start: prefixPos, end: {line: prefixPos.line + 1, ch: 0}});
+                } else {
+                    editGroup.push({text: "", start: prefixPos, end: {line: prefixPos.line, ch: prefixPos.ch + prefix.length}});
+                }
+
+                // Don't fix up the tracked selections here - let the edit fix them up.
+                _.each(selectionsToTrack, function (trackedSel) {
+                    trackedSel.isBeforeEdit = true;
+                });
             }
+
+            edit = {edit: editGroup, selection: selectionsToTrack};
         }
+        
+        return edit;
     }
     
     
     /**
-     * Add or remove block-comment tokens to the selection, preserving selection
-     * and cursor position. Applies to the currently focused Editor.
+     * Generates an edit that adds or removes block-comment tokens to the selection, preserving selection
+     * and cursor position. Applies to the currently focused Editor. The selection must already be a
+     * line selection in the form returned by `Editor.convertToLineSelections()`.
      * 
      * The implementation uses blockCommentPrefixSuffix, with the exception of the case where
      * there is no selection on a uncommented and not empty line. In this case the whole lines gets
@@ -469,72 +507,67 @@ define(function (require, exports, module) {
      * @param {!Editor} editor
      * @param {!String} prefix
      * @param {!String} suffix
+     * @param {!{selectionForEdit: {start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}, 
+     *           selectionsToTrack: Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}>}}
+     *      lineSel A line selection as returned from `Editor.convertToLineSelections()`. `selectionForEdit` is the selection to perform
+     *      the line comment operation on, and `selectionsToTrack` are a set of selections associated with this line that need to be
+     *      tracked through the edit.
+     * @return {{edit: {text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}|Array.<{text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}>,
+     *                  selection: {start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}|Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}}
+     *      An edit description suitable for including in the edits array passed to `Editor.doMultipleEdits()`.
      */
-    function lineCommentPrefixSuffix(editor, prefix, suffix) {
-        var sel             = editor.getSelection(),
+    function _getLineCommentPrefixSuffixEdit(editor, prefix, suffix, lineSel) {
+        var sel             = lineSel.selectionForEdit,
             selStart        = sel.start,
             selEnd          = sel.end,
-            prefixExp       = new RegExp("^" + StringUtils.regexEscape(prefix), "g"),
-            isLineSelection = sel.start.ch === 0 && sel.end.ch === 0 && sel.start.line !== sel.end.line,
-            isMultipleLine  = sel.start.line !== sel.end.line,
-            lineLength      = editor.document.getLine(sel.start.line).length;
+            edit;
         
-        // Line selections already behave like we want to
-        if (!isLineSelection) {
-            // For a multiple line selection transform it to a multiple whole line selection
-            if (isMultipleLine) {
-                selStart = {line: sel.start.line, ch: 0};
-                selEnd   = {line: sel.end.line + 1, ch: 0};
-            
-            // For one line selections, just start at column 0 and end at the end of the line
-            } else {
-                selStart = {line: sel.start.line, ch: 0};
-                selEnd   = {line: sel.end.line, ch: lineLength};
-            }
+        // For one-line selections, we shrink the selection to exclude the trailing newline.
+        if (sel.end.line === sel.start.line + 1 && sel.end.ch === 0) {
+            sel.end = {line: sel.start.line, ch: editor.document.getLine(sel.start.line).length};
         }
         
-        // If the selection includes a comment or is already a line selection, delegate to Block-Comment
-        var ctx       = TokenUtils.getInitialContext(editor._codeMirror, {line: selStart.line, ch: selStart.ch});
-        var result    = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx);
-        var className = ctx.token.type;
-        result        = result && _findNextBlockComment(ctx, selEnd, prefixExp);
-        
-        if (className === "comment" || result || isLineSelection) {
-            blockCommentPrefixSuffix(editor, prefix, suffix, []);
-        } else {
-            // Set the new selection and comment it
-            editor.setSelection(selStart, selEnd);
-            blockCommentPrefixSuffix(editor, prefix, suffix, []);
-            
-            // Restore the old selection taking into account the prefix change
-            if (isMultipleLine) {
-                sel.start.line++;
-                sel.end.line++;
-            } else {
-                sel.start.ch += prefix.length;
-                sel.end.ch += prefix.length;
-            }
-            editor.setSelection(sel.start, sel.end);
-        }
+        // Now just run the standard block comment code, but make sure to track any associated selections
+        // that were subsumed into this line selection.
+        return _getBlockCommentPrefixSuffixEdit(editor, prefix, suffix, [], sel, lineSel.selectionsToTrack);
     }
     
-    
     /**
-     * Invokes a language-specific block-comment/uncomment handler
-     * @param {?Editor} editor If unspecified, applies to the currently focused editor
+     * @private
+     * Generates an array of edits for toggling line comments on the given selections.
+     *
+     * @param {!Editor} editor The editor to edit within.
+     * @param {Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}
+     *      selections The selections we want to line-comment.
+     * @return {Array.<{edit: {text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}|Array.<{text: string, start:{line: number, ch: number}, end:?{line: number, ch: number}}>,
+     *                  selection: {start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}|Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, primary:boolean, reversed: boolean, isBeforeEdit: boolean}>}>}
+     *      An array of edit descriptions suitable for including in the edits array passed to `Editor.doMultipleEdits()`.
      */
-    function blockComment(editor) {
-        editor = editor || EditorManager.getFocusedEditor();
-        if (!editor) {
-            return;
-        }
-        
-        var language = editor.getLanguageForSelection();
-        
-        if (language.hasBlockCommentSyntax()) {
-            // getLineCommentPrefixes always return an array, and will be empty if no line comment syntax is defined
-            blockCommentPrefixSuffix(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix(), language.getLineCommentPrefixes());
-        }
+    function _getLineCommentEdits(editor, selections) {
+        // We need to expand line selections in order to coalesce cursors on the same line, but we
+        // don't want to merge adjacent line selections.
+        var lineSelections = editor.convertToLineSelections(selections, { mergeAdjacent: false }),
+            edits = [];
+        _.each(lineSelections, function (lineSel) {
+            var sel = lineSel.selectionForEdit,
+                mode = editor.getModeForRange(sel.start, sel.end),
+                edit;
+            if (mode) {
+                var language = editor.document.getLanguage().getLanguageForMode(mode.name || mode);
+
+                if (language.hasLineCommentSyntax()) {
+                    edit = _getLineCommentPrefixEdit(editor, language.getLineCommentPrefixes(), lineSel);
+                } else if (language.hasBlockCommentSyntax()) {
+                    edit = _getLineCommentPrefixSuffixEdit(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix(), lineSel);
+                }
+            }
+            if (!edit) {
+                // Even if we didn't want to do an edit, we still need to track the selection.
+                edit = {selection: [sel]};
+            }
+            edits.push(edit);
+        });
+        return edits;
     }
     
     /**
@@ -547,16 +580,52 @@ define(function (require, exports, module) {
             return;
         }
         
-        var language = editor.getLanguageForSelection();
-        
-        if (language.hasLineCommentSyntax()) {
-            lineCommentPrefix(editor, language.getLineCommentPrefixes());
-        } else if (language.hasBlockCommentSyntax()) {
-            lineCommentPrefixSuffix(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix());
-        }
+        editor.setSelections(editor.doMultipleEdits(_getLineCommentEdits(editor, editor.getSelections())));
     }
     
-    
+    /**
+     * Invokes a language-specific block-comment/uncomment handler
+     * @param {?Editor} editor If unspecified, applies to the currently focused editor
+     */
+    function blockComment(editor) {
+        editor = editor || EditorManager.getFocusedEditor();
+        if (!editor) {
+            return;
+        }
+        
+        var edits = [],
+            lineCommentSels = [];
+        _.each(editor.getSelections(), function (sel) {
+            var mode = editor.getModeForRange(sel.start, sel.end),
+                edit = {edit: [], selection: [sel]}; // default edit in case we don't have a mode for this selection
+            if (mode) {
+                var language = editor.document.getLanguage().getLanguageForMode(mode.name || mode);
+
+                if (language.hasBlockCommentSyntax()) {
+                    // getLineCommentPrefixes always return an array, and will be empty if no line comment syntax is defined
+                    edit = _getBlockCommentPrefixSuffixEdit(editor, language.getBlockCommentPrefix(), language.getBlockCommentSuffix(),
+                                                            language.getLineCommentPrefixes(), sel);
+                    if (!edit) {
+                        // This is only null if the block comment code found that the selection is within a line-commented line.
+                        // Add this to the list of line-comment selections we need to handle. Since edit is null, we'll skip
+                        // pushing anything onto the edit list for this selection.
+                        lineCommentSels.push(sel);
+                    }
+                }
+            }
+            if (edit) {
+                edits.push(edit);
+            }
+        });
+        
+        // Handle any line-comment edits. It's okay if these are out-of-order with the other edits, since
+        // they shouldn't overlap, and `doMultipleEdits()` will take care of sorting the edits so the
+        // selections can be tracked appropriately.
+        edits.push.apply(edits, _getLineCommentEdits(editor, lineCommentSels));
+        
+        editor.setSelections(editor.doMultipleEdits(edits));
+    }
+        
     /**
      * Duplicates the selected text, or current line if no selection. The cursor/selection is left
      * on the second copy.

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -664,7 +664,7 @@ define(function (require, exports, module) {
         }
         
         var doc            = editor.document,
-            selections     = editor.getSelections(),
+            lineSelections = editor.getLineSelections(),
             isInlineWidget = !!EditorManager.getFocusedInlineWidget(),
             firstLine      = editor.getFirstVisibleLine(),
             lastLine       = editor.getLastVisibleLine(),
@@ -672,35 +672,8 @@ define(function (require, exports, module) {
             lineLength     = 0,
             edits          = [];
         
-        // Combine adjacent lines with selections so they don't collide with each other, as they would
-        // if we did them individually.
-        var combinedSelections = [], prevSel;
-        _.each(selections, function (sel) {
-            var originalSel = _.cloneDeep(sel);
-            
-            // Adjust selection to encompass whole lines.
-            sel.start.ch = 0;
-            // The end of the selection becomes the start of the next line, if it isn't already
-            var hasSelection = (sel.start.line !== sel.end.line) || (sel.start.ch !== sel.end.ch);
-            if (!hasSelection || sel.end.ch !== 0) {
-                sel.end = {line: sel.end.line + 1, ch: 0};
-            }
-
-            // If the start of the new selection is within the range of the previous (expanded) selection, merge
-            // the two selections together, but keep track of all the original selections that were related to this
-            // selection, so they can be properly adjusted. (We only have to check for the start being inside the previous
-            // range - it can't be before it because the selections started out sorted.)
-            if (prevSel && editor.posWithinRange(sel.start, prevSel.selectionForEdit.start, prevSel.selectionForEdit.end, true)) {
-                prevSel.selectionForEdit.end.line = sel.end.line;
-                prevSel.selectionsToTrack.push(originalSel);
-            } else {
-                prevSel = {selectionForEdit: sel, selectionsToTrack: [originalSel]};
-                combinedSelections.push(prevSel);
-            }
-        });
-        
-        _.each(combinedSelections, function (combinedSel) {
-            var sel = combinedSel.selectionForEdit,
+        _.each(lineSelections, function (lineSel) {
+            var sel = lineSel.selectionForEdit,
                 editGroup = [];
 
             // Make the move
@@ -724,12 +697,12 @@ define(function (require, exports, module) {
 
                     // Make sure CodeMirror hasn't expanded the selection to include
                     // the line we inserted below.
-                    _.each(combinedSel.selectionsToTrack, function (originalSel) {
+                    _.each(lineSel.selectionsToTrack, function (originalSel) {
                         originalSel.start.line--;
                         originalSel.end.line--;
                     });
 
-                    edits.push({edit: editGroup, selection: combinedSel.selectionsToTrack});
+                    edits.push({edit: editGroup, selection: lineSel.selectionsToTrack});
                 }
                 break;
             case DIRECTION_DOWN:
@@ -812,6 +785,9 @@ define(function (require, exports, module) {
         // then indent them all. (We can't easily do them all at once, because doMultipleEdits()
         // won't do the indentation for us, but we want its help tracking any selection changes
         // as the result of the edits.)
+        
+        // Note that we don't just use `editor.getLineSelections()` here because we don't actually want
+        // to coalesce adjacent selections - we just want to ignore dupes.
         
         doc.batchOperation(function () {
             _.each(selections, function (sel, index) {

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -121,7 +121,7 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Generates an edit that adds or remove line-comment tokens to all the lines in the selected range,
+     * Generates an edit that adds or removes line-comment tokens to all the lines in the selected range,
      * preserving selection and cursor position. Applies to currently focused Editor. The given selection
      * must already be a line selection in the form returned by `Editor.convertToLineSelections()`.
      * 

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -947,7 +947,9 @@ define(function (require, exports, module) {
     function selectLine(editor) {
         editor = editor || EditorManager.getFocusedEditor();
         if (editor) {
-            editor.setSelections(editor.expandSelectionsToLines(editor.getSelections()));
+            // We can just use `convertToLineSelections`, but throw away the original tracked selections and just use the
+            // coalesced selections.
+            editor.setSelections(_.pluck(editor.convertToLineSelections(editor.getSelections(), { expandEndAtStartOfLine: true }), "selectionForEdit"));
         }
     }
 

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -1910,6 +1910,16 @@ define(function (require, exports, module) {
         
         
         describe("Move Lines Up/Down", function () {
+            function swapLines(lines, swaps) {
+                _.each(swaps, function (swap) {
+                    var temp = lines[swap[0]], i;
+                    for (i = 0; i < swap.length - 1; i++) {
+                        lines[swap[i]] = lines[swap[i + 1]];
+                    }
+                    lines[swap[swap.length - 1]] = temp;
+                });
+            }
+            
             beforeEach(setupFullEditor);
             
             it("should move whole line up if no selection", function () {
@@ -1919,9 +1929,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[0];
-                lines[0] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[0, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -1935,9 +1943,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[2];
-                lines[2] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[2, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -1976,9 +1982,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[5];
-                lines[5] = lines[6];
-                lines[6] = temp;
+                swapLines(lines, [[5, 6]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -1992,9 +1996,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[7];
-                lines[7] = lines[6];
-                lines[6] = temp;
+                swapLines(lines, [[7, 6]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2008,9 +2010,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[0];
-                lines[0] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[0, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2024,9 +2024,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[2];
-                lines[2] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[2, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2040,9 +2038,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[0];
-                lines[0] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[0, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2056,9 +2052,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[2];
-                lines[2] = lines[1];
-                lines[1] = temp;
+                swapLines(lines, [[2, 1]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2072,10 +2066,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[1];
-                lines[1] = lines[2];
-                lines[2] = lines[3];
-                lines[3] = temp;
+                swapLines(lines, [[1, 2, 3]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2089,10 +2080,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[4];
-                lines[4] = lines[3];
-                lines[3] = lines[2];
-                lines[2] = temp;
+                swapLines(lines, [[4, 3, 2]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2106,10 +2094,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[1];
-                lines[1] = lines[2];
-                lines[2] = lines[3];
-                lines[3] = temp;
+                swapLines(lines, [[1, 2, 3]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2123,10 +2108,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[4];
-                lines[4] = lines[3];
-                lines[3] = lines[2];
-                lines[2] = temp;
+                swapLines(lines, [[4, 3, 2]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2140,9 +2122,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[6];
-                lines[6] = lines[7];
-                lines[7] = temp;
+                swapLines(lines, [[6, 7]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2156,9 +2136,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[1];
-                lines[1] = lines[0];
-                lines[0] = temp;
+                swapLines(lines, [[1, 0]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2172,10 +2150,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[5];
-                lines[5] = lines[6];
-                lines[6] = lines[7];
-                lines[7] = temp;
+                swapLines(lines, [[5, 6, 7]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2189,10 +2164,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
                 
                 var lines = defaultContent.split("\n");
-                var temp = lines[2];
-                lines[2] = lines[1];
-                lines[1] = lines[0];
-                lines[0] = temp;
+                swapLines(lines, [[2, 1, 0]]);
                 var expectedText = lines.join("\n");
                 
                 expect(myDocument.getText()).toEqual(expectedText);
@@ -2215,6 +2187,150 @@ define(function (require, exports, module) {
                 
                 expect(myDocument.getText()).toEqual(defaultContent);
                 expectSelection({start: {line: 0, ch: 0}, end: {line: 7, ch: 1}});
+            });
+            
+            describe("with multiple selections", function () {
+                it("should move discontiguous lines up", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}},
+                                            {start: {line: 5, ch: 4}, end: {line: 5, ch: 4}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[0, 1], [2, 3], [4, 5]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 0, ch: 4}, end: {line: 0, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 4}, end: {line: 4, ch: 4}, primary: true, reversed: false}]);
+                });
+                
+                it("should move discontiguous lines down", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}},
+                                            {start: {line: 5, ch: 4}, end: {line: 5, ch: 4}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[2, 1], [4, 3], [6, 5]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 4}, end: {line: 4, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 6, ch: 4}, end: {line: 6, ch: 4}, primary: true, reversed: false}]);
+                });
+                
+                it("should move adjacent single lines with multiple selections up together", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[0, 1, 2]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 0, ch: 4}, end: {line: 0, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 1, ch: 4}, end: {line: 1, ch: 4}, primary: true, reversed: false}]);
+                });
+
+                it("should move adjacent single lines with multiple selections down together", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[3, 2, 1]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}, primary: true, reversed: false}]);
+                });
+
+                it("should move adjacent blocks of lines with multiple selections up together", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 5}, end: {line: 2, ch: 6}},
+                                            {start: {line: 3, ch: 3}, end: {line: 3, ch: 3}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[0, 1, 2, 3]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 0, ch: 5}, end: {line: 1, ch: 6}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 3}, end: {line: 2, ch: 3}, primary: true, reversed: false}]);
+                });
+
+                it("should move adjacent blocks of lines with multiple selections down together", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 5}, end: {line: 2, ch: 6}},
+                                            {start: {line: 3, ch: 3}, end: {line: 3, ch: 3}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[4, 3, 2, 1]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 5}, end: {line: 3, ch: 6}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 3}, end: {line: 4, ch: 3}, primary: true, reversed: false}]);
+                });
+                
+                it("should move each line up only once if there are multiple cursors/selections on the same line, but preserve the selections", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 1, ch: 6}, end: {line: 1, ch: 6}, primary: true},
+                                            {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}},
+                                            {start: {line: 3, ch: 5}, end: {line: 3, ch: 6}, reversed: true}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[0, 1], [2, 3]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 0, ch: 4}, end: {line: 0, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 0, ch: 6}, end: {line: 0, ch: 6}, primary: true, reversed: false},
+                                      {start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 5}, end: {line: 2, ch: 6}, primary: false, reversed: true}]);
+                });
+                
+                it("should move each line down only once if there are multiple cursors/selections on the same line, but preserve the selections", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                                            {start: {line: 1, ch: 6}, end: {line: 1, ch: 6}, primary: true},
+                                            {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}},
+                                            {start: {line: 3, ch: 5}, end: {line: 3, ch: 6}, reversed: true}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[2, 1], [4, 3]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 2, ch: 6}, end: {line: 2, ch: 6}, primary: true, reversed: false},
+                                      {start: {line: 4, ch: 4}, end: {line: 4, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 4, ch: 5}, end: {line: 4, ch: 6}, primary: false, reversed: true}]);
+                });
+                
+                it("should properly coalesce selections that end/start on the same line when moving up", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 2, ch: 4}},
+                                            {start: {line: 2, ch: 6}, end: {line: 2, ch: 6}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_UP, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[0, 1, 2]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 0, ch: 4}, end: {line: 1, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 1, ch: 6}, end: {line: 1, ch: 6}, primary: true, reversed: false}]);
+                });
+
+                it("should properly coalesce selections that end/start on the same line when moving down", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 2, ch: 4}},
+                                            {start: {line: 2, ch: 6}, end: {line: 2, ch: 6}}]);
+                
+                    CommandManager.execute(Commands.EDIT_LINE_DOWN, myEditor);
+                
+                    var lines = defaultContent.split("\n");
+                    swapLines(lines, [[3, 2, 1]]);
+                    expect(myDocument.getText()).toEqual(lines.join("\n"));
+                    expectSelections([{start: {line: 2, ch: 4}, end: {line: 3, ch: 4}, primary: false, reversed: false},
+                                      {start: {line: 3, ch: 6}, end: {line: 3, ch: 6}, primary: true, reversed: false}]);
+                });
             });
         });
 


### PR DESCRIPTION
@redmunds 

This fixes Move Line Up/Down and Toggle Line/Block Comment to work with multiple selections.
