### PR TITLE
Adding support for .command file ext for bash lang

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -229,7 +229,7 @@
     "bash": {
         "name": "Bash",
         "mode": ["shell", "text/x-sh"],
-        "fileExtensions": ["sh"],
+        "fileExtensions": ["sh", "command"],
         "lineComment": ["#"]
     },
   


### PR DESCRIPTION
The default double-clickable executable bash file extension in OS X is .command. This PR should add bash syntax highlighting to .command files by default.
