### PR TITLE
Using box-shadow for link focus to stop links from shifting a few pixels when tabbed.

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -54,8 +54,7 @@ a:focus {
 
     .dark & {
         color: @dark-bc-text-link;
-        border: 1px solid @dark-bc-btn-border-focused;
-        box-shadow: none;
+        box-shadow: 0 0 0 1px @dark-bc-btn-border-focused;
     }
 }
 


### PR DESCRIPTION
(CC @marcelgerber.)
