### PR TITLE
add support for streamlinejs file extensions

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -57,7 +57,7 @@
     "javascript": {
         "name": "JavaScript",
         "mode": "javascript",
-        "fileExtensions": ["js", "jsx", "js.erb", "jsm"],
+        "fileExtensions": ["js", "jsx", "js.erb", "jsm", "_js"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -143,7 +143,7 @@
     "coffeescript": {
         "name": "CoffeeScript",
         "mode": "coffeescript",
-        "fileExtensions": ["coffee", "cf", "cson"],
+        "fileExtensions": ["coffee", "cf", "cson", "_coffee"],
         "fileNames": ["Cakefile"]
     },
 


### PR DESCRIPTION
Add support for [Streamlinejs](https://github.com/Sage/streamlinejs) file extensions, namely `_js` and `_coffee`
