### PR TITLE
Clear up bug #6722 (Linux: menu items cut/copy/paste not working)

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -72,10 +72,13 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.EDIT_UNDO);
         menu.addMenuItem(Commands.EDIT_REDO);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.EDIT_CUT);
-        menu.addMenuItem(Commands.EDIT_COPY);
-        menu.addMenuItem(Commands.EDIT_PASTE);
-        menu.addMenuDivider();
+        if (brackets.nativeMenus) {
+            // Native-only - can't programmatically trigger clipboard actions from JS menus
+            menu.addMenuItem(Commands.EDIT_CUT);
+            menu.addMenuItem(Commands.EDIT_COPY);
+            menu.addMenuItem(Commands.EDIT_PASTE);
+            menu.addMenuDivider();
+        }
         menu.addMenuItem(Commands.EDIT_SELECT_ALL);
         menu.addMenuItem(Commands.EDIT_SELECT_LINE);
         menu.addMenuItem(Commands.EDIT_SPLIT_SEL_INTO_LINES);


### PR DESCRIPTION
To avoid confusion, don't show Cut/Copy/Paste in HTML menus. They'll only work in the native shell, with specially bound native menu items.

Whenever [Linux native menu support](https://trello.com/c/WMB6vtwO/893-linux-native-menus) lands, these menu items will automatically be exposed, and they should work at that point.  In "in-browser" mode, the menu items will forever stay hidden, since there's simply no way to make them work there.
