### PR TITLE
fixes #7611

### DIFF
--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
      * @return {!$.Promise} A promise object that is resolved with the contents of the requested file
      **/
     function loadFile(module, path) {
-        var url     = isAbsolutePathOrUrl(path) ? path : getModuleUrl(module, path),
+        var url     = PathUtils.isAbsoluteUrl(path) ? path : getModuleUrl(module, path),
             promise = $.get(url);
 
         return promise;


### PR DESCRIPTION
cc @njx @redmunds 

the reason is - path gets modified for OS in `getModuleUrl` method, so check here shouldn't be OS specific, because this one is before that method

tested on win + linux, not mac
