### PR TITLE
Set _fontSizePrefsLoaded to true before calling _adjustFontSize.

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -219,8 +219,8 @@ define(function (require, exports, module) {
             // Font Size preferences only need to be loaded one time
             if (!_fontSizePrefsLoaded) {
                 _removeDynamicFontSize();
-                _adjustFontSize(PreferencesManager.getViewState("fontSizeAdjustment"));
                 _fontSizePrefsLoaded = true;
+                _adjustFontSize(PreferencesManager.getViewState("fontSizeAdjustment"));
             }
             
         } else {


### PR DESCRIPTION
This change fixes the issue #7093 since the flag has to be true in order to set the scroll position to the right location. 

@TomMalbran Can you review this since you're the one who works on this area a lot? 

Note that this specific issue is also introduced by recent CodeMirror update. If I use the CodeMirrror version from sprint-36, then I don't see the issue even if I'm running in the master b64a2a15b with the new view state settings implementation. 
