### PR TITLE
Restore hide sidebar shortcut on Mac

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -216,7 +216,7 @@
             "key" : "Ctrl-Alt-H"
         },
         {
-            "key": "Ctrl-Shift-H",
+            "key": "Cmd-Shift-H",
             "platform": "mac"
         }
     ],


### PR DESCRIPTION
Similar to #8725 - another case I missed. @RaymondLim 
