### PR TITLE
teardown editor when selector does not match

### DIFF
--- a/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorLocalDriver.js
@@ -127,6 +127,7 @@ define(function (require, exports, module) {
     *
     * @throws {TypeError} if the promise result is not a string.
     * @param {!string} response JSON stringified object with CSS property, value
+    * @return {$.Promise}
     */
     function _whenGetRemoteModel(response) {
         if (!response || !response.value || typeof response.value !== "string") {
@@ -134,11 +135,13 @@ define(function (require, exports, module) {
         }
 
         var data = JSON.parse(response.value),
+            deferred = $.Deferred(),
             hasChanged = false,
             key;
 
         if (!data) {
             remove();
+            return deferred.reject().promise();
         }
 
         // sync the local model snapshot with the remote model
@@ -153,6 +156,8 @@ define(function (require, exports, module) {
         if (hasChanged || data.forceUpdate) {
             $(exports).triggerHandler("update.model", [_model, data.forceUpdate]);
         }
+
+        return deferred.promise();
     }
 
     /**

--- a/src/extensions/default/CSSShapesEditor/LiveEditorRemoteDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorRemoteDriver.js
@@ -123,6 +123,7 @@
         _target = document.querySelector(model.selector);
 
         if (!_target) {
+            remove();
             return;
         }
 
@@ -187,7 +188,11 @@
             _activeEditor = undefined;
         }
 
-        _target.style[_model.property] = "";
+        // remove() may be called before an early return when _target is not set.
+        if (_target){
+            _target.style[_model.property] = "";
+        }
+
         _model = null;
     }
 

--- a/src/extensions/default/CSSShapesEditor/LiveEditorRemoteDriver.js
+++ b/src/extensions/default/CSSShapesEditor/LiveEditorRemoteDriver.js
@@ -189,7 +189,7 @@
         }
 
         // remove() may be called before an early return when _target is not set.
-        if (_target){
+        if (_target) {
             _target.style[_model.property] = "";
         }
 

--- a/src/extensions/default/CSSShapesEditor/main.js
+++ b/src/extensions/default/CSSShapesEditor/main.js
@@ -92,41 +92,6 @@ define(function (require, exports, module) {
 
     /**
      * @private
-     * Returns the range that wraps the CSS value at the given pos.
-     * Assumes pos is within or adjacent to a CSS value (between : and ; or })
-     * @param {!Editor} editor
-     * @param {!{line:number, ch:number}} pos
-     * @param {boolean=} trimWhitespace Ignore whitepace surrounding css value; optional
-     * @return {{!start: {line:number, ch:number}, end: {line:number, ch:number}}}
-     */
-    function _getRangeForCSSValueAt(editor, pos, trimWhitespace) {
-        // TODO: support multi-line values
-        var line    = editor.document.getLine(pos.line),
-            start   = pos.ch,
-            end     = pos.ch,
-            value;
-
-        // css values start after a colon (:)
-        start = line.lastIndexOf(":", pos.ch) + 1;
-
-        // css values end before a semicolon (;) or closing bracket (})
-        // TODO support closing bracket and multi-line. Bracket may be lower.
-        end = line.indexOf(";", pos.ch);
-
-        if (trimWhitespace) {
-            value = line.substring(start, end);
-            start = start + value.match(/^\s*/)[0].length;
-            end = end - value.match(/\s*$/)[0].length;
-        }
-
-        return {
-            "start": { line: pos.line, ch: start },
-            "end": { line: pos.line, ch: end }
-        };
-    }
-
-    /**
-     * @private
      * Constructs the global model with data if the cursor is on a CSS rule
      * with a property from SUPPORTED_PROPS.
      *
@@ -170,8 +135,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        // TODO: remove _getRangeForCSSValueAt after CSSInfo.range is merged https://github.com/adobe/brackets/pull/7390
-        range = info.range || _getRangeForCSSValueAt(editor, selection.start, true);
+        range = info.range;
 
         // TODO: support multi-line values when we can handle line breaks.
         if (info.range && (info.range.start.line !== info.range.end.line)) {
@@ -401,7 +365,6 @@ define(function (require, exports, module) {
     // for testing only
     exports.model = model;
     exports._constructModel = _constructModel;
-    exports._getRangeForCSSValueAt = _getRangeForCSSValueAt;
     exports._setCurrentEditor = function (editor) { _currentEditor = editor; };
     exports._updateCodeEditor = _updateCodeEditor;
     exports._updateLiveEditor = _updateLiveEditor;

--- a/src/extensions/default/CSSShapesEditor/unittests.js
+++ b/src/extensions/default/CSSShapesEditor/unittests.js
@@ -141,66 +141,6 @@ define(function (require, exports, module) {
             });
         });
 
-        describe("Get range for CSS value", function () {
-
-            beforeEach(function () {
-                var mock = SpecRunnerUtils.createMockEditor(testContentMatchPositive, "css");
-                testDocument = mock.doc;
-                testEditor = mock.editor;
-            });
-
-            afterEach(function () {
-                SpecRunnerUtils.destroyMockEditor(testDocument);
-                testEditor = null;
-                testDocument = null;
-            });
-
-            function testGetRangeAt(pos, expected, trimWhitespace) {
-                var range = main._getRangeForCSSValueAt(testEditor, pos, trimWhitespace || false);
-                expect(range).toEqual(expected);
-            }
-
-            it("should get range for empty circle() starting at begining", function () {
-                var pos =  {line: 6, ch: 19 };
-                var expected = {
-                    start: {line: 6, ch: 17 },
-                    end:   {line: 6, ch: 27 }
-                };
-
-                testGetRangeAt(pos, expected);
-            });
-
-            it("should get range for empty circle() starting at end", function () {
-                var pos =  {line: 6, ch: 27 };
-                var expected = {
-                    start: {line: 6, ch: 17 },
-                    end:   {line: 6, ch: 27 }
-                };
-
-                testGetRangeAt(pos, expected);
-            });
-
-            it("should get range for empty circle() with trimmed whitespace", function () {
-                var pos =  {line: 6, ch: 19 };
-                var expected = {
-                    start: {line: 6, ch: 18 },
-                    end:   {line: 6, ch: 26 }
-                };
-
-                testGetRangeAt(pos, expected, true);
-            });
-
-            it("should get range for full-notation polygon() starting from arbitrary position", function () {
-                var pos =  {line: 15, ch: 55 };
-                var expected = {
-                    start: {line: 15, ch: 17 },
-                    end:   {line: 15, ch: 61 }
-                };
-
-                testGetRangeAt(pos, expected);
-            });
-        });
-
         /*
           Quick test for shape-like values in Brackets.
 


### PR DESCRIPTION
Attempts to fix #7457

I'm not yet convinced this fixes the original issue, but it handles another case when failing to match a target for the selector. Removes some RTE related to the target's style missing. 

Sill investigating the main issue. Do not merge yet.
**Update** still can't reproduce the 2-editors issue, but this PR does solve a symptom which might cause it. Please test.
