### PR TITLE
[Review Only] Brackets polyfill support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,7 +93,8 @@ module.exports = function (grunt) {
                             'thirdparty/CodeMirror2/mode/{,*/}*',
                             'thirdparty/CodeMirror2/theme/{,*/}*',
                             'thirdparty/i18n/*.js',
-                            'thirdparty/text/*.js'
+                            'thirdparty/text/*.js',
+                            'utils/Compatibility.js'
                         ]
                     },
                     /* styles, fonts and images */

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,22 @@ require.config({
     locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
 });
 
+require.config({
+    // Remember: only use shim config for non-AMD scripts,
+    // scripts that do not already call define(). The shim
+    // config will not work correctly if used on AMD scripts,
+    // in particular, the exports and init config will not
+    // be triggered, and the deps config will be confusing
+    // for those cases.
+    shim: {
+        'brackets': {
+            // These script dependencies should be loaded before loading
+            // brackets.js
+            deps: ['utils/Compatibility']
+        }
+    }
+});
+
 define(function (require, exports, module) {
     "use strict";
     

--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, strict: false */
+/*jshint strict: false */
+/*global define */
+
+/**
+ * Compatibility shims for running Brackets in various environments, browsers.
+ */
+
+// [IE10] String.prototype missing trimRight() and trimLeft()
+if (!String.prototype.trimRight) {
+    String.prototype.trimRight = function () { return this.replace(/\s+$/, ""); };
+}
+if (!String.prototype.trimLeft) {
+    String.prototype.trimLeft = function () { return this.replace(/^\s+/, ""); };
+}
+


### PR DESCRIPTION
This is an _attempt_ to implement functionality from pull request #7231, and also work with minified builds, but it's not yet working. Brackets works (based on very minimal usage), but the polyfill is not applied.

**To create and run a minified build locally:**
1. [Setup Grunt](https://github.com/adobe/brackets/wiki/Grunt-Setup)
2. Run `grunt build`
3. Hold down `Shift` key when starting Brackets
4. When prompted for `index.html`, use `src/dist/index.html`

**Testing Polyfill Mechanism**
The polyfill added to `utils/Compatibility.js` in this PR is for IE10, so I added a `trimAll()` polyfill to that file locally so this could be tested in current desktop Brackets (i.e. CEF3 Chrome):

``` JS
if (!String.prototype.trimAll) {
    String.prototype.trimAll = function () { return this.replace(/\s+/g, ""); };
}
window.console.log("utils/Compatibility loaded!");
```

I then created a `trimTest` extension where contents of `main.js` is:

``` JS
/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
/*global define, brackets */

define(function (require, exports, module) {
    "use strict";

    var CommandManager  = brackets.getModule("command/CommandManager"),
        Menus           = brackets.getModule("command/Menus");


    var testString = " this is a test string ";

    function trimTest() {
        if (testString.trimAll) {
            alert("testString: '" + testString + "';\ntestString.trimAll(): '" + testString.trimAll() + "'");
        } else {
            alert("trimAll is not defined");
        }
    }

    Menus.getMenu("debug-menu").addMenuItem(
        CommandManager.register("Trim Test", "trimTest.trimTest", trimTest)
    );
});
```

**To test:**
Use Debug > Trim Test

**success:** `alert()` says: testString: ' this is a test string '; testString.trimAll(): 'thisisateststring' 

**failure:** `alert()` says: "trimAll is not defined"
