### PR TITLE
Update CSSProperties.json

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -14,6 +14,7 @@
     "backface-visibility":         {"values": ["hidden", "visible"]},
     "background":                  {"values": []},
     "background-attachment":       {"values": ["fixed", "local", "scroll", "inherit"]},
+    "background-blend-mode":       {"values": ["color", "color-burn", "color-dodge", "darken", "difference", "exclusion", "hard-light", "hue", "lighten", "luminosity", "normal", "multiply", "overlay", "saturation", "screen", "soft-light"]},
     "background-clip":             {"values": ["border-box", "content-box", "padding-box", "inherit"]},
     "background-color":            {"values": ["currentColor", "transparent", "inherit"]},
     "background-image":            {"values": ["image()", "linear-gradient()", "radial-gradient()", "repeating-linear-gradient()", "repeating-radial-gradient()", "url()"]},


### PR DESCRIPTION
Added background-blend-mode CSS property. This is in shipping versions of Firefox, Chrome and Opera and Under Consideration for IE. It's an Editor's Draft at W3C and a neat feature so I think worthy of being added to Brackets.

Reference:
http://dev.w3.org/fxtf/compositing-1/
http://docs.webplatform.org/wiki/css/properties/background-blend-mode
http://caniuse.com/#feat=css-backgroundblendmode
