### PR TITLE
Fix ScrollTrackMarkers positioning metrics

### DIFF
--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -40,9 +40,6 @@ define(function (require, exports, module) {
         PanelManager        = require("view/PanelManager");
     
     
-    /** @const @type {number} Height (and width) or scrollbar up/down arrow button on Win */
-    var WIN_ARROW_HT = 17;
-    
     /** @type {?Editor} Editor the markers are currently shown for, or null if not shown */
     var editor;
     
@@ -70,9 +67,11 @@ define(function (require, exports, module) {
         if (trackHt > 0) {
             // Scrollbar visible: determine offset of track from top of scrollbar
             if (brackets.platform === "win") {
-                trackOffset = WIN_ARROW_HT;  // Up arrow pushes down track
-            } else {
-                trackOffset = 0;             // No arrows
+                trackOffset = 0;  // Custom scrollbar CSS has no gap around the track
+            } else if (brackets.platform === "mac") {
+                trackOffset = 4;  // Native scrollbar has padding around the track
+            } else { //(Linux)
+                trackOffset = 2;  // Custom scrollbar CSS has assymmetrical gap; this approximates it
             }
             trackHt -= trackOffset * 2;
             

--- a/src/styles/brackets_scrollbars.less
+++ b/src/styles/brackets_scrollbars.less
@@ -71,6 +71,8 @@
 }
 
 .platform-linux {
+    // Note: when changing padding/margins, may need to adjust metrics in ScrollTrackMarkers.js
+    
     ::-webkit-scrollbar {
         width: 12px;
         height: 12px;
@@ -100,6 +102,8 @@
 }
 
 .platform-win {
+    // Note: when changing padding/margins, may need to adjust metrics in ScrollTrackMarkers.js
+    
     ::-webkit-scrollbar {
         width: 12px;
         height: 12px;


### PR DESCRIPTION
Update ScrollTrackMarkers positioning metrics to better match the scrollbar appearance on each platform.

Makes tickmark positioning much more accurate on Windows, where it had gotten noticeably worse last sprint (#7058) when we switched to custom scrollbar styling.  Should improve it slightly on Mac & Linux too.
