### PR TITLE
Use styleSheetAdded and styleSheetRemoved, replaces getAllStylesheets

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -40,7 +40,7 @@ define(function CSSAgent(require, exports, module) {
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
 
     /** @type {Object.<string, CSS.CSSStyleSheetHeader>} */
-    var _urlToStyle;
+    var _urlToStyle = {};
     
     /** @type {Object.<string, string>} */
     var _styleSheetIdToUrl;
@@ -120,10 +120,6 @@ define(function CSSAgent(require, exports, module) {
      * @param {header: CSSStyleSheetHeader}
      */
     function _styleSheetAdded(event, res) {
-        if (!_urlToStyle) {
-            return;
-        }
-        
         var url = _canonicalize(res.header.sourceURL),
             existing = _urlToStyle[url];
         

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -28,8 +28,10 @@
 /**
  * CSSAgent keeps track of loaded style sheets and allows reloading them
  * from a {Document}.
+ *
+ * CSSAgent dispatches styleSheetAdded and styleSheetRemoved events, passing
+ * the URL for the added/removed style sheet.
  */
-
 define(function CSSAgent(require, exports, module) {
     "use strict";
 
@@ -38,7 +40,12 @@ define(function CSSAgent(require, exports, module) {
     var Inspector = require("LiveDevelopment/Inspector/Inspector");
 
     var _load; // {$.Deferred} load promise
-    var _urlToStyle; // {url -> loaded} style definition
+    
+    /** @type {Object.<string, CSS.CSSStyleSheetHeader>} */
+    var _urlToStyle;
+    
+    /** @type {Object.<string, string>} */
+    var _styleSheetIdToUrl;
 
     /** 
      * Create a canonicalized version of the given URL, stripping off query strings and hashes.
@@ -49,34 +56,29 @@ define(function CSSAgent(require, exports, module) {
         return PathUtils.parseUrl(url).hrefNoSearch;
     }
 
-    // WebInspector Event: Page.loadEventFired
-    function _onLoadEventFired(event, res) {
-        // res = {timestamp}
+    /**
+     * @private
+     * WebInspector Event: Page.frameNavigated
+     * @param {jQuery.Event} event
+     * @param {frame: Frame} res
+     */
+    function _onFrameNavigated(event, res) {
+        // Clear maps when navigating to a new page
         _urlToStyle = {};
-        Inspector.CSS.enable().done(function () {
-            Inspector.CSS.getAllStyleSheets(function onGetAllStyleSheets(res) {
-                var i, header;
-                for (i in res.headers) {
-                    header = res.headers[i];
-                    _urlToStyle[_canonicalize(header.sourceURL)] = header;
-                }
-                _load.resolve();
-            });
-        });
+        _styleSheetIdToUrl = {};
     }
 
     /** Get a style sheet for a url
      * @param {string} url
      */
     function styleForURL(url) {
-        if (_urlToStyle) {
-            return _urlToStyle[_canonicalize(url)];
-        }
-        
-        return null;
+        return _urlToStyle[_canonicalize(url)];
     }
 
-    /** Get a list of all loaded stylesheet files by URL */
+    /**
+     * @deprecated Use styleSheetAdded and styleSheetRemoved events
+     * Get a list of all loaded stylesheet files by URL
+     */
     function getStylesheetURLs() {
         var urls = [], url;
         for (url in _urlToStyle) {
@@ -104,17 +106,62 @@ define(function CSSAgent(require, exports, module) {
         console.assert(style, "Style Sheet for document not loaded: " + doc.url);
         Inspector.CSS.setStyleSheetText(style.styleSheetId, "");
     }
+    
+    /**
+     * @private
+     * @param {jQuery.Event} event
+     * @param {header: CSSStyleSheetHeader}
+     */
+    function _styleSheetAdded(event, res) {
+        if (!_urlToStyle) {
+            return;
+        }
+        
+        var url = _canonicalize(res.header.sourceURL);
+        
+        _urlToStyle[url] = res.header;
+        _styleSheetIdToUrl[res.header.styleSheetId] = url;
+        
+        $(exports).triggerHandler("styleSheetAdded", [url]);
+    }
+    
+    /**
+     * @private
+     * @param {jQuery.Event} event
+     * @param {styleSheetId: StyleSheetId}
+     */
+    function _styleSheetRemoved(event, res) {
+        if (!_urlToStyle) {
+            return;
+        }
+        
+        var url = _styleSheetIdToUrl[res.styleSheetId];
+        
+        if (url) {
+            delete _urlToStyle[url];
+        }
+        
+        delete _styleSheetIdToUrl[res.styleSheetId];
+        
+        $(exports).triggerHandler("styleSheetRemoved", [url]);
+    }
 
     /** Initialize the agent */
     function load() {
-        _load = new $.Deferred();
-        $(Inspector.Page).on("loadEventFired.CSSAgent", _onLoadEventFired);
+        // "loading" is done when the domain is enabled 
+        _load = Inspector.CSS.enable();
+        
+        $(Inspector.Page).on("frameNavigated.CSSAgent", _onFrameNavigated);
+        $(Inspector.CSS).on("styleSheetAdded.CSSAgent", _styleSheetAdded);
+        $(Inspector.CSS).on("styleSheetRemoved.CSSAgent", _styleSheetRemoved);
+        
         return _load.promise();
     }
 
     /** Clean up */
     function unload() {
         $(Inspector.Page).off(".CSSAgent");
+        $(Inspector.CSS).off(".CSSAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -140,10 +140,6 @@ define(function CSSAgent(require, exports, module) {
      * @param {styleSheetId: StyleSheetId}
      */
     function _styleSheetRemoved(event, res) {
-        if (!_urlToStyle) {
-            return;
-        }
-        
         var url = _styleSheetIdToUrl[res.styleSheetId],
             header = url && _urlToStyle[url];
         

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -69,8 +69,10 @@ define(function CSSAgent(require, exports, module) {
         _styleSheetIdToUrl = {};
     }
 
-    /** Get a style sheet for a url
+    /**
+     * Get a style sheet for a url
      * @param {string} url
+     * @return {CSS.CSSStyleSheetHeader}
      */
     function styleForURL(url) {
         return _urlToStyle[_canonicalize(url)];
@@ -90,22 +92,26 @@ define(function CSSAgent(require, exports, module) {
         return urls;
     }
 
-    /** Reload a CSS style sheet from a document
+    /**
+     * Reload a CSS style sheet from a document
      * @param {Document} document
+     * @return {jQuery.Promise}
      */
     function reloadCSSForDocument(doc) {
         var style = styleForURL(doc.url);
         console.assert(style, "Style Sheet for document not loaded: " + doc.url);
-        Inspector.CSS.setStyleSheetText(style.styleSheetId, doc.getText());
+        return Inspector.CSS.setStyleSheetText(style.styleSheetId, doc.getText());
     }
 
-    /** Empties a CSS style sheet given a document that has been deleted
+    /**
+     * Empties a CSS style sheet given a document that has been deleted
      * @param {Document} document
+     * @return {jQuery.Promise}
      */
     function clearCSSForDocument(doc) {
         var style = styleForURL(doc.url);
         console.assert(style, "Style Sheet for document not loaded: " + doc.url);
-        Inspector.CSS.setStyleSheetText(style.styleSheetId, "");
+        return Inspector.CSS.setStyleSheetText(style.styleSheetId, "");
     }
     
     /**
@@ -129,7 +135,7 @@ define(function CSSAgent(require, exports, module) {
         _urlToStyle[url] = res.header;
         _styleSheetIdToUrl[res.header.styleSheetId] = url;
         
-        $(exports).triggerHandler("styleSheetAdded", [url]);
+        $(exports).triggerHandler("styleSheetAdded", [url, res.header]);
     }
     
     /**
@@ -142,7 +148,8 @@ define(function CSSAgent(require, exports, module) {
             return;
         }
         
-        var url = _styleSheetIdToUrl[res.styleSheetId];
+        var url = _styleSheetIdToUrl[res.styleSheetId],
+            header = url && _urlToStyle[url];
         
         if (url) {
             delete _urlToStyle[url];
@@ -150,7 +157,7 @@ define(function CSSAgent(require, exports, module) {
         
         delete _styleSheetIdToUrl[res.styleSheetId];
         
-        $(exports).triggerHandler("styleSheetRemoved", [url]);
+        $(exports).triggerHandler("styleSheetRemoved", [url, header]);
     }
     
     /**

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -83,22 +83,6 @@ define(function CSSDocumentModule(require, exports, module) {
         }
     };
 
-    CSSDocument.prototype._url = null;
-
-    Object.defineProperties(CSSDocument.prototype, {
-        "url": {
-            get: function () { return this._url; },
-            set: function (url) {
-                this._url = url;
-
-                // Force initial update for dirty files
-                if (this.doc.isDirty) {
-                    this._updateBrowser();
-                }
-            }
-        }
-    });
-
     /**
      * @private
      * Get the CSSStyleSheetHeader for this document
@@ -123,7 +107,8 @@ define(function CSSDocumentModule(require, exports, module) {
      */
     CSSDocument.prototype.getSourceFromBrowser = function getSourceFromBrowser() {
         var deferred = new $.Deferred(),
-            inspectorPromise = Inspector.CSS.getStyleSheetText(this._getStyleSheetHeader().styleSheetId);
+            styleSheetId = this._getStyleSheetHeader().styleSheetId,
+            inspectorPromise = Inspector.CSS.getStyleSheetText(styleSheetId);
         
         inspectorPromise.then(function (res) {
             deferred.resolve(res.text);

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -70,8 +70,6 @@ define(function CSSDocumentModule(require, exports, module) {
         this.doc.addRef();
         this.onChange = this.onChange.bind(this);
         this.onDeleted = this.onDeleted.bind(this);
-        
-        this._updateBrowser = _.debounce(this._updateBrowser, 250);
 
         $(this.doc).on("change.CSSDocument", this.onChange);
         $(this.doc).on("deleted.CSSDocument", this.onDeleted);
@@ -91,7 +89,7 @@ define(function CSSDocumentModule(require, exports, module) {
         "url": {
             get: function () { return this._url; },
             set: function (url) {
-                _url = url;
+                this._url = url;
 
                 // Force initial update for dirty files
                 if (this.doc.isDirty) {
@@ -124,7 +122,14 @@ define(function CSSDocumentModule(require, exports, module) {
      * @return {jQuery.promise} Promise resolved with the text content of this CSS document
      */
     CSSDocument.prototype.getSourceFromBrowser = function getSourceFromBrowser() {
-        return Inspector.CSS.getStyleSheetText(this._getStyleSheetHeader().styleSheetId);
+        var deferred = new $.Deferred(),
+            inspectorPromise = Inspector.CSS.getStyleSheetText(this._getStyleSheetHeader().styleSheetId);
+        
+        inspectorPromise.then(function (res) {
+            deferred.resolve(res.text);
+        }, deferred.reject);
+        
+        return deferred.promise();
     };
  
     /** Close the document */

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1189,7 +1189,7 @@ define(function LiveDevelopment(require, exports, module) {
     function showHighlight() {
         var doc = getLiveDocForEditor(EditorManager.getActiveEditor());
         
-        if (doc.updateHighlight) {
+        if (doc && doc.updateHighlight) {
             doc.updateHighlight();
         }
     }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -544,8 +544,6 @@ define(function LiveDevelopment(require, exports, module) {
         allAgentsPromise = Async.withTimeout(allAgentsPromise, 10000);
 
         allAgentsPromise.done(function () {
-            // After (1) the interstitial page loads and (2) then browser navigation
-            // to the base URL is completed, finally set status to STATUS_ACTIVE.
             var doc = (_liveDocument) ? _liveDocument.doc : null;
 
             if (doc) {

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -432,7 +432,6 @@ define(function LiveDevelopment(require, exports, module) {
 
         // Show the message, but include the error object for further information (e.g. error code)
         console.error(message, error);
-        _setStatus(STATUS_ERROR);
     }
     
     function _styleSheetAdded(event, url) {

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1177,7 +1177,6 @@ define(function LiveDevelopment(require, exports, module) {
                 })
                 .fail(function () {
                     _showWrongDocError();
-                    _openDeferred.reject();
                 });
         });
 

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -778,12 +778,15 @@ define(function LiveDevelopment(require, exports, module) {
             });
         }
         
-        // Reject calls to open if requests are still pending
         if (_openDeferred && _openDeferred.state() === "pending") {
+            // Reject calls to open if requests are still pending
             _openDeferred.reject();
+        } else if (exports.status === STATUS_INACTIVE) {
+            // Ignore close if status is inactive
+            deferred.resolve();
+        } else {
+            _doInspectorDisconnect(doCloseWindow).done(cleanup);
         }
-        
-        _doInspectorDisconnect(doCloseWindow).done(cleanup);
         
         return deferred.promise();
     }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -575,9 +575,6 @@ define(function LiveDevelopment(require, exports, module) {
             );
         });
 
-        // resolve/reject the open() promise after agents complete
-        result.then(_openDeferred.resolve, _openDeferred.reject);
-
         return result.promise();
     }
 
@@ -914,7 +911,9 @@ define(function LiveDevelopment(require, exports, module) {
             // navigate to the page first before loading can complete.
             // To accomodate this, we load all agents and navigate in
             // parallel.
-            loadAgents();
+
+            // resolve/reject the open() promise after agents complete
+            loadAgents().then(_openDeferred.resolve, _openDeferred.reject);
 
             _getInitialDocFromCurrent().done(function (doc) {
                 if (doc) {

--- a/src/LiveDevelopment/Servers/BaseServer.js
+++ b/src/LiveDevelopment/Servers/BaseServer.js
@@ -81,12 +81,6 @@ define(function (require, exports, module) {
         // for live development (the file for HTML files)
         // TODO: Issue #2033 Improve how default page is determined
         doc.root = { url: doc.url };
-
-        // TODO: Better workflow of liveDocument.doc.url assignment
-        // Force sync the browser after a URL is assigned
-        if (liveDocument._updateBrowser) {
-            liveDocument._updateBrowser();
-        }
     };
 
     /**

--- a/src/LiveDevelopment/Servers/BaseServer.js
+++ b/src/LiveDevelopment/Servers/BaseServer.js
@@ -81,6 +81,12 @@ define(function (require, exports, module) {
         // for live development (the file for HTML files)
         // TODO: Issue #2033 Improve how default page is determined
         doc.root = { url: doc.url };
+
+        // TODO: Better workflow of liveDocument.doc.url assignment
+        // Force sync the browser after a URL is assigned
+        if (doc.isDirty && liveDocument._updateBrowser) {
+            liveDocument._updateBrowser();
+        }
     };
 
     /**

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -283,7 +283,7 @@ define(function (require, exports, module) {
                 
                 // module spies
                 spyOn(CSSAgentModule, "styleForURL").andReturn("");
-                spyOn(CSSAgentModule, "reloadCSSForDocument").andCallFake(function () {});
+                spyOn(CSSAgentModule, "reloadCSSForDocument").andCallFake(function () { return new $.Deferred().resolve(); });
                 spyOn(HighlightAgentModule, "redraw").andCallFake(function () {});
                 spyOn(HighlightAgentModule, "rule").andCallFake(function () {});
                 InspectorModule.CSS = {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -103,6 +103,19 @@ define(function (require, exports, module) {
         // wrap with a timeout to indicate loadEventFired was not fired
         return Async.withTimeout(deferred.promise(), 2000);
     }
+
+    function waitForLiveDoc(path, callback) {
+        var liveDoc;
+
+        waitsFor(function () {
+            liveDoc = LiveDevelopment.getLiveDocForPath(path);
+            return !!liveDoc;
+        }, "Waiting for LiveDevelopment document", 10000);
+
+        runs(function () {
+            callback(liveDoc);
+        });
+    }
     
     function doOneTest(htmlFile, cssFile) {
         var localText,
@@ -129,10 +142,7 @@ define(function (require, exports, module) {
         });
 
         var liveDoc;
-        waitsFor(function () {
-            liveDoc = LiveDevelopment.getLiveDocForPath(tempDir + "/" + cssFile);
-            return !!liveDoc;
-        }, "Waiting for LiveDevelopment document", 10000);
+        waitForLiveDoc(tempDir + "/" + cssFile, function (doc) { liveDoc = doc; });
         
         var doneSyncing = false;
         runs(function () {
@@ -637,8 +647,9 @@ define(function (require, exports, module) {
                 openLiveDevelopmentAndWait();
                 
                 var liveDoc, doneSyncing = false;
+                waitForLiveDoc(tempDir + "/simple1.css", function (doc) { liveDoc = doc; });
+
                 runs(function () {
-                    liveDoc = LiveDevelopment.getLiveDocForPath(tempDir + "/simple1.css");
                     liveDoc.getSourceFromBrowser().done(function (text) {
                         browserText = text;
                     }).always(function () {
@@ -714,13 +725,13 @@ define(function (require, exports, module) {
                 });
                 
                 // Grab the node that we've modified in Brackets. 
-                var updatedNode, doneSyncing = false;
+                var liveDoc, updatedNode, doneSyncing = false;
+                waitForLiveDoc(tempDir + "/simple1.css", function (doc) { liveDoc = doc; });
+
                 runs(function () {
                     // Inpsector.Page.reload should not be called when saving an HTML file
                     expect(Inspector.Page.reload).not.toHaveBeenCalled();
-                    
                     updatedNode = DOMAgent.nodeAtLocation(501);
-                    var liveDoc = LiveDevelopment.getLiveDocForPath(tempDir + "/simple1.css");
                     
                     liveDoc.getSourceFromBrowser().done(function (text) {
                         browserCssText = text;
@@ -791,8 +802,6 @@ define(function (require, exports, module) {
                         doc.replaceRange("<", { line: 10, ch: 2});
                     }, LiveDevelopmentModule.STATUS_SYNC_ERROR, 11);
                 });
-
-                waits(1000);
 
                 runs(function () {
                     // Undo syntax errors


### PR DESCRIPTION
Fix for #6830 
- Add `styleSheetAdded` and `styleSheetRemoved` event handling to inspector protocol
- Fallback to `getAllStylesheets` for Chrome < 34

Fix for #6912 
- Use `styleSheetAdded` to keep `styleSheetId` values up to date to fix "No style sheet with given id found, code: -32000" when pushing change events from Brackets to Chrome
