### PR TITLE
Alternative fix for Replace ModalBar with 2 lines

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1077,14 +1077,10 @@ a, img {
     }
 
     &.offscreen {
-        -webkit-transform: translate(0, -44px);
-        transform: translate(0, -44px);
+        -webkit-transform: translate(0, -100%);
+        transform: translate(0, -100%);
         transition: -webkit-transform 266ms cubic-bezier(0, 0.56, 0, 1);
         transition: transform 266ms cubic-bezier(0, 0.56, 0, 1);
-
-        body:not(.has-appshell-menus) & {
-            top: 37px;
-        }
     }
 
     input {

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -153,6 +153,13 @@ define(function (require, exports, module) {
         
         this._$root.addClass("popout");
         
+        // Since the modal bar has now an absolute position relative to the editor holder,
+        // when there are html menus we need to adjust the top position
+        if (!brackets.nativeMenus) {
+            var top = $("#titlebar").outerHeight();
+            this._$root.css("top", (top + 10) + "px");
+        }
+        
         // Preserve scroll position of the current full editor across the editor refresh, adjusting for the 
         // height of the modal bar so the code doesn't appear to shift if possible.
         var fullEditor = EditorManager.getCurrentFullEditor(),

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -157,7 +157,7 @@ define(function (require, exports, module) {
         // when there are html menus we need to adjust the top position
         if (!brackets.nativeMenus) {
             var top = $("#titlebar").outerHeight();
-            this._$root.css("top", (top + 10) + "px");
+            this._$root.css("top", top + "px");
         }
         
         // Preserve scroll position of the current full editor across the editor refresh, adjusting for the 


### PR DESCRIPTION
@redmunds This is the alternative fix for #7396.

I noticed that using 100% with translate worked fine, so we no longer need to worry about the height of the modal bar. It also fixes an issue when the html menus use 2 lines, or even more.
