### PR TITLE
Exclude file ext from initial selection when renaming a file.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1807,8 +1807,13 @@ define(function (require, exports, module) {
                 
                 // Since html_titles are enabled, we have to reset the text without markup.
                 // And we also need to explicitly escape all html-sensitive characters.
-                _projectTree.jstree("set_text", $selected, _.escape(entry.name));
+                var escapedName = _.escape(entry.name);
+                _projectTree.jstree("set_text", $selected, escapedName);
                 _projectTree.jstree("rename");
+                var indexOfExtension = escapedName.lastIndexOf('.');
+                if (indexOfExtension > 0) {
+                    $selected.children(".jstree-rename-input")[0].setSelectionRange(0, indexOfExtension);
+                }
             });
         // No fail handler: silently no-op if file doesn't exist in tree
     }


### PR DESCRIPTION
This change performs the rename as usual through JSTree, then
grabs the DOM node and adjusts the selection on it after the fact.
This fixes issue #7019
