### PR TITLE
Always Show the Statusbar

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -261,10 +261,10 @@ define(function (require, exports, module) {
         }
         
         if (!current) {
-            StatusBar.hide();
+            StatusBar.hideAllPanels();
         } else {
             var fullPath = current.document.file.fullPath;
-            StatusBar.show();
+            StatusBar.showAllPanels();
             
             $(current).on("cursorActivity.statusbar", _updateCursorInfo);
             $(current).on("optionChange.statusbar", function () {
@@ -397,8 +397,6 @@ define(function (require, exports, module) {
         });
 
         $statusOverwrite.on("click", _updateEditorOverwriteMode);
-        
-        _onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
     }
 
     // Initialize: status bar focused listener
@@ -409,5 +407,7 @@ define(function (require, exports, module) {
         // Populate language switcher with all languages after startup; update it later if this set changes
         _populateLanguageDropdown();
         $(LanguageManager).on("languageAdded languageModified", _populateLanguageDropdown);
+        _onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
+        StatusBar.show();
     });
 });

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -261,10 +261,10 @@ define(function (require, exports, module) {
         }
         
         if (!current) {
-            StatusBar.hideAllPanels();
+            StatusBar.hideAllPanes();
         } else {
             var fullPath = current.document.file.fullPath;
-            StatusBar.showAllPanels();
+            StatusBar.showAllPanes();
             
             $(current).on("cursorActivity.statusbar", _updateCursorInfo);
             $(current).on("optionChange.statusbar", function () {

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -207,7 +207,7 @@ define(function (require, exports, module) {
     /**
      * Hides all panels but not the status bar
      */
-    function hideAllPanels() {
+    function hideAllPanes() {
         hideInformation();
         hideIndicators();
     }
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
     /**
      * Shows all panels (will not show a hidden statusbar)
      */
-    function showAllPanels() {
+    function showAllPanes() {
         showInformation();
         showIndicators();
     }
@@ -273,8 +273,8 @@ define(function (require, exports, module) {
     exports.hideBusyIndicator = hideBusyIndicator;
     exports.hideIndicators    = hideIndicators;
     exports.showIndicators    = showIndicators;
-    exports.hideAllPanels     = hideAllPanels;
-    exports.showAllPanels     = showAllPanels;
+    exports.hideAllPanes      = hideAllPanes;
+    exports.showAllPanes      = showAllPanes;
     exports.addIndicator      = addIndicator;
     exports.updateIndicator   = updateIndicator;
     exports.hide              = hide;

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
     // These vars are initialized by the AppInit.htmlReady handler
     // below since they refer to DOM elements
     var $editorContainer,
+        $statusInfo,
         $statusBar,
         $indicators,
         $busyIndicator;
@@ -176,6 +177,52 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Hide the statusbar Information Panel
+     */
+    function hideInformation() {
+        $statusInfo.css("display", "none");
+    }
+    
+    /**
+     * Show the statusbar Information Panel
+     */
+    function showInformation() {
+        $statusInfo.css("display", "");
+    }
+    
+    /**
+     * Hide the statusbar Indicators
+     */
+    function hideIndicators() {
+        $indicators.css("display", "none");
+    }
+    
+    /**
+     * Show the statusbar Indicators
+     */
+    function showIndicators() {
+        $indicators.css("display", "");
+    }
+
+    
+    /**
+     * Hides all panels but not the status bar
+     */
+    function hideAllPanels() {
+        hideInformation();
+        hideIndicators();
+    }
+    
+    /**
+     * Shows all panels (will not show a hidden statusbar)
+     */
+    function showAllPanels() {
+        showInformation();
+        showIndicators();
+    }
+    
+    
+    /**
      * Hide the statusbar
      */
     function hide() {
@@ -213,6 +260,7 @@ define(function (require, exports, module) {
         $statusBar          = $("#status-bar");
         $indicators         = $("#status-indicators");
         $busyIndicator      = $("#status-bar .spinner");
+        $statusInfo         = $("#status-info");
 
         _init = true;
 
@@ -220,10 +268,16 @@ define(function (require, exports, module) {
         hide();
     });
 
+    exports.hideInformation   = hideInformation;
+    exports.showInformation   = showInformation;
     exports.showBusyIndicator = showBusyIndicator;
     exports.hideBusyIndicator = hideBusyIndicator;
-    exports.addIndicator = addIndicator;
-    exports.updateIndicator = updateIndicator;
-    exports.hide = hide;
-    exports.show = show;
+    exports.hideIndicators    = hideIndicators;
+    exports.showIndicators    = showIndicators;
+    exports.hideAllPanels     = hideAllPanels;
+    exports.showAllPanels     = showAllPanels;
+    exports.addIndicator      = addIndicator;
+    exports.updateIndicator   = updateIndicator;
+    exports.hide              = hide;
+    exports.show              = show;
 });

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -50,8 +50,7 @@ define(function (require, exports, module) {
     
     // These vars are initialized by the AppInit.htmlReady handler
     // below since they refer to DOM elements
-    var $editorContainer,
-        $statusInfo,
+    var $statusInfo,
         $statusBar,
         $indicators,
         $busyIndicator;


### PR DESCRIPTION
Keeps the status bar visible but hides the statusbar panes when a non-editor is focused.

CC: @larz0 
