### PR TITLE
Make "Show Errors in Status Bar" pref more solid

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
         });
     }
     
-    function toggleErrorNotification(bool) {
+    function toggleErrorNotification(bool, doNotSave) {
         var val;
 
         if (typeof bool === "undefined") {
@@ -250,7 +250,9 @@ define(function (require, exports, module) {
 
         // update menu
         CommandManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR).setChecked(val);
-        PreferencesManager.set(DEBUG_SHOW_ERRORS_IN_STATUS_BAR, val);
+        if (!doNotSave) {
+            PreferencesManager.set(DEBUG_SHOW_ERRORS_IN_STATUS_BAR, val);
+        }
     }
 
     function handleOpenBracketsSource() {
@@ -287,7 +289,11 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_RESTART_NODE,         DEBUG_RESTART_NODE,           NodeDebugUtils.restartNode);
     
     enableRunTestsMenuItem();
-    toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR));
+    toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR), true);
+
+    PreferencesManager.on("change", DEBUG_SHOW_ERRORS_IN_STATUS_BAR, function () {
+        toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR), true);
+    });
     
     /*
      * Debug menu

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -237,11 +237,12 @@ define(function (require, exports, module) {
         });
     }
     
-    function toggleErrorNotification(bool, doNotSave) {
-        var val;
+    function toggleErrorNotification(bool) {
+        var val,
+            oldPref = !!PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR);
 
-        if (typeof bool === "undefined") {
-            val = !PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR);
+        if (bool === undefined) {
+            val = !oldPref;
         } else {
             val = !!bool;
         }
@@ -250,7 +251,7 @@ define(function (require, exports, module) {
 
         // update menu
         CommandManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR).setChecked(val);
-        if (!doNotSave) {
+        if (val !== oldPref) {
             PreferencesManager.set(DEBUG_SHOW_ERRORS_IN_STATUS_BAR, val);
         }
     }
@@ -289,10 +290,10 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_RESTART_NODE,         DEBUG_RESTART_NODE,           NodeDebugUtils.restartNode);
     
     enableRunTestsMenuItem();
-    toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR), true);
+    toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR));
 
     PreferencesManager.on("change", DEBUG_SHOW_ERRORS_IN_STATUS_BAR, function () {
-        toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR), true);
+        toggleErrorNotification(PreferencesManager.get(DEBUG_SHOW_ERRORS_IN_STATUS_BAR));
     });
     
     /*


### PR DESCRIPTION
This particular pref always gets its way into every brackets.json, even though it's unneeded most times.

Steps:
1. Rename your `%AppData%\Brackets` folder
2. Start Brackets
3. Use `Debug > Show prefs file`

Result: There's one single entry: `debug.showErrorsInStatusBar: false`
