### PR TITLE
jslint: remove whitespaces using simple regex

### DIFF
--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -71,8 +71,8 @@ define(function (require, exports, module) {
      * a gold star when no errors are found.
      */
     function lintOneFile(text, fullPath) {
-        // If a line contains only whitespace, remove the whitespace
-        text = text.replace(/^[\x20\t\f]+$/gm, "");
+        // If a line contains only whitespace (here spaces or tabs), remove the whitespace
+        text = text.replace(/^[ \t]+$/gm, "");
         
         var options = prefs.get("options");
 

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -72,15 +72,7 @@ define(function (require, exports, module) {
      */
     function lintOneFile(text, fullPath) {
         // If a line contains only whitespace, remove the whitespace
-        // This should be doable with a regexp: text.replace(/\r[\x20|\t]+\r/g, "\r\r");,
-        // but that doesn't work.
-        var i, arr = text.split("\n");
-        for (i = 0; i < arr.length; i++) {
-            if (!arr[i].match(/\S/)) {
-                arr[i] = "";
-            }
-        }
-        text = arr.join("\n");
+        text = text.replace(/^[\x20\t\f]+$/gm, "");
         
         var options = prefs.get("options");
 


### PR DESCRIPTION
Small speed improvement to the default lintjs extension. Replacing obsolete for loop with a simple regex to remove whitespaces, if a line contains only whitespace.
