### PR TITLE
Fix shapes update

### DIFF
--- a/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
             return deferred.reject().promise();
         }
 
-        _cache.model = undefined; // do not move in _reset(), otherwhise the _reconnect() scenario misses the cache and fails
+        _cache.model = undefined; // do not move in _reset(), otherwise the _reconnect() scenario misses the cache and fails
         _reset();
         var expr = _namespace + ".remove()";
         return _call(expr);
@@ -164,10 +164,8 @@ define(function (require, exports, module) {
     *
     * Promises also fail because of errors thrown in the remote page.
     * If this is the case, remove the editor.
-    *
-    * @param {$.Deferred=} result
     */
-    function _whenRemoteCallFailed(result) {
+    function _whenRemoteCallFailed() {
         // check if the remote editor namespace is still defined on the page
         _call(_namespace)
             .then(function (response) {

--- a/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
@@ -170,7 +170,7 @@ define(function (require, exports, module) {
     function _whenRemoteCallFailed(result) {
         // check if the remote editor namespace is still defined on the page
         _call(_namespace)
-            .then(function(response) {
+            .then(function (response) {
                 if (response.type === "undefined") {
                     _reconnect();
                 } else {

--- a/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
@@ -86,7 +86,6 @@ define(function (require, exports, module) {
     }
 
     /**
-     * @private
      * Inject remote live editor driver and any specified editor providers.
      * The remote live editor driver mirrors most of the local live editor driver API
      * to provide an interface to the in-browser live editor.
@@ -158,7 +157,7 @@ define(function (require, exports, module) {
     * Promises can fail if the user manually refreshes the page or navigates
     * because the injected editor files will be lost.
     *
-    * @param {$.Promise=} result promise result
+    * @param {$.Deferred=} result
     */
     function _whenRemoteCallFailed(result) {
         if (result) {

--- a/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
             return deferred.reject().promise();
         }
 
-        _cache.model = undefined; // do not move in _reset(), otherwhise the _reconnect() scenario miss the cache and fail
+        _cache.model = undefined; // do not move in _reset(), otherwhise the _reconnect() scenario misses the cache and fails
         _reset();
         var expr = _namespace + ".remove()";
         return _call(expr);

--- a/src/extensions/default/CSSShapesEditor/thirdparty/CSSShapesEditorProvider.js
+++ b/src/extensions/default/CSSShapesEditor/thirdparty/CSSShapesEditorProvider.js
@@ -82,7 +82,7 @@
           Declared globally within module so it can be removed by Provider.remove()
           Defined here so it can access scope.inst
 
-          Ctrl+T toggles the free transform editor (scale/rotate)
+          T key toggles the free transform editor (scale/rotate)
           Esc key turns off free transform editor; quietly ignored if editor was never turned on.
 
           @param {Event} e keydown event
@@ -92,8 +92,8 @@
             if (scope.inst.type !== "polygon") {
                 return;
             }
-            // Ctrl+T toggles rotate/scale editor
-            if (e.ctrlKey && e.keyIdentifier === "U+0054") {
+            // T key toggles rotate/scale editor
+            if (e.keyIdentifier === "U+0054") {
                 scope.inst.toggleFreeTransform();
             }
 

--- a/src/extensions/default/CSSShapesEditor/unittests.js
+++ b/src/extensions/default/CSSShapesEditor/unittests.js
@@ -466,17 +466,6 @@ define(function (require, exports, module) {
 
                 expect(LiveEditorLocalDriver.remove).toHaveBeenCalled();
             });
-
-            it("should call remove() when LivePreview is turned off", function () {
-                var deferred = $.Deferred();
-                spyOn(LiveEditorLocalDriver, "remove").andReturn(deferred.promise());
-
-                main._setup();
-                main._teardown();
-
-                expect(LiveEditorLocalDriver.remove).toHaveBeenCalled();
-            });
-
         });
 
         describe("Live Preview Workflow", function () {


### PR DESCRIPTION
Attempts to recover from errors by reconnecting the editor. If that's not possible, turns off everything so the user can trigger it again manually.

These are invalid shape declarations and the editor will turn off:
- `circle(px at 50% 50%)`
- `circle(50% 50%)`
- `circle(50%, 50%)`

This is a valid shape declaration: `circle(50% at)` but it crashes the browser due to an [implementation bug](https://bugs.webkit.org/show_bug.cgi?id=130366) in the browser.  The issue has been fixed, but it will take time for the fix to trickle down into Chrome Stable. That notation will crash the browser before the shapes editor has a chance to load and attempt to catch it.
