### PR TITLE
Update CMD_SHOW_IN_FINDER

### DIFF
--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -348,7 +348,7 @@ define({
     "CMD_SHOW_IN_TREE"                    : "Zobrazit stromovou strukturu",
     "CMD_SHOW_IN_OS"                      : "Zobrazit v OS",
     "CMD_SHOW_IN_EXPLORER"                : "Zobrazit v průzkumníkovi",
-    "CMD_SHOW_IN_FINDER"                  : "Zobrazit ve vyhledávači",
+    "CMD_SHOW_IN_FINDER"                  : "Zobrazit ve Finderu",
 
     // Příkazy menu nápověda
     "HELP_MENU"                           : "Nápověda",


### PR DESCRIPTION
Finder is file browser in OSX. In Apple's localization it's name is not trantlated, therefore it should not be translated.
