### PR TITLE
[cmv4] Fix issues with doc syncing in inline editors

### DIFF
--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -43,13 +43,12 @@ define(function (require, exports, module) {
      *
      * change -- When the text of the editor changes (including due to undo/redo). 
      *
-     *        Passes ({Document}, {ChangeList}), where ChangeList is a linked list (NOT an array)
+     *        Passes ({Document}, {ChangeList}), where ChangeList is an array
      *        of change record objects. Each change record looks like:
      *
      *            { from: start of change, expressed as {line: <line number>, ch: <character offset>},
      *              to: end of change, expressed as {line: <line number>, ch: <chracter offset>},
-     *              text: array of lines of text to replace existing text,
-     *              next: next change record in the linked list, or undefined if this is the last record }
+     *              text: array of lines of text to replace existing text }
      *      
      *        The line and ch offsets are both 0-based.
      *
@@ -62,9 +61,6 @@ define(function (require, exports, module) {
      *        IMPORTANT: If you listen for the "change" event, you MUST also addRef() the document 
      *        (and releaseRef() it whenever you stop listening). You should also listen to the "deleted"
      *        event.
-     *  
-     *        (FUTURE: this is a modified version of the raw CodeMirror change event format; may want to make 
-     *        it an ordinary array)
      *
      * deleted -- When the file for this document has been deleted. All views onto the document should
      *      be closed. The document will no longer be editable or dispatch "change" events.
@@ -295,7 +291,7 @@ define(function (require, exports, module) {
             // TODO: Dumb to split it here just to join it again in the change handler, but this is
             // the CodeMirror change format. Should we document our change format to allow this to
             // either be an array of lines or a single string?
-            $(this).triggerHandler("change", [this, {text: text.split(/\r?\n/)}]);
+            $(this).triggerHandler("change", [this, [{text: text.split(/\r?\n/)}]]);
         }
         this._updateTimestamp(newTimestamp);
        

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -161,10 +161,10 @@ define(function (require, exports, module) {
      */
     TextRange.prototype._applyChangesToRange = function (changeList) {
         var hasChanged = false, hasContentChanged = false;
-        var change;
-        for (change = changeList; change; change = change.next) {
+        var i;
+        for (i = 0; i < changeList.length; i++) {
             // Apply this step of the change list
-            var result = this._applySingleChangeToRange(change);
+            var result = this._applySingleChangeToRange(changeList[i]);
             hasChanged = hasChanged || result.hasChanged;
             hasContentChanged = hasContentChanged || result.hasContentChanged;
             

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -594,8 +594,8 @@ define(function (require, exports, module) {
             }
 
             // Pending Text is used in hintList._keydownHook()
-            if (hintList && changeList.text.length && changeList.text[0].length) {
-                hintList.removePendingText(changeList.text[0]);
+            if (hintList && changeList[0] && changeList[0].text.length && changeList[0].text[0].length) {
+                hintList.removePendingText(changeList[0].text[0]);
             }
         }
     }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -568,8 +568,9 @@ define(function (require, exports, module) {
         // Apply text changes to CodeMirror editor
         var cm = this._codeMirror;
         cm.operation(function () {
-            var change, newText;
-            for (change = changeList; change; change = change.next) {
+            var change, newText, i;
+            for (i = 0; i < changeList.length; i++) {
+                change = changeList[i];
                 newText = change.text.join('\n');
                 if (!change.from || !change.to) {
                     if (change.from || change.to) {
@@ -700,7 +701,9 @@ define(function (require, exports, module) {
         // FUTURE: if this list grows longer, consider making this a more generic mapping
         // NOTE: change is a "private" event--others shouldn't listen to it on Editor, only on
         // Document
-        this._codeMirror.on("change", function (instance, changeList) {
+        // Also, note that we use the new "changes" event in v4, which provides an array of
+        // change objects. Our own event is still called just "change".
+        this._codeMirror.on("changes", function (instance, changeList) {
             $(self).triggerHandler("change", [self, changeList]);
         });
         this._codeMirror.on("beforeChange", function (instance, changeObj) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1226,7 +1226,7 @@ define(function (require, exports, module) {
                 // we have to fix up any selections that overlap or come after the edit.
                 oneOrEach(editDesc.edit, function (edit) {
                     if (edit) {
-                        self._codeMirror.replaceRange(edit.text, edit.start, edit.end, origin);
+                        self.document.replaceRange(edit.text, edit.start, edit.end, origin);
 
                         // Fix up all the selections *except* the one(s) related to this edit list that
                         // are not "before-edit" selections.

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -21,7 +21,7 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $ */
 
 
@@ -839,7 +839,6 @@ define(function (require, exports, module) {
         var selections     = editor.getSelections(),
             isInlineWidget = !!EditorManager.getFocusedInlineWidget(),
             lastLine       = editor.getLastVisibleLine(),
-            cm             = editor._codeMirror,
             doc            = editor.document,
             edits          = [],
             newSelections,
@@ -894,7 +893,11 @@ define(function (require, exports, module) {
             // Now indent each added line (which doesn't mess up any line numbers, and
             // we're going to set the character offset to the last position on each line anyway).
             _.each(newSelections, function (sel) {
-                cm.indentLine(sel.start.line, "smart", true);
+                // This is a bit of a hack. The document is the one that batches operations, but we want
+                // to use CodeMirror's "smart indent" operation. So we need to use the document's own backing editor's
+                // CodeMirror to do the indentation. A better way to fix this would be to expose this
+                // operation on Document, but I'm not sure we want to sign up for that as a public API.
+                doc._masterEditor._codeMirror.indentLine(sel.start.line, "smart", true);
                 sel.start.ch = null; // last character on line
                 sel.end = sel.start;
             });

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1322,7 +1322,7 @@ define(function (require, exports, module) {
      *  partial updates to tern or not.
      *
      * @param {Array.<{from: {line:number, ch: number}, to: {line:number, ch: number},
-     * text: Array<string>}>} changeList - the document changes (since last change event)
+     *     text: Array<string>}>} changeList - the document changes from the current change event
      */
     function trackChange(changeList) {
         var changed = documentChanges, i;

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1321,29 +1321,32 @@ define(function (require, exports, module) {
      *  Track the update area of the current document so we can tell if we can send
      *  partial updates to tern or not.
      *
-     * @param {{from: {line:number, ch: number}, to: {line:number, ch: number},
-     * text: Array<string>}} changeList - the document changes (since last change or cumlative?)
+     * @param {Array.<{from: {line:number, ch: number}, to: {line:number, ch: number},
+     * text: Array<string>}>} changeList - the document changes (since last change event)
      */
     function trackChange(changeList) {
-        var changed = documentChanges;
+        var changed = documentChanges, i;
         if (changed === null) {
-            documentChanges = changed = {from: changeList.from.line, to: changeList.from.line};
+            documentChanges = changed = {from: changeList[0].from.line, to: changeList[0].from.line};
             if (config.debug) {
                 console.debug("ScopeManager: document has changed");
             }
         }
 
-        var end = changeList.from.line + (changeList.text.length - 1);
-        if (changeList.from.line < changed.to) {
-            changed.to = changed.to - (changeList.to.line - end);
-        }
+        for (i = 0; i < changeList.length; i++) {
+            var thisChange = changeList[i],
+                end = thisChange.from.line + (thisChange.text.length - 1);
+            if (thisChange.from.line < changed.to) {
+                changed.to = changed.to - (thisChange.to.line - end);
+            }
 
-        if (end >= changed.to) {
-            changed.to = end + 1;
-        }
+            if (end >= changed.to) {
+                changed.to = end + 1;
+            }
 
-        if (changed.from > changeList.from.line) {
-            changed.from = changeList.from.line;
+            if (changed.from > thisChange.from.line) {
+                changed.from = thisChange.from.line;
+            }
         }
     }
 

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -453,7 +453,7 @@ define(function (require, exports, module) {
             // type has changed since the last hint computation
             if (this.needNewHints(session)) {
                 if (key) {
-                    ScopeManager.handleFileChange({from: cursor, to: cursor, text: [key]});
+                    ScopeManager.handleFileChange([{from: cursor, to: cursor, text: [key]}]);
                     ignoreChange = true;
                 }
 

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
      *
      * @param {Object} previousDOM The root of the HTMLSimpleDOM tree representing a previous state of the DOM.
      * @param {Editor} editor The editor containing the instrumented HTML.
-     * @param {Array=} changeList An optional list of CodeMirror change records representing the
+     * @param {Array=} changeList An optional array of CodeMirror change records representing the
      *     edits the user made in the editor since previousDOM was built. If provided, and the
      *     edits are not structural, DOMUpdater will do a fast incremental reparse. If not provided,
      *     or if one of the edits changes the DOM structure, DOMUpdater will reparse the whole DOM.
@@ -269,16 +269,17 @@ define(function (require, exports, module) {
         }
         
         // If there's more than one change, be conservative and assume we have to do a full reparse.
-        if (changeList && !changeList.next) {
+        if (changeList && changeList.length === 1) {
             // If the inserted or removed text doesn't have any characters that could change the
             // structure of the DOM (e.g. by adding or removing a tag boundary), then we can do
             // an incremental reparse of just the parent tag containing the edit. This should just
             // be the marked range that contains the beginning of the edit range, since that position
             // isn't changed by the edit.
-            if (!isDangerousEdit(changeList.text) && !isDangerousEdit(changeList.removed)) {
+            var change = changeList[0];
+            if (!isDangerousEdit(change.text) && !isDangerousEdit(change.removed)) {
                 // If the edit is right at the beginning or end of a tag, we want to be conservative
                 // and use the parent as the edit range.
-                var startMark = _getMarkerAtDocumentPos(editor, changeList.from, true);
+                var startMark = _getMarkerAtDocumentPos(editor, change.from, true);
                 if (startMark) {
                     var range = startMark.find();
                     if (range) {

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -543,89 +543,89 @@ define(function (require, exports, module) {
      * @private
      * Update the search results using the given list of changes fr the given document
      * @param {Document} doc  The Document that changed, should be the current one
-     * @param {{from: {line:number,ch:number}, to: {line:number,ch:number}, text: string, next: change}} change
-     *      A linked list as described in the Document constructor
-     * @param {boolean} resultsChanged  True when the search results changed from a file change
+     * @param {Array.<{from: {line:number,ch:number}, to: {line:number,ch:number}, text: string, next: change}>} changeList
+     *      An array of changes as described in the Document constructor
+     * @return {boolean}  True when the search results changed from a file change
      */
-    function _updateSearchResults(doc, change, resultsChanged) {
-        var i, diff, matches,
+    function _updateSearchResults(doc, changeList) {
+        var i, diff, matches, resultsChanged = false,
             fullPath = doc.file.fullPath,
-            lines    = [],
-            start    = 0,
-            howMany  = 0;
-            
-        // There is no from or to positions, so the entire file changed, we must search all over again
-        if (!change.from || !change.to) {
-            _addSearchMatches(fullPath, doc.getText(), currentQueryExpr);
-            resultsChanged = true;
+            lines, start, howMany;
         
-        } else {
-            // Get only the lines that changed
-            for (i = 0; i < change.text.length; i++) {
-                lines.push(doc.getLine(change.from.line + i));
-            }
-            
-            // We need to know how many lines changed to update the rest of the lines
-            if (change.from.line !== change.to.line) {
-                diff = change.from.line - change.to.line;
+        changeList.forEach(function (change) {
+            lines = [];
+            start = 0;
+            howMany = 0;
+
+            // There is no from or to positions, so the entire file changed, we must search all over again
+            if (!change.from || !change.to) {
+                _addSearchMatches(fullPath, doc.getText(), currentQueryExpr);
+                resultsChanged = true;
+
             } else {
-                diff = lines.length - 1;
-            }
-            
-            if (searchResults[fullPath]) {
-                // Search the last match before a replacement, the amount of matches deleted and update
-                // the lines values for all the matches after the change
-                searchResults[fullPath].matches.forEach(function (item) {
-                    if (item.end.line < change.from.line) {
-                        start++;
-                    } else if (item.end.line <= change.to.line) {
-                        howMany++;
-                    } else {
-                        item.start.line += diff;
-                        item.end.line   += diff;
-                    }
-                });
-                
-                // Delete the lines that where deleted or replaced
-                if (howMany > 0) {
-                    searchResults[fullPath].matches.splice(start, howMany);
+                // Get only the lines that changed
+                for (i = 0; i < change.text.length; i++) {
+                    lines.push(doc.getLine(change.from.line + i));
                 }
-                resultsChanged = true;
-            }
-            
-            // Searches only over the lines that changed
-            matches = _getSearchMatches(lines.join("\r\n"), currentQueryExpr);
-            if (matches && matches.length) {
-                // Updates the line numbers, since we only searched part of the file
-                matches.forEach(function (value, key) {
-                    matches[key].start.line += change.from.line;
-                    matches[key].end.line   += change.from.line;
-                });
-                
-                // If the file index exists, add the new matches to the file at the start index found before
-                if (searchResults[fullPath]) {
-                    Array.prototype.splice.apply(searchResults[fullPath].matches, [start, 0].concat(matches));
-                // If not, add the matches to a new file index
+
+                // We need to know how many lines changed to update the rest of the lines
+                if (change.from.line !== change.to.line) {
+                    diff = change.from.line - change.to.line;
                 } else {
-                    searchResults[fullPath] = {
-                        matches:   matches,
-                        collapsed: false
-                    };
+                    diff = lines.length - 1;
                 }
-                resultsChanged = true;
+
+                if (searchResults[fullPath]) {
+                    // Search the last match before a replacement, the amount of matches deleted and update
+                    // the lines values for all the matches after the change
+                    searchResults[fullPath].matches.forEach(function (item) {
+                        if (item.end.line < change.from.line) {
+                            start++;
+                        } else if (item.end.line <= change.to.line) {
+                            howMany++;
+                        } else {
+                            item.start.line += diff;
+                            item.end.line   += diff;
+                        }
+                    });
+
+                    // Delete the lines that where deleted or replaced
+                    if (howMany > 0) {
+                        searchResults[fullPath].matches.splice(start, howMany);
+                    }
+                    resultsChanged = true;
+                }
+
+                // Searches only over the lines that changed
+                matches = _getSearchMatches(lines.join("\r\n"), currentQueryExpr);
+                if (matches && matches.length) {
+                    // Updates the line numbers, since we only searched part of the file
+                    matches.forEach(function (value, key) {
+                        matches[key].start.line += change.from.line;
+                        matches[key].end.line   += change.from.line;
+                    });
+
+                    // If the file index exists, add the new matches to the file at the start index found before
+                    if (searchResults[fullPath]) {
+                        Array.prototype.splice.apply(searchResults[fullPath].matches, [start, 0].concat(matches));
+                    // If not, add the matches to a new file index
+                    } else {
+                        searchResults[fullPath] = {
+                            matches:   matches,
+                            collapsed: false
+                        };
+                    }
+                    resultsChanged = true;
+                }
+
+                // All the matches where deleted, remove the file from the results
+                if (searchResults[fullPath] && !searchResults[fullPath].matches.length) {
+                    delete searchResults[fullPath];
+                    resultsChanged = true;
+                }
             }
-            
-            // All the matches where deleted, remove the file from the results
-            if (searchResults[fullPath] && !searchResults[fullPath].matches.length) {
-                delete searchResults[fullPath];
-                resultsChanged = true;
-            }
-            
-            // This is link to the next change object, so we need to keep searching
-            if (change.next) {
-                return _updateSearchResults(doc, change.next, resultsChanged);
-            }
-        }
+        });
+        
         return resultsChanged;
     }
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -548,7 +548,8 @@ define(function (require, exports, module) {
      * @return {boolean}  True when the search results changed from a file change
      */
     function _updateSearchResults(doc, changeList) {
-        var i, diff, matches, resultsChanged = false,
+        var i, diff, matches,
+            resultsChanged = false,
             fullPath = doc.file.fullPath,
             lines, start, howMany;
         


### PR DESCRIPTION
Also addresses #6039. This PR fixes two problems:
- In v4, CodeMirror sends multiple `change` events for a single operation, unlike in v3 where it would send a linked list of all the edits in a single `change`. This PR changes our `change` event to use the new `changes` event in v4, which sends an array of edits. That means our `change` event API will break anyone who was using the old linked list, but a quick survey of extensions showed that the only extension that was even looking at that argument was @peterflynn's Go to Last Edit extension.
  - Note that as part of this, I also fixed an apparent bug in ScopeManager where it was only looking at the first change record in the list. @dangoor might want to take a look at this.
- `doMultipleEdits()` had a bad bug where it was doing each edit in the current Editor's `_codeMirror` instead of the underlying Document's `_codeMirror`, which was bad since it was the Document that was batching the edits.

With this, multiselect edits seem to be working properly within inline editors.

@redmunds
