### PR TITLE
Change theme scrollbar naming and set default dark scrollbars

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -55,40 +55,6 @@
 
 /* Code Styling */
 
-/* Custom scrollbar colors */
-.platform-win & {
-    .CodeMirror-gutter-filler {
-        background-color: rgb(15, 15, 15);
-    }
-    // Note: when changing padding/margins, may need to adjust metrics in ScrollTrackMarkers.js
-
-    ::-webkit-scrollbar {
-        background-color: rgb(15, 15, 15);
-    }
-
-    ::-webkit-scrollbar-thumb {
-        box-shadow: 0 0 0 12px rgb(49, 49, 49) inset;
-    }
-    ::-webkit-scrollbar-thumb:hover,
-    ::-webkit-scrollbar-thumb:focus {
-        box-shadow: 0 0 0 12px rgb(89, 89, 89) inset;
-    }
-    ::-webkit-scrollbar-thumb:active {
-        box-shadow: 0 0 0 12px rgb(169, 169, 169) inset;
-    }
-}
-
-.platform-linux & {
-    ::-webkit-scrollbar-thumb {
-        box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.24) inset;
-    }
-
-    ::-webkit-scrollbar-thumb:window-inactive {
-        box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.12) inset;
-    }
-}
-
-
 .CodeMirror, .CodeMirror-scroll {
     background-color: @background;
     color: @foreground;

--- a/src/htmlContent/themes-settings.html
+++ b/src/htmlContent/themes-settings.html
@@ -16,14 +16,14 @@
             </div>
 
             <div class="control-group">
-                <label class="control-label">{{Strings.CUSTOM_SCROLLBARS}}:</label>
+                <label class="control-label">{{Strings.USE_THEME_SCROLLBARS}}:</label>
                 <div class="controls">
-                    {{#settings.customScrollbars}}
-                        <input type="checkbox" data-target="customScrollbars" checked>
-                    {{/settings.customScrollbars}}
-                    {{^settings.customScrollbars}}
-                        <input type="checkbox" data-target="customScrollbars">
-                    {{/settings.customScrollbars}}
+                    {{#settings.themeScrollbars}}
+                        <input type="checkbox" data-target="themeScrollbars" checked>
+                    {{/settings.themeScrollbars}}
+                    {{^settings.themeScrollbars}}
+                        <input type="checkbox" data-target="themeScrollbars">
+                    {{/settings.themeScrollbars}}
                 </div>
             </div>
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -421,7 +421,7 @@ define({
     
     // Strings for themes-settings.html and themes-general.html
     "CURRENT_THEME"                        : "Current Theme",
-    "CUSTOM_SCROLLBARS"                    : "Custom Scrollbars",
+    "USE_THEME_SCROLLBARS"                 : "Use Theme Scrollbars",
     "FONT_SIZE"                            : "Font Size",
     "FONT_FAMILY"                          : "Font Family",
     "LINE_HEIGHT"                          : "Line Height",

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -170,8 +170,43 @@
  * These are overrides to make the UI look better when the editor theme is dark.
  * Eventually, these will likely be replaced by full-featured UI themes.
  */
-.dark .inline-widget {
-    color: #333;
+.dark {
+    .inline-widget {
+        color: #333;
+    }
+    
+    /* Custom scrollbar colors */
+    .platform-win {
+        .CodeMirror-gutter-filler {
+            background-color: rgb(15, 15, 15);
+        }
+        // Note: when changing padding/margins, may need to adjust metrics in ScrollTrackMarkers.js
+
+        ::-webkit-scrollbar {
+            background-color: rgb(15, 15, 15);
+        }
+
+        ::-webkit-scrollbar-thumb {
+            box-shadow: 0 0 0 12px rgb(49, 49, 49) inset;
+        }
+        ::-webkit-scrollbar-thumb:hover,
+        ::-webkit-scrollbar-thumb:focus {
+            box-shadow: 0 0 0 12px rgb(89, 89, 89) inset;
+        }
+        ::-webkit-scrollbar-thumb:active {
+            box-shadow: 0 0 0 12px rgb(169, 169, 169) inset;
+        }
+    }
+
+    .platform-linux {
+        ::-webkit-scrollbar-thumb {
+            box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.24) inset;
+        }
+
+        ::-webkit-scrollbar-thumb:window-inactive {
+            box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.12) inset;
+        }
+    }
 }
 
 /* Variables and Mixins for non-code UI elements that can be styled */

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -176,7 +176,7 @@
     }
     
     /* Custom scrollbar colors */
-    .platform-win {
+    &.platform-win {
         .CodeMirror-gutter-filler {
             background-color: rgb(15, 15, 15);
         }
@@ -198,7 +198,7 @@
         }
     }
 
-    .platform-linux {
+    &.platform-linux {
         ::-webkit-scrollbar-thumb {
             box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.24) inset;
         }

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -337,7 +337,7 @@ define(function (require, exports, module) {
         $(exports).trigger("themeChange", getCurrentTheme());
     });
 
-    prefs.on("change", "customScrollbars", function () {
+    prefs.on("change", "themeScrollbars", function () {
         refresh();
         ThemeView.updateScrollbars(getCurrentTheme());
     });

--- a/src/view/ThemeSettings.js
+++ b/src/view/ThemeSettings.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
      * Object with all default values that can be configure via the settings UI
      */
     var defaults = {
-        "customScrollbars": true,
+        "themeScrollbars": true,
         "theme": "light-theme"
     };
 
@@ -154,11 +154,11 @@ define(function (require, exports, module) {
      */
     function restore() {
         prefs.set("theme", defaults.theme);
-        prefs.set("customScrollbars", defaults.customScrollbars);
+        prefs.set("themeScrollbars", defaults.themeScrollbars);
     }
 
     prefs.definePreference("theme", "string", defaults.theme);
-    prefs.definePreference("customScrollbars", "boolean", defaults.customScrollbars);
+    prefs.definePreference("themeScrollbars", "boolean", defaults.themeScrollbars);
 
     exports._setThemes = setThemes;
     exports.restore    = restore;

--- a/src/view/ThemeView.js
+++ b/src/view/ThemeView.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
      */
     function updateScrollbars(theme) {
         theme = theme || {};
-        if (prefs.get("customScrollbars")) {
+        if (prefs.get("themeScrollbars")) {
             var scrollbar = (theme.scrollbar || []).join(" ");
             $scrollbars.text(scrollbar || "");
         } else {


### PR DESCRIPTION
This is a fix for #8384 that changes "Custom Scrollbars" to "Use Theme Scrollbars" (and makes the rest of the `customScrollbars` uses consistent with `themeScrollbars`)

Also moves the default dark scrollbars into the core UI theme so that turning off Theme Scrollbars with a dark theme will use Brackets' default dark scrollbar styling.
