### PR TITLE
Fixed bug with PromiseQueue instances sharing same queue.

### DIFF
--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -424,6 +424,8 @@ define(function (require, exports, module) {
      * has finished.
      */
     function PromiseQueue() {
+        this._queue = [];
+        this._curPromise = null;
     }
     
     /**

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -425,7 +425,6 @@ define(function (require, exports, module) {
      */
     function PromiseQueue() {
         this._queue = [];
-        this._curPromise = null;
     }
     
     /**
@@ -434,7 +433,7 @@ define(function (require, exports, module) {
      * The queue of operations to execute sequentially. Note that even if this array is empty, there might
      * still be an operation we need to wait on; that operation's promise is stored in _curPromise.
      */
-    PromiseQueue.prototype._queue = [];
+    PromiseQueue.prototype._queue = null;
     
     /**
      * @private


### PR DESCRIPTION
Fixed issue with Async.PromiseQueue instances sharing the same queue in the prototype.
Fix is to define _queue and _curPromise in the constructor.
Added to Async-test to test for this case.

(From issue #7484 )
