### PR TITLE
Fix #8273: "sortDirectoriesFirst": true in .brackets.json not always working properly 

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -222,8 +222,8 @@ define(function (require, exports, module) {
     function _generateSortPrefixes() {
         var previousDirFirst  = _dirFirst;
         _dirFirst             = PreferencesManager.get("sortDirectoriesFirst");
-        _sortPrefixDir        = _dirFirst ? "0" : "";
-        _sortPrefixFile       = _dirFirst ? "1" : "";
+        _sortPrefixDir        = _dirFirst ? "a" : "";
+        _sortPrefixFile       = _dirFirst ? "b" : "";
         
         return previousDirFirst !== _dirFirst;
     }


### PR DESCRIPTION
The issue is that when using locale compare to compare the filenames, we turn the numeric option to on, so that "1" < "2" < "10". This was done so that we get `Undefined-1, Undefined-2, Undefined-3, Undefined-10`, instead of `Undefined-1, Undefined-10, Undefined-2, Undefined-3`. But this break the file sorting, since we preppend a `0` to folders and a `1` to files. So later we have that "1XX" < "002", where the first is a file and the second a folder. By changing the prefixes to letters, we can fix this.

This is for #8273.
