### PR TITLE
Click to rename works on a timeout.

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -282,6 +282,7 @@ define(function (require, exports, module) {
          */
         getInitialState: function () {
             return {
+                clickTimer: null
             };
         },
 
@@ -300,14 +301,35 @@ define(function (require, exports, module) {
          * context boxes as appropriate.
          */
         componentDidUpdate: function (prevProps, prevState) {
-            if (this.props.entry.get("selected") && !prevProps.entry.get("selected")) {
+            var wasSelected = prevProps.entry.get("selected"),
+                isSelected  = this.props.entry.get("selected");
+            
+            if (isSelected && !wasSelected) {
                 // TODO: This shouldn't really know about project-files-container
                 // directly. It is probably the case that our React tree should actually
                 // start with project-files-container instead of just the interior of
                 // project-files-container and then the file tree will be one self-contained
                 // functional unit.
                 ViewUtils.scrollElementIntoView($("#project-files-container"), $(this.getDOMNode()), true);
+            } else if (!isSelected && wasSelected && this.state.clickTimer !== null) {
+                this.clearTimer();
             }
+        },
+        
+        clearTimer: function () {
+            if (this.state.clickTimer !== null) {
+                window.clearTimeout(this.state.clickTimer);
+                this.setState({
+                    clickTimer: null
+                });
+            }
+        },
+        
+        startRename: function () {
+            if (!this.props.entry.get("rename")) {
+                this.props.actions.startRename(this.myPath());
+            }
+            this.clearTimer();
         },
 
         /**
@@ -319,21 +341,15 @@ define(function (require, exports, module) {
                 return;
             }
             
-            // If the user clicks twice within 500ms, that will be picked up by the double click handler
-            // If they click on the node twice with a pause, we'll start a rename.
-            if (this.props.entry.get("selected") && this.state.clickTime) {
-                var timeSincePreviousClick = new Date().getTime() - this.state.clickTime;
-                if (!this.props.entry.get("rename") && (timeSincePreviousClick > CLICK_RENAME_MINIMUM)) {
-                    this.props.actions.startRename(this.myPath());
+            if (this.props.entry.get("selected")) {
+                if (this.state.clickTimer === null && !this.props.entry.get("rename")) {
+                    var timer = window.setTimeout(this.startRename, CLICK_RENAME_MINIMUM);
                     this.setState({
-                        clickTime: 0
+                        clickTimer: timer
                     });
                 }
             } else {
                 this.props.actions.setSelected(this.myPath());
-                this.setState({
-                    clickTime: new Date().getTime()
-                });
             }
             return false;
         },
@@ -344,10 +360,10 @@ define(function (require, exports, module) {
          */
         handleDoubleClick: function () {
             if (!this.props.entry.get("rename")) {
+                if (this.state.clickTimer !== null) {
+                    this.clearTimer();
+                }
                 this.props.actions.selectInWorkingSet(this.myPath());
-                this.setState({
-                    clickTime: 0
-                });
             }
         },
 


### PR DESCRIPTION
This is more like the earlier implementation of click-to-rename and provides more
consistent behavior for double clicking to add to working set.

Fix for #9200.

cc @ingorichter 
