### PR TITLE
add languages to langauge switcher after they are installed

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -378,6 +378,9 @@ define(function (require, exports, module) {
     // Initialize: status bar focused listener
     $(EditorManager).on("activeEditorChange", _onActiveEditorChange);
     
+    // Add an event listener when the list of languages change
+    $(LanguageManager).on("languageAdded languageModified", _populateLanguageDropdown);
+    
     AppInit.htmlReady(_init);
     AppInit.appReady(_populateLanguageDropdown);
 });


### PR DESCRIPTION
- Fixes #8432

How To test:
1. Make sure your installed user extensions folder is empty
2. Start Brackets
3. Open the language switcher drop list 
4. Notice "Turtle" is missing
5. Install Turtle Language Extension
6. Open the language switcher drop list
==> "Turtle" now listed.
