### PR TITLE
do not calculate size with hidden elements when resizing

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -270,7 +270,7 @@ define(function (require, exports, module) {
             $body.append($resizeShield);
                         
             if ($resizableElement.length) {
-                $element.children().not(".horz-resizer, .vert-resizer, .resizable-content").each(function (index, child) {
+                $element.children(":visible").not(".horz-resizer, .vert-resizer, .resizable-content").each(function (index, child) {
                     if (direction === DIRECTION_HORIZONTAL) {
                         baseSize += $(child).outerWidth();
                     } else {


### PR DESCRIPTION
just a small fix when there's a hidden element (like invisible spinner toggled on demand) which causes $resizableElement to be smaller than it can be (and leaves weird space there)

Before:
![image](https://cloud.githubusercontent.com/assets/1067319/2621134/7d572a1e-bc4b-11e3-8b26-deaa7e228cc0.png)

After:
![image](https://cloud.githubusercontent.com/assets/1067319/2621131/64684bbe-bc4b-11e3-92a4-3733ac8a64e7.png)

cc @peterflynn @RaymondLim 
