### PR TITLE
UI Fixes

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -490,7 +490,7 @@ a, img {
         box-sizing: border-box;
         border-bottom:  1px solid rgba(0, 0, 0, 0.05);
         padding: 5px 10px;
-        color: @bc-text-quiet;
+        color: @bc-text-thin-quiet;
         background-color: @background;
         
         .dark & {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -855,7 +855,8 @@ a, img {
     background: @bc-sidebar-selection;
     border-top: 1px solid @bc-shadow-small;
     border-bottom: 1px solid @bc-highlight;
-    height: 22px;
+    box-sizing: border-box;
+    height: 23px;
     position: absolute;
 }
 
@@ -863,18 +864,19 @@ a, img {
     background: @bc-sidebar-selection;
     border-top: 1px solid @bc-shadow-small;
     border-bottom: 1px solid @bc-highlight;
-    height: 22px;
+    box-sizing: border-box;
+    height: 23px;
     width: 9px; /* quiet scrollbar width */
-    height: 22px;
     position: fixed;
 
     z-index: @z-index-brackets-selection-extension; /* scroller-shadow appears above the extension */
 }
 
 .filetree-context {
-    background: @bc-highlight;
+    background: rgba(255, 255, 255, 0.06);
+    box-sizing: border-box;
     position: absolute;
-    height: 22px;
+    height: 23px;
 }
 
 //Initially start with the open files hidden, they will get show as files are added

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -148,22 +148,24 @@ ins.jstree-icon {
     border: 1px solid #000;
     border-radius: 2px;
     box-shadow: @bc-shadow-small;
+    box-sizing: border-box;
     color: #fff;
     font-style: normal;
     font-weight: 400;
     font-size: 13px;
     left: 3px !important;
+    top: 2px !important;
+    margin: 0;
     padding: 0;
-    position: absolute;
-    top: 4px;
+    position: relative;
     width: 150px;
-    height: 16px;
-    line-height: 16px;
+    height: 17px;
+    line-height: 17px;
 }
 
 #project-files-container .jstree-brackets .jstree-rename-input:focus {
     border: 1px solid @bc-btn-border-focused;
-    box-shadow: 0 0 0 1px @bc-btn-border-focused-glow;
+    box-shadow: none;
     outline: none;
 }
 


### PR DESCRIPTION
- Fix for #9328
- Kept jstree rename input text in the same position as the text before renaming
- Made unfocused pane header text slightly darker

Note: it's strange that the selection background on rename input shifts 2px down. We should fix that in a separate PR once we figure out a fix (it definitely can't be fixed using CSS).
