### PR TITLE
Check for jquery property instead of instanceof

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -200,7 +200,7 @@ define(function (require, exports, module) {
             };
         } else {
             _addHint = function (hint) {
-                view.hints.push({ formattedHint: (hint instanceof $) ? "" : hint });
+                view.hints.push({ formattedHint: (hint.jquery) ? "" : hint });
             };
         }
 
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
                 $element.data("hint", hint);
                 
                 // insert jQuery hint objects after the template is rendered
-                if (hint instanceof $) {
+                if (hint.jquery) {
                     $element.find(".codehint-item").append(hint);
                 }
             });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -1059,7 +1059,7 @@ define(function (require, exports, module) {
         // Unfortunately, we can't just use jQuery's :contains() selector, because it appears that
         // you can't escape quotes in it.
         var i;
-        if (root instanceof $) {
+        if (root.jquery) {
             root = root.get(0);
         }
         if (!root) {


### PR DESCRIPTION
`foo instanceof $` doesn't work if an extension is using it's own version of jquery. Look for `foo.jquery` instead.
