### PR TITLE
Add Live Preview category to SpecRunner

### DIFF
--- a/test/BootstrapReporterView.css
+++ b/test/BootstrapReporterView.css
@@ -39,3 +39,10 @@ pre {
 .testframework-link {
     opacity: 0.45;
 }
+
+@media (min-width: 728px) and (max-width: 1199px) {
+    .navbar-fixed-top .container,
+    .navbar-fixed-bottom .container {
+        width: 800px;
+    }
+}

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -62,10 +62,11 @@
               <li><a id="all" href="?suite=all">All</a></li>
               <li><a id="unit" href="?suite=unit">Unit</a></li>
               <li><a id="integration" href="?suite=integration">Integration</a></li>
+              <li><a id="livepreview" href="?suite=livepreview">Live&nbsp;Preview</a></li>
               <li><a id="performance" href="?suite=performance">Performance</a></li>
               <li><a id="extension" href="?suite=extension">Extensions</a></li>
               <li><a id="reload" href="#">Reload</a></li>
-              <li><a id="show-dev-tools" href="#">Show Developer Tools</a></li>
+              <li><a id="show-dev-tools" href="#">Show&nbsp;Developer&nbsp;Tools</a></li>
             </ul>
           </div>
         </div>

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
         
     describe("Inspector", function () {
         
-        this.category = "integration";
+        this.category = "livepreview";
 
         it("should return a ready socket on Inspector.connect and close the socket on Inspector.disconnect", function () {
             var id  = Math.floor(Math.random() * 100000),
@@ -514,7 +514,7 @@ define(function (require, exports, module) {
 
     describe("Live Development", function () {
         
-        this.category = "integration";
+        this.category = "livepreview";
 
         beforeFirst(function () {
             SpecRunnerUtils.createTempDirectory();
@@ -576,6 +576,8 @@ define(function (require, exports, module) {
 
         describe("CSS Editing", function () {
             
+            this.category = "livepreview";
+
             it("should establish a browser connection for an opened html file", function () {
                 //open a file
                 runs(function () {
@@ -751,6 +753,8 @@ define(function (require, exports, module) {
         
         describe("HTML Editing", function () {
 
+            this.category = "livepreview";
+
             function _openSimpleHTML() {
                 runs(function () {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles simple1.html", 1000);
@@ -873,6 +877,8 @@ define(function (require, exports, module) {
         
         describe("JS Editing", function () {
             
+            this.category = "livepreview";
+
             it("should reload the page when editing a non-live document", function () {
                 var promise,
                     jsdoc,
@@ -997,6 +1003,9 @@ define(function (require, exports, module) {
     });
     
     describe("Default HTML Document", function () {
+
+        this.category = "livepreview";
+
         var brackets,
             LiveDevelopment,
             ProjectManager,
@@ -1030,6 +1039,9 @@ define(function (require, exports, module) {
         }
 
         describe("Find static page for Live Development", function () {
+
+            this.category = "livepreview";
+
             it("should return the same HTML document like the currently open document", function () {
                 var promise,
                     document,
@@ -1202,6 +1214,9 @@ define(function (require, exports, module) {
         });
 
         describe("Find dynamic page for Live Development", function () {
+
+            this.category = "livepreview";
+
             it("should return the same index.php document like the currently opened document", function () {
                 var promise,
                     document,

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -232,6 +232,8 @@ define(function (require, exports, module) {
 
     describe("URL Mapping", function () {
 
+        this.category = "livepreview";
+
         it("should validate base urls", function () {
             expect(PreferencesDialogs._validateBaseUrl("http://localhost"))
                 .toBe("");
@@ -264,6 +266,8 @@ define(function (require, exports, module) {
     
     describe("HighlightAgent", function () {
         
+        this.category = "livepreview";
+
         describe("Highlighting elements in browser from a CSS rule", function () {
             
             var testDocument,
@@ -576,8 +580,6 @@ define(function (require, exports, module) {
 
         describe("CSS Editing", function () {
             
-            this.category = "livepreview";
-
             it("should establish a browser connection for an opened html file", function () {
                 //open a file
                 runs(function () {
@@ -753,8 +755,6 @@ define(function (require, exports, module) {
         
         describe("HTML Editing", function () {
 
-            this.category = "livepreview";
-
             function _openSimpleHTML() {
                 runs(function () {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]), "SpecRunnerUtils.openProjectFiles simple1.html", 1000);
@@ -877,8 +877,6 @@ define(function (require, exports, module) {
         
         describe("JS Editing", function () {
             
-            this.category = "livepreview";
-
             it("should reload the page when editing a non-live document", function () {
                 var promise,
                     jsdoc,
@@ -943,6 +941,9 @@ define(function (require, exports, module) {
     });
 
     describe("Servers", function () {
+
+        this.category = "livepreview";
+
         // Define testing parameters, files do not need to exist on disk
         // File paths used in tests:
         //  * file1 - file inside  project
@@ -1039,8 +1040,6 @@ define(function (require, exports, module) {
         }
 
         describe("Find static page for Live Development", function () {
-
-            this.category = "livepreview";
 
             it("should return the same HTML document like the currently open document", function () {
                 var promise,
@@ -1214,8 +1213,6 @@ define(function (require, exports, module) {
         });
 
         describe("Find dynamic page for Live Development", function () {
-
-            this.category = "livepreview";
 
             it("should return the same index.php document like the currently opened document", function () {
                 var promise,

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -46,6 +46,8 @@ define(function (require, exports, module) {
     
     describe("Node Connection", function () {
 
+        this.category = "livepreview";
+
         var _connectionsToAutoDisconnect = null;
         
         function createConnection() {


### PR DESCRIPTION
Make **Unit** test category of tests faster by removing suites that do not belong:
- Default HTML Document -- opens test windows
- Node Connection -- runs 30 second async test

Instead of adding them to the **Integration** test category and making it even less likely to pass "All", I created a new **Live Preview** test category.
