### PR TITLE
Empty pref file is an empty object, not an error.

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -175,10 +175,15 @@ define(function (require, exports, module) {
                     
                     self._lineEndings = FileUtils.sniffLineEndings(text);
                     
-                    try {
-                        result.resolve(JSON.parse(text));
-                    } catch (e) {
-                        result.reject(new ParsingError("Invalid JSON settings at " + path + "(" + e.toString() + ")"));
+                    // If the file is empty, turn it into an empty object
+                    if (/^\w*$/.test(text)) {
+                        result.resolve({});
+                    } else {
+                        try {
+                            result.resolve(JSON.parse(text));
+                        } catch (e) {
+                            result.reject(new ParsingError("Invalid JSON settings at " + path + "(" + e.toString() + ")"));
+                        }
                     }
                 });
             } else {

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -176,7 +176,7 @@ define(function (require, exports, module) {
                     self._lineEndings = FileUtils.sniffLineEndings(text);
                     
                     // If the file is empty, turn it into an empty object
-                    if (/^\w*$/.test(text)) {
+                    if (/^\s*$/.test(text)) {
                         result.resolve({});
                     } else {
                         try {

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -1067,8 +1067,9 @@ define(function (require, exports, module) {
         });
         
         describe("File Storage", function () {
-            var settingsFile = FileSystem.getFileForPath(testPath + "/.brackets.json"),
-                newSettingsFile = FileSystem.getFileForPath(testPath + "/new.prefs"),
+            var settingsFile      = FileSystem.getFileForPath(testPath + "/.brackets.json"),
+                newSettingsFile   = FileSystem.getFileForPath(testPath + "/new.prefs"),
+                emptySettingsFile = FileSystem.getFileForPath(testPath + "/empty.json"),
                 filestorage,
                 originalText;
             
@@ -1205,6 +1206,21 @@ define(function (require, exports, module) {
                     expect(changes).toEqual([{
                         ids: ["spaceUnits"]
                     }]);
+                });
+            });
+            
+            it("is fine with empty preferences files", function () {
+                var filestorage = new PreferencesBase.FileStorage(emptySettingsFile.fullPath),
+                    promise = filestorage.load();
+                
+                waitsForDone(promise, "loading empty JSON file");
+                runs(function () {
+                    promise.then(function (data) {
+                        expect(data).toEqual({});
+                    })
+                        .fail(function (error) {
+                            expect("There should have been no error").toEqual("");
+                        });
                 });
             });
         });

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -1217,10 +1217,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     promise.then(function (data) {
                         expect(data).toEqual({});
-                    })
-                        .fail(function (error) {
-                            expect("There should have been no error").toEqual("");
-                        });
+                    });
                 });
             });
         });


### PR DESCRIPTION
This is a fix for #7220 (errors caused by a prefs file being empty).

This also fixes #7229 which was duped to #7220.
