### PR TITLE
Disable Integration Test

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -505,10 +505,10 @@ define(function (require, exports, module) {
      * Closes the hint list
      */
     CodeHintList.prototype.close = function () {
-        this.$hintMenu.removeClass("open");
         this.opened = false;
         
         if (this.$hintMenu) {
+            this.$hintMenu.removeClass("open");
             PopUpManager.removePopUp(this.$hintMenu);
             this.$hintMenu.remove();
         }

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -508,8 +508,10 @@ define(function (require, exports, module) {
         this.$hintMenu.removeClass("open");
         this.opened = false;
         
-        PopUpManager.removePopUp(this.$hintMenu);
-        this.$hintMenu.remove();
+        if (this.$hintMenu) {
+            PopUpManager.removePopUp(this.$hintMenu);
+            this.$hintMenu.remove();
+        }
         
         KeyBindingManager.removeGlobalKeydownHook(this._keydownHook);
     };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1610,7 +1610,9 @@ define(function (require, exports, module) {
         // PopUpManager.removePopUp() is called either directly by this closure, or by
         // PopUpManager as a result of another popup being invoked.
         function _removeMessagePopover() {
-            PopUpManager.removePopUp(self._$messagePopover);
+            if (self._$messagePopover) {
+                PopUpManager.removePopUp(self._$messagePopover);
+            }
         }
 
         function _addListeners() {

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -134,7 +134,9 @@ define(function (require, exports, module) {
      * Public close method
      */
     DropdownEventHandler.prototype.close = function () {
-        PopUpManager.removePopUp(this.$list);
+        if (this.$list) {
+            PopUpManager.removePopUp(this.$list);
+        }
     };
 
     /**

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, waitsForFail, runs, $, brackets, beforeFirst, afterLast */
+/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, waitsForFail, runs, $, brackets, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -514,7 +514,10 @@ define(function (require, exports, module) {
                 });
             });
 
-            it("should not open an inline editor when positioned on title attribute", function () {
+            // This recently added test is broken by a more recent change in CM, so disabling this test.
+            // See discussion in https://github.com/adobe/brackets/issues/8344
+            // The call to `waits(4000)` in this test seems to dismiss the popover
+            xit("should not open an inline editor when positioned on title attribute", function () {
                 initInlineTest("test1.html", 12, false);
                 
                 runs(function () {


### PR DESCRIPTION
Add null checks before calling PopUpManager.removePopUp(). While investigating issue #8344, I hit the exception described in https://groups.google.com/forum/?fromgroups#!topic/brackets-dev/IurHDG7AS7E, so this prevents that exception.

cc @peterflynn 
