### PR TITLE
[cmv4] Keyboard commands for multiple selections

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -65,6 +65,9 @@
             "platform": "mac"
         }
     ],
+    "edit.splitSelIntoLines": [
+        "Ctrl-Alt-L"
+    ],
     "edit.find":  [
         "Ctrl-F"
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -68,6 +68,18 @@
     "edit.splitSelIntoLines": [
         "Ctrl-Alt-L"
     ],
+    "edit.addPrevLineToSel": [
+        {
+            "key": "Ctrl-Alt-Up",
+            "displayKey": "Ctrl-Alt-↑"
+        }
+    ],
+    "edit.addNextLineToSel": [
+        {
+            "key": "Ctrl-Alt-Down",
+            "displayKey": "Ctrl-Alt-↓"
+        }
+    ],
     "edit.find":  [
         "Ctrl-F"
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -104,6 +104,11 @@
             "platform": "mac"
         }
     ],
+    "edit.addNextMatch": [
+        {
+            "key": "Ctrl-B"
+        }
+    ],
     "edit.replace":  [
         {
             "key": "Ctrl-H"

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -104,6 +104,15 @@
             "platform": "mac"
         }
     ],
+    "edit.findAllAndSelect": [
+        {
+            "key": "Alt-F3"
+        },
+        {
+            "key": "Cmd-Ctrl-G",
+            "platform": "mac"
+        }
+    ],
     "edit.addNextMatch": [
         {
             "key": "Ctrl-B"

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -70,14 +70,14 @@
     ],
     "edit.addPrevLineToSel": [
         {
-            "key": "Ctrl-Alt-Up",
-            "displayKey": "Ctrl-Alt-↑"
+            "key": "Shift-Alt-Up",
+            "displayKey": "Shift-Alt-↑"
         }
     ],
     "edit.addNextLineToSel": [
         {
-            "key": "Ctrl-Alt-Down",
-            "displayKey": "Ctrl-Alt-↓"
+            "key": "Shift-Alt-Down",
+            "displayKey": "Shift-Alt-↓"
         }
     ],
     "edit.find":  [

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -109,6 +109,11 @@
             "key": "Ctrl-B"
         }
     ],
+    "edit.skipCurrentMatch": [
+        {
+            "key": "Ctrl-Shift-B"
+        }
+    ],
     "edit.replace":  [
         {
             "key": "Ctrl-H"

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -70,6 +70,8 @@ define(function (require, exports, module) {
     
     exports.EDIT_SELECT_LINE            = "edit.selectLine";            // EditorCommandHandlers.js     selectLine()
     exports.EDIT_SPLIT_SEL_INTO_LINES   = "edit.splitSelIntoLines";     // EditorCommandHandlers.js     splitSelIntoLines()
+    exports.EDIT_ADD_NEXT_LINE_TO_SEL   = "edit.addNextLineToSel";      // EditorCommandHandlers.js     addNextLineToSel()
+    exports.EDIT_ADD_PREV_LINE_TO_SEL   = "edit.addPrevLineToSel";      // EditorCommandHandlers.js     addPrevLineToSel()
     exports.EDIT_FIND                   = "edit.find";                  // FindReplace.js               _launchFind()
     exports.EDIT_FIND_IN_FILES          = "edit.findInFiles";           // FindInFiles.js               _doFindInFiles()
     exports.EDIT_FIND_IN_SUBTREE        = "edit.findInSubtree";         // FindInFiles.js               _doFindInSubtree()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -69,6 +69,7 @@ define(function (require, exports, module) {
     exports.EDIT_SELECT_ALL             = "edit.selectAll";             // EditorCommandHandlers.js     _handleSelectAll()
     
     exports.EDIT_SELECT_LINE            = "edit.selectLine";            // EditorCommandHandlers.js     selectLine()
+    exports.EDIT_SPLIT_SEL_INTO_LINES   = "edit.splitSelIntoLines";     // EditorCommandHandlers.js     splitSelIntoLines()
     exports.EDIT_FIND                   = "edit.find";                  // FindReplace.js               _launchFind()
     exports.EDIT_FIND_IN_FILES          = "edit.findInFiles";           // FindInFiles.js               _doFindInFiles()
     exports.EDIT_FIND_IN_SUBTREE        = "edit.findInSubtree";         // FindInFiles.js               _doFindInSubtree()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -77,6 +77,7 @@ define(function (require, exports, module) {
     exports.EDIT_FIND_IN_SUBTREE        = "edit.findInSubtree";         // FindInFiles.js               _doFindInSubtree()
     exports.EDIT_FIND_NEXT              = "edit.findNext";              // FindReplace.js               _findNext()
     exports.EDIT_FIND_PREVIOUS          = "edit.findPrevious";          // FindReplace.js               _findPrevious()
+    exports.EDIT_FIND_ALL_AND_SELECT    = "edit.findAllAndSelect";      // FindReplace.js               _findAllAndSelect()
     exports.EDIT_ADD_NEXT_MATCH         = "edit.addNextMatch";          // FindReplace.js               _expandAndAddNextToSelection()
     exports.EDIT_SKIP_CURRENT_MATCH     = "edit.skipCurrentMatch";      // FindReplace.js               _skipCurrentMatch()
     exports.EDIT_REPLACE                = "edit.replace";               // FindReplace.js               _replace()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -78,6 +78,7 @@ define(function (require, exports, module) {
     exports.EDIT_FIND_NEXT              = "edit.findNext";              // FindReplace.js               _findNext()
     exports.EDIT_FIND_PREVIOUS          = "edit.findPrevious";          // FindReplace.js               _findPrevious()
     exports.EDIT_ADD_NEXT_MATCH         = "edit.addNextMatch";          // FindReplace.js               _expandAndAddNextToSelection()
+    exports.EDIT_SKIP_CURRENT_MATCH     = "edit.skipCurrentMatch";      // FindReplace.js               _skipCurrentMatch()
     exports.EDIT_REPLACE                = "edit.replace";               // FindReplace.js               _replace()
     exports.EDIT_INDENT                 = "edit.indent";                // EditorCommandHandlers.js     indentText()
     exports.EDIT_UNINDENT               = "edit.unindent";              // EditorCommandHandlers.js     unidentText()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
     exports.EDIT_SKIP_CURRENT_MATCH     = "edit.skipCurrentMatch";      // FindReplace.js               _skipCurrentMatch()
     exports.EDIT_REPLACE                = "edit.replace";               // FindReplace.js               _replace()
     exports.EDIT_INDENT                 = "edit.indent";                // EditorCommandHandlers.js     indentText()
-    exports.EDIT_UNINDENT               = "edit.unindent";              // EditorCommandHandlers.js     unidentText()
+    exports.EDIT_UNINDENT               = "edit.unindent";              // EditorCommandHandlers.js     unindentText()
     exports.EDIT_DUPLICATE              = "edit.duplicate";             // EditorCommandHandlers.js     duplicateText()
     exports.EDIT_DELETE_LINES           = "edit.deletelines";           // EditorCommandHandlers.js     deleteCurrentLines()
     exports.EDIT_LINE_COMMENT           = "edit.lineComment";           // EditorCommandHandlers.js     lineComment()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -77,6 +77,7 @@ define(function (require, exports, module) {
     exports.EDIT_FIND_IN_SUBTREE        = "edit.findInSubtree";         // FindInFiles.js               _doFindInSubtree()
     exports.EDIT_FIND_NEXT              = "edit.findNext";              // FindReplace.js               _findNext()
     exports.EDIT_FIND_PREVIOUS          = "edit.findPrevious";          // FindReplace.js               _findPrevious()
+    exports.EDIT_ADD_NEXT_MATCH         = "edit.addNextMatch";          // FindReplace.js               _expandAndAddNextToSelection()
     exports.EDIT_REPLACE                = "edit.replace";               // FindReplace.js               _replace()
     exports.EDIT_INDENT                 = "edit.indent";                // EditorCommandHandlers.js     indentText()
     exports.EDIT_UNINDENT               = "edit.unindent";              // EditorCommandHandlers.js     unidentText()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -84,8 +84,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_FIND);
         menu.addMenuItem(Commands.EDIT_FIND_IN_FILES);
         menu.addMenuItem(Commands.EDIT_FIND_NEXT);
-
         menu.addMenuItem(Commands.EDIT_FIND_PREVIOUS);
+        menu.addMenuItem(Commands.EDIT_ADD_NEXT_MATCH);
 
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_REPLACE);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -78,6 +78,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_SELECT_ALL);
         menu.addMenuItem(Commands.EDIT_SELECT_LINE);
         menu.addMenuItem(Commands.EDIT_SPLIT_SEL_INTO_LINES);
+        menu.addMenuItem(Commands.EDIT_ADD_PREV_LINE_TO_SEL);
+        menu.addMenuItem(Commands.EDIT_ADD_NEXT_LINE_TO_SEL);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_FIND);
         menu.addMenuItem(Commands.EDIT_FIND_IN_FILES);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -77,6 +77,7 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_SELECT_ALL);
         menu.addMenuItem(Commands.EDIT_SELECT_LINE);
+        menu.addMenuItem(Commands.EDIT_SPLIT_SEL_INTO_LINES);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_FIND);
         menu.addMenuItem(Commands.EDIT_FIND_IN_FILES);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -86,6 +86,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_FIND_NEXT);
         menu.addMenuItem(Commands.EDIT_FIND_PREVIOUS);
         menu.addMenuItem(Commands.EDIT_ADD_NEXT_MATCH);
+        menu.addMenuItem(Commands.EDIT_SKIP_CURRENT_MATCH);
 
         menu.addMenuDivider();
         menu.addMenuItem(Commands.EDIT_REPLACE);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -85,6 +85,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_FIND_IN_FILES);
         menu.addMenuItem(Commands.EDIT_FIND_NEXT);
         menu.addMenuItem(Commands.EDIT_FIND_PREVIOUS);
+        menu.addMenuItem(Commands.EDIT_FIND_ALL_AND_SELECT);
         menu.addMenuItem(Commands.EDIT_ADD_NEXT_MATCH);
         menu.addMenuItem(Commands.EDIT_SKIP_CURRENT_MATCH);
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1046,7 +1046,7 @@ define(function (require, exports, module) {
      * making the selection
      *
      * @param {!{line:number, ch:number}} start
-     * @param {={line:number, ch:number}} end If not specified, defaults to start.
+     * @param {{line:number, ch:number}=} end If not specified, defaults to start.
      * @param {boolean} center true to center the viewport
      * @param {number} centerOptions Option value, or 0 for no options; one of the BOUNDARY_* constants above.
      */

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -938,7 +938,7 @@ define(function (require, exports, module) {
     /**
      * Unindent a line of text if no selection. Otherwise, unindent all lines in selection.
      */
-    function unidentText() {
+    function unindentText() {
         var editor = EditorManager.getFocusedEditor();
         if (!editor) {
             return;
@@ -1044,7 +1044,7 @@ define(function (require, exports, module) {
         
     // Register commands
     CommandManager.register(Strings.CMD_INDENT,                 Commands.EDIT_INDENT,                 indentText);
-    CommandManager.register(Strings.CMD_UNINDENT,               Commands.EDIT_UNINDENT,               unidentText);
+    CommandManager.register(Strings.CMD_UNINDENT,               Commands.EDIT_UNINDENT,               unindentText);
     CommandManager.register(Strings.CMD_COMMENT,                Commands.EDIT_LINE_COMMENT,           lineComment);
     CommandManager.register(Strings.CMD_BLOCK_COMMENT,          Commands.EDIT_BLOCK_COMMENT,          blockComment);
     CommandManager.register(Strings.CMD_DUPLICATE,              Commands.EDIT_DUPLICATE,              duplicateText);

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -955,6 +955,13 @@ define(function (require, exports, module) {
             editor.setSelections(_.pluck(editor.convertToLineSelections(editor.getSelections(), { expandEndAtStartOfLine: true }), "selectionForEdit"));
         }
     }
+    
+    function splitSelIntoLines(editor) {
+        editor = editor || EditorManager.getFocusedEditor();
+        if (editor) {
+            editor._codeMirror.execCommand("splitSelectionByLine");
+        }
+    }
 
     function handleUndoRedo(operation) {
         var editor = EditorManager.getFocusedEditor();
@@ -1003,22 +1010,23 @@ define(function (require, exports, module) {
     }
         
     // Register commands
-    CommandManager.register(Strings.CMD_INDENT,           Commands.EDIT_INDENT,           indentText);
-    CommandManager.register(Strings.CMD_UNINDENT,         Commands.EDIT_UNINDENT,         unidentText);
-    CommandManager.register(Strings.CMD_COMMENT,          Commands.EDIT_LINE_COMMENT,     lineComment);
-    CommandManager.register(Strings.CMD_BLOCK_COMMENT,    Commands.EDIT_BLOCK_COMMENT,    blockComment);
-    CommandManager.register(Strings.CMD_DUPLICATE,        Commands.EDIT_DUPLICATE,        duplicateText);
-    CommandManager.register(Strings.CMD_DELETE_LINES,     Commands.EDIT_DELETE_LINES,     deleteCurrentLines);
-    CommandManager.register(Strings.CMD_LINE_UP,          Commands.EDIT_LINE_UP,          moveLineUp);
-    CommandManager.register(Strings.CMD_LINE_DOWN,        Commands.EDIT_LINE_DOWN,        moveLineDown);
-    CommandManager.register(Strings.CMD_OPEN_LINE_ABOVE,  Commands.EDIT_OPEN_LINE_ABOVE,  openLineAbove);
-    CommandManager.register(Strings.CMD_OPEN_LINE_BELOW,  Commands.EDIT_OPEN_LINE_BELOW,  openLineBelow);
-    CommandManager.register(Strings.CMD_SELECT_LINE,      Commands.EDIT_SELECT_LINE,      selectLine);
+    CommandManager.register(Strings.CMD_INDENT,                 Commands.EDIT_INDENT,                 indentText);
+    CommandManager.register(Strings.CMD_UNINDENT,               Commands.EDIT_UNINDENT,               unidentText);
+    CommandManager.register(Strings.CMD_COMMENT,                Commands.EDIT_LINE_COMMENT,           lineComment);
+    CommandManager.register(Strings.CMD_BLOCK_COMMENT,          Commands.EDIT_BLOCK_COMMENT,          blockComment);
+    CommandManager.register(Strings.CMD_DUPLICATE,              Commands.EDIT_DUPLICATE,              duplicateText);
+    CommandManager.register(Strings.CMD_DELETE_LINES,           Commands.EDIT_DELETE_LINES,           deleteCurrentLines);
+    CommandManager.register(Strings.CMD_LINE_UP,                Commands.EDIT_LINE_UP,                moveLineUp);
+    CommandManager.register(Strings.CMD_LINE_DOWN,              Commands.EDIT_LINE_DOWN,              moveLineDown);
+    CommandManager.register(Strings.CMD_OPEN_LINE_ABOVE,        Commands.EDIT_OPEN_LINE_ABOVE,        openLineAbove);
+    CommandManager.register(Strings.CMD_OPEN_LINE_BELOW,        Commands.EDIT_OPEN_LINE_BELOW,        openLineBelow);
+    CommandManager.register(Strings.CMD_SELECT_LINE,            Commands.EDIT_SELECT_LINE,            selectLine);
+    CommandManager.register(Strings.CMD_SPLIT_SEL_INTO_LINES,   Commands.EDIT_SPLIT_SEL_INTO_LINES,   splitSelIntoLines);
 
-    CommandManager.register(Strings.CMD_UNDO,             Commands.EDIT_UNDO,             handleUndo);
-    CommandManager.register(Strings.CMD_REDO,             Commands.EDIT_REDO,             handleRedo);
-    CommandManager.register(Strings.CMD_CUT,              Commands.EDIT_CUT,              ignoreCommand);
-    CommandManager.register(Strings.CMD_COPY,             Commands.EDIT_COPY,             ignoreCommand);
-    CommandManager.register(Strings.CMD_PASTE,            Commands.EDIT_PASTE,            ignoreCommand);
-    CommandManager.register(Strings.CMD_SELECT_ALL,       Commands.EDIT_SELECT_ALL,       _handleSelectAll);
+    CommandManager.register(Strings.CMD_UNDO,                   Commands.EDIT_UNDO,                   handleUndo);
+    CommandManager.register(Strings.CMD_REDO,                   Commands.EDIT_REDO,                   handleRedo);
+    CommandManager.register(Strings.CMD_CUT,                    Commands.EDIT_CUT,                    ignoreCommand);
+    CommandManager.register(Strings.CMD_COPY,                   Commands.EDIT_COPY,                   ignoreCommand);
+    CommandManager.register(Strings.CMD_PASTE,                  Commands.EDIT_PASTE,                  ignoreCommand);
+    CommandManager.register(Strings.CMD_SELECT_ALL,             Commands.EDIT_SELECT_ALL,             _handleSelectAll);
 });

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -956,13 +956,24 @@ define(function (require, exports, module) {
         }
     }
     
+    /**
+     * @private
+     * Takes the current selection and splits each range into separate selections, one per line.
+     * @param {!Editor} editor The editor to operate on.
+     */
     function splitSelIntoLines(editor) {
         editor = editor || EditorManager.getFocusedEditor();
         if (editor) {
             editor._codeMirror.execCommand("splitSelectionByLine");
         }
     }
-    
+
+    /**
+     * @private
+     * Adds a cursor on the next/previous line after/before each selected range to the selection.
+     * @param {!Editor} editor The editor to operate on.
+     * @param {number} dir The direction to add - 1 is down, -1 is up.
+     */
     function addLineToSelection(editor, dir) {
         editor = editor || EditorManager.getFocusedEditor();
         if (editor) {
@@ -988,10 +999,20 @@ define(function (require, exports, module) {
         }
     }
     
+    /**
+     * @private
+     * Adds a cursor on the previous line before each selected range to the selection.
+     * @param {!Editor} editor The editor to operate on.
+     */
     function addPrevLineToSelection(editor) {
         addLineToSelection(editor, -1);
     }
     
+    /**
+     * @private
+     * Adds a cursor on the next line after each selected range to the selection.
+     * @param {!Editor} editor The editor to operate on.
+     */
     function addNextLineToSelection(editor) {
         addLineToSelection(editor, 1);
     }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -269,6 +269,7 @@ define({
     "CMD_FIND_NEXT"                       : "Find Next",
     "CMD_FIND_PREVIOUS"                   : "Find Previous",
     "CMD_ADD_NEXT_MATCH"                  : "Add Next Match to Selection",
+    "CMD_SKIP_CURRENT_MATCH"              : "Skip and Add Next Match",
     "CMD_REPLACE"                         : "Replace",
     "CMD_INDENT"                          : "Indent",
     "CMD_UNINDENT"                        : "Unindent",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -259,6 +259,7 @@ define({
     "CMD_PASTE"                           : "Paste",
     "CMD_SELECT_ALL"                      : "Select All",
     "CMD_SELECT_LINE"                     : "Select Line",
+    "CMD_SPLIT_SEL_INTO_LINES"            : "Split Selection into Lines",
     "CMD_FIND"                            : "Find",
     "CMD_FIND_FIELD_PLACEHOLDER"          : "Find\u2026",
     "CMD_FIND_IN_FILES"                   : "Find in Files",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -260,6 +260,8 @@ define({
     "CMD_SELECT_ALL"                      : "Select All",
     "CMD_SELECT_LINE"                     : "Select Line",
     "CMD_SPLIT_SEL_INTO_LINES"            : "Split Selection into Lines",
+    "CMD_ADD_NEXT_LINE_TO_SEL"            : "Add Next Line to Selection",
+    "CMD_ADD_PREV_LINE_TO_SEL"            : "Add Previous Line to Selection",
     "CMD_FIND"                            : "Find",
     "CMD_FIND_FIELD_PLACEHOLDER"          : "Find\u2026",
     "CMD_FIND_IN_FILES"                   : "Find in Files",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -268,6 +268,7 @@ define({
     "CMD_FIND_IN_SUBTREE"                 : "Find in\u2026",
     "CMD_FIND_NEXT"                       : "Find Next",
     "CMD_FIND_PREVIOUS"                   : "Find Previous",
+    "CMD_FIND_ALL_AND_SELECT"             : "Find All and Select",
     "CMD_ADD_NEXT_MATCH"                  : "Add Next Match to Selection",
     "CMD_SKIP_CURRENT_MATCH"              : "Skip and Add Next Match",
     "CMD_REPLACE"                         : "Replace",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -268,6 +268,7 @@ define({
     "CMD_FIND_IN_SUBTREE"                 : "Find in\u2026",
     "CMD_FIND_NEXT"                       : "Find Next",
     "CMD_FIND_PREVIOUS"                   : "Find Previous",
+    "CMD_ADD_NEXT_MATCH"                  : "Add Next Match to Selection",
     "CMD_REPLACE"                         : "Replace",
     "CMD_INDENT"                          : "Indent",
     "CMD_UNINDENT"                        : "Unindent",

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -398,10 +398,10 @@ define(function (require, exports, module) {
         var cm = editor._codeMirror;
         cm.operation(function () {
             var nextMatch = _getNextMatch(editor, rev, pos);
-            if (!nextMatch) {
-                cm.setCursor(editor.getCursorPos());  // collapses selection, keeping cursor in place to avoid scrolling
-            } else {
+            if (nextMatch) {
                 _selectAndScrollTo(editor, [nextMatch], true, preferNoScroll);
+            } else {
+                cm.setCursor(editor.getCursorPos());  // collapses selection, keeping cursor in place to avoid scrolling
             }
         });
     }

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -3192,7 +3192,103 @@ define(function (require, exports, module) {
                 });
             });
         });
+        
+        describe("Add Line to Selection", function () {
+            beforeEach(setupFullEditor);
+            
+            it("should add a cursor on the next line after a single cursor selection and make it primary", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 1, ch: 5});
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}, primary: true, reversed: false}]);
+            });
 
+            it("should add a cursor on the previous line before a single cursor selection and make it primary", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 1, ch: 5});
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}, primary: true, reversed: false},
+                                  {start: {line: 1, ch: 5}, end: {line: 1, ch: 5}, primary: false, reversed: false}]);
+            });
+
+            it("should add a cursor on the next line after a single-line range selection, below the end pos of the range", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 1, ch: 8});
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 8}, primary: false, reversed: false},
+                                  {start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, primary: true, reversed: false}]);
+            });
+
+            it("should add a cursor on the previous line after a single-line range selection, above the start pos of the range", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 1, ch: 8});
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}, primary: true, reversed: false},
+                                  {start: {line: 1, ch: 5}, end: {line: 1, ch: 8}, primary: false, reversed: false}]);
+            });
+            
+            it("should add a cursor on the next line after a multi-line range selection, below the end pos of the range", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 2, ch: 8});
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 1, ch: 5}, end: {line: 2, ch: 8}, primary: false, reversed: false},
+                                  {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: true, reversed: false}]);
+            });
+
+            it("should add a cursor on the previous line before a multi-line range selection, above the start pos of the range", function () {
+                myEditor.setSelection({line: 1, ch: 5}, {line: 2, ch: 8});
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}, primary: true, reversed: false},
+                                  {start: {line: 1, ch: 5}, end: {line: 2, ch: 8}, primary: false, reversed: false}]);
+            });
+            
+            it("should do nothing if trying to add selection down at last line", function () {
+                myEditor.setSelection({line: 7, ch: 0}, {line: 7, ch: 0});
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 7, ch: 0}, end: {line: 7, ch: 0}, primary: true, reversed: false}]);
+            });
+            
+            it("should do nothing if trying to add selection up at first line", function () {
+                myEditor.setSelection({line: 0, ch: 5}, {line: 0, ch: 5});
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}, primary: true, reversed: false}]);
+            });
+
+            it("should add cursors below each range in a multiple selection, making the correct one primary", function () {
+                myEditor.setSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}},
+                                        {start: {line: 3, ch: 2}, end: {line: 3, ch: 8}}]);
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 3, ch: 2}, end: {line: 3, ch: 8}, primary: false, reversed: false},
+                                  {start: {line: 4, ch: 8}, end: {line: 4, ch: 8}, primary: true, reversed: false}]);
+            });
+
+            it("should add cursors above each range in a multiple selection, making the correct one primary", function () {
+                myEditor.setSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}},
+                                        {start: {line: 3, ch: 2}, end: {line: 3, ch: 8}}]);
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 5}, end: {line: 0, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 1, ch: 5}, end: {line: 1, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 2, ch: 2}, end: {line: 2, ch: 2}, primary: true, reversed: false},
+                                  {start: {line: 3, ch: 2}, end: {line: 3, ch: 8}, primary: false, reversed: false}]);
+            });
+            
+            it("should not add cursors downward that overlap another selection", function () {
+                myEditor.setSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}},
+                                        {start: {line: 2, ch: 2}, end: {line: 2, ch: 8}}]);
+                CommandManager.execute(Commands.EDIT_ADD_NEXT_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 1, ch: 5}, end: {line: 1, ch: 5}, primary: false, reversed: false},
+                                  {start: {line: 2, ch: 2}, end: {line: 2, ch: 8}, primary: false, reversed: false},
+                                  {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}, primary: true, reversed: false}]);
+            });
+
+            it("should not add cursors upward that overlap another selection", function () {
+                myEditor.setSelections([{start: {line: 1, ch: 2}, end: {line: 1, ch: 8}},
+                                        {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}}]);
+                CommandManager.execute(Commands.EDIT_ADD_PREV_LINE_TO_SEL, myEditor);
+                expectSelections([{start: {line: 0, ch: 2}, end: {line: 0, ch: 2}, primary: false, reversed: false},
+                                  {start: {line: 1, ch: 2}, end: {line: 1, ch: 8}, primary: true, reversed: false},
+                                  {start: {line: 2, ch: 5}, end: {line: 2, ch: 5}, primary: false, reversed: false}]);
+            });
+
+        });
         
         describe("EditorCommandHandlers Integration", function () {
             this.category = "integration";

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -30,25 +30,148 @@ define(function (require, exports, module) {
     
     var Commands              = require("command/Commands"),
         KeyEvent              = require("utils/KeyEvent"),
-        SpecRunnerUtils       = require("spec/SpecRunnerUtils");
+        SpecRunnerUtils       = require("spec/SpecRunnerUtils"),
+        FindReplace           = require("search/FindReplace");
 
-    describe("FindReplace", function () {
+    var defaultContent = "/* Test comment */\n" +
+                         "define(function (require, exports, module) {\n" +
+                         "    var Foo = require(\"modules/Foo\"),\n" +
+                         "        Bar = require(\"modules/Bar\"),\n" +
+                         "        Baz = require(\"modules/Baz\");\n" +
+                         "    \n" +
+                         "    function callFoo() {\n" +
+                         "        \n" +
+                         "        foo();\n" +
+                         "        \n" +
+                         "    }\n" +
+                         "\n" +
+                         "}";
+        
+    describe("FindReplace - Unit", function () {
+        var editor, doc;
+        
+        beforeEach(function () {
+            var mocks = SpecRunnerUtils.createMockEditor(defaultContent, "javascript");
+            editor = mocks.editor;
+            doc = mocks.doc;
+        });
+        
+        afterEach(function () {
+            SpecRunnerUtils.destroyMockEditor(doc);
+            editor = null;
+            doc = null;
+        });
+        
+        describe("getWordAt", function () {
+            it("should select a word bounded by whitespace from a pos in the middle of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 9}))
+                    .toEqual({start: {line: 2, ch: 8}, end: {line: 2, ch: 11}, text: "Foo"});
+            });
+            it("should select a word bounded by whitespace from a pos at the beginning of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 8}))
+                    .toEqual({start: {line: 2, ch: 8}, end: {line: 2, ch: 11}, text: "Foo"});
+            });
+            it("should select a word bounded by whitespace from a pos at the end of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 11}))
+                    .toEqual({start: {line: 2, ch: 8}, end: {line: 2, ch: 11}, text: "Foo"});
+            });
+            
+            it("should select a word bounded by nonword characters from a pos in the middle of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 26}))
+                    .toEqual({start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, text: "modules"});
+            });
+            it("should select a word bounded by nonword characters from a pos at the beginning of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 23}))
+                    .toEqual({start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, text: "modules"});
+            });
+            it("should select a word bounded by nonword characters from a pos at the end of the word", function () {
+                expect(FindReplace._getWordAt(editor, {line: 2, ch: 23}))
+                    .toEqual({start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, text: "modules"});
+            });
+            
+            it("should return an empty range in the middle of whitespace", function () {
+                expect(FindReplace._getWordAt(editor, {line: 8, ch: 4}))
+                    .toEqual({start: {line: 8, ch: 4}, end: {line: 8, ch: 4}, text: ""});
+            });
+            it("should return an empty range in the middle of non-word chars", function () {
+                expect(FindReplace._getWordAt(editor, {line: 8, ch: 13}))
+                    .toEqual({start: {line: 8, ch: 13}, end: {line: 8, ch: 13}, text: ""});
+            });
+        });
+        
+        describe("expandAndAddNextToSelection", function () {
+            it("should do nothing if the cursor is in non-word/whitespace", function () {
+                editor.setSelection({line: 8, ch: 4});
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 8, ch: 4}, end: {line: 8, ch: 4}, primary: true, reversed: false}]);
+            });
+            
+            it("should expand a single cursor to the containing word without adding a new selection", function () {
+                editor.setSelection({line: 2, ch: 26});
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, primary: true, reversed: false}]);
+            });
+            
+            it("should add the next match for a single word selection as a new primary selection", function () {
+                editor.setSelection({line: 2, ch: 23}, {line: 2, ch: 30});
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, primary: false, reversed: false},
+                                                        {start: {line: 3, ch: 23}, end: {line: 3, ch: 30}, primary: true, reversed: false}]);
+            });
+            
+            it("should expand two cursors without adding a new selection", function () {
+                editor.setSelections([{start: {line: 2, ch: 26}, end: {line: 2, ch: 26}},
+                                      {start: {line: 3, ch: 16}, end: {line: 3, ch: 16}}]);
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, primary: false, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: true, reversed: false}]);
+            });
+            
+            it("should, when one cursor and one range are selected, expand the cursor and add the next match for the range to the selection", function () {
+                editor.setSelections([{start: {line: 2, ch: 26}, end: {line: 2, ch: 26}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}}]); // "require"
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, primary: false, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: false, reversed: false},
+                                                        {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: true, reversed: false}]);
+            });
+            
+            it("should wrap around the end of the document and add the next instance at the beginning of the document", function () {
+                editor.setSelection({line: 4, ch: 14}, {line: 4, ch: 21}); // "require"
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: true, reversed: false},
+                                                        {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: false, reversed: false}]);
+            });
+            
+            it("should skip over matches that are already in the selection", function () {
+                // select all instances of "require" except the second one
+                editor.setSelections([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}},
+                                      {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}}]);
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: false, reversed: false},
+                                                        {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}, primary: true, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: false, reversed: false},
+                                                        {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: false, reversed: false}]);
+            });
+            
+            it("should do nothing if all instances are already selected", function () {
+                editor.setSelections([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}},
+                                      {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}},
+                                      {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}}]);
+                FindReplace._expandWordAndAddNextToSelection(editor);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: false, reversed: false},
+                                                        {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}, primary: false, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: false, reversed: false},
+                                                        {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: true, reversed: false}]);
+            });
+        });
+    });
+    
+    describe("FindReplace - Integration", function () {
         
         this.category = "integration";
-        
-        var defaultContent = "/* Test comment */\n" +
-                             "define(function (require, exports, module) {\n" +
-                             "    var Foo = require(\"modules/Foo\"),\n" +
-                             "        Bar = require(\"modules/Bar\"),\n" +
-                             "        Baz = require(\"modules/Baz\");\n" +
-                             "    \n" +
-                             "    function callFoo() {\n" +
-                             "        \n" +
-                             "        foo();\n" +
-                             "        \n" +
-                             "    }\n" +
-                             "\n" +
-                             "}";
         
         var LINE_FIRST_REQUIRE = 2;
         var LINE_AFTER_REQUIRES = 5;

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -167,6 +167,56 @@ define(function (require, exports, module) {
                                                         {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: true, reversed: false}]);
             });
         });
+        
+        describe("expandAndAddNextToSelection - with removeCurrent (for Skip Match)", function () {
+            it("should remove a single range selection and select the next instance", function () {
+                editor.setSelection({line: 2, ch: 23}, {line: 2, ch: 30});
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 3, ch: 23}, end: {line: 3, ch: 30}, primary: true, reversed: false}]);
+            });
+            
+            it("should expand a single cursor to a range, then change the selection to the next instance of that range", function () {
+                editor.setSelection({line: 2, ch: 26}, {line: 2, ch: 26});
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 3, ch: 23}, end: {line: 3, ch: 30}, primary: true, reversed: false}]);
+            });
+            
+            it("should, when one cursor and one range are selected, expand the cursor and change the range selection to its next match", function () {
+                editor.setSelections([{start: {line: 2, ch: 26}, end: {line: 2, ch: 26}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}}]); // "require"
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 2, ch: 23}, end: {line: 2, ch: 30}, primary: false, reversed: false},
+                                                        {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}, primary: true, reversed: false}]);
+            });
+            
+            it("should wrap around the end of the document and switch to the next instance at the beginning of the document", function () {
+                editor.setSelection({line: 4, ch: 14}, {line: 4, ch: 21}); // "require"
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: true, reversed: false}]);
+            });
+            
+            it("should skip over matches that are already in the selection (but still remove the current one)", function () {
+                // select all instances of "require" except the second one
+                editor.setSelections([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}},
+                                      {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}}]);
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: false, reversed: false},
+                                                        {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}, primary: true, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: false, reversed: false}]);
+            });
+
+            it("should just remove the primary selection if all instances are already selected", function () {
+                editor.setSelections([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}},
+                                      {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}},
+                                      {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}},
+                                      {start: {line: 4, ch: 14}, end: {line: 4, ch: 21}}]);
+                FindReplace._expandWordAndAddNextToSelection(editor, true);
+                expect(editor.getSelections()).toEqual([{start: {line: 1, ch: 17}, end: {line: 1, ch: 24}, primary: false, reversed: false},
+                                                        {start: {line: 2, ch: 14}, end: {line: 2, ch: 21}, primary: false, reversed: false},
+                                                        {start: {line: 3, ch: 14}, end: {line: 3, ch: 21}, primary: true, reversed: false}]);
+            });
+        });
     });
     
     describe("FindReplace - Integration", function () {


### PR DESCRIPTION
This implements:
- Split Selection into Lines - takes the current selection and splits it into one range per line. We just use CodeMirror's implementation for this.
- Add Line to Selection - adds a cursor on the next/previous line from the start/end of each selection range
- Add Next Match to Selection - expands the current primary selection to a word if it's not already a range, then (if it didn't have to expand it) adds the next instance of the range to the selection
- Skip Match and Add Next - like Add Next Match to Selection, but removes the current primary selection as well
- Find All and Select - takes the primary selection, expands it to a word if necessary, and adds all matches in the current document to the selection (removing all other selections)
