### PR TITLE
Fix error when checking for exclusions

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -214,11 +214,7 @@ define(function (require, exports, module) {
         }
         
         var excludes = preferences.getExcludedFiles();
-        if (!excludes) {
-            return false;
-        }
-        
-        if (excludes.test(file.name)) {
+        if (excludes && excludes.test(file.name)) {
             return true;
         }
 


### PR DESCRIPTION
I noticed this when looking at the JS Code Hints code. If there are no files returned from `preferences.getExcludedFiles()`, then the `jscodehints.defaultExclusions` will not get checked.

@dangoor We should get this in for Release 0.41
