### PR TITLE
Fix a case when extension less file is importing other less files

### DIFF
--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, less */
+/*global define, $, brackets, less, PathUtils */
 
 /**
  * ExtensionUtils defines utility methods for implementing extensions.
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
                 rootpath: dir
             };
 
-            if (url.indexOf("file://") === 0) {
+            if (PathUtils.isAbsoluteUrl(url)) {
                 options.currentFileInfo = {
                     currentDirectory: dir,
                     entryPath: dir,
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
      * @return {!$.Promise} A promise object that is resolved with the contents of the requested file
      **/
     function loadFile(module, path) {
-        var url     = getModuleUrl(module, path),
+        var url     = PathUtils.isAbsoluteUrl(path) ? path : getModuleUrl(module, path),
             promise = $.get(url);
 
         return promise;

--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -88,15 +88,18 @@ define(function (require, exports, module) {
             options = {
                 filename: file,
                 paths:    [dir],
-                rootpath: dir,
-                currentFileInfo: {
+                rootpath: dir
+            };
+
+            if (url.indexOf("file://") === 0) {
+                options.currentFileInfo = {
                     currentDirectory: dir,
                     entryPath: dir,
                     filename: url,
                     rootFilename: url,
                     rootpath: dir
-                }
-            };
+                };
+            }
         }
         
         var parser = new less.Parser(options);

--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -88,7 +88,14 @@ define(function (require, exports, module) {
             options = {
                 filename: file,
                 paths:    [dir],
-                rootpath: dir
+                rootpath: dir,
+                currentFileInfo: {
+                    currentDirectory: dir,
+                    entryPath: dir,
+                    filename: url,
+                    rootFilename: url,
+                    rootpath: dir
+                }
             };
         }
         

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -137,6 +137,36 @@ define(function (require, exports, module) {
                     expect(testWindow.$.contains(testWindow.document, result)).toBeTruthy();
                 });
             });
+
+            // putting everything LESS related in 1 test so it runs faster
+            it("should attach LESS style sheets using absolute url", function () {
+                var promise, result;
+
+                runs(function () {
+                    var indexLocation = testWindow.location.origin + testWindow.location.pathname,
+                        bracketsLocation = indexLocation.substring(0, indexLocation.length - "src/index.html".length),
+                        basicLessLocation = bracketsLocation + "test/spec/ExtensionUtils-test-files/basic.less";
+
+                    promise = loadStyleSheet(testWindow.document, basicLessLocation);
+                    promise.done(function (style) {
+                        result = style;
+                    });
+
+                    waitsForDone(promise);
+                });
+
+                runs(function () {
+                    // convert all line endings to platform default
+                    var windowText = FileUtils.translateLineEndings(testWindow.$(result).text()),
+                        lessText   = FileUtils.translateLineEndings(LESS_RESULT);
+
+                    // confirm style sheet contents
+                    expect(windowText).toBe(lessText);
+
+                    // confirm style is attached to document
+                    expect(testWindow.$.contains(testWindow.document, result)).toBeTruthy();
+                });
+            });
         });
     });
 });

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -111,8 +111,7 @@ define(function (require, exports, module) {
                     waitsForFail(promise, "loadStyleSheet: " + path);
                 });
             });
-            
-            // putting everything LESS related in 1 test so it runs faster
+
             it("should attach LESS style sheets", function () {
                 var promise, result;
                 
@@ -138,7 +137,6 @@ define(function (require, exports, module) {
                 });
             });
 
-            // putting everything LESS related in 1 test so it runs faster
             it("should attach LESS style sheets using absolute url", function () {
                 var promise, result;
 


### PR DESCRIPTION
I wanted to split less file my extension is using into more files, but loading failed when using valid import directives. Through debugging, I found out that some properties of file info were not filled as it should.

These are the values for file `brackets.less`:

```
currentDirectory: "file:///D:/Program%20Files/Brackets/dev/src/styles/"
entryPath:        "file:///D:/Program%20Files/Brackets/dev/src/styles/"
filename:         "file:///D:/Program%20Files/Brackets/dev/src/styles/brackets.less"
relativeUrls:     undefined
rootFilename:     "file:///D:/Program%20Files/Brackets/dev/src/styles/brackets.less"
rootpath:         "file:///D:/Program%20Files/Brackets/dev/src/styles/"
```

And these are the original values calculated for `brackets-git.less`:

```
currentDirectory: ""
entryPath:        ""
filename:         "brackets-git.less"
relativeUrls:     undefined
rootFilename:     "brackets-git.less"
rootpath:         "file:///C:/Users/Zaggi/AppData/Roaming/Brackets/extensions/user/zaggino.brackets-git/less/"
```

The fix makes fileInfo look the same way as in the `brackets.less` case and all references are loaded correctly.
