### PR TITLE
[replace-across-files] Code review fixes

### DIFF
--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -407,6 +407,9 @@ define(function (require, exports, module) {
      * @private
      */
     Document.prototype._handleEditorChange = function (event, editor, changeList) {
+        // TODO: This needs to be kept in sync with SpecRunnerUtils.createMockActiveDocument(). In the
+        // future, we should fix things so that we either don't need mock documents or that this
+        // is factored so it will just run in both.
         if (!this._refreshInProgress) {
             // Sync isDirty from CodeMirror state
             var wasDirty = this.isDirty;
@@ -419,9 +422,6 @@ define(function (require, exports, module) {
         }
         
         // Notify that Document's text has changed
-        // TODO: This needs to be kept in sync with SpecRunnerUtils.createMockActiveDocument(). In the
-        // future, we should fix things so that we either don't need mock documents or that this
-        // is factored so it will just run in both.
         this._notifyDocumentChange(changeList);
     };
     

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -276,6 +276,17 @@ define(function (require, exports, module) {
     };
     
     /**
+     * @private
+     * Triggers the appropriate events when a change occurs: "change" on the Document instance
+     * and "documentChange" on the Document module.
+     * @param {Object} changeList Changelist in CodeMirror format
+     */
+    Document.prototype._notifyDocumentChange = function (changeList) {
+        $(this).triggerHandler("change", [this, changeList]);
+        $(exports).triggerHandler("documentChange", [this, changeList]);
+    };
+    
+    /**
      * Sets the contents of the document. Treated as reloading the document from disk: the document
      * will be marked clean with a new timestamp, the undo/redo history is cleared, and we re-check
      * the text's line-ending style. CAN be called even if there is no backing editor.
@@ -303,9 +314,7 @@ define(function (require, exports, module) {
                 // TODO: Dumb to split it here just to join it again in the change handler, but this is
                 // the CodeMirror change format. Should we document our change format to allow this to
                 // either be an array of lines or a single string?
-                var fakeChangeList = [{text: text.split(/\r?\n/)}];
-                $(this).triggerHandler("change", [this, fakeChangeList]);
-                $(exports).triggerHandler("documentChange", [this, fakeChangeList]);
+                this._notifyDocumentChange([{text: text.split(/\r?\n/)}]);
             }
         }
         this._updateTimestamp(newTimestamp);
@@ -410,11 +419,10 @@ define(function (require, exports, module) {
         }
         
         // Notify that Document's text has changed
-        // TODO: This needs to be kept in sync with SpecRunnerUtils.createMockDocument(). In the
+        // TODO: This needs to be kept in sync with SpecRunnerUtils.createMockActiveDocument(). In the
         // future, we should fix things so that we either don't need mock documents or that this
         // is factored so it will just run in both.
-        $(this).triggerHandler("change", [this, changeList]);
-        $(exports).triggerHandler("documentChange", [this, changeList]);
+        this._notifyDocumentChange(changeList);
     };
     
     /**

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1174,7 +1174,7 @@ define(function (require, exports, module) {
             
         } else {
             // Multiple unsaved files: show a single bulk prompt listing all files
-            var message = Strings.SAVE_CLOSE_MULTI_MESSAGE + StringUtils.makeDialogFileList(_.map(unsavedDocs, _shortTitleForDocument));
+            var message = Strings.SAVE_CLOSE_MULTI_MESSAGE + FileUtils.makeDialogFileList(_.map(unsavedDocs, _shortTitleForDocument));
             
             Dialogs.showModalDialog(
                 DefaultDialogs.DIALOG_ID_SAVE_CLOSE,
@@ -1232,9 +1232,12 @@ define(function (require, exports, module) {
     /**
      * Closes all open documents; equivalent to calling handleFileClose() for each document, except
      * that unsaved changes are confirmed once, in bulk.
-     * @param {?{promptOnly: boolean}}  If true, only displays the relevant confirmation UI and does NOT
+     * @param {?{promptOnly: boolean, _forceClose: boolean}}
+     *          If promptOnly is true, only displays the relevant confirmation UI and does NOT
      *          actually close any documents. This is useful when chaining close-all together with
      *          other user prompts that may be cancelable.
+     *          If _forceClose is true, forces the files to close with no confirmation even if dirty. 
+     *          Should only be used for unit test cleanup.
      * @return {$.Promise} a promise that is resolved when all files are closed
      */
     function handleFileCloseAll(commandData) {

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -184,6 +184,21 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Creates an HTML string for a list of files to be reported on, suitable for use in a dialog.
+     * @param {Array.<string>} Array of filenames or paths to display.
+     */
+    function makeDialogFileList(paths) {
+        var result = "<ul class='dialog-list'>";
+        paths.forEach(function (path) {
+            result += "<li><span class='dialog-filename'>";
+            result += StringUtils.breakableUrl(path);
+            result += "</span></li>";
+        });
+        result += "</ul>";
+        return result;
+    }
+
+    /**
      * Convert a URI path to a native path.
      * On both platforms, this unescapes the URI
      * On windows, URI paths start with a "/", but have a drive letter ("C:"). In this
@@ -446,11 +461,12 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Compares two paths. Useful for sorting.
-     * @param {string} filename1
-     * @param {string} filename2
-     * @param {boolean} extFirst If true it compares the extensions first and then the file names.
-     * @return {number} The result of the local compare function
+     * Compares two paths segment-by-segment, used for sorting. Sorts folders before files,
+     * and sorts files based on `compareFilenames()`.
+     * @param {string} path1
+     * @param {string} path2
+     * @return {number} -1, 0, or 1 depending on whether path1 is less than, equal to, or greater than
+     *     path2 according to this ordering.
      */
     function comparePaths(path1, path2) {
         var entryName1, entryName2,
@@ -486,6 +502,7 @@ define(function (require, exports, module) {
     exports.translateLineEndings           = translateLineEndings;
     exports.showFileOpenError              = showFileOpenError;
     exports.getFileErrorString             = getFileErrorString;
+    exports.makeDialogFileList             = makeDialogFileList;
     exports.readAsText                     = readAsText;
     exports.writeText                      = writeText;
     exports.convertToNativePath            = convertToNativePath;

--- a/src/htmlContent/findreplace-bar.html
+++ b/src/htmlContent/findreplace-bar.html
@@ -3,12 +3,12 @@
         --><div class="search-input-container"><input type="text" id="find-what" placeholder="{{queryPlaceholder}}" value="{{initialQuery}}" /><div class="error"></div><span id="find-counter"></span></div><!--
         --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
         --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button><!--
-        {{#navigator}}
+        {{^multifile}}
         --><div class="navigator"><!--
             --><button id="find-prev" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_PREV_HINT}}">{{Strings.BUTTON_PREV}}</button><!--
             --><button id="find-next" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_NEXT_HINT}}">{{Strings.BUTTON_NEXT}}</button><!--
         --></div><!--
-        {{/navigator}}
+        {{/multifile}}
     --></div>
 
     {{#replace}}
@@ -21,7 +21,7 @@
     {{/replace}}
 </div>
 
-{{#scope}}
+{{#multifile}}
 <div class="scope-group">
     <div class="no-results-message">{{Strings.FIND_NO_RESULTS}}</div>
     <div class="message">
@@ -29,4 +29,4 @@
     </div>
     <!-- For Find in Files, the filter picker will be added here programmatically. -->
 </div>
-{{/scope}}
+{{/multifile}}

--- a/src/htmlContent/findreplace-bar.html
+++ b/src/htmlContent/findreplace-bar.html
@@ -14,10 +14,10 @@
     {{#replace}}
     <div id="replace-group" {{#scope}}class="has-scope"{{/scope}}><!--
         --><input type="text" id="replace-with" placeholder="{{Strings.REPLACE_PLACEHOLDER}}"/><!--
-        {{^replaceAllOnly}}
+        {{^multifile}}
         --><button id="replace-yes" class="btn no-focus" tabindex="-1">{{Strings.BUTTON_REPLACE}}</button><!--
-        {{/replaceAllOnly}}
-        --><button id="replace-all" class="btn no-focus {{#replaceAllOnly}}solo{{/replaceAllOnly}}" tabindex="-1">{{replaceAllLabel}}</button></div>
+        {{/multifile}}
+        --><button id="replace-all" class="btn no-focus {{#multifile}}solo{{/multifile}}" tabindex="-1">{{replaceAllLabel}}</button></div>
     {{/replace}}
 </div>
 

--- a/src/htmlContent/findreplace-bar.html
+++ b/src/htmlContent/findreplace-bar.html
@@ -27,5 +27,6 @@
     <div class="message">
         <span id="searchlabel">{{{scopeLabel}}}</span>
     </div>
+    <!-- For Find in Files, the filter picker will be added here programmatically. -->
 </div>
 {{/scope}}

--- a/src/htmlContent/search-results.html
+++ b/src/htmlContent/search-results.html
@@ -1,14 +1,14 @@
 <table class="bottom-panel-table table table-striped table-condensed row-highlight">
     <tbody>
         {{#searchList}}
-        <tr class="file-section" data-file="{{file}}">
+        <tr class="file-section" data-file-index="{{fileIndex}}">
             <td colspan="{{#replace}}3{{/replace}}{{^replace}}2{{/replace}}">
                 <span class="disclosure-triangle expanded" title="{{Strings.FIND_IN_FILES_EXPAND_COLLAPSE}}"></span>
                 {{{filename}}}
             </td>
         </tr>
         {{#items}}
-        <tr data-file="{{file}}" data-item="{{item}}" data-index="{{index}}">
+        <tr data-file-index="{{fileIndex}}" data-item-index="{{itemIndex}}" data-match-index="{{matchIndex}}">
             {{#replace}}<td class="checkbox-column"><input type="checkbox" class="check-one" {{#isChecked}}checked="true"{{/isChecked}} /></td>{{/replace}}
             <td class="line-number">{{line}}</td>
             <td class="line-text">{{pre}}<span class="highlight">{{highlight}}</span>{{post}}</td>

--- a/src/htmlContent/search-summary-paging.html
+++ b/src/htmlContent/search-summary-paging.html
@@ -1,9 +1,0 @@
-{{#hasPages}}
-<div class="pagination-col">
-    <span class="first-page {{^hasPrev}}disabled{{/hasPrev}}"></span>
-    <span class="prev-page {{^hasPrev}}disabled{{/hasPrev}}"></span>
-    {{{results}}}
-    <span class="next-page {{^hasNext}}disabled{{/hasNext}}"></span>
-    <span class="last-page {{^hasNext}}disabled{{/hasNext}}"></span>
-</div>
-{{/hasPages}}

--- a/src/htmlContent/search-summary.html
+++ b/src/htmlContent/search-summary.html
@@ -13,7 +13,15 @@
 <div class="contracting-col">{{{scope}}}</div>
 {{/scope}}
 <div class="fixed-col">{{{summary}}}</div>
-{{>paging}}
+{{#hasPages}}
+<div class="pagination-col">
+    <span class="first-page {{^hasPrev}}disabled{{/hasPrev}}"></span>
+    <span class="prev-page {{^hasPrev}}disabled{{/hasPrev}}"></span>
+    {{{results}}}
+    <span class="next-page {{^hasNext}}disabled{{/hasNext}}"></span>
+    <span class="last-page {{^hasNext}}disabled{{/hasNext}}"></span>
+</div>
+{{/hasPages}}
 {{#replace}}
 <div class="replace-col">
     <button class="btn small replace-checked">{{Strings.BUTTON_REPLACE}}</button>

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -64,7 +64,8 @@ define(function (require, exports, module) {
      *-  close - when the find bar is closed
      *
      * @param {boolean=} options.multifile - true if this is a Find/Replace in Files (changes the behavior of Enter in
-     *      the fields, hides the navigator controls, and hides the Replace button, so there's only Replace All)
+     *      the fields, hides the navigator controls, shows the scope/filter controls, and if in replace mode, hides the
+     *      Replace button (so there's only Replace All)
      * @param {boolean=} options.replace - true to show the Replace controls - default false
      * @param {string=}  options.queryPlaceholder - label to show in the Find field - default empty string
      * @param {string=}  options.initialQuery - query to populate in the Find field on open - default empty string

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -63,20 +63,17 @@ define(function (require, exports, module) {
      * - doReplaceAll - when the user chooses to initiate a Replace All. Use getReplaceText() to get the current replacement text.
      *-  close - when the find bar is closed
      *
-     * @param {boolean=} options.navigator - true to show the Find Previous/Find Next buttons - default false
-     * @param {boolean=} options.replace - true to show the Replace controls - default false
      * @param {boolean=} options.multifile - true if this is a Find/Replace in Files (changes the behavior of Enter in
-     *      the fields and hides the Replace button, so there's only Replace All)
-     * @param {boolean=} options.scope - true to show the scope filter controls - default false
+     *      the fields, hides the navigator controls, and hides the Replace button, so there's only Replace All)
+     * @param {boolean=} options.replace - true to show the Replace controls - default false
      * @param {string=}  options.queryPlaceholder - label to show in the Find field - default empty string
      * @param {string=}  options.initialQuery - query to populate in the Find field on open - default empty string
      * @param {string=}  scopeLabel - HTML label to show for the scope of the search, expected to be already escaped - default empty string
      */
     function FindBar(options) {
         var defaults = {
-            navigator: false,
-            replace: false,
             multifile: false,
+            replace: false,
             queryPlaceholder: "",
             initialQuery: "",
             scopeLabel: ""
@@ -140,7 +137,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * Options passed into the FindBar.
-     * @type {!{navigator: boolean, replace: boolean, queryPlaceholder: string, initialQuery: string}}
+     * @type {!{multifile: boolean, replace: boolean, queryPlaceholder: string, initialQuery: string, scopeLabel: string}}
      */
     FindBar.prototype._options = null;
     
@@ -282,7 +279,7 @@ define(function (require, exports, module) {
                 }
             });
         
-        if (this._options.navigator) {
+        if (!this._options.multifile) {
             this._addShortcutToTooltip($("#find-next"), Commands.CMD_FIND_NEXT);
             this._addShortcutToTooltip($("#find-prev"), Commands.CMD_FIND_PREVIOUS);
             $root

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
         
         var matches = _getSearchMatches(contents, queryExpr);
         if (matches.length) {
-            searchModel.addResults(fullPath, {matches: matches, timestamp: timestamp});
+            searchModel.setResults(fullPath, {matches: matches, timestamp: timestamp});
             return true;
         }
         return false;
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
      * @private
      * Update the search results using the given list of changes for the given document
      * @param {Document} doc  The Document that changed, should be the current one
-     * @param {Array.<{from: {line:number,ch:number}, to: {line:number,ch:number}, text: string}>} changeList
+     * @param {Array.<{from: {line:number,ch:number}, to: {line:number,ch:number}, text: !Array.<string>}>} changeList
      *      An array of changes as described in the Document constructor
      */
     function _updateResults(doc, changeList) {
@@ -242,11 +242,12 @@ define(function (require, exports, module) {
         
         // Always re-add the results, even if nothing changed.
         if (resultInfo && resultInfo.matches.length) {
-            searchModel.addResults(fullPath, resultInfo);
+            searchModel.setResults(fullPath, resultInfo);
         }
 
         if (resultsChanged) {
-            // Debounce document changes since the user might be typing quickly.
+            // Pass `true` for quickChange here. This will make listeners debounce the change event,
+            // avoiding lots of updates if the user types quickly.
             searchModel.fireChanged(true);
         }
     }
@@ -344,7 +345,7 @@ define(function (require, exports, module) {
      * Tries to update the search result on document changes
      * @param {$.Event} event
      * @param {Document} document
-     * @param {<{from: {line:number,ch:number}, to: {line:number,ch:number}, text: string}>} change
+     * @param {<{from: {line:number,ch:number}, to: {line:number,ch:number}, text: !Array.<string>}>} change
      *      A change list as described in the Document constructor
      */
     _documentChangeHandler = function (event, document, change) {
@@ -506,7 +507,7 @@ define(function (require, exports, module) {
         _.forEach(searchModel.results, function (item, fullPath) {
             if (fullPath.indexOf(oldName) === 0) {
                 searchModel.removeResults(fullPath);
-                searchModel.addResults(fullPath.replace(oldName, newName), item);
+                searchModel.setResults(fullPath.replace(oldName, newName), item);
                 resultsChanged = true;
             }
         });

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -358,6 +358,7 @@ define(function (require, exports, module) {
                     searchModel.setResults(file.fullPath, {matches: matches, timestamp: timestamp});
                     result.resolve(true);
                 } else {
+                    searchModel.removeResults(file.fullPath);
                     result.resolve(false);
                 }
             })

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -354,18 +354,13 @@ define(function (require, exports, module) {
                 // Note that we don't fire a model change here, since this is always called by some outer batch
                 // operation that will fire it once it's done.
                 var matches = _getSearchMatches(text, searchModel.queryExpr);
-                if (matches.length) {
-                    searchModel.setResults(file.fullPath, {matches: matches, timestamp: timestamp});
-                    result.resolve(true);
-                } else {
-                    searchModel.removeResults(file.fullPath);
-                    result.resolve(false);
-                }
+                searchModel.setResults(file.fullPath, {matches: matches, timestamp: timestamp});
+                result.resolve(!!matches.length);
             })
             .fail(function () {
                 // Always resolve. If there is an error, this file
                 // is skipped and we move on to the next file.
-                result.resolve();
+                result.resolve(false);
             });
         
         return result.promise();

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -147,10 +147,8 @@ define(function (require, exports, module) {
         }
 
         _findBar = new FindBar({
-            navigator: false,
+            multifile: true,
             replace: showReplace,
-            multifile: showReplace,
-            scope: true,
             initialQuery: initialString,
             queryPlaceholder: (showReplace ? Strings.CMD_REPLACE_IN_SUBTREE : Strings.CMD_FIND_IN_SUBTREE),
             scopeLabel: FindUtils.labelForScope(scope)
@@ -211,6 +209,8 @@ define(function (require, exports, module) {
         
         $(_findBar)
             .on("doFind.FindInFiles", function () {
+                // Subtle issue: we can't just pass startSearch directly as the handler, because
+                // we don't want it to get the event object as an argument.
                 startSearch();
             })
             .on("queryChange.FindInFiles", handleQueryChange)

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -149,7 +149,7 @@ define(function (require, exports, module) {
         _findBar = new FindBar({
             navigator: false,
             replace: showReplace,
-            replaceAllOnly: showReplace,
+            multifile: showReplace,
             scope: true,
             initialQuery: initialString,
             queryPlaceholder: (showReplace ? Strings.CMD_REPLACE_IN_SUBTREE : Strings.CMD_FIND_IN_SUBTREE),
@@ -210,15 +210,8 @@ define(function (require, exports, module) {
         }
         
         $(_findBar)
-            .on("doFind.FindInFiles", function (e, shiftKey, replace) {
-                // If in Replace mode, just set focus to the Replace field.
-                if (replace) {
-                    startReplace();
-                } else if (showReplace) {
-                    _findBar.focusReplace();
-                } else {
-                    startSearch();
-                }
+            .on("doFind.FindInFiles", function () {
+                startSearch();
             })
             .on("queryChange.FindInFiles", handleQueryChange)
             .on("close.FindInFiles", function (e) {
@@ -227,9 +220,9 @@ define(function (require, exports, module) {
             });
         
         if (showReplace) {
-            $(_findBar).on("doReplace.FindInFiles", function (e, all) {
-                startReplace();
-            });
+            // We shouldn't get a "doReplace" in this case, since the Replace button
+            // is hidden when we set options.multifile.
+            $(_findBar).on("doReplaceAll.FindInFiles", startReplace);
         }
                 
         // Show file-exclusion UI *unless* search scope is just a single file

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -175,25 +175,23 @@ define(function (require, exports, module) {
         function handleQueryChange() {
             // Check the query expression on every input event. This way the user is alerted
             // to any RegEx syntax errors immediately.
-            if (_findBar) {
-                var queryInfo = _findBar.getQueryInfo(),
-                    queryResult = FindInFiles.searchModel.setQueryInfo(queryInfo);
+            var queryInfo = _findBar.getQueryInfo(),
+                queryResult = FindInFiles.searchModel.setQueryInfo(queryInfo);
 
-                // Enable the replace button appropriately.
-                _findBar.enableReplace(queryResult.valid);
-                
-                if (queryResult.valid || queryResult.empty) {
-                    _findBar.showNoResults(false);
-                    _findBar.showError(null);
-                } else {
-                    _findBar.showNoResults(true, false);
-                    _findBar.showError(queryResult.error);
-                }
+            // Enable the replace button appropriately.
+            _findBar.enableReplace(queryResult.valid);
+
+            if (queryResult.valid || queryResult.empty) {
+                _findBar.showNoResults(false);
+                _findBar.showError(null);
+            } else {
+                _findBar.showNoResults(true, false);
+                _findBar.showError(queryResult.error);
             }
         }
         
         function startSearch(replaceText) {
-            var queryInfo = _findBar && _findBar.getQueryInfo();
+            var queryInfo = _findBar.getQueryInfo();
             if (queryInfo && queryInfo.query) {
                 _findBar.enable(false);
                 StatusBar.showBusyIndicator(true);

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -86,6 +86,7 @@ define(function (require, exports, module) {
     
     function SearchState() {
         this.searchStartPos = null;
+        this.parsedQuery = null;
         this.queryInfo = null;
         this.foundAny = false;
         this.marked = [];
@@ -98,9 +99,9 @@ define(function (require, exports, module) {
         return cm._searchState;
     }
 
-    function getSearchCursor(cm, query, queryInfo, pos) {
+    function getSearchCursor(cm, state, pos) {
         // Heuristic: if the query string is all lowercase, do a case insensitive search.
-        return cm.getSearchCursor(query, pos, !queryInfo.isCaseSensitive);
+        return cm.getSearchCursor(state.parsedQuery, pos, !state.queryInfo.isCaseSensitive);
     }
     
     function parseQuery(queryInfo) {
@@ -131,16 +132,16 @@ define(function (require, exports, module) {
     /**
      * @private
      * Determine the query from the given info and store it in the state.
-     * @param {SearchState} state The state to store the query in
+     * @param {SearchState} state The state to store the parsed query in
      * @param {{query: string, caseSensitive: boolean, isRegexp: boolean}} queryInfo 
      *      The query info object as returned by FindBar.getQueryInfo()
      */
     function setQueryInfo(state, queryInfo) {
         state.queryInfo = queryInfo;
         if (!queryInfo) {
-            state.query = null;
+            state.parsedQuery = null;
         } else {
-            state.query = parseQuery(queryInfo);
+            state.parsedQuery = parseQuery(queryInfo);
         }
     }
 
@@ -160,12 +161,12 @@ define(function (require, exports, module) {
     function _getNextMatch(editor, rev, pos, wrap) {
         var cm = editor._codeMirror;
         var state = getSearchState(cm);
-        var cursor = getSearchCursor(cm, state.query, state.queryInfo, pos || editor.getCursorPos(false, rev ? "start" : "end"));
+        var cursor = getSearchCursor(cm, state, pos || editor.getCursorPos(false, rev ? "start" : "end"));
 
         state.lastMatch = cursor.find(rev);
         if (!state.lastMatch && wrap !== false) {
             // If no result found before hitting edge of file, try wrapping around
-            cursor = getSearchCursor(cm, state.query, state.queryInfo, rev ? {line: cm.lineCount() - 1} : {line: 0, ch: 0});
+            cursor = getSearchCursor(cm, state, rev ? {line: cm.lineCount() - 1} : {line: 0, ch: 0});
             state.lastMatch = cursor.find(rev);
         }
         if (!state.lastMatch) {
@@ -410,7 +411,7 @@ define(function (require, exports, module) {
     function clearSearch(cm) {
         cm.operation(function () {
             var state = getSearchState(cm);
-            if (!state.query || !state.queryInfo) {
+            if (!state.parsedQuery) {
                 return;
             }
             setQueryInfo(state, null);
@@ -439,14 +440,12 @@ define(function (require, exports, module) {
             state = getSearchState(cm);
         
         function indicateHasMatches(numResults) {
-            if (findBar) {
-                // Make the field red if it's not blank and it has no matches (which also covers invalid regexes)
-                findBar.showNoResults(!state.foundAny && findBar.getQueryInfo().query);
+            // Make the field red if it's not blank and it has no matches (which also covers invalid regexes)
+            findBar.showNoResults(!state.foundAny && findBar.getQueryInfo().query);
 
-                // Navigation buttons enabled if we have a query and more than one match
-                findBar.enableNavigation(state.foundAny && numResults > 1);
-                findBar.enableReplace(state.foundAny);
-            }
+            // Navigation buttons enabled if we have a query and more than one match
+            findBar.enableNavigation(state.foundAny && numResults > 1);
+            findBar.enableReplace(state.foundAny);
         }
         
         cm.operation(function () {
@@ -455,11 +454,9 @@ define(function (require, exports, module) {
                 clearHighlights(cm, state);
             }
             
-            if (!state.query || !state.queryInfo) {
+            if (!state.parsedQuery) {
                 // Search field is empty - no results
-                if (findBar) {
-                    findBar.showFindCount("");
-                }
+                findBar.showFindCount("");
                 state.foundAny = false;
                 indicateHasMatches();
                 return;
@@ -467,7 +464,7 @@ define(function (require, exports, module) {
             
             // Find *all* matches, searching from start of document
             // (Except on huge documents, where this is too expensive)
-            var cursor = getSearchCursor(cm, state.query, state.queryInfo);
+            var cursor = getSearchCursor(cm, state);
             if (cm.getValue().length <= FIND_MAX_FILE_SIZE) {
                 // FUTURE: if last query was prefix of this one, could optimize by filtering last result set
                 var resultSet = [];
@@ -490,25 +487,21 @@ define(function (require, exports, module) {
                     ScrollTrackMarkers.addTickmarks(editor, scrollTrackPositions);
                 }
                 
-                if (findBar) {
-                    var countInfo;
-                    if (resultSet.length === 0) {
-                        countInfo = Strings.FIND_NO_RESULTS;
-                    } else if (resultSet.length === 1) {
-                        countInfo = Strings.FIND_RESULT_COUNT_SINGLE;
-                    } else {
-                        countInfo = StringUtils.format(Strings.FIND_RESULT_COUNT, resultSet.length);
-                    }
-                    findBar.showFindCount(countInfo);
+                var countInfo;
+                if (resultSet.length === 0) {
+                    countInfo = Strings.FIND_NO_RESULTS;
+                } else if (resultSet.length === 1) {
+                    countInfo = Strings.FIND_RESULT_COUNT_SINGLE;
+                } else {
+                    countInfo = StringUtils.format(Strings.FIND_RESULT_COUNT, resultSet.length);
                 }
+                findBar.showFindCount(countInfo);
                 state.foundAny = (resultSet.length > 0);
                 indicateHasMatches(resultSet.length);
                 
             } else {
                 // On huge documents, just look for first match & then stop
-                if (findBar) {
-                    findBar.showFindCount("");
-                }
+                findBar.showFindCount("");
                 state.foundAny = cursor.findNext();
                 indicateHasMatches();
             }
@@ -516,7 +509,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Called each time the search query field changes. Updates state.query (query will be falsy if the field
+     * Called each time the search query field changes. Updates state.parsedQuery (parsedQuery will be falsy if the field
      * was blank OR contained a regexp with invalid syntax). Then calls updateResultSet(), and then jumps to
      * the first matching result, starting from the original cursor position.
      * @param {!Editor} editor The editor we're searching in.
@@ -525,10 +518,10 @@ define(function (require, exports, module) {
      *     In that case, we don't want to change the selection unnecessarily.
      */
     function handleQueryChange(editor, state, initial) {
-        setQueryInfo(state, findBar && findBar.getQueryInfo());
+        setQueryInfo(state, findBar.getQueryInfo());
         updateResultSet(editor);
         
-        if (state.query && state.queryInfo) {
+        if (state.parsedQuery) {
             // 3rd arg: prefer to avoid scrolling if result is anywhere within view, since in this case user
             // is in the middle of typing, not navigating explicitly; viewport jumping would be distracting.
             findNext(editor, false, true, state.searchStartPos);
@@ -613,7 +606,7 @@ define(function (require, exports, module) {
      */
     function doSearch(editor, rev) {
         var state = getSearchState(editor._codeMirror);
-        if (state.query && state.queryInfo) {
+        if (state.parsedQuery) {
             findNext(editor, rev);
             return;
         }
@@ -643,7 +636,7 @@ define(function (require, exports, module) {
             // Delegate to Replace in Files.
             FindInFilesUI.searchAndShowResults(state.queryInfo, editor.document.file, null, replaceText);
         } else {
-            cm.replaceSelection(typeof state.query === "string" ? replaceText : FindUtils.parseDollars(replaceText, state.lastMatch));
+            cm.replaceSelection(state.queryInfo.isRegexp ? FindUtils.parseDollars(replaceText, state.lastMatch) : replaceText);
 
             updateResultSet(editor);  // we updated the text, so result count & tickmarks must be refreshed
 
@@ -657,7 +650,7 @@ define(function (require, exports, module) {
 
     function replace(editor) {
         // If Replace bar already open, treat the shortcut as a hotkey for the Replace button
-        if (findBar && findBar.getOptions().replace) {
+        if (findBar && findBar.getOptions().replace && findBar.isReplaceEnabled()) {
             doReplace(editor, false);
             return;
         }

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -67,12 +67,6 @@ define(function (require, exports, module) {
     var FIND_HIGHLIGHT_MAX  = 2000;
 
     /**
-     * Maximum number of matches to collect for Replace All; any additional matches are not listed in the panel & are not replaced
-     * @const {number}
-     */
-    var REPLACE_ALL_MAX     = 10000;
-    
-    /**
      * Instance of the currently opened document when replaceAllPanel is visible
      * @type {?Document}
      */

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -651,9 +651,13 @@ define(function (require, exports, module) {
         
         openSearchBar(editor, true);
         
-        $(findBar).on("doReplace.FindReplace", function (e, all) {
-            doReplace(editor, all);
-        });
+        $(findBar)
+            .on("doReplace.FindReplace", function (e) {
+                doReplace(editor, false);
+            })
+            .on("doReplaceAll.FindReplace", function (e) {
+                doReplace(editor, true);
+            });
     }
 
     function _launchFind() {

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -566,7 +566,7 @@ define(function (require, exports, module) {
         
         // Create the search bar UI (closing any previous find bar in the process)
         findBar = new FindBar({
-            navigator: true,
+            multifile: false,
             replace: replace,
             initialQuery: initialQuery,
             queryPlaceholder: Strings.CMD_FIND_FIELD_PLACEHOLDER

--- a/src/search/SearchModel.js
+++ b/src/search/SearchModel.js
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
 
     /**
      * The file/folder path representing the scope that this query was performed in.
-     * @type {string}
+     * @type {FileSystemEntry}
      */
     SearchModel.prototype.scope = null;
     
@@ -121,8 +121,8 @@ define(function (require, exports, module) {
         this.queryInfo = queryInfo;
         this.queryExpr = null;
         
-        // TODO: only apparent difference between this one and the one in FindReplace is that this one returns
-        // null instead of "" for a bad query, and this always returns a regexp even for simple strings. Reconcile.
+        // TODO: only major difference between this one and the one in FindReplace is that 
+        // this always returns a regexp even for simple strings. Reconcile.
         if (!queryInfo || !queryInfo.query) {
             return {empty: true};
         }
@@ -151,12 +151,13 @@ define(function (require, exports, module) {
 
     /**
      * Adds the given result matches to the search results
-     * @param {string} fullpath
-     * @param {Array.<Object>} matches
-     * @return true if at least some matches were added, false if we've hit the limit on how many can be added
+     * @param {string} fullpath Full path to the file containing the matches.
+     * @param {!Array.<Object>} matches Array of matches, in the format returned by FindInFiles._getSearchMatches()
+     * @param {!Date} timestamp The timestamp of the document at the time we searched it.
+     * @return {boolean} true if at least some matches were added, false if we've hit the limit on how many can be added
      */
     SearchModel.prototype.addResultMatches = function (fullpath, matches, timestamp) {
-        if (this.foundMaximum) {
+        if (this.foundMaximum || !matches.length) {
             return false;
         }
         
@@ -175,7 +176,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * @return true if there are any results in this model.
+     * @return {boolean} true if there are any results in this model.
      */
     SearchModel.prototype.hasResults = function () {
         return Object.keys(this.results).length > 0;
@@ -201,10 +202,7 @@ define(function (require, exports, module) {
      * @return {Array.<string>}
      */
     SearchModel.prototype.getSortedFiles = function (firstFile) {
-        var searchFiles = Object.keys(this.results),
-            self        = this;
-
-        searchFiles.sort(function (key1, key2) {
+        return Object.keys(this.results).sort(function (key1, key2) {
             if (firstFile === key1) {
                 return -1;
             } else if (firstFile === key2) {
@@ -212,8 +210,6 @@ define(function (require, exports, module) {
             }
             return FileUtils.comparePaths(key1, key2);
         });
-
-        return searchFiles;
     };
 
     /**

--- a/src/search/SearchModel.js
+++ b/src/search/SearchModel.js
@@ -157,17 +157,20 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Adds the given result matches to the search results.
+     * Sets the list of matches for the given path, removing the previous match info, if any, and updating
+     * the total match count. Note that for the count to remain accurate, the previous match info must not have
+     * been mutated since it was set.
      * @param {string} fullpath Full path to the file containing the matches.
-     * @param {!{matches: Object, timestamp: Date, collapsed: boolean=}} resultInfo Info for the match to add:
+     * @param {!{matches: Object, timestamp: Date, collapsed: boolean=}} resultInfo Info for the matches to set:
      *      matches - Array of matches, in the format returned by FindInFiles._getSearchMatches()
      *      timestamp - The timestamp of the document at the time we searched it.
      *      collapsed - Optional: whether the results should be collapsed in the UI (default false).
-     * @return {boolean} true if at least some matches were added, false if we've hit the limit on how many can be added
      */
-    SearchModel.prototype.addResults = function (fullpath, resultInfo) {
+    SearchModel.prototype.setResults = function (fullpath, resultInfo) {
+        this.removeResults(fullpath);
+        
         if (this.foundMaximum || !resultInfo.matches.length) {
-            return false;
+            return;
         }
         
         this.results[fullpath] = resultInfo;
@@ -175,12 +178,10 @@ define(function (require, exports, module) {
         if (this.numMatches >= SearchModel.MAX_TOTAL_RESULTS) {
             this.foundMaximum = true;
         }
-        
-        return true;
     };
     
     /**
-     * Removes the given result's matches from the search results.
+     * Removes the given result's matches from the search results and updates the total match count.
      * @param {string} fullpath Full path to the file containing the matches.
      */
     SearchModel.prototype.removeResults = function (fullpath) {

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -422,8 +422,9 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Utility for converting a method that takes an errback to one that returns a promise; useful
-     * for using FileSystem methods in a promise-oriented workflow. For example, instead of
+     * Utility for converting a method that takes (error, callback) to one that returns a promise;
+     * useful for using FileSystem methods (or other Node-style API methods) in a promise-oriented
+     * workflow. For example, instead of
      *
      *      var deferred = new $.Deferred();
      *      file.read(function (err, contents) {

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -198,21 +198,6 @@ define(function (require, exports, module) {
         return returnVal;
     }
     
-    /**
-     * Creates an HTML string for a list of files to be reported on, suitable for use in a dialog.
-     * @param {Array.<string>} Array of filenames or paths to display.
-     */
-    function makeDialogFileList(paths) {
-        var result = "<ul class='dialog-list'>";
-        paths.forEach(function (path) {
-            result += "<li><span class='dialog-filename'>";
-            result += breakableUrl(path);
-            result += "</span></li>";
-        });
-        result += "</ul>";
-        return result;
-    }
-
     // Define public API
     exports.format              = format;
     exports.htmlEscape          = htmlEscape;
@@ -224,5 +209,4 @@ define(function (require, exports, module) {
     exports.breakableUrl        = breakableUrl;
     exports.endsWith            = endsWith;
     exports.prettyPrintBytes    = prettyPrintBytes;
-    exports.makeDialogFileList  = makeDialogFileList;
 });

--- a/test/spec/FileFilters-test.js
+++ b/test/spec/FileFilters-test.js
@@ -486,7 +486,7 @@ define(function (require, exports, module) {
             });
         });
         
-        describe("Find in Files filtering", function () {
+        describe("Integration", function () {
             
             this.category = "integration";
             
@@ -499,9 +499,11 @@ define(function (require, exports, module) {
                 CommandManager,
                 $;
             
-            beforeFirst(function () {
+            // We don't directly call beforeFirst/afterLast here because it appears that we need
+            // separate test windows for the nested describe suites.
+            function setupTestWindow(spec) {
                 // Create a new window that will be shared by ALL tests in this spec.
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                SpecRunnerUtils.createTestWindowAndRun(spec, function (w) {
                     testWindow = w;
 
                     // Load module instances from brackets.test
@@ -514,9 +516,9 @@ define(function (require, exports, module) {
                     
                     SpecRunnerUtils.loadProjectInTestWindow(testPath);
                 });
-            });
+            }
 
-            afterLast(function () {
+            function teardownTestWindow() {
                 testWindow = null;
                 FileSystem = null;
                 FileFilters = null;
@@ -525,8 +527,12 @@ define(function (require, exports, module) {
                 CommandManager = null;
                 $ = null;
                 SpecRunnerUtils.closeTestWindow();
-            });
+            }
             
+            // These helper functions are slight variations of the ones in FindInFiles, so need to be
+            // kept in sync with those. It's a bit awkward to try to share them, and as long as
+            // it's just these few functions it's probably okay to just keep them in sync manually,
+            // but if this gets more complicated we should probably figure out how to break them out.
             function openSearchBar(scope) {
                 // Make sure search bar from previous test has animated out fully
                 runs(function () {
@@ -535,7 +541,18 @@ define(function (require, exports, module) {
                     }, "search bar close");
                 });
                 runs(function () {
+                    FindInFiles._searchDone = false;
                     FindInFilesUI._showFindBar(scope);
+                });
+                waitsFor(function () {
+                    return $(".modal-bar").length === 1;
+                }, "search bar open");
+            }
+
+            function closeSearchBar() {
+                runs(function () {
+                    var $searchField = $(".modal-bar #find-group input");
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $searchField[0]);
                 });
             }
 
@@ -549,503 +566,459 @@ define(function (require, exports, module) {
                 }, "Find in Files done");
             }
 
-            it("should search all files by default", function () {
-                openSearchBar();
-                runs(function () {
-                    executeSearch("{1}");
+            describe("Find in Files filtering", function () {
+                beforeFirst(function () {
+                    setupTestWindow(this);
                 });
-                runs(function () {
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeTruthy();
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
+                afterLast(teardownTestWindow);
+                
+                it("should search all files by default", function () {
+                    openSearchBar();
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeTruthy();
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
+                    });
                 });
-            });
-            
-            // This finishes async, since clickDialogButton() finishes async (dialogs close asynchronously)
-            function setExcludeCSSFiles() {
-                // Launch filter editor
-                FileFilters.editFilter({ name: "", patterns: [] }, -1);
 
-                // Edit the filter & confirm changes
-                $(".modal.instance textarea").val("*.css");
-                SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
-            }
-            
-            it("should exclude files from search", function () {
-                openSearchBar();
-                runs(function () {
-                    setExcludeCSSFiles();
-                });
-                runs(function () {
-                    executeSearch("{1}");
-                });
-                runs(function () {
-                    // *.css should have been excluded this time
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
-                });
-            });
-            
-            it("should respect filter when searching folder", function () {
-                var dirEntry = FileSystem.getDirectoryForPath(testPath);
-                openSearchBar(dirEntry);
-                runs(function () {
-                    setExcludeCSSFiles();
-                });
-                runs(function () {
-                    executeSearch("{1}");
-                });
-                runs(function () {
-                    // *.css should have been excluded this time
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
-                });
-            });
-            
-            it("should ignore filter when searching a single file", function () {
-                var fileEntry = FileSystem.getFileForPath(testPath + "/test1.css");
-                openSearchBar(fileEntry);
-                runs(function () {
-                    // Cannot explicitly set *.css filter in dialog because button is hidden
-                    // (which is verified here), but filter persists from previous test
-                    expect($("button.file-filter-picker").is(":visible")).toBeFalsy();
-                });
-                runs(function () {
-                    executeSearch("{1}");
-                });
-                runs(function () {
-                    // ignore *.css exclusion since we're explicitly searching this file
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeTruthy();
-                });
-            });
-            
-            it("should show error when filter excludes all files", function () {
-                openSearchBar();
-                runs(function () {
+                // This finishes async, since clickDialogButton() finishes async (dialogs close asynchronously)
+                function setExcludeCSSFiles() {
                     // Launch filter editor
                     FileFilters.editFilter({ name: "", patterns: [] }, -1);
 
                     // Edit the filter & confirm changes
-                    $(".modal.instance textarea").val("test1.*\n*.css");
+                    $(".modal.instance textarea").val("*.css");
                     SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
-                });
-                runs(function () {
-                    executeSearch("{1}");
-                });
-                runs(function () {
-                    var $modalBar = $(".modal-bar");
+                }
 
-                    // Dialog still showing
-                    expect($modalBar.length).toBe(1);
-
-                    // Error message displayed
-                    expect($modalBar.find("#find-group div.error").is(":visible")).toBeTruthy();
-
-                    // Search panel not showing
-                    expect($("#find-in-files-results").is(":visible")).toBeFalsy();
-
-                    // Close search bar
-                    var $searchField = $modalBar.find("#find-group input");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $searchField[0]);
-                });
-            });
-            
-            it("should respect filter when editing code", function () {
-                openSearchBar();
-                runs(function () {
-                    setExcludeCSSFiles();
-                });
-                runs(function () {
-                    executeSearch("{1}");
-                });
-                runs(function () {
-                    var promise = testWindow.brackets.test.DocumentManager.getDocumentForPath(testPath + "/test1.css");
-                    waitsForDone(promise);
-                    promise.done(function (doc) {
-                        // Modify line that contains potential search result
-                        expect(doc.getLine(5).indexOf("{1}")).not.toBe(-1);
-                        doc.replaceRange("X", {line: 5, ch: 0});
+                it("should exclude files from search", function () {
+                    openSearchBar();
+                    runs(function () {
+                        setExcludeCSSFiles();
+                    });
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        // *.css should have been excluded this time
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
                     });
                 });
-                runs(function () {
-                    waits(800);  // ensure _documentChangeHandler()'s timeout has time to run
+
+                it("should respect filter when searching folder", function () {
+                    var dirEntry = FileSystem.getDirectoryForPath(testPath);
+                    openSearchBar(dirEntry);
+                    runs(function () {
+                        setExcludeCSSFiles();
+                    });
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        // *.css should have been excluded this time
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
+                    });
                 });
-                runs(function () {
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();  // *.css should still be excluded
-                    expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
+
+                it("should ignore filter when searching a single file", function () {
+                    var fileEntry = FileSystem.getFileForPath(testPath + "/test1.css");
+                    openSearchBar(fileEntry);
+                    runs(function () {
+                        // Cannot explicitly set *.css filter in dialog because button is hidden
+                        // (which is verified here), but filter persists from previous test
+                        expect($("button.file-filter-picker").is(":visible")).toBeFalsy();
+                    });
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        // ignore *.css exclusion since we're explicitly searching this file
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeTruthy();
+                    });
+                });
+
+                it("should show error when filter excludes all files", function () {
+                    openSearchBar();
+                    runs(function () {
+                        // Launch filter editor
+                        FileFilters.editFilter({ name: "", patterns: [] }, -1);
+
+                        // Edit the filter & confirm changes
+                        $(".modal.instance textarea").val("test1.*\n*.css");
+                        SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                    });
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        var $modalBar = $(".modal-bar");
+
+                        // Dialog still showing
+                        expect($modalBar.length).toBe(1);
+
+                        // Error message displayed
+                        expect($modalBar.find("#find-group div.error").is(":visible")).toBeTruthy();
+
+                        // Search panel not showing
+                        expect($("#find-in-files-results").is(":visible")).toBeFalsy();
+
+                        // Close search bar
+                        var $searchField = $modalBar.find("#find-group input");
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $searchField[0]);
+                    });
+                });
+
+                it("should respect filter when editing code", function () {
+                    openSearchBar();
+                    runs(function () {
+                        setExcludeCSSFiles();
+                    });
+                    runs(function () {
+                        executeSearch("{1}");
+                    });
+                    runs(function () {
+                        var promise = testWindow.brackets.test.DocumentManager.getDocumentForPath(testPath + "/test1.css");
+                        waitsForDone(promise);
+                        promise.done(function (doc) {
+                            // Modify line that contains potential search result
+                            expect(doc.getLine(5).indexOf("{1}")).not.toBe(-1);
+                            doc.replaceRange("X", {line: 5, ch: 0});
+                        });
+                    });
+                    runs(function () {
+                        waits(800);  // ensure _documentChangeHandler()'s timeout has time to run
+                    });
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.css"]).toBeFalsy();  // *.css should still be excluded
+                        expect(FindInFiles.searchModel.results[testPath + "/test1.html"]).toBeTruthy();
+                    });
                 });
             });
-        });
         
-        describe("Filter picker UI", function () {
-            
-            this.category = "integration";
-            
-            var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
-                testWindow,
-                FileFilters,
-                FileSystem,
-                FindInFiles,
-                CommandManager,
-                $;
-            
-            beforeFirst(function () {
-                // Create a new window that will be shared by ALL tests in this spec.
-                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                    testWindow = w;
-
-                    // Load module instances from brackets.test
-                    FileFilters        = testWindow.brackets.test.FileFilters;
-                    FileSystem         = testWindow.brackets.test.FileSystem;
-                    FindInFiles        = testWindow.brackets.test.FindInFiles;
-                    CommandManager     = testWindow.brackets.test.CommandManager;
-                    $                  = testWindow.$;
-                    
-                    SpecRunnerUtils.loadProjectInTestWindow(testPath);
+            describe("Filter picker UI", function () {
+                beforeFirst(function () {
+                    setupTestWindow(this);
                 });
-            });
+                afterLast(teardownTestWindow);
 
-            afterLast(function () {
-                testWindow = null;
-                FileSystem = null;
-                FileFilters = null;
-                FindInFiles = null;
-                CommandManager = null;
-                $ = null;
-                SpecRunnerUtils.closeTestWindow();
-            });
-            
-            function openSearchBar(scope) {
-                // Make sure search bar from previous test has animated out fully
-                runs(function () {
-                    waitsFor(function () {
-                        return $(".modal-bar").length === 0;
-                    }, "search bar close");
+                beforeEach(function () {
+                    openSearchBar();
                 });
-                runs(function () {
-                    FindInFiles._doFindInFiles(scope);
+
+                afterEach(function () {
+                    closeSearchBar();
                 });
-            }
 
-            function closeSearchBar() {
-                runs(function () {
-                    var $searchField = $(".modal-bar #find-group input");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $searchField[0]);
-                });
-            }
+                function verifyButtonLabel(expectedLabel) {
+                    var newButtonLabel  = StringUtils.format(Strings.EXCLUDE_FILE_FILTER, expectedLabel);
 
-            beforeEach(function () {
-                openSearchBar();
-            });
-            
-            afterEach(function () {
-                closeSearchBar();
-            });
-            
-            function verifyButtonLabel(expectedLabel) {
-                var newButtonLabel  = StringUtils.format(Strings.EXCLUDE_FILE_FILTER, expectedLabel);
-
-                if (expectedLabel) {
-                    // Verify filter picker button label is updated with the patterns of the selected filter set.
-                    expect($("button.file-filter-picker").text()).toEqual(newButtonLabel);
-                } else {
-                    expect($("button.file-filter-picker").text()).toEqual(Strings.NO_FILE_FILTER);
+                    if (expectedLabel) {
+                        // Verify filter picker button label is updated with the patterns of the selected filter set.
+                        expect($("button.file-filter-picker").text()).toEqual(newButtonLabel);
+                    } else {
+                        expect($("button.file-filter-picker").text()).toEqual(Strings.NO_FILE_FILTER);
+                    }
                 }
-            }
-            
-            // This finishes async, since clickDialogButton() finishes async (dialogs close asynchronously)
-            function setExcludeCSSFiles() {
-                // Edit the filter & confirm changes
-                $(".modal.instance .exclusions-name").val("CSS Files");
-                $(".modal.instance .exclusions-editor").val("*.css\n*.less\n*.scss");
-                SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
-            }
 
-            // Trigger a mouseover event on the 'parent' and then click on the button with the given 'selector'.
-            function clickOnMouseOverButton(selector, parent) {
-                runs(function () {
-                    parent.trigger("mouseover");
-                });
-                runs(function () {
-                    expect($(selector, parent).is(":visible")).toBeTruthy();
-                    $(selector, parent).click();
-                });
-            }
-            
-            it("should show 'No files Excluded' in filter picker button by default", function () {
-                runs(function () {
-                    verifyButtonLabel();
-                });
-            });
-            
-            it("should show two filter commands by default", function () {
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    var $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    expect($dropdown.children().length).toEqual(2);
-                    expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
-                    expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
-                });
-
-                runs(function () {
-                    FileFilters.closeDropdown();
-                });
-            });
-
-            it("should launch filter editor and add a new filter set when invoked from new filter command", function () {
-                var $dropdown;
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-                
-                // Invoke new filter command by pressing down arrow key once and then enter key.
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
-                });
-
-                runs(function () {
-                    setExcludeCSSFiles();
-                });
-                
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    var filterSuffix = StringUtils.format(Strings.FILE_FILTER_CLIPPED_SUFFIX, 1);
-                    
-                    // Verify filter picker button is updated with the name of the new filter.
-                    verifyButtonLabel("CSS Files");
-                    
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    expect($dropdown.children().length).toEqual(4);
-                    expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
-                    expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
-                    expect($(".recent-filter-name", $($dropdown.children()[3])).text()).toEqual("CSS Files");
-                    expect($(".recent-filter-patterns", $($dropdown.children()[3])).text()).toEqual(" - *.css, *.less " + filterSuffix);
-                });
-                
-                runs(function () {
-                    FileFilters.closeDropdown();
-                });
-            });
-
-            it("should clear the active filter set when invoked from clear filter command", function () {
-                var $dropdown;
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-
-                // Invoke new filter command by pressing down arrow key twice and then enter key.
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
-                });
-
-                runs(function () {
-                    // Verify filter picker button is updated to show no active filter.
-                    verifyButtonLabel();
-                    expect($dropdown.is(":visible")).toBeFalsy();
-                });
-                
-                // Re-open dropdown list and verify that nothing changed.
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    var filterSuffix = StringUtils.format(Strings.FILE_FILTER_CLIPPED_SUFFIX, 1);
-                    
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    expect($dropdown.children().length).toEqual(4);
-                    expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
-                    expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
-                    expect($(".recent-filter-name", $($dropdown.children()[3])).text()).toEqual("CSS Files");
-                    expect($(".recent-filter-patterns", $($dropdown.children()[3])).text()).toEqual(" - *.css, *.less " + filterSuffix);
-                });
-                
-                runs(function () {
-                    FileFilters.closeDropdown();
-                });
-            });
-
-            it("should switch the active filter set to the selected one", function () {
-                var $dropdown;
-                runs(function () {
-                    // Verify that there is no active filter (was set from the previous test).
-                    verifyButtonLabel();
-                    FileFilters.showDropdown();
-                });
-
-                // Select the last filter set in the dropdown by pressing up arrow key once and then enter key.
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_UP, "keydown", $dropdown[0]);
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
-                });
-
-                runs(function () {
-                    // Verify filter picker button label is updated with the name of the selected filter set.
-                    verifyButtonLabel("CSS Files");
-                    expect($dropdown.is(":visible")).toBeFalsy();
-                });
-            });
-
-            it("should launch filter editor and fill in the text fields with selected filter info", function () {
-                var $dropdown;
-
-                runs(function () {
-                    FileFilters.showDropdown();
-                });
-                
-                // Click on the edit icon that shows up in the first filter set on mouseover.
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    clickOnMouseOverButton(".filter-edit-icon", $($dropdown.children()[3]));
-                });
-                
-                // Remove the name of the filter set and reduce the filter set to '*.css'.
-                runs(function () {
-                    expect($(".modal.instance .exclusions-name").val()).toEqual("CSS Files");
-                    expect($(".modal.instance .exclusions-editor").val()).toEqual("*.css\n*.less\n*.scss");
-                    
-                    $(".modal.instance .exclusions-name").val("");
-                    $(".modal.instance .exclusions-editor").val("*.css");
+                // This finishes async, since clickDialogButton() finishes async (dialogs close asynchronously)
+                function setExcludeCSSFiles() {
+                    // Edit the filter & confirm changes
+                    $(".modal.instance .exclusions-name").val("CSS Files");
+                    $(".modal.instance .exclusions-editor").val("*.css\n*.less\n*.scss");
                     SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
-                });
-                
-                runs(function () {
-                    // Verify filter picker button label is updated with the patterns of the selected filter set.
-                    verifyButtonLabel("*.css");
-                    expect($dropdown.is(":visible")).toBeFalsy();
-                });
-            });
+                }
 
-            it("should remove selected filter from filter sets preferences without changing picker button label", function () {
-                var $dropdown,
-                    filters = [{name: "Node Modules", patterns: ["node_module"]},
-                               {name: "Mark Down Files", patterns: ["*.md"]},
-                               {name: "CSS Files", patterns: ["*.css", "*.less"]}];
-                
-                // Create three filter sets and make the last one active.
-                runs(function () {
-                    FileFilters.editFilter(filters[0], 0);
-                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                // Trigger a mouseover event on the 'parent' and then click on the button with the given 'selector'.
+                function clickOnMouseOverButton(selector, parent) {
+                    runs(function () {
+                        parent.trigger("mouseover");
+                    });
+                    runs(function () {
+                        expect($(selector, parent).is(":visible")).toBeTruthy();
+                        $(selector, parent).click();
+                    });
+                }
+
+                it("should show 'No files Excluded' in filter picker button by default", function () {
+                    runs(function () {
+                        verifyButtonLabel();
+                    });
                 });
 
-                runs(function () {
-                    FileFilters.editFilter(filters[1], -1);
-                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
-                });
-                
-                runs(function () {
-                    FileFilters.editFilter(filters[2], -1);
-                    SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                it("should show two filter commands by default", function () {
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
+
+                    runs(function () {
+                        var $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        expect($dropdown.children().length).toEqual(2);
+                        expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
+                        expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
                 });
 
-                runs(function () {
-                    verifyButtonLabel("CSS Files");
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.children().length).toEqual(6);
+                it("should launch filter editor and add a new filter set when invoked from new filter command", function () {
+                    var $dropdown;
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
+
+                    // Invoke new filter command by pressing down arrow key once and then enter key.
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
+                    });
+
+                    runs(function () {
+                        setExcludeCSSFiles();
+                    });
+
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
+
+                    runs(function () {
+                        var filterSuffix = StringUtils.format(Strings.FILE_FILTER_CLIPPED_SUFFIX, 1);
+
+                        // Verify filter picker button is updated with the name of the new filter.
+                        verifyButtonLabel("CSS Files");
+
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        expect($dropdown.children().length).toEqual(4);
+                        expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
+                        expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
+                        expect($(".recent-filter-name", $($dropdown.children()[3])).text()).toEqual("CSS Files");
+                        expect($(".recent-filter-patterns", $($dropdown.children()[3])).text()).toEqual(" - *.css, *.less " + filterSuffix);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
                 });
 
-                // Click on the delete icon that shows up in the first filter set on mouseover.
-                runs(function () {
-                    clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[3]));
-                });
-                
-                runs(function () {
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    // Verify that button label is still the same since the deleted one is not the active one.
-                    verifyButtonLabel("CSS Files");
-                    
-                    // Verify that the list has one less item (from 6 to 5).
-                    expect($dropdown.children().length).toEqual(5);
-                    
-                    // Verify data-index of the two remaining filter sets.
-                    expect($("a", $dropdown.children()[3]).data("index")).toBe(3);
-                    expect($("a", $dropdown.children()[4]).data("index")).toBe(4);
-                });
-                
-                runs(function () {
-                    FileFilters.closeDropdown();
-                });
-            });
+                it("should clear the active filter set when invoked from clear filter command", function () {
+                    var $dropdown;
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
 
-            it("should remove selected filter from filter sets preferences plus changing picker button label", function () {
-                var $dropdown;
+                    // Invoke new filter command by pressing down arrow key twice and then enter key.
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $dropdown[0]);
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
+                    });
 
-                runs(function () {
-                    verifyButtonLabel("CSS Files");
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.children().length).toEqual(5);
-                });
+                    runs(function () {
+                        // Verify filter picker button is updated to show no active filter.
+                        verifyButtonLabel();
+                        expect($dropdown.is(":visible")).toBeFalsy();
+                    });
 
-                // Click on the delete icon that shows up in the last filter set on mouseover.
-                runs(function () {
-                    clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[4]));
-                });
-                
-                runs(function () {
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    // Verify that button label is changed to "No Files Excluded".
-                    verifyButtonLabel();
-                    
-                    // Verify that the list has one less item.
-                    expect($dropdown.children().length).toEqual(4);
-                });
-                
-                runs(function () {
-                    FileFilters.closeDropdown();
-                });
-            });
+                    // Re-open dropdown list and verify that nothing changed.
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
 
-            it("should also remove the divider from the dropdown list after removing the last remaining filter set", function () {
-                var $dropdown;
+                    runs(function () {
+                        var filterSuffix = StringUtils.format(Strings.FILE_FILTER_CLIPPED_SUFFIX, 1);
 
-                runs(function () {
-                    verifyButtonLabel();
-                    FileFilters.showDropdown();
-                });
-                
-                runs(function () {
-                    $dropdown = $(".dropdown-menu.dropdownbutton-popup");
-                    expect($dropdown.children().length).toEqual(4);
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        expect($dropdown.children().length).toEqual(4);
+                        expect($($dropdown.children()[0]).text()).toEqual(Strings.NEW_FILE_FILTER);
+                        expect($($dropdown.children()[1]).text()).toEqual(Strings.CLEAR_FILE_FILTER);
+                        expect($(".recent-filter-name", $($dropdown.children()[3])).text()).toEqual("CSS Files");
+                        expect($(".recent-filter-patterns", $($dropdown.children()[3])).text()).toEqual(" - *.css, *.less " + filterSuffix);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
                 });
 
-                // Click on the delete icon that shows up in the last filter set on mouseover.
-                runs(function () {
-                    clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[3]));
+                it("should switch the active filter set to the selected one", function () {
+                    var $dropdown;
+                    runs(function () {
+                        // Verify that there is no active filter (was set from the previous test).
+                        verifyButtonLabel();
+                        FileFilters.showDropdown();
+                    });
+
+                    // Select the last filter set in the dropdown by pressing up arrow key once and then enter key.
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_UP, "keydown", $dropdown[0]);
+                        SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $dropdown[0]);
+                    });
+
+                    runs(function () {
+                        // Verify filter picker button label is updated with the name of the selected filter set.
+                        verifyButtonLabel("CSS Files");
+                        expect($dropdown.is(":visible")).toBeFalsy();
+                    });
                 });
-                
-                runs(function () {
-                    expect($dropdown.is(":visible")).toBeTruthy();
-                    // Verify that button label still shows "No Files Excluded".
-                    verifyButtonLabel();
-                    
-                    // Verify that the list has only two filter commands.
-                    expect($dropdown.children().length).toEqual(2);
+
+                it("should launch filter editor and fill in the text fields with selected filter info", function () {
+                    var $dropdown;
+
+                    runs(function () {
+                        FileFilters.showDropdown();
+                    });
+
+                    // Click on the edit icon that shows up in the first filter set on mouseover.
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        clickOnMouseOverButton(".filter-edit-icon", $($dropdown.children()[3]));
+                    });
+
+                    // Remove the name of the filter set and reduce the filter set to '*.css'.
+                    runs(function () {
+                        expect($(".modal.instance .exclusions-name").val()).toEqual("CSS Files");
+                        expect($(".modal.instance .exclusions-editor").val()).toEqual("*.css\n*.less\n*.scss");
+
+                        $(".modal.instance .exclusions-name").val("");
+                        $(".modal.instance .exclusions-editor").val("*.css");
+                        SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                    });
+
+                    runs(function () {
+                        // Verify filter picker button label is updated with the patterns of the selected filter set.
+                        verifyButtonLabel("*.css");
+                        expect($dropdown.is(":visible")).toBeFalsy();
+                    });
                 });
-                
-                runs(function () {
-                    FileFilters.closeDropdown();
+
+                it("should remove selected filter from filter sets preferences without changing picker button label", function () {
+                    var $dropdown,
+                        filters = [{name: "Node Modules", patterns: ["node_module"]},
+                                   {name: "Mark Down Files", patterns: ["*.md"]},
+                                   {name: "CSS Files", patterns: ["*.css", "*.less"]}];
+
+                    // Create three filter sets and make the last one active.
+                    runs(function () {
+                        FileFilters.editFilter(filters[0], 0);
+                        SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                    });
+
+                    runs(function () {
+                        FileFilters.editFilter(filters[1], -1);
+                        SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                    });
+
+                    runs(function () {
+                        FileFilters.editFilter(filters[2], -1);
+                        SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_OK, true);
+                    });
+
+                    runs(function () {
+                        verifyButtonLabel("CSS Files");
+                        FileFilters.showDropdown();
+                    });
+
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.children().length).toEqual(6);
+                    });
+
+                    // Click on the delete icon that shows up in the first filter set on mouseover.
+                    runs(function () {
+                        clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[3]));
+                    });
+
+                    runs(function () {
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        // Verify that button label is still the same since the deleted one is not the active one.
+                        verifyButtonLabel("CSS Files");
+
+                        // Verify that the list has one less item (from 6 to 5).
+                        expect($dropdown.children().length).toEqual(5);
+
+                        // Verify data-index of the two remaining filter sets.
+                        expect($("a", $dropdown.children()[3]).data("index")).toBe(3);
+                        expect($("a", $dropdown.children()[4]).data("index")).toBe(4);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
+                });
+
+                it("should remove selected filter from filter sets preferences plus changing picker button label", function () {
+                    var $dropdown;
+
+                    runs(function () {
+                        verifyButtonLabel("CSS Files");
+                        FileFilters.showDropdown();
+                    });
+
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.children().length).toEqual(5);
+                    });
+
+                    // Click on the delete icon that shows up in the last filter set on mouseover.
+                    runs(function () {
+                        clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[4]));
+                    });
+
+                    runs(function () {
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        // Verify that button label is changed to "No Files Excluded".
+                        verifyButtonLabel();
+
+                        // Verify that the list has one less item.
+                        expect($dropdown.children().length).toEqual(4);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
+                });
+
+                it("should also remove the divider from the dropdown list after removing the last remaining filter set", function () {
+                    var $dropdown;
+
+                    runs(function () {
+                        verifyButtonLabel();
+                        FileFilters.showDropdown();
+                    });
+
+                    runs(function () {
+                        $dropdown = $(".dropdown-menu.dropdownbutton-popup");
+                        expect($dropdown.children().length).toEqual(4);
+                    });
+
+                    // Click on the delete icon that shows up in the last filter set on mouseover.
+                    runs(function () {
+                        clickOnMouseOverButton(".filter-trash-icon", $($dropdown.children()[3]));
+                    });
+
+                    runs(function () {
+                        expect($dropdown.is(":visible")).toBeTruthy();
+                        // Verify that button label still shows "No Files Excluded".
+                        verifyButtonLabel();
+
+                        // Verify that the list has only two filter commands.
+                        expect($dropdown.children().length).toEqual(2);
+                    });
+
+                    runs(function () {
+                        FileFilters.closeDropdown();
+                    });
                 });
             });
         });

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -211,7 +211,7 @@ define(function (require, exports, module) {
                     expectedMessage = StringUtils.format(Strings.FILTER_FILE_COUNT_ALL, 0, Strings.FIND_IN_FILES_NO_SCOPE);
                 });
 
-                // Message loads asynchronously, but dialog should evetually state: "Allows all 0 files in project"
+                // Message loads asynchronously, but dialog should eventually state: "Allows all 0 files in project"
                 waitsFor(function () {
                     actualMessage   = $dlg.find(".exclusions-filecount").text();
                     return (actualMessage === expectedMessage);
@@ -541,16 +541,16 @@ define(function (require, exports, module) {
                 
                 // Check for presence of file and first/last item rows within each file
                 options.matchRanges.forEach(function (range) {
-                    var $fileRow = $("#find-in-files-results tr.file-section[data-file='" + range.file + "']");
+                    var $fileRow = $("#find-in-files-results tr.file-section[data-file-index='" + range.file + "']");
                     expect($fileRow.length).toBe(1);
                     expect($fileRow.find(".dialog-filename").text()).toEqual(range.filename);
                     
-                    var $firstMatchRow = $("#find-in-files-results tr[data-file='" + range.file + "'][data-item='" + range.first + "']");
+                    var $firstMatchRow = $("#find-in-files-results tr[data-file-index='" + range.file + "'][data-item-index='" + range.first + "']");
                     expect($firstMatchRow.length).toBe(1);
                     expect($firstMatchRow.find(".line-number").text().match("\\b" + range.firstLine + "\\b")).toBeTruthy();
                     expect($firstMatchRow.find(".line-text").text().match(range.pattern)).toBeTruthy();
 
-                    var $lastMatchRow = $("#find-in-files-results tr[data-file='" + range.file + "'][data-item='" + range.last + "']");
+                    var $lastMatchRow = $("#find-in-files-results tr[data-file-index='" + range.file + "'][data-item-index='" + range.last + "']");
                     expect($lastMatchRow.length).toBe(1);
                     expect($lastMatchRow.find(".line-number").text().match("\\b" + range.lastLine + "\\b")).toBeTruthy();
                     expect($lastMatchRow.find(".line-text").text().match(range.pattern)).toBeTruthy();

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
         var defaultSourcePath = SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files"),
             testPath,
             nextFolderIndex = 1,
+            searchResults,
             CommandManager,
             DocumentManager,
             EditorManager,
@@ -147,6 +148,110 @@ define(function (require, exports, module) {
             }, "Find in Files done");
         }
 
+        function numMatches(results) {
+            return _.reduce(_.pluck(results, "matches"), function (sum, matches) {
+                return sum + matches.length;
+            }, 0);
+        }
+
+        function doSearch(options) {
+            runs(function () {
+                FindInFiles.doSearchInScope(options.queryInfo, null, null, options.replaceText).done(function (results) {
+                    searchResults = results;
+                });
+            });
+            waitsFor(function () { return searchResults; }, 1000, "search completed");
+            runs(function () {
+                expect(numMatches(searchResults)).toBe(options.numMatches);
+            });
+        }
+
+        function doReplace(options) {
+            return FindInFiles.doReplace(searchResults, options.replaceText, {
+                forceFilesOpen: options.forceFilesOpen,
+                isRegexp: options.queryInfo.isRegexp
+            });
+        }
+
+        /**
+         * Helper function that calls the given asynchronous processor once on each file in the given subtree
+         * and returns a promise that's resolved when all files are processed.
+         * @param {string} rootPath The root of the subtree to search.
+         * @param {function(string, string): $.Promise} processor The function that processes each file. Args are:
+         *      contents: the contents of the file
+         *      fullPath: the full path to the file on disk
+         * @return {$.Promise} A promise that is resolved when all files are processed, or rejected if there was
+         *      an error reading one of the files or one of the process steps was rejected.
+         */
+        function visitAndProcessFiles(rootPath, processor) {
+            var rootEntry = FileSystem.getDirectoryForPath(rootPath),
+                files = [];
+
+            function visitor(file) {
+                if (!file.isDirectory) {
+                    // Skip binary files, since we don't care about them for these purposes and we can't read them
+                    // to get their contents.
+                    if (!LanguageManager.getLanguageForPath(file.fullPath).isBinary()) {
+                        files.push(file);
+                    }
+                }
+                return true;
+            }
+            return promisify(rootEntry, "visit", visitor).then(function () {
+                return Async.doInParallel(files, function (file) {
+                    return promisify(file, "read").then(function (contents) {
+                        return processor(contents, file.fullPath);
+                    });
+                });
+            });
+        }
+
+        function ensureParentExists(file) {
+            var parentDir = FileSystem.getDirectoryForPath(file.parentPath);
+            return promisify(parentDir, "exists").then(function (exists) {
+                if (!exists) {
+                    return promisify(parentDir, "create");
+                }
+                return null;
+            });
+        }
+
+        function copyWithLineEndings(src, dest, lineEndings) {
+            function copyOneFileWithLineEndings(contents, srcPath) {
+                var destPath = dest + srcPath.slice(src.length),
+                    destFile = FileSystem.getFileForPath(destPath),
+                    newContents = FileUtils.translateLineEndings(contents, lineEndings);
+                return ensureParentExists(destFile).then(function () {
+                    return promisify(destFile, "write", newContents);
+                });
+            }
+
+            return promisify(FileSystem.getDirectoryForPath(dest), "create").then(function () {
+                return visitAndProcessFiles(src, copyOneFileWithLineEndings);
+            });
+        }
+
+        // Creates a clean copy of the test project before each test. We don't delete the old
+        // folders as we go along (to avoid problems with deleting the project out from under the
+        // open test window); we just delete the whole temp folder at the end.
+        function openTestProjectCopy(sourcePath, lineEndings) {
+            testPath = SpecRunnerUtils.getTempDirectory() + "/find-in-files-test-" + (nextFolderIndex++);
+            runs(function () {
+                if (lineEndings) {
+                    waitsForDone(copyWithLineEndings(sourcePath, testPath, lineEndings), "copy test files with line endings");
+                } else {
+                    // Note that we don't skip image files in this case, but it doesn't matter since we'll
+                    // only compare files that have an associated file in the known goods folder.
+                    waitsForDone(SpecRunnerUtils.copy(sourcePath, testPath), "copy test files");
+                }
+            });
+            SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        }
+
+        beforeEach(function () {
+            searchResults = null;
+        });
+            
         describe("Find", function () {
             beforeEach(function () {
                 openProject(defaultSourcePath);
@@ -605,84 +710,279 @@ define(function (require, exports, module) {
             });
         });
         
-        describe("Replace", function () {
-            var searchResults;
+        describe("SearchModel update on change events", function () {
+            var oldResults, gotChange, wasQuickChange;
             
-            /**
-             * Helper function that calls the given asynchronous processor once on each file in the given subtree
-             * and returns a promise that's resolved when all files are processed.
-             * @param {string} rootPath The root of the subtree to search.
-             * @param {function(string, string): $.Promise} processor The function that processes each file. Args are:
-             *      contents: the contents of the file
-             *      fullPath: the full path to the file on disk
-             * @return {$.Promise} A promise that is resolved when all files are processed, or rejected if there was
-             *      an error reading one of the files or one of the process steps was rejected.
-             */
-            function visitAndProcessFiles(rootPath, processor) {
-                var rootEntry = FileSystem.getDirectoryForPath(rootPath),
-                    files = [];
-                
-                function visitor(file) {
-                    if (!file.isDirectory) {
-                        // Skip binary files, since we don't care about them for these purposes and we can't read them
-                        // to get their contents.
-                        if (!LanguageManager.getLanguageForPath(file.fullPath).isBinary()) {
-                            files.push(file);
-                        }
+            function fullTestPath(path) {
+                return testPath + "/" + path;
+            }
+            
+            function expectUnchangedExcept(paths) {
+                Object.keys(FindInFiles.searchModel.results).forEach(function (path) {
+                    if (paths.indexOf(path) === -1) {
+                        expect(FindInFiles.searchModel.results[path]).toEqual(oldResults[path]);
                     }
-                    return true;
-                }
-                return promisify(rootEntry, "visit", visitor).then(function () {
-                    return Async.doInParallel(files, function (file) {
-                        return promisify(file, "read").then(function (contents) {
-                            return processor(contents, file.fullPath);
-                        });
-                    });
                 });
             }
             
-            function ensureParentExists(file) {
-                var parentDir = FileSystem.getDirectoryForPath(file.parentPath);
-                return promisify(parentDir, "exists").then(function (exists) {
-                    if (!exists) {
-                        return promisify(parentDir, "create");
-                    }
-                    return null;
+            beforeEach(function () {
+                gotChange = false;
+                oldResults = null;
+                wasQuickChange = false;
+                $(FindInFiles.searchModel).on("change.FindInFilesTest", function (event, quickChange) {
+                    gotChange = true;
+                    wasQuickChange = quickChange;
                 });
-            }
-            
-            function copyWithLineEndings(src, dest, lineEndings) {
-                function copyOneFileWithLineEndings(contents, srcPath) {
-                    var destPath = dest + srcPath.slice(src.length),
-                        destFile = FileSystem.getFileForPath(destPath),
-                        newContents = FileUtils.translateLineEndings(contents, lineEndings);
-                    return ensureParentExists(destFile).then(function () {
-                        return promisify(destFile, "write", newContents);
-                    });
-                }
-                
-                return promisify(FileSystem.getDirectoryForPath(dest), "create").then(function () {
-                    return visitAndProcessFiles(src, copyOneFileWithLineEndings);
+
+                openTestProjectCopy(defaultSourcePath);
+                doSearch({
+                    queryInfo:       {query: "foo"},
+                    numMatches:      14
                 });
-            }
-            
-            // Creates a clean copy of the test project before each test. We don't delete the old
-            // folders as we go along (to avoid problems with deleting the project out from under the
-            // open test window); we just delete the whole temp folder at the end.
-            function openTestProjectCopy(sourcePath, lineEndings) {
-                testPath = SpecRunnerUtils.getTempDirectory() + "/find-in-files-test-" + (nextFolderIndex++);
                 runs(function () {
-                    if (lineEndings) {
-                        waitsForDone(copyWithLineEndings(sourcePath, testPath, lineEndings), "copy test files with line endings");
-                    } else {
-                        // Note that we don't skip image files in this case, but it doesn't matter since we'll
-                        // only compare files that have an associated file in the known goods folder.
-                        waitsForDone(SpecRunnerUtils.copy(sourcePath, testPath), "copy test files");
-                    }
+                    oldResults = _.cloneDeep(FindInFiles.searchModel.results);
                 });
-                SpecRunnerUtils.loadProjectInTestWindow(testPath);
-            }
+            });
             
+            afterEach(function () {
+                $(FindInFiles.searchModel).off(".FindInFilesTest");
+                waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }), "close all files");
+            });
+            
+            describe("when filename changes", function () {
+                it("should handle a filename change", function () {
+                    runs(function () {
+                        FindInFiles._fileNameChangeHandler(null, fullTestPath("foo.html"), fullTestPath("newfoo.html"));
+                    });
+                    waitsFor(function () { return gotChange; }, "model change event");
+                    runs(function () {
+                        expectUnchangedExcept([fullTestPath("foo.html"), fullTestPath("newfoo.html")]);
+                        expect(FindInFiles.searchModel.results[fullTestPath("foo.html")]).toBeUndefined();
+                        expect(FindInFiles.searchModel.results[fullTestPath("newfoo.html")]).toEqual(oldResults[fullTestPath("foo.html")]);
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 3, matches: 14});
+                        expect(wasQuickChange).toBeFalsy();
+                    });
+                });
+
+                it("should handle a folder change", function () {
+                    runs(function () {
+                        FindInFiles._fileNameChangeHandler(null, fullTestPath("css"), fullTestPath("newcss"));
+                    });
+                    waitsFor(function () { return gotChange; }, "model change event");
+                    runs(function () {
+                        expectUnchangedExcept([fullTestPath("css/foo.css"), fullTestPath("newcss/foo.css")]);
+                        expect(FindInFiles.searchModel.results[fullTestPath("css/foo.css")]).toBeUndefined();
+                        expect(FindInFiles.searchModel.results[fullTestPath("newcss/foo.css")]).toEqual(oldResults[fullTestPath("css/foo.css")]);
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 3, matches: 14});
+                        expect(wasQuickChange).toBeFalsy();
+                    });
+                });
+            });
+            
+            describe("when in-memory document changes", function () {
+                it("should update the results when a matching line is added, updating line numbers and adding the match", function () {
+                    runs(function () {
+                        waitsForDone(CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fullTestPath("foo.html") }));
+                    });
+                    runs(function () {
+                        var doc = DocumentManager.getOpenDocumentForPath(fullTestPath("foo.html")),
+                            i;
+                        expect(doc).toBeTruthy();
+
+                        // Insert another line containing "foo" immediately above the second "foo" match.
+                        doc.replaceRange("this is a foo instance\n", {line: 5, ch: 0});
+
+                        // This should update synchronously.
+                        expect(gotChange).toBe(true);
+
+                        var oldFileResults = oldResults[fullTestPath("foo.html")],
+                            newFileResults = FindInFiles.searchModel.results[fullTestPath("foo.html")];
+
+                        // First match should be unchanged.
+                        expect(newFileResults.matches[0]).toEqual(oldFileResults.matches[0]);
+
+                        // Next match should be the new match. We just check the offsets here, not everything in the match record.
+                        expect(newFileResults.matches[1].start).toEqual({line: 5, ch: 10});
+                        expect(newFileResults.matches[1].end).toEqual({line: 5, ch: 13});
+
+                        // Rest of the matches should have had their lines adjusted.
+                        for (i = 2; i < newFileResults.matches.length; i++) {
+                            var newMatch = newFileResults.matches[i],
+                                oldMatch = oldFileResults.matches[i - 1];
+                            expect(newMatch.start).toEqual({line: oldMatch.start.line + 1, ch: oldMatch.start.ch});
+                            expect(newMatch.end).toEqual({line: oldMatch.end.line + 1, ch: oldMatch.end.ch});
+                        }
+
+                        // There should be one new match.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 3, matches: 15});
+
+                        // Make sure the model is adding the flag that will make the view debounce changes.
+                        expect(wasQuickChange).toBeTruthy();
+                    });
+                });
+
+                it("should update the results when a matching line is deleted, updating line numbers and removing the match", function () {
+                    runs(function () {
+                        waitsForDone(CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fullTestPath("foo.html") }));
+                    });
+                    runs(function () {
+                        var doc = DocumentManager.getOpenDocumentForPath(fullTestPath("foo.html")),
+                            i;
+                        expect(doc).toBeTruthy();
+
+                        // Remove the second "foo" match.
+                        doc.replaceRange("", {line: 5, ch: 0}, {line: 6, ch: 0});
+
+                        // This should update synchronously.
+                        expect(gotChange).toBe(true);
+
+                        var oldFileResults = oldResults[fullTestPath("foo.html")],
+                            newFileResults = FindInFiles.searchModel.results[fullTestPath("foo.html")];
+
+                        // First match should be unchanged.
+                        expect(newFileResults.matches[0]).toEqual(oldFileResults.matches[0]);
+
+                        // Second match should be deleted. The rest of the matches should have their lines adjusted.
+                        for (i = 1; i < newFileResults.matches.length; i++) {
+                            var newMatch = newFileResults.matches[i],
+                                oldMatch = oldFileResults.matches[i + 1];
+                            expect(newMatch.start).toEqual({line: oldMatch.start.line - 1, ch: oldMatch.start.ch});
+                            expect(newMatch.end).toEqual({line: oldMatch.end.line - 1, ch: oldMatch.end.ch});
+                        }
+
+                        // There should be one fewer match.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 3, matches: 13});
+
+                        // Make sure the model is adding the flag that will make the view debounce changes.
+                        expect(wasQuickChange).toBeTruthy();
+                    });
+                });
+
+                it("should replace matches in a portion of the document that was edited to include a new match", function () {
+                    runs(function () {
+                        waitsForDone(CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fullTestPath("foo.html") }));
+                    });
+                    runs(function () {
+                        var doc = DocumentManager.getOpenDocumentForPath(fullTestPath("foo.html")),
+                            i;
+                        expect(doc).toBeTruthy();
+
+                        // Replace the second and third foo matches (on two adjacent lines) with a single foo match on a single line.
+                        doc.replaceRange("this is a new foo match\n", {line: 5, ch: 0}, {line: 7, ch: 0});
+
+                        // This should update synchronously.
+                        expect(gotChange).toBe(true);
+
+                        var oldFileResults = oldResults[fullTestPath("foo.html")],
+                            newFileResults = FindInFiles.searchModel.results[fullTestPath("foo.html")];
+
+                        // First match should be unchanged.
+                        expect(newFileResults.matches[0]).toEqual(oldFileResults.matches[0]);
+
+                        // Second match should be changed to reflect the new position.
+                        expect(newFileResults.matches[1].start).toEqual({line: 5, ch: 14});
+                        expect(newFileResults.matches[1].end).toEqual({line: 5, ch: 17});
+
+                        // Third match should be deleted. The rest of the matches should have their lines adjusted.
+                        for (i = 2; i < newFileResults.matches.length; i++) {
+                            var newMatch = newFileResults.matches[i],
+                                oldMatch = oldFileResults.matches[i + 1];
+                            expect(newMatch.start).toEqual({line: oldMatch.start.line - 1, ch: oldMatch.start.ch});
+                            expect(newMatch.end).toEqual({line: oldMatch.end.line - 1, ch: oldMatch.end.ch});
+                        }
+
+                        // There should be one fewer match.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 3, matches: 13});
+
+                        // Make sure the model is adding the flag that will make the view debounce changes.
+                        expect(wasQuickChange).toBeTruthy();
+                    });
+                });
+
+                it("should completely remove the document from the results list if all matches in the document are deleted", function () {
+                    runs(function () {
+                        waitsForDone(CommandManager.execute(Commands.FILE_ADD_TO_WORKING_SET, { fullPath: fullTestPath("foo.html") }));
+                    });
+                    runs(function () {
+                        var doc = DocumentManager.getOpenDocumentForPath(fullTestPath("foo.html")),
+                            i;
+                        expect(doc).toBeTruthy();
+
+                        // Replace all matches and check that the entire file was removed from the results list.
+                        doc.replaceRange("this will not match", {line: 4, ch: 0}, {line: 18, ch: 0});
+
+                        // This should update synchronously.
+                        expect(gotChange).toBe(true);
+                        expect(FindInFiles.searchModel.results[fullTestPath("foo.html")]).toBeUndefined();
+
+                        // There should be one fewer file and the matches for that file should be gone.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 2, matches: 7});
+
+                        // Make sure the model is adding the flag that will make the view debounce changes.
+                        expect(wasQuickChange).toBeTruthy();
+                    });
+                });
+            });
+            
+            // Unfortunately, we can't easily mock file changes, so we just do them in a copy of the project.
+            // This set of tests isn't as thorough as it could be, because it's difficult to perform file
+            // ops that will exercise all possible scenarios of change events (e.g. change events with
+            // both added and removed files), and conversely it's difficult to mock all the filesystem stuff
+            // without doing a bunch of work. So this is really just a set of basic sanity tests to make
+            // sure that stuff being refactored between the change handler and the model doesn't break
+            // basic update functionality.
+            describe("when on-disk file or folder changes", function () {
+                it("should add matches for a new file", function () {
+                    var newFilePath;
+                    runs(function () {
+                        newFilePath = fullTestPath("newfoo.html");
+                        expect(FindInFiles.searchModel.results[newFilePath]).toBeFalsy();
+                        waitsForDone(promisify(FileSystem.getFileForPath(newFilePath), "write", "this is a new foo match\n"), "add new file");
+                    });
+                    waitsFor(function () { return gotChange; }, "model change event");
+                    runs(function () {
+                        var newFileResults = FindInFiles.searchModel.results[newFilePath];
+                        expect(newFileResults).toBeTruthy();
+                        expect(newFileResults.matches.length).toBe(1);
+                        expect(newFileResults.matches[0].start).toEqual({line: 0, ch: 14});
+                        expect(newFileResults.matches[0].end).toEqual({line: 0, ch: 17});
+
+                        // There should be one new file and match.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 4, matches: 15});
+                    });
+                });
+                
+                it("should remove matches for a deleted file", function () {
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[fullTestPath("foo.html")]).toBeTruthy();
+                        waitsForDone(promisify(FileSystem.getFileForPath(fullTestPath("foo.html")), "unlink"), "delete file");
+                    });
+                    waitsFor(function () { return gotChange; }, "model change event");
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[fullTestPath("foo.html")]).toBeFalsy();
+                        
+                        // There should be one fewer file and the matches should be removed.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 2, matches: 7});
+                    });
+                });
+                
+                it("should remove matches for a deleted folder", function () {
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[fullTestPath("css/foo.css")]).toBeTruthy();
+                        waitsForDone(promisify(FileSystem.getFileForPath(fullTestPath("css")), "unlink"), "delete folder");
+                    });
+                    waitsFor(function () { return gotChange; }, "model change event");
+                    runs(function () {
+                        expect(FindInFiles.searchModel.results[fullTestPath("css/foo.css")]).toBeFalsy();
+
+                        // There should be one fewer file and the matches should be removed.
+                        expect(FindInFiles.searchModel.countFilesMatches()).toEqual({files: 2, matches: 11});
+                    });
+                });
+            });
+        });
+        
+        describe("Replace", function () {
             function expectProjectToMatchKnownGood(kgFolder, lineEndings, filesToSkip) {
                 runs(function () {
                     var testRootPath = ProjectManager.getProjectRoot().fullPath,
@@ -701,31 +1001,6 @@ define(function (require, exports, module) {
                     }
                     
                     waitsForDone(visitAndProcessFiles(kgRootPath, compareKnownGoodToTestFile), "project comparison done");
-                });
-            }
-            
-            function numMatches(results) {
-                return _.reduce(_.pluck(results, "matches"), function (sum, matches) {
-                    return sum + matches.length;
-                }, 0);
-            }
-            
-            function doSearch(options) {
-                runs(function () {
-                    FindInFiles.doSearchInScope(options.queryInfo, null, null, options.replaceText).done(function (results) {
-                        searchResults = results;
-                    });
-                });
-                waitsFor(function () { return searchResults; }, 1000, "search completed");
-                runs(function () {
-                    expect(numMatches(searchResults)).toBe(options.numMatches);
-                });
-            }
-            
-            function doReplace(options) {
-                return FindInFiles.doReplace(searchResults, options.replaceText, {
-                    forceFilesOpen: options.forceFilesOpen,
-                    isRegexp: options.queryInfo.isRegexp
                 });
             }
             
@@ -823,10 +1098,6 @@ define(function (require, exports, module) {
                 doBasicTest(options);
                 expectInMemoryFiles(options);
             }
-            
-            beforeEach(function () {
-                searchResults = null;
-            });
             
             afterEach(function () {
                 runs(function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -334,7 +334,7 @@ define(function (require, exports, module) {
             // TODO: This needs to be kept in sync with Document._handleEditorChange(). In the
             // future, we should fix things so that we either don't need mock documents or that this
             // is factored so it will just run in both.
-            $(this).triggerHandler("change", [this, changeList]);
+            this._notifyDocumentChange(changeList);
         };
         docToShim.notifySaved = function () {
             throw new Error("Cannot notifySaved() a unit-test dummy Document");

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -327,13 +327,12 @@ define(function (require, exports, module) {
         var dummyFile = _getFileSystem().getFileForPath(filename);
         var docToShim = new DocumentManager.Document(dummyFile, new Date(), content);
         
-        // Prevent adding doc to working set
+        // Prevent adding doc to working set by not dispatching "dirtyFlagChange".
+        // TODO: Other functionality here needs to be kept in sync with Document._handleEditorChange(). In the
+        // future, we should fix things so that we either don't need mock documents or that this
+        // is factored so it will just run in both.
         docToShim._handleEditorChange = function (event, editor, changeList) {
             this.isDirty = !editor._codeMirror.isClean();
-                    
-            // TODO: This needs to be kept in sync with Document._handleEditorChange(). In the
-            // future, we should fix things so that we either don't need mock documents or that this
-            // is factored so it will just run in both.
             this._notifyDocumentChange(changeList);
         };
         docToShim.notifySaved = function () {


### PR DESCRIPTION
This addresses most of the code review items from #7705 and #7809. Note that this is a pull into nj/replace-across-files - after this is merged, we'll need to put up another PR to actually merge it into master.

All the small cleanups are in c09eaef and 0f3cb18. In addition, I did two bigger cleanups:
- Moved more of the keyboard handling controller logic from FindInFilesUI into FindBar, making the events dispatched from FindBar much more clear.
- Made it so modifications to SearchModel results are done via APIs on SearchModel rather than manipulating `searchModel.results` directly, so that it can keep an accurate count of the number of matches without having to re-count every time results are added.

As part of the latter work I added a number of unit tests for the updating code (there was only one before), and in the process I found and fixed a bug in the line number update calculation (which has probably always been there).

There are a few code review issues that I didn't address, but I think we can land the feature without them:
- Clean up `showError()`/`showNoResults()` (combine them and/or make showNoResults() less confusing)
- Remove error-showing functionality from `FindReplace.parseQuery()`
- Don't pass `replaceText` to `doSearchInScope()` - have caller store it separately
- Move Replace tests to separate file
- Break out event handlers in `SearchResultsView.addPanelListeners()` (see Tom's comment in #7809)
- Move `FindUtils.performReplacements()` back into `FindInFiles.doReplace()`

I'll file a bug for these - I don't think they should impede shipping the feature this release.
