### PR TITLE
Add gitattributes exeption for *.sh files for unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+#make sure that .sh files in the tools are unix-ending
+tools/*.sh text eol=lf


### PR DESCRIPTION
To use tools/*.sh scripts you first have to fix the line endings of these files. Fix that.
