### PR TITLE
Inject remote functions earlier after frameNavigated instead of loadEventFired

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -131,7 +131,7 @@ define(function RemoteAgent(require, exports, module) {
     }
 
     // WebInspector Event: Page.loadEventFired
-    function _onLoadEventFired(event, res) {
+    function _onFrameNavigated(event, res) {
         // res = {timestamp}
 
         // inject RemoteFunctions
@@ -139,7 +139,7 @@ define(function RemoteAgent(require, exports, module) {
 
         Inspector.Runtime.evaluate(command, function onEvaluate(response) {
             if (response.error || response.wasThrown) {
-                _load.reject(null, response.error);
+                _load.reject(response.error);
             } else {
                 _objectId = response.result.objectId;
                 _load.resolve();
@@ -152,7 +152,7 @@ define(function RemoteAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page).on("loadEventFired.RemoteAgent", _onLoadEventFired);
+        $(Inspector.Page).one("frameNavigated.RemoteAgent", _onFrameNavigated);
         $(Inspector.Page).on("frameStartedLoading.RemoteAgent", _onFrameStartedLoading);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
 

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -130,7 +130,7 @@ define(function RemoteAgent(require, exports, module) {
         _stopKeepAliveInterval();
     }
 
-    // WebInspector Event: Page.loadEventFired
+    // WebInspector Event: Page.frameNavigated
     function _onFrameNavigated(event, res) {
         // res = {timestamp}
 
@@ -152,7 +152,7 @@ define(function RemoteAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page).one("frameNavigated.RemoteAgent", _onFrameNavigated);
+        $(Inspector.Page).on("frameNavigated.RemoteAgent", _onFrameNavigated);
         $(Inspector.Page).on("frameStartedLoading.RemoteAgent", _onFrameStartedLoading);
         $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
 


### PR DESCRIPTION
Change `RemoteAgent` to inject our `RemoteFunctions` into the browser window when `frameNavigated` is fired instead of `loadEventFired`. This is a possible fix for network latency issues that cause live development connection timeouts.

See #6122 and #6912.
