### PR TITLE
filter only [Extension] console output for the ExtensionLoader tests

### DIFF
--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -27,13 +27,13 @@
 
 define(function (require, exports, module) {
     'use strict';
-    
+
     // Load dependent modules
     var ExtensionLoader = require("utils/ExtensionLoader"),
         SpecRunnerUtils = require("spec/SpecRunnerUtils");
 
     var testPath = SpecRunnerUtils.getTestPath("/spec/ExtensionLoader-test-files");
-    
+
     describe("ExtensionLoader", function () {
 
         var origTimeout;
@@ -49,7 +49,10 @@ define(function (require, exports, module) {
                 var originalConsoleErrorFn = console.error;
                 spyOn(console, "error").andCallFake(function () {
                     originalConsoleErrorFn.apply(console, arguments);
-                    consoleErrors.push(Array.prototype.join.call(arguments));
+
+                    if (arguments[0].indexOf("[Extension]") === 0) {
+                        consoleErrors.push(Array.prototype.join.call(arguments));
+                    }
                 });
                 promise = ExtensionLoader.loadExtension(name, config, "main");
 
@@ -63,15 +66,14 @@ define(function (require, exports, module) {
             runs(function () {
                 if (error) {
                     if (typeof error === "string") {
-                        expect(console.error.mostRecentCall.args[0]).toBe(error);
+                        expect(consoleErrors[0]).toBe(error);
                     } else {
-                        expect(console.error.mostRecentCall.args[0]).toMatch(error);
+                        expect(consoleErrors[0]).toMatch(error);
                     }
                 } else {
-                    expect(console.error.callCount).toBe(0);
                     expect(consoleErrors).toEqual([]);  // causes console errors to be logged in test failure message
                 }
-                
+
                 expect(promise.state()).toBe(promiseState);
             });
         }
@@ -105,9 +107,9 @@ define(function (require, exports, module) {
             runs(function () {
                 spyOn(console, "log").andCallThrough();
             });
-            
+
             testLoadExtension("RequireJSConfig", "resolved");
-            
+
             runs(function () {
                 expect(console.log.mostRecentCall.args[0]).toBe("bar_exported");
             });

--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -50,7 +50,8 @@ define(function (require, exports, module) {
                 spyOn(console, "error").andCallFake(function () {
                     originalConsoleErrorFn.apply(console, arguments);
 
-                    if (arguments[0].indexOf("[Extension]") === 0) {
+                    if (typeof arguments[0] === "string" && 
+                        arguments[0].indexOf("[Extension]") === 0) {
                         consoleErrors.push(Array.prototype.join.call(arguments));
                     }
                 });


### PR DESCRIPTION
This fix will improve the reliability of this test suite, since we are only checking for extension loader error message in the console output.
