### PR TITLE
Add preference for soft tabs

### DIFF
--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -1079,7 +1079,7 @@ define(function (require, exports, module) {
                 checkSoftTab({line: 0, ch: 8}, 1, "moveH", {line: 0, ch: 9});
             });
 
-            describe("with soft tab preference off", function () {
+            describe("with soft tabs preference off", function () {
                 beforeEach(function () {
                     // Disable soft tabs
                     PreferencesManager.set("softTabs", false);
@@ -1089,19 +1089,19 @@ define(function (require, exports, module) {
                     PreferencesManager.set("softTabs", true);
                 });
 
-                it("should move left by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                it("should move left by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line", function () {
                     myEditor.document.setText("    content");
                     checkSoftTab({line: 0, ch: 4}, -1, "moveH", {line: 0, ch: 3});
                 });
-                it("should backspace by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                it("should backspace by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line", function () {
                     myEditor.document.setText("    content");
                     checkSoftTab({line: 0, ch: 4}, -1, "deleteH", {line: 0, ch: 3}, "   content");
                 });
-                it("should move right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                it("should move right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line", function () {
                     myEditor.document.setText("    content");
                     checkSoftTab({line: 0, ch: 0}, 1, "moveH", {line: 0, ch: 1});
                 });
-                it("should delete right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                it("should delete right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line", function () {
                     myEditor.document.setText("    content");
                     checkSoftTab({line: 0, ch: 0}, 1, "deleteH", {line: 0, ch: 0}, "   content");
                 });

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -28,11 +28,12 @@
 define(function (require, exports, module) {
     'use strict';
     
-    var Editor          = require("editor/Editor").Editor,
-        EditorManager   = require("editor/EditorManager"),
-        SpecRunnerUtils = require("spec/SpecRunnerUtils"),
-        LanguageManager = require("language/LanguageManager"),
-        KeyEvent        = require("utils/KeyEvent");
+    var Editor              = require("editor/Editor").Editor,
+        EditorManager       = require("editor/EditorManager"),
+        KeyEvent            = require("utils/KeyEvent"),
+        LanguageManager     = require("language/LanguageManager"),
+        PreferencesManager  = require("preferences/PreferencesManager"),
+        SpecRunnerUtils     = require("spec/SpecRunnerUtils");
     
     var langNames = {
         css:        {mode: "css",           langName: "CSS"},
@@ -1077,7 +1078,35 @@ define(function (require, exports, module) {
                 myEditor.document.setText("   four  ");
                 checkSoftTab({line: 0, ch: 8}, 1, "moveH", {line: 0, ch: 9});
             });
-            
+
+            describe("with soft tab preference off", function () {
+                beforeEach(function () {
+                    // Disable soft tabs
+                    PreferencesManager.set("softTabs", false);
+                });
+                afterEach(function () {
+                    // Re-enable soft tabs
+                    PreferencesManager.set("softTabs", true);
+                });
+
+                it("should move left by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                    myEditor.document.setText("    content");
+                    checkSoftTab({line: 0, ch: 4}, -1, "moveH", {line: 0, ch: 3});
+                });
+                it("should backspace by 1 space if cursor is immediately after 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                    myEditor.document.setText("    content");
+                    checkSoftTab({line: 0, ch: 4}, -1, "deleteH", {line: 0, ch: 3}, "   content");
+                });
+                it("should move right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                    myEditor.document.setText("    content");
+                    checkSoftTab({line: 0, ch: 0}, 1, "moveH", {line: 0, ch: 1});
+                });
+                it("should delete right by 1 space if cursor is immediately before 1 indent level worth of spaces at beginning of line and soft tab pref is off", function () {
+                    myEditor.document.setText("    content");
+                    checkSoftTab({line: 0, ch: 0}, 1, "deleteH", {line: 0, ch: 0}, "   content");
+                });
+            });
+
             describe("with multiple selections", function () {
                 it("should move left over a soft tab from multiple aligned cursors", function () {
                     myEditor.document.setText("    one\n    two\n    three\n");


### PR DESCRIPTION
Add preference for soft tabs for #6872. Preference name is: "softTabs".

Only lines I added at the top of `Editor.js` was:

```
        SOFT_TABS         = "softTabs",
```

and:

```
    PreferencesManager.definePreference(SOFT_TABS,         "boolean", true);
```

The rest was re-ordering alphabetically. Sorry, I should have done that in a separate commit.

@TomMalbran You've added a few new prefs lately -- can you review this one?
