### PR TITLE
Removing cursor !important to allow themes easily override cursor colors

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -145,7 +145,7 @@
     // border: none !important;
 
     // to make an I-cursor, use something like this:
-    border-left: 1px solid black !important;
+    border-left: 1px solid black;
 
 }
 


### PR DESCRIPTION
So all themes that customize the cursor must have a !important in order to override the default cursor, because that has a !important.  So, let's remove the !important in the default cursor to reduce friction when authoring themes.
