### PR TITLE
Don't delete the last line if the selection ends right at the beginning

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -592,11 +592,12 @@ define(function (require, exports, module) {
         var from,
             to,
             sel = editor.getSelection(),
-            doc = editor.document;
-
+            doc = editor.document,
+            endLine;
+        
         from = {line: sel.start.line, ch: 0};
-        to = {line: sel.end.line + 1, ch: 0};
-        if (to.line === editor.getLastVisibleLine() + 1) {
+        
+        if (sel.end.line === editor.getLastVisibleLine()) {
             // Instead of deleting the newline after the last line, delete the newline
             // before the first line--unless this is the entire visible content of the editor,
             // in which case just delete the line content.
@@ -604,8 +605,16 @@ define(function (require, exports, module) {
                 from.line -= 1;
                 from.ch = doc.getLine(from.line).length;
             }
-            to.line -= 1;
-            to.ch = doc.getLine(to.line).length;
+            to = {line: sel.end.line, ch: doc.getLine(sel.end.line).length};
+        } else {
+            // Don't delete the line that the selection ends on if the selection
+            // starts on a previous line and ends right at the beginning of the
+            // last line.
+            endLine = sel.end.line + 1;
+            if (sel.start.line < sel.end.line && sel.end.ch === 0) {
+                endLine--;
+            }
+            to = {line: endLine, ch: 0};
         }
         
         doc.replaceRange("", from, to);

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2185,6 +2185,23 @@ define(function (require, exports, module) {
                 var expectedText = defaultContent.split("\n").slice(3).join("\n");
                 expect(myDocument.getText()).toEqual(expectedText);
             });
+            
+            it("should not delete an extra line after a whole selected line", function () {
+                myEditor.setSelection({line: 1, ch: 0}, {line: 2, ch: 0});
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                
+                var expectedText = defaultContent.split("\n");
+                expectedText.splice(1, 1);
+                expect(myDocument.getText()).toEqual(expectedText.join("\n"));
+            });
+
+            it("should not delete an extra line after several whole lines that are selected", function () {
+                myEditor.setSelection({line: 0, ch: 0}, {line: 3, ch: 0});
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                
+                var expectedText = defaultContent.split("\n").slice(3).join("\n");
+                expect(myDocument.getText()).toEqual(expectedText);
+            });
 
             it("should delete multiple lines ending at the bottom when selection spans them", function () {
                 myEditor.setSelection({line: 5, ch: 5}, {line: 7, ch: 0});


### PR DESCRIPTION
For #7075. Note that this is a fix in master. I haven't looked at the fix in cmv4 yet - it might be different.
