### PR TITLE
Tweak update-dialog style

### DIFF
--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -2,7 +2,7 @@
     <div class="modal-header">
         <h1 class="dialog-title">{{Strings.ABOUT}}</h1>
     </div>
-    <div class="modal-body">
+    <div class="modal-body no-padding">
         <img class="about-icon" src="{{ABOUT_ICON}}">
         <div class="about-text">
             <h2>{{APP_NAME_ABOUT_BOX}}</h2>

--- a/src/htmlContent/update-dialog.html
+++ b/src/htmlContent/update-dialog.html
@@ -2,7 +2,7 @@
     <div class="modal-header">
         <h1 class="dialog-title">{{UPDATE_AVAILABLE_TITLE}}</h1>
     </div>
-    <div class="modal-body">
+    <div class="modal-body no-padding">
         <img class="update-icon" src="styles/images/update_large_icon.svg">
         <div class="update-text">
             <p class="dialog-message">{{UPDATE_MESSAGE}}</p>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -704,7 +704,7 @@ a[href^="http"] {
     }
     .update-text {
         // Icon is 120px, so we need at least that much left padding/margin to avoid overlap
-        margin-left: 123px;
+        margin-left: 130px;
 
         padding-top: 20px;
         max-height: 280px;
@@ -966,7 +966,7 @@ a[href^="http"] {
     }
     .about-text {
         // Icon is 120px, so we need at least that much left padding/margin to avoid overlap
-        margin-left: 123px;
+        margin-left: 130px;
         overflow: auto;
 
         #about-build-number {
@@ -978,6 +978,7 @@ a[href^="http"] {
         }
         .about-contributors {
             min-height: 100px;
+            padding-bottom: 13px;
 
             a {
                 text-decoration: none;
@@ -996,7 +997,7 @@ a[href^="http"] {
         font-weight: normal;
         font-size: 25px;
         margin-bottom: -4px;
-        margin-top: 3px;
+        margin-top: 13px;
     }
     .dialog-message {
         font-size: 14px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -694,7 +694,7 @@ a[href^="http"] {
 
 /* Update dialog */
 .update-dialog .modal-body {
-    padding-bottom: 0;
+    margin-right: 0; // the scrollbar should be at the right edge
     position: relative;
     .update-icon {
         position: absolute;
@@ -705,12 +705,14 @@ a[href^="http"] {
     }
     .update-text {
         // Icon is 120px, so we need at least that much left padding/margin to avoid overlap
-        margin: 0 10px 0 123px;
+        margin: 0 0 0 123px;
+
+        padding-top: 20px;
+        max-height: 280px;
+        overflow: auto;
 
         .update-info {
-            max-height: 280px;
-            overflow: auto;
-
+            margin-right: 10px;
             // Enable text selection
             cursor: auto;
             .user-select(text);

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -694,7 +694,6 @@ a[href^="http"] {
 
 /* Update dialog */
 .update-dialog .modal-body {
-    margin-right: 0; // the scrollbar should be at the right edge
     position: relative;
     .update-icon {
         position: absolute;
@@ -705,7 +704,7 @@ a[href^="http"] {
     }
     .update-text {
         // Icon is 120px, so we need at least that much left padding/margin to avoid overlap
-        margin: 0 0 0 123px;
+        margin-left: 123px;
 
         padding-top: 20px;
         max-height: 280px;
@@ -967,14 +966,15 @@ a[href^="http"] {
     }
     .about-text {
         // Icon is 120px, so we need at least that much left padding/margin to avoid overlap
-        margin: 0 10px 0 123px;
+        margin-left: 123px;
+        overflow: auto;
 
         #about-build-number {
             color: @tc-light-weight-quiet-text;
         }
         .about-info {
             max-height: 300px;
-            overflow: auto;
+            margin-right: 10px;
         }
         .about-contributors {
             min-height: 100px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -694,6 +694,7 @@ a[href^="http"] {
 
 /* Update dialog */
 .update-dialog .modal-body {
+    padding-bottom: 0;
     position: relative;
     .update-icon {
         position: absolute;
@@ -707,7 +708,7 @@ a[href^="http"] {
         margin: 0 10px 0 123px;
 
         .update-info {
-            max-height: 200px;
+            max-height: 280px;
             overflow: auto;
 
             // Enable text selection


### PR DESCRIPTION
@larz0 This makes the UpdateNotification dialog look less weird.
- Remove the `padding-bottom` so that the scroll content fills the complete `.modal-body`
- Increase the `max-height` so that more changes are shown at once
