### PR TITLE
[Review Only] Create a list of long running promises and quit only when all of them are done.

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1268,7 +1268,7 @@ define(function (require, exports, module) {
      * the same except for the final step
     */
     function _handleWindowGoingAway(commandData, postCloseHandler, failHandler) {
-        if (_windowGoingAway && !brackets.app.longRunningPromises) {
+        if (_windowGoingAway) {
             //if we get called back while we're closing, then just return
             return (new $.Deferred()).reject().promise();
         }

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1155,8 +1155,10 @@ define(function (require, exports, module) {
          *
          * We can clean up the web worker we use to calculate hints now, since
          * we know we will need to re-init it in any new project that is opened.  
+         *
+         * @param {boolean=} quitting - whether the app is closing or not.
          */
-        function closeWorker() {
+        function closeWorker(quitting) {
             function terminateWorker() {
                 var worker = _ternWorker;
                 
@@ -1175,6 +1177,10 @@ define(function (require, exports, module) {
             
             if (_ternWorker) {
                 if (addFilesPromise) {
+                    if (quitting) {
+                        brackets.app.longRunningPromises.push(addFilesPromise);
+                    }
+                    
                     // If we're in the middle of added files, don't terminate 
                     // until we're done or we might get NPEs
                     addFilesPromise.done(terminateWorker).fail(terminateWorker);
@@ -1391,10 +1397,12 @@ define(function (require, exports, module) {
      *
      * We can clean up the web worker we use to calculate hints now, since
      * we know we will need to re-init it in any new project that is opened.  
+     *
+     * @param {boolean=} quitting - whether the app is closing or not.
      */
-    function handleProjectClose() {
+    function handleProjectClose(quitting) {
         if (currentWorker) {
-            currentWorker.closeWorker();
+            currentWorker.closeWorker(quitting);
             currentWorker = null;
         }
     }

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -810,6 +810,10 @@ define(function (require, exports, module) {
                 installEditorListeners(activeEditor);
             });
         
+        $(ProjectManager).on("beforeAppClose", function () {
+            ScopeManager.handleProjectClose(true);
+        });
+
         $(ProjectManager).on("beforeProjectClose", function () {
             ScopeManager.handleProjectClose();
         });


### PR DESCRIPTION
This is another attempt to fix the remaining crash issue of #7683. The solution here is copying the idea from @redmunds  pull request #8062, but correctly identify the long running promise in JS Code Hints provider. So it does fix the remaining crash issue. 

This may be another one-off solution, but does provide an easy way for others to do the same thing in preventing cef-1750 crash.
