### PR TITLE
Fix AboutDialog to show more than 30 contributors again

### DIFF
--- a/src/brackets.config.json
+++ b/src/brackets.config.json
@@ -14,7 +14,7 @@
         "twitter_url"                : "https://twitter.com/brackets",
         "troubleshoot_url"           : "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
         "twitter_name"               : "@brackets",
-        "contributors_url"           : "https://api.github.com/repos/adobe/brackets/contributors",
+        "contributors_url"           : "https://api.github.com/repos/adobe/brackets/contributors?per_page=300",
         "extension_listing_url"      : "",
         "extension_registry"         : "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url"              : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
         "twitter_url": "https://twitter.com/brackets",
         "troubleshoot_url": "https://github.com/adobe/brackets/wiki/Troubleshooting#wiki-livedev",
         "twitter_name": "@brackets",
-        "contributors_url": "https://api.github.com/repos/adobe/brackets/contributors",
+        "contributors_url": "https://api.github.com/repos/adobe/brackets/contributors?per_page=300",
         "extension_listing_url": "",
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",


### PR DESCRIPTION
This fixes #7614 and #7615.

I hardcoded it to show 300 contributors at max (because the dialog would get pretty inflated with more), but we can simply increase the limit.
