### PR TITLE
Don't MVM.updateLayout() until we're ready

### DIFF
--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1507,12 +1507,13 @@ define(function (require, exports, module) {
      */
     AppInit.htmlReady(function () {
         _initialize($("#editor-holder"));
+        // Ingnore workspace manager events until we're initialized
+        $(WorkspaceManager).on("workspaceUpdateLayout", _updateLayout);
     });
     
     // Event handlers
     $(ProjectManager).on("projectOpen",                       _loadViewState);
     $(ProjectManager).on("beforeProjectClose beforeAppClose", _saveViewState);
-    $(WorkspaceManager).on("workspaceUpdateLayout",           _updateLayout);
     $(EditorManager).on("activeEditorChange",                 _activeEditorChange);
     $(DocumentManager).on("pathDeleted",                      _removeDeletedFileFromMRU);
     


### PR DESCRIPTION
MVM.updateLayout was getting called before its htmlInit handler was run. This was due to the statusbar's htmlInit handler running first which triggered a workspace updatelayout which then triggered an MVM updatelayout before MVM was initialized.

Fixes #9114 
@ingorichter 
