### PR TITLE
Moved .notification icon in Extension Manager dialog

### DIFF
--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -5,7 +5,7 @@
                 <li><a href="#registry" class="registry" data-toggle="tab"><img src="styles/images/extension-manager-registry.svg"/><br/>{{Strings.EXTENSIONS_AVAILABLE_TITLE}}</a></li>
                 <!--<li><a href="#updates" class="updates" data-toggle="tab"><img src="styles/images/extension-manager-updates.svg"/><br/>{{Strings.EXTENSIONS_UPDATES_TITLE}}</a></li>-->
             {{/showRegistry}}
-            <li><a href="#installed" class="installed" data-toggle="tab"><img src="styles/images/extension-manager-installed.svg"/><br/>{{Strings.EXTENSIONS_INSTALLED_TITLE}}</a><span class="notification"></span></li>
+            <li><a href="#installed" class="installed" data-toggle="tab"><span class="notification"></span><img src="styles/images/extension-manager-installed.svg"/><br/>{{Strings.EXTENSIONS_INSTALLED_TITLE}}</a></li>
         </ul>
         <div>
             <button class="search-clear">&times;</button>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -790,7 +790,7 @@ a[href^="http"] {
             
             > li {
                 position: relative;  // for positioning .notification icon
-                > .notification {
+                .notification {
                     display: none;  // hidden by default
                     background-color: #91CC41;
                     color: white;


### PR DESCRIPTION
I've rearranged the `.notification` item (installed extensions number) badge so that clicking it switches to the `Installed Extensions` tab. Appropriate .less files also got modified in order to get the icon themed properly. This aims to fix bug #7280.
