### PR TITLE
Exclude `node_modules` by default from JS Code Hints.

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Preferences.js
+++ b/src/extensions/default/JavaScriptCodeHints/Preferences.js
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
      *  Convert an array of strings with optional wildcards, to an equivalent
      *  regular expression.
      *
-     * @param {Array.<string|RegExp>} settings
+     * @param {Array.<string|RegExp>} settings from the file (note: this may be mutated by this function)
      * @param {?RegExp} baseRegExp - base regular expression that is always used
      * @param {?RegExp} defaultRegExp - additional regular expression that is only used if the user has not configured settings
      * @return {RegExp} Regular expression that captures the array of string
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
 
         if (settings instanceof Array && settings.length > 0) {
 
-            // Append default settings to user settings. The default
+            // Append base settings to user settings. The base
             // settings are builtin and cannot be overridden.
             if (baseRegExp) {
                 settings.push("/" + baseRegExp.source + "/");

--- a/src/extensions/default/JavaScriptCodeHints/Preferences.js
+++ b/src/extensions/default/JavaScriptCodeHints/Preferences.js
@@ -73,20 +73,20 @@ define(function (require, exports, module) {
      *  regular expression.
      *
      * @param {Array.<string|RegExp>} settings
-     * @param {?RegExp} defaultRegExp - default regular expression to use
-     * if none if provided.
+     * @param {?RegExp} baseRegExp - base regular expression that is always used
+     * @param {?RegExp} defaultRegExp - additional regular expression that is only used if the user has not configured settings
      * @return {RegExp} Regular expression that captures the array of string
      * with optional wildcards.
      */
-    function settingsToRegExp(settings, defaultRegExp) {
+    function settingsToRegExp(settings, baseRegExp, defaultRegExp) {
         var regExpString = "";
 
         if (settings instanceof Array && settings.length > 0) {
 
             // Append default settings to user settings. The default
             // settings are builtin and cannot be overridden.
-            if (defaultRegExp) {
-                settings.push("/" + defaultRegExp.source + "/");
+            if (baseRegExp) {
+                settings.push("/" + baseRegExp.source + "/");
             }
 
             // convert each string, with optional wildcards to an equivalent
@@ -121,7 +121,18 @@ define(function (require, exports, module) {
         }
 
         if (!regExpString) {
-            return defaultRegExp;
+            var defaultParts = [];
+            if (baseRegExp) {
+                defaultParts.push(baseRegExp.source);
+            }
+            if (defaultRegExp) {
+                defaultParts.push(defaultRegExp.source);
+            }
+            if (defaultParts.length > 0) {
+                regExpString  = defaultParts.join("|");
+            } else {
+                return null;
+            }
         }
 
         return new RegExp(regExpString);
@@ -134,19 +145,20 @@ define(function (require, exports, module) {
      * @param {Object=} prefs - preference object
      */
     function Preferences(prefs) {
-        var DEFAULT_EXCLUDED_DIRECTORIES = null, /* no exclusions */
+        var BASE_EXCLUDED_DIRECTORIES = null, /* if the user has settings, we don't exclude anything by default */
+            // exclude node_modules for performance reasons and because we don't do full hinting for those anyhow.
+            DEFAULT_EXCLUDED_DIRECTORIES = /node_modules/,
             // exclude require and jquery since we have special knowledge of those
-            // temporarily exclude less*min.js because it is causing instability in tern.
-            // exclude ember*.js as it is currently causing problems
-            DEFAULT_EXCLUDED_FILES = /^require.*\.js$|^jquery.*\.js$|^less.*\.min\.js$/,
+            BASE_EXCLUDED_FILES = /^require.*\.js$|^jquery.*\.js$/,
             DEFAULT_MAX_FILE_COUNT = 100,
             DEFAULT_MAX_FILE_SIZE = 512 * 1024;
 
         if (prefs) {
             this._excludedDirectories = settingsToRegExp(prefs["excluded-directories"],
-                DEFAULT_EXCLUDED_DIRECTORIES);
+                                                         BASE_EXCLUDED_DIRECTORIES,
+                                                         DEFAULT_EXCLUDED_DIRECTORIES);
             this._excludedFiles = settingsToRegExp(prefs["excluded-files"],
-                DEFAULT_EXCLUDED_FILES);
+                BASE_EXCLUDED_FILES);
             this._maxFileCount = prefs["max-file-count"];
             this._maxFileSize = prefs["max-file-size"];
 
@@ -161,7 +173,7 @@ define(function (require, exports, module) {
 
         } else {
             this._excludedDirectories = DEFAULT_EXCLUDED_DIRECTORIES;
-            this._excludedFiles = DEFAULT_EXCLUDED_FILES;
+            this._excludedFiles = BASE_EXCLUDED_FILES;
             this._maxFileCount = DEFAULT_MAX_FILE_COUNT;
             this._maxFileSize = DEFAULT_MAX_FILE_SIZE;
         }

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -1564,9 +1564,9 @@ define(function (require, exports, module) {
                 });
 
                 runs(function () {
-                    expect(preferences.getExcludedDirectories()).toBeNull();
+                    expect(preferences.getExcludedDirectories()).toEqual(/node_modules/);
                     expect(preferences.getExcludedFiles().source).
-                        toBe(/^require.*\.js$|^jquery.*\.js$|^less.*\.min\.js$/.source);
+                        toBe(/^require.*\.js$|^jquery.*\.js$/.source);
                     expect(preferences.getMaxFileCount()).toBe(100);
                     expect(preferences.getMaxFileSize()).toBe(512 * 1024);
                 });
@@ -1581,9 +1581,9 @@ define(function (require, exports, module) {
                 });
 
                 runs(function () {
-                    expect(preferences.getExcludedDirectories()).toBeNull();
+                    expect(preferences.getExcludedDirectories()).toEqual(/node_modules/);
                     expect(preferences.getExcludedFiles().source).
-                        toBe(/^require.*\.js$|^jquery.*\.js$|^less.*\.min\.js$/.source);
+                        toBe(/^require.*\.js$|^jquery.*\.js$/.source);
                     expect(preferences.getMaxFileCount()).toBe(100);
                     expect(preferences.getMaxFileSize()).toBe(512 * 1024);
                 });


### PR DESCRIPTION
See #8646.

This can be overridden by adding a .jscodehints file and setting
excluded-directories in there.
