### PR TITLE
Added ClojureScript and cljx extensions to clojure fileExtensions

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -148,7 +148,7 @@
     "clojure": {
         "name": "Clojure",
         "mode": "clojure",
-        "fileExtensions": ["clj"],
+        "fileExtensions": ["clj", "cljs", "cljx"],
         "lineComment": [";", ";;"]
     },
 


### PR DESCRIPTION
[ClojureScript](https://github.com/clojure/clojurescript/) is a Clojure implementation targeting JavaScript. [cljx](https://github.com/lynaghk/cljx) helps write Clojure/ClojureScript portable projects.
Both are very common and should probably be recognized out-of-the-box by Brackets.
