### PR TITLE
Added Quick Open drop-down animation delay to stop it from stuttering.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1301,7 +1301,7 @@ textarea.exclusions-editor {
     // Need this for border-radius because there are no borders
     overflow: hidden;
     
-    .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99), 0, 1);
+    .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99), 190ms, 1);
     -webkit-animation-fill-mode: forwards;
     animation-fill-mode: forwards;
     -webkit-transform-origin: 0 0;


### PR DESCRIPTION
Initially we removed the delay because there's a natural delay when quick open is used on the Brackets project (due to its size) but on smaller projects the drop-down animation would start while the modal bar is moving down, causing the animation to stutter. The drop-down animation should start only when the modal bar is stopped. 
