### PR TITLE
Fix occasional NPE in EditorStatusBar during startup

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -403,9 +403,10 @@ define(function (require, exports, module) {
     // Initialize: status bar focused listener
     $(EditorManager).on("activeEditorChange", _onActiveEditorChange);
     
-    // Add an event listener when the list of languages change
-    $(LanguageManager).on("languageAdded languageModified", _populateLanguageDropdown);
-    
     AppInit.htmlReady(_init);
-    AppInit.appReady(_populateLanguageDropdown);
+    AppInit.appReady(function () {
+        // Populate language switcher with all languages after startup; update it later if this set changes
+        _populateLanguageDropdown();
+        $(LanguageManager).on("languageAdded languageModified", _populateLanguageDropdown);
+    });
 });


### PR DESCRIPTION
Fix occasional NPE I've seen a few times in EditorStatusBar during startup -- fallout from PR #8668 which was merged earlier this sprint.

This is a race condition: it crashes if LanguageManager sends a change event before htmlReady() triggers `EditorStatusBar._init()` to create `languageSelect`.  It's not immediately obvious how this could happen: LM synchronously requires languages.json, so it has all the core languages before the ESB module loads; and extensions don't start loading until after htmlReady(), so extension-added languages can't cause this either. BUT prefs load async in between module init and htmlReady(), and LanguageManager populates partially async too since it needs to wait for CM modes to load dynamically. I think either of those can trigger a LM event during the window where ESB would crash.
