### PR TITLE
fix a bunch of failing unit tests.

### DIFF
--- a/test/spec/EditorOptionHandlers-test-files/test.html
+++ b/test/spec/EditorOptionHandlers-test-files/test.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-<p class="longLineClass">Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome!</p>
+<p class="longLineClass">Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome! Brackets is awesome!</p>
 <p class="shortLineClass">Brackets is awesome!</p>
 </body>
 </html>

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     var editor = EditorManager.getCurrentFullEditor(),
-                        oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 0, 200);
+                        oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 200);
 
                     // Use two cursor positions to detect line wrapping. First position at 
                     // the beginning of a long line and the second position to be

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -205,13 +205,17 @@ define(function (require, exports, module) {
                 openEditor(HTML_FILE);
                 
                 runs(function () {
-                    var editor = EditorManager.getCurrentFullEditor();
-                    
+                    var editor = EditorManager.getCurrentFullEditor(),
+                        oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 0, 200);
+
                     // Use two cursor positions to detect line wrapping. First position at 
                     // the beginning of a long line and the second position to be
                     // somewhere on the long line that will be part of an extra line 
                     // created by word-wrap and get its bottom coordinate.
                     checkLineWrapping(editor, {line: 8, ch: 0}, {line: 8, ch: 210}, true);
+
+                    // reset to previous values
+                    SpecRunnerUtils.resizeEditor(editor, testWindow.$, oldEditorSize.width, oldEditorSize.height);
                 });
             });
     

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -204,22 +204,14 @@ define(function (require, exports, module) {
             it("should wrap long lines in main editor by default", function () {
                 openEditor(HTML_FILE);
 
-                var editor, oldEditorSize, flag;
-                
                 runs(function () {
-                    editor = EditorManager.getCurrentFullEditor();
-                    oldEditorSize = SpecRunnerUtils.resizeEditor(editor, 800);
+                    var editor = EditorManager.getCurrentFullEditor();
 
                     // Use two cursor positions to detect line wrapping. First position at 
                     // the beginning of a long line and the second position to be
                     // somewhere on the long line that will be part of an extra line 
                     // created by word-wrap and get its bottom coordinate.
-                    checkLineWrapping(editor, {line: 8, ch: 0}, {line: 8, ch: 210}, true);
-                });
-
-                runs(function () {
-                    // reset to previous values
-                    SpecRunnerUtils.resizeEditor(editor, oldEditorSize.width, oldEditorSize.height);
+                    checkLineWrapping(editor, {line: 8, ch: 0}, {line: 8, ch: 320}, true);
                 });
             });
 

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -203,22 +203,26 @@ define(function (require, exports, module) {
         describe("Toggle Word Wrap", function () {
             it("should wrap long lines in main editor by default", function () {
                 openEditor(HTML_FILE);
+
+                var editor, oldEditorSize, flag;
                 
                 runs(function () {
-                    var editor = EditorManager.getCurrentFullEditor(),
-                        oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 200);
+                    editor = EditorManager.getCurrentFullEditor();
+                    oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 800);
 
                     // Use two cursor positions to detect line wrapping. First position at 
                     // the beginning of a long line and the second position to be
                     // somewhere on the long line that will be part of an extra line 
                     // created by word-wrap and get its bottom coordinate.
                     checkLineWrapping(editor, {line: 8, ch: 0}, {line: 8, ch: 210}, true);
+                });
 
+                runs(function () {
                     // reset to previous values
                     SpecRunnerUtils.resizeEditor(editor, testWindow.$, oldEditorSize.width, oldEditorSize.height);
                 });
             });
-    
+
             it("should also wrap long lines in inline editor by default", function () {
                 openInlineEditor();
                 

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -208,7 +208,7 @@ define(function (require, exports, module) {
                 
                 runs(function () {
                     editor = EditorManager.getCurrentFullEditor();
-                    oldEditorSize = SpecRunnerUtils.resizeEditor(editor, testWindow.$, 800);
+                    oldEditorSize = SpecRunnerUtils.resizeEditor(editor, 800);
 
                     // Use two cursor positions to detect line wrapping. First position at 
                     // the beginning of a long line and the second position to be
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
 
                 runs(function () {
                     // reset to previous values
-                    SpecRunnerUtils.resizeEditor(editor, testWindow.$, oldEditorSize.width, oldEditorSize.height);
+                    SpecRunnerUtils.resizeEditor(editor, oldEditorSize.width, oldEditorSize.height);
                 });
             });
 

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     if (gotoLineQuery) {
                         var editor = EditorManager.getCurrentFullEditor();
-                        SpecRunnerUtils.resizeEditor(editor, testWindow.$, 200);
+                        SpecRunnerUtils.resizeEditor(editor, testWindow.$, 0, 600);
 
                         waitsFor(function () {
                             return getSearchField().val() === gotoLineQuery;

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -155,7 +155,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     if (gotoLineQuery) {
                         var editor = EditorManager.getCurrentFullEditor();
-                        SpecRunnerUtils.resizeEditor(editor, testWindow.$, 0, 600);
+                        SpecRunnerUtils.resizeEditor(editor, 0, 600);
 
                         waitsFor(function () {
                             return getSearchField().val() === gotoLineQuery;

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -151,22 +151,27 @@ define(function (require, exports, module) {
                         enterSearchText(gotoLineQuery);
                     }
                 });
-                
-                if (gotoLineQuery) {
-                    waitsFor(function () {
-                        return getSearchField().val() === gotoLineQuery;
-                    }, "goto line entry timeout", 1000);
-                    
-                    runs(function () {
-                        pressEnter();
-                    });
-    
-                    // wait for ModalBar to close
-                    waitsFor(function () {
-                        return getSearchBar().length === 0;
-                    }, "ModalBar close", 1000);
-                }
-    
+
+                runs(function () {
+                    if (gotoLineQuery) {
+                        var editor = EditorManager.getCurrentFullEditor();
+                        SpecRunnerUtils.resizeEditor(editor, testWindow.$, 200);
+
+                        waitsFor(function () {
+                            return getSearchField().val() === gotoLineQuery;
+                        }, "goto line entry timeout", 1000);
+
+                        runs(function () {
+                            pressEnter();
+                        });
+
+                        // wait for ModalBar to close
+                        waitsFor(function () {
+                            return getSearchBar().length === 0;
+                        }, "ModalBar close", 1000);
+                    }
+                });
+
                 runs(function () {
                     // The user enters a 1-based number, but the reported position
                     // is 0 based, so we check for line-1, col-1.

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -1015,7 +1015,45 @@ define(function (require, exports, module) {
     function setLoadExtensionsInTestWindow(doLoadExtensions) {
         _doLoadExtensions = doLoadExtensions;
     }
-    
+
+    /**
+     * Change the size of an editor. The window size is not affected by this function.
+     * CodeMirror will change it's size withing Brackets.
+     *
+     * @param {!Editor} editor - instance of Editor
+     * @param {!Object} jquery - instance of jquery that belongs to the window which hosts the editor
+     * @param {?number} width - the new width of the editor in pixel
+     * @param {?number} height - the new height of the editor in pixel
+     */
+    function resizeEditor(editor, jquery, width, height) {
+        var oldSize = {};
+
+        if (editor && jquery) {
+            var $editorHolder = jquery('#editor-holder'),
+                $content = jquery('.content');
+
+            // preserve old size
+            oldSize.width = $editorHolder.width();
+            oldSize.height = $editorHolder.height();
+
+            if (width) {
+                $content.width(width);
+                $editorHolder.width(width);
+                editor.setSize(width, null); // Update CM size
+            }
+
+            if (height) {
+                $content.height(height);
+                $editorHolder.height(height);
+                editor.setSize(null, height); // Update CM size
+            }
+
+            editor.refreshAll(true); // update CM
+        }
+
+        return oldSize;
+    }
+
     /**
      * Extracts the jasmine.log() and/or jasmine.expect() messages from the given result,
      * including stack traces if available.
@@ -1302,4 +1340,5 @@ define(function (require, exports, module) {
     exports.runAfterLast                    = runAfterLast;
     exports.removeTempDirectory             = removeTempDirectory;
     exports.setUnitTestReporter             = setUnitTestReporter;
+    exports.resizeEditor                    = resizeEditor;
 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -1021,15 +1021,15 @@ define(function (require, exports, module) {
      * CodeMirror will change it's size withing Brackets.
      *
      * @param {!Editor} editor - instance of Editor
-     * @param {!Object} jquery - instance of jquery that belongs to the window which hosts the editor
      * @param {?number} width - the new width of the editor in pixel
      * @param {?number} height - the new height of the editor in pixel
      */
-    function resizeEditor(editor, jquery, width, height) {
+    function resizeEditor(editor, width, height) {
         var oldSize = {};
 
-        if (editor && jquery) {
-            var $editorHolder = jquery('#editor-holder'),
+        if (editor) {
+            var jquery = editor.getRootElement().ownerDocument.defaultView.$,
+                $editorHolder = jquery('#editor-holder'),
                 $content = jquery('.content');
 
             // preserve old size


### PR DESCRIPTION
The fix is to resize the editor to a specific size to make those tests pass again. Some of the test expected that the editor will always scroll and word wrap in the same way, regardless of the window/editor size. This fix will resize the editor for a few tests to make their behavior predictable.
