### PR TITLE
[JSLint] Respects tabSize setting when useTabChar is true

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -60,6 +60,11 @@ define(function (require, exports, module) {
     // Predefined environments understood by JSLint.
     var ENVIRONMENTS = ["browser", "node", "couch", "rhino"];
     
+    // gets indentation size depending whether the tabs or spaces are used
+    function _getIndentSize() {
+        return PreferencesManager.get("useTabChar") ? PreferencesManager.get("tabSize") : PreferencesManager.get("spaceUnits");
+    }
+
     /**
      * Run JSLint on the current document. Reports results to the main UI. Displays
      * a gold star when no errors are found.
@@ -88,7 +93,7 @@ define(function (require, exports, module) {
         
         if (!options.indent) {
             // default to using the same indentation value that the editor is using
-            options.indent = PreferencesManager.get("spaceUnits");
+            options.indent = _getIndentSize();
         }
         
         // If the user has not defined the environment, we use browser by default.

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -61,8 +61,11 @@ define(function (require, exports, module) {
     var ENVIRONMENTS = ["browser", "node", "couch", "rhino"];
     
     // gets indentation size depending whether the tabs or spaces are used
-    function _getIndentSize() {
-        return PreferencesManager.get("useTabChar") ? PreferencesManager.get("tabSize") : PreferencesManager.get("spaceUnits");
+    function _getIndentSize(fullPath) {
+        return PreferencesManager.get(
+            PreferencesManager.get("useTabChar", fullPath) ? "tabSize" : "spaceUnits",
+            fullPath
+        );
     }
 
     /**
@@ -93,7 +96,7 @@ define(function (require, exports, module) {
         
         if (!options.indent) {
             // default to using the same indentation value that the editor is using
-            options.indent = _getIndentSize();
+            options.indent = _getIndentSize(fullPath);
         }
         
         // If the user has not defined the environment, we use browser by default.


### PR DESCRIPTION
Original issue here: https://github.com/adobe/brackets/issues/7240

Similar approach is taken here:
https://github.com/adobe/brackets/blob/master/src/editor/EditorStatusBar.js#L74-76
