### PR TITLE
Use the correct name of CodeMirror option for tab size.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
     cmOptions[SMART_INDENT]       = "smartIndent";
     cmOptions[SPACE_UNITS]        = "indentUnit";
     cmOptions[STYLE_ACTIVE_LINE]  = "styleActiveLine";
-    cmOptions[TAB_SIZE]           = "indentUnit";
+    cmOptions[TAB_SIZE]           = "tabSize";
     cmOptions[USE_TAB_CHAR]       = "indentWithTabs";
     cmOptions[WORD_WRAP]          = "lineWrapping";
     

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -380,6 +380,12 @@ define(function (require, exports, module) {
         
         if (this._ranges.length === 1) {
             this.$relatedContainer.remove();
+            
+            // Refresh the height of the inline editor since we remove
+            // the entire selector list.
+            if (this.editor) {
+                this.editor.refresh();
+            }
         }
         
         this._updateCommands();


### PR DESCRIPTION
This fixes issue #7218.
