### PR TITLE
Adds preferences that map extensions and filenames to languages.

### DIFF
--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -676,33 +676,28 @@ define(function (require, exports, module) {
             it("should be able to add extension mappings via a preference", function () {
                 var language = LanguageManager.getLanguageForExtension("foo");
                 expect(language).toBeUndefined();
-                PreferencesManager.set("language.fileExtensions", {
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, {
                     foo: "javascript"
                 });
                 language = LanguageManager.getLanguageForExtension("foo");
                 expect(language.getId()).toBe("javascript");
-            });
-            
-            it("should remove extension mappings when preferences change", function () {
-                var language = LanguageManager.getLanguageForExtension("foo");
-                expect(language).toBeDefined();
-                PreferencesManager.set("language.fileExtensions", { });
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, { });
                 language = LanguageManager.getLanguageForExtension("foo");
                 expect(language).toBeUndefined();
             });
             
             it("should manage overridden default extensions", function () {
-                PreferencesManager.set("language.fileExtensions", {
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, {
                     js: "html"
                 });
                 var language = LanguageManager.getLanguageForExtension("js");
                 expect(language.getId()).toBe("html");
-                PreferencesManager.set("language.fileExtensions", {
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, {
                     js: "php"
                 });
                 language = LanguageManager.getLanguageForExtension("js");
                 expect(language.getId()).toBe("php");
-                PreferencesManager.set("language.fileExtensions", { });
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, { });
                 language = LanguageManager.getLanguageForExtension("js");
                 expect(language.getId()).toBe("javascript");
             });
@@ -710,28 +705,28 @@ define(function (require, exports, module) {
             it("should be able to manage file name mappings via a preference", function () {
                 var language = LanguageManager.getLanguageForPath("/bar/Foofile");
                 expect(language.getId()).toBe("unknown");
-                PreferencesManager.set("language.fileNames", {
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, {
                     "Foofile": "javascript"
                 });
                 language = LanguageManager.getLanguageForPath("/bar/Foofile");
                 expect(language.getId()).toBe("javascript");
-                PreferencesManager.set("language.fileNames", { });
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, { });
                 language = LanguageManager.getLanguageForPath("/bar/Foofile");
                 expect(language.getId()).toBe("unknown");
             });
             
             it("should manage overridden default file names", function () {
-                PreferencesManager.set("language.fileNames", {
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, {
                     Gemfile: "python"
                 });
                 var language = LanguageManager.getLanguageForPath("Gemfile");
                 expect(language.getId()).toBe("python");
-                PreferencesManager.set("language.fileNames", {
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, {
                     Gemfile: "php"
                 });
                 language = LanguageManager.getLanguageForPath("Gemfile");
                 expect(language.getId()).toBe("php");
-                PreferencesManager.set("language.fileNames", { });
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, { });
                 language = LanguageManager.getLanguageForPath("Gemfile");
                 expect(language.getId()).toBe("ruby");
             });


### PR DESCRIPTION
This adds `language.fileExtensions` and `language.fileNames` preferences
that can set the language associated with the provided extensions or
filenames. These prefs are both objects.

This is a fix for #6831 
