### PR TITLE
Fix for [Linux Only] Extension Test Suite has failures #7816

### DIFF
--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    var expectedHints = (brackets.platform === "mac") ? UrlCodeHintsDirHintsMac : UrlCodeHintsDirHints;
+                    var expectedHints = (brackets.platform !== "win") ? UrlCodeHintsDirHintsMac : UrlCodeHintsDirHints;
                     verifyUrlHints(hintsObj.hints, expectedHints);
                 });
             });


### PR DESCRIPTION
The order of the expected result was in a different order than expected. The order is the same as on OSX and  now the `brackets.platform` will be checked and for every other platform than `win`, the `urlCodeHintsDirHintsMac` will be used for comparison.
