### PR TITLE
Add an explicit non-breaking space before "with" in template

### DIFF
--- a/src/htmlContent/search-summary.html
+++ b/src/htmlContent/search-summary.html
@@ -5,7 +5,7 @@
 <div class="contracting-col">{{query}}</div>
 <div class="fixed-col">&quot;</div>
 {{#replace}}
-<div class="fixed-col">{{Strings.FIND_REPLACE_TITLE_WITH}} &quot;</div>
+<div class="fixed-col">&nbsp;{{Strings.FIND_REPLACE_TITLE_WITH}} &quot;</div>
 <div class="contracting-col">{{replaceWith}}</div>
 <div class="fixed-col">&quot;</div>
 {{/replace}}


### PR DESCRIPTION
This fixes #8195.
