### PR TITLE
Added 'Collapse File Tree' feature

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -671,6 +671,29 @@ define(function (require, exports, module) {
             ViewUtils.addScrollerShadow(_projectTree.get(0));
             
             _projectTree
+                .off("click.jstree", "li > ins")
+                .on("click.jstree", "li > ins", function (event) {
+                    var $node = $(event.target).parent("li");
+                    if (event.ctrlKey || event.metaKey) {
+                        if (event.altKey) {
+                            // collapse subtree
+                            // note: expanding using open_all is a bad idea due to poor performance
+                            if ($node.is(".jstree-open")) {
+                                _projectTree.jstree("close_all", $node);
+                                return;
+                            }
+                        } else {
+                            // toggle siblings
+                            var methodName = $node.is(".jstree-open") ? "close_node" : "open_node";
+                            $node.parent().children("li").each(function () {
+                                _projectTree.jstree(methodName, $(this));
+                            });
+                            return;
+                        }
+                    }
+                    // original behaviour
+                    _projectTree.jstree("toggle_node", $node);
+                })
                 .unbind("dblclick.jstree")
                 .bind("dblclick.jstree", function (event) {
                     var entry = $(event.target).closest("li").data("entry");

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -684,18 +684,18 @@ define(function (require, exports, module) {
             };
             var createCustomHandler = function(originalHandler) {
                 return function (event) {
-                    var $node = $(event.target).parent("li");
+                    var $node = $(event.target).parent("li"),
+                        methodName;
                     if (event.ctrlKey || event.metaKey) {
                         if (event.altKey) {
                             // collapse subtree
                             // note: expanding using open_all is a bad idea due to poor performance
-                            if ($node.is(".jstree-open")) {
-                                _projectTree.jstree("close_all", $node);
-                                return;
-                            }
+                            methodName = $node.is(".jstree-open") ? "close_all" : "open_node";
+                            _projectTree.jstree(methodName, $node);
+                            return;
                         } else {
                             // toggle siblings
-                            var methodName = $node.is(".jstree-open") ? "close_node" : "open_node";
+                            methodName = $node.is(".jstree-open") ? "close_node" : "open_node";
                             $node.parent().children("li").each(function () {
                                 _projectTree.jstree(methodName, $(this));
                             });


### PR DESCRIPTION
When working with a file tree, I miss the ability to collapse whole section recursively - so when I open the top directory again later, not everything under it will also be expanded. This is a feature for it.

Sample:
I want to collapse everything under "test" folder and when I open "test" folder again, I don't want to see "node", "node-modules", "fs-extra" and "lib" expanded too.
![image](https://f.cloud.github.com/assets/1067319/2288568/7c62c59e-9ffb-11e3-8943-72a96be19194.png)
