### PR TITLE
Fix EditOptionHandlers word wrap test

### DIFF
--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var editor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
-                    checkLineWrapping(editor, {line: 0, ch: 0}, {line: 0, ch: 160}, true);
+                    checkLineWrapping(editor, {line: 0, ch: 0}, {line: 0, ch: 320}, true);
                 });
             });
             


### PR DESCRIPTION
This EditorOptionHandlers unit test fails for me every time:

"should also wrap long lines in inline editor by default"

```
Error: Expected 30 to be less than 30.
    at new jasmine.ExpectationResult (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:102:32)
    at null.toBeLessThan (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:1194:29)
    at null.<anonymous> (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/spec/EditorOptionHandlers-test.js:101:45)
    at jasmine.Block.execute (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:1024:15)
    at jasmine.Queue.next_ (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:1842:31)
    at onComplete (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:1838:18)
    at jasmine.WaitsForBlock.execute (file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:2322:5)
    at file:///C:/Users/redmunds/dev/github/brackets-shell/Release/dev/test/thirdparty/jasmine-core/jasmine.js:2336:12
```

I seem to be the only one seeing this. I think it has something to do with the combination of:
- My new Windows HiDPI laptop (1920x1200)
- Recent change where test windows no longer inherit user options (i.e. font size zoom)
- Test windows seem to be wider now

So, the line of code is not wrapping lines any more. I checked in a fix in PR #7289 for a similar test that no longer was scrolling horizontally.
