### PR TITLE
Fix appearance of rename input

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
             var width = _measureText(this.props.name);
             
             return DOM.input({
-                className: "jstree-rename-input",
+                className: "jstree-rename-input " + this.props.fileClasses,
                 type: "text",
                 defaultValue: this.props.name,
                 autoFocus: true,
@@ -377,11 +377,11 @@ define(function (require, exports, module) {
 
             var fileClasses = "";
             if (this.props.entry.get("selected")) {
-                fileClasses += "jstree-clicked selected-node";
+                fileClasses += " jstree-clicked selected-node";
             }
             
             if (this.props.entry.get("context")) {
-                fileClasses += "context-node";
+                fileClasses += " context-node";
             }
 
             var nameDisplay;
@@ -391,7 +391,8 @@ define(function (require, exports, module) {
                     actions: this.props.actions,
                     entry: this.props.entry,
                     name: this.props.name,
-                    parentPath: this.props.parentPath
+                    parentPath: this.props.parentPath,
+                    fileClasses: fileClasses
                 });
             } else {
                 // Need to flatten the argument list because getIcons returns an array

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -113,6 +113,22 @@ define(function (require, exports, module) {
             this.props.actions.setRenameValue(this.refs.name.getDOMNode().value.trim());
         }
     };
+    
+    /**
+     * @private
+     * 
+     * Gets an appropriate width given the text provided.
+     * 
+     * @param {string} text Text to measure
+     * @return {int} Width to use
+     */
+    function _measureText(text) {
+        var measuringElement = $("<div />", { css : { "position" : "absolute", "top" : "-200px", "left" : ("-1000px"), "visibility" : "hidden" } }).appendTo("body");
+        measuringElement.text("pW" + text);
+        var width = measuringElement.width();
+        measuringElement.remove();
+        return width;
+    }
 
     /**
      * @private
@@ -141,11 +157,8 @@ define(function (require, exports, module) {
         },
 
         render: function () {
-            var measuringElement = $("<div />", { css : { "position" : "absolute", "top" : "-200px", "left" : ("-1000px"), "visibility" : "hidden" } }).appendTo("body");
-            measuringElement.text("pW" + this.props.name);
-            var width = measuringElement.width();
-            measuringElement.remove();
-
+            var width = _measureText(this.props.name);
+            
             return DOM.input({
                 className: "jstree-rename-input",
                 type: "text",
@@ -465,14 +478,19 @@ define(function (require, exports, module) {
         mixins: [renameBehavior],
 
         render: function () {
+            var width = _measureText(this.props.name);
+            
             return DOM.input({
-                className: "rename-input",
+                className: "jstree-rename-input",
                 type: "text",
                 defaultValue: this.props.name,
                 autoFocus: true,
                 onKeyDown: this.handleKeyDown,
                 onKeyUp: this.handleKeyUp,
-                ref: "name"
+                ref: "name",
+                style: {
+                    width: width
+                }
             });
         }
     });
@@ -640,7 +658,7 @@ define(function (require, exports, module) {
             var extensions = this.props.extensions,
                 iconClass = extensions && extensions.get("icons") ? "jstree-icons" : "jstree-no-icons",
                 ulProps = this.props.isRoot ? {
-                    className: "jstree-no-dots " + iconClass
+                    className: "jstree-brackets jstree-no-dots " + iconClass
                 } : null;
 
             var contents = this.props.contents,

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     /**
      * @private
      * @type {Immutable.Map}
-     * 
+     *
      * Stores the file tree extensions for adding classes and icons. The keys of the map
      * are the "categories" of the extensions and values are vectors of the callback functions.
      */
@@ -113,12 +113,12 @@ define(function (require, exports, module) {
             this.props.actions.setRenameValue(this.refs.name.getDOMNode().value.trim());
         }
     };
-    
+
     /**
      * @private
-     * 
+     *
      * Gets an appropriate width given the text provided.
-     * 
+     *
      * @param {string} text Text to measure
      * @return {int} Width to use
      */
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
 
         render: function () {
             var width = _measureText(this.props.name);
-            
+
             return DOM.input({
                 className: "jstree-rename-input " + this.props.fileClasses,
                 type: "text",
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
             return classes;
         }
     };
-    
+
     /**
      * @private
      *
@@ -375,16 +375,13 @@ define(function (require, exports, module) {
                 }, "." + extension);
             }
 
-            var fileClasses = "";
-            if (this.props.entry.get("selected")) {
-                fileClasses += " jstree-clicked selected-node";
-            }
-            
-            if (this.props.entry.get("context")) {
-                fileClasses += " context-node";
-            }
+            var nameDisplay,
+                cx = React.addons.classSet;
 
-            var nameDisplay;
+            var fileClasses = cx({
+                'jstree-clicked selected-node': this.props.entry.get("selected"),
+                'context-node': this.props.entry.get("context")
+            });
 
             if (this.props.entry.get("rename")) {
                 nameDisplay = fileRenameInput({
@@ -480,7 +477,7 @@ define(function (require, exports, module) {
 
         render: function () {
             var width = _measureText(this.props.name);
-            
+
             return DOM.input({
                 className: "jstree-rename-input",
                 type: "text",
@@ -531,7 +528,7 @@ define(function (require, exports, module) {
         handleClick: function (event) {
             var isOpen = this.props.entry.get("open"),
                 setOpen = isOpen ? false : true;
-            
+
             if (event.metaKey || event.ctrlKey) {
                 // ctrl-alt-click toggles this directory and its children
                 if (event.altKey) {
@@ -698,14 +695,14 @@ define(function (require, exports, module) {
      * Displays the absolutely positioned box for the selection or context in the
      * file tree. Its position is determined by passed-in info about the scroller in which
      * the tree resides and the top of the selected node (as reported by the node itself).
-     * 
+     *
      * Props:
      * * selectionViewInfo: Immutable.Map with width, scrollTop, scrollLeft and offsetTop for the tree container
      * * visible: should this be visible now
      * * widthAdjustment: if this box should not fill the entire width, pass in a positive number here which is subtracted from the width in selectionViewInfo
      */
     var fileSelectionBox = React.createClass({
-        
+
         /**
          * Sets up initial state.
          */
@@ -714,7 +711,7 @@ define(function (require, exports, module) {
                 initialScroll: 0
             };
         },
-        
+
         /**
          * When the component has updated in the DOM, reposition it to where the currently
          * selected node is located now.
@@ -723,7 +720,7 @@ define(function (require, exports, module) {
             if (!this.props.visible) {
                 return;
             }
-            
+
             var node = this.getDOMNode(),
                 selectedNode = $(node.parentNode).find(this.props.selectedClassName),
                 selectionViewInfo = this.props.selectionViewInfo;
@@ -731,13 +728,13 @@ define(function (require, exports, module) {
             if (selectedNode.length === 0) {
                 return;
             }
-            
+
             node.style.top = selectedNode.offset().top - selectionViewInfo.get("offsetTop") + selectionViewInfo.get("scrollTop") + "px";
         },
-        
+
         render: function () {
             var selectionViewInfo = this.props.selectionViewInfo;
-            
+
             return DOM.div({
                 style: {
                     overflow: "auto",
@@ -775,7 +772,7 @@ define(function (require, exports, module) {
                 this.props.extensions !== nextProps.extensions ||
                 this.props.selectionViewInfo !== nextProps.selectionViewInfo;
         },
-        
+
         render: function () {
             var selectionBackground = fileSelectionBox({
                 ref: "selectionBackground",
@@ -795,7 +792,7 @@ define(function (require, exports, module) {
                     selectedClassName: ".context-node",
                     forceUpdate: true
                 });
-            
+
             return DOM.div(
                 null,
                 selectionBackground,

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -142,7 +142,7 @@ ins.jstree-icon {
 .jstree-brackets a.jstree-search { color:aqua; }
 .jstree-brackets .jstree-locked a { color:silver; cursor:default; }
 
-.jstree-brackets .jstree-rename-input {
+#project-files-container .jstree-brackets .jstree-rename-input {
     background: #000;
     border: 1px solid #000;
     border-radius: 2px;
@@ -150,14 +150,17 @@ ins.jstree-icon {
     color: #fff;
     font-style: normal;
     font-weight: 400;
+    font-size: 13px;
     left: 3px !important;
     padding: 0;
     position: absolute;
     top: 2px;
     width: 150px;
+    height: 16px;
+    line-height: 16px;
 }
 
-.jstree-brackets .jstree-rename-input:focus {
+#project-files-container .jstree-brackets .jstree-rename-input:focus {
     border: 1px solid @bc-btn-border-focused;
     box-shadow: 0 0 0 1px @bc-btn-border-focused-glow;
     outline: none;

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -24,13 +24,14 @@
 
 /* Styles for jsTree control */
 /* (these are based on jsTree's default theme .css file, so they are not very LESS-like) */
+@li-min-height: 22px;
 
 .jstree ul, .jstree li { display:block; margin:0 0 0 0; padding:0 0 0 0; list-style-type:none; }
-.jstree li { display:block; min-height:18px; line-height:16px; white-space:nowrap; margin-left:18px; min-width:18px; }
+.jstree li { display:block; min-height:@li-min-height; line-height:16px; white-space:nowrap; margin-left:18px; min-width:18px; }
 .jstree-rtl li { margin-left:0; margin-right:18px; }
 .jstree > ul > li { margin-left:0px; }
 .jstree-rtl > ul > li { margin-right:0px; }
-.jstree ins { display:inline-block; text-decoration:none; width:18px; height:18px; margin:0 0 0 0; padding:0; } + 
+.jstree ins { display:inline-block; text-decoration:none; width:18px; height:18px; margin:0 0 0 0; padding:0; } +
 .jstree a { display:inline-block; line-height:16px; height:16px; color:black; white-space:nowrap; text-decoration:none; padding:1px 2px; margin:0; }
 .jstree a:focus { outline: none; }
 .jstree a > ins { height:16px; width:16px; }
@@ -154,7 +155,7 @@ ins.jstree-icon {
     left: 3px !important;
     padding: 0;
     position: absolute;
-    top: 2px;
+    top: 4px;
     width: 150px;
     height: 16px;
     line-height: 16px;


### PR DESCRIPTION
Also sets the width of the directory rename input in the same way as the file input (which is the same way jstree would do it).

The fundamental problem here was that the theme styles were taking precedence over the tree styles.

Fixes:
- #9201 
- #9210 
- #9262 

Note: at the moment, you can still see the height of the entry change a little bit, which didn't happen on the old tree. I'm not sure why that is. It could be that the line height of the non-input nodes is taller in the new tree than the old.
