### PR TITLE
Making sure line error background color always overrides other background colors.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1387,8 +1387,8 @@ label input {
 
 /* Live Preview */
 .live-preview-sync-error .CodeMirror-linenumber {
-    background-color: @live-preview-sync-error-background;
-    color: @live-preview-sync-error-color;
+    background-color: @live-preview-sync-error-background !important;
+    color: @live-preview-sync-error-color !important;
 }
 
 .install-extension-dialog .spinner {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1386,6 +1386,8 @@ label input {
 }
 
 /* Live Preview */
+
+// CodeMirror uses inline styles for active line number, so must use !important here to override
 .live-preview-sync-error .CodeMirror-linenumber {
     background-color: @live-preview-sync-error-background !important;
     color: @live-preview-sync-error-color !important;


### PR DESCRIPTION
This is a fix for #6702. 
