### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Together with your contributions, we're getting close to our first release candi
 
 #### Download
 
-Installers for the latest stable build for Mac, Windows and Linux (Debian/Ubuntu) can be [downloaded here](http://download.brackets.io/).
+Installers for the latest stable build for Mac, Windows and Linux (Debian/Ubuntu) can be [downloaded here](http://brackets.io/).
 
 The Linux version has most of the features of the Mac and Windows versions, but
 is still missing a few things. See the [Linux wiki page](https://github.com/adobe/brackets/wiki/Linux-Version)


### PR DESCRIPTION
- Directs visitors to download from brackets.io rather than download.brackets.io
