### PR TITLE
Change search bar UI to always say "Find..." in the first field, instead...

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -133,11 +133,12 @@ define({
     "DELETE"                            : "Delete",
     "BUTTON_YES"                        : "Yes",
     "BUTTON_NO"                         : "No",
-        
+    
     // Find, Replace, Find in Files
     "FIND_RESULT_COUNT"                 : "{0} results",
     "FIND_RESULT_COUNT_SINGLE"          : "1 result",
     "FIND_NO_RESULTS"                   : "No results",
+    "FIND_QUERY_PLACEHOLDER"            : "Find\u2026",
     "REPLACE_PLACEHOLDER"               : "Replace with\u2026",
     "BUTTON_REPLACE_ALL"                : "Batch\u2026",
     "BUTTON_REPLACE_ALL_IN_FILES"       : "Replace\u2026",
@@ -320,7 +321,6 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Find",
     "CMD_FIND"                            : "Find",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Find\u2026",
     "CMD_FIND_NEXT"                       : "Find Next",
     "CMD_FIND_PREVIOUS"                   : "Find Previous",
     "CMD_FIND_ALL_AND_SELECT"             : "Find All and Select",

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
             multifile: true,
             replace: showReplace,
             initialQuery: initialString,
-            queryPlaceholder: (showReplace ? Strings.CMD_REPLACE_IN_SUBTREE : Strings.CMD_FIND_IN_SUBTREE),
+            queryPlaceholder: Strings.FIND_QUERY_PLACEHOLDER,
             scopeLabel: FindUtils.labelForScope(scope)
         });
         _findBar.open();

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -569,7 +569,7 @@ define(function (require, exports, module) {
             multifile: false,
             replace: replace,
             initialQuery: initialQuery,
-            queryPlaceholder: Strings.CMD_FIND_FIELD_PLACEHOLDER
+            queryPlaceholder: Strings.FIND_QUERY_PLACEHOLDER
         });
         findBar.open();
 


### PR DESCRIPTION
Change search bar UI to always say "Find..." in the first field, instead of sometimes saying "Find in..." or "Replace in..." (which makes it sound like it's describing the set of files to search in).

Talked this over with @njx and he thought it was a good change to make too.
