### PR TITLE
Ensure that the selection marker is drawn in the right place...

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -391,6 +391,7 @@ define(function (require, exports, module) {
      */
     function _fileViewControllerChange() {
         actionCreator.setFocused(_hasFileSelectionFocus());
+        $projectTreeContainer.trigger("scroll");
     }
 
     /**


### PR DESCRIPTION
when switching from the working set to the file tree.

Fix for #9205.

cc @ingorichter 
