### PR TITLE
Cleans up viewstate loading at startup

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -384,7 +384,9 @@ define(function (require, exports, module) {
     }
 
     // Dispatch htmlReady event
-    _beforeHTMLReady();
-    AppInit._dispatchReady(AppInit.HTML_READY);
-    $(window.document).ready(_onReady);
+    PreferencesManager._smUserScopeLoading.always(function () {
+        _beforeHTMLReady();
+        AppInit._dispatchReady(AppInit.HTML_READY);
+        $(window.document).ready(_onReady);
+    });
 });

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -382,9 +382,12 @@ define(function (require, exports, module) {
             }
         }, true);
     }
-
-    // Dispatch htmlReady event
+    
+    // Wait for view state to load.
+    var viewStateTimer = PerfUtils.markStart("User viewstate loading");
     PreferencesManager._smUserScopeLoading.always(function () {
+        PerfUtils.addMeasurement(viewStateTimer);
+        // Dispatch htmlReady event
         _beforeHTMLReady();
         AppInit._dispatchReady(AppInit.HTML_READY);
         $(window.document).ready(_onReady);

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -86,6 +86,14 @@ define(function (require, exports, module) {
     });
     
     /**
+     * Ensures that we don't start running until the app is ready.
+     * 
+     * @private
+     * @type {boolean}
+     */
+    var _ready = false;
+    
+    /**
      * When disabled, the errors panel is closed and the status bar icon is grayed out.
      * Takes precedence over _collapsed.
      * @private
@@ -259,6 +267,10 @@ define(function (require, exports, module) {
      * @param {?string} providerName name of the provider that is requesting a run
      */
     function run() {
+        if (!_ready) {
+            return;
+        }
+        
         if (!_enabled) {
             _hasErrors = false;
             Resizer.hide($problemsPanel);
@@ -568,6 +580,10 @@ define(function (require, exports, module) {
         // Set initial UI state
         toggleEnabled(prefs.get(PREF_ENABLED), true);
         toggleCollapsed(prefs.get(PREF_COLLAPSED), true);
+    });
+    
+    AppInit.appReady(function () {
+        _ready = true;
     });
 
     // Testing

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -86,14 +86,6 @@ define(function (require, exports, module) {
     });
     
     /**
-     * Ensures that we don't start running until the app is ready.
-     * 
-     * @private
-     * @type {boolean}
-     */
-    var _ready = false;
-    
-    /**
      * When disabled, the errors panel is closed and the status bar icon is grayed out.
      * Takes precedence over _collapsed.
      * @private
@@ -267,10 +259,6 @@ define(function (require, exports, module) {
      * @param {?string} providerName name of the provider that is requesting a run
      */
     function run() {
-        if (!_ready) {
-            return;
-        }
-        
         if (!_enabled) {
             _hasErrors = false;
             Resizer.hide($problemsPanel);
@@ -580,10 +568,6 @@ define(function (require, exports, module) {
         // Set initial UI state
         toggleEnabled(prefs.get(PREF_ENABLED), true);
         toggleCollapsed(prefs.get(PREF_COLLAPSED), true);
-    });
-    
-    AppInit.appReady(function () {
-        _ready = true;
     });
 
     // Testing

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -581,6 +581,7 @@ define(function (require, exports, module) {
     exports._manager                = preferencesManager;
     exports._setCurrentEditingFile  = _setCurrentEditingFile;
     exports._setProjectSettingsFile = _setProjectSettingsFile;
+    exports._smUserScopeLoading     = smUserScopeLoading;
     
     // Public API
     

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -38,6 +38,7 @@ define(function (require, exports, module) {
         ExtensionLoader      = require("utils/ExtensionLoader"),
         PreferencesBase      = require("preferences/PreferencesBase"),
         FileSystem           = require("filesystem/FileSystem"),
+        AppInit              = require("utils/AppInit"),
         _                    = require("thirdparty/lodash");
     
     /**
@@ -234,6 +235,7 @@ define(function (require, exports, module) {
     }
 
     var preferencesManager = new PreferencesBase.PreferencesSystem();
+    preferencesManager.pauseChangeEvents();
     
     var userScopeLoading = preferencesManager.addScope("user", new PreferencesBase.FileStorage(userPrefFile, true));
     
@@ -576,6 +578,10 @@ define(function (require, exports, module) {
             stateManager.save();
         }
     }
+    
+    AppInit.appReady(function () {
+        preferencesManager.resumeChangeEvents();
+    });
     
     // Private API for unit testing and use elsewhere in Brackets core
     exports._manager                = preferencesManager;


### PR DESCRIPTION
This is a fix for #6944. This change does a couple of things:
1. user-level viewstate is loaded _before_ HTML rendering. This simulates the synchronous nature of localStorage in the old viewstate implementation
2. preference changes are queued up until `appReady` fires. This prevents a problem caused by the first change in which code attempts to update the status bar before the status bar is ready.
