### PR TITLE
Clean up how Extension Manager handles long descriptions

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -601,31 +601,6 @@ define(function (require, exports, module) {
         }, []);
     }
 
-    /**
-     * Toggles between truncated and full length extension descriptions
-     * @param {string} id The id of the extension clicked
-     * @param {JQueryElement} $element The DOM element of the extension clicked
-     * @param {boolean} showFull true if full length description should be shown, false for shorten version.
-     */
-    function toggleDescription(id, $element, showFull) {
-        var description, linkTitle,
-            entry = extensions[id];
-
-        // Toggle between appropriate descriptions and link title,
-        // depending on if extension is installed or not
-        if (showFull) {
-            description = entry.installInfo ? entry.installInfo.metadata.description : entry.registryInfo.metadata.description;
-            linkTitle = Strings.VIEW_TRUNCATED_DESCRIPTION;
-        } else {
-            description = entry.installInfo ? entry.installInfo.metadata.shortdescription : entry.registryInfo.metadata.shortdescription;
-            linkTitle = Strings.VIEW_COMPLETE_DESCRIPTION;
-        }
-
-        $element.attr("data-toggle-desc", showFull ? "trunc-desc" : "expand-desc")
-                .attr("title", linkTitle)
-                .prev(".ext-full-description").html(description);
-    }
-
     // Listen to extension load and loadFailed events
     $(ExtensionLoader)
         .on("load", _handleExtensionLoad)
@@ -651,7 +626,6 @@ define(function (require, exports, module) {
     exports.updateExtensions        = updateExtensions;
     exports.getAvailableUpdates     = getAvailableUpdates;
     exports.cleanAvailableUpdates   = cleanAvailableUpdates;
-    exports.toggleDescription       = toggleDescription;
     exports.ENABLED       = ENABLED;
     exports.START_FAILED  = START_FAILED;
 

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -115,26 +115,26 @@ define(function (require, exports, module) {
      * Toggles between truncated and full length extension descriptions
      * @param {string} id The id of the extension clicked
      * @param {JQueryElement} $element The DOM element of the extension clicked
-     * @param {boolean} showFull true if full length description should be shown, false for shorten version.
+     * @param {boolean} showFull true if full length description should be shown, false for shortened version.
      */
-    function _toggleDescription(id, $element, showFull) {
+    ExtensionManagerView.prototype._toggleDescription = function (id, $element, showFull) {
         var description, linkTitle,
-            entry = ExtensionManager.extensions[id];
+            info = this.model._getEntry(id);
 
         // Toggle between appropriate descriptions and link title,
         // depending on if extension is installed or not
         if (showFull) {
-            description = entry.installInfo ? entry.installInfo.metadata.description : entry.registryInfo.metadata.description;
+            description = info.metadata.description;
             linkTitle = Strings.VIEW_TRUNCATED_DESCRIPTION;
         } else {
-            description = entry.installInfo ? entry.installInfo.metadata.shortdescription : entry.registryInfo.metadata.shortdescription;
+            description = info.metadata.shortdescription;
             linkTitle = Strings.VIEW_COMPLETE_DESCRIPTION;
         }
 
-        $element.attr("data-toggle-desc", showFull ? "trunc-desc" : "expand-desc")
+        $element.data("toggle-desc", showFull ? "trunc-desc" : "expand-desc")
                 .attr("title", linkTitle)
                 .prev(".ext-full-description").text(description);
-    }
+    };
     
     /**
      * @private
@@ -179,12 +179,12 @@ define(function (require, exports, module) {
                     ExtensionManager.markForRemoval($target.attr("data-extension-id"), true);
                 } else if ($target.hasClass("undo-update")) {
                     ExtensionManager.removeUpdate($target.attr("data-extension-id"));
-                } else if ($target.attr("data-toggle-desc") === "expand-desc") {
-                    _toggleDescription($target.attr("data-extension-id"), $target, true);
-                } else if ($target.attr("data-toggle-desc") === "trunc-desc") {
-                    _toggleDescription($target.attr("data-extension-id"), $target, false);
+                } else if ($target.data("toggle-desc") === "expand-desc") {
+                    this._toggleDescription($target.attr("data-extension-id"), $target, true);
+                } else if ($target.data("toggle-desc") === "trunc-desc") {
+                    this._toggleDescription($target.attr("data-extension-id"), $target, false);
                 }
-            })
+            }.bind(this))
             .on("click", "button.install", function (e) {
                 self._installUsingDialog($(e.target).attr("data-extension-id"));
             })

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -112,6 +112,31 @@ define(function (require, exports, module) {
     ExtensionManagerView.prototype._itemViews = null;
 
     /**
+     * Toggles between truncated and full length extension descriptions
+     * @param {string} id The id of the extension clicked
+     * @param {JQueryElement} $element The DOM element of the extension clicked
+     * @param {boolean} showFull true if full length description should be shown, false for shorten version.
+     */
+    function _toggleDescription(id, $element, showFull) {
+        var description, linkTitle,
+            entry = ExtensionManager.extensions[id];
+
+        // Toggle between appropriate descriptions and link title,
+        // depending on if extension is installed or not
+        if (showFull) {
+            description = entry.installInfo ? entry.installInfo.metadata.description : entry.registryInfo.metadata.description;
+            linkTitle = Strings.VIEW_TRUNCATED_DESCRIPTION;
+        } else {
+            description = entry.installInfo ? entry.installInfo.metadata.shortdescription : entry.registryInfo.metadata.shortdescription;
+            linkTitle = Strings.VIEW_COMPLETE_DESCRIPTION;
+        }
+
+        $element.attr("data-toggle-desc", showFull ? "trunc-desc" : "expand-desc")
+                .attr("title", linkTitle)
+                .prev(".ext-full-description").text(description);
+    }
+    
+    /**
      * @private
      * Attaches our event handlers. We wait to do this until we've fully fetched the extension list.
      */
@@ -155,9 +180,9 @@ define(function (require, exports, module) {
                 } else if ($target.hasClass("undo-update")) {
                     ExtensionManager.removeUpdate($target.attr("data-extension-id"));
                 } else if ($target.attr("data-toggle-desc") === "expand-desc") {
-                    ExtensionManager.toggleDescription($target.attr("data-extension-id"), $target, true);
+                    _toggleDescription($target.attr("data-extension-id"), $target, true);
                 } else if ($target.attr("data-toggle-desc") === "trunc-desc") {
-                    ExtensionManager.toggleDescription($target.attr("data-extension-id"), $target, false);
+                    _toggleDescription($target.attr("data-extension-id"), $target, false);
                 }
             })
             .on("click", "button.install", function (e) {


### PR DESCRIPTION
- Move UI code out of ExtensionManagerView into ExtensionManager
- Properly escape extension description when toggling truncated part
