### PR TITLE
Fix Replace in... unit tests

### DIFF
--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -385,10 +385,11 @@ define(function (require, exports, module) {
     
     // Initialize: command handlers
     CommandManager.register(Strings.CMD_FIND_IN_FILES,       Commands.CMD_FIND_IN_FILES,       _showFindBar);
-    CommandManager.register(Strings.CMD_REPLACE_IN_FILES,    Commands.CMD_REPLACE_IN_FILES,    _showReplaceBar);
     CommandManager.register(Strings.CMD_FIND_IN_SELECTED,    Commands.CMD_FIND_IN_SELECTED,    _showFindBarForSubtree);
-    CommandManager.register(Strings.CMD_REPLACE_IN_SELECTED, Commands.CMD_REPLACE_IN_SELECTED, _showReplaceBarForSubtree);
     CommandManager.register(Strings.CMD_FIND_IN_SUBTREE,     Commands.CMD_FIND_IN_SUBTREE,     _showFindBarForSubtree);
+    
+    CommandManager.register(Strings.CMD_REPLACE_IN_FILES,    Commands.CMD_REPLACE_IN_FILES,    _showReplaceBar);
+    CommandManager.register(Strings.CMD_REPLACE_IN_SELECTED, Commands.CMD_REPLACE_IN_SELECTED, _showReplaceBarForSubtree);
     CommandManager.register(Strings.CMD_REPLACE_IN_SUBTREE,  Commands.CMD_REPLACE_IN_SUBTREE,  _showReplaceBarForSubtree);
     
     // Public exports

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -1394,8 +1394,8 @@ define(function (require, exports, module) {
 
                     it("should do a search in folder, replace all from find bar", function () {
                         openTestProjectCopy(defaultSourcePath);
-                        var dirEntry = FileSystem.getDirectoryForPath(defaultSourcePath + "/css/");
-                        openSearchBar(null, true);
+                        var dirEntry = FileSystem.getDirectoryForPath(testPath + "/css/");
+                        openSearchBar(dirEntry, true);
                         executeReplace("foo", "bar", true);
 
                         waitsFor(function () {
@@ -1418,8 +1418,8 @@ define(function (require, exports, module) {
 
                     it("should do a search in file, replace all from find bar", function () {
                         openTestProjectCopy(defaultSourcePath);
-                        var dirEntry = FileSystem.getDirectoryForPath(defaultSourcePath + "/css/foo.css");
-                        openSearchBar(null, true);
+                        var fileEntry = FileSystem.getFileForPath(testPath + "/css/foo.css");
+                        openSearchBar(fileEntry, true);
                         executeReplace("foo", "bar", true);
 
                         waitsFor(function () {


### PR DESCRIPTION
This addresses [this comment](https://github.com/adobe/brackets/pull/8029/files#r13728201).
1. In both tests, I forgot to pass the `dirEntry` as the first param to the `openSearchBar()` function.
2. After doing that, I discovered that that the path was wrong
3. In the second test, should have created a `fileEntry`.

cc @njx 
