### PR TITLE
Fix fontSizeChange event for Restore Font Size command

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -102,16 +102,23 @@ define(function (require, exports, module) {
      * @param {string=} fontSizeStyle  A string with the font size and the size unit
      */
     function _setSizeAndRestoreScroll(fontSizeStyle) {
-        var editor    = EditorManager.getCurrentFullEditor(),
-            oldWidth  = editor._codeMirror.defaultCharWidth(),
-            scrollPos = editor.getScrollPos(),
-            line      = editor._codeMirror.lineAtHeight(scrollPos.y, "local");
+        var editor          = EditorManager.getCurrentFullEditor(),
+            oldWidth        = editor._codeMirror.defaultCharWidth(),
+            newFontSize     = "",
+            oldFontSize     = $(".CodeMirror").css("font-size"),
+            fontSizeChange  = 0,
+            scrollPos       = editor.getScrollPos(),
+            line            = editor._codeMirror.lineAtHeight(scrollPos.y, "local");
         
         _removeDynamicFontSize();
         if (fontSizeStyle) {
             _addDynamicFontSize(fontSizeStyle);
         }
         editor.refreshAll();
+        
+        newFontSize = $(".CodeMirror").css("font-size");
+        fontSizeChange = parseInt(newFontSize, 10) - parseInt(oldFontSize, 10);
+        $(exports).triggerHandler("fontSizeChange", [fontSizeChange, newFontSize]);
         
         // Calculate the new scroll based on the old font sizes and scroll position
         var newWidth   = editor._codeMirror.defaultCharWidth(),

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -120,7 +120,10 @@ define(function (require, exports, module) {
         delta = /em$/.test(oldFontSize) ? 10 : 1;
         newFontSize = $(".CodeMirror").css("font-size");
         adjustment = parseInt((parseFloat(newFontSize) - parseFloat(oldFontSize)) * delta, 10);
-        $(exports).triggerHandler("fontSizeChange", [adjustment, newFontSize]);
+        
+        if (adjustment) {
+            $(exports).triggerHandler("fontSizeChange", [adjustment, newFontSize]);
+        }
         
         // Calculate the new scroll based on the old font sizes and scroll position
         var newWidth   = editor._codeMirror.defaultCharWidth(),

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -102,13 +102,14 @@ define(function (require, exports, module) {
      * @param {string=} fontSizeStyle  A string with the font size and the size unit
      */
     function _setSizeAndRestoreScroll(fontSizeStyle) {
-        var editor          = EditorManager.getCurrentFullEditor(),
-            oldWidth        = editor._codeMirror.defaultCharWidth(),
-            newFontSize     = "",
-            oldFontSize     = $(".CodeMirror").css("font-size"),
-            fontSizeChange  = 0,
-            scrollPos       = editor.getScrollPos(),
-            line            = editor._codeMirror.lineAtHeight(scrollPos.y, "local");
+        var editor      = EditorManager.getCurrentFullEditor(),
+            oldWidth    = editor._codeMirror.defaultCharWidth(),
+            oldFontSize = $(".CodeMirror").css("font-size"),
+            newFontSize = "",
+            delta       = 0,
+            adjustment  = 0,
+            scrollPos   = editor.getScrollPos(),
+            line        = editor._codeMirror.lineAtHeight(scrollPos.y, "local");
         
         _removeDynamicFontSize();
         if (fontSizeStyle) {
@@ -116,9 +117,10 @@ define(function (require, exports, module) {
         }
         editor.refreshAll();
         
+        delta = /em$/.test(oldFontSize) ? 10 : 1;
         newFontSize = $(".CodeMirror").css("font-size");
-        fontSizeChange = parseInt(newFontSize, 10) - parseInt(oldFontSize, 10);
-        $(exports).triggerHandler("fontSizeChange", [fontSizeChange, newFontSize]);
+        adjustment = parseInt((parseFloat(newFontSize) - parseFloat(oldFontSize)) * delta, 10);
+        $(exports).triggerHandler("fontSizeChange", [adjustment, newFontSize]);
         
         // Calculate the new scroll based on the old font sizes and scroll position
         var newWidth   = editor._codeMirror.defaultCharWidth(),
@@ -160,7 +162,6 @@ define(function (require, exports, module) {
         _setSizeAndRestoreScroll(fsStr);
         PreferencesManager.setViewState("fontSizeStyle", fsStr);
         
-        $(exports).triggerHandler("fontSizeChange", [adjustment, fsStr]);
         return true;
     }
     


### PR DESCRIPTION
Some of the recent changes to font size adjustment broke the fontSizeChange event when the Restore Font Size command is used.  This fix makes the event fire correctly again.
