### PR TITLE
Fix 8131: installing extensions with post-install dialogs causes brackets to hang

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -297,7 +297,6 @@ define(function (require, exports, module) {
             promise = result.promise(),
             $dlg    = $(template)
                 .addClass("instance")
-                .prop("tabindex", "-1")
                 .appendTo(".modal-inner-wrapper:last");
 
         // Don't allow dialog to exceed viewport size
@@ -343,7 +342,7 @@ define(function (require, exports, module) {
             } else if ($otherBtn.length) {
                 $otherBtn.focus();
             } else {
-                $dlg.focus();
+                document.activeElement.blur();
             }
 
             // Push our global keydown handler onto the global stack of handlers.


### PR DESCRIPTION
When fixing #7598 I gave the focus to the dialog when it had no inputs. But to do it I had to make the dialog focusable, which makes Bootstrap enter into an infinite focus loop. Since the idea about giving focus to the dialog was to blur current editor, this alternative fix, actually blurs any element that had focus.

This fixes #8131 and other similar issues.
