### PR TITLE
Fix for #7374 project prefs path breaking project open.

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -14,8 +14,7 @@
         },
         "src/thirdparty/globmatch.js": {
             "spaceUnits": 2,
-            "linting.enabled": false,
-            "brackets-git.defaultRemotes./Users/dangoor/projects/brackets/": "origin"
+            "linting.enabled": false
         }
     },
     "spaceUnits": 4,

--- a/.brackets.json
+++ b/.brackets.json
@@ -11,6 +11,11 @@
         "src/thirdparty/CodeMirror2/**/*.js": {
             "spaceUnits": 2,
             "linting.enabled": false
+        },
+        "src/thirdparty/globmatch.js": {
+            "spaceUnits": 2,
+            "linting.enabled": false,
+            "brackets-git.defaultRemotes./Users/dangoor/projects/brackets/": "origin"
         }
     },
     "spaceUnits": 4,

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1076,6 +1076,20 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @private
+     * Reloads the project preferences.
+     */
+    function _reloadProjectPreferencesScope() {
+        var root = getProjectRoot();
+        if (root) {
+            // Alias the "project" Scope to the path Scope for the project-level settings file
+            PreferencesManager._setProjectSettingsFile(root.fullPath + SETTINGS_FILENAME);
+        } else {
+            PreferencesManager._setProjectSettingsFile();
+        }
+    }
+    
+    /**
      * Loads the given folder as a project. Normally, you would call openProject() instead to let the
      * user choose a folder.
      *
@@ -1154,15 +1168,16 @@ define(function (require, exports, module) {
                             _projectRoot.fullPath !== rootEntry.fullPath;
                         var i;
                         
-                        if (projectRootChanged) {
-                            PreferencesManager._setCurrentEditingFile(rootPath);
-                        }
-
-
                         // Success!
                         var perfTimerName = PerfUtils.markStart("Load Project: " + rootPath);
 
                         _projectRoot = rootEntry;
+                        
+                        if (projectRootChanged) {
+                            _reloadProjectPreferencesScope();
+                            PreferencesManager._setCurrentEditingFile(rootPath);
+                        }
+
                         _projectBaseUrl = PreferencesManager.getViewState("project.baseUrl", context) || "";
                         _allFilesCachePromise = null;  // invalidate getAllFiles() cache as soon as _projectRoot changes
 
@@ -2266,18 +2281,6 @@ define(function (require, exports, module) {
         "welcomeProjects": "user",
         "projectBaseUrl_": "user"
     }, true, _checkPreferencePrefix);
-    
-    function _reloadProjectPreferencesScope() {
-        var root = getProjectRoot();
-        if (root) {
-            // Alias the "project" Scope to the path Scope for the project-level settings file
-            PreferencesManager._setProjectSettingsFile(root.fullPath + SETTINGS_FILENAME);
-        } else {
-            PreferencesManager._setProjectSettingsFile();
-        }
-    }
-    
-    $(exports).on("projectOpen", _reloadProjectPreferencesScope);
     
     // Initialize the sort prefixes and make sure to change them when the sort pref changes
     _generateSortPrefixes();

--- a/src/thirdparty/globmatch.js
+++ b/src/thirdparty/globmatch.js
@@ -14,7 +14,13 @@ module.exports = fnmatch;
 minimatch.Minimatch = Minimatch;
     
 function fnmatch(filepath, glob) {
-  var matchOptions = {matchBase: true, dot: true, noext: true};
+  var matchOptions = {dot: true, noext: true};
+  
+  // brackets #7374: don't try to match base if a directory name is passed in
+  if (filepath[filepath.length - 1] !== "/") {
+    matchOptions.matchBase = true;
+  }
+  
   glob = glob.replace(/\*\*/g, '{*,**/**/**}');
   return minimatch(filepath, glob, matchOptions);
 };


### PR DESCRIPTION
This fixes the bug in two ways:
- globmatch no longer uses the "matchBase" flag for directories
- the current editing file is set to the new project directory _after_ the project
  scoped preferences is changed

Either one individually would fix it, but both prevent potential other problems.

Fix for #7374 
