### PR TITLE
Do not invoke rename when CMD+clicking on a recently clicked file

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -688,7 +688,10 @@ define(function (require, exports, module) {
                     }
                 }
             ).bind("mouseup.jstree", function (event) {
-                if (event.button !== 0) { // 0 = Left mouse button
+
+                // 0 = Left mouse button
+                // ctrlKey pressed indicates right click (context menu) requested instead
+                if (event.button !== 0 || event.ctrlKey) {
                     return;
                 }
 


### PR DESCRIPTION
This commit resolves issue #9095.
