### PR TITLE
Fix bug #8556 (Find/Replace in Files with /^/ finds 100K matches at start of file)

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -130,6 +130,11 @@ define(function (require, exports, module) {
                 queryExpr.lastIndex = 0;
                 break;
             }
+            
+            // Pathological regexps like /^/ return 0-length matches. Ensure we make progress anyway
+            if (totalMatchLength === 0) {
+                queryExpr.lastIndex++;
+            }
         }
 
         return matches;

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -1230,6 +1230,29 @@ define(function (require, exports, module) {
                     });
                 });
 
+                it("should replace instances of regexp with 0-length matches on disk", function () {
+                    openTestProjectCopy(defaultSourcePath);
+                    doBasicTest({
+                        queryInfo:       {query: "^", isRegexp: true},
+                        numMatches:      55,
+                        replaceText:     "CHANGED",
+                        knownGoodFolder: "regexp-zero-length"
+                    });
+                });
+                
+                it("should replace instances of regexp with 0-length matches in memory", function () {
+                    openTestProjectCopy(defaultSourcePath);
+                    doInMemoryTest({
+                        queryInfo:       {query: "^", isRegexp: true},
+                        numMatches:      55,
+                        replaceText:     "CHANGED",
+                        knownGoodFolder:   "unchanged",
+                        forceFilesOpen:    true,
+                        inMemoryFiles:     ["/css/foo.css", "/foo.html", "/foo.js"],
+                        inMemoryKGFolder: "regexp-zero-length"
+                    });
+                });
+
                 it("should replace instances of a string in a project respecting CRLF line endings", function () {
                     openTestProjectCopy(defaultSourcePath, FileUtils.LINE_ENDINGS_CRLF);
                     doBasicTest({

--- a/test/spec/FindReplace-known-goods/regexp-zero-length/bar.txt
+++ b/test/spec/FindReplace-known-goods/regexp-zero-length/bar.txt
@@ -1,0 +1,4 @@
+CHANGEDbar.txt file
+CHANGED
+CHANGEDThis file should *not* show up in certain searches
+CHANGED

--- a/test/spec/FindReplace-known-goods/regexp-zero-length/css/foo.css
+++ b/test/spec/FindReplace-known-goods/regexp-zero-length/css/foo.css
@@ -1,0 +1,14 @@
+CHANGED/* foo.css */
+CHANGEDbody {
+CHANGED    margin: 0;
+CHANGED}
+CHANGEDh1, footer {
+CHANGED    padding: 2px auto;
+CHANGED}
+CHANGEDul.foo {
+CHANGED    list-style: none;
+CHANGED}
+CHANGED.bar {
+CHANGED    font-size: large;
+CHANGED}
+CHANGED

--- a/test/spec/FindReplace-known-goods/regexp-zero-length/foo.html
+++ b/test/spec/FindReplace-known-goods/regexp-zero-length/foo.html
@@ -1,0 +1,23 @@
+CHANGED<!doctype html>
+CHANGED<html>
+CHANGED<head>
+CHANGED<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+CHANGED<title>Foo</title>
+CHANGED<link rel="stylesheet" href="css/foo.css">
+CHANGED<script src="foo.js"></script>
+CHANGED</head>
+CHANGED    
+CHANGED<body>
+CHANGED
+CHANGED  <h1>Foo</h1>
+CHANGED  <p>Intro to foo</p>
+CHANGED  <ul class="foo">
+CHANGED    <li>foo</li>
+CHANGED    <li>bar</li>
+CHANGED    <li>baz</li>
+CHANGED  </ul>
+CHANGED  <p class="bar">It's all about the bar</p>
+CHANGED
+CHANGED</body>
+CHANGED</html>
+CHANGED

--- a/test/spec/FindReplace-known-goods/regexp-zero-length/foo.js
+++ b/test/spec/FindReplace-known-goods/regexp-zero-length/foo.js
@@ -1,0 +1,14 @@
+CHANGED/* Test comment */
+CHANGEDdefine(function (require, exports, module) {
+CHANGED    var Foo = require("modules/Foo"),
+CHANGED        Bar = require("modules/Bar"),
+CHANGED        Baz = require("modules/Baz");
+CHANGED    
+CHANGED    function callFoo() {
+CHANGED        
+CHANGED        foo();
+CHANGED        
+CHANGED    }
+CHANGED
+CHANGED}
+CHANGED

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -1099,8 +1099,32 @@ define(function (require, exports, module) {
                 twCommandManager.execute(Commands.CMD_FIND);
 
                 toggleRegexp(true);
-                enterSearchText(".*/");
+                enterSearchText(".*");
                 expectSelection({start: {line: 0, ch: 0}, end: {line: 0, ch: 18}});
+            });
+            
+            it("shouldn't freeze on /.*/ regexp", function () {
+                myEditor.setCursorPos(0, 0);
+
+                twCommandManager.execute(Commands.CMD_FIND);
+
+                toggleRegexp(true);
+                enterSearchText(".*");
+                expectSelection({start: {line: 0, ch: 0}, end: {line: 0, ch: 18}});
+            });
+            
+            it("shouldn't freeze on regexp with 0-length matches", function () {
+                myEditor.setCursorPos(0, 0);
+
+                twCommandManager.execute(Commands.CMD_FIND);
+
+                // CodeMirror coerces all 0-length matches to 1 char
+                toggleRegexp(true);
+                enterSearchText("^");  // matches pos before start of every line, but 0-length match text
+                expectSelection({start: {line: 0, ch: 0}, end: {line: 0, ch: 1}});
+                
+                enterSearchText("()"); // matches pos before every char, but 0-length match text
+                expectSelection({start: {line: 0, ch: 0}, end: {line: 0, ch: 1}});
             });
         });
 


### PR DESCRIPTION
 Fix bug #8556 -- `/^/` is a pathological regexp that returns 0-length matches, so `FindInFiles._getSearchMatches()` was going into an infinite loop (saved from freezing only by the 100K match limit).

This fixes Find/Replace in Files to return the correct results: an insertion point at the start of every line in the file.

Single-file Find/Replace is inconsistent with this because it uses CM searchcursor instead of `_getSearchMatches()`. That code already avoids an infinite loop, but it does it in a way where the result set is slightly different (the 1st char of every non-empty line).  Trello card https://trello.com/c/yho8jb7y is probably a good spot down the road to clean up all such inconsistencies in one batch.

Adds unit tests for both multi-file & single-file cases (also corrects an older FindReplace regexp test that was broken).
