### PR TITLE
Define English (UK) language to use for differences between US and UK

### DIFF
--- a/src/nls/en-uk/strings.js
+++ b/src/nls/en-uk/strings.js
@@ -24,43 +24,6 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 
-define(function (require, exports, module) {
+define({
 
-    "use strict";
-
-    // Code that needs to display user strings should call require("strings") to load
-    // src/strings.js. This file will dynamically load strings.js for the specified brackets.locale.
-    //
-    // See the README.md file in this folder for information on how to add a new translation for
-    // another language or locale.
-    //
-    // TODO: dynamically populate the local prefix list below?
-    module.exports = {
-        root: true,
-        "cs": true,
-        "de": true,
-        "el": true,
-        "en-uk": true,
-        "es": true,
-        "fa-ir": true,
-        "fi": true,
-        "fr": true,
-        "hu": true,
-        "id": true,
-        "it": true,
-        "ja": true,
-        "ko": true,
-        "nb": true,
-        "nl": true,
-        "pl": true,
-        "pt-br": true,
-        "pt-pt": true,
-        "ro": true,
-        "ru": true,
-        "sk": true,
-        "sr": true,
-        "sv": true,
-        "tr": true,
-        "zh-cn": true
-    };
 });

--- a/src/nls/root/strings-app.js
+++ b/src/nls/root/strings-app.js
@@ -33,6 +33,7 @@ define({
     "LOCALE_DE"                                 : "Deutsch",
     "LOCALE_EL"                                 : "Ελληνικά",
     "LOCALE_EN"                                 : "English",
+    "LOCALE_EN_UK"                              : "English (UK)",
     "LOCALE_ES"                                 : "Español",
     "LOCALE_FI"                                 : "suomi",
     "LOCALE_FR"                                 : "Français",


### PR DESCRIPTION
I need to use different date formats for US & UK and this'd enable me to do so.

Discussed also here:
https://groups.google.com/forum/#!topic/brackets-dev/aeilzKeMeCw

P.S.: I'm not sure if the current language should be renamed into `English (US)`

ping @SAPlayer
