### PR TITLE
Fix bug #7112 (Out-of-scope files added to Find in Files results)

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -188,11 +188,13 @@ define(function (require, exports, module) {
         }
     }
     
-    
+    /** Remove listeners that were tracking potential search result changes */
     function _removeListeners() {
         $(DocumentModule).off(".findInFiles");
         FileSystem.off("change", _fileSystemChangeHandler);
     }
+    
+    /** Add listeners to track events that might change the search result set */
     function _addListeners() {
         // Avoid adding duplicate listeners - e.g. if a 2nd search is run without closing the old results panel first
         _removeListeners();
@@ -211,7 +213,6 @@ define(function (require, exports, module) {
         }
         _removeListeners();
     }
-    
     
     /**
      * @private

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -149,7 +149,8 @@ define(function (require, exports, module) {
             _handleTab(e, this);
         } else if (e.which === KeyEvent.DOM_VK_ESCAPE) {
             buttonId = DIALOG_BTN_CANCEL;
-        } else if (e.which === KeyEvent.DOM_VK_RETURN && !inTextArea) {  // enter key in single-line text input still dismisses
+        } else if (e.which === KeyEvent.DOM_VK_RETURN && (!inTextArea || e.ctrlKey)) {
+            // Enter key in single-line text input always dismisses; in text area, only Ctrl+Enter dismisses
             // Click primary
             $primaryBtn.click();
         } else if (e.which === KeyEvent.DOM_VK_SPACE) {


### PR DESCRIPTION
Fix bug #7112 -- Apply all the same filtering when updating incrementally as we do when performing the initial search.  Consolidate many of these checks in a new _inSearchScope() and rename the old _inScope() to sound less confusingly similar.

I added a unit test for _one_ case of #7112, but since there aren't tests in general for the incremental results updating it would have been tricky to add lots more.  The [Unit tests for existing find features](https://trello.com/c/lBKh0WXZ/1077-unit-tests-for-existing-find-replace-find-in-files-features) card is tracking writing more tests for this area.

_Also:_ tweak Dialog to allow closing with Ctrl+Enter when focus is in a textarea (where regular Enter is prevented from closing). Helps filter editing.
