### PR TITLE
Fix a second infinite loop in CSSUtils.findSelectorAtDocumentPos()

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1599,7 +1599,7 @@ define(function (require, exports, module) {
             } else {
                 TokenUtils.movePrevToken(ctx);
             }
-        } while (!(ctx.pos.line === 0 && ctx.pos.ch === 0));
+        } while (!TokenUtils.isAtStart(ctx));
         
         selector = _stripAtRules(selector);
         

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -76,6 +76,11 @@ define(function (require, exports, module) {
         return true;
     }
     
+    /** Returns true if movePrevToken() would return false without changing pos */
+    function isAtStart(ctx) {
+        return (ctx.pos.ch <= 0 || ctx.token.start <= 0) && (ctx.pos.line <= 0);
+    }
+    
     /**
      * Moves the given context forward by one token.
      * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} ctx
@@ -101,6 +106,12 @@ define(function (require, exports, module) {
         }
         ctx.token = ctx.editor.getTokenAt(ctx.pos, precise);
         return true;
+    }
+    
+    /** Returns true if moveNextToken() would return false without changing pos */
+    function isAtEnd(ctx) {
+        var eol = ctx.editor.getLine(ctx.pos.line).length;
+        return (ctx.pos.ch >= eol || ctx.token.end >= eol) && (ctx.pos.line >= ctx.editor.lineCount() - 1);
     }
     
    /**
@@ -153,6 +164,8 @@ define(function (require, exports, module) {
 
     exports.movePrevToken           = movePrevToken;
     exports.moveNextToken           = moveNextToken;
+    exports.isAtStart               = isAtStart;
+    exports.isAtEnd                 = isAtEnd;
     exports.moveSkippingWhitespace  = moveSkippingWhitespace;
     exports.getInitialContext       = getInitialContext;
     exports.offsetInToken           = offsetInToken;

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -38,9 +38,9 @@ define(function (require, exports, module) {
    /**
      * Creates a context object for the given editor and position, suitable for passing to the
      * move functions.
-     * @param {CodeMirror} editor
-     * @param {{ch:{string}, line:{number}} pos
-     * @return {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}}
+     * @param {!CodeMirror} editor
+     * @param {!{ch:number, line:number}} pos
+     * @return {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}}
      */
     function getInitialContext(editor, pos) {
         return {
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
     
     /**
      * Moves the given context backwards by one token.
-     * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} ctx
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} ctx
      * @param {boolean=} precise If code is being edited, use true (default) for accuracy.
      *      If parsing unchanging code, use false to use cache for performance.
      * @return {boolean} whether the context changed
@@ -76,14 +76,17 @@ define(function (require, exports, module) {
         return true;
     }
     
-    /** Returns true if movePrevToken() would return false without changing pos */
+    /**
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} ctx
+     * @return {boolean} true if movePrevToken() would return false without changing pos
+     */
     function isAtStart(ctx) {
         return (ctx.pos.ch <= 0 || ctx.token.start <= 0) && (ctx.pos.line <= 0);
     }
     
     /**
      * Moves the given context forward by one token.
-     * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} ctx
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} ctx
      * @param {boolean=} precise If code is being edited, use true (default) for accuracy.
      *      If parsing unchanging code, use false to use cache for performance.
      * @return {boolean} whether the context changed
@@ -108,7 +111,10 @@ define(function (require, exports, module) {
         return true;
     }
     
-    /** Returns true if moveNextToken() would return false without changing pos */
+    /**
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} ctx
+     * @return {boolean} true if moveNextToken() would return false without changing pos
+     */
     function isAtEnd(ctx) {
         var eol = ctx.editor.getLine(ctx.pos.line).length;
         return (ctx.pos.ch >= eol || ctx.token.end >= eol) && (ctx.pos.line >= ctx.editor.lineCount() - 1);
@@ -117,7 +123,7 @@ define(function (require, exports, module) {
    /**
      * Moves the given context in the given direction, skipping any whitespace it hits.
      * @param {function} moveFxn the function to move the context
-     * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} ctx
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} ctx
      * @return {boolean} whether the context changed
      */
     function moveSkippingWhitespace(moveFxn, ctx) {
@@ -134,7 +140,7 @@ define(function (require, exports, module) {
 
     /**
      * In the given context, get the character offset of pos from the start of the token.
-     * @param {editor:{CodeMirror}, pos:{ch:{string}, line:{number}}, token:{object}} context
+     * @param {!{editor:!CodeMirror, pos:!{ch:number, line:number}, token:Object}} context
      * @return {number}
      */
     function offsetInToken(ctx) {
@@ -147,8 +153,8 @@ define(function (require, exports, module) {
 
     /**
      * Returns the mode object and mode name string at a given position
-     * @param {CodeMirror} cm CodeMirror instance
-     * @param {line:{number}, ch:{number}} pos Position to query for mode
+     * @param {!CodeMirror} cm CodeMirror instance
+     * @param {!{line:number, ch:number}} pos Position to query for mode
      * @return {mode:{Object}, name:string}
      */
     function getModeAt(cm, pos) {


### PR DESCRIPTION
Fix a second infinite loop in `CSSUtils.findSelectorAtDocumentPos()`, caused by cleanups in the fix for the earlier infinite loop bug (#9002). To keep loop exit condition more precisely in sync with TokenUtils's logic for when to stop advancing, create new TokenUtils methods for checking if at a stopping point.

The existing unit test `"should find the first selector when pos is at beginning of selector name"` already hits the case that was broken here -- basically a curly brace that's _not_ alone on a line, afaict -- so I didn't bother adding any additional unit tests in this PR.

@RaymondLim @MarcelGerber
