### PR TITLE
Fix bug #3963 (Home/End goes to start/end of entire line, not just current line-wrapped segment)

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -263,8 +263,8 @@ define(function (require, exports, module) {
                     self.removeAllInlineWidgets();
                 }
             },
-            "Home":     "goLineLeftSmart",
-            "Cmd-Left": "goLineLeftSmart",
+            "Home":      "goLineLeftSmart",
+            "Cmd-Left":  "goLineLeftSmart",
             "End":       "goLineRight",
             "Cmd-Right": "goLineRight"
         };

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -263,7 +263,10 @@ define(function (require, exports, module) {
                     self.removeAllInlineWidgets();
                 }
             },
-            "Cmd-Left": "goLineStartSmart"
+            "Home":     "goLineLeftSmart",
+            "Cmd-Left": "goLineLeftSmart",
+            "End":       "goLineRight",
+            "Cmd-Right": "goLineRight"
         };
         
         var currentOptions = this._currentOptions = _.zipObject(


### PR DESCRIPTION
Fix bug #3963 -- For Home, use new CodeMirror command that joins "goLineLeft" (line-wrap aware Home) with the "smart home" indent-aware behavior we still want.  See discussion here: https://github.com/marijnh/CodeMirror/issues/1544#issuecomment-49494252.
