### PR TITLE
Restore correct keyboard shortcut for Replace in Files on the Mac

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -161,7 +161,7 @@
             "key": "Ctrl-Shift-H"
         },
         {
-            "key": "Ctrl-Alt-Shift-F",
+            "key": "Cmd-Alt-Shift-F",
             "platform": "mac"
         }
     ],


### PR DESCRIPTION
#8623 inadvertently changed the keyboard shortcut for Replace in Files on the Mac from Cmd-Alt-Shift-F to Ctrl-Alt-Shift-F. I think the issue is that if you don't specify a platform for the shortcut, we translate Ctrl to Cmd on the Mac, but if you specifically list a shortcut as a Mac shortcut, we don't translate Ctrl (since we assume you really mean the Mac Ctrl key). This restores the shortcut.

@RaymondLim @JeffryBooher Could one of you review and merge?
