### PR TITLE
Brazilian Portuguese translation update (0.43)

### DIFF
--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -40,7 +40,9 @@ define({
     "UNSUPPORTED_ENCODING_ERR"          : "O arquivo não contém texto codificado em UTF-8.",
     "FILE_EXISTS_ERR"                   : "Arquivo ou pasta já existe.",
     "FILE"                              : "arquivo",
+    "FILE_TITLE"                        : "Arquivo",
     "DIRECTORY"                         : "diretório",
+    "DIRECTORY_TITLE"                   : "Diretório",
     "DIRECTORY_NAMES_LEDE"              : "Nomes de diretórios",
     "FILENAMES_LEDE"                    : "Nomes de arquivos",
     "FILENAME"                          : "Nome de arquivo",
@@ -123,6 +125,7 @@ define({
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> foi excluído no disco, mas tem alterações não salvas em {APP_NAME}.<br /><br />Deseja manter suas alterações?",
 
     // Generic dialog/button labels
+    "DONE"                              : "Concluído",
     "OK"                                : "OK",
     "CANCEL"                            : "Cancelar",
     "DONT_SAVE"                         : "Não salvar",
@@ -134,11 +137,12 @@ define({
     "BUTTON_NO"                         : "Não",
 
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} resultados",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 resultado",
+    "FIND_MATCH_INDEX"                  : "{0} de {1}",
     "FIND_NO_RESULTS"                   : "Nenhum resultado",
+    "FIND_QUERY_PLACEHOLDER"            : "Localizar\u2026",
     "REPLACE_PLACEHOLDER"               : "Substituir por\u2026",
     "BUTTON_REPLACE_ALL"                : "Tudo\u2026",
+    "BUTTON_REPLACE_ALL_IN_FILES"       : "Substituir\u2026",
     "BUTTON_REPLACE"                    : "Substituir",
     "BUTTON_NEXT"                       : "\u25B6",
     "BUTTON_PREV"                       : "\u25C0",
@@ -146,6 +150,9 @@ define({
     "BUTTON_PREV_HINT"                  : "Resultado anterior",
     "BUTTON_CASESENSITIVE_HINT"         : "Diferenciar maiúsculas/minúsculas",
     "BUTTON_REGEXP_HINT"                : "Expressão regular",
+    "REPLACE_WITHOUT_UNDO_WARNING_TITLE": "Substituir sem Desfazer",
+    "REPLACE_WITHOUT_UNDO_WARNING"      : "Porque mais de {0} arquivos precisam ser alterados, {APP_NAME} irá modificar arquivos não abertos no disco.<br />Não será possível desfazer as modificações nestes arquivos.",
+    "BUTTON_REPLACE_WITHOUT_UNDO"       : "Substituir sem Desfazer",
 
     "OPEN_FILE"                         : "Abrir arquivo",
     "SAVE_FILE_AS"                      : "Salvar arquivo",
@@ -155,15 +162,14 @@ define({
     "NO_UPDATE_TITLE"                   : "Você está atualizado!",
     "NO_UPDATE_MESSAGE"                 : "Você está executando a versão mais recente do {APP_NAME}.",
 
-    // Replace All (in single file)
-    "FIND_REPLACE_TITLE_PART1"          : "Substituir \"",
-    "FIND_REPLACE_TITLE_PART2"          : "\" por \"",
-    "FIND_REPLACE_TITLE_PART3"          : "\" &mdash; {2} {0} {1}",
+    // Find and Replace
+    "FIND_REPLACE_TITLE_LABEL"          : "Substituir",
+    "FIND_REPLACE_TITLE_WITH"           : "por",
+    "FIND_TITLE_LABEL"                  : "Encontrados",
+    "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} em {3}",
 
     // Find in Files
-    "FIND_IN_FILES_TITLE_PART1"         : "\"",
-    "FIND_IN_FILES_TITLE_PART2"         : "\" encontrado(s)",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} em {3} {4}",
+    "FIND_NUM_FILES"                    : "{0} {1}",
     "FIND_IN_FILES_SCOPED"              : "em <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "no projeto",
     "FIND_IN_FILES_ZERO_FILES"          : "Filtro exclui todos os arquivos {0}",
@@ -175,15 +181,21 @@ define({
     "FIND_IN_FILES_PAGING"              : "{0}&mdash;{1}",
     "FIND_IN_FILES_FILE_PATH"           : "<span class='dialog-filename'>{0}</span> {2} <span class='dialog-path'>{1}</span>", // We should use normal dashes on Windows instead of em dash eventually
     "FIND_IN_FILES_EXPAND_COLLAPSE"     : "Ctrl/Cmd + clique para expandir/comprimir tudo",
+    "REPLACE_IN_FILES_ERRORS_TITLE"     : "Erro na substituição",
+    "REPLACE_IN_FILES_ERRORS"           : "Os seguintes arquivos não foram modificados porque eles foram alterados antes da busca ou não puderam ser escritos.",
+
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Erro ao receber informações de atualização",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Houve um problema ao obter informações sobre a última atualização do servidor. Por favor, certifique-se de estar conectado à Internet e tente novamente.",
-
+    
     // File exclusion filters
-    "NO_FILE_FILTER"                    : "Filtrar arquivos\u2026",
+    "NEW_FILE_FILTER"                   : "Adicionar filtro\u2026",
+    "CLEAR_FILE_FILTER"                 : "Limpar filtro de arquivos",
+    "NO_FILE_FILTER"                    : "Nenhum filtro de arquivos",
+    "EXCLUDE_FILE_FILTER"               : "Excetua {0}",
     "EDIT_FILE_FILTER"                  : "Editar\u2026",
     "FILE_FILTER_DIALOG"                : "Editar filtro",
     "FILE_FILTER_INSTRUCTIONS"          : "Exclui dos resultados os arquivos e pastas que correspondam a qualquer das strings, substrings ou <a href='{0}' title='{0}'>wildcards</a> abaixo. Insira cada string em uma linha separada.",
-    "FILE_FILTER_LIST_PREFIX"           : "exceto",
+    "FILTER_NAME_PLACEHOLDER"           : "Nome desta configuração de filtro (opcional)",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "e outros {0}",
     "FILTER_COUNTING_FILES"             : "Contando arquivos\u2026",
     "FILTER_FILE_COUNT"                 : "Permite {0} de {1} arquivos {2}",
@@ -200,7 +212,7 @@ define({
 
     // Quick Docs
     "ERROR_QUICK_DOCS_PROVIDER_NOT_FOUND"   : "Quick Docs não disponível para a posição atual do cursor",
-
+    
     /**
      * ProjectManager
      */
@@ -235,6 +247,11 @@ define({
     "STATUSBAR_USER_EXTENSIONS_DISABLED"    : "Extensões desativadas",
     "STATUSBAR_INSERT"                      : "INS",
     "STATUSBAR_OVERWRITE"                   : "OVR",
+    "STATUSBAR_INSOVR_TOOLTIP"              : "Clique para alternar o cursor entre os modos Insert (INS) e Overwrite (OVR)",
+    "STATUSBAR_LANG_TOOLTIP"                : "Clique para alterar o tipo de arquivo",
+    "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Clique para abrir/fechar o painel de reatórios.",
+    "STATUSBAR_DEFAULT_LANG"                : "(padrão)",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Definir como padrão para arquivos .{0}.",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "Problemas de {0}",
@@ -272,12 +289,13 @@ define({
     "CMD_FILE_SAVE_ALL"                   : "Salvar todos",
     "CMD_FILE_SAVE_AS"                    : "Salvar como\u2026",
     "CMD_LIVE_FILE_PREVIEW"               : "Live Preview",
+    "CMD_RELOAD_LIVE_PREVIEW"             : "Forçar recarregamento do Live Preview",
     "CMD_PROJECT_SETTINGS"                : "Configurações do projeto\u2026",
     "CMD_FILE_RENAME"                     : "Renomear",
     "CMD_FILE_DELETE"                     : "Excluir",
     "CMD_INSTALL_EXTENSION"               : "Instalar extensão\u2026",
     "CMD_EXTENSION_MANAGER"               : "Gerenciador de extensões\u2026",
-    "CMD_FILE_REFRESH"                    : "Recarregar árvore de arquivos",
+    "CMD_FILE_REFRESH"                    : "Atualizar árvore de arquivos",
     "CMD_QUIT"                            : "Sair",
     // Used in native File menu on Windows
     "CMD_EXIT"                            : "Sair",
@@ -310,7 +328,6 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Localizar",
     "CMD_FIND"                            : "Localizar",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Localizar\u2026",
     "CMD_FIND_NEXT"                       : "Localizar próximo",
     "CMD_FIND_PREVIOUS"                   : "Localizar anterior",
     "CMD_FIND_ALL_AND_SELECT"             : "Localizar tudo e selecionar",
@@ -320,11 +337,14 @@ define({
     "CMD_FIND_IN_SELECTED"                : "Localizar no arquivo/diretório selecionado",
     "CMD_FIND_IN_SUBTREE"                 : "Localizar em\u2026",
     "CMD_REPLACE"                         : "Substituir",
+    "CMD_REPLACE_IN_FILES"                : "Substituir em arquivos",
+    "CMD_REPLACE_IN_SELECTED"             : "Substituir no arquivo/diretório selecionado",
+    "CMD_REPLACE_IN_SUBTREE"              : "Substituir em\u2026",
 
     // View menu commands
-    "VIEW_MENU"                           : "Ver",
-    "CMD_HIDE_SIDEBAR"                    : "Esconder Barra Lateral",
-    "CMD_SHOW_SIDEBAR"                    : "Mostrar Barra Lateral",
+    "VIEW_MENU"                           : "Visualizar",
+    "CMD_HIDE_SIDEBAR"                    : "Esconder barra lateral",
+    "CMD_SHOW_SIDEBAR"                    : "Mostrar barra lateral",
     "CMD_INCREASE_FONT_SIZE"              : "Aumentar tamanho da fonte",
     "CMD_DECREASE_FONT_SIZE"              : "Diminuir tamanho da fonte",
     "CMD_RESTORE_FONT_SIZE"               : "Restaurar tamanho da fonte",
@@ -339,13 +359,14 @@ define({
     "CMD_SORT_WORKINGSET_BY_NAME"         : "Ordenar por Nome",
     "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ordenar por Tipo",
     "CMD_SORT_WORKINGSET_AUTO"            : "Ordenação automática",
+    "CMD_THEMES"                          : "Temas\u2026",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navegar",
     "CMD_QUICK_OPEN"                      : "Abertura rápida",
     "CMD_GOTO_LINE"                       : "Ir para linha",
     "CMD_GOTO_DEFINITION"                 : "Encontrar definição",
-    "CMD_GOTO_FIRST_PROBLEM"              : "Ir ao primeiro Erro/Aviso",
+    "CMD_GOTO_FIRST_PROBLEM"              : "Ir ao primeiro erro/aviso",
     "CMD_TOGGLE_QUICK_EDIT"               : "Edição rápida",
     "CMD_TOGGLE_QUICK_DOCS"               : "Documentação rápida",
     "CMD_QUICK_EDIT_PREV_MATCH"           : "Resultado anterior",
@@ -382,6 +403,7 @@ define({
     "ABOUT"                                : "Sobre",
     "CLOSE"                                : "Fechar",
     "ABOUT_TEXT_LINE1"                     : "sprint {VERSION_MINOR} {BUILD_TYPE} {VERSION}",
+    "ABOUT_TEXT_BUILD_TIMESTAMP"           : "timestamp da versão: ",
     "ABOUT_TEXT_LINE3"                     : "Avisos, termos e condições de softwares de terceiros estão localizados em <a href='{ADOBE_THIRD_PARTY}'>{ADOBE_THIRD_PARTY}</a> e aqui incorporados por referência.",
     "ABOUT_TEXT_LINE4"                     : "Documentação e código-fonte em <a href='https://github.com/adobe/brackets/'>https://github.com/adobe/brackets/</a>",
     "ABOUT_TEXT_LINE5"                     : "Feito com \u2764 e JavaScript por:",
@@ -393,13 +415,20 @@ define({
     "GET_IT_NOW"                           : "Obtenha agora!",
     "PROJECT_SETTINGS_TITLE"               : "Configurações do projeto para: {0}",
     "PROJECT_SETTING_BASE_URL"             : "URL base do Live Preview",
-    "PROJECT_SETTING_BASE_URL_HINT"        : "Para usar um servidor local, insira uma url como http://localhost:8000/",
+    "PROJECT_SETTING_BASE_URL_HINT"        : "Para usar um servidor local, insira uma URL como http://localhost:8000/",
     "BASEURL_ERROR_INVALID_PROTOCOL"       : "O protocolo {0} não é suportado pelo Live Preview&mdash;por favor, use http: ou https: .",
     "BASEURL_ERROR_SEARCH_DISALLOWED"      : "A URL base não pode conter parâmetros de busca como \"{0}\".",
     "BASEURL_ERROR_HASH_DISALLOWED"        : "A URL base não pode conter hashes como \"{0}\".",
     "BASEURL_ERROR_INVALID_CHAR"           : "Caracteres especiais como '{0}' devem ser codificados para URL encoding.",
     "BASEURL_ERROR_UNKNOWN_ERROR"          : "Erro desconhecido ao parsear URL base",
-
+    
+    // Strings for themes-settings.html and themes-general.html
+    "CURRENT_THEME"                        : "Tema atual",
+    "USE_THEME_SCROLLBARS"                 : "Usar barra de rolagens do tema",
+    "FONT_SIZE"                            : "Tamanho da fonte",
+    "FONT_FAMILY"                          : "Família da fonte",
+    "THEMES_SETTINGS"                      : "Configurações de temas",
+    
     // CSS Quick Edit
     "BUTTON_NEW_RULE"                      : "Nova regra",
     
@@ -421,6 +450,8 @@ define({
     "CANCELING_INSTALL"                    : "Cancelando\u2026",
     "CANCELING_HUNG"                       : "Cancelar a instalação está demorando muito. Um erro interno deve ter ocorrido.",
     "INSTALL_CANCELED"                     : "Instalação cancelada.",
+    "VIEW_COMPLETE_DESCRIPTION"            : "Ver descrição completa",
+    "VIEW_TRUNCATED_DESCRIPTION"           : "Ver descrição reduzida",
     // These must match the error codes in ExtensionsDomain.Errors.* :
     "INVALID_ZIP_FILE"                     : "O conteúdo baixado não é um arquivo zip válido.",
     "INVALID_PACKAGE_JSON"                 : "O arquivo package.json não é válido (o erro foi: {0}).",
@@ -446,7 +477,11 @@ define({
     // For NOT_FOUND_ERR, see generic strings above
     "EXTENSION_MANAGER_TITLE"              : "Gerenciador de Extensões",
     "EXTENSION_MANAGER_ERROR_LOAD"         : "Não foi possível acessar o registro de extensões. Por favor,tente novamente mais tarde.",
+    "INSTALL_EXTENSION_DRAG"               : "Arraste o .zip aqui ou",
+    "INSTALL_EXTENSION_DROP"               : "Solte o .zip aqui ou",
+    "INSTALL_EXTENSION_DROP_ERROR"         : "Instalação/atualização cancelada devido aos seguintes erros:",
     "INSTALL_FROM_URL"                     : "Instalar a partir de URL\u2026",
+    "INSTALL_EXTENSION_VALIDATING"         : "Validando\u2026",
     "EXTENSION_AUTHOR"                     : "Autor",
     "EXTENSION_DATE"                       : "Data",
     "EXTENSION_INCOMPATIBLE_NEWER"         : "Esta extensão requer uma versão mais recente do {APP_NAME}.",
@@ -457,6 +492,9 @@ define({
     "EXTENSION_MORE_INFO"                  : "Mais informações...",
     "EXTENSION_ERROR"                      : "Erro na extensão",
     "EXTENSION_KEYWORDS"                   : "Palavras-chave",
+    "EXTENSION_TRANSLATED_USER_LANG"       : "Traduzido para {0} idiomas, incluindo o seu",
+    "EXTENSION_TRANSLATED_GENERAL"         : "Traduzido para {0} idiomas",
+    "EXTENSION_TRANSLATED_LANGS"           : "Essa extensão foi traduzida para os seguintes idiomas: {0}",
     "EXTENSION_INSTALLED"                  : "Instalada",
     "EXTENSION_UPDATE_INSTALLED"           : "Esta atualização foi baixada e será instalada quando você sair do {APP_NAME}.",
     "EXTENSION_SEARCH_PLACEHOLDER"         : "Pesquisar",
@@ -471,17 +509,18 @@ define({
     "MARKED_FOR_UPDATE"                    : "Marcada para atualização",
     "UNDO_UPDATE"                          : "Desfazer",
     "CHANGE_AND_RELOAD_TITLE"              : "Alterar extensões",
-    "CHANGE_AND_RELOAD_MESSAGE"              : "Para atualizar ou remover as extensões marcadas, o {APP_NAME} precisa ser recarregado. Você será solicitado a salvar suas alterações.",
+    "CHANGE_AND_RELOAD_MESSAGE"            : "Para atualizar ou remover as extensões marcadas, o {APP_NAME} precisa ser recarregado. Você será solicitado a salvar suas alterações.",
     "REMOVE_AND_RELOAD"                    : "Remover extensões e recarregar",
     "CHANGE_AND_RELOAD"                    : "Alterar extensões e recarregar",
     "UPDATE_AND_RELOAD"                    : "Atualizar extensões e recarregar",
-    "PROCESSING_EXTENSIONS"                : "Processing extension changes\u2026",
-    "EXTENSION_NOT_INSTALLED"              : "Não foi possível remover a extensão {0} porque não estava instalada.",
+    "PROCESSING_EXTENSIONS"                : "Processando alterações nas extensões\u2026",
+    "EXTENSION_NOT_INSTALLED"              : "Não foi possível remover a extensão {0} porque ela não estava instalada.",
     "NO_EXTENSIONS"                        : "Nenhuma extensão instalada ainda.<br>Clique na aba Disponíveis acima para começar.",
     "NO_EXTENSION_MATCHES"                 : "Nenhuma extensão corresponde à sua pesquisa.",
     "REGISTRY_SANITY_CHECK_WARNING"        : "Tenha cuidado ao instalar extensões de fontes desconhecidas.",
     "EXTENSIONS_INSTALLED_TITLE"           : "Instaladas",
     "EXTENSIONS_AVAILABLE_TITLE"           : "Disponíveis",
+    "EXTENSIONS_THEMES_TITLE"              : "Temas",
     "EXTENSIONS_UPDATES_TITLE"             : "Atualizações",
     
     "INLINE_EDITOR_NO_MATCHES"             : "Nenhuma correspondência.",
@@ -489,7 +528,7 @@ define({
     "CSS_QUICK_EDIT_NO_STYLESHEETS"        : "Seu projeto não tem uma folha de estilos.<br>Crie uma para adicionar regras CSS.",
 
     // Custom Viewers
-    "IMAGE_VIEWER_LARGEST_ICON"            : "largest",
+    "IMAGE_VIEWER_LARGEST_ICON"            : "maior",
 
     /**
      * Unit names
@@ -501,20 +540,20 @@ define({
     "DEBUG_MENU"                                : "Depurar",
     "ERRORS"                                    : "Erros",
     "CMD_SHOW_DEV_TOOLS"                        : "Mostrar Ferramentas do Desenvolvedor",
-    "CMD_REFRESH_WINDOW"                        : "Recarregar com Extensões",
-    "CMD_RELOAD_WITHOUT_USER_EXTS"              : "Recarregar sem Extensões",
+    "CMD_REFRESH_WINDOW"                        : "Recarregar com extensões",
+    "CMD_RELOAD_WITHOUT_USER_EXTS"              : "Recarregar sem extensões",
     "CMD_NEW_BRACKETS_WINDOW"                   : "Nova janela do {APP_NAME}",
-    "CMD_SWITCH_LANGUAGE"                       : "Trocar idioma",
+    "CMD_SWITCH_LANGUAGE"                       : "Alterar idioma\u2026",
     "CMD_RUN_UNIT_TESTS"                        : "Executar testes",
     "CMD_SHOW_PERF_DATA"                        : "Mostrar dados de desempenho",
-    "CMD_ENABLE_NODE_DEBUGGER"                  : "Habilitar Depurador Node",
-    "CMD_LOG_NODE_STATE"                        : "Registrar estado do Node no Console",
+    "CMD_ENABLE_NODE_DEBUGGER"                  : "Habilitar depurador do Node",
+    "CMD_LOG_NODE_STATE"                        : "Registrar estado do Node no console",
     "CMD_RESTART_NODE"                          : "Reiniciar Node",
     "CMD_SHOW_ERRORS_IN_STATUS_BAR"             : "Mostrar erros na barra de status",
     
-    "LANGUAGE_TITLE"                            : "Trocar idioma",
+    "LANGUAGE_TITLE"                            : "Alterar idioma",
     "LANGUAGE_MESSAGE"                          : "Idioma:",
-    "LANGUAGE_SUBMIT"                           : "Recarregar {APP_NAME}",
+    "LANGUAGE_SUBMIT"                           : "Reiniciar {APP_NAME}",
     "LANGUAGE_CANCEL"                           : "Cancelar",
     "LANGUAGE_SYSTEM_DEFAULT"                   : "Padrão do sistema",
     
@@ -531,13 +570,15 @@ define({
     "COLOR_EDITOR_RGBA_BUTTON_TIP"              : "Formato RGBa",
     "COLOR_EDITOR_HEX_BUTTON_TIP"               : "Formato Hex",
     "COLOR_EDITOR_HSLA_BUTTON_TIP"              : "Formato HSLa",
-    "COLOR_EDITOR_USED_COLOR_TIP_SINGULAR"      : "{0} (Usada {1} vez)",
-    "COLOR_EDITOR_USED_COLOR_TIP_PLURAL"        : "{0} (Usada {1} vezes)",
+    "COLOR_EDITOR_USED_COLOR_TIP_SINGULAR"      : "{0} (usada {1} vez)",
+    "COLOR_EDITOR_USED_COLOR_TIP_PLURAL"        : "{0} (usada {1} vezes)",
     
     // extensions/default/JavaScriptCodeHints
     "CMD_JUMPTO_DEFINITION"                     : "Pular para definição",
-    "CMD_SHOW_PARAMETER_HINT"                   : "Mostrar dica de parâmetro",
+    "CMD_SHOW_PARAMETER_HINT"                   : "Mostrar dicas de parâmetro",
     "NO_ARGUMENTS"                              : "<nenhum parâmetro>",
+    "DETECTED_EXCLUSION_TITLE"                  : "Problema de inferência de arquivo JavaScript",
+    "DETECTED_EXCLUSION_INFO"                   : "Brackets enfrentou um problema ao processar:<br><br>{0}<br><br>Este arquivo não será mais processado para dicas de código e definições. Para reverter, abra <code>.brackets.json</code> em seu projeto e remova o arquivo de jscodehints.detectedExclusions.",
     
     // extensions/default/JSLint
     "JSLINT_NAME"                               : "JSLint",
@@ -551,5 +592,3 @@ define({
     // extensions/default/WebPlatformDocs
     "DOCS_MORE_LINK"                            : "Leia mais"
 });
-
-/* Last translated for 5af956bd6a7b12345e0f1db2c0459a05067ccc58 */


### PR DESCRIPTION
Brazilian Portuguese (PT-BR) language file updated to match Sprint 0.43... It was quite outdated (I think v0.3x), and I corrected some grammar mistakes, mistranslations (like between reload <=> refresh) and improved some of them for better understanding.
