### PR TITLE
Test: PreferencesManager doesn't handle isDirty on objects correctly

### DIFF
--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -154,6 +154,17 @@ define(function (require, exports, module) {
             });
         });
         
+        it("should correctly handle changes on objects", function () {
+            var foo = {
+                value: 42
+            };
+            PreferencesManager.set("foo", foo);
+            expect(foo.value).toBe(42);
+            foo.value = "!!!";
+            expect(foo.value).toBe("!!!");
+            var isDirty = PreferencesManager.set("foo", foo);
+            expect(isDirty).toBe(true);
+        });
         
         // Old tests follow
         it("should use default preferences", function () {


### PR DESCRIPTION
Ping @dangoor & @RaymondLim - failing test for https://github.com/adobe/brackets/pull/7064
