### PR TITLE
Only kick off project pref loading when the project changes

### DIFF
--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
         if (!filename || !projectDirectory) {
             return false;
         }
-        return FileUtils.getRelativeFilename(projectDirectory, filename) ? true : false;
+        return FileUtils.getRelativeFilename(projectDirectory, filename) !== undefined;
     }
     
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1142,10 +1142,14 @@ define(function (require, exports, module) {
                 var rootEntry = FileSystem.getDirectoryForPath(rootPath);
                 rootEntry.exists(function (err, exists) {
                     if (exists) {
-                        PreferencesManager._setCurrentEditingFile(rootPath);
                         var projectRootChanged = (!_projectRoot || !rootEntry) ||
                             _projectRoot.fullPath !== rootEntry.fullPath;
                         var i;
+                        
+                        if (projectRootChanged) {
+                            PreferencesManager._setCurrentEditingFile(rootPath);
+                        }
+
 
                         // Success!
                         var perfTimerName = PerfUtils.markStart("Load Project: " + rootPath);


### PR DESCRIPTION
This is a fix for #7250. What was happening is that there was a file tree refresh occurring and that was causing the `PreferencesManager._setCurrentEditingFile` in `_loadProject` to fire. The purpose of that call is to start the loading of project-level prefs, but in this case we weren't actually loading a new project and the result was that the preferences context for editing was being set incorrectly.
