### PR TITLE
Changes to allow backward compatibility with plain ole CodeMirror themes

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -79,13 +79,11 @@ define(function (require, exports, module) {
         options = options || {};
         var fileName = file.name;
 
-        // The name is used to map the loaded themes to the list in the settings dialog. So we want
-        // a unique name if one is not provided.  This is particularly important when loading just
-        // files where there is no other way to feed in meta data to provide unique names.  Say, there
-        // is a theme1.css and a theme1.less that are entirely different themes...
+        // Portip: If no options.name or options.title is provided, then we will rely solely on
+        // the name of the file to be unique
 
         this.file        = file;
-        this.name        = options.name  || (options.title || fileName).toLocaleLowerCase().replace(/[\W]/g, '-');
+        this.name        = options.name  || (options.title || fileName.replace(/.[\w]+$/gi, '')).toLocaleLowerCase().replace(/[\W]/g, '-');
         this.displayName = options.title || toDisplayName(fileName);
         this.dark        = options.theme !== undefined && options.theme.dark === true;
     }

--- a/test/spec/ThemeManager-test.js
+++ b/test/spec/ThemeManager-test.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
 
                 waitsForDone(promise, "theme with scrollbar and other css", 5000);
             });
-            
+
             it("should extract scrollbars from a theme with only scrollbars", function () {
                 var themeFile = FileSystem.getFileForPath(testFilePath + "/simple-scrollbars.css");
                 var promise = FileUtils.readAsText(themeFile).done(function (content) {
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
 
                 waitsForDone(promise, "theme with only scrollbars", 5000);
             });
-            
+
             it("should be fine with an empty theme", function () {
                 var themeFile = FileSystem.getFileForPath(testFilePath + "/empty.css");
                 var promise = FileUtils.readAsText(themeFile).done(function (content) {
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
         describe("Load themes", function () {
             it("should load a theme from a single CSS file", function () {
                 var promise = ThemeManager.loadFile(testFilePath + "/scrollbars.css").done(function (theme) {
-                    expect(theme.name).toEqual("scrollbars-css");
+                    expect(theme.name).toEqual("scrollbars");
                     expect(theme.displayName).toEqual("Scrollbars");
                 });
 


### PR DESCRIPTION
Loading theme files directly instead of a package breaks old themes; e.g. vanilla codemirror themes.  The issue is caused by adding the file extension as part of the theme name.  This logic was to handle edge cases when themes had the same filename but different extensions, but this edge case should really be resolved by giving files a better name.  This was important in earlier impls of themes that provided an interface to load all the theme files in a diretory (loadDirectory) but that interface was removed a while ago.
