### PR TITLE
replace trim() with regex

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
                 var attributeValue = tagInfo.attr.value;
                 if (/\S/.test(attributeValue)) {
                     var startIndex = attributeValue.substr(0, tagInfo.position.offset).lastIndexOf(" ");
-                    var endIndex = attributeValue.search(/\s+$/g);
+                    var endIndex = attributeValue.search(/\s+$/);
                     if (endIndex < tagInfo.position.offset) {
                         endIndex = -1;
                     }

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -76,11 +76,8 @@ define(function (require, exports, module) {
                 // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
                 if (/\S/.test(attributeValue)) {
-                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).search(/\s\S*$/);
-                    var endIndex =  attributeValue.substr(tagInfo.position.offset).search(/\s/);
-                    if (endIndex !== -1) {
-                        endIndex += tagInfo.position.offset;
-                    }
+                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).lastIndexOf(" ");
+                    var endIndex = attributeValue.indexOf(" ", tagInfo.position.offset);
                     selectorName = "." +
                         attributeValue.substring(
                             startIndex === -1 ? 0 : startIndex + 1,

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -75,9 +75,12 @@ define(function (require, exports, module) {
                 //   class="error-dialog modal hide"
                 // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
-                if (attributeValue.trim()) {
+                if (/\S/.test(attributeValue)) {
                     var startIndex = attributeValue.substr(0, tagInfo.position.offset).lastIndexOf(" ");
-                    var endIndex = attributeValue.indexOf(" ", tagInfo.position.offset);
+                    var endIndex = attributeValue.search(/\s+$/g);
+                    if (endIndex < tagInfo.position.offset) {
+                        endIndex = -1;
+                    }
                     selectorName = "." +
                         attributeValue.substring(
                             startIndex === -1 ? 0 : startIndex + 1,

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
                 // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
                 if (/\S/.test(attributeValue)) {
-                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).search(/\s+.*$/);
+                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).search(/\s\S*$/);
                     var endIndex =  attributeValue.substr(tagInfo.position.offset).search(/\s/);
                     if (endIndex !== -1) {
                         endIndex += tagInfo.position.offset;

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -22,7 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint regexp: true, vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, $, window, Mustache */
 
 define(function (require, exports, module) {
@@ -76,10 +76,10 @@ define(function (require, exports, module) {
                 // and the insertion point is inside "modal", we want ".modal"
                 var attributeValue = tagInfo.attr.value;
                 if (/\S/.test(attributeValue)) {
-                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).lastIndexOf(" ");
-                    var endIndex = attributeValue.search(/\s+$/);
-                    if (endIndex < tagInfo.position.offset) {
-                        endIndex = -1;
+                    var startIndex = attributeValue.substr(0, tagInfo.position.offset).search(/\s+.*$/);
+                    var endIndex =  attributeValue.substr(tagInfo.position.offset).search(/\s/);
+                    if (endIndex !== -1) {
+                        endIndex += tagInfo.position.offset;
                     }
                     selectorName = "." +
                         attributeValue.substring(

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -303,7 +303,7 @@ define(function (require, exports, module) {
         var result, text, line;
 
         // Move the context to the first non-empty token.
-        if (!ctx.token.type && ctx.token.string.trim().length === 0) {
+        if (!ctx.token.type && !/\S/.test(ctx.token.string)) {
             result = TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx);
         }
 

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
                 break;
             }
             next = this.getToken(cursor);
-        } while (skipWhitespace && !/\S/.match(next.string));
+        } while (skipWhitespace && !/\S/.test(next.string));
         
         return next;
     };

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -200,7 +200,7 @@ define(function (require, exports, module) {
                 break;
             }
             prev = this.getToken(cursor);
-        } while (prev.string.trim() === "");
+        } while (!/\S/.test(prev.string));
         
         return prev;
     };

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
                 break;
             }
             next = this.getToken(cursor);
-        } while (skipWhitespace && next.string.trim() === "");
+        } while (skipWhitespace && !/\S/.match(next.string));
         
         return next;
     };

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
         
         // If the pos is at the beginning of a name, token will be the 
         // preceding whitespace or dot. In that case, try the next pos.
-        if (token.string.trim().length === 0 || token.string === ".") {
+        if (!/\S/.test(token.string) || token.string === ".") {
             token = hostEditor._codeMirror.getTokenAt({line: pos.line, ch: pos.ch + 1}, true);
         }
         

--- a/src/extensions/samples/InlineImageViewer/main.js
+++ b/src/extensions/samples/InlineImageViewer/main.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         
         // If the pos is at the beginning of a name, token will be the 
         // preceding whitespace or dot. In that case, try the next pos.
-        if (token.string.trim().length === 0 || token.string === ".") {
+        if (!/\S/.match(token.string) || token.string === ".") {
             token = hostEditor._codeMirror.getTokenAt({line: pos.line, ch: pos.ch + 1}, true);
         }
         

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
         if (ctx.token.type === "property" || ctx.token.type === "property error" ||
                 ctx.token.type === "tag") {
             propName = tokenString;
-            if (TokenUtils.movePrevToken(ctx) && ctx.token.string.trim() !== "" &&
+            if (TokenUtils.movePrevToken(ctx) && /\S/.test(ctx.token.string) &&
                     excludedCharacters.indexOf(ctx.token.string) === -1) {
                 propName = ctx.token.string + tokenString;
                 offset += ctx.token.string.length;
@@ -196,7 +196,7 @@ define(function (require, exports, module) {
                     ctx.token.type === "tag")) {
                 propName += ctx.token.string;
             }
-        } else if (tokenString.trim() !== "" && excludedCharacters.indexOf(tokenString) === -1) {
+        } else if (/\S/.test(tokenString) && excludedCharacters.indexOf(tokenString) === -1) {
             // We're not inside the property name context.
             return createInfo();
         } else {
@@ -360,14 +360,14 @@ define(function (require, exports, module) {
         
         // Skip the ":" and any leading whitespace
         while (TokenUtils.moveNextToken(startCtx)) {
-            if (startCtx.token.string.trim()) {
+            if (/\S/.test(startCtx.token.string)) {
                 break;
             }
         }
         
         // Skip the trailing whitespace and property separators.
         while (endCtx.token.string === ";" || endCtx.token.string === "}" ||
-                !endCtx.token.string.trim()) {
+                !/\S/.test(endCtx.token.string)) {
             TokenUtils.movePrevToken(endCtx);
         }
         
@@ -1033,7 +1033,7 @@ define(function (require, exports, module) {
                 result.push(entry);
             } else if (!classOrIdSelector) {
                 // Special case for tag selectors - match "*" as the rightmost character
-                if (entry.selector.trim().search(/\*$/) !== -1) {
+                if (/.*\*\s*$/.test(entry.selector)) {
                     result.push(entry);
                 }
             }
@@ -1230,7 +1230,7 @@ define(function (require, exports, module) {
                     selector = _parseSelector(ctx);
                     break;
                 } else {
-                    if (ctx.token.string.trim() !== "") {
+                    if (/\S/.test(ctx.token.string)) {
                         foundChars = true;
                     }
                 }
@@ -1249,7 +1249,7 @@ define(function (require, exports, module) {
         // special case - we aren't in a selector and haven't found any chars,
         // look at the next immediate token to see if it is non-whitespace
         if (!selector && !foundChars) {
-            if (TokenUtils.moveNextToken(ctx) && ctx.token.type !== "comment" && ctx.token.string.trim() !== "") {
+            if (TokenUtils.moveNextToken(ctx) && ctx.token.type !== "comment" && /\S/.test(ctx.token.string)) {
                 foundChars = true;
                 ctx = TokenUtils.getInitialContext(cm, $.extend({}, pos));
             }

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1033,7 +1033,7 @@ define(function (require, exports, module) {
                 result.push(entry);
             } else if (!classOrIdSelector) {
                 // Special case for tag selectors - match "*" as the rightmost character
-                if (/.*\*\s*$/.test(entry.selector)) {
+                if (/\*\s*$/.test(entry.selector)) {
                     result.push(entry);
                 }
             }

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
                         }
                         // If we type the first letter of the next attribute, it comes as an error
                         // token. We need to double check for possible invalidated attributes.
-                        if (/\S/.test(forwardCtx.token.string) !== "" &&
+                        if (/\S/.test(forwardCtx.token.string) &&
                                 forwardCtx.token.string.indexOf("\"") === -1 &&
                                 forwardCtx.token.string.indexOf("'") === -1 &&
                                 forwardCtx.token.string.indexOf("=") === -1) {

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
                         }
                         // If we type the first letter of the next attribute, it comes as an error
                         // token. We need to double check for possible invalidated attributes.
-                        if (forwardCtx.token.string.trim() !== "" &&
+                        if (/\S/.test(forwardCtx.token.string) !== "" &&
                                 forwardCtx.token.string.indexOf("\"") === -1 &&
                                 forwardCtx.token.string.indexOf("'") === -1 &&
                                 forwardCtx.token.string.indexOf("=") === -1) {
@@ -316,7 +316,7 @@ define(function (require, exports, module) {
         }
         
         //check and see where we are in the tag
-        if (ctx.token.string.length > 0 && ctx.token.string.trim().length === 0) {
+        if (ctx.token.string.length > 0 && !/\S/.test(ctx.token.string)) {
 
             // token at (i.e. before) pos is whitespace, so test token at next pos
             //
@@ -326,7 +326,7 @@ define(function (require, exports, module) {
             var testPos = {ch: ctx.pos.ch + 1, line: ctx.pos.line},
                 testToken = editor._codeMirror.getTokenAt(testPos, true);
 
-            if (testToken.string.length > 0 && testToken.string.trim().length > 0 &&
+            if (testToken.string.length > 0 && /\S/.test(testToken.string) &&
                     testToken.string.charAt(0) !== ">") {
                 // pos has whitespace before it and non-whitespace after it, so use token after
                 ctx.token = testToken;

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
         if (!moveFxn(ctx)) {
             return false;
         }
-        while (!ctx.token.type && ctx.token.string.trim().length === 0) {
+        while (!ctx.token.type && !/\S/.test(ctx.token.string)) {
             if (!moveFxn(ctx)) {
                 return false;
             }

--- a/test/spec/InlineEditorProviders-test-files/test1.css
+++ b/test/spec/InlineEditorProviders-test-files/test1.css
@@ -7,6 +7,10 @@
 {{5}}    color: #f00;
 {{6}} }{{3}}
 {{7}}
+{{8}}.bar {
+        background-image: url(fu.bar);
+}
+
 {{2}}#myDiv {
     display: block;
 }

--- a/test/spec/InlineEditorProviders-test-files/test1.html
+++ b/test/spec/InlineEditorProviders-test-files/test1.html
@@ -16,5 +16,6 @@
     <div{{8}} {{7}}class="foo"></{{9}}div>
     <div class="{{10}}embeddedClass" title="abc{{12}}xyz"></div>
     <div class="embeddedClass" title="abc xyz">This is a long line of text so that cursor position at end of line will have to be scrolled into view. This is a long line of text so that cursor position at end of line will have to be scrolled into view.</div>{{13}}
+    <div class="f{{14}}oo{{17}} {{15}} b{{16}}ar">the quick brown fox jumped over the moon.</div>
 </body>
 </html>

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -396,6 +396,52 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should work with multiple classes when the cursor is on the first class in the list", function () {
+                initInlineTest("test1.html", 14);
+
+                runs(function () {
+                    var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
+                    var inlinePos = inlineWidget.editor.getCursorPos();
+
+                    // verify cursor position in inline editor
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
+
+                    inlineWidget = null;
+                });
+            });
+
+            it("should work when the cursor is between classes", function () {
+                initInlineTest("test1.html", 15, false);
+
+                runs(function () {
+                    // verify no inline editor open
+                    expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
+
+                    // verify popover message is displayed with correct string
+                    expectPopoverMessageWithText(Strings.ERROR_CSSQUICKEDIT_BETWEENCLASSES);
+
+                    // verify popover message is automatically dismissed after short wait
+                    // current delay is 5 sec + 0.5 sec fade-out transition
+                    waits(6000);
+                });
+            });
+
+
+            it("should work with multiple classes when the cursor is on the first class in the list", function () {
+                initInlineTest("test1.html", 16);
+
+                runs(function () {
+                    var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
+                    var inlinePos = inlineWidget.editor.getCursorPos();
+
+                    // verify cursor position in inline editor
+                    expect(inlinePos).toEqual(infos["test1.css"].offsets[8]);
+
+                    inlineWidget = null;
+                });
+            });
+            
+            
             it("should close, then remove the inline widget and restore focus", function () {
                 initInlineTest("test1.html", 0);
                 
@@ -536,6 +582,7 @@ define(function (require, exports, module) {
                 });
             });
             
+                        
             it("should close popover message on selection change", function () {
                 var editor,
                     openFile = "test1.html";
@@ -648,7 +695,7 @@ define(function (require, exports, module) {
                     widgetHeight = inlineEditor.totalHeight();
                     
                     // verify original line count
-                    expect(inlineEditor.lineCount()).toBe(12);
+                    expect(inlineEditor.lineCount()).toBe(16);
                     
                     // change inline editor content
                     var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
@@ -661,7 +708,7 @@ define(function (require, exports, module) {
                     );
                     
                     // verify widget resizes when contents is changed
-                    expect(inlineEditor.lineCount()).toBe(17);
+                    expect(inlineEditor.lineCount()).toBe(21);
                     expect(inlineEditor.totalHeight()).toBeGreaterThan(widgetHeight);
                     
                     inlineEditor = null;
@@ -678,7 +725,7 @@ define(function (require, exports, module) {
                     widgetHeight = inlineEditor.totalHeight();
                     
                     // verify original line count
-                    expect(inlineEditor.lineCount()).toBe(12);
+                    expect(inlineEditor.lineCount()).toBe(16);
                     
                     // replace the entire .foo rule with an empty string
                     // set text on the editor, can't mutate document directly at this point
@@ -689,7 +736,7 @@ define(function (require, exports, module) {
                     );
                     
                     // verify widget resizes when contents is changed
-                    expect(inlineEditor.lineCount()).toBe(10);
+                    expect(inlineEditor.lineCount()).toBe(14);
                     expect(inlineEditor.totalHeight()).toBeLessThan(widgetHeight);
 
                     inlineEditor = null;


### PR DESCRIPTION
Optimizes some string ops to use regex where ever possible based on http://jsperf.com/exec-vs-match-vs-test-vs-search/5
- optimizes string.trim() calls with regex.test()
- optimizes string.lastIndexOf() calls with regex.search()

@redmunds can you review?
/cc:@RaymondLim 
