### PR TITLE
Highlight Selection Matches

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror2/addon/selection/active-line");
     require("thirdparty/CodeMirror2/addon/mode/multiplex");
     require("thirdparty/CodeMirror2/addon/mode/overlay");
+    require("thirdparty/CodeMirror2/addon/search/match-highlighter");
     require("thirdparty/CodeMirror2/addon/search/searchcursor");
     require("thirdparty/CodeMirror2/keymap/sublime");
     

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -81,6 +81,7 @@ define(function (require, exports, module) {
     /** Editor preferences */
     var CLOSE_BRACKETS    = "closeBrackets",
         CLOSE_TAGS        = "closeTags",
+        HIGHLIGHT_MATCHES = "highlightMatches",
         SCROLL_PAST_END   = "scrollPastEnd",
         SHOW_LINE_NUMBERS = "showLineNumbers",
         SMART_INDENT      = "smartIndent",
@@ -104,6 +105,7 @@ define(function (require, exports, module) {
     // Mappings from Brackets preferences to CodeMirror options
     cmOptions[CLOSE_BRACKETS]     = "autoCloseBrackets";
     cmOptions[CLOSE_TAGS]         = "autoCloseTags";
+    cmOptions[HIGHLIGHT_MATCHES]  = "highlightSelectionMatches";
     cmOptions[SCROLL_PAST_END]    = "scrollPastEnd";
     cmOptions[SHOW_LINE_NUMBERS]  = "lineNumbers";
     cmOptions[SMART_INDENT]       = "smartIndent";
@@ -115,15 +117,16 @@ define(function (require, exports, module) {
     
     PreferencesManager.definePreference(CLOSE_BRACKETS,    "boolean", false);
     PreferencesManager.definePreference(CLOSE_TAGS,        "Object", { whenOpening: true, whenClosing: true, indentTags: [] });
+    PreferencesManager.definePreference(HIGHLIGHT_MATCHES, "boolean", false);
     PreferencesManager.definePreference(SCROLL_PAST_END,   "boolean", false);
     PreferencesManager.definePreference(SHOW_LINE_NUMBERS, "boolean", true);
     PreferencesManager.definePreference(SMART_INDENT,      "boolean", true);
     PreferencesManager.definePreference(SOFT_TABS,         "boolean", true);
-    PreferencesManager.definePreference(SPACE_UNITS, "number", DEFAULT_SPACE_UNITS, {
+    PreferencesManager.definePreference(SPACE_UNITS,       "number", DEFAULT_SPACE_UNITS, {
         validator: _.partialRight(ValidationUtils.isIntegerInRange, MIN_SPACE_UNITS, MAX_SPACE_UNITS)
     });
     PreferencesManager.definePreference(STYLE_ACTIVE_LINE, "boolean", false);
-    PreferencesManager.definePreference(TAB_SIZE, "number", DEFAULT_TAB_SIZE, {
+    PreferencesManager.definePreference(TAB_SIZE,          "number", DEFAULT_TAB_SIZE, {
         validator: _.partialRight(ValidationUtils.isIntegerInRange, MIN_TAB_SIZE, MAX_TAB_SIZE)
     });
     PreferencesManager.definePreference(USE_TAB_CHAR,      "boolean", false);
@@ -261,6 +264,7 @@ define(function (require, exports, module) {
             dragDrop                    : false,
             electricChars               : false,   // we use our own impl of this to avoid CodeMirror bugs; see _checkElectricChars()
             extraKeys                   : codeMirrorKeyMap,
+            highlightSelectionMatches   : currentOptions[HIGHLIGHT_MATCHES],
             indentUnit                  : currentOptions[USE_TAB_CHAR] ? currentOptions[TAB_SIZE] : currentOptions[SPACE_UNITS],
             indentWithTabs              : currentOptions[USE_TAB_CHAR],
             lineNumbers                 : currentOptions[SHOW_LINE_NUMBERS],

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -71,6 +71,12 @@
     }
 }
 
+.CodeMirror-focused .cm-matchhighlight {
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVQI12NgYGBgkKzc8x9CMDAwAAAmhwSbidEoSQAAAABJRU5ErkJggg==);
+    background-position: bottom;
+    background-repeat: repeat-x;
+}
+
 
 .cm-s-default {
     span.cm-keyword {color: @accent-keyword;}

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -72,9 +72,7 @@
 }
 
 .CodeMirror-focused .cm-matchhighlight {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVQI12NgYGBgkKzc8x9CMDAwAAAmhwSbidEoSQAAAABJRU5ErkJggg==);
-    background-position: bottom;
-    background-repeat: repeat-x;
+    border-bottom: 2px solid #78B2F2;
 }
 
 


### PR DESCRIPTION
I added a new preference to enable the `match-highlighter` addon from CodeMirror. When enabled and when a word is selected, it will highlight all the matches in the file. Similar to many other editors. [CodeMirror Demo](http://codemirror.net/demo/matchhighlighter.html)

I used the same style as in the CodeMirror demo, but maybe @larz0 might want to change it.

cc @redmunds since you merged a couple of this CM addons additions.
