### PR TITLE
updated wording of UTF-8 file load error.

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -37,7 +37,7 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
-    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text. Brackets currently only supports UTF-8 encoded text files.",
+    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text. {APP_NAME} currently only supports UTF-8 encoded text files.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -37,7 +37,7 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
-    "UNSUPPORTED_ENCODING_ERR"          : "Brackets currently only supports UTF-8 encoded text files.",
+    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text. Brackets currently only supports UTF-8 encoded text files.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -37,7 +37,7 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
-    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text. {APP_NAME} currently only supports UTF-8 encoded text files.",
+    "UNSUPPORTED_ENCODING_ERR"          : "{APP_NAME} currently only supports UTF-8 encoded text files.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -37,7 +37,7 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
-    "UNSUPPORTED_ENCODING_ERR"          : "The file is not UTF-8 encoded text.",
+    "UNSUPPORTED_ENCODING_ERR"          : "Brackets currently only supports UTF-8 encoded text files.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "DIRECTORY"                         : "directory",


### PR DESCRIPTION
addresses Issue #7850
When opening a non UTF-8 file, the second and third sentences of the error message will now read: "The file is not UTF-8 encoded text. Brackets currently only supports UTF-8 encoded text files."
