### PR TITLE
Revert change from 908868a that caused linting.enabled pref to not be saved

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -446,6 +446,7 @@ define(function (require, exports, module) {
         updateListeners();
         if (!doNotSave) {
             prefs.set(PREF_ENABLED, _enabled);
+            prefs.save();
         }
     
         // run immediately


### PR DESCRIPTION
This is a fix for #7144.
