### PR TITLE
Fix bug #6923: Brackets freezes for a while after saving when Find in Files  panel is open

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -552,6 +552,8 @@ define(function (require, exports, module) {
                 dialog._close();
             }
             
+            // May already have a listener if refreshing panel that's already open; remove first to ensure we don't add multiple copies (#6923)
+            FileSystem.off("change", _fileSystemChangeHandler);
             FileSystem.on("change", _fileSystemChangeHandler);
         
         } else {


### PR DESCRIPTION
Fix bug #6923 - Ensure we're not accumulating many copies of the FileSystem "change" listener.

jQuery happily adds duplicate listeners (even though, confusingly, removal with `.off()` removes all duplicates at once). Since `_showSearchResults()` is re-run any time you page through search results and many times when you're making text edits near a search result, you can easily accumulate 1000s of copies of the listener. On the next save or external change, Brackets will run all the listeners back to back, in some cases freezing for a minute or more.
