### PR TITLE
Open extension dialog to Installed tab if updates are available

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -293,8 +293,14 @@ define(function (require, exports, module) {
                 });
             });
             
-            // Show the first tab
-            $dlg.find(".nav-tabs a:first").tab("show");
+            // Open dialog to Installed tab if extension updates are available
+            if ($("#toolbar-extension-manager").hasClass('updatesAvailable')) {
+                $dlg.find(".nav-tabs a.installed").tab("show");
+            }
+            // Otherwise show the first tab
+            else {
+                $dlg.find(".nav-tabs a:first").tab("show");
+            }
         });
     
         // Handle the install button.


### PR DESCRIPTION
Now we have indicators that extension updates are available, it would be great to open the EM dialog to the installed tab for quick updating. This PR does just that.
