### PR TITLE
fix dropdown items going off screen

### DIFF
--- a/src/styles/bootstrap/dropdowns.less
+++ b/src/styles/bootstrap/dropdowns.less
@@ -46,6 +46,8 @@
   display: none; // none by default, but block on "open" of the menu
   float: left;
   min-width: 160px;
+  max-height: 700px;
+  overflow-x: hidden;
   padding: 5px 0;
   margin: 2px 0 0; // override default ul
   list-style: none;


### PR DESCRIPTION
This was an issue involving the drop down menus containing too many items that leaves "excess" items going off screen and not being able to see/select them. 

My laptop screen resolution is 1366x768. 

The code makes the drop down menus scrollable when it reaches the max height.
