### PR TITLE
Actually set the USE_TAB_CHAR pref when it needs to be set.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1557,6 +1557,7 @@ define(function (require, exports, module) {
             this._currentOptions[prefName] = newValue;
             
             if (prefName === USE_TAB_CHAR) {
+                this._codeMirror.setOption(cmOptions[prefName], newValue);
                 this._codeMirror.setOption("indentUnit", newValue === true ?
                                            this._currentOptions[TAB_SIZE] :
                                            this._currentOptions[SPACE_UNITS]


### PR DESCRIPTION
Fix for #6996. I would have written a test for this, but I wasn't sure how to simulate pressing the tab key. Regardless, this code gets exercised a fair bit and the fix is a straightforward one liner.

cc @njx 
