### PR TITLE
Improve LocalizationExample extension & nls README instructions

### DIFF
--- a/src/extensions/samples/LocalizationExample/README.md
+++ b/src/extensions/samples/LocalizationExample/README.md
@@ -1,67 +1,55 @@
-
-
 ## Localization in Brackets
-Brackets has basic support for displaying user visible text in other languages. The document describes how localized text can be added to core Brackets code and Brackets Plugins 
+Brackets supports localizing user visible strings, so the displayed text varies according to the user's locale. This extension is a simple example of using this capability.
 
-Javascript and HTML that displays user visible strings in Brackets should not use static English strings directly in code. Instead,  strings should be stored in a the file brackets \src\nls\root\strings.js. Code that wishes to display strings should import the String module from src\string.js. This module dynamically loads a strings.js file in the nls folder for the current local. JavaScript can then directly reference properties of the String module to access strings, and HTML can use the String module in combination with Mustache.js templating to display localized strings. Brackets uses the i18n RequireJS plugin for to load localized strings. The plugin loads the strings.js file according to the user’s locale and also provides a fallback to English for missing translations. 
+To see it in action, move this extension to `src/extensions/dev/` or to your user extensions folder, then restart Brackets. It will add a "My Localized Command" menu item to the end of the Edit menu, which shows tw modal dialog boxes with localized text.
 
-## Adding new localized strings to Brackets
-Add new English strings to the file brackets\src\nls\root\strings.js. Translations in other languages should be added to the strings.js file in each of the locale folders inside the “nls” folder. For example, modify brackets\src\nls\fr\strings.js for French
+### Brackets core
+Localization is very similar when working in Brackets core code. See the [Localization wiki page](https://github.com/adobe/brackets/wiki/Localization) for details.
 
-## Using Localized strings in Brackets modules
+## Localizing your extension
 
-## Strings JavaScript
-1. Load the Strings module in the file where the string is to be used
-`Strings = require("strings");`
+### Defining strings
 
-2. Reference a string by selecting a property from the String module. For example, `Strings.NOT_FOUND_ERR` yields the string “The file could not be found." for an English locale.
+ To store your strings, set up a structure like this inside your extension:
 
-## Strings HTML
-Localizing HTML in Brackets requires use of the templating framework mustache.js since HTML cannot directly reference properties in strings.js. Strings for both JavaScript and HTML are stored \src\nls\root\strings.js, but in HTML they are referenced using the template syntax `{{stringKeyName}}`. 
+* `nls/`
+    * `root/strings.js` - Original English strings
+    * `fr/strings.js` - Translated French strings ("fr" locale)
+    * `<...>/strings.js` - Etc. for other locales
+    * `strings.js` - Acts like an index, listing which locale subfolders are available
+* `strings.js` - Wrapper file that other modules in your extension reference, dynamically populated with the appropriate localized strings. This file is just boilerplate -- you shouldn't need to chnage it at all.
 
-For example,
+The "root" language is special, since it acts as a fallback: if other translations are incomplete, your code will get the "root" string for anything that's missing from the translation.
 
-`<h1 class="dialog-title">{{SAVE_CHANGES}}</h1>`
+The individual `<locale>/strings.js` files use a simple JavaScript object literal to store strings as **key-value pairs**. (See this extension's root/strings.js & fr/strings.js for examples). You'll use the keys to reference your strings from JS & HTML code.
 
-yields 
+### Using strings in JS
+_See `main.js` for several examples of this._
 
-`<h1 class="dialog-title">Save Changes</h1>`
+1. Load the Strings module: `var Strings = require("strings");`
+2. Reference a string by its key, for example: `Strings.DIALOG_TITLE` yields the string `"Localized Dialog Example"` in this extension (in English locale).
 
-Mustache recognizes this syntax and can substite the appropriate string. Mustache is run when Brackets launches during module load. Code in brackets.js loads the appropriate strings.js file using i18n, loads html content from a file as a text, runs Mustache on the text using strings.js for the data lookup, and then inserts the result into the DOM. Core brackets code that depends on the DOM should listen for the “htmlContentLoadComplete” before inspecting or manipulating the dome
+### Using strings in HTML
+For large chunks of HTML, you can use Mustache templates to inject localized strings.
 
-## Localization Guidelines
-Multiple strings keys in strings.js should not be concatenated together since word order often varies between languages
+_See `main.js` for an example of this._
 
-## Limitations
-Brackets does not support localizing keyboard shortcuts yet
+1. Create an HTML file inside your extension (for example, `htmlContent/sampleHTMLFragment.html`)
+2. In the HTML code, reference strings like this: `<h1 class='dialog-title'>{{DIALOG_TITLE}}</h1>`
+3. In your JS code, load the raw HTML template: `var htmlTemplate = require("text!htmlContent/sampleHTMLFragment.html");`
+4. Convert to localized HTML: `Mustache.render(htmlTemplate, Strings);` will yield the string `"<h1 class='dialog-title'>Localized Dialog Example</h1>"`
+
+Note: Mustache automatically HTML-escapes your strings. Use triples braces if you need to opt out of this (carefully).
+
+### String concatenation
+Because word order varies between languages, don't assume you can append separate strings together in a fixed order (e.g. using `+` in JavaScript). [Instead, make a single _parameterized_ string](https://github.com/adobe/brackets/wiki/Localization#string-concatenation).
+
+### Reusing Brackets core strings
+Brackets core has its own strings.js file, separate from the one in your extension. To reference Brackets core strings, use `var BracketsStrings = brackets.getModule("strings")`. _However_, Brackets strings are not treated treated as a stable API, so they may change at any time without warning.
 
 
-## Localization Support for Brackets Plugins
+## Testing localization
+Use _Debug > Switch Language_ to force Brackets to use a different locale (without needing to switch your overall OS locale).
 
-Localization in plugins works very similarly to how localization works for core Brackets module. The i18n RequireJS plugin is used to dynamically load a string.js file for the appropriate locale. JavaString can then reference strings via property name from the loaded string module and mustache can be used on on html fragments to insert localized text.
-
-For an example of a simple localized plugin see: brackets\src\extensions\disabled\LocalizationExample
-
-Move this plugin to the extensions\user\ folder to run the plugin. It will add a "My New Command" menu item to the end of the Edit menu. This command shows an alert with localized text and then a modal dialog with localized HTML content.
-
-#### Below is the folder structure and comments on the role of each file
-
-* main.js – loads the Strings module for the plugin and uses mustache to localize html content
-
-* package.json - add the translation languages as in the example: `"i18n: ["en", "fr" ]`
-
-* strings.js – uses i18n to load a strings.js file in the nls folder
-
-* htmlContent
-    * htmlfragment.html – html template to be localized by mustache
-* nls
-    * strings.js – configures i18n by specifying the  root folder and listing the locales supported by the plugin
-    * root
-        * strings.js – contains the English strings
-    * fr
-        * strings.js – contains the French strings
-    * etc. for each locale
-
-#### Strings for plugins vs Brackets
-Note that there is a distinction between loading strings for a plugin vs. strings in the Brackets core. To access strings local to your plugin use `var strings = require("strings")`. To load the core Brackets strings use `var bracketsStrings = brackets.getModule("strings")`
-
+## Advertising that you're localized
+Once your extension is localized, don't forget to advertise this in the extension listing! Just add an `i18n` array to your [`package.json` file](https://github.com/adobe/brackets/wiki/Extension-package-format#packagejson-format), as illustrated in this extension. Extension Manager will automatically highlight whether your extension supports the user's current locale.

--- a/src/extensions/samples/LocalizationExample/main.js
+++ b/src/extensions/samples/LocalizationExample/main.js
@@ -21,18 +21,8 @@
  * 
  */
 
-
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, require, Mustache, navigator  */
-
-
-require.config({
-    paths: {
-        "text" : "lib/text",
-        "i18n" : "lib/i18n"
-    },
-    locale: brackets.getLocale()
-});
+/*global define, brackets, $, require, Mustache  */
 
 define(function (require, exports, module) {
     "use strict";
@@ -42,32 +32,38 @@ define(function (require, exports, module) {
         Menus               = brackets.getModule("command/Menus"),
         Dialogs             = brackets.getModule("widgets/Dialogs");
 
+    // 1) Localization using Mustache templates
     // Load an html fragment using the require text plugin. Mustache will later
     // be used to localize some of the text
     var browserWrapperHtml  = require("text!htmlContent/sampleHTMLFragment.html");
     
-    // Load the string module for this plugin. Not this references to the strings.js
-    // file next to the main.js fiel for this plugin. To access core brackets strings
-    // you would call brackets.getModule("strings") instead of require("strings")
+    // 2) Localization for strings used by JS code
+    // Load the string module for this extension. This references the strings.js
+    // file next to this extension's main.js file. To access core brackets strings,
+    // call brackets.getModule("strings") instead of require("strings").
     var Strings             = require("strings");
 
 
-    // This sample command first shows an alert passing in a localized
-    // string in JavaScript then it shows a localized HTML dialog.
+    // This sample command shows two modal dialogs, with strings localized using the
+    // two approaches above
     function testCommand() {
-        alert(Strings.ALERT_MESSAGE);
-
+        // 1) Mustache template
         // Localize the dialog using Strings as the datasource and use it as the dialog template
         var localizedTemplate = Mustache.render(browserWrapperHtml, Strings);
         Dialogs.showModalDialogUsingTemplate(localizedTemplate);
+        
+        // 2) String used by JS code
+        alert(Strings.ALERT_MESSAGE);
     }
 
 
     // Register the command
-    // A localized command name is used by passing in Strings.COMMAND_NAME
-    var myCommandID = "localizationExample.command";
-    var command = CommandManager.register(Strings.COMMAND_NAME, myCommandID, testCommand);
+    // Command ID is *not* localized, since it's not user visible and should stay constant.
+    // Command name *is* localized, using approach (2) from above.
+    var COMMAND_ID = "localizationExample.command";
+    var command = CommandManager.register(Strings.COMMAND_NAME, COMMAND_ID, testCommand);
 
+    // Add command to menu - menu will display the localized COMMAND_NAME we used above
     var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
-    menu.addMenuItem(myCommandID, null, Menus.AFTER, myCommandID);
+    menu.addMenuItem(COMMAND_ID);
 });

--- a/src/extensions/samples/LocalizationExample/nls/fr/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/fr/strings.js
@@ -22,13 +22,13 @@
  */
 
 // French Translation
+// Any strings that are missing from here will be provided by nls/root/strings.js instead
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 
-
 define({
-    "COMMAND_NAME"      : "Ma nouvelle commande",
+    "COMMAND_NAME"      : "Ma commande localisée",
     "ALERT_MESSAGE"     : "Ceci est un exemple d'alerte",
     "DIALOG_TITLE"      : "Exemple de boite de dialogue traduite",
     "DIALOG_TEXT"       : "Ceci est un exemple de texte traduit dans Brackets",

--- a/src/extensions/samples/LocalizationExample/nls/root/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/root/strings.js
@@ -22,12 +22,14 @@
  */
 
 // English - root strings
+// Since this is the "root" language, any strings missing from other languages will automatically
+// fall back to the strings provided here.
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 
 define({
-    "COMMAND_NAME"      : "My New Command",
+    "COMMAND_NAME"      : "My Localized Command",
     "ALERT_MESSAGE"     : "This is a sample alert message",
     "DIALOG_TITLE"      : "Localized Dialog Example",
     "DIALOG_TEXT"       : "This is an example of localized text in Brackets",

--- a/src/extensions/samples/LocalizationExample/nls/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/strings.js
@@ -24,17 +24,19 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 
+/**
+ * This file tells the Require i18n plugin which localized versions of strings.js exist. If you add a new
+ * folder under nls/, you must list it here or else Require won't know it exists.
+ * 
+ * The extension does not reference this file directly. It references strings.js in the extension's
+ * root, which in turn references this file and the rest of the files under nls/ via RequireJS i18n
+ * plugin.
+ */
 define(function (require, exports, module) {
     
     'use strict';
     
-    // Code that needs to display user strings should call require("strings") to load
-    // strings.js. This file will dynamically load strings.js for the specified by bracketes.locale.
-    // 
-    // Translations for other locales should be placed in nls/<locale<optional country code>>/strings.js
-    // Localization is provided via the i18n plugin.
-    // All other bundles for languages need to add a prefix to the exports below so i18n can find them.
-    // TODO: dynamically populate the local prefix list below?
+    // Translations for individual locales are placed in nls/<locale<optional country code>>/strings.js
     module.exports = {
         root: true,
         "fr": true

--- a/src/extensions/samples/LocalizationExample/package.json
+++ b/src/extensions/samples/LocalizationExample/package.json
@@ -1,14 +1,15 @@
 {
-    "name": "localization-example",
-    "title": "Localization Example",
-    "description": "A guide on how to localize your extension.",
+    "name": "example.localization-example",
+    "title": "Brackets Extension Localization Example",
+    "description": "Example of how to localize your extension.",
+    
     "homepage": "https://github.com/adobe/brackets/tree/master/src/extensions/samples/LocalizationExample",
+    
     "version": "1.0.0",
-    "author": "The Brackets team",
-    "license": "MIT",
     "engines": {
         "brackets": ">=0.42.0"
     },
+    
     "i18n": [
         "en", 
         "fr" 

--- a/src/extensions/samples/LocalizationExample/strings.js
+++ b/src/extensions/samples/LocalizationExample/strings.js
@@ -25,10 +25,11 @@
 /*global define */
 
 /**
- * This file provides the interface to user visible strings in Brackets. Code that needs
- * to display strings should should load this module by calling var Strings = require("strings").
- * The i18n plugin will dynamically load the strings for the right locale and populate
- * the exports variable. See src\nls\strings.js for the master file of English strings.
+ * This file is a wrapper that tells Require to load whichever version of nls/.../strings.js is
+ * appropriate for the current locale. If no folders under nls match, then nls/root is used.
+ * 
+ * The extension can reference this module via require("strings") without having to worry about
+ * which localized copy gets loaded. For example usage, see main.js.
  */
 define(function (require, exports, module) {
     "use strict";

--- a/src/nls/README.md
+++ b/src/nls/README.md
@@ -1,41 +1,4 @@
-# How to add translations for a *new* locale
-
-1. Create a subfolder of the `nls` folder whose name is the language or locale you want to
-   create a translation for.
-    * If you're creating a general translation for a language, just use its two-letter code
-      (e.g. `en`, `de`).
-    * If you're creating a locale-specific translation for a particular country, add a hyphen
-      and the country code in lowercase (e.g. `en-ca`, `en-gb`).
-2. Add an entry for your translation to the `module.exports` object in `nls/strings.js`.
-3. Edit the root `strings-app.js` file and add a new `LOCALE_`* entry for your language, as seen in
-   the Debug > Switch Language UI.
-4. Copy the root `strings.js` file into your subfolder and start translating!
-5. Use the [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests) to
-   see strings in context.
-6. Add this comment ``/* Last translated for commit_SHA_of_root_strings.js */`` at the end 
-   of your `strings.js` and replace `commit_SHA_of_root_strings.js` with the actual SHA.
-   You can copy the actual SHA in this [history page](https://github.com/adobe/brackets/commits/master/src/nls/root/strings.js)
-   by hovering on the one you used for this translation and click on Copy SHA button.
-7. Edit this file and update the list of languages below!
-
-Strings not specified in a given locale will fall back to the general language (without hyphen)
-first, and then will fall back to the English string from `nls/root/strings.js`.
-
-Localization is provided via the [require.js i18n plugin](http://requirejs.org/docs/api.html#i18n).
-
-### Translating the Getting Started project
-
-When first installed, Brackets will open a Getting Started project that serves
-as an introduction to Brackets features. This project can be translated by
-providing a ``urls.js`` file that points to a localized directory under the
-``samples`` folder at the root of the Brackets repository. See the French
-localization (`src/nls/fr/urls.js`) for an example.
-
-It is also recommended to add this comment ``<!-- Last translated for commit_SHA_of_root_index.html -->``
-at the end of your `index.html` and replace `commit_SHA_of_root_index.html` with the actual SHA.
-
-
-# How to modify *existing* translations
+# Translation process
 
 ### Adobe-maintained translations
 
@@ -44,7 +7,7 @@ Adobe provides translations for the following languages:
 * French (fr)
 * Japanese (ja)
 
-These translations cannot be modified through our normal pull request
+These translations _cannot_ be modified through our normal pull request
 process. Please contribute changes one of these ways:
 
 1. File an issue in our GitHub repository
@@ -55,7 +18,7 @@ process. Please contribute changes one of these ways:
 
 ### Community-maintained translations
 
-The following languages have been contributed by the Brackets community:
+The following translations have been contributed by the Brackets community:
 
 * Czech (cs)
 * Danish (da)
@@ -67,7 +30,7 @@ The following languages have been contributed by the Brackets community:
 * Galician (gl)
 * Croatian (hr)
 * Hungarian (hu)
-* Indonesia (id)
+* Indonesian (id)
 * Italian (it)
 * Korean (ko)
 * Norwegian (nb)
@@ -86,95 +49,143 @@ The following languages have been contributed by the Brackets community:
 * Traditional Chinese (zh-tw)
 
 These translations _can be directly modified_ through our normal pull request
-process. Make sure that you also update the comment on the last line with the 
-correct SHA of `strings.js` from root directory, which you used for your translation.
-If the SHA comment is missing, then add one with the correct SHA. See step 6 in 
-__How to add translations for a *new* locale__ section for adding a new one.
+process. Read the next section for instructions.
 
-In the future, Adobe may begin maintaining some of these languages too, at which
-point the process will switch to the one above. But until then, please _do not
-use_ http://translate.adobe.com for these languages.
+Please _do not_ use http://translate.adobe.com for these languages.
 
 
-## Contributing Translations directly from github.com
+# How to contribute translations
 
-You must be logged in to your github.com id (e.g. `user1`).
+Localized strings are stored in language-specific `strings.js` files, which are loaded by
+[Require.js](http://requirejs.org/docs/api.html#i18n). You can edit these files online at
+GitHub.com, or locally on your computer using Git and a text editor.
 
-### Adding a New Translation
-To add a new translation, you need to start with a copy of the
-root `strings.js` file which is located at
-[https://github.com/adobe/brackets/blob/master/src/nls/root/strings.js](https://github.com/adobe/brackets/blob/master/src/nls/root/strings.js).
-New translations can be added by navigating to the
-[nls folder on github](https://github.com/adobe/brackets/tree/master/src/nls)
-and then clicking on the [+] button to add a new file.
-You will be taken to a New File page where you:
+## Using GitHub.com online
 
-1. Specify the file name as *language-id*/strings.js
-2. Paste in the contents of root/strings.js and edit strings for new language
-3. Add this comment `/* Last translated for commit_SHA_of_root_strings.js */`
-at the end of your strings.js and replace `commit_SHA_of_root_strings.js` with the
-actual SHA.
-You can copy the actual SHA in this
-[history page](https://github.com/adobe/brackets/commits/master/src/nls/root/strings.js)
-by hovering on the one you used for this translation and click on Copy SHA button.
-4. Add short and (optional) long description of new file
-5. Click "Propose New File" button
+### Adding a New Locale
+Adding translations for a new locale requires modifying several files at once, so
+it's best to use Git with local source files (see "Using a local Git clone of Brackets"
+below). For help with this, [contact the Brackets team](https://github.com/adobe/brackets#contact-info).
 
 ### Editing an Existing Translation
-Existing files can be edited directly in
-[brackets repo on github](https://github.com/adobe/brackets).
+If you're just correcting mistakes/typos, the process is simple:
 
-Navigate to the file to edit and click "Edit" button above file.
-You will be taken to an Edit File page where you:
+1. Navigate to the appropriate file in the [nls folder on GitHub](https://github.com/adobe/brackets/tree/master/src/nls)
+and click "Edit" button above file.
+2. Edit the strings in the file
+3. Add a short description at bottom
+4. Click "Propose File Change"
 
-1. Make desired edits to file
-2. Make sure that you also update the comment on the last line with the correct SHA of
-strings.js from root directory, which you used for your translation. If the SHA comment
-is missing, then add one with the correct SHA. See step 6 in How to add translations
-for a new locale section for adding a new one.
-3. Add short and (optional) long description of Commit changes
-4. Click "Commit changes" button
+When updating a translation to reflect changes in the Brackets UI, it's important to
+make sure you're covering _all_ changes since the last translation udate:
 
-### Branch and Pull Request
-For either case, if you have not yet forked the brackets repository in your
-github account (`https://github.com/user1/brackets`), it's done automatically.
-A new branch will be created in your Brackets fork with a unique name
-which is something like `patch-1` that contains your changes.
+1. Locate the "SHA" commit code for the last version of the translation: look for "Last
+translated for" at the bottom of the file.
+2. Go to this URL: `https://github.com/adobe/brackets/compare/<SHA>...master` (replacing
+`<SHA>` with the value from step 1).
+3. Click "Files changed," then search for "nls/root/strings.js" on the page. You'll see a
+comparison view showing every string that was added, removed, or modified since the
+translation was last updated. (If there is no "nls/root/strings.js", then the translation
+is already fully up to date!).
+4. Update the translation accordingly
+5. Update the "Last translated for" comment with the _current_ SHA code: visit the 
+[history page](https://github.com/adobe/brackets/commits/master/src/nls/root/strings.js),
+and click the clipboard icon ("Copy the full SHA") on the right.
+6. Add a short description and click "Propose File Change" to finish
 
-You are then taken to the New Pull Request dialog which is filled in
-with all of the information from previous dialog.
-It also shows contents of new file or a "diff" of changes to existing file.
-You can make any changes if desired, then click "Send Pull Request" when done
-(or close page to Cancel).
-A pull request for your branch is created and submitted to the Brackets "repo".
+#### Creating the Pull Request
+The New Pull Request screen will appear, reviewing your changes. If everything looks ok,
+click "Send Pull Request" to submit your changes to the Brackets team.
 
-### Code Review
-Someone on the Brackets team will review the pull request. If it's ok, it will
-be merged. If changes need to be made, the reviewer will post comments in the
-pull request which will send you an e-mail notification.
+> Behind the scenes, GitHub has automatically created your own personal fork of the
+Brackets repository (e.g. `https://github.com/user1/brackets`) if you don't have one
+already, and a new branch within it (named something like `patch-1`) that contains your
+changes.
 
-### Updating Existing Branch and Pull Request
+#### Code Review: Updating Your Pull Request
+Someone on the Brackets team will review the pull request. If any changes need to be made
+the reviewer will post comments in the pull request, which will send you an e-mail
+notification.
 
-If you need to make changes to an existing branch, 
-you should make updates in the `patch-1` branch in your Github fork of Brackets
-so all of your changes for this update are in a single branch.
-Creating a new branch for every update makes it difficult for core team
-to see all changes at once, and can even create conflicts that are
-very difficult to resolve. For example:
+You should make updates in the _same_ branch your pull request was created from (e.g.
+`patch-1`):
 
-1. After submitting your pull request, look at the top where it says something like:
+1. Find the branch name listed at the top of your pull request's web page (e.g. "`user1`
+   wants to merge 1 commit into `adobe:master` from `user1:patch-1`" tells you the branch
+   name is `patch-1`)
+2. Go to your fork of Brackets on GitHub (e.g. `https://github.com/user1/brackets`)
+3. Change the branch dropdown at upper left to your pull request's branch name
+4. Navigate to "strings.js" and click "Edit" button.
+5. Make any changes requested, and save by clicking "Commit changes." This will
+automatically update your pull request.
 
-    `user1` wants to merge 1 commit into `adobe:master` from `user1:patch-1`
-    
-2. Go to your github fork of brackets page: `github.com/user1/brackets`
-3. Click on the Branches Tab: `github.com/user1/brackets/branches`
-4. Click on the link to the branch: `github.com/user1/brackets/tree/patch-1`
-5. This is where you make changes to your `patch-1` branch.
+After you finish addressing code review feedback, add a comment to the pull request to
+notify the reviewer that it's ready to look at again.
 
-Saved edits show up as a new commit, so they automatically show up in the original
-pull request. After making an update, add a comment to the pull request such as
-"Changes made -- ready for another review" to notify reviewer
-that it's time to review the changes again.
+
+## Using a local Git clone of Brackets
+
+### Adding a New Locale
+
+1. Create a `src/nls/*language-id*` subfolder
+    * If you're creating a general language translation, use its two-letter code (e.g. `en`, `de`).
+    * If you're creating a locale-specific translation for a particular country, add a hyphen
+      and the country code in lowercase (e.g. `en-ca`, `en-gb`).
+2. Add an entry for your translation in `nls/strings.js`.
+3. Edit the root `strings-app.js` file and add a new `LOCALE_`* entry for your language, as seen in
+   the Debug > Switch Language UI.
+4. Copy the `nls/root/strings.js` file into your subfolder and start translating!
+    * Tip: Use the [UI walkthrough steps](https://github.com/adobe/brackets/wiki/Localization-Tests)
+      to see strings in context.
+    * If you omit any strings, Brackets will fall back to the general language (without hyphen) if
+      any, and then to the English string in `nls/root/strings.js`.
+5. Use `git log -- src/nls/root/strings.js` to find the commit SHA code of the `root/strings.js`
+   copy you used (latest version is listed first).
+6. Add a comment `/* Last translated for <SHA> */` to the bottom of your new file,
+   using the value you got on the previous step in place of `<SHA>`. This records which
+   version of the original English strings you used as a reference point, which aids in
+   updating the translation later.
+7. Edit this README and update the list of languages at the top!
+
+Also consider **translating the Getting Started project**:
+
+1. Create a new `samples/*language-id*` folder and copy the `samples/root/Getting Started`
+content into it to use as a starting point. (You can translate the "Getting Started" folder
+name as well, but it _cannot_ contain Unicode characters -
+[see bug #2425](https://github.com/adobe/brackets/issues/2425)).
+2. Create or edit the `src/nls/*language-id*/urls.js` file to point to your new folder.
+3. If `urls.js` didn't exist before, update `src/nls/urls.js` to add a `true` entry for this
+locale.
+4. Add a comment `<!-- Last translated for <SHA> -->` to the bottom of index.html, similar
+to above.
+
+
+### Editing an Existing Translation
+If you're just correcting mistakes/typos, simply edit the appropriate `strings.js` file and
+submit a pull request with your changes.
+
+But to update a translation to reflect changes in the Brackets UI, it's important to
+make sure you're covering _all_ changes since the last translation udate:
+
+1. Ensure your local Git copy is
+[up to date from upstream/master](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets#getting-updates-from-the-main-repository).
+2. Locate the SHA code for the last translation update: look for "Last translated for" at
+the bottom of the file.
+3. Run `git difftool <SHA>...master -- src/nls/root/strings.js` to see a diff showing every
+string that was added, removed, or modified since the translation was last updated.
+4. Update the translation accordingly
+5. Update the "Last translated for" comment with the _current_ SHA code: use
+`git log master -- src/nls/root/strings.js` to find the version that was used in the diff
+above.
+
+
+
+# Translation timing
+
+During a Brackets release cycle, English strings are modified and added. Near the end of the cycle,
+there's a _string freeze_ - the changes stop. This is the window of opportunity to update translations
+before the build is released. Watch the [brackets-dev forum](http://groups.google.com/group/brackets-dev)
+for announcements of each string freeze and its translation deadline.
 
 
 # Translation limitations
@@ -184,5 +195,3 @@ Some strings cannot be localized yet:
 * [Keyboard shortcuts](https://trello.com/c/4k2yalBd)
 * [Some native menus on Mac](https://trello.com/c/0IsE7q02) (hardcoded support only for English, French, Japanese)
 * Windows installer UI (hardcoded support only for English, Japanese - with some limitations)
-* Localized folder name of "Getting Started" has to be made of up basic English characters only, as described
-[here](https://github.com/adobe/brackets/pull/8332#issuecomment-48767847).


### PR DESCRIPTION
LocalizationExample :
- Fix some incorrect/unnecessary code
- Add explanatory notes to more files
- Clarify which code in main.js applies to which string-usage approach
- Rework README so it more clearly applies to extensions (linking to wiki & nls README for info on other topics)

nls README:
- Move 'how to add new locale' & 'translate Getting Started' sections down from the top, since they're not the most common tasks.
- Explain how to use SHA to diff English string changes (which is the point of the SHA, after all)
- Clearly separate info on local Git workflows vs. using GitHub online
- Remove info on adding a new locale using GitHub online - it omitted all the other files that need to get updated (and multi-file updates are tricky on GH online anyway)
- Add more info on using Git locally: how to get the SHA & how to update existing translations
- Smaller updates: clean up wording, eliminate unnecessary details, add clarifications
