### PR TITLE
Improvements to Close Others

### DIFF
--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -44,10 +44,9 @@ define(function (require, exports, module) {
     var commandsRegistered  = false,
         menuEntry           = {},
         prefs               = PreferencesManager.getExtensionPrefs("closeOthers");
-    prefs.definePreference("enabled", "boolean", true);
-    prefs.definePreference("closeAbove", "boolean", true);
     prefs.definePreference("closeBelow", "boolean", true);
     prefs.definePreference("closeOthers", "boolean", true);
+    prefs.definePreference("closeAbove", "boolean", true);
 
     function handleClose(mode) {
 
@@ -98,36 +97,25 @@ define(function (require, exports, module) {
     }
 
     function prefChangeHandler() {
-        // it's senseless to look prefs up for the current file, instead look them up for the current project
-        var enabled         = prefs.get("enabled", PreferencesManager.CURRENT_PROJECT),
-            prefCloseAbove  = prefs.get("closeAbove", PreferencesManager.CURRENT_PROJECT) && enabled,
-            prefCloseBelow  = prefs.get("closeBelow", PreferencesManager.CURRENT_PROJECT) && enabled,
-            prefCloseOthers = prefs.get("closeOthers", PreferencesManager.CURRENT_PROJECT) && enabled;
-        console.log(enabled);
+        // it's senseless to look prefs up for the current file, instead look them up for
+        // the current project (or globally)
+        var prefCloseBelow  = prefs.get("closeBelow", PreferencesManager.CURRENT_PROJECT),
+            prefCloseOthers = prefs.get("closeOthers", PreferencesManager.CURRENT_PROJECT),
+            prefCloseAbove  = prefs.get("closeAbove", PreferencesManager.CURRENT_PROJECT);
         
-        if (enabled) {
-            if (!commandsRegistered) {
-                CommandManager.register(Strings.CMD_FILE_CLOSE_BELOW, closeBelow, function () {
-                    handleClose(closeBelow);
-                });
-                CommandManager.register(Strings.CMD_FILE_CLOSE_OTHERS, closeOthers, function () {
-                    handleClose(closeOthers);
-                });
-                CommandManager.register(Strings.CMD_FILE_CLOSE_ABOVE, closeAbove, function () {
-                    handleClose(closeAbove);
-                });
-                commandsRegistered = true;
-            }
+        if (!commandsRegistered && (prefCloseBelow || prefCloseOthers || prefCloseAbove)) {
+            CommandManager.register(Strings.CMD_FILE_CLOSE_BELOW, closeBelow, function () {
+                handleClose(closeBelow);
+            });
+            CommandManager.register(Strings.CMD_FILE_CLOSE_OTHERS, closeOthers, function () {
+                handleClose(closeOthers);
+            });
+            CommandManager.register(Strings.CMD_FILE_CLOSE_ABOVE, closeAbove, function () {
+                handleClose(closeAbove);
+            });
+            commandsRegistered = true;
         }
         
-        if (prefCloseAbove !== menuEntry.closeAbove) {
-            if (prefCloseAbove) {
-                workingSetCmenu.addMenuItem(closeAbove, "", Menus.AFTER, Commands.FILE_CLOSE);
-            } else {
-                workingSetCmenu.removeMenuItem(closeAbove);
-            }
-            menuEntry.closeAbove = prefCloseAbove;
-        }
         if (prefCloseBelow !== menuEntry.closeBelow) {
             if (prefCloseBelow) {
                 workingSetCmenu.addMenuItem(closeBelow, "", Menus.AFTER, Commands.FILE_CLOSE);
@@ -143,6 +131,14 @@ define(function (require, exports, module) {
                 workingSetCmenu.removeMenuItem(closeOthers);
             }
             menuEntry.closeOthers = prefCloseOthers;
+        }
+        if (prefCloseAbove !== menuEntry.closeAbove) {
+            if (prefCloseAbove) {
+                workingSetCmenu.addMenuItem(closeAbove, "", Menus.AFTER, Commands.FILE_CLOSE);
+            } else {
+                workingSetCmenu.removeMenuItem(closeAbove);
+            }
+            menuEntry.closeAbove = prefCloseAbove;
         }
     }
 

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
 
     // Global vars and preferences
     var commandsRegistered  = false,
-        menuEntry           = {},
+        menuEntriesShown    = {},
         prefs               = PreferencesManager.getExtensionPrefs("closeOthers");
     prefs.definePreference("below", "boolean", true);
     prefs.definePreference("others", "boolean", true);
@@ -116,30 +116,28 @@ define(function (require, exports, module) {
             commandsRegistered = true;
         }
         
-        if (prefCloseBelow !== menuEntry.closeBelow) {
+        if (prefCloseBelow !== menuEntriesShown.closeBelow) {
             if (prefCloseBelow) {
                 workingSetCmenu.addMenuItem(closeBelow, "", Menus.AFTER, Commands.FILE_CLOSE);
             } else {
                 workingSetCmenu.removeMenuItem(closeBelow);
             }
-            menuEntry.closeBelow = prefCloseBelow;
         }
-        if (prefCloseOthers !== menuEntry.closeOthers) {
+        if (prefCloseOthers !== menuEntriesShown.closeOthers) {
             if (prefCloseOthers) {
                 workingSetCmenu.addMenuItem(closeOthers, "", Menus.AFTER, Commands.FILE_CLOSE);
             } else {
                 workingSetCmenu.removeMenuItem(closeOthers);
             }
-            menuEntry.closeOthers = prefCloseOthers;
         }
-        if (prefCloseAbove !== menuEntry.closeAbove) {
+        if (prefCloseAbove !== menuEntriesShown.closeAbove) {
             if (prefCloseAbove) {
                 workingSetCmenu.addMenuItem(closeAbove, "", Menus.AFTER, Commands.FILE_CLOSE);
             } else {
                 workingSetCmenu.removeMenuItem(closeAbove);
             }
-            menuEntry.closeAbove = prefCloseAbove;
         }
+        menuEntriesShown = {"closeBelow": prefCloseBelow, "closeOthers": prefCloseOthers, "closeAbove": prefCloseAbove};
     }
 
     // Initialize using the prefs

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -27,28 +27,27 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var Menus             = brackets.getModule("command/Menus"),
-        CommandManager    = brackets.getModule("command/CommandManager"),
-        Commands          = brackets.getModule("command/Commands"),
-        dm                = brackets.getModule("document/DocumentManager"),
-        docCH             = brackets.getModule("document/DocumentCommandHandlers"),
-        strings           = brackets.getModule("i18n!nls/strings"),
-        settings          = JSON.parse(require("text!settings.json")),
-        working_set_cmenu = Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_MENU),
-        close_others      = "file.close_others",
-        close_above       = "file.close_above",
-        close_below       = "file.close_below";
+    var Menus                   = brackets.getModule("command/Menus"),
+        CommandManager          = brackets.getModule("command/CommandManager"),
+        Commands                = brackets.getModule("command/Commands"),
+        DocumentManager         = brackets.getModule("document/DocumentManager"),
+        Strings                 = brackets.getModule("strings"),
+        Settings                = JSON.parse(require("text!settings.json")),
+        workingSetCmenu         = Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_MENU),
+        closeOthers             = "file.close_others",
+        closeAbove              = "file.close_above",
+        closeBelow              = "file.close_below";
 
     function handleClose(mode) {
 
-        var targetIndex = dm.findInWorkingSet(dm.getCurrentDocument().file.fullPath),
-            workingSet   = dm.getWorkingSet().slice(0),
-            start = (mode === close_below) ? (targetIndex + 1) : 0,
-            end   = (mode === close_above) ? (targetIndex) : (workingSet.length),
+        var targetIndex = DocumentManager.findInWorkingSet(DocumentManager.getCurrentDocument().file.fullPath),
+            workingSet   = DocumentManager.getWorkingSet().slice(0),
+            start = (mode === closeBelow) ? (targetIndex + 1) : 0,
+            end   = (mode === closeAbove) ? (targetIndex) : (workingSet.length),
             files = [],
             i;
         
-        if (mode === close_others) {
+        if (mode === closeOthers) {
             end--;
             workingSet.splice(targetIndex, 1);
         }
@@ -60,54 +59,54 @@ define(function (require, exports, module) {
         CommandManager.execute(Commands.FILE_CLOSE_LIST, {fileList: files});
     }
 
-    function _currentDocChangedHandler() {
-        var doc = dm.getCurrentDocument();
+    function _contextMenuOpenHandler() {
+        var doc = DocumentManager.getCurrentDocument();
         
         if (doc) {
-            var docIndex   = dm.findInWorkingSet(doc.file.fullPath),
-                workingSet = dm.getWorkingSet().slice(0);
+            var docIndex   = DocumentManager.findInWorkingSet(doc.file.fullPath),
+                workingSet = DocumentManager.getWorkingSet().slice(0);
             
-            if (docIndex === workingSet.length - 1) { // hide "Close Others Below" when the last file in Working Files is selected
-                CommandManager.get(close_below).setEnabled(false);
+            if (docIndex === workingSet.length - 1) { // hide "Close Others Below" if the last file in Working Files is selected
+                CommandManager.get(closeBelow).setEnabled(false);
             } else {
-                CommandManager.get(close_below).setEnabled(true);
+                CommandManager.get(closeBelow).setEnabled(true);
             }
             
-            if (workingSet.length === 1) { // hide "Close Others" when there is only one file in Working Files
-                CommandManager.get(close_others).setEnabled(false);
+            if (workingSet.length === 1) { // hide "Close Others" if there is only one file in Working Files
+                CommandManager.get(closeOthers).setEnabled(false);
             } else {
-                CommandManager.get(close_others).setEnabled(true);
+                CommandManager.get(closeOthers).setEnabled(true);
             }
             
-            if (docIndex === 0) { // hide "Close Others Above" when the first file in Working Files is selected
-                CommandManager.get(close_above).setEnabled(false);
+            if (docIndex === 0) { // hide "Close Others Above" if the first file in Working Files is selected
+                CommandManager.get(closeAbove).setEnabled(false);
             } else {
-                CommandManager.get(close_above).setEnabled(true);
+                CommandManager.get(closeAbove).setEnabled(true);
             }
         }
     }
 
-    if (settings.close_below) {
-        CommandManager.register(strings.CMD_FILE_CLOSE_BELOW, close_below, function () {
-            handleClose(close_below);
+    if (Settings.close_below) {
+        CommandManager.register(Strings.CMD_FILE_CLOSE_BELOW, closeBelow, function () {
+            handleClose(closeBelow);
         });
-        working_set_cmenu.addMenuItem(close_below, "", Menus.AFTER, Commands.FILE_CLOSE);
+        workingSetCmenu.addMenuItem(closeBelow, "", Menus.AFTER, Commands.FILE_CLOSE);
     }
 
-    if (settings.close_others) {
-        CommandManager.register(strings.CMD_FILE_CLOSE_OTHERS, close_others, function () {
-            handleClose(close_others);
+    if (Settings.close_others) {
+        CommandManager.register(Strings.CMD_FILE_CLOSE_OTHERS, closeOthers, function () {
+            handleClose(closeOthers);
         });
-        working_set_cmenu.addMenuItem(close_others, "", Menus.AFTER, Commands.FILE_CLOSE);
+        workingSetCmenu.addMenuItem(closeOthers, "", Menus.AFTER, Commands.FILE_CLOSE);
     }
 
-    if (settings.close_above) {
-        CommandManager.register(strings.CMD_FILE_CLOSE_ABOVE, close_above, function () {
-            handleClose(close_above);
+    if (Settings.close_above) {
+        CommandManager.register(Strings.CMD_FILE_CLOSE_ABOVE, closeAbove, function () {
+            handleClose(closeAbove);
         });
-        working_set_cmenu.addMenuItem(close_above, "", Menus.AFTER, Commands.FILE_CLOSE);
+        workingSetCmenu.addMenuItem(closeAbove, "", Menus.AFTER, Commands.FILE_CLOSE);
     }
 
-    // Add a document change handler
-    $(dm).on("currentDocumentChange", _currentDocChangedHandler);
+    // Add a context menu open handler
+    $(workingSetCmenu).on("beforeContextMenuOpen", _contextMenuOpenHandler);
 });

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -44,9 +44,9 @@ define(function (require, exports, module) {
     var commandsRegistered  = false,
         menuEntry           = {},
         prefs               = PreferencesManager.getExtensionPrefs("closeOthers");
-    prefs.definePreference("closeBelow", "boolean", true);
-    prefs.definePreference("closeOthers", "boolean", true);
-    prefs.definePreference("closeAbove", "boolean", true);
+    prefs.definePreference("below", "boolean", true);
+    prefs.definePreference("others", "boolean", true);
+    prefs.definePreference("above", "boolean", true);
 
     function handleClose(mode) {
 
@@ -99,9 +99,9 @@ define(function (require, exports, module) {
     function prefChangeHandler() {
         // it's senseless to look prefs up for the current file, instead look them up for
         // the current project (or globally)
-        var prefCloseBelow  = prefs.get("closeBelow", PreferencesManager.CURRENT_PROJECT),
-            prefCloseOthers = prefs.get("closeOthers", PreferencesManager.CURRENT_PROJECT),
-            prefCloseAbove  = prefs.get("closeAbove", PreferencesManager.CURRENT_PROJECT);
+        var prefCloseBelow  = prefs.get("below", PreferencesManager.CURRENT_PROJECT),
+            prefCloseOthers = prefs.get("others", PreferencesManager.CURRENT_PROJECT),
+            prefCloseAbove  = prefs.get("above", PreferencesManager.CURRENT_PROJECT);
         
         if (!commandsRegistered && (prefCloseBelow || prefCloseOthers || prefCloseAbove)) {
             CommandManager.register(Strings.CMD_FILE_CLOSE_BELOW, closeBelow, function () {

--- a/src/extensions/default/CloseOthers/settings.json
+++ b/src/extensions/default/CloseOthers/settings.json
@@ -1,5 +1,0 @@
-{
-    "close_others": true,
-    "close_above": true,
-    "close_below": true
-}


### PR DESCRIPTION
As mentioned in https://github.com/adobe/brackets/pull/6020#issuecomment-36387113, I just did some improvements to the Close Others extension:
- Removed the `DocumentCommandHandlers` module - it wasn't used
- Renamed modules (beginning with an uppercase char) and vars (camelCase) to match the Brackets standard
- Using the handler `beforeContextMenuOpen`

Unit tests still passing.
@JeffryBooher
