### PR TITLE
Made "Show in OS" OS-specific

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -27,9 +27,9 @@
 
 define(function (require, exports, module) {
     "use strict";
-    
+
     var _ = require("thirdparty/lodash");
-    
+
     // Load dependent modules
     var AppInit             = require("utils/AppInit"),
         CommandManager      = require("command/CommandManager"),
@@ -57,11 +57,11 @@ define(function (require, exports, module) {
         Menus               = require("command/Menus"),
         UrlParams           = require("utils/UrlParams").UrlParams,
         StatusBar           = require("widgets/StatusBar");
-    
+
     /**
      * Handlers for commands related to document handling (opening, saving, etc.)
      */
-    
+
     /** @type {jQueryObject} Container for label shown above editor; must be an inline element */
     var _$title = null;
     /** @type {jQueryObject} Container for dirty dot; must be an inline element */
@@ -72,23 +72,23 @@ define(function (require, exports, module) {
     var _currentTitlePath = null;
     /** @type {string} String template for window title. Use emdash on mac only. */
     var WINDOW_TITLE_STRING = (brackets.platform !== "mac") ? "{0} - {1}" : "{0} \u2014 {1}";
-    
+
     /** @type {jQueryObject} Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize */
     var _$titleContainerToolbar = null;
     /** @type {Number} Last known height of _$titleContainerToolbar */
     var _lastToolbarHeight = null;
-    
+
     /** @type {Number} index to use for next, new Untitled document */
     var _nextUntitledIndexToUse = 1;
-    
+
     /** @type {boolean} prevents reentrancy of browserReload() */
     var _isReloading = false;
-    
+
     /** Unique token used to indicate user-driven cancellation of Save As (as opposed to file IO error) */
     var USER_CANCELED = { userCanceled: true };
-    
+
     PreferencesManager.definePreference("defaultExtension", "string", "");
-    
+
     /** @type {function} JSLint workaround for circular dependency */
     var handleFileSaveAs;
 
@@ -145,7 +145,7 @@ define(function (require, exports, module) {
         // update shell/browser window title
         window.document.title = windowTitle;
     }
-    
+
     /**
      * Returns a short title for a given document.
      *
@@ -164,11 +164,11 @@ define(function (require, exports, module) {
             return ProjectManager.makeProjectRelativeIfPossible(fullPath);
         }
     }
-    
+
     function updateDocumentTitle() {
         var newDocument = DocumentManager.getCurrentDocument();
 
-        // TODO: This timer is causing a "Recursive tests with the same name are not supporte"
+        // TODO: This timer is causing a "Recursive tests with the same name are not supported"
         // exception. This code should be removed (if not needed), or updated with a unique
         // timer name (if needed).
         // var perfTimerName = PerfUtils.markStart("DocumentCommandHandlers._onCurrentDocumentChange():\t" + (!newDocument || newDocument.file.fullPath));
@@ -189,7 +189,7 @@ define(function (require, exports, module) {
 
         // PerfUtils.addMeasurement(perfTimerName);
     }
-    
+
     function handleDirtyChange(event, changedDoc) {
         var currentDoc = DocumentManager.getCurrentDocument();
         
@@ -226,8 +226,8 @@ define(function (require, exports, module) {
                 // custom viewer but the file is still showing in the current custom viewer. This only
                 // occurs on Mac since opening a non-text file always fails on Mac and triggers an error
                 // message that in turn calls _cleanup() after the user clicks OK in the message box.
-                // So we need to explicitly close the currently viewing image file whose filename is  
-                // no longer valid. Calling notifyPathDeleted will close the image vieer and then select 
+                // So we need to explicitly close the currently viewing image file whose filename is
+                // no longer valid. Calling notifyPathDeleted will close the image vieer and then select
                 // the previously opened text file or show no-editor if none exists.
                 EditorManager.notifyPathDeleted(fullFilePath);
             } else {
@@ -284,13 +284,13 @@ define(function (require, exports, module) {
 
         return result.promise();
     }
-    
+
     /**
      * @private
      * Used to track the default directory for the file open dialog
      */
     var _defaultOpenDialogFullPath = null;
-    
+
     /**
      * @private
      * Creates a document and displays an editor for the specified file path.
@@ -298,7 +298,7 @@ define(function (require, exports, module) {
      * @param {?string} fullPath - The path of the file to open; if it's null we'll prompt for it
      * @param {boolean=} silent - If true, don't show error message
      * @return {$.Promise} a jQuery promise that will be resolved with a new
-     * document for the specified file path or be resolved without document, i.e. when an image is displayed, 
+     * document for the specified file path or be resolved without document, i.e. when an image is displayed,
      * or rejected if the file can not be read.
      */
     function _doOpenWithOptionalPath(fullPath, silent) {
@@ -411,7 +411,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Opens the given file, makes it the current document, AND adds it to the working set 
+     * Opens the given file, makes it the current document, AND adds it to the working set
      * only if the file does not have a custom viewer.
      * @param {!{fullPath:string, index:number=, forceRedraw:boolean}} commandData  File to open; optional position in
      *   working set list (defaults to last); optional flag to force working set redraw
@@ -441,7 +441,7 @@ define(function (require, exports, module) {
             deferred        = $.Deferred();
         
         if (_nextUntitledIndexToUse > 9999) {
-            //we've tried this enough            
+            //we've tried this enough
             deferred.reject();
         } else {
             var path = dir.fullPath + suggestedName,
@@ -469,7 +469,7 @@ define(function (require, exports, module) {
      * file creation call is outstanding
      */
     var fileNewInProgress = false;
-    
+
     /**
      * Bottleneck function for creating new files and folders in the project tree.
      */
@@ -518,7 +518,7 @@ define(function (require, exports, module) {
         //if (defaultExtension) {
         //    defaultExtension = "." + defaultExtension;
         //}
-        var defaultExtension = "";  // disable preference setting for now 
+        var defaultExtension = "";  // disable preference setting for now
         
         var doc = DocumentManager.createUntitledDocument(_nextUntitledIndexToUse++, defaultExtension);
         DocumentManager.setCurrentDocument(doc);
@@ -526,14 +526,14 @@ define(function (require, exports, module) {
         
         return new $.Deferred().resolve(doc).promise();
     }
-    
+
     /**
      * Create a new file in the project tree.
      */
     function handleFileNewInProject() {
         _handleNewItemInProject(false);
     }
-    
+
     /**
      * Create a new folder in the project tree.
      */
@@ -559,7 +559,7 @@ define(function (require, exports, module) {
             )
         );
     }
-    
+
     /**
      * Saves a document to its existing path. Does NOT support untitled documents.
      * @param {!Document} docToSave
@@ -640,7 +640,7 @@ define(function (require, exports, module) {
                 // The user has decided to keep conflicting changes in the editor. Check to make sure
                 // the file hasn't changed since they last decided to do that.
                 docToSave.file.stat(function (err, stat) {
-                    // If the file has been deleted on disk, the stat will return an error, but that's fine since 
+                    // If the file has been deleted on disk, the stat will return an error, but that's fine since
                     // that means there's no file to overwrite anyway, so the save will succeed without us having
                     // to set force = true.
                     if (!err && docToSave.keepChangesTime === stat.mtime.getTime()) {
@@ -661,7 +661,7 @@ define(function (require, exports, module) {
         });
         return result.promise();
     }
-    
+
     /**
      * Reverts the Document to the current contents of its file on disk. Discards any unsaved changes
      * in the Document.
@@ -686,7 +686,7 @@ define(function (require, exports, module) {
         
         return result.promise();
     }
-    
+
     /**
      * Opens the native OS save as dialog and saves document.
      * The original document is reverted in case it was dirty.
@@ -809,7 +809,7 @@ define(function (require, exports, module) {
         }
         return result.promise();
     }
-    
+
     /**
      * Saves the given file. If no file specified, assumes the current document.
      * @param {?{doc: ?Document}} commandData  Document to close, or null
@@ -842,7 +842,7 @@ define(function (require, exports, module) {
         
         return $.Deferred().reject().promise();
     }
-    
+
     /**
      * Saves all unsaved documents corresponding to 'fileList'. Returns a Promise that will be resolved
      * once ALL the save operations have been completed. If ANY save operation fails, an error dialog is
@@ -893,7 +893,7 @@ define(function (require, exports, module) {
             return filesAfterSave;
         });
     }
-    
+
     /**
      * Saves all unsaved documents. See _saveFileList() for details on the semantics.
      * @return {$.Promise}
@@ -901,7 +901,7 @@ define(function (require, exports, module) {
     function saveAll() {
         return _saveFileList(DocumentManager.getWorkingSet());
     }
-    
+
     /**
      * Prompts user with save as dialog and saves document.
      * @return {$.Promise} a promise that is resolved once the save has been completed
@@ -937,7 +937,7 @@ define(function (require, exports, module) {
     function handleFileSaveAll() {
         return saveAll();
     }
-    
+
     /**
      * Closes the specified file: removes it from the working set, and closes the main editor if one
      * is open. Prompts user about saving changes first, if document is dirty.
@@ -947,7 +947,7 @@ define(function (require, exports, module) {
      *      promptOnly - If true, only displays the relevant confirmation UI and does NOT actually
      *          close the document. This is useful when chaining file-close together with other user
      *          prompts that may be cancelable.
-     *      _forceClose - If true, closes the document without prompting even if there are unsaved 
+     *      _forceClose - If true, closes the document without prompting even if there are unsaved
      *          changes. Only for use in unit tests.
      * @return {$.Promise} a promise that is resolved when the file is closed, or if no file is open.
      *      FUTURE: should we reject the promise if no file is open?
@@ -994,7 +994,7 @@ define(function (require, exports, module) {
 
         // Close custom viewer if, either
         // - a custom viewer is currently displayed and no file specified in command data
-        // - a custom viewer is currently displayed and the file specified in command data 
+        // - a custom viewer is currently displayed and the file specified in command data
         //   is the file in the custom viewer
         if (!DocumentManager.getCurrentDocument()) {
             if ((EditorManager.getCurrentlyViewedPath() && !file) ||
@@ -1086,7 +1086,7 @@ define(function (require, exports, module) {
         }
         return promise;
     }
-    
+
     /**
      * @param {!Array.<FileEntry>} list
      * @param {boolean} promptOnly
@@ -1184,7 +1184,7 @@ define(function (require, exports, module) {
         
         return result.promise();
     }
-    
+
     /**
      * Closes all open documents; equivalent to calling handleFileClose() for each document, except
      * that unsaved changes are confirmed once, in bulk.
@@ -1201,7 +1201,7 @@ define(function (require, exports, module) {
             }
         });
     }
-    
+
     function handleFileCloseList(commandData) {
         return _closeList(commandData.fileList, false, false).done(function () {
             if (!DocumentManager.getCurrentDocument()) {
@@ -1209,12 +1209,12 @@ define(function (require, exports, module) {
             }
         });
     }
-    
+
     /**
      * @private - tracks our closing state if we get called again
      */
     var _windowGoingAway = false;
-    
+
     /**
      * @private
      * Common implementation for close/quit/reload which all mostly
@@ -1249,7 +1249,7 @@ define(function (require, exports, module) {
                 }
             });
     }
-    
+
     /**
      * @private
      * Implementation for abortQuit callback to reset quit sequence settings
@@ -1257,7 +1257,7 @@ define(function (require, exports, module) {
     function handleAbortQuit() {
         _windowGoingAway = false;
     }
-    
+
     /**
      * @private
      * Implementation for native APP_BEFORE_MENUPOPUP callback to trigger beforeMenuPopup event
@@ -1265,7 +1265,7 @@ define(function (require, exports, module) {
     function handleBeforeMenuPopup() {
         $(PopUpManager).triggerHandler("beforeMenuPopup");
     }
-    
+
     /** Confirms any unsaved changes, then closes the window */
     function handleFileCloseWindow(commandData) {
         return _handleWindowGoingAway(
@@ -1282,7 +1282,7 @@ define(function (require, exports, module) {
             }
         );
     }
-    
+
     /** Show a textfield to rename whatever is currently selected in the sidebar (or current doc if nothing else selected) */
     function handleFileRename() {
         // Prefer selected sidebar item (which could be a folder)
@@ -1314,10 +1314,10 @@ define(function (require, exports, module) {
         );
     }
 
-    
+
     /** Are we already listening for a keyup to call detectDocumentNavEnd()? */
     var _addedNavKeyHandler = false;
-    
+
     /**
      * When the Ctrl key is released, if we were in the middle of a next/prev document navigation
      * sequence, now is the time to end it and update the MRU order. If we allowed the order to update
@@ -1333,7 +1333,7 @@ define(function (require, exports, module) {
             $(window.document.body).off("keyup", detectDocumentNavEnd);
         }
     }
-    
+
     /** Navigate to the next/previous (MRU) document. Don't update MRU order yet */
     function goNextPrevDoc(inc) {
         var file = DocumentManager.getNextPrevFile(inc);
@@ -1348,18 +1348,18 @@ define(function (require, exports, module) {
             }
         }
     }
-    
+
     function handleGoNextDoc() {
         goNextPrevDoc(+1);
     }
     function handleGoPrevDoc() {
         goNextPrevDoc(-1);
     }
-    
+
     function handleShowInTree() {
         ProjectManager.showInTree(DocumentManager.getCurrentDocument().file);
     }
-    
+
     function handleFileDelete() {
         var entry = ProjectManager.getSelectedItem();
         if (entry.isDirectory) {
@@ -1404,7 +1404,7 @@ define(function (require, exports, module) {
             });
         }
     }
-    
+
     /**
      * Disables Brackets' cache via the remote debugging protocol.
      * @return {$.Promise} A jQuery promise that will be resolved when the cache is disabled and be rejected in any other case
@@ -1441,7 +1441,7 @@ define(function (require, exports, module) {
          
         return result.promise();
     }
-    
+
     /**
     * Does a full reload of the browser window
     * @param {string} href The url to reload into the window
@@ -1475,7 +1475,7 @@ define(function (require, exports, module) {
             _isReloading = false;
         });
     }
-    
+
     function handleReload() {
         var href    = window.location.href,
             params  = new UrlParams();
@@ -1501,7 +1501,7 @@ define(function (require, exports, module) {
             browserReload(href);
         }, 100);
     }
-    
+
     function handleReloadWithoutExts() {
         var href    = window.location.href,
             params  = new UrlParams();
@@ -1524,7 +1524,7 @@ define(function (require, exports, module) {
             browserReload(href);
         }, 100);
     }
-    
+
     AppInit.htmlReady(function () {
         // If in Reload Without User Extensions mode, update UI and log console message
         var params      = new UrlParams(),
@@ -1551,48 +1551,49 @@ define(function (require, exports, module) {
     exports._parseDecoratedPath = _parseDecoratedPath;
 
     // Register global commands
-    CommandManager.register(Strings.CMD_FILE_OPEN,              Commands.FILE_OPEN, handleFileOpen);
-    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,     Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
+    CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET, Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
     // TODO: (issue #274) For now, hook up File > New to the "new in project" handler. Eventually
     // File > New should open a new blank tab, and handleFileNewInProject should
     // be called from a "+" button in the project
-    CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,      Commands.FILE_NEW_UNTITLED, handleFileNew);
-    CommandManager.register(Strings.CMD_FILE_NEW,               Commands.FILE_NEW, handleFileNewInProject);
-    CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,        Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
-    CommandManager.register(Strings.CMD_FILE_SAVE,              Commands.FILE_SAVE, handleFileSave);
-    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,          Commands.FILE_SAVE_ALL, handleFileSaveAll);
-    CommandManager.register(Strings.CMD_FILE_SAVE_AS,           Commands.FILE_SAVE_AS, handleFileSaveAs);
-    CommandManager.register(Strings.CMD_FILE_RENAME,            Commands.FILE_RENAME, handleFileRename);
-    CommandManager.register(Strings.CMD_FILE_DELETE,            Commands.FILE_DELETE, handleFileDelete);
-    
-    CommandManager.register(Strings.CMD_FILE_CLOSE,             Commands.FILE_CLOSE, handleFileClose);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,         Commands.FILE_CLOSE_ALL, handleFileCloseAll);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,        Commands.FILE_CLOSE_LIST, handleFileCloseList);
+    CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,  Commands.FILE_NEW_UNTITLED, handleFileNew);
+    CommandManager.register(Strings.CMD_FILE_NEW,           Commands.FILE_NEW, handleFileNewInProject);
+    CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,    Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
+    CommandManager.register(Strings.CMD_FILE_SAVE,          Commands.FILE_SAVE, handleFileSave);
+    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,      Commands.FILE_SAVE_ALL, handleFileSaveAll);
+    CommandManager.register(Strings.CMD_FILE_SAVE_AS,       Commands.FILE_SAVE_AS, handleFileSaveAs);
+    CommandManager.register(Strings.CMD_FILE_RENAME,        Commands.FILE_RENAME, handleFileRename);
+    CommandManager.register(Strings.CMD_FILE_DELETE,        Commands.FILE_DELETE, handleFileDelete);
 
+    CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,    Commands.FILE_CLOSE_LIST, handleFileCloseList);
+
+    var quitString = Strings.CMD_QUIT;
     if (brackets.platform === "win") {
-        CommandManager.register(Strings.CMD_EXIT,               Commands.FILE_QUIT, handleFileQuit);
-    } else {
-        CommandManager.register(Strings.CMD_QUIT,               Commands.FILE_QUIT, handleFileQuit);
+        quitString = Strings.CMD_EXIT;
     }
+    CommandManager.register(quitString,                     Commands.FILE_QUIT, handleFileQuit);
 
-    CommandManager.register(Strings.CMD_NEXT_DOC,               Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
-    CommandManager.register(Strings.CMD_PREV_DOC,               Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
-    CommandManager.register(Strings.CMD_SHOW_IN_TREE,           Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
+    CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
+    CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
+    CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
+
+    var showInOS = Strings.CMD_SHOW_IN_OS;
     if (brackets.platform === "win") {
-        CommandManager.register(Strings.CMD_SHOW_IN_EXPLORER,   Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+        showInOS = Strings.CMD_SHOW_IN_EXPLORER;
     } else if (brackets.platform === "mac") {
-        CommandManager.register(Strings.CMD_SHOW_IN_FINDER,     Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
-    } else {
-        CommandManager.register(Strings.CMD_SHOW_IN_OS,         Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+        showInOS = Strings.CMD_SHOW_IN_FINDER;
     }
-    
+    CommandManager.register(showInOS,                       Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+
     // These commands have no UI representation and are only used internally
     CommandManager.registerInternal(Commands.APP_ABORT_QUIT,            handleAbortQuit);
     CommandManager.registerInternal(Commands.APP_BEFORE_MENUPOPUP,      handleBeforeMenuPopup);
     CommandManager.registerInternal(Commands.FILE_CLOSE_WINDOW,         handleFileCloseWindow);
     CommandManager.registerInternal(Commands.APP_RELOAD,                handleReload);
     CommandManager.registerInternal(Commands.APP_RELOAD_WITHOUT_EXTS,   handleReloadWithoutExts);
-    
+
     // Listen for changes that require updating the editor titlebar
     $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
     $(DocumentManager).on("fileNameChange", updateDocumentTitle);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1569,9 +1569,13 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
     CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,    Commands.FILE_CLOSE_LIST, handleFileCloseList);
 
-    var quitString = Strings.CMD_QUIT;
+    var quitString  = Strings.CMD_QUIT,
+        showInOS    = Strings.CMD_SHOW_IN_OS;
     if (brackets.platform === "win") {
-        quitString = Strings.CMD_EXIT;
+        quitString  = Strings.CMD_EXIT;
+        showInOS    = Strings.CMD_SHOW_IN_EXPLORER;
+    } else if (brackets.platform === "mac") {
+        showInOS    = Strings.CMD_SHOW_IN_FINDER;
     }
     CommandManager.register(quitString,                     Commands.FILE_QUIT, handleFileQuit);
 
@@ -1579,12 +1583,6 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
 
-    var showInOS = Strings.CMD_SHOW_IN_OS;
-    if (brackets.platform === "win") {
-        showInOS = Strings.CMD_SHOW_IN_EXPLORER;
-    } else if (brackets.platform === "mac") {
-        showInOS = Strings.CMD_SHOW_IN_FINDER;
-    }
     CommandManager.register(showInOS,                       Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
 
     // These commands have no UI representation and are only used internally

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1551,34 +1551,40 @@ define(function (require, exports, module) {
     exports._parseDecoratedPath = _parseDecoratedPath;
 
     // Register global commands
-    CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
-    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET, Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
+    CommandManager.register(Strings.CMD_FILE_OPEN,              Commands.FILE_OPEN, handleFileOpen);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,     Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
     // TODO: (issue #274) For now, hook up File > New to the "new in project" handler. Eventually
     // File > New should open a new blank tab, and handleFileNewInProject should
     // be called from a "+" button in the project
-    CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,  Commands.FILE_NEW_UNTITLED, handleFileNew);
-    CommandManager.register(Strings.CMD_FILE_NEW,           Commands.FILE_NEW, handleFileNewInProject);
-    CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,    Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
-    CommandManager.register(Strings.CMD_FILE_SAVE,          Commands.FILE_SAVE, handleFileSave);
-    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,      Commands.FILE_SAVE_ALL, handleFileSaveAll);
-    CommandManager.register(Strings.CMD_FILE_SAVE_AS,       Commands.FILE_SAVE_AS, handleFileSaveAs);
-    CommandManager.register(Strings.CMD_FILE_RENAME,        Commands.FILE_RENAME, handleFileRename);
-    CommandManager.register(Strings.CMD_FILE_DELETE,        Commands.FILE_DELETE, handleFileDelete);
+    CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,      Commands.FILE_NEW_UNTITLED, handleFileNew);
+    CommandManager.register(Strings.CMD_FILE_NEW,               Commands.FILE_NEW, handleFileNewInProject);
+    CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,        Commands.FILE_NEW_FOLDER, handleNewFolderInProject);
+    CommandManager.register(Strings.CMD_FILE_SAVE,              Commands.FILE_SAVE, handleFileSave);
+    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,          Commands.FILE_SAVE_ALL, handleFileSaveAll);
+    CommandManager.register(Strings.CMD_FILE_SAVE_AS,           Commands.FILE_SAVE_AS, handleFileSaveAs);
+    CommandManager.register(Strings.CMD_FILE_RENAME,            Commands.FILE_RENAME, handleFileRename);
+    CommandManager.register(Strings.CMD_FILE_DELETE,            Commands.FILE_DELETE, handleFileDelete);
     
-    CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,    Commands.FILE_CLOSE_LIST, handleFileCloseList);
+    CommandManager.register(Strings.CMD_FILE_CLOSE,             Commands.FILE_CLOSE, handleFileClose);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,         Commands.FILE_CLOSE_ALL, handleFileCloseAll);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,        Commands.FILE_CLOSE_LIST, handleFileCloseList);
 
     if (brackets.platform === "win") {
-        CommandManager.register(Strings.CMD_EXIT,           Commands.FILE_QUIT, handleFileQuit);
+        CommandManager.register(Strings.CMD_EXIT,               Commands.FILE_QUIT, handleFileQuit);
     } else {
-        CommandManager.register(Strings.CMD_QUIT,           Commands.FILE_QUIT, handleFileQuit);
+        CommandManager.register(Strings.CMD_QUIT,               Commands.FILE_QUIT, handleFileQuit);
     }
 
-    CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
-    CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
-    CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
-    CommandManager.register(Strings.CMD_SHOW_IN_OS,         Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+    CommandManager.register(Strings.CMD_NEXT_DOC,               Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
+    CommandManager.register(Strings.CMD_PREV_DOC,               Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
+    CommandManager.register(Strings.CMD_SHOW_IN_TREE,           Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
+    if (brackets.platform === "win") {
+        CommandManager.register(Strings.CMD_SHOW_IN_EXPLORER,   Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+    } else if (brackets.platform === "mac") {
+        CommandManager.register(Strings.CMD_SHOW_IN_FINDER,     Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+    } else {
+        CommandManager.register(Strings.CMD_SHOW_IN_OS,         Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
+    }
     
     // These commands have no UI representation and are only used internally
     CommandManager.registerInternal(Commands.APP_ABORT_QUIT,            handleAbortQuit);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1550,6 +1550,16 @@ define(function (require, exports, module) {
     // Exported for unit testing only
     exports._parseDecoratedPath = _parseDecoratedPath;
 
+    // Set some command strings
+    var quitString  = Strings.CMD_QUIT,
+        showInOS    = Strings.CMD_SHOW_IN_OS;
+    if (brackets.platform === "win") {
+        quitString  = Strings.CMD_EXIT;
+        showInOS    = Strings.CMD_SHOW_IN_EXPLORER;
+    } else if (brackets.platform === "mac") {
+        showInOS    = Strings.CMD_SHOW_IN_FINDER;
+    }
+
     // Register global commands
     CommandManager.register(Strings.CMD_FILE_OPEN,          Commands.FILE_OPEN, handleFileOpen);
     CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET, Commands.FILE_ADD_TO_WORKING_SET, handleFileAddToWorkingSet);
@@ -1568,21 +1578,11 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_CLOSE,         Commands.FILE_CLOSE, handleFileClose);
     CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,     Commands.FILE_CLOSE_ALL, handleFileCloseAll);
     CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,    Commands.FILE_CLOSE_LIST, handleFileCloseList);
-
-    var quitString  = Strings.CMD_QUIT,
-        showInOS    = Strings.CMD_SHOW_IN_OS;
-    if (brackets.platform === "win") {
-        quitString  = Strings.CMD_EXIT;
-        showInOS    = Strings.CMD_SHOW_IN_EXPLORER;
-    } else if (brackets.platform === "mac") {
-        showInOS    = Strings.CMD_SHOW_IN_FINDER;
-    }
     CommandManager.register(quitString,                     Commands.FILE_QUIT, handleFileQuit);
 
     CommandManager.register(Strings.CMD_NEXT_DOC,           Commands.NAVIGATE_NEXT_DOC, handleGoNextDoc);
     CommandManager.register(Strings.CMD_PREV_DOC,           Commands.NAVIGATE_PREV_DOC, handleGoPrevDoc);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,       Commands.NAVIGATE_SHOW_IN_FILE_TREE, handleShowInTree);
-
     CommandManager.register(showInOS,                       Commands.NAVIGATE_SHOW_IN_OS, handleShowInOS);
 
     // These commands have no UI representation and are only used internally

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -305,6 +305,8 @@ define({
     "CMD_NEXT_DOC"                        : "Nächstes Dokument",
     "CMD_PREV_DOC"                        : "Voriges Dokument",
     "CMD_SHOW_IN_TREE"                    : "Im Dateibaum anzeigen",
+    "CMD_SHOW_IN_EXPLORER"                : "Im Explorer anzeigen",
+    "CMD_SHOW_IN_FINDER"                  : "Im Finder anzeigen",
     "CMD_SHOW_IN_OS"                      : "Im Dateisystem anzeigen",
 
     // Help menu commands

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -307,6 +307,8 @@ define({
     "CMD_NEXT_DOC"                        : "Next Document",
     "CMD_PREV_DOC"                        : "Previous Document",
     "CMD_SHOW_IN_TREE"                    : "Show in File Tree",
+    "CMD_SHOW_IN_EXPLORER"                : "Show in Explorer",
+    "CMD_SHOW_IN_FINDER"                  : "Show in Finder",
     "CMD_SHOW_IN_OS"                      : "Show in OS",
     
     // Help menu commands


### PR DESCRIPTION
This is for #6970, it makes `CMD_SHOW_IN_OS` OS-specific (`Finder` on Mac, `Explorer` on Win).
@couzteau for the german strings
