### PR TITLE
added .bash to bash highlighting and .ino to cpp highlighting

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -109,7 +109,7 @@
     "cpp": {
         "name": "C++",
         "mode": ["clike", "text/x-c++src"],
-        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii"],
+        "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "ino"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -229,7 +229,7 @@
     "bash": {
         "name": "Bash",
         "mode": ["shell", "text/x-sh"],
-        "fileExtensions": ["sh", "command"],
+        "fileExtensions": ["sh", "command", "bash"],
         "lineComment": ["#"]
     },
   


### PR DESCRIPTION
This small change to src/language/languages.json should add bash syntax highlighting to .bash files and C++ highlighting to arduino (.ino) files.
