### PR TITLE
Remove .livehtml flag

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -213,7 +213,7 @@ define(function HTMLDocumentModule(require, exports, module) {
     /** Triggered on change by the editor */
     HTMLDocument.prototype._onChange = function (event, editor, change) {
         // Make sure LiveHTML is turned on
-        if (!brackets.livehtml || !this._instrumentationEnabled) {
+        if (!this._instrumentationEnabled) {
             return;
         }
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -131,10 +131,6 @@ define(function LiveDevelopment(require, exports, module) {
 
     launcherUrl = launcherUrl.substr(0, launcherUrl.lastIndexOf("/")) + "/LiveDevelopment/launch.html";
     launcherUrl = window.location.origin + launcherUrl;
-    
-    // TODO: Remove this temporary flag. Once we're certain that Live HTML is ready,
-    // we can remove all traces of this flag.
-    brackets.livehtml = true;
 
     // Some agents are still experimental, so we don't enable them all by default
     // However, extensions can enable them by calling enableAgent().


### PR DESCRIPTION
This is for #6987 @dangoor
It removes all occurrences of `brackets.livehtml` - these were the only ones I found.
