### PR TITLE
Disable file watching on XP

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  * 
  */
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+  
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true  , indent: 4, maxerr: 50 */
 /*global define, $ */
 
 /**
@@ -260,6 +260,10 @@ define(function (require, exports, module) {
             recursiveWatch = impl.recursiveWatch,
             commandName = shouldWatch ? "watchPath" : "unwatchPath";
 
+        if (!impl.fileWatchingEnabled) {
+            return;
+        }
+        
         if (recursiveWatch) {
             if (entry !== watchedRoot.entry) {
                 // Watch and unwatch calls to children of the watched root are

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -261,6 +261,8 @@ define(function (require, exports, module) {
             commandName = shouldWatch ? "watchPath" : "unwatchPath";
 
         if (!impl.fileWatchingEnabled) {
+            // Watching is not enabled so this call results in a no-op
+            callback(null);
             return;
         }
         

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -21,7 +21,7 @@
  * 
  */
   
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true  , indent: 4, maxerr: 50 */
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
 /*global define, $ */
 
 /**

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -92,6 +92,7 @@ define(function (require, exports, module) {
     var Directory       = require("filesystem/Directory"),
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
+        FileSystemError = require("filesystem/FileSystemError"),
         WatchedRoot     = require("filesystem/WatchedRoot");
     
     /**
@@ -262,7 +263,7 @@ define(function (require, exports, module) {
 
         if (!impl.fileWatchingEnabled) {
             // Watching is not enabled so this call results in a no-op
-            callback(null);
+            callback(FileSystemError.FILE_WATCHING_DISABLED);
             return;
         }
         
@@ -888,7 +889,7 @@ define(function (require, exports, module) {
         callback = callback || function () {};
         
         if (!watchedRoot) {
-            callback("Root is not watched.");
+            callback(FileSystemError.ROOT_NOT_WATCHED);
             return;
         }
 

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -35,15 +35,17 @@ define(function (require, exports, module) {
     "use strict";
 
     module.exports = {
-        UNKNOWN             : "Unknown",
-        INVALID_PARAMS      : "InvalidParams",
-        NOT_FOUND           : "NotFound",
-        NOT_READABLE        : "NotReadable",
-        NOT_WRITABLE        : "NotWritable",
-        OUT_OF_SPACE        : "OutOfSpace",
-        TOO_MANY_ENTRIES    : "TooManyEntries",
-        ALREADY_EXISTS      : "AlreadyExists",
-        CONTENTS_MODIFIED   : "ContentsModified"
+        UNKNOWN                 : "Unknown",
+        INVALID_PARAMS          : "InvalidParams",
+        NOT_FOUND               : "NotFound",
+        NOT_READABLE            : "NotReadable",
+        NOT_WRITABLE            : "NotWritable",
+        OUT_OF_SPACE            : "OutOfSpace",
+        TOO_MANY_ENTRIES        : "TooManyEntries",
+        ALREADY_EXISTS          : "AlreadyExists",
+        CONTENTS_MODIFIED       : "ContentsModified",
+        FILE_WATCHING_DISABLED  : "FileWatchingDisabled",
+        ROOT_NOT_WATCHED        : "RootNotWatched"
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -567,6 +567,14 @@ define(function (require, exports, module) {
         (appshell.platform === "win" && navigator.userAgent.indexOf("Windows NT 5.") === -1));
     
     /**
+     * Indicates whether or not watching is available for the selected platform
+     *
+     * @type {boolean}
+     */
+    exports.fileWatchingEnabled = (navigator.userAgent.indexOf("Windows NT 5.") === -1);
+        
+    
+    /**
      * Indicates whether or not the filesystem should expect and normalize UNC
      * paths. If set, then //server/directory/ is a normalized path; otherwise the
      * filesystem will normalize it to /server/directory. Currently, UNC path 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -991,7 +991,11 @@ define(function (require, exports, module) {
             FileSystem.unwatch(_projectRoot, function (err) {
                 if (err) {
                     console.error("Error unwatching project root: ", _projectRoot.fullPath, err);
-                    result.reject();
+                    if (err !== FileSystemError.FILE_WATCHING_DISABLED) {
+                        result.reject();
+                    } else {
+                       result.resolve();
+                    }
                 } else {
                     result.resolve();
                 }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -992,6 +992,9 @@ define(function (require, exports, module) {
                 if (err) {
                     console.error("Error unwatching project root: ", _projectRoot.fullPath, err);
                     if (err !== FileSystemError.FILE_WATCHING_DISABLED) {
+                        // Treat a disabled error as a success so that downstream promise 
+                        //  holders don't mistakenly change the code to stop after unwatching 
+                        //  due to that condition.
                         result.reject();
                     } else {
                         result.resolve();

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -994,7 +994,7 @@ define(function (require, exports, module) {
                     if (err !== FileSystemError.FILE_WATCHING_DISABLED) {
                         result.reject();
                     } else {
-                       result.resolve();
+                        result.resolve();
                     }
                 } else {
                     result.resolve();


### PR DESCRIPTION
This should basically behave as it did in sprint 35
File caching should check updated file changes on app activate so test this as well.  (make a change in notepad and switch back to brackets to see if you are prompted to reload)
