### PR TITLE
Simple code hints preferences to enable/disable individual/all code hints providers.

### DIFF
--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -242,18 +242,23 @@ define(function (require, exports, module) {
         CodeHintList        = require("editor/CodeHintList").CodeHintList,
         PreferencesManager  = require("preferences/PreferencesManager");
 
-    var hintProviders   = { "all" : [] },
-        lastChar        = null,
-        sessionProvider = null,
-        sessionEditor   = null,
-        hintList        = null,
-        deferredHints   = null,
-        keyDownEditor   = null;
+    var hintProviders    = { "all" : [] },
+        lastChar         = null,
+        sessionProvider  = null,
+        sessionEditor    = null,
+        hintList         = null,
+        deferredHints    = null,
+        keyDownEditor    = null,
+        codeHintsEnabled = true;
 
 
+    PreferencesManager.definePreference("showCodeHints", "boolean", true);
     PreferencesManager.definePreference("insertHintOnTab", "boolean", false);
 
-
+    PreferencesManager.on("change", "showCodeHints", function () {
+        codeHintsEnabled = PreferencesManager.get("showCodeHints");
+    });
+    
     /**
      * Comparator to sort providers from high to low priority
      */
@@ -347,7 +352,15 @@ define(function (require, exports, module) {
      * @return {?Array.<{provider: Object, priority: number}>}
      */
     function _getProvidersForLanguageId(languageId) {
-        return hintProviders[languageId] || hintProviders.all;
+        var providers = hintProviders[languageId] || hintProviders.all;
+        
+        // Exclude providers that are explicitly disabled in the preferences.
+        // All code hint providers that do not have their constructor
+        // names listed in the preferences are enabled by default.
+        return providers.filter(function (provider) {
+            var prefKey = "codehint." + provider.provider.constructor.name;
+            return PreferencesManager.get(prefKey) !== false;
+        });
     }
 
     var _beginSession;
@@ -451,6 +464,10 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      */
     _beginSession = function (editor) {
+        if (!codeHintsEnabled) {
+            return;
+        }
+
         // Don't start a session if we have a multiple selection.
         if (editor.getSelections().length > 1) {
             return;
@@ -501,6 +518,9 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      */
     function _startNewSession(editor) {
+        if (!codeHintsEnabled) {
+            return;
+        }
         if (!editor) {
             editor = EditorManager.getFocusedEditor();
         }

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
         codeHintsEnabled = true;
 
 
-    PreferencesManager.definePreference("showCodeHints", "boolean", codeHintsEnabled);
+    PreferencesManager.definePreference("showCodeHints", "boolean", true);
     PreferencesManager.definePreference("insertHintOnTab", "boolean", false);
 
     PreferencesManager.on("change", "showCodeHints", function () {

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
         codeHintsEnabled = true;
 
 
-    PreferencesManager.definePreference("showCodeHints", "boolean", true);
+    PreferencesManager.definePreference("showCodeHints", "boolean", codeHintsEnabled);
     PreferencesManager.definePreference("insertHintOnTab", "boolean", false);
 
     PreferencesManager.on("change", "showCodeHints", function () {
@@ -518,9 +518,6 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      */
     function _startNewSession(editor) {
-        if (!codeHintsEnabled) {
-            return;
-        }
         if (!editor) {
             editor = EditorManager.getFocusedEditor();
         }


### PR DESCRIPTION
This fixes #8173. You can use one or more of the following preferences to turn on/off individual hints provider.
By default, `showCodeHints` is true and you don't need any of the following preferences to use the existing code hints providers. When you want to disable any of them, just add `"codehint.<HINT_PROVIDER_CONSTRUCTOR_NAME>": false` in the brackets.json file.

```
    "codehint.TagHints": false,
    "codehint.AttrHints": true,
    "codehint.CssPropHints": true,
    "codehint.UrlCodeHints": true,
    "codehint.SpecialCharHints": false,
    "codehint.JSHints": true,
    "showCodeHints": true
```
