### PR TITLE
about screen shows build timestamp if running from /dist

### DIFF
--- a/src/brackets.config.json
+++ b/src/brackets.config.json
@@ -19,6 +19,7 @@
         "extension_listing_url"      : "",
         "extension_registry"         : "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url"              : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
-        "linting.enabled_by_default" : true
+        "linting.enabled_by_default" : true,
+        "build_timestamp"            : ""
     }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -18,7 +18,8 @@
         "extension_listing_url": "",
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
-        "linting.enabled_by_default": true
+        "linting.enabled_by_default": true,
+        "build_timestamp": "DEBUG"
     },
     "name": "Brackets",
     "version": "0.41.0-0",

--- a/src/config.json
+++ b/src/config.json
@@ -19,7 +19,7 @@
         "extension_registry": "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
-        "build_timestamp": "DEBUG"
+        "build_timestamp": ""
     },
     "name": "Brackets",
     "version": "0.41.0-0",

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
         var templateVars = {
             ABOUT_ICON          : brackets.config.about_icon,
             APP_NAME_ABOUT_BOX  : brackets.config.app_name_about,
+            BUILD_TIMESTAMP     : brackets.config.build_timestamp,
             BUILD_INFO          : buildInfo || "",
             Strings             : Strings
         };

--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -7,7 +7,12 @@
         <div class="about-text">
             <h2>{{APP_NAME_ABOUT_BOX}}</h2>
             <div class="about-info">
-                <p class="dialog-message">{{Strings.ABOUT_TEXT_LINE1}} <span id="about-build-number">{{BUILD_INFO}}</span></p>
+                <p class="dialog-message">{{Strings.ABOUT_TEXT_LINE1}} <span id="about-build-number">{{BUILD_INFO}}</span>
+                  {{#BUILD_TIMESTAMP}}
+                  <br><span class="dialog-message">{{Strings.ABOUT_TEXT_BUILD_TIMESTAMP}}{{BUILD_TIMESTAMP}}</span>
+                  {{/BUILD_TIMESTAMP}}
+                </p>
+
                 <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2012 - 2014 Adobe Systems Incorporated and its licensors. All rights reserved.</p>
                 <p class="dialog-message">{{{Strings.ABOUT_TEXT_WEB_PLATFORM_DOCS}}}</p>
                 <p class="dialog-message">{{{Strings.ABOUT_TEXT_LINE3}}}</p>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -386,6 +386,7 @@ define({
     "ABOUT"                                : "About",
     "CLOSE"                                : "Close",
     "ABOUT_TEXT_LINE1"                     : "sprint {VERSION_MINOR} {BUILD_TYPE} {VERSION}",
+    "ABOUT_TEXT_BUILD_TIMESTAMP"           : "build timestamp: ",
     "ABOUT_TEXT_LINE3"                     : "Notices, terms and conditions pertaining to third party software are located at <a href='{ADOBE_THIRD_PARTY}'>{ADOBE_THIRD_PARTY}</a> and incorporated by reference herein.",
     "ABOUT_TEXT_LINE4"                     : "Documentation and source at <a href='https://github.com/adobe/brackets/'>https://github.com/adobe/brackets/</a>",
     "ABOUT_TEXT_LINE5"                     : "Made with \u2764 and JavaScript by:",

--- a/tasks/write-config.js
+++ b/tasks/write-config.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
     });
     
     // task: build-config
-    grunt.registerTask("build-config", "Update config.json with the branch and SHA being built", function () {
+    grunt.registerTask("build-config", "Update config.json with the build timestamp, branch and SHA being built", function () {
         var done = this.async(),
             distConfig = grunt.file.readJSON("src/config.json");
         
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
             distConfig.version = distConfig.version.substr(0, distConfig.version.lastIndexOf("-") + 1) + gitInfo.commits;
             distConfig.repository.SHA = gitInfo.sha;
             distConfig.repository.branch = gitInfo.branch;
+            distConfig.config.build_timestamp = new Date().toString().split('(')[0].trim();
     
             common.writeJSON(grunt, "dist/config.json", distConfig);
             


### PR DESCRIPTION
addresses issue #7716 
this pull request replaces #7954

grunt task writes date to dist/config.json
uses local time
I chop off the long time zone section of the string because it wrapped to the next line on the about page

if running from src/ build timestamp line will be hidden

if running from /dist build timestamp is displayed

![withtimestamp](https://cloud.githubusercontent.com/assets/7686073/3170042/5b5dcd0a-ebad-11e3-8923-7c69b7a33226.PNG)
