### PR TITLE
Remove Arrow from Split View and FIx Open Next File issue

### DIFF
--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -186,9 +186,7 @@ define(function (require, exports, module) {
     function sidebarList($scrollerElement, selectedClassName, leafClassName) {
         var $listElement = $scrollerElement.find("ul"),
             $selectionMarker,
-            $selectionTriangle,
-            $sidebar = $("#sidebar"),
-            showTriangle = true;
+            $sidebar = $("#sidebar");
         
         // build selectionMarker and position absolute within the scroller
         $selectionMarker = $(window.document.createElement("div")).addClass("sidebar-selection");
@@ -199,41 +197,12 @@ define(function (require, exports, module) {
         
         // use relative postioning for clipping the selectionMarker within the scrollElement
         $scrollerElement.css("position", "relative");
-        
-        // build selectionTriangle and position fixed to the window
-        $selectionTriangle = $(window.document.createElement("div")).addClass("sidebar-selection-triangle");
-        
-        $scrollerElement.append($selectionTriangle);
+
         
         selectedClassName = "." + (selectedClassName || "selected");
         
-        var updateSelectionTriangle = function () {
-            var selectionMarkerHeight = $selectionMarker.height(),
-                selectionMarkerOffset = $selectionMarker.offset(),  // offset relative to *document*
-                scrollerOffset = $scrollerElement.offset(),
-                triangleHeight = $selectionTriangle.outerHeight(),
-                scrollerTop = scrollerOffset.top,
-                scrollerBottom = scrollerTop + $scrollerElement.outerHeight(),
-                scrollerLeft = scrollerOffset.left,
-                triangleTop = selectionMarkerOffset.top;
-            
-            $selectionTriangle.css("top", triangleTop);
-            $selectionTriangle.css("left", $sidebar.width() - $selectionTriangle.outerWidth());
-            toggleClass($selectionTriangle, "triangle-visible", showTriangle);
-                
-            var triangleClipOffsetYBy = Math.floor((selectionMarkerHeight - triangleHeight) / 2),
-                triangleBottom = triangleTop + triangleHeight + triangleClipOffsetYBy;
-            
-            if (triangleTop < scrollerTop || triangleBottom > scrollerBottom) {
-                $selectionTriangle.css("clip", "rect(" + Math.max(scrollerTop - triangleTop - triangleClipOffsetYBy, 0) + "px, auto, " +
-                                           (triangleHeight - Math.max(triangleBottom - scrollerBottom, 0)) + "px, auto)");
-            } else {
-                $selectionTriangle.css("clip", "");
-            }
-        };
         
         var hideSelectionMarker = function (event) {
-            $selectionTriangle.addClass("forced-hidden");
             $selectionMarker.addClass("forced-hidden");
         };
         
@@ -241,15 +210,9 @@ define(function (require, exports, module) {
             // find the selected list item
             var $listItem = $listElement.find(selectedClassName).closest("li");
             
-            if (leafClassName) {
-                showTriangle = $listItem.hasClass(leafClassName);
-            }
-
-            $selectionTriangle.removeClass("forced-hidden");
             $selectionMarker.removeClass("forced-hidden");
             
             // always hide selection visuals first to force layout (issue #719)
-            $selectionTriangle.hide();
             $selectionMarker.hide();
             
             if ($listItem.length === 1) {
@@ -263,9 +226,6 @@ define(function (require, exports, module) {
                 $selectionMarker.css("top", selectionMarkerTop);
                 $selectionMarker.show();
                 
-                updateSelectionTriangle();
-                $selectionTriangle.show();
-            
                 // fully scroll to the selectionMarker if it's not initially in the viewport
                 var scrollerElement = $scrollerElement.get(0),
                     scrollerHeight = scrollerElement.clientHeight,
@@ -285,15 +245,10 @@ define(function (require, exports, module) {
         };
         
         $listElement.on("selectionChanged", updateSelectionMarker);
-        $scrollerElement.on("scroll", updateSelectionTriangle);
-        $scrollerElement.on("selectionRedraw", updateSelectionTriangle);
         $scrollerElement.on("selectionHide", hideSelectionMarker);
         
         // update immediately
         updateSelectionMarker();
-        
-        // update clipping when the window resizes
-        _resizeHandlers.push(updateSelectionTriangle);
     }
     
     /**

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -934,7 +934,7 @@ define(function (require, exports, module) {
      */
     Pane.prototype.removeView = function (file, suppressOpenNextFile) {
         var nextFile = !suppressOpenNextFile && this.traverseViewListByMRU(1, file.fullPath);
-        if (nextFile && nextFile.fullPath !== file.fullPath && this.getCurrentlyViewedFile() === file) {
+        if (nextFile && nextFile.fullPath !== file.fullPath && this.getCurrentlyViewedPath() === file.fullPath) {
             var self = this,
                 fullPath = nextFile.fullPath,
                 needOpenNextFile = this.findInViewList(fullPath) !== -1;


### PR DESCRIPTION
Fixes #9035 
Fixes #9052 
@RaymondLim 

@larz0 take a look and see if there is anything you want to do about styling the selection bar.  Since there is no more arrow, the space where there is a scroll bar is empty.  If there is no scrollbar then the selection bar goes all the way to the edge.  To see this, open just one or two files in the working set then there won't be a scrollbar. Then split the view and open a bunch of files so that there is a scrollbar. 

It looks strange that in one view it goes to the edge and in the other it leaves room for the scrollbar.
