### PR TITLE
Fix bug #8882 (Background flickers when opening themes dropdown)

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1844,12 +1844,20 @@ select {
     &:active {
         background-color: @bc-btn-bg-down;
         box-shadow: inset 0 1px 0 @bc-shadow-small;
-    }
-
-    > option { // This works on windows.
+        
         .dark & {
-            background: @dark-bc-menu-bg !important;
-            color: @dark-bc-menu-text !important;
+            background-color: @dark-bc-btn-bg-down;
+            box-shadow: inset 0 1px 0 @dark-bc-shadow-small;
+        }
+    }
+    
+    > option { // Windows (but not Mac) lets you style the dropdown items
+        background-color: @bc-menu-bg;
+        color: @bc-menu-text;
+
+        .dark & {
+            background: @dark-bc-menu-bg;
+            color: @dark-bc-menu-text;
         }
     }
 


### PR DESCRIPTION
Fix bug #8882 -- Ensure the `select:active > option` colors exactly match the `select > option` colors by explicitly specifying `> option` colors instead of letting them
be quasi-inherited from the parent `select`.  (Removed unneeded `!important` in the process).

Also, add a mousedown (`select:active`) state for dark mode similar to the one in light mode, based on how other dark mode buttons are styled.
