### PR TITLE
Fix autotrimmed leading space

### DIFF
--- a/src/htmlContent/search-summary.html
+++ b/src/htmlContent/search-summary.html
@@ -12,7 +12,7 @@
 {{#scope}}
 <div class="contracting-col">{{{scope}}}</div>
 {{/scope}}
-<div class="fixed-col">{{{summary}}}</div>
+<div class="fixed-col">&nbsp;{{{summary}}}</div>
 {{#hasPages}}
 <div class="pagination-col">
     <span class="first-page {{^hasPrev}}disabled{{/hasPrev}}"></span>

--- a/src/nls/da/strings.js
+++ b/src/nls/da/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Erstat",
     "FIND_REPLACE_TITLE_WITH"           : "med",
     "FIND_TITLE_LABEL"                  : "Fundet",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} i {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} i {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Ersetze",
     "FIND_REPLACE_TITLE_WITH"           : "mit",
     "FIND_TITLE_LABEL"                  : "",
-    "FIND_TITLE_SUMMARY"                : " gefunden &mdash; {0} {1} {2} in {3}",
+    "FIND_TITLE_SUMMARY"                : "gefunden &mdash; {0} {1} {2} in {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Reemplazar",
     "FIND_REPLACE_TITLE_WITH"           : "con",
     "FIND_TITLE_LABEL"                  : "Se encontró",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} en {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} en {3}",
     
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/fi/strings.js
+++ b/src/nls/fi/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Korvaa",
     "FIND_REPLACE_TITLE_WITH"           : "merkkijonolla",
     "FIND_TITLE_LABEL"                  : "löytyi",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} kohteessa {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} kohteessa {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Reemprazar",
     "FIND_REPLACE_TITLE_WITH"           : "con",
     "FIND_TITLE_LABEL"                  : "Atopado",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} en {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} en {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Înlocuiește",
     "FIND_REPLACE_TITLE_WITH"           : "cu",
     "FIND_TITLE_LABEL"                  : "S-a găsit",
-    "FIND_TITLE_SUMMARY"                : " : {0} {1} {2} în {3}",
+    "FIND_TITLE_SUMMARY"                : ": {0} {1} {2} în {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Replace",
     "FIND_REPLACE_TITLE_WITH"           : "with",
     "FIND_TITLE_LABEL"                  : "Found",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} in {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} in {3}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} {1}",

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -163,7 +163,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "Заменить",
     "FIND_REPLACE_TITLE_WITH"           : "на",
     "FIND_TITLE_LABEL"                  : "Найдено",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {0} {1} {2} в {3}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} в {3}",
 	
     // Find in Files
     "FIND_IN_FILES_TITLE_PART1"         : "\"",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -165,7 +165,7 @@ define({
     "FIND_REPLACE_TITLE_LABEL"          : "將",
     "FIND_REPLACE_TITLE_WITH"           : "取代成",
     "FIND_TITLE_LABEL"                  : "找到",
-    "FIND_TITLE_SUMMARY"                : " &mdash; {3}中共有{0} {1} 筆{2}",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {3}中共有{0} {1} 筆{2}",
 
     // Find in Files
     "FIND_NUM_FILES"                    : "{0} 個{1}",


### PR DESCRIPTION
An easy fix for the following issue:

Steps:
1. Use `Find In Files`
2. In the result bar, look at the title

Result:
It says `Found "..."— 2 matches in 2 files` (no space before dash)
Expected:
It says `Found "..." — 2 matches in 2 files` (space before dash)
