### PR TITLE
Strip leading/trailing whitespace from extension url

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -296,7 +296,7 @@ define(function (require, exports, module) {
             $dlg.find(".nav-tabs a:first").tab("show");
         });
     
-        // Handle the install button.                
+        // Handle the install button.
         $(".extension-manager-dialog .install-from-url")
             .click(function () {
                 InstallExtensionDialog.showDialog().done(ExtensionManager.updateFromDownload);

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
             break;
             
         case STATE_INSTALLING:
-            url = this.$url.val();
+            url = $.trim(this.$url.val());
             this.$inputArea.hide();
             this.$browseExtensionsButton.hide();
             this.$msg.text(StringUtils.format(Strings.INSTALLING_FROM, url))
@@ -297,9 +297,10 @@ define(function (require, exports, module) {
      * @private
      * Handle typing in the URL field.
      */
-    InstallExtensionDialog.prototype._handleUrlInput = function () {
-        var url = this.$url.val(),
-            valid = (url !== "");
+    InstallExtensionDialog.prototype._handleUrlInput = function (e) {
+        var url         = this.$url.val(),
+            trimmedUrl  = $.trim(url),
+            valid       = (trimmedUrl !== "");
         if (!valid && this._state === STATE_VALID_URL) {
             this._enterState(STATE_START);
         } else if (valid && this._state === STATE_START) {

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
             break;
             
         case STATE_INSTALLING:
-            url = $.trim(this.$url.val());
+            url = this.$url.val().trim();
             this.$inputArea.hide();
             this.$browseExtensionsButton.hide();
             this.$msg.text(StringUtils.format(Strings.INSTALLING_FROM, url))
@@ -298,9 +298,8 @@ define(function (require, exports, module) {
      * Handle typing in the URL field.
      */
     InstallExtensionDialog.prototype._handleUrlInput = function (e) {
-        var url         = this.$url.val(),
-            trimmedUrl  = $.trim(url),
-            valid       = (trimmedUrl !== "");
+        var url     = this.$url.val().trim(),
+            valid   = (url !== "");
         if (!valid && this._state === STATE_VALID_URL) {
             this._enterState(STATE_START);
         } else if (valid && this._state === STATE_START) {


### PR DESCRIPTION
This fixes #7043 by trimming the extension url input.
