### PR TITLE
Restore scroll position after Quick Open

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -512,7 +512,7 @@ define(function (require, exports, module) {
         // So we wait until after this call chain is complete before actually closing the dialog.
         var self = this;
         setTimeout(function () {
-            self.modalBar.close(scrollPos).done(function () {
+            self.modalBar.close(!!scrollPos).done(function () {
                 self._closeDeferred.resolve();
             });
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -512,7 +512,7 @@ define(function (require, exports, module) {
         // So we wait until after this call chain is complete before actually closing the dialog.
         var self = this;
         setTimeout(function () {
-            self.modalBar.close(!scrollPos).done(function () {
+            self.modalBar.close(scrollPos).done(function () {
                 self._closeDeferred.resolve();
             });
 


### PR DESCRIPTION
This is for #9037 

This seems to be caused by a typo in [this commit](https://github.com/adobe/brackets/commit/ca59748b95aeef3c5e9f6e646f0020f6021af276).

cc @peterflynn @JeffryBooher 
