### PR TITLE
Fix several problems with Jump to Definition API

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -632,7 +632,7 @@ define(function (require, exports, module) {
 
                         
             // Only provide jump-to-definition results when cursor is in JavaScript content
-            if (session.editor.getModeForSelection() !== "javascript") {
+            if (!session || session.editor.getModeForSelection() !== "javascript") {
                 return null;
             }
 


### PR DESCRIPTION
Fix bug #7065/#5773 and other several problems with the Jump to Definition extensibility API:
- JS impl would always crash on non-JS code, blocking any other provider from responding
- Provider was not called with the args the docs described
- Other errors in docs
