### PR TITLE
Replace String.trimRight() with regex in order to support IE10+

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -37,7 +37,10 @@
  */
 define(function (require, exports, module) {
     "use strict";
-    
+
+    // Load compatibility shims--these need to load early, be careful moving this
+    require("utils/Compatibility");
+
     // Load dependent non-module scripts
     require("widgets/bootstrap-dropdown");
     require("widgets/bootstrap-modal");
@@ -57,7 +60,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror2/addon/mode/overlay");
     require("thirdparty/CodeMirror2/addon/search/searchcursor");
     require("thirdparty/CodeMirror2/keymap/sublime");
-    
+
     // Load dependent modules
     var Global                  = require("utils/Global"),
         AppInit                 = require("utils/AppInit"),

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -38,9 +38,6 @@
 define(function (require, exports, module) {
     "use strict";
 
-    // Load compatibility shims--these need to load early, be careful moving this
-    require("utils/Compatibility");
-
     // Load dependent non-module scripts
     require("widgets/bootstrap-dropdown");
     require("widgets/bootstrap-modal");

--- a/src/main.js
+++ b/src/main.js
@@ -50,9 +50,12 @@ require.config({
     locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
 });
 
-define(function (require, exports, module) {
+define(function (require) {
     "use strict";
-    
-    // Load the brackets module. This is a self-running module that loads and runs the entire application.
-    require("brackets");
+
+    // Load compatibility shims--these need to load early, be careful moving this
+    require(["utils/Compatibility"], function () {
+        // Load the brackets module. This is a self-running module that loads and runs the entire application.
+        require(["brackets"]);
+    });
 });

--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+/**
+ * Compatibility shims for running Brackets in various environments, browsers.
+ */
+define(function (require, exports, module) {
+    "use strict";
+
+    // [IE10] String.prototype missing trimRight() and trimLeft()
+    if (!String.prototype.trimRight) {
+        String.prototype.trimRight = function () { return this.replace(/\s+$/, ""); };
+    }
+    if (!String.prototype.trimLeft) {
+        String.prototype.trimLeft = function () { return this.replace(/^\s+/, ""); };
+    }
+
+});

--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -1,24 +1,24 @@
 /*
- * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
- *  
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -28,7 +28,7 @@
 /**
  * Compatibility shims for running Brackets in various environments, browsers.
  */
-define(function (require, exports, module) {
+define(function () {
     "use strict";
 
     // [IE10] String.prototype missing trimRight() and trimLeft()

--- a/src/utils/UrlParams.js
+++ b/src/utils/UrlParams.js
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
             queryString = url.substring(url.indexOf("?") + 1);
         }
         
-        queryString = queryString.trimRight();
+        queryString = queryString.replace(/\s*$/, "");
         
         if (queryString) {
             urlParams = queryString.split("&");

--- a/src/utils/UrlParams.js
+++ b/src/utils/UrlParams.js
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
             queryString = url.substring(url.indexOf("?") + 1);
         }
         
-        queryString = queryString.replace(/\s*$/, "");
+        queryString = queryString.trimRight();
         
         if (queryString) {
             urlParams = queryString.split("&");


### PR DESCRIPTION
For work I've been doing on brackets-in-browser (see https://blog.webmaker.org/webmaker-experiments-with-brackets) I had to fix this use of `trimRight` so it would work in IE10+.  With this change, I'm able to run things in IE10+:

![screen shot 2014-03-18 at 9 50 30 am](https://f.cloud.github.com/assets/427398/2448574/13c299ea-aea8-11e3-8700-2cd1f8e4efbb.png)
