### PR TITLE
Typing performance improvement

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -878,12 +878,15 @@ define(function (require, exports, module) {
      */
     Editor.prototype.getColOffset = function (pos) {
         var line    = this._codeMirror.getRange({line: pos.line, ch: 0}, pos),
-            tabSize = Editor.getTabSize(),
+            tabSize,
             column  = 0,
             i;
 
         for (i = 0; i < line.length; i++) {
             if (line[i] === '\t') {
+                if (!tabSize) {
+                    tabSize = Editor.getTabSize();
+                }
                 column += (tabSize - (column % tabSize));
             } else {
                 column++;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -887,7 +887,9 @@ define(function (require, exports, module) {
                 if (tabSize === null) {
                     tabSize = Editor.getTabSize();
                 }
-                column += (tabSize - (column % tabSize));
+                if (tabSize > 0) {
+                    column += (tabSize - (column % tabSize));
+                }
             } else {
                 column++;
             }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -878,13 +878,13 @@ define(function (require, exports, module) {
      */
     Editor.prototype.getColOffset = function (pos) {
         var line    = this._codeMirror.getRange({line: pos.line, ch: 0}, pos),
-            tabSize,
+            tabSize = null,
             column  = 0,
             i;
 
         for (i = 0; i < line.length; i++) {
             if (line[i] === '\t') {
-                if (!tabSize) {
+                if (tabSize === null) {
                     tabSize = Editor.getTabSize();
                 }
                 column += (tabSize - (column % tabSize));


### PR DESCRIPTION
I discovered this when implementing editor preference validation. For `EditorStatusBar` to display the cursor position, it calls `Editor.getCursorPos()` with `expandTabs` option. This causes the "tabSize" preference to be retrieved on _every_ keystroke. This really sucks in a document that doesn't have any Tab characters!

This changes it so the "tabSize" pref is not retrieved until a until a Tab char is found.

This value could be cached to improve it for docs with Tab chars since it rarely changes.
