### PR TITLE
Fixed bug in utils/Async.PromiseQueue where a rejected promise keeps the...

### DIFF
--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -487,7 +487,7 @@ define(function (require, exports, module) {
         if (this._queue.length) {
             var op = this._queue.shift();
             this._curPromise = op();
-            this._curPromise.done(function () {
+            this._curPromise.always(function () {
                 self._curPromise = null;
                 self._doNext();
             });


### PR DESCRIPTION
... PromiseQueue from going to the next promise. ( issue #7393 )

Above bug caused by adding to _curPromise.done() instead of _curPromise.always(). Fix is simply to use .always().
Added to Async-test to test rejected promise cases.

Signed-off-by: jayther jayther@gmail.com
