### PR TITLE
Fix three issues in project-based view states.

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -816,7 +816,8 @@ define(function (require, exports, module) {
             currentDoc   = getCurrentDocument(),
             projectRoot  = ProjectManager.getProjectRoot(),
             context      = { location : { scope: "user",
-                                          layer: "project" } };
+                                          layer: "project",
+                                          layerID: projectRoot.fullPath } };
 
         if (!projectRoot) {
             return;


### PR DESCRIPTION
Set project root path to the project layer immediately after loading the project so that project tree (expanded/collapsed) states can be restored. (fix #6998)
Explicitly provide project root folder as layer ID so that new project-based keys can be created before recording view states in those keys.(fix #6993 and #6998)
Migrate project base url that I missed to convert since it is also one of the old preferences that uses the prefix with the project root path as keys. (fix (#6999)
