### PR TITLE
Move selection bar to top when not needed.

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -717,15 +717,21 @@ define(function (require, exports, module) {
         },
         
         render: function () {
-            var selectionViewInfo = this.props.selectionViewInfo;
-            
-            return DOM.div({
-                style: {
+            var selectionViewInfo = this.props.selectionViewInfo,
+                style = {
                     overflow: "auto",
                     left: selectionViewInfo.get("scrollLeft"),
                     width: selectionViewInfo.get("width") - this.props.widthAdjustment,
                     visibility: this.props.visible ? "visible" : "hidden"
-                },
+                };
+            
+            if (!this.props.visible) {
+                style.width = 0;
+                style.top = 0;
+            }
+            
+            return DOM.div({
+                style: style,
                 className: this.props.className
             });
         }


### PR DESCRIPTION
By moving the selection bar to the top when it's not needed, we fix extraneous blank
spaces and scrollbars.

This provides fixes for:
- #9259
- #9252
- #9197.

cc @ingorichter 
