### PR TITLE
Addresses #1976 by implementing 2nd click to rename in the project tree

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -644,6 +644,7 @@ define(function (require, exports, module) {
                     var $treenode = $(event.target).closest("li");
                     // select tree node on right-click
                     if (event.which === 3 || (event.ctrlKey && event.which === 1 && brackets.platform === "mac")) {
+                        console.log('IF, not else!');
                         if ($treenode) {
                             var saveSuppressToggleOpen = suppressToggleOpen;
                            
@@ -653,14 +654,17 @@ define(function (require, exports, module) {
                             _projectTree.jstree("select_node", $treenode, false);
                             suppressToggleOpen = saveSuppressToggleOpen;
                         }
-                    } else {
-                        // if it's not a right click interaction first check to see if the item is selected
-                        var isSelected = $treenode.hasClass("jstree-leaf") && $treenode.children("a").hasClass("jstree-clicked");
-                        if (isSelected) {
-                            CommandManager.execute(Commands.FILE_RENAME);
-                        }
                     }
                    
+                }
+            ).bind(
+                "mouseup.jstree",
+                function (event) {
+                    var $treenode = $(event.target).closest("li");
+                    var isSelected = $treenode.hasClass("jstree-leaf") && $treenode.children("a").hasClass("jstree-clicked");
+                    if (isSelected) {
+                        CommandManager.execute(Commands.FILE_RENAME);
+                    }
                 }
             );
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -670,8 +670,8 @@ define(function (require, exports, module) {
                 "mouseup.jstree",
                 function (event) {
                     var treenode = $(event.target).closest("li");
-                    // How long do we wait for the long press. OS X testing seemed to imply 2 seconds
-                    var longPressThreshhold = 200;
+                    // Guess (based on eye-test) for Mac and Win length of a long press before the rename input show sup.
+                    var longPressThreshhold = 250;
                     
                     // Check to make sure the event is happening on the selected item
                     if ($(treenode)[0] === $(_lastSelected)[0]) {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -208,6 +208,14 @@ define(function (require, exports, module) {
     
     /**
      * @private
+     * @type {Number}
+     * Tracks the last mouseup event in the project tree to test whether an 
+     * event is a doubleclick or not.
+     */
+    var _lastMouseup;
+    
+    /**
+     * @private
      * Generates the prefixes used for sorting the files in the project tree
      * @return {boolean} true if the sort prefixes have changed
      */
@@ -641,32 +649,31 @@ define(function (require, exports, module) {
             ).bind(
                 "mousedown.jstree",
                 function (event) {
-                    var $treenode = $(event.target).closest("li");
                     // select tree node on right-click
                     if (event.which === 3 || (event.ctrlKey && event.which === 1 && brackets.platform === "mac")) {
-                        console.log('IF, not else!');
-                        if ($treenode) {
+                        var treenode = $(event.target).closest("li");
+                        if (treenode) {
                             var saveSuppressToggleOpen = suppressToggleOpen;
-                           
+                            
                             // don't toggle open folders (just select)
                             suppressToggleOpen = true;
                             _projectTree.jstree("deselect_all");
-                            _projectTree.jstree("select_node", $treenode, false);
+                            _projectTree.jstree("select_node", treenode, false);
                             suppressToggleOpen = saveSuppressToggleOpen;
                         }
                     }
-                   
                 }
-            ).bind(
-                "mouseup.jstree",
-                function (event) {
+            ).bind("mouseup.jstree", function (event) {
+                // check to see if this is a doubleclick event
+                if (event.timeStamp - _lastMouseup > 500) {
                     var $treenode = $(event.target).closest("li");
                     var isSelected = $treenode.hasClass("jstree-leaf") && $treenode.children("a").hasClass("jstree-clicked");
                     if (isSelected) {
                         CommandManager.execute(Commands.FILE_RENAME);
                     }
                 }
-            );
+                _lastMouseup = event.timeStamp;
+            });
 
         // jstree has a default event handler for dblclick that attempts to clear the
         // global window selection (presumably because it doesn't want text within the tree

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -664,7 +664,7 @@ define(function (require, exports, module) {
                 }
             ).bind("mouseup.jstree", function (event) {
                 var $treenode = $(event.target).closest("li");
-                if ($treenode[0] === $(_projectTree.jstree("get_selected")).closest("li")[0]) {
+                if ($treenode.is($(_projectTree.jstree("get_selected")))) {
                     // wrap this in a setTimeout function so that we can check if it's a double click.
                     _mouseupTimeoutId = window.setTimeout(function (event) {
                         // if we get a double-click,_mouseupTimeoutId will have been set to lull by the double-click handler before this runs.
@@ -737,8 +737,9 @@ define(function (require, exports, module) {
                     }
                     if (_mouseupTimeoutId !== null) {
                         window.clearTimeout(_mouseupTimeoutId);
+                        _mouseupTimeoutId = null;
                     }
-                    _mouseupTimeoutId = null;
+                    
                 });
 
             // fire selection changed events for sidebar-selection

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -208,13 +208,6 @@ define(function (require, exports, module) {
     
     /**
      * @private
-     * @type {number}
-     * Timestamp of the last mousedown event. For tracking long presses.
-     */
-    var _mousedownTimestamp;
-    
-    /**
-     * @private
      * Generates the prefixes used for sorting the files in the project tree
      * @return {boolean} true if the sort prefixes have changed
      */
@@ -648,38 +641,26 @@ define(function (require, exports, module) {
             ).bind(
                 "mousedown.jstree",
                 function (event) {
-                    // Track the mousedown time
-                    _mousedownTimestamp = event.timeStamp;
-                    
+                    var $treenode = $(event.target).closest("li");
                     // select tree node on right-click
                     if (event.which === 3 || (event.ctrlKey && event.which === 1 && brackets.platform === "mac")) {
-                        var treenode = $(event.target).closest("li");
-                        if (treenode) {
+                        if ($treenode) {
                             var saveSuppressToggleOpen = suppressToggleOpen;
                            
                             // don't toggle open folders (just select)
                             suppressToggleOpen = true;
                             _projectTree.jstree("deselect_all");
-                            _projectTree.jstree("select_node", treenode, false);
+                            _projectTree.jstree("select_node", $treenode, false);
                             suppressToggleOpen = saveSuppressToggleOpen;
                         }
-                    }
-                   
-                }
-            ).bind(
-                "mouseup.jstree",
-                function (event) {
-                    var treenode = $(event.target).closest("li");
-                    // Guess (based on eye-test) for Mac and Win length of a long press before the rename input show sup.
-                    var longPressThreshhold = 250;
-                    
-                    // Check to make sure the event is happening on the selected item
-                    if ($(treenode)[0] === $(_lastSelected)[0]) {
-                        var pressLength = event.timeStamp - _mousedownTimestamp;
-                        if (pressLength >= longPressThreshhold) {
+                    } else {
+                        // if it's not a right click interaction first check to see if the item is selected
+                        var isSelected = $treenode.hasClass("jstree-leaf") && $treenode.children("a").hasClass("jstree-clicked");
+                        if (isSelected) {
                             CommandManager.execute(Commands.FILE_RENAME);
                         }
                     }
+                   
                 }
             );
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -208,6 +208,13 @@ define(function (require, exports, module) {
     
     /**
      * @private
+     * @type {number}
+     * Timestamp of the last mousedown event. For tracking long presses.
+     */
+    var _mousedownTimestamp;
+    
+    /**
+     * @private
      * Generates the prefixes used for sorting the files in the project tree
      * @return {boolean} true if the sort prefixes have changed
      */
@@ -641,17 +648,36 @@ define(function (require, exports, module) {
             ).bind(
                 "mousedown.jstree",
                 function (event) {
+                    // Track the mousedown time
+                    _mousedownTimestamp = event.timeStamp;
+                    
                     // select tree node on right-click
                     if (event.which === 3 || (event.ctrlKey && event.which === 1 && brackets.platform === "mac")) {
                         var treenode = $(event.target).closest("li");
                         if (treenode) {
                             var saveSuppressToggleOpen = suppressToggleOpen;
-                            
+                           
                             // don't toggle open folders (just select)
                             suppressToggleOpen = true;
                             _projectTree.jstree("deselect_all");
                             _projectTree.jstree("select_node", treenode, false);
                             suppressToggleOpen = saveSuppressToggleOpen;
+                        }
+                    }
+                   
+                }
+            ).bind(
+                "mouseup.jstree",
+                function (event) {
+                    var treenode = $(event.target).closest("li");
+                    // How long do we wait for the long press. OS X testing seemed to imply 2 seconds
+                    var longPressThreshhold = 200;
+                    
+                    // Check to make sure the event is happening on the selected item
+                    if ($(treenode)[0] === $(_lastSelected)[0]) {
+                        var pressLength = event.timeStamp - _mousedownTimestamp;
+                        if (pressLength >= longPressThreshhold) {
+                            CommandManager.execute(Commands.FILE_RENAME);
                         }
                     }
                 }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -664,13 +664,11 @@ define(function (require, exports, module) {
                 }
             ).bind("mouseup.jstree", function (event) {
                 var $treenode = $(event.target).closest("li");
-                var isSelected = $treenode.hasClass("jstree-leaf") && $treenode.children("a").hasClass("jstree-clicked");
-                
-                if (isSelected) {
+                if ($treenode[0] === $(_projectTree.jstree("get_selected")).closest("li")[0]) {
                     // wrap this in a setTimeout function so that we can check if it's a double click.
                     _mouseupTimeoutId = window.setTimeout(function (event) {
-                        // if it's a double-click, _mouseupTimeoutId is null and this won't trigger.
-                        if (_mouseupTimeoutId) {
+                        // if we get a double-click,_mouseupTimeoutId will have been set to lull by the double-click handler before this runs.
+                        if (_mouseupTimeoutId !== null) {
                             CommandManager.execute(Commands.FILE_RENAME);
                         }
                     }, 500);
@@ -737,7 +735,9 @@ define(function (require, exports, module) {
                     if (entry && entry.isFile && !_isInRename(event.target)) {
                         FileViewController.addToWorkingSetAndSelect(entry.fullPath);
                     }
-                    window.clearTimeout(_mouseupTimeoutId);
+                    if (_mouseupTimeoutId !== null) {
+                        window.clearTimeout(_mouseupTimeoutId);
+                    }
                     _mouseupTimeoutId = null;
                 });
 


### PR DESCRIPTION
...ee.

This only implements hold->rename for the project tree. In digging into the working set it seems like it's a bit of an edge case because the inlineRename doesn't touch the working set, it just jumps to that file in the project tree and invokes the inline rename there.

I felt like this was the more common case. It may not close the bug altogether, but at least it's a start.
