### PR TITLE
Clone preference values to our storage instead of direct assignment.

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -352,7 +352,7 @@ define(function (require, exports, module) {
                 if (value === undefined) {
                     delete this.data[id];
                 } else {
-                    this.data[id] = value;
+                    this.data[id] = _.cloneDeep(value);
                 }
                 return true;
             }
@@ -623,7 +623,7 @@ define(function (require, exports, module) {
                 if (value === undefined) {
                     delete section[id];
                 } else {
-                    section[id] = value;
+                    section[id] = _.cloneDeep(value);
                 }
                 return true;
             }
@@ -751,7 +751,7 @@ define(function (require, exports, module) {
                 if (value === undefined) {
                     delete section[id];
                 } else {
-                    section[id] = value;
+                    section[id] = _.cloneDeep(value);
                 }
                 return true;
             }

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -381,12 +381,12 @@ define(function (require, exports, module) {
                 layer = layers[layerCounter];
                 result = layer.get(data[layer.key], id, context);
                 if (result !== undefined) {
-                    return _.cloneDeep(result);
+                    return result;
                 }
             }
             
             if (this._exclusions.indexOf(id) === -1) {
-                return _.cloneDeep(data[id]);
+                return data[id];
             }
         },
         
@@ -1431,7 +1431,7 @@ define(function (require, exports, module) {
                 if (scope) {
                     var result = scope.get(id, context);
                     if (result !== undefined) {
-                        return result;
+                        return _.cloneDeep(result);
                     }
                 }
             }

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -381,12 +381,12 @@ define(function (require, exports, module) {
                 layer = layers[layerCounter];
                 result = layer.get(data[layer.key], id, context);
                 if (result !== undefined) {
-                    return result;
+                    return _.cloneDeep(result);
                 }
             }
             
             if (this._exclusions.indexOf(id) === -1) {
-                return data[id];
+                return _.cloneDeep(data[id]);
             }
         },
         

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -265,31 +265,40 @@ define(function (require, exports, module) {
                     value: 42
                 };
                 
-                var scope = new PreferencesBase.Scope(new PreferencesBase.MemoryStorage());
+                var scope = new PreferencesBase.Scope(new PreferencesBase.MemoryStorage()),
+                    pm = new PreferencesBase.PreferencesSystem();
+                
+                // Explicitly create a PreferencesSystem and add the scope object to it
+                // so that we can call set/get functions on the PreferencesSystem instead
+                // of calling directly on scope object. Note that calling 'get' function on 
+                // scope object will not clone a preference object as it does in 'get' function
+                // on PreferencesSystem object.
+                pm.addScope("test", scope);
+                
                 // MemoryStorage operates synchronously
                 scope.load();
                 
-                expect(scope.set("foo", foo)).toBe(true);
+                expect(pm.set("foo", foo)).toBe(true);
                 
-                expect(scope.get("foo").value).toBe(42);
+                expect(pm.get("foo").value).toBe(42);
                 expect(scope._dirty).toBe(true);
 
                 // Explicitly save it in order to clear dirty flag.
-                scope.save();
+                pm.save();
                 expect(scope._dirty).toBe(false);
                                 
                 foo.value = "!!!";
                 expect(foo.value).toBe("!!!");
-                expect(scope.set("foo", foo)).toBe(true);
+                expect(pm.set("foo", foo)).toBe(true);
                 expect(scope._dirty).toBe(true);
                 
-                var fooCopyFromPref = scope.get("foo");
+                var fooCopyFromPref = pm.get("foo");
                 expect(fooCopyFromPref.value).toBe("!!!");
                 
                 // Add 'bar' to our local copy and then 
                 // verify that our change is not in the pref.
                 fooCopyFromPref.bar = "'bar' should not be in pref";
-                expect(scope.get("foo").bar).toBe(undefined);
+                expect(pm.get("foo").bar).toBe(undefined);
             });
 
             it("should remove the preference when setting it with 'undefined' value", function () {

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -260,6 +260,30 @@ define(function (require, exports, module) {
                 expect(scope._dirty).toBe(false);
             });
             
+            it("should correctly handle changes on objects", function () {
+                var foo = {
+                    value: 42
+                };
+                
+                var scope = new PreferencesBase.Scope(new PreferencesBase.MemoryStorage());
+                // MemoryStorage operates synchronously
+                scope.load();
+                
+                expect(scope.set("foo", foo)).toBe(true);
+                
+                expect(scope.get("foo").value).toBe(42);
+                expect(scope._dirty).toBe(true);
+
+                // Explicitly save it in order to clear dirty flag.
+                scope.save();
+                expect(scope._dirty).toBe(false);
+                                
+                foo.value = "!!!";
+                expect(foo.value).toBe("!!!");
+                expect(scope.set("foo", foo)).toBe(true);
+                expect(scope._dirty).toBe(true);
+            });
+
             it("should remove the preference when setting it with 'undefined' value", function () {
                 var data = {
                     spaceUnits: 0,

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -282,6 +282,14 @@ define(function (require, exports, module) {
                 expect(foo.value).toBe("!!!");
                 expect(scope.set("foo", foo)).toBe(true);
                 expect(scope._dirty).toBe(true);
+                
+                var fooCopyFromPref = scope.get("foo");
+                expect(fooCopyFromPref.value).toBe("!!!");
+                
+                // Add 'bar' to our local copy and then 
+                // verify that our change is not in the pref.
+                fooCopyFromPref.bar = "'bar' should not be in pref";
+                expect(scope.get("foo").bar).toBe(undefined);
             });
 
             it("should remove the preference when setting it with 'undefined' value", function () {


### PR DESCRIPTION
This fixes the issue reported in #7130.
