### PR TITLE
Add status bar error indicator clear shortcut

### DIFF
--- a/src/extensions/default/DebugCommands/ErrorNotification.js
+++ b/src/extensions/default/DebugCommands/ErrorNotification.js
@@ -49,6 +49,14 @@ define(function (require, exports, module) {
         }
     }
 
+    function handleClick(event) {
+        if (event.shiftKey) {
+            window.console.clear();
+        } else {
+            showDeveloperTools();
+        }
+    }
+
     function refreshIndicator() {
         // never show 0 errors
         if (!_attached || errorCount === 0) {
@@ -73,7 +81,7 @@ define(function (require, exports, module) {
             .attr("title", Strings.CMD_SHOW_DEV_TOOLS + "\u2026")
             .text(Strings.ERRORS + ": ")
             .append($span)
-            .on("click", showDeveloperTools)
+            .on("click", handleClick)
             .insertBefore("#status-bar .spinner");
     }
 


### PR DESCRIPTION
Perhaps it would be useful to add a shortcut to reset the status bar error indicator.

I don't feel strongly either way about the `Shift` click modifier, so do let me know if another combination would be more appropriate. Also, perhaps just calling `clearErrorCount` instead of `window.console.clear` (which also obviously clears the console) would be sufficient. Thoughts?
