### PR TITLE
revert xp to native node file watching impl

### DIFF
--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -564,7 +564,7 @@ define(function (require, exports, module) {
      * @type {boolean}
      */
     exports.recursiveWatch = (appshell.platform === "mac" ||
-        (appshell.platform === "win" && navigator.userAgent.indexOf("Windows NT 6.") >= 0));
+        (appshell.platform === "win" && navigator.userAgent.indexOf("Windows NT 5.") === -1));
     
     /**
      * Indicates whether or not the filesystem should expect and normalize UNC

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -563,7 +563,8 @@ define(function (require, exports, module) {
      *
      * @type {boolean}
      */
-    exports.recursiveWatch = appshell.platform === "mac" || appshell.platform === "win";
+    exports.recursiveWatch = (appshell.platform === "mac" ||
+        (appshell.platform === "win" && navigator.userAgent.indexOf("Windows NT 6.") >= 0));
     
     /**
      * Indicates whether or not the filesystem should expect and normalize UNC

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -28,6 +28,7 @@
 
 var fspath = require("path"),
     fs = require("fs"),
+    os = require("os"),
     fsevents;
 
 /*
@@ -58,7 +59,11 @@ var fspath = require("path"),
 if (process.platform === "darwin") {
     fsevents = require("fsevents");
 } else if (process.platform === "win32") {
-    fsevents = require("fsevents_win/fsevents_win");
+    var version = os.release();
+    // XP will use node's built in file watcher module.
+    if (version && version.length > 0 && version[0] !== "5") {
+        fsevents = require("fsevents_win/fsevents_win");
+    }
 }
 
 var _domainManager,


### PR DESCRIPTION
This pull request reverts the filewatcher on windows to use the native node implementation since our filewatcher_win extension does not load on XP for some reason and causes other node modules to not load.
