### PR TITLE
Don't open next view during close all command

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -115,9 +115,7 @@ define(function (require, exports, module) {
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()
 
-    exports.CMD_ADD_TO_WORKING_SET       = "cmd.addToWorkingSet";        // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()
-    exports.CMD_OPEN                     = "cmd.open";
-    
+    exports.CMD_OPEN                        = "cmd.open";
     exports.CMD_ADD_TO_WORKINGSET_AND_OPEN  = "cmd.addToWorkingSetAndOpen";          // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()
     exports.CMD_WORKINGSET_SORT_BY_ADDED    = "cmd.sortWorkingSetByAdded";           // WorkingSetSort.js          _handleSort()
     exports.CMD_WORKINGSET_SORT_BY_NAME     = "cmd.sortWorkingSetByName";            // WorkingSetSort.js          _handleSort()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -115,8 +115,8 @@ define(function (require, exports, module) {
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()
 
-    exports.CMD_ADD_TO_WORKINGSET_AND_OPEN  = "cmd.addToWorkingSetAndOpen";          // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()
-    exports.CMD_OPEN                        = "cmd.open";
+    exports.CMD_ADD_TO_WORKING_SET       = "cmd.addToWorkingSet";        // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()
+    exports.CMD_OPEN                     = "cmd.open";
     
     exports.CMD_ADD_TO_WORKINGSET_AND_OPEN  = "cmd.addToWorkingSetAndOpen";          // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()
     exports.CMD_WORKINGSET_SORT_BY_ADDED    = "cmd.sortWorkingSetByAdded";           // WorkingSetSort.js          _handleSort()

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1666,7 +1666,7 @@ define(function (require, exports, module) {
     }
 
     // Deprecated commands
-    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKING_SET,         handleFileAddToWorkingSet);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.FILE_ADD_TO_WORKING_SET,        handleFileAddToWorkingSet);
     CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.FILE_OPEN,                      handleDocumentOpen);
     
     // New commands

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1666,12 +1666,12 @@ define(function (require, exports, module) {
     }
 
     // Deprecated commands
-    CommandManager.register(Strings.CMD_ADD_TO_WORKINGSET_AND_OPEN,  Commands.FILE_ADD_TO_WORKING_SET,        handleFileAddToWorkingSet);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKING_SET,         handleFileAddToWorkingSet);
     CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.FILE_OPEN,                      handleDocumentOpen);
     
     // New commands
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, handleFileAddToWorkingSetAndOpen);
     CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.CMD_OPEN,                       handleFileOpen);
-    CommandManager.register(Strings.CMD_ADD_TO_WORKINGSET_AND_OPEN,  Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, handleFileAddToWorkingSetAndOpen);
     
     // File Commands
     CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,           Commands.FILE_NEW_UNTITLED,              handleFileNew);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -278,14 +278,14 @@ define({
     /**
      * Command Name Constants
      */
-
+ 
     // File menu commands
     "FILE_MENU"                           : "File",
     "CMD_FILE_NEW_UNTITLED"               : "New",
     "CMD_FILE_NEW"                        : "New File",
     "CMD_FILE_NEW_FOLDER"                 : "New Folder",
     "CMD_FILE_OPEN"                       : "Open\u2026",
-    "CMD_ADD_TO_WORKINGSET_AND_OPEN"      : "Add To Working Set and Open",
+    "CMD_ADD_TO_WORKING_SET"              : "Open To Working Set",
     "CMD_OPEN_DROPPED_FILES"              : "Open Dropped Files",
     "CMD_OPEN_FOLDER"                     : "Open Folder\u2026",
     "CMD_FILE_CLOSE"                      : "Close",

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -1057,11 +1057,11 @@ define(function (require, exports, module) {
      */
     Pane.prototype.removeViews = function (list) {
         var self = this,
-            removeCurrentView = false,
+            needsDestroyCurrentView = false,
             result;
 
-        // Check to see if we need to remove the current view later
-        removeCurrentView = _.findIndex(list, function (file) {
+        // Check to see if we need to destroy the current view later
+        needsDestroyCurrentView = _.findIndex(list, function (file) {
             return file.fullPath === self.getCurrentlyViewedPath();
         });
 
@@ -1072,7 +1072,7 @@ define(function (require, exports, module) {
 
 
         // we may have been passed a list of files that did not include the current view
-        if (removeCurrentView) {
+        if (needsDestroyCurrentView) {
             // _doRemove will have whittled the MRU list down to just the remaining views 
             if (this._viewListMRUOrder.length) {
                 // Don't need to destroy the current view. 

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -1014,7 +1014,7 @@ define(function (require, exports, module) {
      * @param {boolean} suppressOpenNextFile - suppresses opening the next file in MRU order
      * @param {boolean} preventViewChange - if suppressOpenNextFile is truthy, this flag can be used to 
      *                                      prevent the current view from being destroyed. 
-     *                                      Ignred if suppressOpenNextFile is falsy 
+     *                                      Ignored if suppressOpenNextFile is falsy 
      * @return {boolean} true if the file was removed from the working set
      *  This function will remove a temporary view of a file but will return false in that case
      */

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -1014,7 +1014,7 @@ define(function (require, exports, module) {
      * @param {boolean} suppressOpenNextFile - suppresses opening the next file in MRU order
      * @param {boolean} preventViewChange - if suppressOpenNextFile is truthy, this flag can be used to 
      *                                      prevent the current view from being destroyed. 
-     *                                      Ignred if suppressOpenNextFile IS falsy 
+     *                                      Ignred if suppressOpenNextFile is falsy 
      * @return {boolean} true if the file was removed from the working set
      *  This function will remove a temporary view of a file but will return false in that case
      */

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -1029,12 +1029,8 @@ define(function (require, exports, module) {
                 if (needOpenNextFile) {
                     this._execOpenFile(fullPath)
                         .fail(function () {
-                            // the FILE_OPEN op failed so
-                            //  we need to cleanup by hiding and destroying the current view
-                            self._hideCurrentView();
-                            var view = self._views[file.fullPath];
-                            delete self._views[file.fullPath];
-                            view.destroy();
+                            // the FILE_OPEN op failed so destroy the current view
+                            self._doDestroyView(self._currentView);
                         });
                 }
                 return true;
@@ -1078,10 +1074,14 @@ define(function (require, exports, module) {
                 // Don't need to destroy the current view. 
                 // It was marked for destroy so it's now a temporary view
                 //  and will get destroyed when the FILE_OPEN command opens the new view
-                this._execOpenFile(this._viewListMRUOrder[0].fullPath);
+                this._execOpenFile(this._viewListMRUOrder[0].fullPath)
+                    .fail(function () {
+                        // the FILE_OPEN op failed so destroy the current view
+                        self._doDestroyView(self._currentView);
+                    });
             } else {
-                // Nothing left to show.
-                this._doDestroyView(self._currentView);
+                // Nothing left to show so destroy the current view
+                this._doDestroyView(this._currentView);
             }
         }
         

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -673,7 +673,7 @@ define(function (require, exports, module) {
                     waitsForDone(promise, "CMD_ADD_TO_WORKINGSET_AND_OPEN");
                 });
             });
-            it("should should not close the current view", function () {
+            it("should not close the current view", function () {
                 var currentPath,
                     docsToClose;
                 runs(function () {
@@ -690,7 +690,7 @@ define(function (require, exports, module) {
                     expect(MainViewManager.getCurrentlyViewedPath()).toBe(currentPath);
                 });
             });
-            it("should should close all views", function () {
+            it("should close all views", function () {
                 var docsToClose;
                 runs(function () {
                     docsToClose = DocumentManager.getAllOpenDocuments();
@@ -703,7 +703,7 @@ define(function (require, exports, module) {
                     expect(MainViewManager.getCurrentlyViewedFile()).toBeFalsy();
                 });
             });
-            it("should should open the next view when the current view is closed", function () {
+            it("should open the next view when the current view is closed", function () {
                 var currentPath,
                     docsToClose;
                 runs(function () {

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -661,6 +661,67 @@ define(function (require, exports, module) {
                 });
             });
         });
+        
+        describe("Close List", function () {
+            beforeEach(function () {
+                runs(function () {
+                    promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, {fullPath: testPath + "/test.js"});
+                    waitsForDone(promise, "CMD_ADD_TO_WORKINGSET_AND_OPEN");
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, {fullPath: testPath + "/test2.js"});
+                    waitsForDone(promise, "CMD_ADD_TO_WORKINGSET_AND_OPEN");
+                });
+            });
+            it("should should not close the current view", function () {
+                var currentPath,
+                    docsToClose;
+                runs(function () {
+                    currentPath = MainViewManager.getCurrentlyViewedPath();
+                    docsToClose = DocumentManager.getAllOpenDocuments().filter(function (doc) {
+                        return (doc !== DocumentManager.getCurrentDocument());
+                    });
+                    promise = CommandManager.execute(Commands.FILE_CLOSE_LIST, {fileList: docsToClose.map(function (doc) {
+                        return doc.file;
+                    })});
+                    waitsForDone(promise, "FILE_CLOSE_LIST");
+                });
+                runs(function () {
+                    expect(MainViewManager.getCurrentlyViewedPath()).toBe(currentPath);
+                });
+            });
+            it("should should close all views", function () {
+                var docsToClose;
+                runs(function () {
+                    docsToClose = DocumentManager.getAllOpenDocuments();
+                    promise = CommandManager.execute(Commands.FILE_CLOSE_LIST, {fileList: docsToClose.map(function (doc) {
+                        return doc.file;
+                    })});
+                    waitsForDone(promise, "FILE_CLOSE_LIST");
+                });
+                runs(function () {
+                    expect(MainViewManager.getCurrentlyViewedFile()).toBeFalsy();
+                });
+            });
+            it("should should open the next view when the current view is closed", function () {
+                var currentPath,
+                    docsToClose;
+                runs(function () {
+                    currentPath = MainViewManager.getCurrentlyViewedPath();
+                    docsToClose = DocumentManager.getAllOpenDocuments().filter(function (doc) {
+                        return (doc === DocumentManager.getCurrentDocument());
+                    });
+                    promise = CommandManager.execute(Commands.FILE_CLOSE_LIST, {fileList: docsToClose.map(function (doc) {
+                        return doc.file;
+                    })});
+                    waitsForDone(promise, "FILE_CLOSE_LIST");
+                });
+                runs(function () {
+                    expect(MainViewManager.getCurrentlyViewedPath()).not.toBe(currentPath);
+                    expect(MainViewManager.getCurrentlyViewedPath()).toBeTruthy();
+                });
+            });
+        });
 
         describe("Open File", function () {
             it("should open a file in the editor", function () {
@@ -1105,96 +1166,6 @@ define(function (require, exports, module) {
             });
         });
 
-        
-/* 
-    TODO: Disabled until image support is added for splitview
-    
-        describe("Opens image file and validates EditorManager APIs", function () {
-            it("should return null after opening an image", function () {
-                var path = testPath + "/couz.png",
-                    promise;
-                runs(function () {
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: path });
-                    waitsForDone(promise, Commands.FILE_OPEN);
-                });
-
-                runs(function () {
-                    expect(EditorManager.getActiveEditor()).toEqual(null);
-                    expect(EditorManager.getCurrentFullEditor()).toEqual(null);
-                    expect(EditorManager.getFocusedEditor()).toEqual(null);
-                    expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE)).toEqual(path);
-                    var d = DocumentManager.getCurrentDocument();
-                    expect(d).toEqual(null);
-                });
-            });
-        });
-        
-        describe("Open image file while a text file is open", function () {
-            it("should fire currentDocumentChange and activeEditorChange events", function () {
-                var promise,
-                    docChangeListener = jasmine.createSpy(),
-                    activeEditorChangeListener = jasmine.createSpy();
-
-                runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
-                    
-                    
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/test.js" });
-                    waitsForDone(promise, Commands.FILE_OPEN);
-                });
-                runs(function () {
-                    expect(docChangeListener.callCount).toBe(1);
-                    expect(activeEditorChangeListener.callCount).toBe(1);
-                });
-                
-                runs(function () {
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/couz.png" });
-                    waitsForDone(promise, Commands.FILE_OPEN);
-                });
-                runs(function () {
-                    expect(docChangeListener.callCount).toBe(2);
-                    expect(activeEditorChangeListener.callCount).toBe(2);
-                    _$(DocumentManager).off("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).off("activeEditorChange", activeEditorChangeListener);
-                });
-            });
-        });
-        
-        describe("Open image file while neither text editor nor image file is open", function () {
-            it("should NOT fire currentDocumentChange and activeEditorChange events", function () {
-
-                var promise,
-                    docChangeListener = jasmine.createSpy(),
-                    activeEditorChangeListener = jasmine.createSpy();
-
-
-                runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
-                    
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/couz.png" });
-                    waitsForDone(promise, Commands.FILE_OPEN);
-                });
-                runs(function () {
-                    expect(docChangeListener.callCount).toBe(0);
-                    expect(activeEditorChangeListener.callCount).toBe(0);
-                });
-                
-                runs(function () {
-                    promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/couz2.png" });
-                    waitsForDone(promise, Commands.FILE_OPEN);
-                });
-                runs(function () {
-                    expect(docChangeListener.callCount).toBe(0);
-                    expect(activeEditorChangeListener.callCount).toBe(0);
-                    _$(DocumentManager).off("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).off("activeEditorChange", activeEditorChangeListener);
-                });
-    
-            });
-        });
-*/
         describe("Open a text file while a text file is open", function () {
             it("should fire currentDocumentChange and activeEditorChange events", function () {
 


### PR DESCRIPTION
Fixes #9087

The fix is a little more complex than just suppressing the open next command because the api allows for any arbitrary list of files to be passed in to it so we need to do something special if the current file is closed.
