### PR TITLE
[Themes] Logic to reuse theme style node

### DIFF
--- a/src/view/ThemeView.js
+++ b/src/view/ThemeView.js
@@ -78,6 +78,12 @@ define(function (require, exports, module) {
     }
 
 
+    /**
+     * Load scrollbar styling based on whether or not theme scrollbars are enabled.
+     *
+     * @param {ThemeManager.Theme} theme Is the theme object with the corresponding scrollbar style
+     *   to be updated
+     */
     function updateScrollbars(theme) {
         theme = theme || {};
         if (prefs.get("customScrollbars")) {
@@ -124,9 +130,6 @@ define(function (require, exports, module) {
     }
 
 
-    //
-    // Expose API
-    //
     exports.updateFonts      = updateFonts;
     exports.updateLineHeight = updateLineHeight;
     exports.updateFontSize   = updateFontSize;


### PR DESCRIPTION
Changed ThemeManager around so that the style nodes for themes are reused.  Also added logic to only process theme prefs events only when there is a theme selection. Update jsdoc

https://github.com/adobe/brackets/issues/8457
https://github.com/adobe/brackets/issues/8441
https://github.com/adobe/brackets/issues/8420
