### PR TITLE
fix for https://github.com/adobe/brackets/issues/6931

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -789,8 +789,8 @@ define(function (require, exports, module) {
              */
             function findNameInProject() {
                 // check for any files in project that end with the right path.
-                var fileName = name.substring(name.lastIndexOf("/"));
-                
+                var fileName = name.substring(name.lastIndexOf("/") + 1);
+
                 function _fileFilter(entry) {
                     return entry.name === fileName;
                 }

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/module-test-files/china/Cup.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/module-test-files/china/Cup.js
@@ -1,0 +1,24 @@
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    function Cup() {
+        this.empty = true;
+    }
+
+    Cup.prototype.fill = function () {
+        this.empty = false;
+    };
+
+    Cup.prototype.emptyIt = function () {
+    };
+
+    Cup.prototype.full = function () {
+    };
+
+    Cup.prototype.empty = function () {
+    };
+
+    exports.Cup = Cup;
+});

--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/module-test-files/china/cupFiller.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/module-test-files/china/cupFiller.js
@@ -1,0 +1,10 @@
+/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    var Cup = require('china/Cup').Cup;
+    
+    var coffeeCup = new Cup(false);
+    coffeeCup.
+});

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -1806,6 +1806,32 @@ define(function (require, exports, module) {
 
         });
 
+        describe("Code Hinting Regression", function () {
+            var testFile = extensionPath + "/unittest-files/module-test-files/china/cupFiller.js";
+
+            beforeEach(function () {
+                setupTest(testFile, true);
+            });
+
+            afterEach(function () {
+                tearDownTest();
+            });
+
+            // The test is disabled, because the TernWorker will consult the ProjectManager to
+            // determine all the files in the project root. We don't have a project root for this
+            // testcase. Perhaps we need to change the testsetup or find another way of dealing with this
+            // Test makes sure that http://github.com/adobe/brackets/issue/6931 doesn't show up
+            xit("should show hints for members of referenced class", function () {
+                var start = { line: 8, ch: 15 };
+
+                runs(function () {
+                    testEditor.setCursorPos(start);
+                    var hintObj = expectHints(JSCodeHints.jsHintProvider);
+                    hintsPresentExact(hintObj, ["empty", "emptyIt", "fill", "full"]);
+                });
+            });
+        });
+
         describe("JavaScript Code Hinting format parameters tests", function () {
 
             it("should format parameters with no params", function () {
@@ -1859,7 +1885,5 @@ define(function (require, exports, module) {
             });
 
         });
-
-
     });
 });


### PR DESCRIPTION
The fix is to cutoff the leading slash on a module name.
Test is not working due to missing projectRoot in the ProjectManager. I've experimented with different test setups by loading a project, but this didn't solve the issue. Perhaps this can be fixed in a different PR.
