### PR TITLE
Show splitview icons in the sidebar popup menu

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -204,16 +204,14 @@ define(function (require, exports, module) {
             menu.addMenuItem(Commands.HELP_ABOUT);
         }
         
+        
         /*
-         * WorkingSet context and gear menus
-         * NOTE: Unlike most context menus defined here, these menus cannot
-         *       be setup to listen to click or context menu events when 
-         *       this module intializes because the DOM nodes for these are 
-         *       created by pane views which are created at runtime. 
-         *       All other context menus have DOM elements to attach to
-         *       out of index.html
+         * Context Menus
          */
-
+        
+        // WorkingSet context menu - Unlike most context menus, we can't attach
+        // listeners here because the DOM nodes for each pane's working set are
+        // created dynamically. Each WorkingSetView attaches its own listeners.
         var workingset_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU);
         workingset_cmenu.addMenuItem(Commands.FILE_SAVE);
         workingset_cmenu.addMenuItem(Commands.FILE_SAVE_AS);
@@ -238,9 +236,6 @@ define(function (require, exports, module) {
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_VERTICAL);
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_HORIZONTAL);
         
-        /*
-         * Context Menus
-         */
         var project_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.PROJECT_MENU);
         project_cmenu.addMenuItem(Commands.FILE_NEW);
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -63,9 +63,6 @@ define(function (require, exports, module) {
         _cmdSplitVertical,
         _cmdSplitHorizontal;
     
-    var SPRITE_BASE   =  5,
-        SPRITE_OFFSET = 21;
-    
     /**
      * @private
      * Update project title when the project root changes
@@ -136,6 +133,7 @@ define(function (require, exports, module) {
      */
     function _updateUIStates() {
         var ypos, spriteIndex,
+            ICON_CLASSES = ["splitview-icon-none", "splitview-icon-vertical", "splitview-icon-horizontal"],
             layoutScheme = MainViewManager.getLayoutScheme();
 
         if (layoutScheme.columns > 1) {
@@ -147,8 +145,8 @@ define(function (require, exports, module) {
         }
         
         // SplitView Icon
-        ypos  = SPRITE_BASE - (spriteIndex * SPRITE_OFFSET);
-        $splitViewMenu.css("background-position-y", ypos);
+        $splitViewMenu.removeClass(ICON_CLASSES.join(" "))
+                      .addClass(ICON_CLASSES[spriteIndex]);
 
         // SplitView Menu
         _cmdSplitNone.setChecked(spriteIndex === 0);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
      * @private
      */
     function _updateUIStates() {
-        var ypos, spriteIndex,
+        var spriteIndex,
             ICON_CLASSES = ["splitview-icon-none", "splitview-icon-vertical", "splitview-icon-horizontal"],
             layoutScheme = MainViewManager.getLayoutScheme();
 

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -34,8 +34,7 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var AppInit               = require("utils/AppInit"),
-        DocumentManager       = require("document/DocumentManager"),
+    var DocumentManager       = require("document/DocumentManager"),
         MainViewManager       = require("view/MainViewManager"),
         CommandManager        = require("command/CommandManager"),
         Commands              = require("command/Commands"),
@@ -54,13 +53,6 @@ define(function (require, exports, module) {
      * 
      */
     var _views = [];
-    
-    /**
-     * Context Menu
-     * @private
-     * @type {Menu}
-     */
-    var _workingset_cmenu;
     
     /**
      * Constants for event.which values
@@ -784,7 +776,7 @@ define(function (require, exports, module) {
         this.$openFilesContainer.css("overflow-x", "hidden");
         
         this.$openFilesContainer.on("contextmenu.workingSetView", function (e) {
-            _workingset_cmenu.open(e);
+            Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU).open(e);
         });
 
         this._redraw();
@@ -852,9 +844,6 @@ define(function (require, exports, module) {
         });
     }
     
-    AppInit.appReady(function () {
-        _workingset_cmenu = Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU);
-    });
     
     // Public API
     exports.createWorkingSetViewForPane   = createWorkingSetViewForPane;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -729,13 +729,13 @@ a, img {
     z-index: 1;
 }
 .splitview-icon-none {
-    background-position: center 2px;
+    background-position: center 1px;
 }
 .splitview-icon-vertical {
-    background-position: center -19px;
+    background-position: center -20px;
 }
 .splitview-icon-horizontal {
-    background-position: center -40px;
+    background-position: center -41px;
 }
 
 // Show splitview icons on the button's dropdown menu too
@@ -744,6 +744,7 @@ a, img {
         display: inline-block;
         .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
         margin: 0 5px 0 -1px;
+        vertical-align: -2px;
     }
     &:nth-child(1) .menu-name::before {
         .splitview-icon-none();

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -724,9 +724,36 @@ a, img {
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
-    background-position: center 5px;
-    z-index: 1;
+    background-origin: content-box;  // center image within the 13x13 area - ignore button's padding
     -webkit-filter: drop-shadow(0 1px 0 rgba(0,0,0,0.36));
+    z-index: 1;
+}
+.splitview-icon-none {
+    background-position: center 2px;
+}
+.splitview-icon-vertical {
+    background-position: center -19px;
+}
+.splitview-icon-horizontal {
+    background-position: center -40px;
+}
+
+// Show splitview icons on the button's dropdown menu too
+#splitview-menu ul.dropdown-menu > li {
+    .menu-name::before {
+        display: inline-block;
+        .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
+        margin: 0 5px 0 -1px;
+    }
+    &:nth-child(1) .menu-name::before {
+        .splitview-icon-none();
+    }
+    &:nth-child(2) .menu-name::before {
+        .splitview-icon-vertical();
+    }
+    &:nth-child(3) .menu-name::before {
+        .splitview-icon-horizontal();
+    }
 }
 
 #sidebar {


### PR DESCRIPTION
@larz0 what do you think of this UI tweak?  Showing splitview icons in the sidebar popup menu helps reinforce their meaning, and also disambiguates the terms "horizontal" & "vertical" (i.e. does "horizontal" mean two panes arranged horizontally, or two panes arranged in a vertical stack with a horizontal divide running between them?)

And a few small technical cleanups in here:
(the first is directly related to the menu icons; the others are side things I just happened to hit upon while working on this)
- Don't programmatically compute spritesheet offset in SidebarView.js, and avoid using `background-position-y` (which apparently is not W3C and isn't supported in Firefox)
- Remove unneeded `appReady()` listener in WorkingSetView (also fwiw, it could have been just `htmlReady()`)
- Fix out of date comments in DefaultMenus
