### PR TITLE
fix closing issue when pointer-events for CodeMirror are exposed

### DIFF
--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -57,7 +57,8 @@ define(function (require, exports, module) {
     /** @type {$.Element} jQuery elements used for the dropdown menu */
     var $dropdownItem,
         $dropdown,
-        $links;
+        $links,
+        currentEditor;
 
     /**
      * Get the stored list of recent projects, fixing up paths as appropriate.
@@ -266,6 +267,9 @@ define(function (require, exports, module) {
         $("#project-files-container").off("scroll", closeDropdown);
         $(SidebarView).off("hide", closeDropdown);
         $("#titlebar .nav").off("click", closeDropdown);
+        if (currentEditor) {
+            currentEditor._codeMirror.off("focus", closeDropdown);
+        }
         $dropdown = null;
 
         EditorManager.focusEditor();
@@ -411,6 +415,12 @@ define(function (require, exports, module) {
         // Hacky: if we detect a click in the menubar, close ourselves.
         // TODO: again, we should have centralized popup management.
         $("#titlebar .nav").on("click", closeDropdown);
+
+        // close dropdown when editor is focused
+        currentEditor = EditorManager.getCurrentFullEditor();
+        if (currentEditor) {
+            currentEditor._codeMirror.on("focus", closeDropdown);
+        }
 
         _handleListEvents();
         $(window).on("keydown", keydownHook);


### PR DESCRIPTION
This fixes https://github.com/zaggino/brackets-git/issues/447

Brackets-Git enables https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events over the CodeMirror

cc @RaymondLim, @MiguelCastillo
