### PR TITLE
Restore default font-family definition

### DIFF
--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -131,6 +131,8 @@
     .dark & {
         color: @dark-bc-text;
     }
+
+    font-family: "SourceCodePro-Medium", "ＭＳ ゴシック", "MS Gothic", monospace;
 }
 
 .code-font-win() {


### PR DESCRIPTION
This is for #9277 

This restores a changes made for optimizing Themes.

cc @peterflynn 
