### PR TITLE
Fixes bug #7667: Keyboard shortcut overlap with Chrome

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -166,6 +166,7 @@ define(function (require, exports, module) {
     // APP
     exports.APP_RELOAD                  = "app.reload";                 // DocumentCommandHandlers.js   handleReload()
     exports.APP_RELOAD_WITHOUT_EXTS     = "app.reload_without_exts";    // DocumentCommandHandlers.js   handleReloadWithoutExts()
+    exports.APP_BROWSER_FORCE_RELOAD    = "app.browser_force_reload";   // DocumentCommandHandlers.js   handleBrowserForceReload()
     
     // File shell callbacks - string must MATCH string in native code (appshell/command_callbacks.h)
     exports.APP_ABORT_QUIT              = "app.abort_quit";             // DocumentCommandHandlers.js   handleAbortQuit()

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -53,6 +53,7 @@ define(function (require, exports, module) {
         PerfUtils           = require("utils/PerfUtils"),
         KeyEvent            = require("utils/KeyEvent"),
         LanguageManager     = require("language/LanguageManager"),
+        LiveDevelopment     = require("LiveDevelopment/LiveDevelopment"),
         Inspector           = require("LiveDevelopment/Inspector/Inspector"),
         Menus               = require("command/Menus"),
         UrlParams           = require("utils/UrlParams").UrlParams,
@@ -1564,6 +1565,22 @@ define(function (require, exports, module) {
             browserReload(href);
         }, 100);
     }
+    
+    function handleBrowserForceReload() {
+        if (!Inspector.connected()) {
+            return;
+        }
+        
+        // Unload and reload agents before reloading the page
+        // Some agents (e.g. DOMAgent and RemoteAgent) require us to
+        // navigate to the page first before loading can complete.
+        // To accomodate this, we load all agents (in reconnect())
+        // and navigate in parallel.
+        LiveDevelopment.reconnect();
+
+        // Reload HTML page
+        Inspector.Page.reload();
+    }
 
     AppInit.htmlReady(function () {
         // If in Reload Without User Extensions mode, update UI and log console message
@@ -1628,6 +1645,7 @@ define(function (require, exports, module) {
     CommandManager.registerInternal(Commands.FILE_CLOSE_WINDOW,         handleFileCloseWindow);
     CommandManager.registerInternal(Commands.APP_RELOAD,                handleReload);
     CommandManager.registerInternal(Commands.APP_RELOAD_WITHOUT_EXTS,   handleReloadWithoutExts);
+    CommandManager.registerInternal(Commands.APP_BROWSER_FORCE_RELOAD,  handleBrowserForceReload);
 
     // Listen for changes that require updating the editor titlebar
     $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);

--- a/src/extensions/default/DebugCommands/keyboard.json
+++ b/src/extensions/default/DebugCommands/keyboard.json
@@ -19,6 +19,15 @@
     ],
     "reloadWithoutUserExts":  [
         {
+            "key": "Opt-F5"
+        },
+        {
+            "key": "Opt-Shift-R",
+            "platform": "mac"
+        }
+    ],
+    "browserForceReload":  [
+        {
             "key": "Shift-F5"
         },
         {

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -62,6 +62,7 @@ define(function (require, exports, module) {
         DEBUG_RUN_UNIT_TESTS            = "debug.runUnitTests",
         DEBUG_SHOW_PERF_DATA            = "debug.showPerfData",
         DEBUG_RELOAD_WITHOUT_USER_EXTS  = "debug.reloadWithoutUserExts",
+        DEBUG_BROWSER_FORCE_RELOAD      = "debug.browserForceReload",
         DEBUG_NEW_BRACKETS_WINDOW       = "debug.newBracketsWindow",
         DEBUG_SWITCH_LANGUAGE           = "debug.switchLanguage",
         DEBUG_ENABLE_NODE_DEBUGGER      = "debug.enableNodeDebugger",
@@ -103,6 +104,10 @@ define(function (require, exports, module) {
     
     function handleReloadWithoutUserExts() {
         CommandManager.execute(Commands.APP_RELOAD_WITHOUT_EXTS);
+    }
+    
+    function handleBrowserForceReload() {
+        CommandManager.execute(Commands.APP_BROWSER_FORCE_RELOAD);
     }
         
     function handleNewBracketsWindow() {
@@ -266,6 +271,7 @@ define(function (require, exports, module) {
         .setEnabled(!!brackets.app.showDeveloperTools);
     CommandManager.register(Strings.CMD_REFRESH_WINDOW,             DEBUG_REFRESH_WINDOW,           handleReload);
     CommandManager.register(Strings.CMD_RELOAD_WITHOUT_USER_EXTS,   DEBUG_RELOAD_WITHOUT_USER_EXTS, handleReloadWithoutUserExts);
+    CommandManager.register(Strings.CMD_BROWSER_FORCE_RELOAD,       DEBUG_BROWSER_FORCE_RELOAD,     handleBrowserForceReload);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,        DEBUG_NEW_BRACKETS_WINDOW,      handleNewBracketsWindow);
     
     // Start with the "Run Tests" item disabled. It will be enabled later if the test file can be found.
@@ -291,6 +297,7 @@ define(function (require, exports, module) {
     menu.addMenuItem(DEBUG_SHOW_DEVELOPER_TOOLS, KeyboardPrefs.showDeveloperTools);
     menu.addMenuItem(DEBUG_REFRESH_WINDOW, KeyboardPrefs.refreshWindow);
     menu.addMenuItem(DEBUG_RELOAD_WITHOUT_USER_EXTS, KeyboardPrefs.reloadWithoutUserExts);
+    menu.addMenuItem(DEBUG_BROWSER_FORCE_RELOAD, KeyboardPrefs.browserForceReload);
     menu.addMenuItem(DEBUG_NEW_BRACKETS_WINDOW);
     menu.addMenuDivider();
     menu.addMenuItem(DEBUG_SWITCH_LANGUAGE);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -508,6 +508,7 @@ define({
     "CMD_SHOW_DEV_TOOLS"                        : "Show Developer Tools",
     "CMD_REFRESH_WINDOW"                        : "Reload With Extensions",
     "CMD_RELOAD_WITHOUT_USER_EXTS"              : "Reload Without Extensions",
+    "CMD_BROWSER_FORCE_RELOAD"                  : "Force Browser Reload",
     "CMD_NEW_BRACKETS_WINDOW"                   : "New {APP_NAME} Window",
     "CMD_SWITCH_LANGUAGE"                       : "Switch Language",
     "CMD_RUN_UNIT_TESTS"                        : "Run Tests",


### PR DESCRIPTION
Changed shortcut for reloading without extensions to Opt-Shift-R and
created a browserForceReload function that is triggered by Cmd-Shift-R.
Changes to src/nls/root/strings.js will need to be localized for other
languages as well.
