### PR TITLE
Fix ridiculously long timeout

### DIFF
--- a/src/extensions/default/CloseOthers/unittests.js
+++ b/src/extensions/default/CloseOthers/unittests.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
                 });
 
                 var promise = CommandManager.execute(Commands.FILE_SAVE_ALL);
-                waitsForDone(promise, "FILE_SAVE_ALL", 60000);
+                waitsForDone(promise, "FILE_SAVE_ALL", 5000);
             });
         });
         


### PR DESCRIPTION
1 minute timeout is ridiculously long; change to 5 sec

This timeout hit (3 times) in jeff/splitview-merge branch

cc @JeffryBooher 
