### PR TITLE
Including Missing translation for pt-br (pt-br string.js)

### DIFF
--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -296,7 +296,7 @@ define({
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Mostrar pasta de extensões",
     "CMD_TWITTER"                         : "{TWITTER_NAME} no Twitter",
     "CMD_ABOUT"                           : "Sobre o {APP_TITLE}",
-    "CMD_OPEN_PREFERENCES"                : "Abrir preferências do arquivo",
+    "CMD_OPEN_PREFERENCES"                : "Abrir arquivo de configurações",
 
 
     // Special commands invoked by the native shell

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -296,6 +296,7 @@ define({
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Mostrar pasta de extensões",
     "CMD_TWITTER"                         : "{TWITTER_NAME} no Twitter",
     "CMD_ABOUT"                           : "Sobre o {APP_TITLE}",
+    "CMD_OPEN_PREFERENCES"                : "Abrir preferências do arquivo",
 
 
     // Special commands invoked by the native shell


### PR DESCRIPTION
Added line for "CMD_OPEN_PREFERENCES" in Brazilian Portuguese language.
