### PR TITLE
Don't set dirty flag if the preference value does not change.

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -347,11 +347,12 @@ define(function (require, exports, module) {
          * @return {boolean} always returns true
          */
         _performSet: function (id, value) {
-            this._dirty = true;
-            if (value === undefined) {
+            if (value === undefined && this.data[id]) {
                 delete this.data[id];
-            } else {
+                this._dirty = true;
+            } else if (this.data[id] !== value) {
                 this.data[id] = value;
+                this._dirty = true;
             }
             return true;
         },

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -347,15 +347,13 @@ define(function (require, exports, module) {
          * @return {boolean} true if the value was set.
          */
         _performSet: function (id, value) {
-            if (value === undefined) {
-                if (this.data[id]) {
-                    delete this.data[id];
-                    this._dirty = true;
-                    return true;
-                }
-            } else if (!_.isEqual(this.data[id], value)) {
-                this.data[id] = value;
+            if (!_.isEqual(this.data[id], value)) {
                 this._dirty = true;
+                if (value === undefined) {
+                    delete this.data[id];
+                } else {
+                    this.data[id] = value;
+                }
                 return true;
             }
             return false;
@@ -621,13 +619,12 @@ define(function (require, exports, module) {
             if (!section) {
                 data[layerID] = section = {};
             }
-            if (value === undefined) {
-                if (section[id]) {
+            if (!_.isEqual(section[id], value)) {
+                if (value === undefined) {
                     delete section[id];
-                    return true;
+                } else {
+                    section[id] = value;
                 }
-            } else if (!_.isEqual(section[id], value)) {
-                section[id] = value;
                 return true;
             }
             return false;
@@ -750,13 +747,12 @@ define(function (require, exports, module) {
             if (!section) {
                 data[layerID] = section = {};
             }
-            if (value === undefined) {
-                if (section[id]) {
+            if (!_.isEqual(section[id], value)) {
+                if (value === undefined) {
                     delete section[id];
-                    return true;
+                } else {
+                    section[id] = value;
                 }
-            } else if (!_.isEqual(section[id], value)) {
-                section[id] = value;
                 return true;
             }
             return false;

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -348,7 +348,7 @@ define(function (require, exports, module) {
          */
         _performSet: function (id, value) {
             if (value === undefined) {
-                if(this.data[id]) {
+                if (this.data[id]) {
                     delete this.data[id];
                     this._dirty = true;
                     return true;

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -344,17 +344,21 @@ define(function (require, exports, module) {
          * 
          * @param {string} id key to set or delete
          * @param {*} value value for this key (undefined to delete)
-         * @return {boolean} always returns true
+         * @return {boolean} true if the value was set.
          */
         _performSet: function (id, value) {
-            if (value === undefined && this.data[id]) {
-                delete this.data[id];
-                this._dirty = true;
-            } else if (this.data[id] !== value) {
+            if (value === undefined) {
+                if(this.data[id]) {
+                    delete this.data[id];
+                    this._dirty = true;
+                    return true;
+                }
+            } else if (!_.isEqual(this.data[id], value)) {
                 this.data[id] = value;
                 this._dirty = true;
+                return true;
             }
-            return true;
+            return false;
         },
         
         /**
@@ -618,11 +622,15 @@ define(function (require, exports, module) {
                 data[layerID] = section = {};
             }
             if (value === undefined) {
-                delete section[id];
-            } else {
+                if (section[id]) {
+                    delete section[id];
+                    return true;
+                }
+            } else if (!_.isEqual(section[id], value)) {
                 section[id] = value;
+                return true;
             }
-            return true;
+            return false;
         },
 
         /**
@@ -743,11 +751,15 @@ define(function (require, exports, module) {
                 data[layerID] = section = {};
             }
             if (value === undefined) {
-                delete section[id];
-            } else {
+                if (section[id]) {
+                    delete section[id];
+                    return true;
+                }
+            } else if (!_.isEqual(section[id], value)) {
                 section[id] = value;
+                return true;
             }
-            return true;
+            return false;
         },
         
         /**

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -185,6 +185,39 @@ define(function (require, exports, module) {
                 
                 expect(layer.set(data, "spaceUnits", 13, {}, "**.md")).toBe(true);
             });
+
+            it("should not set the same value twice", function () {
+                var data = {
+                    "**.html": {
+                        spaceUnits: 2
+                    },
+                    "lib/*.js": {
+                        spaceUnits: 3
+                    }
+                };
+                
+                var originalData = _.clone(data, true);
+                
+                var layer = new PreferencesBase.PathLayer("/.brackets.json");
+                
+                expect(layer.set(data, "spaceUnits", 11, {
+                    filename: "/index.html"
+                })).toBe(true);
+
+                // Try to set the same value again.
+                expect(layer.set(data, "spaceUnits", 11, {
+                    filename: "/index.html"
+                })).toBe(false);
+
+                expect(data).toEqual({
+                    "**.html": {
+                        spaceUnits: 11
+                    },
+                    "lib/*.js": {
+                        spaceUnits: 3
+                    }
+                });
+            });
         });
         
         describe("Scope", function () {
@@ -200,6 +233,25 @@ define(function (require, exports, module) {
                 
                 expect(scope.get("spaceUnits")).toBe(4);
                 expect(scope.getKeys().sort()).toEqual(["spaceUnits", "useTabChar"].sort());
+            });
+            
+            it("should not set the same value twice", function () {
+                var data = {
+                    spaceUnits: 4,
+                    useTabChar: false
+                };
+                
+                var scope = new PreferencesBase.Scope(new PreferencesBase.MemoryStorage(data));
+                // MemoryStorage operates synchronously
+                scope.load();
+                
+                expect(scope.get("spaceUnits")).toBe(4);
+
+                expect(scope.set("spaceUnits", 12)).toBe(true);
+
+                // Try to set the same value again.
+                expect(scope.set("spaceUnits", 12)).toBe(false);
+                expect(scope.get("spaceUnits")).toBe(12);
             });
             
             it("should look up a value with a path layer", function () {

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -248,12 +248,43 @@ define(function (require, exports, module) {
                 expect(scope.get("spaceUnits")).toBe(4);
 
                 expect(scope.set("spaceUnits", 12)).toBe(true);
+                expect(scope._dirty).toBe(true);
 
-                // Try to set the same value again.
+                // Explicitly save it in order to clear dirty flag.
+                scope.save();
+                expect(scope._dirty).toBe(false);
+                
+                // Try to set the same value again and verify that the dirty flag is not set.
                 expect(scope.set("spaceUnits", 12)).toBe(false);
                 expect(scope.get("spaceUnits")).toBe(12);
+                expect(scope._dirty).toBe(false);
             });
             
+            it("should remove the preference when setting it with 'undefined' value", function () {
+                var data = {
+                    spaceUnits: 0,
+                    useTabChar: false
+                };
+                
+                var scope = new PreferencesBase.Scope(new PreferencesBase.MemoryStorage(data));
+                // MemoryStorage operates synchronously
+                scope.load();
+                
+                expect(scope.get("spaceUnits")).toBe(0);
+
+                // Remove 'spaceUnits' by calling set with 'undefined' second argument
+                expect(scope.set("spaceUnits")).toBe(true);
+                expect(scope._dirty).toBe(true);
+                expect(scope.getKeys()).toEqual(["useTabChar"]);
+
+                expect(scope.get("useTabChar")).toBe(false);
+                
+                // Remove 'useTabChar' by calling set with 'undefined' second argument
+                expect(scope.set("useTabChar")).toBe(true);
+                expect(scope._dirty).toBe(true);
+                expect(scope.getKeys()).toEqual([]);
+            });
+
             it("should look up a value with a path layer", function () {
                 var data = {
                     spaceUnits: 4,


### PR DESCRIPTION
This fixes #7063 by not writing out no-op changes to disk.
