### PR TITLE
Add encodeFilePath to FileUtils to convert file paths into encoded strings (replace metacharacters such as %, @, $, #, etc.)

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
      */
     function ImageView(file, $container) {
         this.file = file;
-        this.$el = $(Mustache.render(ImageViewTemplate, {fullPath: file.fullPath,
+        this.$el = $(Mustache.render(ImageViewTemplate, {fullPath: FileUtils.encodeFilePath(file.fullPath),
                                                          now: new Date().valueOf()}));
         
         $container.append(this.$el);

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -521,6 +521,19 @@ define(function (require, exports, module) {
         return 0;
     }
 
+    /**
+     * @param {string} path Native path in the format used by FileSystemEntry.fullPath
+     * @return {string} URI-encoded version suitable for appending to 'file:///`. It's not safe to use encodeURI()
+     *     directly since it doesn't escape chars like "#".
+     */
+    function encodeFilePath(path) {
+        var pathArray = path.split("/");
+        pathArray = pathArray.map(function (subPath) {
+            return encodeURIComponent(subPath);
+        });
+        return pathArray.join("/");
+    }
+
     // Asynchronously loading Dialogs to avoid the circular dependency
     require(["widgets/Dialogs"], function (dialogsModule) {
         Dialogs = dialogsModule;
@@ -554,4 +567,5 @@ define(function (require, exports, module) {
     exports.compareFilenames               = compareFilenames;
     exports.comparePaths                   = comparePaths;
     exports.MAX_FILE_SIZE                  = MAX_FILE_SIZE;
+    exports.encodeFilePath                 = encodeFilePath;
 });

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -183,6 +183,21 @@ define(function (require, exports, module) {
             });
         });
 
+        describe("encodeFilePath", function () {
+
+            it("should encode symbols in path", function () {
+                expect(FileUtils.encodeFilePath("#?@test&\".js")).toBe("%23%3F%40test%26%22.js");
+            });
+
+            it("should work with a common path", function () {
+                expect(FileUtils.encodeFilePath("C:/test/$data.txt")).toBe("C%3A/test/%24data.txt");
+            });
+
+            it("should work with a path with no special symbols", function () {
+                expect(FileUtils.encodeFilePath("/Applications/Test/test.html")).toBe("/Applications/Test/test.html");
+            });
+        });
+
         describe("compareFilenames", function () {
 
             it("should compare filenames using German rules", function () {


### PR DESCRIPTION
Cannot use encodeURI/encodeURIComponent because they replace `#` with `%25`, which is incorrect - should be replaced by `%23`.

I'm not sure if there is a Brackets' utility for this already (I searched for it but couldn't find it).

I've tested with `test#tt.jpg` and `test%tt.jpg`, but nothing else - are there any other special characters that should be added to this replace scheme?

Should this be moved to a module in `utils/` and loaded from ImageViewer?

Fixes #9117.
