### PR TITLE
Fix UpdateNotification.Locale Fallback tests

### DIFF
--- a/test/spec/UpdateNotification-test.js
+++ b/test/spec/UpdateNotification-test.js
@@ -218,13 +218,16 @@ define(function (require, exports, module) {
 
             function setupAjaxSpy(defaultUpdateUrl) {
                 var jq = spyOn(testWindow.$, "ajax").andCallFake(function (req) {
-                    var d = $.Deferred();
+                    var d = new $.Deferred();
 
-                    if (req.url === defaultUpdateUrl) {
-                        d.resolve(expectedResult);
-                    } else {
-                        d.reject();
-                    }
+                    testWindow.setTimeout(function () {
+                        if (req.url === defaultUpdateUrl) {
+                            d.resolve(expectedResult);
+                        } else {
+                            d.reject();
+                        }
+                    }, 75);
+                    // we need to set a timeout in order to emulate the async behavior of $.ajax
 
                     return d.promise();
                 });
@@ -235,8 +238,8 @@ define(function (require, exports, module) {
 
                 setupAjaxSpy(defaultUpdateUrl);
 
-                // pretend that we are using the italian locale and we don't have a translation for the update notification
-                spyOn(testWindow.brackets, "getLocale").andReturn("de-ch");
+                // pretend that we are using the German (Switzerland) locale and we don't have a translation for the update notification
+                spyOn(testWindow.brackets, "getLocale").andReturn("de-CH");
 
                 runs(function () {
                     var promise = UpdateNotification.checkForUpdate(true, updateInfo);
@@ -254,7 +257,7 @@ define(function (require, exports, module) {
 
                 setupAjaxSpy(defaultUpdateUrl);
 
-                // pretend that we are using the italian locale and we don't have a translation for the update notification
+                // pretend that we are using the Italian locale and we don't have a translation for the update notification
                 spyOn(testWindow.brackets, "getLocale").andReturn("it");
 
                 runs(function () {


### PR DESCRIPTION
As explained in #7811, the tests for that particular feature are succeeding right now while they shouldn't.
This fixes it - they'll fail right now on master, but as soon as release is merged back into master (including b325668), they'll work again.
@ingorichter
