### PR TITLE
Show LESS errors in console

### DIFF
--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -124,9 +124,9 @@ define(function (require, exports, module) {
             } else {
                 try {
                     result.resolve(tree.toCSS());
-                } catch (err) {
-                    console.error(err.filename + ":" + err.line + " " + err.message)
-                    result.reject(err);
+                } catch (toCSSError) {
+                    console.error(toCSSError.filename + ":" + toCSSError.line + " " + toCSSError.message);
+                    result.reject(toCSSError);
                 }
             }
         });

--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -122,7 +122,12 @@ define(function (require, exports, module) {
             if (err) {
                 result.reject(err);
             } else {
-                result.resolve(tree.toCSS());
+                try {
+                    result.resolve(tree.toCSS());
+                } catch (err) {
+                    console.error(err.filename + ":" + err.line + " " + err.message)
+                    result.reject(err);
+                }
             }
         });
         


### PR DESCRIPTION
For @larz0 to help debug LESS errors, e.g.

```
/Users/jasonsj/Library/Application%20Support/Brackets/extensions/user/extension/styles/override.less:322 variable @bc-border-radius is undefined 
```
