### PR TITLE
Don't resize window for modal bar until after query text is set

### DIFF
--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -224,41 +224,36 @@ define(function (require, exports, module) {
             // is hidden when we set options.multifile.
             $(_findBar).on("doReplaceAll.FindInFiles", startReplace);
         }
-                
+        
+        var oldModalBarHeight = _findBar._modalBar.height();
+        
         // Show file-exclusion UI *unless* search scope is just a single file
         if (!scope || scope.isDirectory) {
-            var oldModalBarHeight = _findBar._modalBar.height(),
-                exclusionsContext = {
-                    label: FindUtils.labelForScope(scope),
-                    promise: candidateFilesPromise
-                };
+            var exclusionsContext = {
+                label: FindUtils.labelForScope(scope),
+                promise: candidateFilesPromise
+            };
 
             filterPicker = FileFilters.createFilterPicker(exclusionsContext);
             // TODO: include in FindBar? (and disable it when FindBar is disabled)
             _findBar._modalBar.getRoot().find(".scope-group").append(filterPicker);
-
-            // Appending FilterPicker can change height of modal bar, so resize editor.
-            // Preserve scroll position of the current full editor across the editor refresh, adjusting for the 
-            // height of the modal bar so the code doesn't appear to shift if possible.
-            //
-            // TODO: This is an isolated fix for #8242.
-            // 1. If we keep this code, then this is done in a couple places in ModalBar,
-            //    so this code should be a utility function
-            // 2. Another solution is to pass this info FindBar.open
-            // 3. Also could make exclusion part of dialog a fixed height
-            var fullEditor = EditorManager.getCurrentFullEditor(),
-                scrollPos;
-            if (fullEditor) {
-                scrollPos = fullEditor.getScrollPos();
-                scrollPos.y -= oldModalBarHeight;   // modalbar already showing, adjust for old height
-            }
-            EditorManager.resizeEditor();
-            if (fullEditor) {
-                fullEditor._codeMirror.scrollTo(scrollPos.x, scrollPos.y + _findBar._modalBar.height());
-            }
         }
         
         handleQueryChange();
+        
+        // Appending FilterPicker and query text can change height of modal bar, so resize editor.
+        // Preserve scroll position of the current full editor across the editor refresh, adjusting
+        // for the height of the modal bar so the code doesn't appear to shift if possible.
+        var fullEditor = EditorManager.getCurrentFullEditor(),
+            scrollPos;
+        if (fullEditor) {
+            scrollPos = fullEditor.getScrollPos();
+            scrollPos.y -= oldModalBarHeight;   // modalbar already showing, adjust for old height
+        }
+        EditorManager.resizeEditor();
+        if (fullEditor) {
+            fullEditor._codeMirror.scrollTo(scrollPos.x, scrollPos.y + _findBar._modalBar.height());
+        }
     }
     
     /**


### PR DESCRIPTION
This is for #8242 and #8254.

Original fix resizes editor after File button is resized. This delays resizing until after query string is also changed.
