### PR TITLE
Fix bug #7150 (Switching projects or quitting sometimes pauses for several seconds)

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -350,7 +350,9 @@ define(function (require, exports, module) {
             // entries always return cached data if it exists!
             this._index.visitAll(function (child) {
                 if (child.fullPath.indexOf(entry.fullPath) === 0) {
-                    child._clearCachedData();
+                    // 'true' so entry doesn't try to clear its immediate childrens' caches too. That would be redundant
+                    // with the visitAll() here, and could be slow if we've already cleared its parent (#7150).
+                    child._clearCachedData(true);
                 }
             }.bind(this));
             
@@ -773,7 +775,8 @@ define(function (require, exports, module) {
         if (!path) {
             // This is a "wholesale" change event; clear all caches
             this._index.visitAll(function (entry) {
-                entry._clearCachedData();
+                // Passing 'true' for a similar reason as in _unwatchEntry() - see #7150
+                entry._clearCachedData(true);
             });
             
             this._fireChangeEvent(null);

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -720,7 +720,8 @@ define(function (require, exports, module) {
             if (!watchedRoot || !watchedRoot.filter(directory.name, directory.parentPath)) {
                 this._index.visitAll(function (entry) {
                     if (entry.fullPath.indexOf(directory.fullPath) === 0) {
-                        entry._clearCachedData();
+                        // Passing 'true' for a similar reason as in _unwatchEntry() - see #7150
+                        entry._clearCachedData(true);
                     }
                 }.bind(this));
                 

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -162,7 +162,7 @@ define(function (require, exports, module) {
                 if (options.expectedContents !== _model.readFile(path)) {
                     cb(FileSystemError.CONTENTS_MODIFIED);
                     return;
-                } 
+                }
             } else {
                 cb(FileSystemError.CONTENTS_MODIFIED);
                 return;


### PR DESCRIPTION
Fix bug #7150 -- Don't let Directory try to clear its immediate childrens' caches. If we've already visited the parent dir and then we visit one of its children, that child would have no _content anymore and would resort to a full index-walk to try to find its own immediate children. This is slow to do many times, and redundant since we're already doing a full walk anyway.
