### PR TITLE
Improve search highlight maintainability / themability

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -90,10 +90,13 @@
 
 /* Extra CSS */
 
-.CodeMirror.find-highlighting div.CodeMirror-selected,
-.CodeMirror .CodeMirror.find-highlighting div.CodeMirror-selected {
-    background: red;
+.CodeMirror-searching {
+    background-color: #d3cd69;
+    &.searching-current-match {
+        background-color: #f6a644;
+    }
 }
+
 
 .CodeMirror-cursor {
     border-left: 1px solid #c5c8c6 !important;

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -84,6 +84,7 @@ define(function (require, exports, module) {
         this.queryInfo = null;
         this.foundAny = false;
         this.marked = [];
+        this.markedCurrent = null;
     }
 
     function getSearchState(cm) {
@@ -368,6 +369,13 @@ define(function (require, exports, module) {
         }
     }
 
+    /** Removes the current-match highlight, leaving all matches marked in the generic highlight style */
+    function clearCurrentMatchHighlight(cm, state) {
+        if (state.markedCurrent) {
+            state.markedCurrent.clear();
+        }
+    }
+    
     /**
      * Selects the next match (or prev match, if rev==true) starting from either the current position
      * (if pos unspecified) or the given position (if pos specified explicitly). The starting position
@@ -382,22 +390,30 @@ define(function (require, exports, module) {
     function findNext(editor, rev, preferNoScroll, pos) {
         var cm = editor._codeMirror;
         cm.operation(function () {
+            var state = getSearchState(cm);
+            clearCurrentMatchHighlight(cm, state);
+            
             var nextMatch = _getNextMatch(editor, rev, pos);
             if (nextMatch) {
                 _selectAndScrollTo(editor, [nextMatch], true, preferNoScroll);
+                state.markedCurrent = cm.markText(nextMatch.start, nextMatch.end,
+                     { className: "searching-current-match", startStyle: "searching-first", endStyle: "searching-last" });
             } else {
                 cm.setCursor(editor.getCursorPos());  // collapses selection, keeping cursor in place to avoid scrolling
             }
         });
     }
 
+    /** Clears all match highlights, including the current match */
     function clearHighlights(cm, state) {
         cm.operation(function () {
             state.marked.forEach(function (markedRange) {
                 markedRange.clear();
             });
+            clearCurrentMatchHighlight(cm, state);
         });
         state.marked.length = 0;
+        state.markedCurrent = null;
         
         ScrollTrackMarkers.clear();
     }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1323,32 +1323,22 @@ textarea.exclusions-editor {
 }
 
 
-// Search result highlighting - CodeMirror highlighting is pretty constrained. Highlights are
-// blended on TOP of the selection color. The "current" search result is indicated by selection,
-// so we want the selection visible underneath the highlight. To do this, the highlight must be
-// transparent; it has to look good atop both the selection color AND the regular text bg color.
+// Find/Replace result highlighting
 .CodeMirror-searching {
-    // Highlight color, overlaid on top of the .find-highlighting color
     background-color: @cm-match-highlight;
     box-shadow: @tc-small-shadow-bottom;
     color: @match-text !important;
-    &.searching-first {
+    &.searching-current-match {
+        background-color: @cm-current-match-highlight;
+    }
+    &.searching-first {  // first in a contiguous run of highlights
         border-top-left-radius: @tc-inline-border-radius;
         border-bottom-left-radius: @tc-inline-border-radius;
     }
-    &.searching-last {
+    &.searching-last {  // last in a contiguous run of highlights
         border-top-right-radius: @tc-inline-border-radius;
         border-bottom-right-radius: @tc-inline-border-radius;
     }
-}
-.CodeMirror.find-highlighting div.CodeMirror-selected,
-.CodeMirror .CodeMirror.find-highlighting div.CodeMirror-selected {
-    // Selection color while highlighting shown - ALWAYS has the .CodeMirror-searching color
-    // blended atop it.
-    // Note: the 2nd selector reflecting CM nesting is needed to override the similar rules in
-    // brackets_codemirror_override.less (see the note about #324).
-    background: @cm-current-match-highlight;
-    border-radius: @tc-inline-border-radius;
 }
 #find-counter {
     font-weight: @font-weight-semibold;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -88,8 +88,8 @@
 @accent-minus: #dc322f;
 @accent-plus: #859900;
 @match-text: #121212;
-@cm-match-highlight: rgba(244, 237, 98, 0.7);
-@cm-current-match-highlight: rgb(255, 108, 0);
+@cm-match-highlight: #f4ef8d;
+@cm-current-match-highlight: #f6c644;
 
 /* code highlight */
 @matching-bracket: #cfead6;


### PR DESCRIPTION
Stop using a blend of translucent match-highlight + modified selection color to indicate the current Find/Replace match. Use a simpler system where we use two different, opaque highlight styles for general matches and the current match, moving the current-match highlight marker around the editor as the user navigates between matches.

This makes it easier to create themes; and gives much more flexibility in choosing the two highlight colors (some color combinations were previously impossible).
