### PR TITLE
Warn user when project has too many files

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -83,7 +83,7 @@ define({
     
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Error Indexing Files",
-    "ERROR_MAX_FILES"                   : "The maximum number of files have been indexed. Actions that look up files in the index may function incorrectly.",
+    "ERROR_MAX_FILES"                   : "This project contains more than 30,000 files. Features that operate across multiple files may be disabled. <a href='https://github.com/adobe/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Error Launching Browser",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -83,7 +83,7 @@ define({
     
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Error Indexing Files",
-    "ERROR_MAX_FILES"                   : "This project contains more than 30,000 files. Features that operate across multiple files may be disabled. <a href='https://github.com/adobe/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
+    "ERROR_MAX_FILES"                   : "This project contains more than 30,000 files. Features that operate across multiple files may be disabled or behave as if the project is empty. <a href='https://github.com/adobe/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Error Launching Browser",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -2079,7 +2079,6 @@ define(function (require, exports, module) {
                         _projectWarnedForTooManyFiles = true;
                     }
                     deferred.reject(err);
-                    _allFilesCachePromise = null;
                 } else {
                     deferred.resolve(allFiles);
                 }


### PR DESCRIPTION
This is for #6962 and https://trello.com/c/fpu67Ep7/1375-brackets-8508-6962-search-issue-with-large-folder-issue.

Warn user when project has too many files, but only warn once per project session.
