### PR TITLE
Language switcher: connect to prefs & clean up some code

### DIFF
--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -672,19 +672,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * Overrides the default language of this document and sets it to the given
-     * language. This change is not persisted if the document is closed.
-     * @param {?Language} language The language to be set for this document; if
-     * null, the language will be set back to the default.
-     */
-    Document.prototype.setLanguageOverride = function (language) {
-        LanguageManager._setLanguageOverrideForPath(this.file.fullPath, language);
-        this._updateLanguage();
-    };
-
-    /**
-     * Updates the language according to the file extension. If the current
-     * language was forced (set manually by user), don't change it.
+     * Updates the language to match the current mapping given by LanguageManager
      */
     Document.prototype._updateLanguage = function () {
         var oldLanguage = this.language;

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -65,6 +65,9 @@ define(function (require, exports, module) {
      *
      * __deleted__ -- When the file for this document has been deleted. All views onto the document should
      * be closed. The document will no longer be editable or dispatch "change" events.
+     * 
+     * __languageChanged__ -- When the value of getLanguage() has changed. 2nd argument is the old value,
+     * 3rd argument is the new value.
      *
      * @constructor
      * @param {!File} file  Need not lie within the project.

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -365,9 +365,9 @@ define(function (require, exports, module) {
             var document = EditorManager.getActiveEditor().document,
                 fullPath = document.file.fullPath,
                 defaultLang = LanguageManager.getLanguageForPath(fullPath, true);
-            // if default language selected, don't "force" it
-            // (passing in null will reset the force flag)
-            document.setLanguageOverride(lang === defaultLang ? null : lang);
+            
+            // if default language selected, pass null to clear the override
+            LanguageManager.setLanguageOverrideForPath(fullPath, lang === defaultLang ? null : lang);
         });
 
         $statusOverwrite.on("click", _updateEditorOverwriteMode);

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -327,7 +327,8 @@ define(function (require, exports, module) {
                 defaultLang = LanguageManager.getLanguageForPath(document.file.fullPath, true);
             
             if (item === LANGUAGE_SET_AS_DEFAULT) {
-                return _.escape(StringUtils.format(Strings.STATUSBAR_SET_DEFAULT_LANG, FileUtils.getSmartFileExtension(document.file.fullPath)));
+                var label = _.escape(StringUtils.format(Strings.STATUSBAR_SET_DEFAULT_LANG, FileUtils.getSmartFileExtension(document.file.fullPath)));
+                return { html: label, enabled: document.getLanguage() !== defaultLang };
             }
             
             var html = _.escape(item.getName());
@@ -376,20 +377,17 @@ define(function (require, exports, module) {
         // Language select change handler
         $(languageSelect).on("select", function (e, lang) {
             var document = EditorManager.getActiveEditor().document,
-                fullPath = document.file.fullPath,
-                defaultLang = LanguageManager.getLanguageForPath(fullPath, true);
+                fullPath = document.file.fullPath;
             
             if (lang === LANGUAGE_SET_AS_DEFAULT) {
-                lang = document.getLanguage();
-                if (lang !== defaultLang) {
-                    // Set file's current language in preferences as a file extension override
-                    var fileExtensionMap = PreferencesManager.get("language.fileExtensions");
-                    fileExtensionMap[FileUtils.getSmartFileExtension(fullPath)] = lang.getId();
-                    PreferencesManager.set("language.fileExtensions", fileExtensionMap);
-                }
+                // Set file's current language in preferences as a file extension override (only enabled if not default already)
+                var fileExtensionMap = PreferencesManager.get("language.fileExtensions");
+                fileExtensionMap[FileUtils.getSmartFileExtension(fullPath)] = document.getLanguage().getId();
+                PreferencesManager.set("language.fileExtensions", fileExtensionMap);
                 
             } else {
                 // Set selected language as a path override for just this one file (not persisted)
+                var defaultLang = LanguageManager.getLanguageForPath(fullPath, true);
                 // if default language selected, pass null to clear the override
                 LanguageManager.setLanguageOverrideForPath(fullPath, lang === defaultLang ? null : lang);
             }

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -41,7 +41,7 @@ define(function (require, exports, module) {
         NodeConnection       = require("utils/NodeConnection"),
         PreferencesManager   = require("preferences/PreferencesManager");
     
-    PreferencesManager.definePreference("proxy", "string");
+    PreferencesManager.definePreference("proxy", "string", undefined);
     
     var Errors = {
         ERROR_LOADING: "ERROR_LOADING",

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
      */
     var _lastRunOptions;
     
-    prefs.definePreference("options", "object")
+    prefs.definePreference("options", "object", undefined)
         .on("change", function (e, data) {
             var options = prefs.get("options");
             if (!_.isEqual(options, _lastRunOptions)) {

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1137,7 +1137,7 @@ define(function (require, exports, module) {
          * Called each time a new editor becomes active.
          *
          * @param {Session} session - the active hinting session
-         * @param {Document} document - the document of the editor that has changed
+         * @param {!Document} document - the document of the editor that has changed
          * @param {?Document} previousDocument - the document of the editor is changing from
          */
         function handleEditorChange(session, document, previousDocument) {

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1037,8 +1037,8 @@ define(function (require, exports, module) {
          *  Do the work to initialize a code hinting session.
          *
          * @param {Session} session - the active hinting session
-         * @param {Document} document - the document the editor has changed to
-         * @param {Document} previousDocument - the document the editor has changed from
+         * @param {!Document} document - the document the editor has changed to
+         * @param {?Document} previousDocument - the document the editor has changed from
          */
         function doEditorChange(session, document, previousDocument) {
             var file        = document.file,
@@ -1138,7 +1138,7 @@ define(function (require, exports, module) {
          *
          * @param {Session} session - the active hinting session
          * @param {Document} document - the document of the editor that has changed
-         * @param {Document} previousDocument - the document of the editor is changing from
+         * @param {?Document} previousDocument - the document of the editor is changing from
          */
         function handleEditorChange(session, document, previousDocument) {
             if (addFilesPromise === null) {
@@ -1376,7 +1376,7 @@ define(function (require, exports, module) {
      *
      * @param {Session} session - the active hinting session
      * @param {Document} document - the document of the editor that has changed
-     * @param {Document} previousDocument - the document of the editor is changing from
+     * @param {?Document} previousDocument - the document of the editor is changing from
      */
     function handleEditorChange(session, document, previousDocument) {
 

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -1036,7 +1036,7 @@ define(function (require, exports, module) {
         /**
          *  Do the work to initialize a code hinting session.
          *
-         * @param {Session} session - the active hinting session
+         * @param {Session} session - the active hinting session (TODO: currently unused)
          * @param {!Document} document - the document the editor has changed to
          * @param {?Document} previousDocument - the document the editor has changed from
          */
@@ -1136,7 +1136,7 @@ define(function (require, exports, module) {
         /**
          * Called each time a new editor becomes active.
          *
-         * @param {Session} session - the active hinting session
+         * @param {Session} session - the active hinting session (TODO: currently unused by doEditorChange())
          * @param {!Document} document - the document of the editor that has changed
          * @param {?Document} previousDocument - the document of the editor is changing from
          */

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -563,7 +563,7 @@ define(function (require, exports, module) {
          * When the editor is changed, reset the hinting session and cached 
          * information, and reject any pending deferred requests.
          * 
-         * @param {Editor} editor - editor context to be initialized.
+         * @param {!Editor} editor - editor context to be initialized.
          * @param {?Editor} previousEditor - the previous editor.
          */
         function initializeSession(editor, previousEditor) {
@@ -575,10 +575,10 @@ define(function (require, exports, module) {
         }
 
         /*
-         * Install editor change listeners
+         * Connects to the given editor, creating a new Session & adding listeners
          * 
-         * @param {Editor} editor - editor context on which to listen for
-         *      changes
+         * @param {?Editor} editor - editor context on which to listen for
+         *      changes. If null, 'session' is cleared.
          * @param {?Editor} previousEditor - the previous editor
          */
         function installEditorListeners(editor, previousEditor) {

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -120,6 +120,12 @@
  *         isBinary: true    
  *     }); 
  * 
+ * 
+ * LanguageManager dispatches two events:
+ * 
+ *  - languageAdded -- When any new Language is added. 2nd arg is the new Language.
+ *  - languageModified -- When the attributes of a Language change, or when the Language gains or loses
+ *          file extension / filename mappings. 2nd arg is the modified Language.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1006,7 +1006,7 @@ define(function (require, exports, module) {
      *     }
      */
     function _updateFromPrefs(pref) {
-        var newMapping = PreferencesManager.get(pref) || {},
+        var newMapping = PreferencesManager.get(pref),
             newNames = Object.keys(newMapping),
             state = _prefState[pref],
             last = state.last,
@@ -1103,14 +1103,14 @@ define(function (require, exports, module) {
         // depends on FileUtils) here. Using the async form of require fixes this.
         require(["preferences/PreferencesManager"], function (pm) {
             PreferencesManager = pm;
-            _updateFromPrefs(_EXTENSION_MAP_PREF);
-            _updateFromPrefs(_NAME_MAP_PREF);
-            pm.definePreference(_EXTENSION_MAP_PREF, "object").on("change", function () {
+            pm.definePreference(_EXTENSION_MAP_PREF, "object", {}).on("change", function () {
                 _updateFromPrefs(_EXTENSION_MAP_PREF);
             });
-            pm.definePreference(_NAME_MAP_PREF, "object").on("change", function () {
+            pm.definePreference(_NAME_MAP_PREF, "object", {}).on("change", function () {
                 _updateFromPrefs(_NAME_MAP_PREF);
             });
+            _updateFromPrefs(_EXTENSION_MAP_PREF);
+            _updateFromPrefs(_NAME_MAP_PREF);
         });
     });
     

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -247,6 +247,7 @@ define({
     "STATUSBAR_INSERT"                      : "INS",
     "STATUSBAR_OVERWRITE"                   : "OVR",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for .{0} Files",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problems",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1117,8 +1117,8 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Loads the given folder as a project. Normally, you would call openProject() instead to let the
-     * user choose a folder.
+     * Loads the given folder as a project. Does NOT prompt about any unsaved changes - use openProject()
+     * instead to check for unsaved changes and (optionally) let the user choose the folder to open.
      *
      * @param {!string} rootPath  Absolute path to the root folder of the project.
      *  A trailing "/" on the path is optional (unlike many Brackets APIs that assume a trailing "/").
@@ -1155,8 +1155,9 @@ define(function (require, exports, module) {
             DocumentManager.closeAll();
     
             _unwatchProjectRoot().always(function () {
-                // Done closing old project (if any)
+                // Finish closing old project (if any)
                 if (_projectRoot) {
+                    LanguageManager._resetPathLanguageOverrides();
                     PreferencesManager._reloadUserPrefs(_projectRoot);
                     $(exports).triggerHandler("projectClose", _projectRoot);
                 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -479,6 +479,13 @@ a:focus {
     &.dropdown-menu li a {
         padding: 1px 15px 1px 15px;
         color: @bc-black;
+        
+        &.disabled {
+            color: @bc-gray;
+            &:hover {
+                background: @bc-white;
+            }
+        }
     }
     
     &.dropdown-menu .stylesheet-link {

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -48,6 +48,8 @@ define(function (require, exports, module) {
      * - Esc         - dismiss list
      * - Up/Down     - change selection
      * - PageUp/Down - change selection
+     * 
+     * Items whose <a> has the .disabled class do not respond to selection.
      *
      * @constructor
      * @param {jQueryObject} $list  associated list object
@@ -88,13 +90,23 @@ define(function (require, exports, module) {
                 keyCode = event.keyCode;
     
                 if (keyCode === KeyEvent.DOM_VK_UP) {
-                    self._rotateSelection(-1);
+                    // Move up one, wrapping at edges (if nothing selected, select the last item)
+                    self._tryToSelect(self._selectedIndex === -1 ? -1 : self._selectedIndex - 1, -1);
                 } else if (keyCode === KeyEvent.DOM_VK_DOWN) {
-                    self._rotateSelection(1);
+                    // Move down one, wrapping at edges (if nothing selected, select the first item)
+                    self._tryToSelect(self._selectedIndex === -1 ? 0 : self._selectedIndex + 1, +1);
                 } else if (keyCode === KeyEvent.DOM_VK_PAGE_UP) {
-                    self._rotateSelection(-self._itemsPerPage());
+                    // Move up roughly one 'page', stopping at edges (not wrapping) (if nothing selected, selects the first item)
+                    self._tryToSelect((self._selectedIndex || 0) - self._itemsPerPage(), -1, true);
                 } else if (keyCode === KeyEvent.DOM_VK_PAGE_DOWN) {
-                    self._rotateSelection(self._itemsPerPage());
+                    // Move down roughly one 'page', stopping at edges (not wrapping) (if nothing selected, selects the item one page down from the top)
+                    self._tryToSelect((self._selectedIndex || 0) + self._itemsPerPage(), +1, true);
+                    
+                } else if (keyCode === KeyEvent.DOM_VK_HOME) {
+                    self._tryToSelect(0, +1);
+                } else if (keyCode === KeyEvent.DOM_VK_END) {
+                    self._tryToSelect(self.$items.length - 1, -1);
+                    
                 } else if (self._selectedIndex !== -1 &&
                         (keyCode === KeyEvent.DOM_VK_RETURN)) {
     
@@ -150,48 +162,42 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Change selection by specified amount. After selection reaches the last item
-     * in the rotation direction, then it wraps around to the start.
-     *
-     * @param {number} distance  Number of items to move change selection where
-     *      positive distance rotates down and negative distance rotates up
+     * Try to select item at the given index. If it's disabled or a divider, keep trying by incrementing
+     * index by 'direction' each time (wrapping around if needed).
+     * @param {number} index  If out of bounds, index either wraps around to remain in range (e.g. -1 yields
+     *                      last item, length+1 yields 2nd item) or if noWrap set, clips instead (e.g. -1 yields
+     *                      first item, length+1 yields last item).
+     * @param {number} direction  Either +1 or -1
+     * @param {boolean=} noWrap  Clip out of range index values instead of wrapping. Default false (wrap).
      */
-    DropdownEventHandler.prototype._rotateSelection = function (distance) {
-        var len = this.$items.length,
-            pos;
-
-        if (this._selectedIndex < 0) {
-            // set the initial selection
-            pos = (distance > 0) ? distance - 1 : len - 1;
-
+    DropdownEventHandler.prototype._tryToSelect = function (index, direction, noWrap) {
+        // Wrap around if index out of bounds (>= len or < 0)
+        var len = this.$items.length;
+        if (noWrap) {
+            // Clip to stay in range (and set direction so we don't wrap in the recursion case either)
+            if (index < 0) {
+                index = 0;
+                direction = +1;
+            } else if (index >= len) {
+                index = len - 1;
+                direction = -1;
+            }
         } else {
-            // adjust current selection
-            pos = this._selectedIndex;
-
-            // Don't "rotate" until all items have been shown
-            if (distance > 0) {
-                if (pos === (len - 1)) {
-                    pos = 0;  // wrap
-                } else {
-                    pos = Math.min(pos + distance, len - 1);
-                }
-            } else {
-                if (pos === 0) {
-                    pos = (len - 1);  // wrap
-                } else {
-                    pos = Math.max(pos + distance, 0);
-                }
+            index = index % len;
+            if (index < 0) {
+                index = len + index;
             }
         }
-
-        // If the item to be selected is a divider, then rotate one more.
-        if ($(this.$items[pos]).hasClass("divider")) {
-            this._rotateSelection((distance > 0) ? (distance + 1) : (distance - 1));
+        
+        var $item = this.$items.eq(index);
+        if ($item.hasClass("divider") || $item.find("a.disabled").length) {
+            // Desired item is ineligible for selection: try next one
+            this._tryToSelect(index + direction, direction, noWrap);
         } else {
-            this._setSelectedIndex(pos, true);
+            this._setSelectedIndex(index, true);
         }
     };
-
+    
     /**
      * @return {number} The number of items per scroll page.
      */
@@ -232,6 +238,9 @@ define(function (require, exports, module) {
     DropdownEventHandler.prototype._clickHandler = function ($link) {
 
         if (!this.selectionCallback || !this.$list || !$link) {
+            return;
+        }
+        if ($link.is(".disabled")) {
             return;
         }
         
@@ -285,9 +294,10 @@ define(function (require, exports, module) {
                     viewOffset = self.$list.offset(),
                     elementOffset = $item.offset();
 
-                // Only set selected if in view
-                if (elementOffset.top < viewOffset.top + self.$list.height()) {
-                    if (viewOffset.top <= elementOffset.top) {
+                // Only set selected if enabled & in view
+                // (dividers are already screened out since they don't have an "a" tag in them)
+                if (!$link.is(".disabled")) {
+                    if (elementOffset.top < viewOffset.top + self.$list.height() && viewOffset.top <= elementOffset.top) {
                         self._setSelectedIndex(self.$items.index($item), false);
                     }
                 }

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -171,7 +171,7 @@ define(function (require, exports, module) {
      * @param {boolean=} noWrap  Clip out of range index values instead of wrapping. Default false (wrap).
      */
     DropdownEventHandler.prototype._tryToSelect = function (index, direction, noWrap) {
-        // Wrap around if index out of bounds (>= len or < 0)
+        // Fix up 'index' if out of bounds (>= len or < 0)
         var len = this.$items.length;
         if (noWrap) {
             // Clip to stay in range (and set direction so we don't wrap in the recursion case either)
@@ -183,9 +183,10 @@ define(function (require, exports, module) {
                 direction = -1;
             }
         } else {
-            index = index % len;
+            // Wrap around to keep index in bounds
+            index %= len;
             if (index < 0) {
-                index = len + index;
+                index += len;
             }
         }
         
@@ -240,7 +241,7 @@ define(function (require, exports, module) {
         if (!this.selectionCallback || !this.$list || !$link) {
             return;
         }
-        if ($link.is(".disabled")) {
+        if ($link.hasClass("disabled")) {
             return;
         }
         
@@ -296,7 +297,7 @@ define(function (require, exports, module) {
 
                 // Only set selected if enabled & in view
                 // (dividers are already screened out since they don't have an "a" tag in them)
-                if (!$link.is(".disabled")) {
+                if (!$link.hasClass("disabled")) {
                     if (elementOffset.top < viewOffset.top + self.$list.height() && viewOffset.top <= elementOffset.top) {
                         self._setSelectedIndex(self.$items.index($item), false);
                     }

--- a/src/widgets/DropdownButton.js
+++ b/src/widgets/DropdownButton.js
@@ -59,8 +59,9 @@ define(function (require, exports, module) {
      * @param {!Array.<*>} items  Items in the dropdown list. It generally doesn't matter what type/value the
      *          items have, except that any item === "---" will be treated as a divider. Such items are not
      *          clickable and itemRenderer() will not be called for them.
-     * @param {?function(*, number):!string} itemRenderer  Optional function to convert a single item to HTML
-     *          (see itemRenderer() docs below). If not provided, items are assumed to be plain text strings.
+     * @param {?function(*, number):!string|{html:string, enabled:boolean} itemRenderer  Optional function to
+     *          convert a single item to HTML (see itemRenderer() docs below). If not provided, items are
+     *          assumed to be plain text strings.
      */
     function DropdownButton(label, items, itemRenderer) {
         this.items = items;
@@ -142,7 +143,9 @@ define(function (require, exports, module) {
      * Called for each item when rendering the dropdown.
      * @param {*} item from items array
      * @param {number} index in items array
-     * @return {!string} Formatted & escaped HTML
+     * @return {!string|{html:string, enabled:boolean}} Formatted & escaped HTML, either as a simple string
+     *      or as the 'html' field in an object that also conveys enabled state. Disabled items inherit gray
+     *      text color and cannot be selected.
      */
     DropdownButton.prototype.itemRenderer = function (item, index) {
         return _.escape(String(item));
@@ -163,8 +166,12 @@ define(function (require, exports, module) {
             if (item === "---") {
                 html += "<li class='divider'></li>";
             } else {
-                html += "<li><a class='stylesheet-link' data-index='" + i + "'>";
-                html += this.itemRenderer(item, i);
+                var rendered = this.itemRenderer(item, i),
+                    itemHtml = rendered.html || rendered,
+                    disabledClass = (rendered.html && !rendered.enabled) ? "disabled" : "";
+                
+                html += "<li><a class='stylesheet-link " + disabledClass + "' data-index='" + i + "'>";
+                html += itemHtml;
                 html += "</a></li>";
             }
         }.bind(this));

--- a/src/widgets/DropdownButton.js
+++ b/src/widgets/DropdownButton.js
@@ -56,7 +56,9 @@ define(function (require, exports, module) {
      *  - "select" - when an option in the dropdown is clicked. Passed item object and index.
      * 
      * @param {!string} label  Label to display on the button
-     * @param {!Array.<*>} items  Items in the dropdown list
+     * @param {!Array.<*>} items  Items in the dropdown list. It generally doesn't matter what type/value the
+     *          items have, except that any item === "---" will be treated as a divider. Such items are not
+     *          clickable and itemRenderer() will not be called for them.
      * @param {?function(*, number):!string} itemRenderer  Optional function to convert a single item to HTML
      *          (see itemRenderer() docs below). If not provided, items are assumed to be plain text strings.
      */

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
         });
         
         afterEach(function () {
-            LanguageManager._resetLanguageOverrides();
+            LanguageManager._resetPathLanguageOverrides();
         });
         
         function defineLanguage(definition) {
@@ -544,7 +544,7 @@ define(function (require, exports, module) {
 
                 var renameDeferred = $.Deferred();
                 runs(function () {
-                    DocumentManager.setCurrentDocument(doc);                    
+                    DocumentManager.setCurrentDocument(doc);
                     javascript = LanguageManager.getLanguage("javascript");
                     
                     // sanity check language
@@ -705,7 +705,7 @@ define(function (require, exports, module) {
                 // make active
                 doc.addRef();
                 
-                doc.setLanguageOverride(phpLang);
+                LanguageManager.setLanguageOverrideForPath(doc.file.fullPath, phpLang);
                 
                 // language should change
                 expect(doc.getLanguage()).toBe(phpLang);
@@ -747,7 +747,7 @@ define(function (require, exports, module) {
                 // make active
                 doc.addRef();
                 
-                doc.setLanguageOverride(phpLang);
+                LanguageManager.setLanguageOverrideForPath(doc.file.fullPath, phpLang);
                 
                 // language should change
                 expect(doc.getLanguage()).toBe(phpLang);
@@ -756,7 +756,7 @@ define(function (require, exports, module) {
                 expect(spy.mostRecentCall.args[2]).toBe(phpLang);
                 expect(LanguageManager.getLanguageForPath(doc.file.fullPath)).toBe(phpLang);
                 
-                doc.setLanguageOverride(null);
+                LanguageManager.setLanguageOverrideForPath(doc.file.fullPath, null);
                 
                 // language should revert
                 expect(doc.getLanguage()).toBe(unknownLang);
@@ -777,7 +777,7 @@ define(function (require, exports, module) {
                 expect(LanguageManager.getLanguageForPath(doc.file.fullPath)).toBe(modifiedLanguage);
                 
                 // override again
-                doc.setLanguageOverride(phpLang);
+                LanguageManager.setLanguageOverrideForPath(doc.file.fullPath, phpLang);
                 
                 expect(doc.getLanguage()).toBe(phpLang);
                 expect(spy.callCount).toBe(4);
@@ -786,7 +786,7 @@ define(function (require, exports, module) {
                 expect(LanguageManager.getLanguageForPath(doc.file.fullPath)).toBe(phpLang);
                 
                 // remove override, should restore to modifiedLanguage
-                doc.setLanguageOverride(null);
+                LanguageManager.setLanguageOverrideForPath(doc.file.fullPath, null);
                 
                 expect(doc.getLanguage()).toBe(modifiedLanguage);
                 expect(spy.callCount).toBe(5);


### PR DESCRIPTION
Follow-on to PR #6409...

It may be easiest to review each commit individually, since they're fairly distinct:

Second commit - new feature:
- Add "Set as Default" menu item to status bar language switcher -- adds a permanent file extension mapping to preferences, based on the current file's path-specific language override (if any) and its file extension.

First commit - cleanups:
- Make LanguageManager the official public API that is used to set per-file overrides, rather than proxying through Document objects - remove `Document.setLanguageOverride()`
- Clear path overrides when switching projects, so it's more obvious to users it's not something that gets persisted across sessions
- Simplify how JS Code Hints listen for language updates: remove dependency on `"currentDocumentLanguageChanged"` event; remove unneeded extra 'if' tests

Third commit:
- Improve "Set as Default" menu item -- gray it out when the current file has no path-specific override (i.e., when the current language already is the default for the current filetype)
- Extend DropdownButton / DropdownEventHandler to support disabled items.
- In the process, clean up dropdown keyboard navigation substantially -- fixing #8433.

~~For clarity, I'd ideally like the "Set as Default" menu item to be grayed out when there is no path-specific override on the current file (i.e., when the current language already _is_ the default for the current filetype)... but disabled items aren't a think in DropdownButton yet and I will need to do some cleanup there to get it working -- so I wanted to post this initial for review first.~~ _(this is now implemented)_
