### PR TITLE
Fix bug #7300 (Prefs never saved again after opening ancestor folder of user prefs.json)

### DIFF
--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -27,6 +27,8 @@
 /**
  * PreferenceStorage defines an interface for persisting preference data as
  * name/value pairs for a module or plugin.
+ * 
+ * @deprecated Use PreferencesManager APIs instead.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -115,9 +115,9 @@ define(function (require, exports, module) {
         /**
          * MemoryStorage is not stored in a file, so fileChanged is ignored.
          * 
-         * @param {string} filename File that has changed
+         * @param {string} filePath File that has changed
          */
-        fileChanged: function (filename) {
+        fileChanged: function (filePath) {
         }
     };
     
@@ -241,10 +241,10 @@ define(function (require, exports, module) {
         /**
          * If the filename matches this Storage's path, a changed message is triggered.
          * 
-         * @param {string} filename File that has changed
+         * @param {string} filePath File that has changed
          */
-        fileChanged: function (filename) {
-            if (filename === this.path) {
+        fileChanged: function (filePath) {
+            if (filePath === this.path) {
                 $(this).trigger("changed");
             }
         }
@@ -485,10 +485,10 @@ define(function (require, exports, module) {
          * Tells the Scope that the given file has been changed so that the
          * Storage can be reloaded if needed.
          * 
-         * @param {string} filename Name of the file that has changed
+         * @param {string} filePath File that has changed
          */
-        fileChanged: function (filename) {
-            this.storage.fileChanged(filename);
+        fileChanged: function (filePath) {
+            this.storage.fileChanged(filePath);
         },
         
         /**
@@ -1693,11 +1693,11 @@ define(function (require, exports, module) {
          * Tells the PreferencesSystem that the given file has been changed so that any
          * related Scopes can be reloaded.
          * 
-         * @param {string} filename Name of the file that has changed
+         * @param {string} filePath File that has changed
          */
-        fileChanged: function (filename) {
+        fileChanged: function (filePath) {
             _.forEach(this._scopes, function (scope) {
-                scope.fileChanged(filename);
+                scope.fileChanged(filePath);
             });
         },
         


### PR DESCRIPTION
Fix bug #7300 -- ensure that FileSystem always knows we've read the JSON file before we try to write to it. We don't want to enable the 'blind' flag since it will mean we virtually always overwrite external changes to the prefs file, and we don't want to start using file watchers to observe external changes on the fly since we haven't yet deeply tested having multiple watch roots active at once (see #7375).

Also:
- Rename confusing "filename" vars in PreferencesBase
- Fix JSLint errors in ProjectManager from #7026
