### PR TITLE
More specific error message when non-UTF-8 files opened

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -160,6 +160,8 @@ define(function (require, exports, module) {
             result = Strings.NO_MODIFICATION_ALLOWED_ERR_FILE;
         } else if (name === FileSystemError.CONTENTS_MODIFIED) {
             result = Strings.CONTENTS_MODIFIED_ERR;
+        } else if (name === FileSystemError.UNSUPPORTED_ENCODING) {
+            result = Strings.UNSUPPORTED_ENCODING_ERR;
         } else {
             result = StringUtils.format(Strings.GENERIC_ERROR, name);
         }

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         INVALID_PARAMS              : "InvalidParams",
         NOT_FOUND                   : "NotFound",
         NOT_READABLE                : "NotReadable",
+        UNSUPPORTED_ENCODING        : "UnsupportedEncoding",
         NOT_SUPPORTED               : "NotSupported",
         NOT_WRITABLE                : "NotWritable",
         OUT_OF_SPACE                : "OutOfSpace",

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
         case appshell.fs.ERR_CANT_WRITE:
             return FileSystemError.NOT_WRITABLE;
         case appshell.fs.ERR_UNSUPPORTED_ENCODING:
-            return FileSystemError.NOT_READABLE;
+            return FileSystemError.UNSUPPORTED_ENCODING;
         case appshell.fs.ERR_OUT_OF_SPACE:
             return FileSystemError.OUT_OF_SPACE;
         case appshell.fs.ERR_FILE_EXISTS:

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -37,6 +37,7 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
+    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",


### PR DESCRIPTION
Give a more specific error message in cases where Brackets refuses to open a file that is not UTF-8 (message is also shown when trying to open binary files).

The right error code is already returned from the native shell -- we just need to plumb it down to FileSystem and add a case-specific string for it.

I haven't tested this on Mac but I think this will give us the same benefit there too -- it looks like the same brackets.fs-level encoding error code is returned in the right cases there already. But if not, it's not critical since Mac has always refused to open UTF-8 (whereas for Win it's a new and potentially confusing behavior).
