### PR TITLE
Fix edge case for #7075 where selection ends at beginning of last line of document

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -597,7 +597,16 @@ define(function (require, exports, module) {
         
         from = {line: sel.start.line, ch: 0};
         
-        if (sel.end.line === editor.getLastVisibleLine()) {
+        // endLine is the line after the last one we want to delete.
+        endLine = sel.end.line + 1;
+        if (sel.start.line < sel.end.line && sel.end.ch === 0) {
+            // The selection is more than one line and ends right at the beginning
+            // of a line. In this case, we don't want to delete that last line - we
+            // only want to delete the one before it.
+            endLine--;
+        }
+        
+        if (endLine === editor.getLastVisibleLine() + 1) {
             // Instead of deleting the newline after the last line, delete the newline
             // before the first line--unless this is the entire visible content of the editor,
             // in which case just delete the line content.
@@ -605,15 +614,8 @@ define(function (require, exports, module) {
                 from.line -= 1;
                 from.ch = doc.getLine(from.line).length;
             }
-            to = {line: sel.end.line, ch: doc.getLine(sel.end.line).length};
+            to = {line: endLine - 1, ch: doc.getLine(endLine - 1).length};
         } else {
-            // Don't delete the line that the selection ends on if the selection
-            // starts on a previous line and ends right at the beginning of the
-            // last line.
-            endLine = sel.end.line + 1;
-            if (sel.start.line < sel.end.line && sel.end.ch === 0) {
-                endLine--;
-            }
             to = {line: endLine, ch: 0};
         }
         

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -2195,6 +2195,15 @@ define(function (require, exports, module) {
                 expect(myDocument.getText()).toEqual(expectedText.join("\n"));
             });
 
+            it("should not delete an extra line at the end of the document after a whole selected line", function () {
+                myEditor.setSelection({line: 5, ch: 5}, {line: 7, ch: 0});
+                CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
+                
+                var expectedText = defaultContent.split("\n");
+                expectedText.splice(5, 2);
+                expect(myDocument.getText()).toEqual(expectedText.join("\n"));                
+            });
+
             it("should not delete an extra line after several whole lines that are selected", function () {
                 myEditor.setSelection({line: 0, ch: 0}, {line: 3, ch: 0});
                 CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
@@ -2202,9 +2211,9 @@ define(function (require, exports, module) {
                 var expectedText = defaultContent.split("\n").slice(3).join("\n");
                 expect(myDocument.getText()).toEqual(expectedText);
             });
-
+            
             it("should delete multiple lines ending at the bottom when selection spans them", function () {
-                myEditor.setSelection({line: 5, ch: 5}, {line: 7, ch: 0});
+                myEditor.setSelection({line: 5, ch: 5}, {line: 7, ch: 1});
                 CommandManager.execute(Commands.EDIT_DELETE_LINES, myEditor);
                 
                 var expectedText = defaultContent.split("\n").slice(0, 5).join("\n");


### PR DESCRIPTION
@redmunds - as I mentioned in email, this case is already fixed in the cmv4 version of the fix (so when I merge this over into cmv4 I'll just ignore this change, but keep the new unit test).

Note that there's an edge case of this edge case which is arguably still wrong :) - if the last line of the file is empty, then there's no way to delete it at the end of a block selection using Delete Line. I could imagine we add that as a special case - though it seems inconsistent, it might match what the user's intent usually is in this case. Let me know what you think.
