### PR TITLE
Make sure all switches between working set and file tree are displayed.

### DIFF
--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -1104,7 +1104,6 @@ define(function (require, exports, module) {
             this._selectionViewInfo = this._selectionViewInfo.set("offsetTop", offsetTop);
         }
         
-        $(this).trigger(EVENT_CHANGE);
     };
     
     /**

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -59,8 +59,8 @@ define(function (require, exports, module) {
      */
     function FileTreeViewModel() {
         // For convenience in callbacks, make a bound version of this method so that we can
-        // just refer to it as this._commitTreeData when passing in a callback.
-        this._commitTreeData = this._commitTreeData.bind(this);
+        // just refer to it as this._commit when passing in a callback.
+        this._commit = this._commit.bind(this);
     }
 
     /**
@@ -136,9 +136,18 @@ define(function (require, exports, module) {
      *
      * @param {Immutable.Map} treeData new treeData state
      */
-    FileTreeViewModel.prototype._commitTreeData = function (treeData) {
+    FileTreeViewModel.prototype._commit = function (treeData, selectionViewInfo) {
+        var changed = false;
         if (treeData && treeData !== this._treeData) {
             this._treeData = treeData;
+            changed = true;
+        }
+        
+        if (selectionViewInfo && selectionViewInfo !== this._selectionViewInfo) {
+            this._selectionViewInfo = selectionViewInfo;
+            changed = true;
+        }
+        if (changed) {
             $(this).trigger(EVENT_CHANGE);
         }
     };
@@ -435,14 +444,15 @@ define(function (require, exports, module) {
      * @param {string|null} newPath Project relative file path with where to place the marker, or null if the marker is being removed from the tree
      */
     FileTreeViewModel.prototype.moveMarker = function (markerName, oldPath, newPath) {
-        var newTreeData = _moveMarker(this._treeData, markerName, oldPath, newPath);
+        var newTreeData = _moveMarker(this._treeData, markerName, oldPath, newPath),
+            selectionViewInfo = this._selectionViewInfo;
         
         if (markerName === "selected") {
-            this._selectionViewInfo = this._selectionViewInfo.set("hasSelection", !!newPath);
+            selectionViewInfo = selectionViewInfo.set("hasSelection", !!newPath);
         } else if (markerName === "context") {
-            this._selectionViewInfo = this._selectionViewInfo.set("hasContext", !!newPath);
+            selectionViewInfo = selectionViewInfo.set("hasContext", !!newPath);
         }
-        this._commitTreeData(newTreeData);
+        this._commit(newTreeData, selectionViewInfo);
     };
 
     /**
@@ -471,7 +481,7 @@ define(function (require, exports, module) {
             return directory;
         });
 
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
 
     /**
@@ -531,7 +541,7 @@ define(function (require, exports, module) {
     FileTreeViewModel.prototype.setDirectoryOpen = function (path, open) {
         var result = _setDirectoryOpen(this._treeData, path, open);
         if (result && result.treeData) {
-            this._commitTreeData(result.treeData);
+            this._commit(result.treeData);
         }
         return result ? result.needsLoading : false;
     };
@@ -591,7 +601,7 @@ define(function (require, exports, module) {
         
         directory = _closeSubtree(directory);
         treeData = _setIn(treeData, subtreePath, directory);
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
 
     /**
@@ -783,7 +793,7 @@ define(function (require, exports, module) {
 
         children = _mergeContentsIntoChildren(children, contents);
         treeData = _setIn(treeData, objectPath, children);
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
 
     /**
@@ -825,7 +835,7 @@ define(function (require, exports, module) {
      * @param {string} path Project-relative path
      */
     FileTreeViewModel.prototype.openPath = function (path) {
-        this._commitTreeData(_openPath(this._treeData, path));
+        this._commit(_openPath(this._treeData, path));
     };
 
     /**
@@ -887,7 +897,7 @@ define(function (require, exports, module) {
      */
     FileTreeViewModel.prototype.createPlaceholder = function (basedir, name, isFolder) {
         var treeData = _createPlaceholder(this._treeData, basedir, name, isFolder);
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
 
     /**
@@ -923,7 +933,7 @@ define(function (require, exports, module) {
     FileTreeViewModel.prototype.deleteAtPath = function (path) {
         var treeData = _deleteAtPath(this._treeData, path);
         if (treeData) {
-            this._commitTreeData(treeData);
+            this._commit(treeData);
         }
     };
 
@@ -1020,7 +1030,7 @@ define(function (require, exports, module) {
             });
         }
 
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
     
     /**
@@ -1060,7 +1070,7 @@ define(function (require, exports, module) {
             children: null
         }));
         
-        this._commitTreeData(treeData);
+        this._commit(treeData);
     };
 
     /**
@@ -1082,12 +1092,15 @@ define(function (require, exports, module) {
      * @param {int} width New width
      */
     FileTreeViewModel.prototype.setSelectionWidth = function (width) {
-        this._selectionViewInfo = this._selectionViewInfo.set("width", width);
-        $(this).trigger(EVENT_CHANGE);
+        var selectionViewInfo = this._selectionViewInfo;
+        selectionViewInfo = selectionViewInfo.set("width", width);
+        this._commit(null, selectionViewInfo);
     };
     
     /**
      * Sets the scroll position of the file tree to help position the selection bar.
+     * SPECIAL CASE NOTE: this does not trigger a change event because this data is
+     * explicitly set in the rendering process (see ProjectManager._renderTree).
      * 
      * @param {int} scrollTop Scroll position
      * @param {int=} scrollLeft Horizontal scroll position
@@ -1103,7 +1116,7 @@ define(function (require, exports, module) {
         if (offsetTop !== undefined) {
             this._selectionViewInfo = this._selectionViewInfo.set("offsetTop", offsetTop);
         }
-        
+        // Does not emit change event. See SPECIAL CASE NOTE in docstring above.
     };
     
     /**

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -134,7 +134,8 @@ define(function (require, exports, module) {
      * state moves atomically from one value to the next. This method stores the next version
      * of the state, if it has changed, and triggers a change event so that the UI can update.
      *
-     * @param {Immutable.Map} treeData new treeData state
+     * @param {?Immutable.Map} treeData new treeData state
+     * @param {?Immutable.Map} selectionViewInfo updated information for the selection/context bars
      */
     FileTreeViewModel.prototype._commit = function (treeData, selectionViewInfo) {
         var changed = false;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -391,6 +391,7 @@ define(function (require, exports, module) {
      */
     function _fileViewControllerChange() {
         actionCreator.setFocused(_hasFileSelectionFocus());
+        _renderTree();
     }
 
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1127,7 +1127,7 @@ define(function (require, exports, module) {
         });
 
         $(Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU)).on("beforeContextMenuClose", function () {
-            actionCreator.setContext(null);
+            model.setContext(null, false, true);
         });
 
         $projectTreeContainer.on("contextmenu", function () {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -266,9 +266,6 @@ define(function (require, exports, module) {
      */
     ActionCreator.prototype.setContext = function (path) {
         this.model.setContext(path);
-        if (path !== null && !_hasFileSelectionFocus()) {
-            $projectTreeContainer.trigger("scroll");
-        }
     };
 
     /**
@@ -394,7 +391,6 @@ define(function (require, exports, module) {
      */
     function _fileViewControllerChange() {
         actionCreator.setFocused(_hasFileSelectionFocus());
-        $projectTreeContainer.trigger("scroll");
     }
 
     /**
@@ -615,6 +611,7 @@ define(function (require, exports, module) {
         if (!projectRoot) {
             return;
         }
+        model.setScrollerInfo($projectTreeContainer.scrollTop(), $projectTreeContainer.scrollLeft(), $projectTreeContainer.offset().top);
         FileTreeView.render(fileTreeViewContainer, model._viewModel, projectRoot, actionCreator, forceRender);
     };
 
@@ -1106,15 +1103,6 @@ define(function (require, exports, module) {
         _renderTree();
     }
     
-    /**
-     * @private
-     * 
-     * Updates the scroller positioning on scroll or sidebar changes.
-     */
-    function _updateScrollerInfo() {
-        model.setScrollerInfo($projectTreeContainer.scrollTop(), $projectTreeContainer.scrollLeft(), $projectTreeContainer.offset().top);
-    }
-    
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
         $projectTreeContainer = $("#project-files-container");
@@ -1158,7 +1146,7 @@ define(function (require, exports, module) {
                 Menus.closeAll();
                 actionCreator.setContext(null);
             }
-            _updateScrollerInfo();
+            _renderTree();
         });
         
         _renderTree();

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -390,27 +390,26 @@ define(function (require, exports, module) {
     /**
      * @private
      *
+     * Handler for changes in the focus between working set and file tree view.
+     */
+    function _fileViewControllerChange() {
+        actionCreator.setFocused(_hasFileSelectionFocus());
+        $projectTreeContainer.trigger("scroll");
+    }
+
+    /**
+     * @private
+     *
      * Handler for changes in document selection.
      */
     function _documentSelectionFocusChange() {
         var curFullPath = MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE);
         if (curFullPath && _hasFileSelectionFocus()) {
             actionCreator.setSelected(curFullPath, true);
-            actionCreator.setFocused(true);
         } else {
             actionCreator.setSelected(null);
-            actionCreator.setFocused(false);
         }
-    }
-
-    /**
-     * @private
-     *
-     * Handler for changes in the focus between working set and file tree view.
-     */
-    function _fileViewControllerChange() {
-        actionCreator.setFocused(_hasFileSelectionFocus());
-        $projectTreeContainer.trigger("scroll");
+        _fileViewControllerChange();
     }
 
     /**

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -709,17 +709,22 @@ define(function (require, exports, module) {
      *
      * @param {string} path full path of file or directory to which the context should be setBaseUrl
      * @param {boolean} _doNotRename True if this context change should not cause a rename operation to finish. This is a special case that goes with context menu handling.
+     * @param {boolean} _saveContext True if the current context should be saved (see comment below)
      */
-    ProjectModel.prototype.setContext = function (path, _doNotRename) {
+    ProjectModel.prototype.setContext = function (path, _doNotRename, _saveContext) {
         // This bit is not ideal: when the user right-clicks on an item in the file tree
         // and there is already a context menu up, the FileTreeView sends a signal to set the
         // context to the new element but the PopupManager follows that with a message that it's
         // closing the context menu (because it closes the previous one and then opens the new
         // one.) This timing means that we need to provide some special case handling here.
-        if (!path) {
-            this._selections.previousContext = this._selections.context;
+        if (_saveContext) {
+            if (!path) {
+                this._selections.previousContext = this._selections.context;
+            } else {
+                this._selections.previousContext = path;
+            }
         } else {
-            this._selections.previousContext = path;
+            delete this._selections.previousContext;
         }
 
         path = _getPathFromFSObject(path);

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -649,10 +649,14 @@ define(function (require, exports, module) {
             return;
         }
 
-        this.performRename();
-
         var oldProjectPath = this.makeProjectRelativeIfPossible(this._selections.selected),
             pathInProject = this.makeProjectRelativeIfPossible(path);
+
+        if (path && !this._viewModel.isFilePathVisible(pathInProject)) {
+            return;
+        }
+        
+        this.performRename();
 
         this._viewModel.moveMarker("selected", oldProjectPath, pathInProject);
         if (this._selections.context) {

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -903,6 +903,10 @@ define(function (require, exports, module) {
         
         delete this._selections.rename;
         delete this._selections.context;
+        if (this._selections.selected === oldPath) {
+            this._selections.selected = newPath;
+        }
+        
         viewModel.moveMarker("rename", oldProjectPath, null);
         viewModel.moveMarker("context", oldProjectPath, null);
         viewModel.moveMarker("creating", oldProjectPath, null);
@@ -910,6 +914,7 @@ define(function (require, exports, module) {
         if (renameInfo.type === FILE_CREATING) {
             this.createAtPath(newPath).done(function (entry) {
                 viewModel.renameItem(oldProjectPath, newName);
+                self.selectInWorkingSet(newPath);
                 renameInfo.deferred.resolve(entry);
             }).fail(function (error) {
                 self._viewModel.deleteAtPath(self.makeProjectRelativeIfPossible(renameInfo.path));

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -919,7 +919,11 @@ define(function (require, exports, module) {
         if (renameInfo.type === FILE_CREATING) {
             this.createAtPath(newPath).done(function (entry) {
                 viewModel.renameItem(oldProjectPath, newName);
-                self.selectInWorkingSet(newPath);
+                
+                if (!isFolder) {
+                    self.selectInWorkingSet(newPath);
+                }
+                
                 renameInfo.deferred.resolve(entry);
             }).fail(function (error) {
                 self._viewModel.deleteAtPath(self.makeProjectRelativeIfPossible(renameInfo.path));

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -653,7 +653,8 @@ define(function (require, exports, module) {
             pathInProject = this.makeProjectRelativeIfPossible(path);
 
         if (path && !this._viewModel.isFilePathVisible(pathInProject)) {
-            return;
+            path = null;
+            pathInProject = null;
         }
         
         this.performRename();
@@ -928,10 +929,6 @@ define(function (require, exports, module) {
             this.createAtPath(newPath).done(function (entry) {
                 viewModel.renameItem(oldProjectPath, newName);
                 
-                if (!isFolder) {
-                    self.selectInWorkingSet(newPath);
-                }
-                
                 renameInfo.deferred.resolve(entry);
             }).fail(function (error) {
                 self._viewModel.deleteAtPath(self.makeProjectRelativeIfPossible(renameInfo.path));
@@ -969,7 +966,7 @@ define(function (require, exports, module) {
 
         return doCreate(path, isFolder).done(function (entry) {
             if (!isFolder) {
-                self.setSelected(entry.fullPath);
+                self.selectInWorkingSet(entry.fullPath);
             }
         }).fail(function (error) {
             $(self).trigger(ERROR_CREATION, {

--- a/test/spec/FileTreeViewModel-test.js
+++ b/test/spec/FileTreeViewModel-test.js
@@ -632,6 +632,15 @@ define(function (require, exports, module) {
                 vm.moveMarker("context", "subdir1/afile.js", null);
                 expect(vm._selectionViewInfo.get("hasContext")).toBe(false);
             });
+            
+            it("should signal a change when just selectionViewInfo changes", function () {
+                vm.moveMarker("context", null, "subdir1/afile.js");
+                vm.deleteAtPath("subdir1/afile.js");
+                changesFired = 0;
+                vm.moveMarker("context", "subdir1/afile.js", null);
+                expect(vm._selectionViewInfo.get("hasContext")).toBe(false);
+                expect(changesFired).toBe(1);
+            });
         });
 
         describe("createPlaceholder", function () {

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -467,17 +467,17 @@ define(function (require, exports, module) {
                     expect(changesFired).toBe(1);
                 });
 
-                it("can select a file that is not visible", function () {
+                it("won't select a file that is not visible", function () {
                     model.setSelected("/foo/subdir2/bar.js");
                     expect(changesFired).toBe(0);
-                    expect(model._selections.selected).toBe("/foo/subdir2/bar.js");
+                    expect(model._selections.selected).toBeUndefined();
                 });
 
-                it("will unselect the previously selected file when selecting one that's not visible", function () {
+                it("will maintain the previously selected file when selecting one that's not visible", function () {
                     model.setSelected("/foo/subdir1/afile.js");
                     model.setSelected("/foo/subdir2/bar.js");
-                    expect(vm._treeData.getIn(["subdir1", "children", "afile.js", "selected"])).toBeUndefined();
-                    expect(model._selections.selected).toBe("/foo/subdir2/bar.js");
+                    expect(vm._treeData.getIn(["subdir1", "children", "afile.js", "selected"])).toBe(true);
+                    expect(model._selections.selected).toBe("/foo/subdir1/afile.js");
                 });
                 
                 it("can accept a filesystem object", function () {

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -453,7 +453,7 @@ define(function (require, exports, module) {
                 
                 it("should be able to restore the context to handle the context menu events", function () {
                     model.setContext("/foo/afile.js");
-                    model.setContext(null);
+                    model.setContext(null, false, true);
                     model.restoreContext();
                     expect(model._selections.context).toBe("/foo/afile.js");
                 });
@@ -617,7 +617,6 @@ define(function (require, exports, module) {
                     expect(vm._treeData.getIn(["afile.js", "context"])).toBe(true);
                     expect(model._selections).toEqual({
                         context: "/foo/afile.js",
-                        previousContext: "/foo/afile.js",
                         rename: {
                             deferred: jasmine.any(Object),
                             path: "/foo/afile.js",

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -481,14 +481,14 @@ define(function (require, exports, module) {
                 it("won't select a file that is not visible", function () {
                     model.setSelected("/foo/subdir2/bar.js");
                     expect(changesFired).toBe(0);
-                    expect(model._selections.selected).toBeUndefined();
+                    expect(model._selections.selected).toBeNull();
                 });
 
-                it("will maintain the previously selected file when selecting one that's not visible", function () {
+                it("will clear the selected file when selecting one that's not visible", function () {
                     model.setSelected("/foo/subdir1/afile.js");
                     model.setSelected("/foo/subdir2/bar.js");
-                    expect(vm._treeData.getIn(["subdir1", "children", "afile.js", "selected"])).toBe(true);
-                    expect(model._selections.selected).toBe("/foo/subdir1/afile.js");
+                    expect(vm._treeData.getIn(["subdir1", "children", "afile.js", "selected"])).toBeUndefined();
+                    expect(model._selections.selected).toBeNull();
                 });
                 
                 it("can accept a filesystem object", function () {
@@ -792,10 +792,14 @@ define(function (require, exports, module) {
                     expect(vm._treeData.getIn(["subdir1", "children", "newfile.js", "creating"])).toBeUndefined();
                     expect(vm._treeData.getIn(["subdir1", "children", "newfile.js", "rename"])).toBeUndefined();
                     expect(model._selections.rename).toBeUndefined();
-                    expect(selectionEvents).toEqual([{
-                        path: "/foo/subdir1/newfile.js",
-                        add: true
-                    }]);
+                    
+                    // The selectionEvent now comes from createAtPath which we have mocked out.
+                    // We can restore this check once we have chosen a way to hook into RequireJS
+                    // loading.
+//                    expect(selectionEvents).toEqual([{
+//                        path: "/foo/subdir1/newfile.js",
+//                        add: true
+//                    }]);
                 });
                 
                 it("should create a directory but not open it", function () {

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -786,6 +786,16 @@ define(function (require, exports, module) {
                         add: true
                     }]);
                 });
+                
+                it("should create a directory but not open it", function () {
+                    spyOn(model, "createAtPath").andReturn(new $.Deferred().resolve().promise());
+                    model.startCreating("/foo/", "Untitled", true);
+                    model.setRenameValue("newdir");
+                    model.performRename();
+                    expect(model.createAtPath).toHaveBeenCalledWith("/foo/newdir/");
+                    expect(vm._treeData.getIn(["newdir", "children"]).toJS()).toEqual({});
+                    expect(selectionEvents).toEqual([]);
+                });
 
                 it("can create an item with the default filename", function () {
                     spyOn(model, "createAtPath").andReturn(new $.Deferred().resolve().promise());

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -692,6 +692,14 @@ define(function (require, exports, module) {
                     expect(vm._treeData.getIn(["afile.js", "rename"])).toBe(true);
                     expect(model._selections.rename).toBeDefined();
                 });
+                
+                it("adjusts the selection if the renamed file was selected", function () {
+                    model.setSelected("/foo/afile.js");
+                    model.startRename("/foo/afile.js");
+                    model.setRenameValue("something.js");
+                    model.performRename();
+                    expect(model._selections.selected).toBe("/foo/something.js");
+                });
 
                 it("does nothing if setRenameValue is called when there's no rename in progress", function () {
                     model.setRenameValue("/foo/bar/baz");
@@ -759,7 +767,7 @@ define(function (require, exports, module) {
                     expect(changesFired).toBeGreaterThan(0);
                 });
 
-                it("should save the item when done creating", function () {
+                it("should save the item and open it in working set when done creating", function () {
                     spyOn(model, "createAtPath").andReturn(new $.Deferred().resolve().promise());
                     model.startCreating("/foo/subdir1/", "Untitled");
                     expect(model._selections.rename.path).toBe("/foo/subdir1/Untitled");
@@ -774,6 +782,10 @@ define(function (require, exports, module) {
                     expect(vm._treeData.getIn(["subdir1", "children", "newfile.js", "creating"])).toBeUndefined();
                     expect(vm._treeData.getIn(["subdir1", "children", "newfile.js", "rename"])).toBeUndefined();
                     expect(model._selections.rename).toBeUndefined();
+                    expect(selectionEvents).toEqual([{
+                        path: "/foo/subdir1/newfile.js",
+                        add: true
+                    }]);
                 });
 
                 it("can create an item with the default filename", function () {


### PR DESCRIPTION
I've got a couple of fixes in one here, because I wanted to make it easier to test the behavior together. What I realized is that I was prematurely optimizing by trying to avoid recomputing the offsets for the project-files-container. That change alone cleans up various "selection highlight is in the wrong place" sorts of bugs. Additionally, I caught an instance where the FileTreeViewModel wasn't signaling a change (because the treeData didn't change but the selectionViewInfo did), so I fixed that to work in a more predictable manner.

Also, one problem was that newly created files weren't being selected which caused funny behavior. Rather than just selecting the file, I selected it and added to the working set (which fixes #9294). It was just a matter of choosing one function call over another.

This now fixes:
- #9225 
- #9312 (I couldn't reproduce, but this should be fixed because of the premature optimization elimination)
- #9340 
- #9344 
- #9343 
- #9342 
- #9337 
- #9294 
- #9366
- #9367

cc @ingorichter @RaymondLim 
