### PR TITLE
Fix spurious file write dialog

### DIFF
--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -149,7 +149,8 @@ define(function (require, exports, module) {
         
         // Request a consistency check if the write is not blind
         if (!options.blind) {
-            options.expectedHash = this._hash;
+            options.expectedHash = this._hash; 
+            options.checkData = this._contents;
         }
         
         // Block external change events until after the write has finished

--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
         // Request a consistency check if the write is not blind
         if (!options.blind) {
             options.expectedHash = this._hash; 
-            options.checkData = this._contents;
+            options.expectedContents = this._contents;
         }
         
         // Block external change events until after the write has finished

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -390,7 +390,7 @@ define(function (require, exports, module) {
      * 
      * @param {string} path
      * @param {string} data
-     * @param {{encoding : string=, mode : number=, expectedHash : object=}} options
+     * @param {{encoding : string=, mode : number=, expectedHash : object=, expectedContents : string=}} options
      * @param {function(?string, FileSystemStats=, boolean)} callback
      */
     function writeFile(path, data, options, callback) {
@@ -423,9 +423,9 @@ define(function (require, exports, module) {
             if (options.hasOwnProperty("expectedHash") && options.expectedHash !== stats._hash) {
                 console.error("Blind write attempted: ", path, stats._hash, options.expectedHash);
 
-                if (options.hasOwnProperty("checkData")) {
+                if (options.hasOwnProperty("expectedContents")) {
                     appshell.fs.readFile(path, encoding, function (_err, _data) {
-                        if (_err || _data !== options.checkData) {
+                        if (_err || _data !== options.expectedContents) {
                             callback(FileSystemError.CONTENTS_MODIFIED);
                             return;
                         }

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -422,8 +422,21 @@ define(function (require, exports, module) {
             
             if (options.hasOwnProperty("expectedHash") && options.expectedHash !== stats._hash) {
                 console.error("Blind write attempted: ", path, stats._hash, options.expectedHash);
-                callback(FileSystemError.CONTENTS_MODIFIED);
-                return;
+
+                if (options.hasOwnProperty("checkData")) {
+                    appshell.fs.readFile(path, encoding, function (_err, _data) {
+                        if (_err || _data !== options.checkData) {
+                            callback(FileSystemError.CONTENTS_MODIFIED);
+                            return;
+                        }
+                    
+                        _finishWrite(false);
+                    });
+                    return;
+                } else {
+                    callback(FileSystemError.CONTENTS_MODIFIED);
+                    return;
+                }
             }
             
             _finishWrite(false);

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -158,8 +158,15 @@ define(function (require, exports, module) {
         var cb = _getCallback("writeFile", path, callback);
                 
         if (_model.exists(path) && options.hasOwnProperty("expectedHash") && options.expectedHash !== _model.stat(path)._hash) {
-            cb(FileSystemError.CONTENTS_MODIFIED);
-            return;
+            if (options.hasOwnProperty("expectedContents")) {
+                if (options.expectedContents !== _model.readFile(path)) {
+                    cb(FileSystemError.CONTENTS_MODIFIED);
+                    return;
+                } 
+            } else {
+                cb(FileSystemError.CONTENTS_MODIFIED);
+                return;
+            }
         }
         
         _model.writeFile(path, data);


### PR DESCRIPTION
This pull request adds a read and compare when a blind-write detection has occurred to prevent 
- Fixes #6437 
