### PR TITLE
Removed Quick Open dropdown menu border and tweaked its dropshadow to compensate

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1293,11 +1293,14 @@ textarea.exclusions-editor {
 
 .smart_autocomplete_container {
     // the borders show up even if the container is empty, must set height to zero using JS.
-    border: 1px solid @tc-gray-panel-border;
     background-color: @tc-gray-panel;
     border-radius: 0 0 4px 4px;
     box-shadow: @tc-normal-shadow-bottom;
     opacity: 0;
+    
+    // Need this for border-radius because there are no borders
+    overflow: hidden;
+    
     .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99), 0, 1);
     -webkit-animation-fill-mode: forwards;
     animation-fill-mode: forwards;

--- a/src/styles/brackets_colors.less
+++ b/src/styles/brackets_colors.less
@@ -98,7 +98,7 @@
 @tc-panel-border-radius:           5px;
 @tc-small-shadow-top:              0 -1px 3px rgba(0, 0, 0, 0.12);
 @tc-small-shadow-bottom:           0 1px 3px rgba(0, 0, 0, 0.12);
-@tc-normal-shadow-bottom:          0 5px 10px rgba(0, 0, 0, 0.1);
+@tc-normal-shadow-bottom:          0 5px 10px rgba(0, 0, 0, 0.21);
 @tc-highlight:                     #e0f0fa;
 @tc-selected-row:                  #d0d5d5;
 @tc-hover-highlight:               rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
This is for #7307. 

![screen shot 2014-03-24 at 3 55 30 pm](https://f.cloud.github.com/assets/1495261/2506497/de37bc2e-b3a7-11e3-98e3-136fbde3f2c6.png)
