### PR TITLE
fix issue 8395

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -380,6 +380,13 @@ define(function (require, exports, module) {
             var lineStr = instance.getLine(cursor.line);
             var nonWS = lineStr.search(/\S/);
 
+            // if the entire line is whitespace, it is set to a blank line to eliminate possible
+            // embedded whitespace like a softindent or tab which would otherwise be to the
+            // right of the newly indented electric char
+            if (nonWS === -1) {
+                instance.replaceRange("", {line: cursor.line, ch: 0}, {line: cursor.line});
+            }
+
             if (nonWS === -1 || nonWS >= cursor.ch) {
                 // Need to do the auto-indent on a timeout to ensure
                 // the keypress is handled before auto-indenting.


### PR DESCRIPTION
This is a PR to address #8395

I am not super happy about testing the nonWS again as is done below in the || comparison but I couldn't immediately think of a better way to do this.

As per the issue discussion, if the line has non-whitespace characters, the whitespace is not stripped.
