### PR TITLE
Fix bug with file caching

### DIFF
--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -85,10 +85,21 @@ define(function (require, exports, module) {
     Directory.prototype._clearCachedData = function (preserveImmediateChildren) {
         FileSystemEntry.prototype._clearCachedData.apply(this);
         
-        if (!preserveImmediateChildren && this._contents) {
-            this._contents.forEach(function (child) {
-                child._clearCachedData(true);
-            });
+        if (!preserveImmediateChildren) {
+            if (this._contents) {
+                this._contents.forEach(function (child) {
+                    child._clearCachedData(true);
+                });
+            } else {
+                // Our _contents is cleared, but File objects that are our children may still exist.
+                // Scan the full index to catch all of them.
+                var dirPath = this.fullPath;
+                this._fileSystem._index.visitAll(function (entry) {
+                    if (entry.parentPath === dirPath) {
+                        entry._clearCachedData(true);
+                    }
+                });
+            }
         }
         
         this._contents = undefined;

--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
                     child._clearCachedData(true);
                 });
             } else {
-                // Our _contents is cleared, but File objects that are our children may still exist.
+                // No cached _contents, but child entries may still exist.
                 // Scan the full index to catch all of them.
                 var dirPath = this.fullPath;
                 this._fileSystem._index.visitAll(function (entry) {

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -1251,7 +1251,7 @@ define(function (require, exports, module) {
                 waitsFor(function () { return fileChanged; });
                 
                 runs(function () {
-                    expect(file._contents).toBeTruthy();
+                    expect(file._contents).toBe(cb1.data);
                     fileChanged = false;
                     
                     // Next, invalidate the parent which should also cause the

--- a/test/spec/MockFileSystemModel.js
+++ b/test/spec/MockFileSystemModel.js
@@ -58,6 +58,15 @@ define(function (require, exports, module) {
             isFile: true,
             mtime: new Date(),
             contents: "File 4 Contents"
+        },
+        "/subdir/child/": {
+            isFile: false,
+            mtime: new Date()
+        },
+        "/subdir/child/file5.txt": {
+            isFile: true,
+            mtime: new Date(),
+            contents: "File 5 Contents"
         }
     };
     


### PR DESCRIPTION
This is a fix for #7006 and #6978. @peterflynn wrote the fix and I added a test. Peter's commit has a good description of the problem:

Fix bug where file caches aren't cleared when the parent directory changes

if that directory's own parent (the file's grandparent) has changed recently:
1. Grandparent dir gets change event. Calls _clearCachedData() on all immediate children
2. File's parent dir is one of those children, so it erases its _contents
3. File's parent dir gets change event of its own.
4. Since it has no _content, it has no idea what children it has, and thus
fails to clear any of them.

The fix is to use FileIndex to find children when cached dir content is
missing.

Glenn noted we might consider simply not clearing child dirs' content (only
clear child files), but NJ pointed out we don't have any firm guarantee
that a file's parent dir is ever read before the file itself is read - so
this bug could repro in other cases. (It just so happens that JS code hints
call visitAll() very early in typical Brackets usage, but there's no
guarantee in general). So we really shouldn't ever require cached dir
content for clearing children, regardless of what grandparent change
handling does.
