### PR TITLE
Make html menus scroll to avoid truncation

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -118,6 +118,11 @@ a:focus {
         > li {
             float: left;
         }
+        .dropdown-menu {
+            //max-height: calc(~"100vh - 34px"); doesn't seem to work...
+            max-height: 90vh;
+            overflow-y: auto;
+        }
     }
     .title {
         float: none;


### PR DESCRIPTION
This is for #7496 

This is an alternate solution for https://github.com/adobe/brackets/pull/7693. This isolates the change to only HTML main menus.

Using a max-height such as `calc(100vh - 34px)` (which would need to be something like `calc(~"100vh - 34px")` in LESS) was discussed, but doesn't seem to work. I don't think it really that important to have the menu go _exactly_ to the bottom of the screen, anyway.

This solution does _not_ resize the menu _while it is open_ on window resize, but it _will_ be properly resized on next open after resize is complete.

I think this is a reasonable solution to prevent HTML menu truncation for now, and we can continue to improve it as priorities allow.
