### PR TITLE
Trigger for shadow on file tree to move when working set changes.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1133,6 +1133,10 @@ define(function (require, exports, module) {
                 actionCreator.setContext(null);
             }
         });
+        
+        $("#working-set-list-container").on("contentChanged", function () {
+            $projectTreeContainer.trigger("contentChanged");
+        });
 
         $(Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU)).on("beforeContextMenuOpen", function () {
             actionCreator.restoreContext();


### PR DESCRIPTION
This restores the same handling that was in ProjectManager previously.

This is a fix for #9358.

cc @ingorichter 
