### PR TITLE
Introduce new event type syntax domain:event for NodeConnection events

### DIFF
--- a/src/utils/NodeDomain.js
+++ b/src/utils/NodeDomain.js
@@ -134,13 +134,16 @@ define(function (require, exports, module) {
                 
                 var eventNames = Object.keys(connection.domainEvents[this._domainName]);
                 eventNames.forEach(function (domainEvent) {
-                    var connectionEvent = this._domainName + "." + domainEvent + EVENT_NAMESPACE;
+                    var connectionEvent = this._domainName + ":" + domainEvent + EVENT_NAMESPACE;
                     
                     $(connection).on(connectionEvent, function () {
                         var params = Array.prototype.slice.call(arguments, 1);
                         $(this).triggerHandler(domainEvent, params);
                     }.bind(this));
                 }, this);
+            }.bind(this))
+            .fail(function (err) {
+                console.error("[NodeDomain] Error loading domain \"" + this._domainName + "\": " + err);
             }.bind(this));
     };
     

--- a/test/spec/NodeConnection-test-files/TestCommandsOne.js
+++ b/test/spec/NodeConnection-test-files/TestCommandsOne.js
@@ -62,6 +62,22 @@ maxerr: 50, node: true */
     function cmdRaiseException(m) {
         throw new Error(m);
     }
+
+    /**
+     * @private
+     * Emit eventOne
+     */
+    function emitEventOne() {
+        _domainManager.emitEvent("test", "eventOne", ["foo", "bar"]);
+    }
+
+    /**
+     * @private
+     * Emit eventTwo
+     */
+    function emitEventTwo() {
+        _domainManager.emitEvent("test", "eventOne", ["foo", "bar"]);
+    }
     
     /**
      * Initializes the test domain with several test commands.
@@ -114,6 +130,20 @@ maxerr: 50, node: true */
                 {name: "argOne", type: "boolean"},
                 {name: "argTwo", type: "boolean"}
             ]
+        );
+        _domainManager.registerCommand(
+            "test",
+            "emitEventOne",
+            emitEventOne,
+            false,
+            "emit eventOne"
+        );
+        _domainManager.registerCommand(
+            "test",
+            "emitEventTwo",
+            emitEventTwo,
+            false,
+            "emit eventTwo"
         );
     }
     

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -194,23 +194,27 @@ define(function (require, exports, module) {
         it("should receive events", function () {
             var connection = createConnection();
             var eventMessages = [];
-            $(connection).on(
-                "base.log",
-                function (evt, level, timestamp, message) {
-                    eventMessages.push(message);
-                }
+            var spy = jasmine.createSpy()
+            $(connection).one(
+                "test:eventOne",
+                spy
             );
             runConnectAndWait(connection, false);
             runLoadDomainsAndWait(connection, ["TestCommandsOne"], false);
             runs(function () {
-                connection.domains.test.log("1234");
+                connection.domains.test.emitEventOne();
             });
             waitsFor(
                 function () {
-                    return eventMessages.indexOf("1234") >= 0;
+                    return spy.calls.length === 1;
                 },
                 CONNECTION_TIMEOUT
             );
+            runs(function () {
+                expect(spy.calls[0].args[0].type).toBe("test:eventOne"); // event.type
+                expect(spy.calls[0].args[1]).toBe("foo"); // argOne
+                expect(spy.calls[0].args[2]).toBe("bar"); // argTwo
+            });
         });
         
         it("should parse domain event specifications", function () {

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -25,7 +25,7 @@
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true,
 indent: 4, maxerr: 50 */
 /*global define, describe, it, xit, expect, beforeEach, afterEach, waits,
-waitsFor, runs, $, brackets, waitsForDone, ArrayBuffer, DataView */
+waitsFor, runs, $, brackets, waitsForDone, ArrayBuffer, DataView, jasmine */
 
 define(function (require, exports, module) {
     "use strict";
@@ -194,7 +194,7 @@ define(function (require, exports, module) {
         it("should receive events", function () {
             var connection = createConnection();
             var eventMessages = [];
-            var spy = jasmine.createSpy()
+            var spy = jasmine.createSpy();
             $(connection).one(
                 "test:eventOne",
                 spy


### PR DESCRIPTION
Fix for #6933 
- Leaves old `domain.event` event type intact
- Adds new `domain:event` event type to avoid namespace issues mentioned in #6933 
- Update unit tests
