### PR TITLE
let the build fail if there are unit test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "grunt-usemin": "0.1.11",
         "load-grunt-tasks": "0.2.0",
         "q": "0.9.2",
-        "jshint": "2.1.4"
+        "jshint": "2.1.4",
+        "xmldoc": "^0.1.2"
     },
     "scripts": {
         "postinstall": "grunt install",

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -28,8 +28,26 @@ module.exports = function (grunt) {
     var common          = require("./lib/common")(grunt),
         child_process   = require("child_process"),
         q               = require("q"),
-        qexec           = q.denodeify(child_process.exec);
-    
+        qexec           = q.denodeify(child_process.exec),
+        XmlDocument     = require("xmldoc").XmlDocument;
+
+    /**
+     * Check the unit test results for failures
+     */
+    function checkForTestFailures(pathToResult) {
+        var resultXml = grunt.file.read(pathToResult),
+            xmlDocument = new XmlDocument(resultXml);
+
+        var testSuites = xmlDocument.childrenNamed("testsuite");
+        var failures = 0;
+
+        testSuites.forEach(function (testSuite) {
+            failures += Number(testSuite.attr.failures);
+        });
+
+        return failures;
+    }
+
     // task: test-integration
     grunt.registerTask("test-integration", "Run tests in brackets-shell. Requires 'grunt full-build' in shell.", function () {
         var done            = this.async(),
@@ -52,11 +70,16 @@ module.exports = function (grunt) {
         grunt.log.writeln(cmd);
 
         qexec(cmd, opts).then(function (stdout, stderr) {
-            done();
+            var failures = checkForTestFailures(resultsPath);
+            if (failures) {
+                var e = new Error(failures + ' test failure(s). Results are available from ' + resultsPath);
+                done(e);
+            } else {
+                done();
+            }
         }, function (err) {
             grunt.log.writeln(err);
             done(false);
         });
     });
-    
 };

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -36,10 +36,9 @@ module.exports = function (grunt) {
      */
     function checkForTestFailures(pathToResult) {
         var resultXml = grunt.file.read(pathToResult),
-            xmlDocument = new XmlDocument(resultXml);
-
-        var testSuites = xmlDocument.childrenNamed("testsuite");
-        var failures = 0;
+            xmlDocument = new XmlDocument(resultXml),
+            testSuites = xmlDocument.childrenNamed("testsuite"),
+            failures = 0;
 
         testSuites.forEach(function (testSuite) {
             failures += Number(testSuite.attr.failures);


### PR DESCRIPTION
Usually I run all the test from the command line during release testing. I had several occasions, where I saw tests fail in the UI testrunner, but the test run has been reported as success.

This PR will examine the unit test result file and inspects all testsuites for failures and accumulates the number of failed tests. If there are any errors, then the number of failed tests will be reported and the build fails accordingly.
