### PR TITLE
Remove vendor prefix

### DIFF
--- a/src/extensions/default/InlineTimingFunctionEditor/BezierCurveEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/BezierCurveEditor.js
@@ -305,7 +305,7 @@ define(function (require, exports, module) {
             bezierEditor._commitTimingFunction();
 
             bezierEditor._updateCanvas();
-            animationRequest = window.webkitRequestAnimationFrame(mouseMoveRedraw);
+            animationRequest = window.requestAnimationFrame(mouseMoveRedraw);
         }
 
         // This is a dragging state, but left button is no longer down, so mouse
@@ -336,7 +336,7 @@ define(function (require, exports, module) {
             .concat(bezierEditor.bezierCanvas.offsetsToCoordinates(bezierEditor.P2));
 
         if (!animationRequest) {
-            animationRequest = window.webkitRequestAnimationFrame(mouseMoveRedraw);
+            animationRequest = window.requestAnimationFrame(mouseMoveRedraw);
         }
     }
 

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -320,7 +320,7 @@ define(function (require, exports, module) {
                     }
                 }
                 
-                animationRequest = window.webkitRequestAnimationFrame(doRedraw);
+                animationRequest = window.requestAnimationFrame(doRedraw);
             }
             
             function onMouseMove(e) {
@@ -337,7 +337,7 @@ define(function (require, exports, module) {
                 e.preventDefault();
                 
                 if (animationRequest === null) {
-                    animationRequest = window.webkitRequestAnimationFrame(doRedraw);
+                    animationRequest = window.requestAnimationFrame(doRedraw);
                 }
             }
             


### PR DESCRIPTION
`window.webkitRequestAnimationFrame` is being deprecated in CEF 1916 and `window.requestAnimationFrame` now works in brackets-shell master, so convert calls.

cc @JeffryBooher 

**Testing:**

**Resizer.js**: drag side panel right edge to change width and verify panel redraws as you drag.

**BezierEditor.js**: Create CSS rule with declaration something like this:

``` CSS
    transition-timing-function: cubic-bezier(.62, 0, 1, .98);
```

Drag control points and verify curve redraws as you drag.
