### PR TITLE
Don't rescan doc for html instrumentation when reattaching to editor

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -162,8 +162,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         }
 
         if (this._instrumentationEnabled) {
-            // Update instrumentation for new editor
-            HTMLInstrumentation.scanDocument(this.doc);
+            // Resync instrumentation with editor
             HTMLInstrumentation._markText(this.editor);
         }
     };


### PR DESCRIPTION
This is for #9303 

Rescanning doc blows away old ids and replaces them, so synchronization is lost.

This was broken with fix for #7886, so verify that is still fixed.
