### PR TITLE
Set the font size before opening the documents

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -99,6 +99,7 @@ define(function (require, exports, module) {
         ColorUtils              = require("utils/ColorUtils"),
         CodeInspection          = require("language/CodeInspection"),
         NativeApp               = require("utils/NativeApp"),
+        ViewCommandHandlers     = require("view/ViewCommandHandlers"),
         _                       = require("thirdparty/lodash");
         
     // Load modules that self-register and just need to get included in the main project
@@ -107,7 +108,6 @@ define(function (require, exports, module) {
     require("editor/EditorStatusBar");
     require("editor/EditorCommandHandlers");
     require("editor/EditorOptionHandlers");
-    require("view/ViewCommandHandlers");
     require("help/HelpCommandHandlers");
     require("search/FindInFiles");
     require("search/FindReplace");
@@ -220,6 +220,7 @@ define(function (require, exports, module) {
             // Load the initial project after extensions have loaded
             extensionLoaderPromise.always(function () {
                 // Finish UI initialization
+                ViewCommandHandlers.restoreFontSize();
                 var initialProjectPath = ProjectManager.getInitialProjectPath();
                 ProjectManager.openProject(initialProjectPath).always(function () {
                     _initTest();

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -218,6 +218,13 @@ define(function (require, exports, module) {
             var rule = rules[key];
             if (!rule && prefCheckCallback) {
                 rule = prefCheckCallback(key);
+            } else if (prefCheckCallback) {
+                // Check whether we have a new preference key-value pair
+                // for an old preference.
+                var newRule = prefCheckCallback(key, prefs[key]);
+                if (newRule) {
+                    rule = _.cloneDeep(newRule);
+                }
             }
             if (!rule) {
                 console.warn("Preferences conversion for ", self._clientID, " has no rule for", key);
@@ -238,6 +245,11 @@ define(function (require, exports, module) {
                     manager.set(newKey, prefs[key], options);
                     convertedKeys.push(key);
                 }
+            } else if (_.isObject(rule)) {
+                Object.keys(rule).forEach(function (ruleKey) {
+                    manager.set(ruleKey, rule[ruleKey]);
+                });
+                convertedKeys.push(key);
             } else {
                 complete = false;
             }

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -144,10 +144,8 @@
  */
 .code-font() {
     color: @content-color;
-    // line-height must be specified in px not em because the code font and line number font sizes are different.
-    // Sizing via em will cause the code and line numbers to misalign
-    line-height: 15px;
     font-size: 12px;
+    line-height: 1.25;
     font-family: "SourceCodePro-Medium", "ＭＳ ゴシック", "MS Gothic", monospace;
 }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -318,7 +318,7 @@ define(function (require, exports, module) {
      * @return {Object} JSON object for the new view state equivalent to
      *      the old "fontSizeAdjustment" preference.
      */
-    function _convertToNewViewStates(key, value) {
+    function _convertToNewViewState(key, value) {
         return { "fontSizeStyle": (DEFAULT_FONT_SIZE + value) + "px" };
     }
     
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,     _handleScrollLineUp);
     CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
 
-    PreferencesManager.convertPreferences(module, {"fontSizeAdjustment": "user"}, true, _convertToNewViewStates);
+    PreferencesManager.convertPreferences(module, {"fontSizeAdjustment": "user"}, true, _convertToNewViewState);
 
     // Update UI when opening or closing a document
     $(DocumentManager).on("currentDocumentChange", _updateUI);

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -323,6 +323,23 @@ define(function (require, exports, module) {
         _scrollLine(1);
     }
     
+    /**
+     * @private
+     * Convert the old "fontSizeAdjustment" preference to the new view states.
+     *
+     * @param {string} key The key of the preference to be examined for migration
+     *      of old preferences. Not used since we only have one in this module.
+     * @param {string} value The value of "fontSizeAdjustment" preference
+     * @return {Object} - JSON object for the new view states equivalent to
+     *      the old "fontSizeAdjustment" preference.
+     */
+    function _convertToNewViewStates(key, value) {
+        var fontSize = 12 + value,
+            newRule = { "fontSizeStyle": fontSize + "px",
+                        "lineHeightStyle": Math.ceil(fontSize * LINE_HEIGHT) + "px" };
+        
+        return newRule;
+    }
     
     // Register command handlers
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE, _handleIncreaseFontSize);
@@ -331,9 +348,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,     _handleScrollLineUp);
     CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,   _handleScrollLineDown);
 
-    // Initialize the default font size
-    PreferencesManager.stateManager.definePreference("fontSizeAdjustment", "number", 0);
-    PreferencesManager.convertPreferences(module, {"fontSizeAdjustment": "user"}, true);
+    PreferencesManager.convertPreferences(module, {"fontSizeAdjustment": "user"}, true, _convertToNewViewStates);
 
     // Update UI when opening or closing a document
     $(DocumentManager).on("currentDocumentChange", _updateUI);

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -94,8 +94,6 @@ define(function (require, exports, module) {
      * @param {string} lineHeightStyle  A string with the line height and the size unit
      */
     function _addDynamicFontSize(fontSizeStyle, lineHeightStyle) {
-        // It's necessary to inject a new rule to address all editors.
-        _removeDynamicFontSize();
         var style = $("<style type='text/css'></style>").attr("id", DYNAMIC_FONT_STYLE_ID);
         style.html(".CodeMirror {" +
                    "font-size: "   + fontSizeStyle   + " !important;" +
@@ -114,11 +112,10 @@ define(function (require, exports, module) {
             oldWidth  = editor._codeMirror.defaultCharWidth(),
             scrollPos = editor.getScrollPos(),
             line      = editor._codeMirror.lineAtHeight(scrollPos.y, "local");
-        console.log(line);
+        
+        _removeDynamicFontSize();
         if (fontSizeStyle && lineHeightStyle) {
             _addDynamicFontSize(fontSizeStyle, lineHeightStyle);
-        } else {
-            _removeDynamicFontSize();
         }
         editor.refreshAll();
         
@@ -127,7 +124,7 @@ define(function (require, exports, module) {
             deltaX     = scrollPos.x / oldWidth,
             scrollPosX = scrollPos.x + Math.round(deltaX * (newWidth  - oldWidth)),
             scrollPosY = editor._codeMirror.heightAtLine(line, "local");
-        console.log(scrollPosY);
+        
         editor.setScrollPos(scrollPosX, scrollPosY);
     }
     
@@ -199,8 +196,8 @@ define(function (require, exports, module) {
     /** Restores the font size to the original size */
     function _handleRestoreFontSize() {
         _setSizeAndRestoreScroll();
-        PreferencesManager.setViewState("fontSizeStyle",   undefined);
-        PreferencesManager.setViewState("lineHeightStyle", undefined);
+        PreferencesManager.setViewState("fontSizeStyle");
+        PreferencesManager.setViewState("lineHeightStyle");
     }
     
     
@@ -233,6 +230,7 @@ define(function (require, exports, module) {
             lhStr = PreferencesManager.getViewState("lineHeightStyle");
         
         if (fsStr && lhStr) {
+            _removeDynamicFontSize();
             _addDynamicFontSize(fsStr, lhStr);
         }
     }

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
      * @const
      * @private
      * The smallest font size in pixels
-     * @type {int}
+     * @type {number}
      */
     var MIN_FONT_SIZE = 1;
     
@@ -64,17 +64,17 @@ define(function (require, exports, module) {
      * @const
      * @private
      * The largest font size in pixels
-     * @type {int}
+     * @type {number}
      */
     var MAX_FONT_SIZE = 72;
     
     /**
      * @const
      * @private
-     * The ratio of line-height to font-size when they use the same units
-     * @type {float}
+     * The default font size used only to convert the old fontSizeAdjustment view state to the new fontSizeStyle
+     * @type {number}
      */
-    var LINE_HEIGHT = 1.25;
+    var DEFAULT_FONT_SIZE = 12;
     
     
     /**
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Increases or decreases the editor's font size.
-     * @param {number} adjustment Negative number to make the font smaller; positive number to make it bigger
+     * @param {number} adjustment  Negative number to make the font smaller; positive number to make it bigger
      * @return {boolean} true if adjustment occurred, false if it did not occur 
      */
     function _adjustFontSize(adjustment) {
@@ -196,7 +196,8 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Restores the Font Size and Line Height using the saved strings
+     * Restores the font size using the saved style and migrates the old fontSizeAdjustment
+     * view state to the new fontSizeStyle, when required
      */
     function restoreFontSize() {
         var fsStyle      = PreferencesManager.getViewState("fontSizeStyle"),
@@ -208,7 +209,7 @@ define(function (require, exports, module) {
 
             if (!fsStyle) {
                 // Migrate the old view state to the new one.
-                fsStyle = (12 + fsAdjustment) + "px";
+                fsStyle = (DEFAULT_FONT_SIZE + fsAdjustment) + "px";
                 PreferencesManager.setViewState("fontSizeStyle", fsStyle);
             }
         }
@@ -309,16 +310,16 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * Convert the old "fontSizeAdjustment" preference to the new view states.
+     * Convert the old "fontSizeAdjustment" preference to the new view state.
      *
-     * @param {string} key The key of the preference to be examined for migration
+     * @param {string} key  The key of the preference to be examined for migration
      *      of old preferences. Not used since we only have one in this module.
-     * @param {string} value The value of "fontSizeAdjustment" preference
-     * @return {Object} - JSON object for the new view states equivalent to
+     * @param {string} value  The value of "fontSizeAdjustment" preference
+     * @return {Object} JSON object for the new view state equivalent to
      *      the old "fontSizeAdjustment" preference.
      */
     function _convertToNewViewStates(key, value) {
-        return { "fontSizeStyle": (12 + value) + "px" };
+        return { "fontSizeStyle": (DEFAULT_FONT_SIZE + value) + "px" };
     }
     
     // Register command handlers


### PR DESCRIPTION
This is a fix for issue #7093. The idea is to add the styles with the new font-size and line-height before opening any document. To do this, when changing the font-size, we now save the strings that we use to set the styles, so we can use them to set the styles without having any editor open.
