### PR TITLE
Implement jscodehints.defaultExclusions preference.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
         FileSystem          = brackets.getModule("filesystem/FileSystem"),
         FileUtils           = brackets.getModule("file/FileUtils"),
         CodeMirror          = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         HintUtils           = require("HintUtils"),
         MessageIds          = require("MessageIds"),
         Preferences         = require("Preferences");
@@ -739,7 +740,18 @@ define(function (require, exports, module) {
 
             return addPendingRequest(path, OFFSET_ZERO, MessageIds.TERN_UPDATE_FILE_MSG);
         }
-
+        
+        /**
+         * Checks filename to see if it matches the exclusion regex.
+         * 
+         * @param {string} name filename to check
+         * @param {string} exclusion uncompiled exclusion regular expression
+         * @return {boolean} true if the file should be excluded
+         */
+        function checkExclusion(name, exclusion) {
+            return new RegExp(exclusion).exec(name);
+        }
+        
         /**
          * Handle a request from the worker for text of a file
          *
@@ -756,7 +768,17 @@ define(function (require, exports, module) {
                 });
             }
     
-            var name = request.file;
+            var name = request.file,
+                defaultExclusions = PreferencesManager.get("jscodehints.defaultExclusions");
+            
+            // The defaultExclusions are the ones we ship with Brackets to filter out files that we know
+            // to be troublesome with current versions of Tern. They can be overridden with a .brackets.json
+            // file in your project.
+            if (defaultExclusions
+                    && _.isArray(defaultExclusions)
+                    && _.some(defaultExclusions, _.partial(checkExclusion, name))) {
+                replyWith(name, "");
+            }
     
             /**
              * Helper function to get the text of a given document and send it to tern.

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -227,9 +227,9 @@ define(function (require, exports, module) {
         // The defaultExclusions are the ones we ship with Brackets to filter out files that we know
         // to be troublesome with current versions of Tern. They can be overridden with a .brackets.json
         // file in your project. defaultExclusions is an array of globs.
-        return defaultExclusions
-            && _.isArray(defaultExclusions)
-            && _.some(defaultExclusions, _.partial(globmatch, file.fullPath));
+        return defaultExclusions &&
+            _.isArray(defaultExclusions) &&
+            _.some(defaultExclusions, _.partial(globmatch, file.fullPath));
     }
 
     /**

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
         StringMatch          = brackets.getModule("utils/StringMatch"),
         LanguageManager      = brackets.getModule("language/LanguageManager"),
         ProjectManager       = brackets.getModule("project/ProjectManager"),
+        PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
         ParameterHintManager = require("ParameterHintManager"),
         HintUtils            = require("HintUtils"),
         ScopeManager         = require("ScopeManager"),
@@ -54,7 +55,9 @@ define(function (require, exports, module) {
         cachedToken  = null,  // the token used in the current hinting session
         matcher      = null,  // string matcher for hints
         ignoreChange;         // can ignore next "change" event if true;
-
+    
+    PreferencesManager.definePreference("jscodehints.defaultExclusions", "array", ["ionic(-.*|\\.bundle|)\\.min\\.js$"]);
+    
     /**
      * Sets the configuration, generally for testing/debugging use.
      * Configuration keys are merged into the current configuration.

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -56,7 +56,8 @@ define(function (require, exports, module) {
         matcher      = null,  // string matcher for hints
         ignoreChange;         // can ignore next "change" event if true;
     
-    PreferencesManager.definePreference("jscodehints.defaultExclusions", "array", ["ionic(-.*|\\.bundle|)\\.min\\.js$"]);
+    // Define the defaultExclusions which are files that are known to cause Tern to run out of control.
+    PreferencesManager.definePreference("jscodehints.defaultExclusions", "array", ["ionic*.min.js"]);
     
     /**
      * Sets the configuration, generally for testing/debugging use.


### PR DESCRIPTION
We've had a number of people report problems with Ionic in their projects.
Tern appears to have an issue with the minified Ionic files. I had planned
to add default exclusions so that we could quickly solve pain like this
and this problem appeared to be a good candidate. The repro steps
[reported here](https://github.com/adobe/brackets/issues/7262#issuecomment-41851396)
are fixed with this change.
#7262
