### PR TITLE
Removes line height setting

### DIFF
--- a/src/htmlContent/themes-settings.html
+++ b/src/htmlContent/themes-settings.html
@@ -40,13 +40,6 @@
                     <input type="text" data-target="fontFamily" value="{{settings.fontFamily}}">
                 </div>
             </div>
-
-            <div class="control-group">
-                <label class="control-label">{{Strings.LINE_HEIGHT}}:</label>
-                <div class="controls">
-                    <input type="text" data-target="lineHeight" value="{{settings.lineHeight}}">
-                </div>
-            </div>
         </form>
     </div>
     <div class="modal-footer">

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -75,16 +75,6 @@
     border-bottom: 2px solid #78B2F2;
 }
 
-/**
- * These classes are set to inline-block because they are spans and they need block dimension properties when
- * when calculation height and width.
- */
-.CodeMirror-searching,
-.CodeMirror-matchingtag,
-.CodeMirror-matchingbracket {
-    display: inline-block;
-}
-
 span.cm-keyword {color: @accent-keyword;}
 span.cm-atom {color: @accent-atom;}
 span.cm-number {color: @accent-number;}

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -144,6 +144,7 @@
  */
 .code-font() {
     color: @content-color;
+    line-height: 1.25;
 }
 
 .code-font-win() {

--- a/src/view/ThemeSettings.js
+++ b/src/view/ThemeSettings.js
@@ -70,7 +70,6 @@ define(function (require, exports, module) {
 
         result.fontFamily = ViewCommandHandlers.getFontFamily();
         result.fontSize   = ViewCommandHandlers.getFontSize();
-        result.lineHeight = ViewCommandHandlers.getLineHeight();
         return result;
     }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -62,12 +62,6 @@ define(function (require, exports, module) {
 
     /**
      * @const
-     * @type {string}
-     */
-    var DYNAMIC_LINE_HEIGHT_ID = "codemirror-dynamic-line-height";
-
-    /**
-     * @const
      * @private
      * The smallest font size in pixels
      * @type {number}
@@ -89,14 +83,6 @@ define(function (require, exports, module) {
      * @type {number}
      */
     var DEFAULT_FONT_SIZE = 12;
-
-    /**
-     * @const
-     * @private
-     * The default line height
-     * @type {number}
-     */
-    var DEFAULT_LINE_HEIGHT = 1.25;
 
     /**
      * @const
@@ -166,23 +152,6 @@ define(function (require, exports, module) {
      */
     function _addDynamicFontFamily(fontFamily) {
         _addDynamicProperty(DYNAMIC_FONT_FAMILY_ID, "font-family", fontFamily);
-    }
-
-    /**
-     * @private
-     * Removes the styles used to update the font family
-     */
-    function _removeDynamicLineHeight() {
-        _removeDynamicProperty(DYNAMIC_LINE_HEIGHT_ID);
-    }
-
-    /**
-     * @private
-     * Add the styles used to update the line height
-     * @param {string} lineHeight  A string with the line height with size unit
-     */
-    function _addDynamicLineHeight(lineHeight) {
-        _addDynamicProperty(DYNAMIC_LINE_HEIGHT_ID, "line-height", lineHeight, true, ".CodeMirror-lines > div");
     }
 
     /**
@@ -287,43 +256,6 @@ define(function (require, exports, module) {
 
 
     /**
-     * Line height setter to set the line height of the document editor
-     * @param {string} lineHeight The line height. The value is in 'em'.
-     */
-    function setLineHeight(lineHeight) {
-        var editor = EditorManager.getCurrentFullEditor(),
-            oldValue = prefs.get("lineHeight");
-
-        // Make sure the incoming value is a number...  Strip off any size units
-        lineHeight = parseFloat(lineHeight);
-
-        if (oldValue === lineHeight) {
-            return;
-        }
-
-        _removeDynamicLineHeight();
-        if (lineHeight) {
-            _addDynamicLineHeight(lineHeight);
-        }
-
-        $(exports).triggerHandler("lineHeightChange", [lineHeight, oldValue]);
-        prefs.set("lineHeight", lineHeight);
-
-        if (editor) {
-            editor.refreshAll();
-        }
-    }
-
-    /**
-     * Line height getter to get the line height for the document editor
-     * @return {string} The line height with size unit as 'em' for the document editor
-     */
-    function getLineHeight() {
-        return prefs.get("lineHeight");
-    }
-
-
-    /**
      * @private
      * Increases or decreases the editor's font size.
      * @param {number} adjustment  Negative number to make the font smaller; positive number to make it bigger
@@ -397,7 +329,6 @@ define(function (require, exports, module) {
     function init() {
         _addDynamicFontFamily(prefs.get("fontFamily"));
         _addDynamicFontSize(prefs.get("fontSize"));
-        _addDynamicLineHeight(prefs.get("lineHeight"));
         _updateUI();
     }
 
@@ -427,12 +358,11 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Restores the font size, font family, and line height back to factory settings.
+     * Restores the font size and font family back to factory settings.
      */
     function restoreFonts() {
         setFontFamily(DEFAULT_FONT_FAMILY);
         setFontSize(DEFAULT_FONT_SIZE + "px");
-        setLineHeight(DEFAULT_LINE_HEIGHT);
     }
 
 
@@ -553,7 +483,6 @@ define(function (require, exports, module) {
     PreferencesManager.convertPreferences(module, {"fontSizeAdjustment": "user"}, true, _convertToNewViewState);
 
     prefs.definePreference("fontSize",   "string", DEFAULT_FONT_SIZE + "px");
-    prefs.definePreference("lineHeight", "number", DEFAULT_LINE_HEIGHT);
     prefs.definePreference("fontFamily", "string", DEFAULT_FONT_FAMILY);
 
     // Update UI when opening or closing a document
@@ -568,6 +497,4 @@ define(function (require, exports, module) {
     exports.setFontSize     = setFontSize;
     exports.getFontFamily   = getFontFamily;
     exports.setFontFamily   = setFontFamily;
-    exports.getLineHeight   = getLineHeight;
-    exports.setLineHeight   = setLineHeight;
 });


### PR DESCRIPTION
This may not be the fix we want, but it removes the line height setting as an approach for #8519 and some of the behavior noted in the comments of #8523.

Removing the line height setting entirely seems like the easiest solution at this stage and we could try to resurrect it for a future release.

cc @MiguelCastillo @TomMalbran @peterflynn @redmunds 
