### PR TITLE
Prevent window.open() from loading untrusted web content

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -436,7 +436,8 @@ define(function (require, exports, module) {
         // Prevent extensions from using window.open() to insecurely load untrusted web content
         var real_windowOpen = window.open;
         window.open = function (url) {
-            if (!url.match(/^file:\/\//) && url.indexOf(":") !== -1) {
+            // Allow file:// URLs, relative URLs (implicitly file: also), and about:blank
+            if (!url.match(/^file:\/\//) && url !== "about:blank" && url.indexOf(":") !== -1) {
                 throw new Error("Brackets-shell is not a secure general purpose web browser. Use NativeApp.openURLInDefaultBrowser() to open URLs in the user's main browser");
             }
             return real_windowOpen.apply(window, arguments);

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -432,6 +432,15 @@ define(function (require, exports, module) {
                 node = node.parentElement;
             }
         }, true);
+        
+        // Prevent extensions from using window.open() to insecurely load untrusted web content
+        var real_windowOpen = window.open;
+        window.open = function (url) {
+            if (!url.match(/^file:\/\//) && url.indexOf(":") !== -1) {
+                throw new Error("Brackets-shell is not a secure general purpose web browser. Use NativeApp.openURLInDefaultBrowser() to open URLs in the user's main browser");
+            }
+            return real_windowOpen.apply(window, arguments);
+        };
     }
     
     // Wait for view state to load.


### PR DESCRIPTION
As discussed recently... Prevent extensions from using `window.open()` as a quick way to show the user general, untrusted web content. Throw exception pointing out the 'right' safe API to use. Still allows file: URLs and relative paths (which are by definition file: too, and used by Debug > Run Tests).
