### PR TITLE
Update twitter URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Not sure you needed the exclamation point there, but we like your enthusiasm.
 
 #### Contact info
 
-* **Twitter:** [@brackets](http://twitter.com/#!/brackets)
+* **Twitter:** [@brackets](https://twitter.com/brackets)
 * **Blog:** http://blog.brackets.io/
 * **IRC:** [#brackets on freenode](http://webchat.freenode.net/?channels=brackets)
 * **Developers mailing list:** http://groups.google.com/group/brackets-dev


### PR DESCRIPTION
Twitter now uses https by default and you no longer need the hash bang (#!)
