### PR TITLE
Remove `brackets.app.abortQuit` checks

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1280,10 +1280,7 @@ define(function (require, exports, module) {
             },
             function () {
                 // if fail, tell the app to abort any pending quit operation.
-                // TODO: remove this if statement when we move to the new CEF3 shell
-                if (brackets.app.abortQuit) {
-                    brackets.app.abortQuit();
-                }
+                brackets.app.abortQuit();
             }
         );
     }
@@ -1311,10 +1308,7 @@ define(function (require, exports, module) {
             },
             function () {
                 // if fail, don't exit: user canceled (or asked us to save changes first, but we failed to do so)
-                // TODO: remove this if statement when we move to the new CEF3 shell
-                if (brackets.app.abortQuit) {
-                    brackets.app.abortQuit();
-                }
+                brackets.app.abortQuit();
             }
         );
     }


### PR DESCRIPTION
Removes the two year old `brackets.app.abortQuit` checks added before the switch to the CEF3 shell. Fixes #7883.
