### PR TITLE
Fix several bugs with Live Preview and LESS/SCSS files

### DIFF
--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -214,6 +214,7 @@ define(function CSSDocumentModule(require, exports, module) {
      * @return {{body: string}}
      */
     CSSDocument.prototype.getResponseData = function getResponseData(enabled) {
+        // Serve up the in-memory text, including any unsaved changes
         return {
             body: this.doc.getText()
         };

--- a/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
+++ b/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
@@ -69,6 +69,13 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
         this.doc.releaseRef();
         this.detachFromEditor();
     };
+    
+    /** Return false so edits cause "out of sync" icon to appear */
+    CSSPreprocessorDocument.prototype.isLiveEditingEnabled = function () {
+        // Normally this isn't called since wasURLRequested() returns false for us, but if user's
+        // page uses less.js to dynamically load LESS files, then it'll be true and we'll get called.
+        return false;
+    };
 
     CSSPreprocessorDocument.prototype.attachToEditor = function (editor) {
         this.editor = editor;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1239,15 +1239,18 @@ define(function LiveDevelopment(require, exports, module) {
         
         // open browser to the interstitial page to prepare for loading agents
         _openInterstitialPage();
+        
+        // Once all agents loaded (see _onInterstitialPageLoad()), begin Live Highlighting for preprocessor documents
+        _openDeferred.done(function () {
+            // Setup activeEditorChange event listener so that we can track cursor positions in
+            // CSS preprocessor files and perform live preview highlighting on all elements with
+            // the current selector in the preprocessor file.
+            $(EditorManager).on("activeEditorChange", onActiveEditorChange);
 
-        // Setup activeEditorChange event listener so that we can track cursor positions in 
-        // CSS preprocessor files and perform live preview highlighting on all elements with 
-        // the current selector in the preprocessor file.
-        $(EditorManager).on("activeEditorChange", onActiveEditorChange);
-
-        // Explicitly trigger onActiveEditorChange so that live preview highlighting
-        // can be set up for the preprocessor files.
-        onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
+            // Explicitly trigger onActiveEditorChange so that live preview highlighting
+            // can be set up for the preprocessor files.
+            onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
+        });
     }
     
     function _prepareServer(doc) {

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
         if (liveDocument && liveDocument.getResponseData) {
             response = liveDocument.getResponseData();
         } else {
-            response = {};
+            response = {};  // let server fall back on loading file off disk
         }
         response.id = request.id;
         

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -151,7 +151,8 @@
             
             // ignore most HTTP methods and files that we're not watching
             if (("GET" !== req.method && "HEAD" !== req.method) || !hasListener) {
-                return next();
+                next();
+                return;
             }
             
             // pause the request and wait for listeners to possibly respond
@@ -193,7 +194,7 @@
 
                 // resume the HTTP ServerResponse, pass to next middleware if 
                 // no response data was passed
-                resume(!resData);
+                resume(!resData.body);
             };
 
             location.hostname = address.address;


### PR DESCRIPTION
- #8877: Fix StaticServerDomain to properly fall back to serving from disk
  when Brackets-side code takes a pass on filtering a file that was listed in
  `_rewritePaths`
- #8917: Wait until RemoteAgent is ready before first `onActiveEditorChange()`
  call, which may immediately create a CSSPreprocessorDocument & immediately
  try to do a HighlightAgent remote call.
- #8918: Implement `CSSPreprocessorDocument.isLiveEditingEnabled()`, which
  LiveDevelopment assumes exists on all "live documents."
