### PR TITLE
Return LESS/SCSS instead of CSS language when in a LESS/SCSS file

### DIFF
--- a/src/extensions/default/LESSSupport/main.js
+++ b/src/extensions/default/LESSSupport/main.js
@@ -36,5 +36,11 @@ define(function (require, exports, module) {
         fileExtensions: ["less"],
         blockComment: ["/*", "*/"],
         lineComment: ["//"]
+    }).done(function (lessLanguage) {
+        // Hack to make it so that when we see a "css" mode inside a LESS file,
+        // we know that it's really LESS. Ideally we would have a way to get the
+        // actual mime type from CodeMirror, so we know what mode configuration is
+        // in use (see #7345).
+        lessLanguage._setLanguageForMode("css", lessLanguage);
     });
 });

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -874,6 +874,10 @@ define(function (require, exports, module) {
         // Similarly, the php mode uses clike internally for the PHP parts
         var php = getLanguage("php");
         php._setLanguageForMode("clike", php);
+
+        // Similar hack to the above for dealing with SCSS/CSS.
+        var scss = getLanguage("scss");
+        scss._setLanguageForMode("css", scss);
         
         // The fallback language for unknown modes and file extensions
         _fallbackLanguage = getLanguage("unknown");


### PR DESCRIPTION
For #7268.

The new `Editor.getModeForRange()` assumes that the modes being returned by `TokenUtils.getModeAt()` will properly map to the right language in the current document. These modes aren't actually accurate in general when one language uses a mime-type version of a CodeMirror mode that is also used by another language. For example, our CSS language uses the css mode, and our LESS language uses the "text/x-less" configuration of the css mode.

We currently have a hack for dealing with HTML and XML. This PR adds similar hacks for LESS and SCSS. Looking at `languages.json`, there are a few other cases that might be similar, but in the other cases the commenting syntax is the same, so we wouldn't run into this specific issue. Nevertheless, we should eventually try to make this more accurate by requesting support in CM for accurately looking up the mime-type in use for a given location (filed as #7345).

@peterflynn 
