### PR TITLE
Change CodeInspection Public API to expose providers

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -165,6 +165,15 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Returns a list of providers
+     *
+     * @return {{languageId:string, Array.<{name:string, scanFileAsync:?function(string, string):!{$.Promise}, scanFile:?function(string, string):Object}>}} providers
+     */
+    function getProviders() {
+        return _providers;
+    }
+
+    /**
      * Runs a file inspection over passed file. Uses the given list of providers if specified, otherwise uses
      * the set of providers that are registered for the file's language.
      * This method doesn't update the Brackets UI, just provides inspection results.
@@ -469,6 +478,27 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Deregisters a provider, given a languageId and the provider.
+     * Allows code to remove providers which provide the same functionality
+     * as the code provides
+     *
+     * @param {string} languageId
+     * @param {{name:string, scanFileAsync:?function(string, string):!{$.Promise},
+     *         scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}} provider
+     *
+     * Returns false if no provider was removed.
+     */
+    function deregister(languageId, provider) {
+        if (_providers[languageId]) {
+            _.remove(_providers[languageId], function (registeredProvider) {
+                return registeredProvider.name === provider.name;
+            });
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Update DocumentManager listeners.
      */
     function updateListeners() {
@@ -643,9 +673,12 @@ define(function (require, exports, module) {
     exports._PREF_ASYNC_TIMEOUT     = PREF_ASYNC_TIMEOUT;
 
     // Public API
-    exports.register       = register;
-    exports.Type           = Type;
-    exports.toggleEnabled  = toggleEnabled;
-    exports.inspectFile    = inspectFile;
-    exports.requestRun     = run;
+    exports.register            = register;
+    exports.deregister          = deregister;
+    exports.Type                = Type;
+    exports.toggleEnabled       = toggleEnabled;
+    exports.inspectFile         = inspectFile;
+    exports.requestRun          = run;
+    exports.getProvidersForPath = getProvidersForPath;
+    exports.getProviders        = getProviders;
 });

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -165,15 +165,6 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Returns a list of providers
-     *
-     * @return {{languageId:string, Array.<{name:string, scanFileAsync:?function(string, string):!{$.Promise}, scanFile:?function(string, string):Object}>}} providers
-     */
-    function getProviders() {
-        return _providers;
-    }
-
-    /**
      * Runs a file inspection over passed file. Uses the given list of providers if specified, otherwise uses
      * the set of providers that are registered for the file's language.
      * This method doesn't update the Brackets UI, just provides inspection results.
@@ -486,16 +477,19 @@ define(function (require, exports, module) {
      * @param {{name:string, scanFileAsync:?function(string, string):!{$.Promise},
      *         scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}} provider
      *
-     * Returns false if no provider was removed.
+     * @return {boolean} Returns true if at least one provider was removed.
      */
-    function deregister(languageId, provider) {
+    function unregister(languageId, providerName) {
+        var isRemoved = false;
         if (_providers[languageId]) {
             _.remove(_providers[languageId], function (registeredProvider) {
-                return registeredProvider.name === provider.name;
+                if (registeredProvider.name === providerName) {
+                    isRemoved = true;
+                    return true;
+                }
             });
-        } else {
-            return false;
         }
+        return isRemoved;
     }
 
     /**
@@ -674,11 +668,10 @@ define(function (require, exports, module) {
 
     // Public API
     exports.register            = register;
-    exports.deregister          = deregister;
+    exports.unregister          = unregister;
     exports.Type                = Type;
     exports.toggleEnabled       = toggleEnabled;
     exports.inspectFile         = inspectFile;
     exports.requestRun          = run;
     exports.getProvidersForPath = getProvidersForPath;
-    exports.getProviders        = getProviders;
 });

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
      * @return ?{Array.<{name:string, scanFileAsync:?function(string, string):!{$.Promise}, scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}>} provider
      */
     function getProvidersForPath(filePath) {
-        return _providers[LanguageManager.getLanguageForPath(filePath).getId()] || [];
+        return _providers[LanguageManager.getLanguageForPath(filePath).getId()].slice(0) || [];
     }
 
     /**

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -469,30 +469,6 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Deregisters a provider, given a languageId and the provider.
-     * Allows code to remove providers which provide the same functionality
-     * as the code provides
-     *
-     * @param {string} languageId
-     * @param {{name:string, scanFileAsync:?function(string, string):!{$.Promise},
-     *         scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}} provider
-     *
-     * @return {boolean} Returns true if at least one provider was removed.
-     */
-    function unregister(languageId, providerName) {
-        var isRemoved = false;
-        if (_providers[languageId]) {
-            _.remove(_providers[languageId], function (registeredProvider) {
-                if (registeredProvider.name === providerName) {
-                    isRemoved = true;
-                    return true;
-                }
-            });
-        }
-        return isRemoved;
-    }
-
-    /**
      * Update DocumentManager listeners.
      */
     function updateListeners() {
@@ -668,7 +644,6 @@ define(function (require, exports, module) {
 
     // Public API
     exports.register            = register;
-    exports.unregister          = unregister;
     exports.Type                = Type;
     exports.toggleEnabled       = toggleEnabled;
     exports.inspectFile         = inspectFile;

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
      * @return ?{Array.<{name:string, scanFileAsync:?function(string, string):!{$.Promise}, scanFile:?function(string, string):?{errors:!Array, aborted:boolean}}>} provider
      */
     function getProvidersForPath(filePath) {
-        return _providers[LanguageManager.getLanguageForPath(filePath).getId()];
+        return _providers[LanguageManager.getLanguageForPath(filePath).getId()] || [];
     }
 
     /**

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -167,6 +167,19 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should get the correct linter given a file path", function () {
+                var codeInspector1 = createCodeInspector("text linter 1", successfulLintResult());
+                var codeInspector2 = createCodeInspector("text linter 2", successfulLintResult());
+
+                CodeInspection.register("javascript", codeInspector1);
+                CodeInspection.register("javascript", codeInspector2);
+
+                var providers = CodeInspection.getProvidersForPath("test.js");
+                expect(providers.length).toBe(2);
+                expect(providers[0]).toBe(codeInspector1);
+                expect(providers[1]).toBe(codeInspector2);
+            });
+
             it("should run two linters", function () {
                 var codeInspector1 = createCodeInspector("text linter 1", successfulLintResult());
                 var codeInspector2 = createCodeInspector("text linter 2", successfulLintResult());

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
             });
 
             it("should return an empty array if no providers are registered", function () {
-               expect(CodeInspection.getProvidersForPath("test.js").length).toBe(0);
+                expect(CodeInspection.getProvidersForPath("test.js").length).toBe(0);
             });
 
             it("should run two linters", function () {

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -180,6 +180,10 @@ define(function (require, exports, module) {
                 expect(providers[1]).toBe(codeInspector2);
             });
 
+            it("should return an empty array if no providers are registered", function () {
+               expect(CodeInspection.getProvidersForPath("test.js").length).toBe(0);
+            });
+
             it("should run two linters", function () {
                 var codeInspector1 = createCodeInspector("text linter 1", successfulLintResult());
                 var codeInspector2 = createCodeInspector("text linter 2", successfulLintResult());


### PR DESCRIPTION
- Changes getProvidersForPath to be public - allows extensions to query providers for custom linting.
- Adds getProviders to allow extensions to get all providers.
- Adds deregister to allow extensions to remove a provider when the extension provides a provider with the same functionality.

Although this changes the public API, it does not change any existing methods - it just expands upon them. For this reason, I think that this should not produce any backwards compatibility issues.

Some discussion on this topic has been done here: MiguelCastillo/Brackets-InteractiveLinter#44.

/cc @MiguelCastillo
