### PR TITLE
Disallow file and folder names that end with dots

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -65,7 +65,7 @@ define({
     "ERROR_DELETING_FILE_TITLE"         : "Error deleting file",
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the file <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid {0}",
-    "INVALID_FILENAME_MESSAGE"          : "{0} cannot contain the following characters: {1}, use any system reserved words or end with dots (.).",
+    "INVALID_FILENAME_MESSAGE"          : "{0} cannot use any system reserved words, end with dots (.) or use any of the following characters: <code class='emphasized'>{1}</code>",
     "ENTRY_WITH_SAME_NAME_EXISTS"       : "A file or directory with the name <span class='dialog-filename'>{0}</span> already exists.",
     "ERROR_CREATING_FILE_TITLE"         : "Error creating {0}",
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -40,6 +40,11 @@ define({
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",
+    "DIRECTORY_NAMES_LEDE"              : "Directory names",
+    "FILENAMES_LEDE"                    : "Filenames",
+    "FILENAME"                          : "filename",
+    "DIRECTORY_NAME"                    : "directory name",
+    
 
     // Project error strings
     "ERROR_LOADING_PROJECT"             : "Error loading project",
@@ -59,9 +64,9 @@ define({
     "ERROR_RENAMING_FILE"               : "An error occurred when trying to rename the file <span class='dialog-filename'>{0}</span>. {1}",
     "ERROR_DELETING_FILE_TITLE"         : "Error deleting file",
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the file <span class='dialog-filename'>{0}</span>. {1}",
-    "INVALID_FILENAME_TITLE"            : "Invalid {0} name",
-    "INVALID_FILENAME_MESSAGE"          : "Filenames cannot contain the following characters: {0} or use any system reserved words.",
-    "FILE_ALREADY_EXISTS"               : "The {0} <span class='dialog-filename'>{1}</span> already exists.",
+    "INVALID_FILENAME_TITLE"            : "Invalid {0}",
+    "INVALID_FILENAME_MESSAGE"          : "{0} cannot contain the following characters: {1}, use any system reserved words or end with dots (.).",
+    "ENTRY_WITH_SAME_NAME_EXISTS"       : "A file or directory with the name <span class='dialog-filename'>{0}</span> already exists.",
     "ERROR_CREATING_FILE_TITLE"         : "Error creating {0}",
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1530,8 +1530,8 @@ define(function (require, exports, module) {
                 filename.match(_illegalFilenamesRegEx)) {
             Dialogs.showModalDialog(
                 DefaultDialogs.DIALOG_ID_ERROR,
-                StringUtils.format(Strings.INVALID_FILENAME_TITLE, isFolder ? Strings.DIRECTORY : Strings.FILE),
-                StringUtils.format(Strings.INVALID_FILENAME_MESSAGE, _invalidChars)
+                StringUtils.format(Strings.INVALID_FILENAME_TITLE, isFolder ? Strings.DIRECTORY_NAME : Strings.FILENAME),
+                StringUtils.format(Strings.INVALID_FILENAME_MESSAGE, isFolder ? Strings.DIRECTORY_NAMES_LEDE : Strings.FILENAMES_LEDE,  _invalidChars)
             );
             return false;
         }
@@ -1658,15 +1658,13 @@ define(function (require, exports, module) {
                 };
                 
                 var errorCallback = function (error, entry) {
-                    var entryType = isFolder ? Strings.DIRECTORY : Strings.FILE,
-                        oppositeEntryType = isFolder ? Strings.FILE : Strings.DIRECTORY;
+                    var titleType = isFolder ? Strings.DIRECTORY_NAME : Strings.FILENAME,
+                        entryType = isFolder ? Strings.DIRECTORY : Strings.FILE;
                     if (error === FileSystemError.ALREADY_EXISTS) {
-                        var useOppositeType = (isFolder === entry.isFile);
                         Dialogs.showModalDialog(
                             DefaultDialogs.DIALOG_ID_ERROR,
-                            StringUtils.format(Strings.INVALID_FILENAME_TITLE, entryType),
-                            StringUtils.format(Strings.FILE_ALREADY_EXISTS,
-                                useOppositeType ? oppositeEntryType : entryType,
+                            StringUtils.format(Strings.INVALID_FILENAME_TITLE, titleType),
+                            StringUtils.format(Strings.ENTRY_WITH_SAME_NAME_EXISTS, 
                                 StringUtils.breakableUrl(data.rslt.name))
                         );
                     } else {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1664,7 +1664,7 @@ define(function (require, exports, module) {
                         Dialogs.showModalDialog(
                             DefaultDialogs.DIALOG_ID_ERROR,
                             StringUtils.format(Strings.INVALID_FILENAME_TITLE, titleType),
-                            StringUtils.format(Strings.ENTRY_WITH_SAME_NAME_EXISTS, 
+                            StringUtils.format(Strings.ENTRY_WITH_SAME_NAME_EXISTS,
                                 StringUtils.breakableUrl(data.rslt.name))
                         );
                     } else {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -185,7 +185,8 @@ define(function (require, exports, module) {
      * RegEx to validate if a filename is not allowed even if the system allows it.
      * This is done to prevent cross-platform issues.
      */
-    var _illegalFilenamesRegEx = /^(\.+|com[1-9]|lpt[1-9]|nul|con|prn|aux)$/i;
+            
+    var _illegalFilenamesRegEx = /^(\.+|com[1-9]|lpt[1-9]|nul|con|prn|aux|)$|\.+$/i;
     
     var suppressToggleOpen = false;
     

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1551,3 +1551,8 @@ label input {
         transform: scale(1);
     }
 }
+
+.emphasized {
+    font-weight: 900;
+    font-size: 1.01em;
+}


### PR DESCRIPTION
Fixes:
#5468 (although I was never able to entire reproduce this case)
#7224

This will allow for the user to create dots at the end of a file or directory name using the OS (finder/explorer) and Brackets will honor those but, because of the complexities of how the OS treats trailing dots in entity names, we disallow the user from creating entities that end with dots.

This is not for Sprint 39 
