### PR TITLE
Fix for Running extension test suite on clean system fails #5821

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -333,7 +333,7 @@ define(function (require, exports, module) {
         // configure spawned test windows to load extensions
         SpecRunnerUtils.setLoadExtensionsInTestWindow(selectedSuites.indexOf("extension") >= 0);
         
-        _loadExtensionTests(selectedSuites).done(function () {
+        _loadExtensionTests(selectedSuites).always(function () {
             var jasmineEnv = jasmine.getEnv();
             jasmineEnv.updateInterval = 1000;
             


### PR DESCRIPTION
Start executing the tests when the returned promise was fulfilled and not only in the `done` handler.
This will ensure that the tests are able to start even if the extension directory hasn't been found.
