### PR TITLE
Fix bug #7143 (Edit Filter dialog's dismissal buttons are in wrong order)

### DIFF
--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -71,8 +71,8 @@ define(function (require, exports, module) {
         var html = StringUtils.format(Strings.FILE_FILTER_INSTRUCTIONS, brackets.config.glob_help_url) +
             "<textarea class='exclusions-editor'></textarea>";
         var buttons = [
-            { className : Dialogs.DIALOG_BTN_CLASS_PRIMARY, id: Dialogs.DIALOG_BTN_OK, text: Strings.OK },
-            { className : Dialogs.DIALOG_BTN_CLASS_NORMAL, id: Dialogs.DIALOG_BTN_CANCEL, text: Strings.CANCEL }
+            { className : Dialogs.DIALOG_BTN_CLASS_NORMAL, id: Dialogs.DIALOG_BTN_CANCEL, text: Strings.CANCEL },
+            { className : Dialogs.DIALOG_BTN_CLASS_PRIMARY, id: Dialogs.DIALOG_BTN_OK, text: Strings.OK }
         ];
         var dialog = Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_INFO, Strings.FILE_FILTER_DIALOG, html, buttons);
         


### PR DESCRIPTION
Fix bug #7143 - Dialogs expects to be passed Mac button order, not Win.

@redmunds, could you review?
