### PR TITLE
[cmv4] Fix case of hitting Tab at the beginning of a whitespace-only line

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -477,7 +477,7 @@ define(function (require, exports, module) {
                 // Case 1 - we found a multiline selection. We can bail as soon as we find one of these.
                 selectionType = "indentAtBeginning";
                 return false;
-            } else if (sel.end.ch >= instance.getLine(sel.end.line).search(/\S/)) {
+            } else if (sel.end.ch > 0 && sel.end.ch >= instance.getLine(sel.end.line).search(/\S/)) {
                 // Case 2 - we found a selection that ends at or after the first non-whitespace
                 // character on the line. We need to keep looking in case we find a later multiline
                 // selection though.

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -1323,6 +1323,99 @@ define(function (require, exports, module) {
                 instance.setOption("indentWithTabs", useTabs);
                 instance.setOption("indentUnit", 4);
             }
+            
+            it("should indent and move cursor to correct position if at beginning of an empty line - spaces", function () {
+                var content = "function foo() {\n" +
+                    "    if (bar) {\n" +
+                    "\n" +
+                    "    }\n" +
+                    "}";
+                makeEditor(content);
+                myEditor.setCursorPos({line: 2, ch: 0});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, reversed: false});
+                
+                var lines = content.split("\n");
+                lines[2] = "        ";
+                expect(myEditor.document.getText()).toEqual(lines.join("\n"));
+            });
+
+            it("should indent and move cursor to correct position if at beginning of an empty line - tabs", function () {
+                var content = "function foo() {\n" +
+                    "\tif (bar) {\n" +
+                    "\n" +
+                    "\t}\n" +
+                    "}";
+                makeEditor(content, true);
+                myEditor.setCursorPos({line: 2, ch: 0});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 2}, end: {line: 2, ch: 2}, reversed: false});
+                
+                var lines = content.split("\n");
+                lines[2] = "\t\t";
+                expect(myEditor.document.getText()).toEqual(lines.join("\n"));
+            });
+            
+            it("should move cursor to end of whitespace (without adding more) if at beginning of a line with correct amount of whitespace - spaces", function () {
+                var content = "function foo() {\n" +
+                    "    if (bar) {\n" +
+                    "        \n" +
+                    "    }\n" +
+                    "}";
+                makeEditor(content);
+                myEditor.setCursorPos({line: 2, ch: 0});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 8}, end: {line: 2, ch: 8}, reversed: false});
+                
+                expect(myEditor.document.getText()).toEqual(content);
+            });
+
+            it("should move cursor to end of whitespace (without adding more) if at beginning of a line with correct amount of whitespace - tabs", function () {
+                var content = "function foo() {\n" +
+                    "\tif (bar) {\n" +
+                    "\t\t\n" +
+                    "\t}\n" +
+                    "}";
+                makeEditor(content, true);
+                myEditor.setCursorPos({line: 2, ch: 0});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 2}, end: {line: 2, ch: 2}, reversed: false});
+                expect(myEditor.document.getText()).toEqual(content);
+            });
+            
+            it("should add another indent whitespace if already past correct indent level on an all whitespace line - spaces", function () {
+                var content = "function foo() {\n" +
+                    "    if (bar) {\n" +
+                    "            \n" +
+                    "    }\n" +
+                    "}";
+                makeEditor(content);
+                myEditor.setCursorPos({line: 2, ch: 12});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 16}, end: {line: 2, ch: 16}, reversed: false});
+                
+                var lines = content.split("\n");
+                lines[2] = "    " + lines[2];
+                expect(myEditor.document.getText()).toEqual(lines.join("\n"));
+
+            });
+            
+            it("should add another indent whitespace if already past correct indent level on an all whitespace line - tabs", function () {
+                var content = "function foo() {\n" +
+                    "\tif (bar) {\n" +
+                    "\t\t\t\n" +
+                    "\t}\n" +
+                    "}";
+                makeEditor(content, true);
+                myEditor.setCursorPos({line: 2, ch: 3});
+                myEditor._handleTabKey();
+                expect(myEditor.getSelection()).toEqual({start: {line: 2, ch: 4}, end: {line: 2, ch: 4}, reversed: false});
+                
+                var lines = content.split("\n");
+                lines[2] = "\t" + lines[2];
+                expect(myEditor.document.getText()).toEqual(lines.join("\n"));
+
+            });
 
             it("should indent improperly indented line to proper level and move cursor to beginning of content if cursor is in whitespace before content - spaces", function () {
                 var content = "function foo() {\n" +


### PR DESCRIPTION
Update to fix for #7022 to deal with a regression that the previous fix introduced. If you hit tab at the beginning of a whitespace-only line, we used to autoindent to the right level. Now we just insert another indent. This brings back the original behavior (and adds unit tests for it).

Note that the ideal fix here would be to do autoindent when you're anywhere in a whitespace-only line if the amount of whitespace is less than or equal to the correct indent level. However, this isn't easy for us to fix because we can't easily tell in advance what the right indent level is, so we don't know if you're before it or past it (and if you're past it, we don't want to autoindent on Tab, since that would actually outdent; we want to just add another indent in that case). So, the prior behavior (which this reinstates) is to only do the autoindent if the cursor is at the left edge of the line to begin with.

That same issue prevents us from autoindenting when you're immediately before the first non-whitespace character in the line. I'll file a bug to address these cases in the future.
