### PR TITLE
Prevent Reload from being blocked by URL fragments

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1466,6 +1466,12 @@ define(function (require, exports, module) {
                     Menus.removeMenu(key);
                 });
                 
+                // If there's a fragment in both URLs, setting location.href won't actually reload
+                var fragment = href.indexOf("#");
+                if (fragment !== -1) {
+                    href = href.substr(0, fragment);
+                }
+                
                 window.location.href = href;
             });
         }).fail(function () {


### PR DESCRIPTION
Guard against cases where an extension has set the fragment part of the page URL (some MVC frameworks do this automatically) - this prevents Reload from actually refreshing the page, but it will get far enough to delete the menu bar contents first, leaving Brackets broken until a full quit-restart cycle.

This used to work, but in 9dff969f we stopped using `window.location.reload()` and instead started just writing to `window.location.href`.  It turns out that, although no-op overwrites there _usually_ trigger a refresh, if the value has a fragment part the browser doesn't actually refresh.  So this will strip off the fragment to ensure that doesn't happen.
