### PR TITLE
Add missing cursor properties

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -78,7 +78,7 @@
     "content":                     {"values": ["attr()", "close-quote", "no-close-quote", "no-open-quote", "normal", "none", "open-quote", "inherit"]},
     "counter-increment":           {"values": ["none", "inherit"]},
     "counter-reset":               {"values": ["none", "inherit"]},
-    "cursor":                      {"values": ["alias", "all-scroll", "auto", "cell", "col-resize", "copy", "crosshair", "default", "e-resize", "ew-resize", "grab", "grabbing", "help", "inherit", "move", "n-resize", "ne-resize", "nesw-resize", "no-drop", "none", "not-allowed", "ns-resize", "nw-resize", "nwse-resize", "pointer", "progress", "row-resize", "s-resize", "se-resize", "sw-resize", "text", "vertical-text", "w-resize", "wait", "zoom-in", "zoom-out"]},
+    "cursor":                      {"values": ["alias", "all-scroll", "auto", "cell", "col-resize", "context-menu", "copy", "crosshair", "default", "e-resize", "ew-resize", "grab", "grabbing", "help", "inherit", "move", "n-resize", "ne-resize", "nesw-resize", "no-drop", "none", "not-allowed", "ns-resize", "nw-resize", "nwse-resize", "pointer", "progress", "row-resize", "s-resize", "se-resize", "sw-resize", "text", "vertical-text", "w-resize", "wait", "zoom-in", "zoom-out"]},
     "direction":                   {"values": ["ltr", "rtl", "inherit"]},
     "display":                     {"values": ["block", "flex", "grid", "inline", "inline-block", "inline-flex", "inline-grid", "inline-table", "list-item", "none", "run-in", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group", "table-row", "table-row-group", "inherit"]},
     "empty-cells":                 {"values": ["hide", "show", "inherit"]},

--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -78,7 +78,7 @@
     "content":                     {"values": ["attr()", "close-quote", "no-close-quote", "no-open-quote", "normal", "none", "open-quote", "inherit"]},
     "counter-increment":           {"values": ["none", "inherit"]},
     "counter-reset":               {"values": ["none", "inherit"]},
-    "cursor":                      {"values": ["auto", "crosshair", "e-resize", "default", "help", "move", "n-resize", "ne-resize", "nw-resize", "pointer", "progress", "s-resize", "se-resize", "sw-resize", "text", "w-resize", "wait", "inherit", "alias", "all-scroll", "cell", "col-resize", "copy", "none", "vertical-text", "no-drop", "not-allowed", "row-resize", "ew-resize", "ns-resize", "nesw-resize", "nwse-resize", "zoom-in", "zoom-out", "grab", "grabbing"]},
+    "cursor":                      {"values": ["alias", "all-scroll", "auto", "cell", "col-resize", "copy", "crosshair", "default", "e-resize", "ew-resize", "grab", "grabbing", "help", "inherit", "move", "n-resize", "ne-resize", "nesw-resize", "no-drop", "none", "not-allowed", "ns-resize", "nw-resize", "nwse-resize", "pointer", "progress", "row-resize", "s-resize", "se-resize", "sw-resize", "text", "vertical-text", "w-resize", "wait", "zoom-in", "zoom-out"]},
     "direction":                   {"values": ["ltr", "rtl", "inherit"]},
     "display":                     {"values": ["block", "flex", "grid", "inline", "inline-block", "inline-flex", "inline-grid", "inline-table", "list-item", "none", "run-in", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group", "table-row", "table-row-group", "inherit"]},
     "empty-cells":                 {"values": ["hide", "show", "inherit"]},

--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -78,7 +78,7 @@
     "content":                     {"values": ["attr()", "close-quote", "no-close-quote", "no-open-quote", "normal", "none", "open-quote", "inherit"]},
     "counter-increment":           {"values": ["none", "inherit"]},
     "counter-reset":               {"values": ["none", "inherit"]},
-    "cursor":                      {"values": ["auto", "crosshair", "e-resize", "default", "help", "move", "n-resize", "ne-resize", "nw-resize", "pointer", "progress", "s-resize", "se-resize", "sw-resize", "text", "w-resize", "wait", "inherit"]},
+    "cursor":                      {"values": ["auto", "crosshair", "e-resize", "default", "help", "move", "n-resize", "ne-resize", "nw-resize", "pointer", "progress", "s-resize", "se-resize", "sw-resize", "text", "w-resize", "wait", "inherit", "alias", "all-scroll", "cell", "col-resize", "copy", "none", "vertical-text", "no-drop", "not-allowed", "row-resize", "ew-resize", "ns-resize", "nesw-resize", "nwse-resize", "zoom-in", "zoom-out", "grab", "grabbing"]},
     "direction":                   {"values": ["ltr", "rtl", "inherit"]},
     "display":                     {"values": ["block", "flex", "grid", "inline", "inline-block", "inline-flex", "inline-grid", "inline-table", "list-item", "none", "run-in", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group", "table-row", "table-row-group", "inherit"]},
     "empty-cells":                 {"values": ["hide", "show", "inherit"]},


### PR DESCRIPTION
I was working on a project a few days ago and found that `cursor` is missing some properties, so I went on and added them up. Most of [these properties](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) are quite old and has support in many browsers.
