### PR TITLE
Clear search filter when switching tabs in Extension Manager

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -210,6 +210,7 @@ define(function (require, exports, module) {
                 models[_activeTabIndex].scrollPos = $(".modal-body", $dlg).scrollTop();
                 $(this).tab("show");
                 $(".modal-body", $dlg).scrollTop(models[_activeTabIndex].scrollPos || 0);
+                $searchClear.click();
             });
         
         // Update & hide/show the notification overlay on a tab's icon, based on its model's notifyCount


### PR DESCRIPTION
#5856.

I did simple changes in src and wanted to fix unit test, but couldn't find any tests for function _showDialog. May be they are should be written? I could try to do it.
