### PR TITLE
Add class to #editor-holder for split orientation

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -486,15 +486,9 @@ a, img {
             display: block;
         }
     }
-    #second-pane {
-        border-left: 1px solid @bc-panel-border;
-        .dark & {
-            border-left: 1px solid @dark-bc-highlight-hard;
-        }
-    }
     .pane-header {
         box-sizing: border-box;
-        border-bottom:  1px solid @bc-shadow-small;
+        border-bottom:  1px solid rgba(0, 0, 0, 0.03);
         padding: 5px 10px;
         color: @bc-text-quiet;
         background-color: @background;
@@ -502,7 +496,7 @@ a, img {
         .dark & {
             color: @dark-bc-text-quiet;
             background-color: #1d1f21; // not using a variable on purpose.
-            border-bottom-color: @dark-bc-highlight;
+            border-bottom-color: rgba(255, 255, 255, 0.03);
         }
     }
     .active-pane {
@@ -516,6 +510,20 @@ a, img {
     }
 }
 
+// Split View Separator Styles
+.split-vertical #second-pane {
+    border-left: 1px solid @bc-panel-border;
+    .dark & {
+        border-left: 1px solid @dark-bc-highlight-hard;
+    }
+}
+
+.split-horizontal #second-pane {
+    border-top: 1px solid @bc-panel-border;
+    .dark & {
+        border-top: 1px solid @dark-bc-highlight-hard;
+    }
+}
 
 .vert-resizer {
     position: absolute;

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1011,6 +1011,11 @@ define(function (require, exports, module) {
         var firstPane = _panes[FIRST_PANE];
         Resizer.removeSizable(firstPane.$el);
 
+        if (_orientation) {
+            _$el.removeClass("split-" + _orientation.toLowerCase());
+        }
+        _$el.addClass("split-" + orientation.toLowerCase());
+        
         _orientation = orientation;
         _createPaneIfNecessary(SECOND_PANE);
         _makeFirstPaneResizable();
@@ -1162,6 +1167,7 @@ define(function (require, exports, module) {
                 }
             });
             
+            _$el.removeClass("split-" + _orientation.toLowerCase());
             _orientation = null;
             // this will set the remaining pane to 100%
             _initialLayout();
@@ -1365,6 +1371,7 @@ define(function (require, exports, module) {
                 }
                 
                 if (_orientation) {
+                    _$el.addClass("split-" + _orientation.toLowerCase());
                     $(exports).triggerHandler("paneLayoutChange", _orientation);
                 }
 


### PR DESCRIPTION
For #9146

@larz0 you can play with this branch

classes are:
"split-vertical"
"split-horizontal"

No class when there is only one pane

@redmunds can merge it if he likes it
