### PR TITLE
Change the host of the update_info_url from dev.brackets.io to bracket.io

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,7 +3,7 @@
         "app_title": "Brackets",
         "app_name_about": "Brackets",
         "about_icon": "styles/images/brackets_icon.svg",
-        "update_info_url": "http://dev.brackets.io/updates/stable/",
+        "update_info_url": "http://brackets.io/updates/stable/",
         "how_to_use_url": "https://github.com/adobe/brackets/wiki/How-to-Use-Brackets",
         "support_url": "https://github.com/adobe/brackets/wiki/Troubleshooting",
         "suggest_feature_url": "https://github.com/adobe/brackets/wiki/Suggest-a-Feature",


### PR DESCRIPTION
This change is required to get rid of [dev|download].brackets.io.
