### PR TITLE
Decrease the green update count when an extension was marked for update

### DIFF
--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -439,7 +439,7 @@ define(function (require, exports, module) {
         var self = this;
         this.notifyCount = 0;
         this.sortedFullSet.forEach(function (key) {
-            if (self.extensions[key].installInfo.updateCompatible) {
+            if (self.extensions[key].installInfo.updateCompatible && !ExtensionManager.isMarkedForUpdate(key)) {
                 self.notifyCount++;
             }
         });


### PR DESCRIPTION
This fixes #7849.
The update count will decrease whenever you mark an extension for update.
