### PR TITLE
Disable File Watchers on XP (For real this time)

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -92,6 +92,7 @@ define(function (require, exports, module) {
     var Directory       = require("filesystem/Directory"),
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
+        FileSystemError = require("filesystem/FileSystemError"),
         WatchedRoot     = require("filesystem/WatchedRoot");
     
     /**
@@ -886,7 +887,7 @@ define(function (require, exports, module) {
         callback = callback || function () {};
         
         if (!watchedRoot) {
-            callback("Root is not watched.");
+            callback(FileSystemError.ROOT_NOT_WATCHED);
             return;
         }
 

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -35,15 +35,17 @@ define(function (require, exports, module) {
     "use strict";
 
     module.exports = {
-        UNKNOWN             : "Unknown",
-        INVALID_PARAMS      : "InvalidParams",
-        NOT_FOUND           : "NotFound",
-        NOT_READABLE        : "NotReadable",
-        NOT_WRITABLE        : "NotWritable",
-        OUT_OF_SPACE        : "OutOfSpace",
-        TOO_MANY_ENTRIES    : "TooManyEntries",
-        ALREADY_EXISTS      : "AlreadyExists",
-        CONTENTS_MODIFIED   : "ContentsModified"
+        UNKNOWN                     : "Unknown",
+        INVALID_PARAMS              : "InvalidParams",
+        NOT_FOUND                   : "NotFound",
+        NOT_READABLE                : "NotReadable",
+        NOT_WRITABLE                : "NotWritable",
+        OUT_OF_SPACE                : "OutOfSpace",
+        TOO_MANY_ENTRIES            : "TooManyEntries",
+        ALREADY_EXISTS              : "AlreadyExists",
+        CONTENTS_MODIFIED           : "ContentsModified",
+        PATH_WATCHING_NOT_SUPPORTED : "PathWatchingNotSupported"
+        
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -44,7 +44,8 @@ define(function (require, exports, module) {
         TOO_MANY_ENTRIES            : "TooManyEntries",
         ALREADY_EXISTS              : "AlreadyExists",
         CONTENTS_MODIFIED           : "ContentsModified",
-        PATH_WATCHING_NOT_SUPPORTED : "PathWatchingNotSupported"
+        PATH_WATCHING_NOT_SUPPORTED : "PathWatchingNotSupported",
+        ROOT_NOT_WATCHED            : "RootNotBeingWatched"
         
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -39,12 +39,12 @@ define(function (require, exports, module) {
         INVALID_PARAMS              : "InvalidParams",
         NOT_FOUND                   : "NotFound",
         NOT_READABLE                : "NotReadable",
+        NOT_SUPPORTED               : "NotSupported",
         NOT_WRITABLE                : "NotWritable",
         OUT_OF_SPACE                : "OutOfSpace",
         TOO_MANY_ENTRIES            : "TooManyEntries",
         ALREADY_EXISTS              : "AlreadyExists",
         CONTENTS_MODIFIED           : "ContentsModified",
-        PATH_WATCHING_NOT_SUPPORTED : "PathWatchingNotSupported",
         ROOT_NOT_WATCHED            : "RootNotBeingWatched"
         
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -578,8 +578,7 @@ define(function (require, exports, module) {
      *
      * @type {boolean}
      */
-    exports.recursiveWatch = (appshell.platform === "mac" ||
-        (appshell.platform === "win" && navigator.userAgent.indexOf("Windows NT 5.") === -1));
+    exports.recursiveWatch = (appshell.platform === "mac" || appshell.platform === "win");
     
     /**
      * Indicates whether or not the filesystem should expect and normalize UNC

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -46,6 +46,8 @@ define(function (require, exports, module) {
         _domainPath     = [_bracketsPath, _modulePath, _nodePath].join("/"),
         _nodeDomain     = new NodeDomain("fileWatcher", _domainPath);
     
+    var _isRunningOnWindowsXP = navigator.userAgent.indexOf("Windows NT 5.") >= 0;
+    
     // If the connection closes, notify the FileSystem that watchers have gone offline.
     $(_nodeDomain.connection).on("close", function (event, promise) {
         if (_offlineCallback) {
@@ -146,13 +148,6 @@ define(function (require, exports, module) {
             return FileSystemError.ALREADY_EXISTS;
         }
         return FileSystemError.UNKNOWN;
-    }
-    
-    /**
-     * Determines if we're running on Windows XP
-     */
-    function _isRunningOnWindowsXP() {
-        return (navigator.userAgent.indexOf("Windows NT 5.") >= 0);
     }
     
     /**
@@ -492,13 +487,13 @@ define(function (require, exports, module) {
      * cleared when the offlineCallback is called.
      * 
      * @param {function(?string, FileSystemStats=)} changeCallback
-     * @param {function()=} callback
+     * @param {function()=} offlineCallback
      */
     function initWatchers(changeCallback, offlineCallback) {
         _changeCallback = changeCallback;
         _offlineCallback = offlineCallback;
         
-        if (_isRunningOnWindowsXP() && _offlineCallback) {
+        if (_isRunningOnWindowsXP && _offlineCallback) {
             _offlineCallback();
         }
     }
@@ -515,8 +510,8 @@ define(function (require, exports, module) {
      * @param {function(?string)=} callback
      */
     function watchPath(path, callback) {
-        if (_isRunningOnWindowsXP()) {
-            callback(FileSystemError.PATH_WATCHING_NOT_SUPPORTED);
+        if (_isRunningOnWindowsXP) {
+            callback(FileSystemError.NOT_SUPPORTED);
             return;
         }
         appshell.fs.isNetworkDrive(path, function (err, isNetworkDrive) {

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -149,6 +149,13 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Determines if we're running on Windows XP
+     */
+    function _isRunningOnWindowsXP() {
+        return (navigator.userAgent.indexOf("Windows NT 5.") >= 0);
+    }
+    
+    /**
      * Convert a callback to one that transforms its first parameter from an
      * appshell error code to a FileSystemError string.
      * 
@@ -490,6 +497,10 @@ define(function (require, exports, module) {
     function initWatchers(changeCallback, offlineCallback) {
         _changeCallback = changeCallback;
         _offlineCallback = offlineCallback;
+        
+        if (_isRunningOnWindowsXP() && _offlineCallback) {
+            _offlineCallback();
+        }
     }
     
     /**
@@ -504,6 +515,10 @@ define(function (require, exports, module) {
      * @param {function(?string)=} callback
      */
     function watchPath(path, callback) {
+        if (_isRunningOnWindowsXP()) {
+            callback(FileSystemError.PATH_WATCHING_NOT_SUPPORTED);
+            return;
+        }
         appshell.fs.isNetworkDrive(path, function (err, isNetworkDrive) {
             if (err || isNetworkDrive) {
                 callback(FileSystemError.UNKNOWN);


### PR DESCRIPTION
This pull request disabled file watching on XP. Here are the highlights:
- Short circuiting the logic that passes file watching off to Node on XP
- Continues to Disable our custom Windows File watcher Node Extension because it breaks extension loading
- Clean up a few FileSystemError related things
