### PR TITLE
Fix Extension Manager crash when other Bootstrap tabs present in DOM

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -255,7 +255,7 @@ define(function (require, exports, module) {
             });
             
             // Update search UI before new tab is shown
-            $("a[data-toggle='tab']").each(function (index, tabElement) {
+            $("a[data-toggle='tab']", $dlg).each(function (index, tabElement) {
                 $(tabElement).on("show", function (event) {
                     _activeTabIndex = index;
                     


### PR DESCRIPTION
Fix Extension Manager bug: a poorly-scoped jQuery call causes it to see _all_ Bootstrap tabs in the entire DOM as part of its tab set, so it will crash if any other such tabs exist in the UI (leaving the Extension Manager dialog blank).

This was the only jQuery call in the Extension Manager code that wasn't already scoped down to $dlg (or used an equivalent parent selector).
