### PR TITLE
Fix bug #8507 (Themes code throws errors during wholesale file updates)

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
     // Monitor file changes.  If the file that has changed is actually the currently loaded
     // theme, then we just reload the theme.  This allows to live edit the theme
     FileSystem.on("change", function (evt, file) {
-        if (file.isDirectory) {
+        if (!file || file.isDirectory) {
             return;
         }
 


### PR DESCRIPTION
Fix bug #8507 -- Don't assume FileSystem `"change"` event's `entry` arg is non-null
