### PR TITLE
Restore 'browser: false' to Brackets core's JSLint setup

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -2,6 +2,7 @@
     "jslint.options": {
         "vars": true,
         "plusplus": true,
+        "browser": false,
         "devel": true,
         "nomen": true,
         "maxerr": 50

--- a/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
             if (match && _validateCubicBezierParams(match)) {
                 return _tagMatch(match, BEZIER);
             } else { // this should not happen!
-                window.console.log("brackets-cubic-bezier: TimingFunctionUtils._getValidBezierParams created invalid code");
+                console.log("brackets-cubic-bezier: TimingFunctionUtils._getValidBezierParams created invalid code");
             }
         }
 
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
             if (match && _validateStepsParams(match)) {
                 return _tagMatch(match, STEP);
             } else { // this should not happen!
-                window.console.log("brackets-steps: TimingFunctionUtils._getValidStepsParams created invalid code");
+                console.log("brackets-steps: TimingFunctionUtils._getValidStepsParams created invalid code");
             }
         }
 

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
         _domainPath     = [_bracketsPath, _modulePath, _nodePath].join("/"),
         _nodeDomain     = new NodeDomain("fileWatcher", _domainPath);
     
-    var _isRunningOnWindowsXP = navigator.userAgent.indexOf("Windows NT 5.") >= 0;
+    var _isRunningOnWindowsXP = window.navigator.userAgent.indexOf("Windows NT 5.") >= 0;
     
     
     // If the connection closes, notify the FileSystem that watchers have gone offline.

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4 */
-/*global define, $, Mustache, brackets */
+/*global define, $, Mustache, brackets, window */
 
 /**
  * Manages linters and other code inspections on a per-language basis. Provides a UI and status indicator for

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -147,38 +147,6 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Loads the extension that lives at baseUrl into its own Require.js context
-     *
-     * @param {!string} name, used to identify the extension
-     * @param {!{baseUrl: string}} config object with baseUrl property containing absolute path of extension
-     * @param {!string} entryPoint, name of the main js file to load
-     * @return {!$.Promise} A promise object that is resolved when the extension is loaded, or rejected
-     *              if the extension fails to load or throws an exception immediately when loaded.
-     *              (Note: if extension contains a JS syntax error, promise is resolved not rejected).
-     */
-    function loadExtension(name, config, entryPoint) {
-        var promise = new $.Deferred();
-
-        // Try to load the package.json to figure out if we are loading a theme.
-        ExtensionUtils.loadPackageJson(config.baseUrl).always(promise.resolve);
-
-        return promise
-            .then(function(metadata) {
-                // No special handling for themes... Let the promise propagate into the ExtensionManager
-                if (metadata && "theme" in metadata) {
-                    return;
-                }
-
-                return loadExtensionModule(name, config, entryPoint);
-            })
-            .then(function () {
-                $(exports).triggerHandler("load", config.baseUrl);
-            }, function (err) {
-                $(exports).triggerHandler("loadFailed", config.baseUrl);
-            });
-    }
-    
-    /**
      * Loads the extension module that lives at baseUrl into its own Require.js context
      *
      * @param {!string} name, used to identify the extension
@@ -253,6 +221,38 @@ define(function (require, exports, module) {
         return promise;
     }
 
+    /**
+     * Loads the extension that lives at baseUrl into its own Require.js context
+     *
+     * @param {!string} name, used to identify the extension
+     * @param {!{baseUrl: string}} config object with baseUrl property containing absolute path of extension
+     * @param {!string} entryPoint, name of the main js file to load
+     * @return {!$.Promise} A promise object that is resolved when the extension is loaded, or rejected
+     *              if the extension fails to load or throws an exception immediately when loaded.
+     *              (Note: if extension contains a JS syntax error, promise is resolved not rejected).
+     */
+    function loadExtension(name, config, entryPoint) {
+        var promise = new $.Deferred();
+
+        // Try to load the package.json to figure out if we are loading a theme.
+        ExtensionUtils.loadPackageJson(config.baseUrl).always(promise.resolve);
+
+        return promise
+            .then(function (metadata) {
+                // No special handling for themes... Let the promise propagate into the ExtensionManager
+                if (metadata && metadata.theme) {
+                    return;
+                }
+
+                return loadExtensionModule(name, config, entryPoint);
+            })
+            .then(function () {
+                $(exports).triggerHandler("load", config.baseUrl);
+            }, function (err) {
+                $(exports).triggerHandler("loadFailed", config.baseUrl);
+            });
+    }
+    
     /**
      * Runs unit tests for the extension that lives at baseUrl into its own Require.js context
      *

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -302,11 +302,11 @@ define(function (require, exports, module) {
                 // downloadRegistry, will be resolved in _onRegistryDownloaded
                 ExtensionManager.downloadRegistry().done(function () {
                     // schedule another check in 24 hours + 2 minutes
-                    setTimeout(checkForExtensionsUpdate, ONE_DAY + TWO_MINUTES);
+                    window.setTimeout(checkForExtensionsUpdate, ONE_DAY + TWO_MINUTES);
                 });
             } else {
                 // schedule the download of the registry in appropriate time
-                setTimeout(checkForExtensionsUpdate, (timeOfNextCheck - currentTime) + TWO_MINUTES);
+                window.setTimeout(checkForExtensionsUpdate, (timeOfNextCheck - currentTime) + TWO_MINUTES);
             }
         }
     }

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -342,7 +342,7 @@ define(function (require, exports, module) {
             } else if ($otherBtn.length) {
                 $otherBtn.focus();
             } else {
-                document.activeElement.blur();
+                window.document.activeElement.blur();
             }
 
             // Push our global keydown handler onto the global stack of handlers.

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -544,7 +544,7 @@ define(function (require, exports, module) {
 
                 var renameDeferred = $.Deferred();
                 runs(function () {
-                    DocumentManager.setCurrentDocument(doc);                    
+                    DocumentManager.setCurrentDocument(doc);
                     javascript = LanguageManager.getLanguage("javascript");
                     
                     // sanity check language


### PR DESCRIPTION
Fix Brackets project settings so `browser: true` is not set (which is how we had it before 834c4e9 in Sprint 37). Fix a few JSLint errors that snuck in because of this, plus some additional errors in ExtensionLoader that seem to have come from the Themes work in 0.42
