### PR TITLE
Remove all Path Filtering from Drag and Drop

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -337,15 +337,14 @@ define(function (require, exports, module) {
                     if (paths.length > 0) {
                         // Add all files to the workingset without verifying that
                         // they still exist on disk (for faster opening)
-                        var filesToOpen = [],
-                            filteredPaths = DragAndDrop.filterFilesToOpen(paths);
+                        var filesToOpen = [];
                         
-                        filteredPaths.forEach(function (file) {
-                            filesToOpen.push(FileSystem.getFileForPath(file));
+                        paths.forEach(function (path) {
+                            filesToOpen.push(FileSystem.getFileForPath(path));
                         });
                         MainViewManager.addListToWorkingSet(paneId, filesToOpen);
                         
-                        _doOpen(filteredPaths[filteredPaths.length - 1], silent, paneId)
+                        _doOpen(paths[paths.length - 1], silent, paneId)
                             .done(function (file) {
                                 _defaultOpenDialogFullPath =
                                     FileUtils.getDirectoryPath(

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -51,7 +51,6 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         PopUpManager        = require("widgets/PopUpManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
-        DragAndDrop         = require("utils/DragAndDrop"),
         PerfUtils           = require("utils/PerfUtils"),
         KeyEvent            = require("utils/KeyEvent"),
         LanguageManager     = require("language/LanguageManager"),

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -28,36 +28,20 @@
 define(function (require, exports, module) {
     "use strict";
    
-    var Async           = require("utils/Async"),
-        CommandManager  = require("command/CommandManager"),
-        Commands        = require("command/Commands"),
-        Dialogs         = require("widgets/Dialogs"),
-        DefaultDialogs  = require("widgets/DefaultDialogs"),
-        MainViewManager = require("view/MainViewManager"),
-        MainViewFactory = require("view/MainViewFactory"),
-        LanguageManager = require("language/LanguageManager"),
-        FileSystem      = require("filesystem/FileSystem"),
-        EditorManager   = require("editor/EditorManager"),
-        FileUtils       = require("file/FileUtils"),
-        ProjectManager  = require("project/ProjectManager"),
-        Strings         = require("strings"),
-        StringUtils     = require("utils/StringUtils");
-    
-    /**
-     * Return an array of files excluding all files without a registered viewer. 
-     *
-     * @param {Array.<string>} paths - filenames to filter before opening.
-     * @return {Array.<string>} paths which can actually be opened (may be empty)
-     */
-    function filterFilesToOpen(paths) {
-        // Filter out file in which we have no registered viewer
-        var filteredFiles = paths.filter(function (fullPath) {
-            return !LanguageManager.getLanguageForPath(fullPath).isBinary() ||
-                MainViewFactory.findSuitableFactoryForPath(fullPath);
-        });
-        
-        return filteredFiles;
-    }
+    var Async               = require("utils/Async"),
+        CommandManager      = require("command/CommandManager"),
+        Commands            = require("command/Commands"),
+        Dialogs             = require("widgets/Dialogs"),
+        DefaultDialogs      = require("widgets/DefaultDialogs"),
+        MainViewManager     = require("view/MainViewManager"),
+        MainViewFactory     = require("view/MainViewFactory"),
+        LanguageManager     = require("language/LanguageManager"),
+        FileSystem          = require("filesystem/FileSystem"),
+        EditorManager       = require("editor/EditorManager"),
+        FileUtils           = require("file/FileUtils"),
+        ProjectManager      = require("project/ProjectManager"),
+        Strings             = require("strings"),
+        StringUtils         = require("utils/StringUtils");
     
     /**
      * Returns true if the drag and drop items contains valid drop objects.
@@ -91,11 +75,10 @@ define(function (require, exports, module) {
      * @return {Promise} Promise that is resolved if all files are opened, or rejected
      *     if there was an error. 
      */
-    function openDroppedFiles(files) {
-        var errorFiles = [],
-            filteredFiles = filterFilesToOpen(files);
+    function openDroppedFiles(paths) {
+        var errorFiles = [];
         
-        return Async.doInParallel(filteredFiles, function (path, idx) {
+        return Async.doInParallel(paths, function (path, idx) {
             var result = new $.Deferred();
             
             // Only open files.
@@ -104,7 +87,7 @@ define(function (require, exports, module) {
                     // If the file is already open, and this isn't the last
                     // file in the list, return. If this *is* the last file,
                     // always open it so it gets selected.
-                    if (idx < filteredFiles.length - 1) {
+                    if (idx < paths.length - 1) {
                         if (MainViewManager.findInWorkingSet(MainViewManager.ALL_PANES, path) !== -1) {
                             result.resolve();
                             return;
@@ -120,7 +103,7 @@ define(function (require, exports, module) {
                             errorFiles.push(path);
                             result.reject();
                         });
-                } else if (!err && item.isDirectory && filteredFiles.length === 1) {
+                } else if (!err && item.isDirectory && paths.length === 1) {
                     // One folder was dropped, open it.
                     ProjectManager.openProject(path)
                         .done(function () {
@@ -164,5 +147,4 @@ define(function (require, exports, module) {
     // Export public API
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
-    exports.filterFilesToOpen   = filterFilesToOpen;
 });


### PR DESCRIPTION
Fixes #9096 

@peterflynn -- This was done intentionally because we didn't throw error messages when dragging images onto brackets. We just silently bailed. It seemed to make sense that we wouldn't throw an error for files that can't be opened.  

I wonder if we some drag and drop tests to our smoke test script?
