### PR TITLE
Fix bug #7402 (Focus not set to inline editor after creating new rule)

### DIFF
--- a/src/widgets/DropdownButton.js
+++ b/src/widgets/DropdownButton.js
@@ -188,10 +188,14 @@ define(function (require, exports, module) {
     DropdownButton.prototype._onDropdownClose = function () {
         window.document.body.removeEventListener("click", this._onClickOutside, true);
         $(PanelManager).off("editorAreaResize", this.closeDropdown);
+
+        // Restore focus to old pos, unless "select" handler changed it
+        if (window.document.activeElement === this.$dropdown[0]) {
+            this._lastFocus.focus();
+        }
+        
         this._dropdownEventHandler = null;
         this.$dropdown = null;  // already remvoed from DOM automatically by PopUpManager
-
-        this._lastFocus.focus();  // restore focus to old pos
     };
     
     /** Closes the dropdown if currently open */


### PR DESCRIPTION
Fix bug #7402 -- If the client of the DropdownButton changes focus in response to the `"select"` event that closes it, leave focus in that new location. Only restore focus to where it was before the dropdown was opened if no one has touched the focus while it's closing.

You can test the case where it _is_ supposed to restore focus by commenting out the body of `CSSInlineEditor._onDropdownSelect()` -- choosing an item from the dropdown should restore focus to the original editor in that case.

@njx, up to you if you think this should go into Sprint 38 or not.
