### PR TITLE
Fix bug #8416 (Preview for SVG url data types does not work)

### DIFF
--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -427,9 +427,8 @@ define(function (require, exports, module) {
         }
         
         if (tokenString) {
-            // Strip quotes, if present
-            var quotesRegEx = /(\'|\")?([^(\'|\")]*)(\'|\")?/;
-            tokenString = tokenString.replace(quotesRegEx, "$2");
+            // Strip leading/trailing quotes, if present
+            tokenString = tokenString.replace(/(^['"])|(['"]$)/g, "");
             
             if (/^(data\:image)|(\.gif|\.png|\.jpg|\.jpeg|\.svg)$/i.test(tokenString)) {
                 var sPos, ePos;

--- a/src/extensions/default/QuickView/unittest-files/test.css
+++ b/src/extensions/default/QuickView/unittest-files/test.css
@@ -179,3 +179,9 @@ background: -ms-linear-gradient(top,  #d2dfed 0%,#c8d7eb 26%,#bed0ea 51%,#a6c0e3
     background :radial-gradient(red, white 50%, blue 100%);
     background:radial-gradient(red, white 50%, blue 100%);
 }
+
+.quotes {
+    background: url(img/don't.png);
+    background: url("img/don't.png");
+    background:url("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg'></svg>");
+}

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -420,6 +420,12 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("Should show image preview for URIs containing quotes", function () {
+                checkImagePathAtPos("img/don't.png", 183, 26);  // url() containing '
+                checkImagePathAtPos("img/don't.png", 184, 26);  // url("") containing '
+                checkImageDataAtPos("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg'></svg>", 185, 26);  // data url("") containing '
+            });
+            
             it("Should show image preview for a data URI inside url()", function () {
                 runs(function () {
                     checkImageDataAtPos("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAABq0lEQVQoU11RPUgcURD+Zt/unnrcCf4QIugRMcS7a2xjmmArRlRIFRBFgrVtGgmBRFCwTBoLsQiBGMxiJ4iksLRSFEzQRC2EAwm5g727feP3LpyFy1tm5s33zcz7RnDvG4x0zFgMJRY/jiewhy/w8FKSJkyaTuG7Fumvi+ARbQiLpcMDvH/Qj1S6Bf6vI5SxKPUG4fGm5kMf6wr08MKHILCKldoZlk0OIeuHjNuDBBcNAqvvENTLwKii1ZFoF/7G2PQDpNo8dFUt1AcSGfymz42PVfI8ghxht1bHh9MpucCiegMFdJoUOtSD+MxLPtI5T/GaHWhg+NjRk3G5utPikwb5bjzhq40JSChs6Sx1eOYAojg/fCFv7yvnBLGCLPMqxS2dZrtXnDthhySuYebnpFw3ST2RtmUVIx5z1sIKdX9qgDcOTJAj7WsNa8eTUhrY0Gwqg2FldeZiduH5r9JHvqEDigzDS/4VJvYJfMh9VLmbNO9+s9hNg5D/qjkJ8I6uW0yFtkrwHydCg+AhVgsp/8Pnu00XI+0jYJ7gjANRiEsmQ3aNOXuJhG035i1QA6g+uONCrgAAAABJRU5ErkJggg==",  159, 26);


### PR DESCRIPTION
Fix bug #8416 -- Strip only leading/trailing quotes from image url()s, not quotes inside the value.  Fixes problems with filenames containing apostrophes too.
