### PR TITLE
More rename filetree fixes

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -277,6 +277,14 @@ define(function (require, exports, module) {
         mixins: [contextSettable, pathComputer, extendable],
 
         /**
+         * Ensures that we always have a state object.
+         */
+        getInitialState: function () {
+            return {
+            };
+        },
+
+        /**
          * Thanks to immutable objects, we can just do a start object identity check to know
          * whether or not we need to re-render.
          */

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -54,7 +54,8 @@ define(function (require, exports, module) {
     // Constants
 
     // Time range from first click to second click to invoke renaming.
-    var CLICK_RENAME_MINIMUM = 500;
+    var CLICK_RENAME_MINIMUM = 500,
+        LEFT_MOUSE_BUTTON = 0;
 
     /**
      * @private
@@ -314,6 +315,10 @@ define(function (require, exports, module) {
          * with a bit of delay in between, we'll invoke the `startRename` action.
          */
         handleClick: function (e) {
+            if (e.button !== LEFT_MOUSE_BUTTON) {
+                return;
+            }
+            
             // If the user clicks twice within 500ms, that will be picked up by the double click handler
             // If they click on the node twice with a pause, we'll start a rename.
             if (this.props.entry.get("selected") && this.state.clickTime) {
@@ -518,6 +523,10 @@ define(function (require, exports, module) {
          * If you click on a directory, it will toggle between open and closed.
          */
         handleClick: function (event) {
+            if (event.button !== LEFT_MOUSE_BUTTON) {
+                return;
+            }
+            
             var isOpen = this.props.entry.get("open"),
                 setOpen = isOpen ? false : true;
             

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -888,7 +888,7 @@ define(function (require, exports, module) {
             viewModel       = this._viewModel,
             self            = this;
 
-        if (oldName === newName) {
+        if (renameInfo.type !== FILE_CREATING && oldName === newName) {
             this.cancelRename();
             return;
         }

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -896,7 +896,7 @@ define(function (require, exports, module) {
         if (isFolder) {
             newPath += "/";
         }
-
+        
         delete this._selections.rename;
         delete this._selections.context;
         viewModel.moveMarker("rename", oldProjectPath, null);
@@ -908,7 +908,7 @@ define(function (require, exports, module) {
                 viewModel.renameItem(oldProjectPath, newName);
                 renameInfo.deferred.resolve(entry);
             }).fail(function (error) {
-                self._cancelCreating();
+                self._viewModel.deleteAtPath(self.makeProjectRelativeIfPossible(renameInfo.path));
                 renameInfo.deferred.reject(error);
             });
         } else {

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -770,6 +770,21 @@ define(function (require, exports, module) {
                     expect(model._selections.rename).toBeUndefined();
                 });
 
+                it("can create an item with the default filename", function () {
+                    spyOn(model, "createAtPath").andReturn(new $.Deferred().resolve().promise());
+                    model.startCreating("/foo/subdir1/", "Untitled");
+                    expect(model._selections.rename.path).toBe("/foo/subdir1/Untitled");
+                    expect(model._selections.rename.newName).toBe("Untitled");
+                    changesFired = 0;
+                    model.performRename();
+                    expect(changesFired).toBeGreaterThan(0);
+                    expect(model.createAtPath).toHaveBeenCalledWith("/foo/subdir1/Untitled");
+                    expect(vm._treeData.getIn(["subdir1", "children", "Untitled"])).toBeDefined();
+                    expect(vm._treeData.getIn(["subdir1", "children", "Untitled", "creating"])).toBeUndefined();
+                    expect(vm._treeData.getIn(["subdir1", "children", "Untitled", "rename"])).toBeUndefined();
+                    expect(model._selections.rename).toBeUndefined();
+                });
+
                 it("should do nothing if there is no creation in progress when _doneCreating is called", function () {
                     var treeData = vm._treeData;
                     model.performRename();

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -785,7 +785,7 @@ define(function (require, exports, module) {
                     expect(model._selections.rename).toBeUndefined();
                 });
 
-                it("should do nothing if there is no creation in progress when _doneCreating is called", function () {
+                it("should do nothing if there is no creation in progress when performRename is called", function () {
                     var treeData = vm._treeData;
                     model.performRename();
                     expect(changesFired).toBe(0);
@@ -856,6 +856,7 @@ define(function (require, exports, module) {
                                 isFolder: false
                             }
                         ]);
+                        expect(vm._treeData.get("Untitled")).toBeUndefined();
                     });
                 });
             });


### PR DESCRIPTION
This fixes:
- #9230 
- #9216 
- #9232 
- property `clickTime` not found on null error in FileTreeView
- #9241 

cc @ingorichter 
