### PR TITLE
Ctrl-X: Cut line on no selection

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -1047,6 +1047,34 @@ define(function (require, exports, module) {
         // Do nothing. The shell will call the native handler for the command.
         return (new $.Deferred()).reject().promise();
     }
+
+    /**
+     * @private
+     * Cuts the selected text of editor to clipboard. If there are cursors (empty selections) then the selected lines
+     * (which the cursors are active at) will be cut to clipboard.
+     * @param (!Editor) editor The editor to operate on.
+     */
+    function cut(editor) {
+        // Returns true if the selection is cursor (i.e. no text selected).
+        function _isCursor(selection) {
+            return selection.start.line === selection.end.line && selection.start.ch === selection.end.ch;
+        }
+        
+        editor = editor || EditorManager.getFocusedEditor();
+        if (!editor) {
+            return;
+        }
+        
+        // Convert all cursors to line selections.
+        var _cursors = _.pluck(editor.convertToLineSelections(_.filter(editor.getSelections(), _isCursor), {expandEndAtStartOfLine: true, mergeAdjacent: false}), "selectionForEdit");
+        var _ranges = _.reject(editor.getSelections(), _isCursor);
+        var _selections = _cursors.concat(_ranges);
+        editor.setSelections(_selections);
+        
+        // Since the shell needs to perform the actual cut to clipboard, and the cursors now have been
+        // transformed to line selections, the command can be ignored in order for the native shell to do the cutting.
+        return ignoreCommand();
+    }
 	
 	function _handleSelectAll() {
         var result = new $.Deferred(),
@@ -1080,7 +1108,7 @@ define(function (require, exports, module) {
 
     CommandManager.register(Strings.CMD_UNDO,                   Commands.EDIT_UNDO,                   handleUndo);
     CommandManager.register(Strings.CMD_REDO,                   Commands.EDIT_REDO,                   handleRedo);
-    CommandManager.register(Strings.CMD_CUT,                    Commands.EDIT_CUT,                    ignoreCommand);
+    CommandManager.register(Strings.CMD_CUT,                    Commands.EDIT_CUT,                    cut);
     CommandManager.register(Strings.CMD_COPY,                   Commands.EDIT_COPY,                   ignoreCommand);
     CommandManager.register(Strings.CMD_PASTE,                  Commands.EDIT_PASTE,                  ignoreCommand);
     CommandManager.register(Strings.CMD_SELECT_ALL,             Commands.EDIT_SELECT_ALL,             _handleSelectAll);

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -3489,5 +3489,48 @@ define(function (require, exports, module) {
                 });
             });
         });
+
+        describe("Cut command", function () {
+            beforeEach(setupFullEditor);
+
+            it("should not alter selection", function () {
+                var _selection = {start: {line: 1, ch: 1}, end: {line: 1, ch: 2}};
+                myEditor.setSelection(_selection.start, _selection.end);
+                CommandManager.execute(Commands.EDIT_CUT, myEditor);
+
+                expectSelection(_selection);
+            });
+
+            it("should convert cursor to line selection", function () {
+                myEditor.setCursorPos({line: 1, ch: 5});
+                CommandManager.execute(Commands.EDIT_CUT, myEditor);
+
+                expectSelection({start: {line: 1, ch: 0}, end: {line: 2, ch: 0}});
+            });
+
+            describe("with multiple selections", function () {
+                it("should convert cursors to line selections", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                            {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}},
+                                            {start: {line: 4, ch: 5}, end: {line: 4, ch: 5}}]);
+                    CommandManager.execute(Commands.EDIT_CUT, myEditor);
+
+                    expectSelections([{start: {line: 1, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 2, ch: 4}, end: {line: 2, ch: 6}, reversed: false, primary: false},
+                                      {start: {line: 4, ch: 0}, end: {line: 5, ch: 0}, reversed: false, primary: true}]);
+                });
+
+                it("should be able to handle overlapping cursor and selections", function () {
+                    myEditor.setSelections([{start: {line: 1, ch: 1}, end: {line: 1, ch: 1}},
+                                             {start: {line: 1, ch: 3}, end: {line: 1, ch: 3}},
+                                             {start: {line: 3, ch: 4}, end: {line: 3, ch: 6}},
+                                             {start: {line: 3, ch: 8}, end: {line: 3, ch: 8}}]);
+                    CommandManager.execute(Commands.EDIT_CUT, myEditor);
+
+                    expectSelections([{start: {line: 1, ch: 0}, end: {line: 2, ch: 0}, reversed: false, primary: false},
+                                      {start: {line: 3, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: true}]);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
As discussed is issue #2017 and at trello https://trello.com/c/XVyzky6d

This enables the use of Ctrl-X to cut lines when no text is selected, just like in Sublime, IntelliJ and other modern editors.

Since cutting is done by the shell, this fix simply selects the whole line of each cursor that doesn't have a selection, before letting the shell do it's thing. This results in the desired behaviour.

So to sum up: 
- If you have a cursor at a line (with no selection), hitting Ctrl-X will cut the whole line. 
- If you have a text selection, hitting Ctrl-X will work normal as before. 
- Any combinations with multiple cursors is supported.
