### PR TITLE
Add timeout to animation callback

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1434,7 +1434,7 @@ define(function (require, exports, module) {
             // Set up the widget to start closed, then animate open when its initial height is set.
             inlineWidget.$htmlContent.height(0);
             AnimationUtils.animateUsingClass(inlineWidget.htmlContent, "animating")
-                .always(function () {
+                .done(function () {
                     deferred.resolve();
                 });
 
@@ -1487,7 +1487,7 @@ define(function (require, exports, module) {
             // back to the editor.)
             if (self.isFullyVisible()) {
                 AnimationUtils.animateUsingClass(inlineWidget.htmlContent, "animating")
-                    .always(finishRemoving);
+                    .done(finishRemoving);
                 inlineWidget.$htmlContent.height(0);
             } else {
                 finishRemoving();
@@ -1679,7 +1679,7 @@ define(function (require, exports, module) {
         _addListeners();
 
         // Animate open
-        AnimationUtils.animateUsingClass(this._$messagePopover[0], "animateOpen").always(function () {
+        AnimationUtils.animateUsingClass(this._$messagePopover[0], "animateOpen").done(function () {
             // Make sure we still have a popover
             if (self._$messagePopover && self._$messagePopover.length > 0) {
                 self._$messagePopover.addClass("open");
@@ -1690,7 +1690,7 @@ define(function (require, exports, module) {
 
                 // Animate closed -- which includes delay to show message
                 AnimationUtils.animateUsingClass(self._$messagePopover[0], "animateClose", 600)
-                    .always(_removeMessagePopover);
+                    .done(_removeMessagePopover);
             }
         });
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1434,7 +1434,7 @@ define(function (require, exports, module) {
             // Set up the widget to start closed, then animate open when its initial height is set.
             inlineWidget.$htmlContent.height(0);
             AnimationUtils.animateUsingClass(inlineWidget.htmlContent, "animating")
-                .done(function () {
+                .always(function () {
                     deferred.resolve();
                 });
 
@@ -1487,7 +1487,7 @@ define(function (require, exports, module) {
             // back to the editor.)
             if (self.isFullyVisible()) {
                 AnimationUtils.animateUsingClass(inlineWidget.htmlContent, "animating")
-                    .done(finishRemoving);
+                    .always(finishRemoving);
                 inlineWidget.$htmlContent.height(0);
             } else {
                 finishRemoving();
@@ -1679,7 +1679,7 @@ define(function (require, exports, module) {
         _addListeners();
 
         // Animate open
-        AnimationUtils.animateUsingClass(this._$messagePopover[0], "animateOpen").done(function () {
+        AnimationUtils.animateUsingClass(this._$messagePopover[0], "animateOpen").always(function () {
             // Make sure we still have a popover
             if (self._$messagePopover && self._$messagePopover.length > 0) {
                 self._$messagePopover.addClass("open");
@@ -1689,8 +1689,8 @@ define(function (require, exports, module) {
                 $(self).on("scroll.msgbox", _removeMessagePopover);
 
                 // Animate closed -- which includes delay to show message
-                AnimationUtils.animateUsingClass(self._$messagePopover[0], "animateClose")
-                    .done(_removeMessagePopover);
+                AnimationUtils.animateUsingClass(self._$messagePopover[0], "animateClose", 600)
+                    .always(_removeMessagePopover);
             }
         });
     };

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -204,7 +204,7 @@ define(function (require, exports, module) {
         $statusOverwrite.text(newstate ? Strings.STATUSBAR_OVERWRITE : Strings.STATUSBAR_INSERT);
 
         if (!doNotAnimate) {
-            AnimationUtils.animateUsingClass($statusOverwrite[0], "flash");
+            AnimationUtils.animateUsingClass($statusOverwrite[0], "flash", 1500);
         }
     }
 

--- a/src/extensions/default/DebugCommands/ErrorNotification.js
+++ b/src/extensions/default/DebugCommands/ErrorNotification.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
     }
 
     var blink = _.debounce(function () {
-        AnimationUtils.animateUsingClass($span.parent()[0], "flash");
+        AnimationUtils.animateUsingClass($span.parent()[0], "flash", 1500);
     }, 100);
 
     function incErrorCount() {

--- a/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
@@ -266,8 +266,8 @@ define(function (require, exports, module) {
             hint.elem.css("display", "block");
         } else if (hint.shown) {
             hint.animationInProgress = true;
-            AnimationUtils.animateUsingClass(hint.elem[0], "fadeout")
-                .done(function () {
+            AnimationUtils.animateUsingClass(hint.elem[0], "fadeout", 750)
+                .always(function () {
                     if (hint.animationInProgress) { // do this only if the animation was not cancelled
                         hint.elem.hide();
                     }

--- a/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
@@ -267,7 +267,7 @@ define(function (require, exports, module) {
         } else if (hint.shown) {
             hint.animationInProgress = true;
             AnimationUtils.animateUsingClass(hint.elem[0], "fadeout", 750)
-                .always(function () {
+                .done(function () {
                     if (hint.animationInProgress) { // do this only if the animation was not cancelled
                         hint.elem.hide();
                     }

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
      * @param {Element} target The DOM node to animate.
      * @param {string} animClass The class that applies the animation/transition to the target.
      * @param {number} timeoutDuration Time to wait in ms before rejecting promise
-     * @return {$.Promise} A promise that is resolved when the animation completes. Never rejected.
+     * @return {$.Promise} A promise that is resolved if the animation completes,
+     *                     otherwise it times out and is rejected.
      */
     function animateUsingClass(target, animClass, timeoutDuration) {
         var result  = new $.Deferred(),

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -41,8 +41,7 @@ define(function (require, exports, module) {
      * @param {Element} target The DOM node to animate.
      * @param {string} animClass The class that applies the animation/transition to the target.
      * @param {number=} timeoutDuration Time to wait in ms before rejecting promise. Default is 400.
-     * @return {$.Promise} A promise that is resolved if the animation completes,
-     *                     otherwise it times out and is rejected.
+     * @return {$.Promise} A promise that is resolved when the animation completes. Never rejected.
      */
     function animateUsingClass(target, animClass, timeoutDuration) {
         var result  = new $.Deferred(),
@@ -72,7 +71,7 @@ define(function (require, exports, module) {
         }
         
         // Use timeout in case transition end event is not sent
-        return Async.withTimeout(result.promise(), timeoutDuration);
+        return Async.withTimeout(result.promise(), timeoutDuration, true);
     }
     
     exports.animateUsingClass = animateUsingClass;

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
      *
      * @param {Element} target The DOM node to animate.
      * @param {string} animClass The class that applies the animation/transition to the target.
-     * @param {number} timeoutDuration Time to wait in ms before rejecting promise
+     * @param {number=} timeoutDuration Time to wait in ms before rejecting promise. Default is 400.
      * @return {$.Promise} A promise that is resolved if the animation completes,
      *                     otherwise it times out and is rejected.
      */

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         var result  = new $.Deferred(),
             $target = $(target);
         
-        timeoutDuration = timeoutDuration || 1000;
+        timeoutDuration = timeoutDuration || 400;
         
         function finish(e) {
             if (e.target === target) {

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
      *
      * @param {Element} target The DOM node to animate.
      * @param {string} animClass The class that applies the animation/transition to the target.
+     * @param {number} timeoutDuration Time to wait in ms before rejecting promise
      * @return {$.Promise} A promise that is resolved when the animation completes. Never rejected.
      */
     function animateUsingClass(target, animClass, timeoutDuration) {
@@ -67,13 +68,10 @@ define(function (require, exports, module) {
             $target
                 .addClass(animClass)
                 .on("webkitTransitionEnd", finish);
-            
-            // Use timeout in case transition never ends
-            Async.withTimeout(result.promise(), timeoutDuration)
-                .fail(result.reject);
         }
         
-        return result.promise();
+        // Use timeout in case transition end event is not sent
+        return Async.withTimeout(result.promise(), timeoutDuration);
     }
     
     exports.animateUsingClass = animateUsingClass;

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -31,6 +31,8 @@
 define(function (require, exports, module) {
     "use strict";
     
+    var Async   = require("utils/Async");
+    
     /**
      * Start an animation by adding the given class to the given target. When the
      * animation is complete, removes the class, clears the event handler we attach
@@ -40,9 +42,11 @@ define(function (require, exports, module) {
      * @param {string} animClass The class that applies the animation/transition to the target.
      * @return {$.Promise} A promise that is resolved when the animation completes. Never rejected.
      */
-    function animateUsingClass(target, animClass) {
+    function animateUsingClass(target, animClass, timeoutDuration) {
         var result  = new $.Deferred(),
             $target = $(target);
+        
+        timeoutDuration = timeoutDuration || 1000;
         
         function finish(e) {
             if (e.target === target) {
@@ -63,6 +67,10 @@ define(function (require, exports, module) {
             $target
                 .addClass(animClass)
                 .on("webkitTransitionEnd", finish);
+            
+            // Use timeout in case transition never ends
+            Async.withTimeout(result.promise(), timeoutDuration)
+                .fail(result.reject);
         }
         
         return result.promise();

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -285,23 +285,28 @@ define(function (require, exports, module) {
     var ERROR_TIMEOUT = {};
     
     /**
-     * Adds timeout-driven failure to a Promise: returns a new Promise that is resolved/rejected when
-     * the given original Promise is resolved/rejected, OR is rejected after the given delay - whichever
-     * happens first.
+     * Adds timeout-driven termination to a Promise: returns a new Promise that is resolved/rejected when
+     * the given original Promise is resolved/rejected, OR is resolved/rejected after the given delay -
+     * whichever happens first.
      * 
      * If the original Promise is resolved/rejected first, done()/fail() handlers receive arguments
-     * piped from the original Promise. If the timeout occurs first instead, fail() is called with the
-     * token Async.ERROR_TIMEOUT.
+     * piped from the original Promise. If the timeout occurs first instead, then resolve() or
+     * fail() (with Async.ERROR_TIMEOUT) is called based on value of resolveTimeout.
      * 
      * @param {$.Promise} promise
      * @param {number} timeout
+     * @param {boolean=} resolveTimeout If true, then resolve deferred on timeout, otherwise reject. Default is false.
      * @return {$.Promise}
      */
-    function withTimeout(promise, timeout) {
+    function withTimeout(promise, timeout, resolveTimeout) {
         var wrapper = new $.Deferred();
         
         var timer = window.setTimeout(function () {
-            wrapper.reject(ERROR_TIMEOUT);
+            if (resolveTimeout) {
+                wrapper.resolve();
+            } else {
+                wrapper.reject(ERROR_TIMEOUT);
+            }
         }, timeout);
         promise.always(function () {
             window.clearTimeout(timer);

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -219,7 +219,6 @@ define(function (require, exports, module) {
         if (animate) {
             AnimationUtils.animateUsingClass(this._$root.get(0), "offscreen")
                 .done(doRemove);
-
         } else {
             doRemove();
         }

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -218,7 +218,8 @@ define(function (require, exports, module) {
         
         if (animate) {
             AnimationUtils.animateUsingClass(this._$root.get(0), "offscreen")
-                .done(doRemove);
+                .always(doRemove);
+
         } else {
             doRemove();
         }

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -218,7 +218,7 @@ define(function (require, exports, module) {
         
         if (animate) {
             AnimationUtils.animateUsingClass(this._$root.get(0), "offscreen")
-                .always(doRemove);
+                .done(doRemove);
 
         } else {
             doRemove();


### PR DESCRIPTION
This is for CEF 1750 issue #7689 

I haven't figured out why we not getting `webkitTransitionEnd` (or `transitionEnd`) event in CEF 1750 branch for these integration tests, but it seems like a good idea to add a timeout to `AnimateUtils.animateUsingClass()` callback, anyway.

cc @njx @JeffryBooher 
