### PR TITLE
Allow nested parens in the property value context

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -84,6 +84,19 @@ define(function (require, exports, module) {
      * @return {boolean} true if the context is in property value
      */
     function _isInPropValue(ctx) {
+        
+        function isInsideParens(context) {
+            if (context.type !== "parens" || !context.prev) {
+                return false;
+            }
+                                                             
+            if (context.prev.type === "prop") {
+                return true;
+            }
+            
+            return isInsideParen(context.prev);
+        }
+        
         var state;
         if (!ctx || !ctx.token || !ctx.token.state || ctx.token.type === "comment") {
             return false;
@@ -96,7 +109,7 @@ define(function (require, exports, module) {
         }
         return ((state.context.type === "prop" &&
                     (state.context.prev.type === "rule" || state.context.prev.type === "block")) ||
-                    (state.context.type === "parens" && state.context.prev.type === "prop"));
+                    isInsideParens(state.context));
     }
     
     /**

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
                 return true;
             }
             
-            return isInsideParen(context.prev);
+            return isInsideParens(context.prev);
         }
         
         var state;


### PR DESCRIPTION
This is a fix for CodeMirror changes that provide nested parens in token context which in turn break a "CSS Context Info" unit test.
