### PR TITLE
Resolve the issue with the default scope being overriden

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -216,7 +216,6 @@ define(function (require, exports, module) {
      * Setup Brackets
      */
     function _onReady() {
-window.alert("brackets.js _onReady()");
         PerfUtils.addMeasurement("window.document Ready");
 
         // Let the user know Brackets doesn't run in a web browser yet

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -103,7 +103,8 @@ define(function (require, exports, module) {
             if (err.name && err.name === "ParsingError") {
                 userScopeCorrupt = true;
             }
-        })
+        });
+    userScopeLoading
         .then(fnUserScopeAlways, fnUserScopeAlways);
     
     // "State" is stored like preferences but it is not generally intended to be user-editable.


### PR DESCRIPTION
The default's scope load() was executing after the scope was already filled out with preferences.

Also, re-work adding to scope using explicit shadow entry state tracking (instead of promises).

cc: @redmunds 
