### PR TITLE
Add code hints for text-rendering

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -184,6 +184,7 @@
     "text-indent":                 {"values": ["inherit"]},
     "text-overflow":               {"values": ["clip", "ellipsis", "inherit"]},
     "text-shadow":                 {"values": []},
+    "text-rendering":              {"values": ["auto", "geometricPrecision", "optimizeLegibility", "optimizeSpeed"]},
     "text-transform":              {"values": ["capitalize", "full-width", "lowercase", "none", "uppercase", "inherit"]},
     "text-underline-position":     {"values": ["alphabetic", "auto", "below", "left", "right"]},
     "top":                         {"values": ["auto", "inherit"]},


### PR DESCRIPTION
This pull request adds code hints for the [text-rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering) CSS property.
