### PR TITLE
Enable image viewer for .ico files

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         ProjectManager      = require("project/ProjectManager"),
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils"),
-        FileSystem          = require("filesystem/FileSystem");
+        FileSystem          = require("filesystem/FileSystem"),
+        FileUtils           = require("file/FileUtils");
     
     var _naturalWidth = 0,
         _scale = 100,
@@ -312,7 +313,11 @@ define(function (require, exports, module) {
         $("#img-preview").on("load", function () {
             // add dimensions and size
             _naturalWidth = this.naturalWidth;
+            var ext = FileUtils.getFileExtension(fullPath);
             var dimensionString = _naturalWidth + " &times; " + this.naturalHeight + " " + Strings.UNIT_PIXELS;
+            if (ext === "ico") {
+                dimensionString += " (" + Strings.IMAGE_VIEWER_LARGEST_ICON + ")";
+            }
             // get image size
             var file = FileSystem.getFileForPath(fullPath);
             var minimumPixels = 20;     // for showing crosshair cursor

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -233,7 +233,7 @@
   
     "image": {
         "name": "Image",
-        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg"],
+        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico"],
         "isBinary": true
     },
     

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -458,6 +458,9 @@ define({
     "INLINE_EDITOR_NO_MATCHES"             : "No matches available.",
     "CSS_QUICK_EDIT_NO_MATCHES"            : "There are no existing CSS rules that match your selection.<br> Click \"New Rule\" to create one.",
     "CSS_QUICK_EDIT_NO_STYLESHEETS"        : "There are no stylesheets in your project.<br>Create one to add CSS rules.",
+
+    // Custom Viewers
+    "IMAGE_VIEWER_LARGEST_ICON"            : "largest",
     
     /**
      * Unit names


### PR DESCRIPTION
For #7017 @peterflynn @larz0
This adds `.ico` files to the image language and attaches a `largest` label to a shown ico file (as discussed in the issue).
