### PR TITLE
Disable code hints when multiple selections are active

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -454,8 +454,7 @@ define(function (require, exports, module) {
      */
     _beginSession = function (editor) {
         // Don't start a session if we have a multiple selection.
-        var selection = editor.getSelections();
-        if (selection.length > 1) {
+        if (editor.getSelections().length > 1) {
             return;
         }
         
@@ -575,8 +574,7 @@ define(function (require, exports, module) {
      */
     function _handleCursorActivity(jqEvent, editor) {
         if (_inSession(editor)) {
-            var selection = editor.getSelections();
-            if (selection.length > 1) {
+            if (editor.getSelections().length > 1) {
                 _endSession();
             }
         }

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -453,6 +453,12 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      */
     _beginSession = function (editor) {
+        // Don't start a session if we have a multiple selection.
+        var selection = editor.getSelections();
+        if (selection.length > 1) {
+            return;
+        }
+        
         // Find a suitable provider, if any
         var language = editor.getLanguageForSelection(),
             enabledProviders = _getProvidersForLanguageId(language.getId());
@@ -560,6 +566,21 @@ define(function (require, exports, module) {
             }
         }
     }
+    
+    /**
+     * Handle a selection change event in the editor. If the selection becomes a
+     * multiple selection, end our current session.
+     * @param {Event} jqEvent
+     * @param {Editor} editor
+     */
+    function _handleCursorActivity(jqEvent, editor) {
+        if (_inSession(editor)) {
+            var selection = editor.getSelections();
+            if (selection.length > 1) {
+                _endSession();
+            }
+        }
+    }
 
     /**
      * Start a new implicit hinting session, or update the existing hint list.
@@ -640,6 +661,7 @@ define(function (require, exports, module) {
             $(current).on("keydown",  _handleKeydownEvent);
             $(current).on("keypress", _handleKeypressEvent);
             $(current).on("keyup",    _handleKeyupEvent);
+            $(current).on("cursorActivity", _handleCursorActivity);
         }
 
         if (previous) {
@@ -648,6 +670,7 @@ define(function (require, exports, module) {
             $(previous).off("keydown",  _handleKeydownEvent);
             $(previous).off("keypress", _handleKeypressEvent);
             $(previous).off("keyup",    _handleKeyupEvent);
+            $(previous).off("cursorActivity", _handleCursorActivity);
         }
     }
 

--- a/test/spec/CodeHint-test-files/test1.html
+++ b/test/spec/CodeHint-test-files/test1.html
@@ -2,5 +2,6 @@
 <html>
 <body>
 <
+<
 </body>
 </html>

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -48,7 +48,8 @@ define(function (require, exports, module) {
          * Performs setup for a code hint test. Opens a file and set pos.
          * 
          * @param {!string} openFile Project relative file path to open in a main editor.
-         * @param {!number} openPos The pos within openFile to place the IP.
+         * @param {!number|Array} openPos The pos within openFile to place the IP, or an array
+         *      representing a multiple selection to set.
          */
         function initCodeHintTest(openFile, openPos) {
             SpecRunnerUtils.loadProjectInTestWindow(testPath);
@@ -60,7 +61,11 @@ define(function (require, exports, module) {
             
             runs(function () {
                 var editor = EditorManager.getCurrentFullEditor();
-                editor.setCursorPos(openPos.line, openPos.ch);
+                if (Array.isArray(openPos)) {
+                    editor.setSelections(openPos);
+                } else {
+                    editor.setCursorPos(openPos.line, openPos.ch);
+                }
             });
         }
         
@@ -230,6 +235,42 @@ define(function (require, exports, module) {
                     expectNoHints();
 
                     editor = null;
+                });
+            });
+            
+            it("should not show code hints if there is a multiple selection", function () {
+                // minimal markup with an open '<' before IP
+                // Note: line for pos is 0-based and editor lines numbers are 1-based
+                initCodeHintTest("test1.html", [
+                    {start: {line: 3, ch: 1}, end: {line: 3, ch: 1}, primary: true},
+                    {start: {line: 4, ch: 1}, end: {line: 4, ch: 1}}
+                ]);
+
+                runs(function () {
+                    invokeCodeHints();
+                    expectNoHints();
+                });
+            });
+
+            it("should dismiss existing code hints if selection changes to a multiple selection", function () {
+                var editor;
+
+                initCodeHintTest("test1.html", {line: 3, ch: 1});
+
+                runs(function () {
+                    editor = EditorManager.getCurrentFullEditor();
+                    expect(editor).toBeTruthy();
+
+                    invokeCodeHints();
+                    expectSomeHints();
+                });
+                
+                runs(function () {
+                    editor.setSelections([
+                        {start: {line: 3, ch: 1}, end: {line: 3, ch: 1}, primary: true},
+                        {start: {line: 4, ch: 1}, end: {line: 4, ch: 1}}
+                    ]);
+                    expectNoHints();
                 });
             });
 


### PR DESCRIPTION
This is a short-term workaround for #7625.

Currently, if multiple selections are active, code hints appear at the primary selection. That seems okay, but if you then choose a hint, we only insert it at the primary selection. This feels broken, because it's a typing/insertion operation, so the user would expect it to insert at all selections. I've run into this many times myself.

I've added https://trello.com/c/F567vo1F to Nominations for making code hints actually work with multiple selections.
