### PR TITLE
Fix capitalization error in name="keywords" meta attribute

### DIFF
--- a/src/extensions/default/HTMLCodeHints/HtmlAttributes.json
+++ b/src/extensions/default/HTMLCodeHints/HtmlAttributes.json
@@ -167,7 +167,7 @@
     "multiple":           { "attribOption": [], "type": "flag" },
     "muted":              { "attribOption": [], "type": "flag" },
     "name":               { "attribOption": [] },
-    "meta/name":          { "attribOption": ["application-name", "author", "description", "generator", "Keywords"] },
+    "meta/name":          { "attribOption": ["application-name", "author", "description", "generator", "keywords"] },
     "novalidate":         { "attribOption": [], "type": "flag" },
     "open":               { "attribOption": [], "type": "flag" },
     "optimum":            { "attribOption": [] },


### PR DESCRIPTION
Both the [HTML5](http://www.w3.org/TR/html5/document-metadata.html#meta-keywords) and [WHATWG](http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#meta-keywords) define it as "keywords", not "Keywords".
