### PR TITLE
added a force reload command for live preview

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -921,6 +921,19 @@ define(function LiveDevelopment(require, exports, module) {
         return loadAgents();
     }
 
+    /** reload the live preview */
+    function reload() {
+        // Unload and reload agents before reloading the page
+        // Some agents (e.g. DOMAgent and RemoteAgent) require us to
+        // navigate to the page first before loading can complete.
+        // To accomodate this, we load all agents (in reconnect())
+        // and navigate in parallel.
+        reconnect();
+
+        // Reload HTML page
+        Inspector.Page.reload();
+    }
+
     /**
      * Close the connection and the associated window asynchronously
      * @return {jQuery.Promise} Resolves once the connection is closed
@@ -1368,15 +1381,7 @@ define(function LiveDevelopment(require, exports, module) {
             wasRequested    = agents.network && agents.network.wasURLRequested(documentUrl);
         
         if (wasRequested) {
-            // Unload and reload agents before reloading the page
-            // Some agents (e.g. DOMAgent and RemoteAgent) require us to
-            // navigate to the page first before loading can complete.
-            // To accomodate this, we load all agents (in reconnect())
-            // and navigate in parallel.
-            reconnect();
-
-            // Reload HTML page
-            Inspector.Page.reload();
+            reload();
         }
     }
 
@@ -1447,6 +1452,7 @@ define(function LiveDevelopment(require, exports, module) {
     exports.open                = open;
     exports.close               = close;
     exports.reconnect           = reconnect;
+    exports.reload              = reload;
     exports.enableAgent         = enableAgent;
     exports.disableAgent        = disableAgent;
     exports.getLiveDocForPath   = getLiveDocForPath;

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -226,6 +226,13 @@ define(function main(require, exports, module) {
         window.report = function report(params) { window.params = params; console.info(params); };
     }
 
+    /** force reload the live preview */
+    function _handleReloadLivePreviewCommand() {
+        if (LiveDevelopment.status >= LiveDevelopment.STATUS_ACTIVE) {
+            LiveDevelopment.reload();
+        }
+    }
+
     /** Initialize LiveDevelopment */
     AppInit.appReady(function () {
         params.parse();
@@ -275,6 +282,7 @@ define(function main(require, exports, module) {
     // init commands
     CommandManager.register(Strings.CMD_LIVE_FILE_PREVIEW,  Commands.FILE_LIVE_FILE_PREVIEW, _handleGoLiveCommand);
     CommandManager.register(Strings.CMD_LIVE_HIGHLIGHT, Commands.FILE_LIVE_HIGHLIGHT, _handlePreviewHighlightCommand);
+    CommandManager.register(Strings.CMD_RELOAD_LIVE_PREVIEW, Commands.FILE_RELOAD_LIVE_PREVIEW, _handleReloadLivePreviewCommand);
     CommandManager.get(Commands.FILE_LIVE_HIGHLIGHT).setEnabled(false);
 
     // Export public functions

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -26,6 +26,11 @@
     "file.liveFilePreview":  [
         "Ctrl-Alt-P"
     ],
+    "file.reloadLivePreview": [
+        {
+            "key": "Ctrl-Shift-R"
+        }
+    ],
     "file.previewHighlight":  [
         "Ctrl-Shift-C"
     ],

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -67,6 +67,7 @@ define(function (require, exports, module) {
     exports.FILE_ADD_TO_WORKING_SET     = "file.addToWorkingSet";       // DocumentCommandHandlers.js   handleFileAddToWorkingSet()
     exports.FILE_OPEN_DROPPED_FILES     = "file.openDroppedFiles";      // DragAndDrop.js               openDroppedFiles()
     exports.FILE_LIVE_FILE_PREVIEW      = "file.liveFilePreview";       // LiveDevelopment/main.js      _handleGoLiveCommand()
+    exports.FILE_RELOAD_LIVE_PREVIEW    = "file.reloadLivePreview";       // LiveDevelopment/main.js      _handleGoLiveCommand()
     exports.FILE_LIVE_HIGHLIGHT         = "file.previewHighlight";      // LiveDevelopment/main.js      _handlePreviewHighlightCommand()
     exports.FILE_PROJECT_SETTINGS       = "file.projectSettings";       // ProjectManager.js            _projectSettings()
     exports.FILE_RENAME                 = "file.rename";                // DocumentCommandHandlers.js   handleFileRename()

--- a/src/extensions/default/DebugCommands/keyboard.json
+++ b/src/extensions/default/DebugCommands/keyboard.json
@@ -20,10 +20,6 @@
     "reloadWithoutUserExts":  [
         {
             "key": "Shift-F5"
-        },
-        {
-            "key": "Cmd-Shift-R",
-            "platform": "mac"
         }
     ]
 }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -276,6 +276,7 @@ define({
     "CMD_FILE_SAVE_ALL"                   : "Save All",
     "CMD_FILE_SAVE_AS"                    : "Save As\u2026",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
+    "CMD_RELOAD_LIVE_PREVIEW"             : "Force Reload Live Preview",
     "CMD_PROJECT_SETTINGS"                : "Project Settings\u2026",
     "CMD_FILE_RENAME"                     : "Rename",
     "CMD_FILE_DELETE"                     : "Delete",


### PR DESCRIPTION
Unbound Cmd-Shift-R on mac and bound the new command to Ctrl-Shift-R (Cmd-Shift-R on mac works automagically). This leaves the Debug > Reload Without Extensions command at Shift+F5 on all platforms (works on mac, too).

Putting this up for review - not sure what tests are needed (none are included right now).

This should resolve Issue #7667
