### PR TITLE
Grunt build error, case sensitive name CodeMirror.js

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
         PreferencesManager  = require("preferences/PreferencesManager"),
         ViewUtils           = require("utils/ViewUtils"),
         _                   = require("thirdparty/lodash"),
-        CodeMirror          = require("thirdparty/CodeMirror2/lib/CodeMirror");
+        CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror");
     
     var searchBarTemplate            = require("text!htmlContent/findreplace-bar.html"),
         searchReplacePanelTemplate   = require("text!htmlContent/search-replace-panel.html"),


### PR DESCRIPTION
Building from a fresh checkout (with recursive submodules) using `grunt build`, I get the following error on the `requirejs:dist` task:

```
Running "requirejs:dist" (requirejs) task

Tracing dependencies for: main
Error: ENOENT, no such file or directory '/home/miki/vcs/git/adobe/brackets/src/thirdparty/CodeMirror2/lib/CodeMirror.js'
In module tree:
    main
      brackets
        search/FindInFiles
          search/FindReplace

{ [Error: Error: ENOENT, no such file or directory '/home/miki/vcs/git/adobe/brackets/src/thirdparty/CodeMirror2/lib/CodeMirror.js'
In module tree:
    main
      brackets
        search/FindInFiles
          search/FindReplace

    at Object.fs.openSync (fs.js:427:18)
]
  originalError: 
   { [Error: ENOENT, no such file or directory '/home/miki/vcs/git/adobe/brackets/src/thirdparty/CodeMirror2/lib/CodeMirror.js']
     errno: 34,
     code: 'ENOENT',
     path: '/home/miki/vcs/git/adobe/brackets/src/thirdparty/CodeMirror2/lib/CodeMirror.js',
     syscall: 'open',
     fileName: '/home/miki/vcs/git/adobe/brackets/src/thirdparty/CodeMirror2/lib/CodeMirror.js',
     moduleTree: [ 'search/FindReplace', 'search/FindInFiles', 'brackets', 'main' ] } }
```

```
$ ls -l src/thirdparty/CodeMirror2/lib/
total 296
-rw-r--r-- 1 miki users   6309 Mar 19 20:33 codemirror.css
-rw-r--r-- 1 miki users 293877 Mar 19 20:33 codemirror.js
```

or, in other words: on *nix, case does matter, you [insensitive clod!](http://en.wikipedia.org/wiki/Slashdot#Culture) ;-)
