### PR TITLE
Adds dark class and moves inline-widget color into core UI theme

### DIFF
--- a/src/extensions/default/ThorDarkTheme/main.less
+++ b/src/extensions/default/ThorDarkTheme/main.less
@@ -167,10 +167,6 @@
     border-bottom: 9px solid transparent;
 }
 
-.inline-widget {
-    color: #333;
-}
-
 .inline-widget .CodeMirror, .inline-widget .CodeMirror-gutters {
     background: transparent;
 }

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -165,5 +165,14 @@
 
 }
 
+/* Dark theme styling
+ * 
+ * These are overrides to make the UI look better when the editor theme is dark.
+ * Eventually, these will likely be replaced by full-featured UI themes.
+ */
+.dark .inline-widget {
+    color: #333;
+}
+
 /* Variables and Mixins for non-code UI elements that can be styled */
 

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -241,6 +241,11 @@ define(function (require, exports, module) {
             })
             .then(function (cssContent) {
                 styleNode.text(cssContent);
+                if (theme.dark) {
+                    $("body").addClass("dark");
+                } else {
+                    $("body").removeClass("dark");
+                }
                 return theme;
             });
 


### PR DESCRIPTION
See [this comment](https://github.com/adobe/brackets/pull/8484#discussion_r15225897) from #8484.

cc @MiguelCastillo to review the ThemeManager change and @larz0 to make sure that the new location for the `.inline-widget` style makes sense.
