### PR TITLE
Skip all embedded php code when parsing the style blocks in php documents.

### DIFF
--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -496,7 +496,7 @@ define(function (require, exports, module) {
                 // Check for end of this block which normally is the </style> tag
                 // with tokenModeName in "xml". If we encounter embedded php code, we
                 // will get "clike" tokenModeName and we need to skip all of them.
-                if (tokenModeName != "clike" && tokenModeName !== modeName) {
+                if (tokenModeName !== "clike" && tokenModeName !== modeName) {
                     // currentBlock.end is already set to pos of the last token by now
                     currentBlock.text = editor.document.getRange(currentBlock.start, currentBlock.end);
                     inBlock = false;

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -493,8 +493,10 @@ define(function (require, exports, module) {
                     // Handle empty blocks
                     currentBlock.end = currentBlock.start;
                 }
-                // Check for end of this block
-                if (tokenModeName !== modeName) {
+                // Check for end of this block which normally is the </style> tag
+                // with tokenModeName in "xml". If we encounter embedded php code, we
+                // will get "clike" tokenModeName and we need to skip all of them.
+                if (tokenModeName != "clike" && tokenModeName !== modeName) {
                     // currentBlock.end is already set to pos of the last token by now
                     currentBlock.text = editor.document.getRange(currentBlock.start, currentBlock.end);
                     inBlock = false;

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -484,7 +484,8 @@ define(function (require, exports, module) {
             currentBlock = null,
             inBlock = false,
             outerMode = editor._codeMirror.getMode(),
-            tokenModeName;
+            tokenModeName,
+            previousMode;
         
         while (TokenUtils.moveNextToken(ctx, false)) {
             tokenModeName = CodeMirror.innerMode(outerMode, ctx.token.state).mode.name;
@@ -493,10 +494,8 @@ define(function (require, exports, module) {
                     // Handle empty blocks
                     currentBlock.end = currentBlock.start;
                 }
-                // Check for end of this block which normally is the </style> tag
-                // with tokenModeName in "xml". If we encounter embedded php code, we
-                // will get "clike" tokenModeName and we need to skip all of them.
-                if (tokenModeName !== "clike" && tokenModeName !== modeName) {
+                // Check for end of this block
+                if (tokenModeName === previousMode) {
                     // currentBlock.end is already set to pos of the last token by now
                     currentBlock.text = editor.document.getRange(currentBlock.start, currentBlock.end);
                     inBlock = false;
@@ -511,6 +510,8 @@ define(function (require, exports, module) {
                     };
                     blocks.push(currentBlock);
                     inBlock = true;
+                } else {
+                    previousMode = tokenModeName;
                 }
                 // else, random token: ignore
             }

--- a/test/spec/InlineEditorProviders-test-files/test1.php
+++ b/test/spec/InlineEditorProviders-test-files/test1.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style type="text/css">
+{{0}}   body {
+            background: url("<?php echo $img; ?>") no-repeat;
+            background-size: 100% 100%;
+            color: white;
+        }
+    </style>
+  </head>
+
+  <bo{{1}}dy onclick="goHome()"></body>
+</html>

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -257,6 +257,21 @@ define(function (require, exports, module) {
             });
 
 
+            it("should open a type selector and show correct range including the embedded php", function () {
+                initInlineTest("test1.php", 1);
+                
+                runs(function () {
+                    var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
+                    var inlinePos = inlineWidget.editor.getCursorPos();
+                    
+                    // verify cursor position and displayed range in inline editor
+                    expect(inlinePos).toEqual(infos["test1.php"].offsets[0]);
+                    expect(inlineWidget.editor).toHaveInlineEditorRange(toRange(4, 8));
+                    
+                    inlineWidget = null;
+                });
+            });
+            
             it("should open a type selector on opening tag", function () {
                 initInlineTest("test1.html", 0);
                 


### PR DESCRIPTION
This fixes #6948.
