### PR TITLE
Use correct path for docs in subfolders

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -60,6 +60,7 @@ define(function (require, exports, module) {
         var directory,
             doc,
             docDir,
+            editor,
             queryDir = "",
             queryUrl,
             result = [],
@@ -67,8 +68,13 @@ define(function (require, exports, module) {
             targetDir,
             unfiltered = [];
 
-        // get path to current document
-        doc = DocumentManager.getCurrentDocument();
+        // get path to document in focused editor
+        editor = EditorManager.getFocusedEditor();
+        if (!editor) {
+            return result;
+        }
+
+        doc = editor.document;
         if (!doc || !doc.file) {
             return result;
         }

--- a/src/extensions/default/UrlCodeHints/testfiles/subfolder/test.css
+++ b/src/extensions/default/UrlCodeHints/testfiles/subfolder/test.css
@@ -1,4 +1,5 @@
 /* test.css */
 body {
     margin: 0;
+    background-image: url();
 }

--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, $, brackets, waitsForDone */
+/*global define, describe, it, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, $, brackets, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, $, brackets, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";
@@ -132,11 +132,14 @@ define(function (require, exports, module) {
 
         describe("HTML Url Code Hints", function () {
 
-            // This MUST be the FIRST "test"
-            it("should setup before tests", function () {
+            beforeFirst(function () {
                 setupTests();
             });
             
+            afterLast(function () {
+                tearDownTests();
+            });
+
             it("should hint for href attribute", function () {
                 runs(function () {
                     testEditor.setCursorPos({ line: 12, ch: 12 });
@@ -189,20 +192,18 @@ define(function (require, exports, module) {
                     verifyUrlHints(hintsObj.hints, expectedFirstItem);
                 });
             });
-            
-            // This MUST be the LAST "test"
-            it("should cleanup after tests", function () {
-                tearDownTests();
-            });
         });
         
         describe("CSS Url Code Hints", function () {
             
-            // This MUST be the FIRST "test"
-            it("should setup before tests", function () {
+            beforeFirst(function () {
                 setupTests();
             });
             
+            afterLast(function () {
+                tearDownTests();
+            });
+
             it("should hint for @import url()", function () {
                 runs(function () {
                     testEditor.setCursorPos({ line: 4, ch: 12 });
@@ -271,11 +272,6 @@ define(function (require, exports, module) {
                 runs(function () {
                     verifyUrlHints(hintsObj.hints);
                 });
-            });
-            
-            // This MUST be the LAST "test"
-            it("should cleanup after tests", function () {
-                tearDownTests();
             });
         });
             


### PR DESCRIPTION
This is for #7077 

I also updated unit tests:
- added test for hints in subfolder
- to use `beforeFirst()` and `afterLast()` callbacks
- to verify all hints (not just first one)
- cleanup hints object
