### PR TITLE
String tweaks

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -168,8 +168,6 @@ define(function (require, exports, module) {
             result = Strings.CONTENTS_MODIFIED_ERR;
         } else if (name === FileSystemError.UNSUPPORTED_ENCODING) {
             result = Strings.UNSUPPORTED_ENCODING_ERR;
-        } else if (name === FileSystemError.UNSUPPORTED_FILETYPE) {
-            result = Strings.UNSUPPORTED_FILE_TYPE_ERR;
         } else {
             result = StringUtils.format(Strings.GENERIC_ERROR, name);
         }

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -50,8 +50,7 @@ define(function (require, exports, module) {
         TOO_MANY_ENTRIES            : "TooManyEntries",
         ALREADY_EXISTS              : "AlreadyExists",
         CONTENTS_MODIFIED           : "ContentsModified",
-        ROOT_NOT_WATCHED            : "RootNotBeingWatched",
-        UNSUPPORTED_FILETYPE        : "UnsupportedFileType"
+        ROOT_NOT_WATCHED            : "RootNotBeingWatched"
         
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -598,7 +598,7 @@ define({
     "CMD_SHOW_PARAMETER_HINT"                   : "Show Parameter Hint",
     "NO_ARGUMENTS"                              : "<no parameters>",
     "DETECTED_EXCLUSION_TITLE"                  : "JavaScript File Inference Problem",
-    "DETECTED_EXCLUSION_INFO"                   : "Brackets ran into trouble processing <span class='dialog-filename'>{0}</span>.<br><br>This file will no longer be processed for code hints, Jump to Definition or Quick Edit. To reenable this file, open <code>.brackets.json</code> in your project and edit <code>jscodehints.detectedExclusions</code>.<br><br>This is likely a Brackets bug. If you can provide a copy of this file, please <a href='http://github.com/adobe/brackets/issues'>file a bug</a> with a link to the file named here.",
+    "DETECTED_EXCLUSION_INFO"                   : "Brackets ran into trouble processing <span class='dialog-filename'>{0}</span>.<br><br>This file will no longer be processed for code hints, Jump to Definition or Quick Edit. To reenable this file, open <code>.brackets.json</code> in your project and edit <code>jscodehints.detectedExclusions</code>.<br><br>This is likely a Brackets bug. If you can provide a copy of this file, please <a href='https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue'>file a bug</a> with a link to the file named here.",
     
     // extensions/default/JSLint
     "JSLINT_NAME"                               : "JSLint",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -38,7 +38,6 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",
     "CONTENTS_MODIFIED_ERR"             : "The file has been modified outside of {APP_NAME}.",
     "UNSUPPORTED_ENCODING_ERR"          : "{APP_NAME} currently only supports UTF-8 encoded text files.",
-    "UNSUPPORTED_FILE_TYPE_ERR"         : "The file is not a supported file type.",
     "FILE_EXISTS_ERR"                   : "The file or directory already exists.",
     "FILE"                              : "file",
     "FILE_TITLE"                        : "File",
@@ -440,7 +439,7 @@ define({
     "BASEURL_ERROR_HASH_DISALLOWED"        : "The base URL can't contain hashes like \"{0}\".",
     "BASEURL_ERROR_INVALID_CHAR"           : "Special characters like '{0}' must be %-encoded.",
     "BASEURL_ERROR_UNKNOWN_ERROR"          : "Unknown error parsing Base URL",
-    "EMPTY_VIEW_HEADER"                    : "<em>Select a file while this view has focus</em>",
+    "EMPTY_VIEW_HEADER"                    : "<em>Open a file while this pane has focus</em>",
     
     // Strings for themes-settings.html and themes-general.html
     "CURRENT_THEME"                        : "Current Theme",
@@ -599,7 +598,7 @@ define({
     "CMD_SHOW_PARAMETER_HINT"                   : "Show Parameter Hint",
     "NO_ARGUMENTS"                              : "<no parameters>",
     "DETECTED_EXCLUSION_TITLE"                  : "JavaScript File Inference Problem",
-    "DETECTED_EXCLUSION_INFO"                   : "Brackets ran into trouble processing:<br><br>{0}<br><br>This file will no longer be processed for code hints and jump to definition. To turn this back on, open <code>.brackets.json</code> in your project and remove the file from jscodehints.detectedExclusions.",
+    "DETECTED_EXCLUSION_INFO"                   : "Brackets ran into trouble processing <span class='dialog-filename'>{0}</span>.<br><br>This file will no longer be processed for code hints, Jump to Definition or Quick Edit. To reenable this file, open <code>.brackets.json</code> in your project and edit <code>jscodehints.detectedExclusions</code>.<br><br>This is likely a Brackets bug. If you can provide a copy of this file, please <a href='http://github.com/adobe/brackets/issues'>file a bug</a> with a link to the file named here.",
     
     // extensions/default/JSLint
     "JSLINT_NAME"                               : "JSLint",


### PR DESCRIPTION
Wanted to post this for discussion/review before the 0.44 string freeze hits.
- Empty pane message:
  - say "pane" instead of "view"
  - say "open" instead of "select" (to reduce the confusion in #9254)
- JS File Inference Problem dialog:
  - ask users to file a Brackets bug
  - fix capitalization
  - format more like other errors that call out a filename
- Remove unused UNSUPPORTED_FILETYPE error & its corresponding string (I think this was leftover from an earlier part of splitview)
