### PR TITLE
Fix #7905: Dotfiles should be colored in white

### DIFF
--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -397,7 +397,7 @@ define(function (require, exports, module) {
             ext = FileUtils.getSmartFileExtension(name),
             i = name.lastIndexOf("." + ext);
         
-        if (i >= 0) {
+        if (i > 0) {
             // Escape all HTML-sensitive characters in filename.
             name = _.escape(name.substring(0, i)) + "<span class='extension'>" + _.escape(name.substring(i)) + "</span>";
         } else {


### PR DESCRIPTION
Dotfiles are now colored in white instead of grey. See attached screenshots for details.
## Before

![before](https://cloud.githubusercontent.com/assets/141435/3152421/1fb2b394-ea8e-11e3-9d9e-d2318d011915.png)
## After

![after](https://cloud.githubusercontent.com/assets/141435/3152420/1f9c0414-ea8e-11e3-898d-cd17acb7f4e3.png)

for #7905
