### PR TITLE
Fix convertPreferences to accept non-module clientIDs

### DIFF
--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -336,13 +336,17 @@ define(function (require, exports, module) {
     function convertPreferences(clientID, rules, isViewState, prefCheckCallback) {
         PreferencesImpl.smUserScopeLoading.done(function () {
             PreferencesImpl.userScopeLoading.done(function () {
+                if (!clientID || (typeof clientID === "object" && (!clientID.id || !clientID.uri))) {
+                    console.error("Invalid clientID");
+                    return;
+                }
                 var prefs = getPreferenceStorage(clientID, null, true);
 
                 if (!prefs) {
                     return;
                 }
 
-                var prefsID = getClientID(clientID);
+                var prefsID = typeof clientID === "object" ? getClientID(clientID) : clientID;
                 if (prefStorage.convertedKeysMap === undefined) {
                     prefStorage.convertedKeysMap = {};
                 }
@@ -354,7 +358,7 @@ define(function (require, exports, module) {
                         savePreferences();
                     });
             }).fail(function (error) {
-                console.error("Error while converting ", getClientID(clientID));
+                console.error("Error while converting ", typeof clientID === "object" ? getClientID(clientID) : clientID);
                 console.error(error);
             });
         });


### PR DESCRIPTION
Quick story:
I wanted to update the Theseus preferences system (adobe-research/theseus#55), but after a while I saw that convertPreferences will only work if the passed `clientID` is `module`. But in the case of Theseus, strings are used as clientID (like `com.adobe.theseus`).
This fixes this issue.
