### PR TITLE
Unregister commands

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -193,6 +193,23 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Un-registers a command.
+     * @param {string} id - unique identifier for command.
+     *      Core commands in Brackets use a simple command title as an id, for example "open.file".
+     *      Extensions should use the following format: "author.myextension.mycommandname".
+     *      For example, "lschmitt.csswizard.format.css".
+     * @param {boolean} checked
+     */
+    function unregister(id) {
+        if (typeof _commands[id] === "undefined") {
+            console.error("Attempting to unregister a command that is not registered: " + id);
+            return false;
+        }
+        delete _commands[id];
+        return true;
+    }
+
+    /**
      * Registers a global internal only command.
      * @param {string} id - unique identifier for command.
      *      Core commands in Brackets use a simple command title as an id, for example "app.abort_quit".
@@ -280,6 +297,7 @@ define(function (require, exports, module) {
 
     // Define public API
     exports.register            = register;
+    exports.unregister          = unregister;
     exports.registerInternal    = registerInternal;
     exports.execute             = execute;
     exports.get                 = get;

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
             CommandManager._testRestore();
         });
         
-        it("register and get a command and validate parameters", function () {
+        it("register and get a command, unregister command, and validate parameters", function () {
             var command = CommandManager.register("test command", commandID, testCommandFn);
             expect(command).toBeTruthy();
             expect(command.getName()).toBe("test command");
@@ -58,6 +58,12 @@ define(function (require, exports, module) {
 
             // duplicate command
             expect(CommandManager.register("test command", commandID, testCommandFn)).toBeFalsy();
+
+            // unregister command
+            expect(CommandManager.unregister(commandID)).toBeTruthy();
+
+            // unregister command again
+            expect(CommandManager.unregister(commandID)).toBeFalsy();
 
             // missing arguments
             expect(CommandManager.register(null, "test-command-id2", testCommandFn)).toBe(null);


### PR DESCRIPTION
Currently it is not possible to have multiple key event handlers for the same command. This can be solved by unregistering the command, wrapping the handler and registering again.
