### PR TITLE
fix the position of the selection div when entering rename mode

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
     /**
      * @private
      *
-     * This mixin handles right click (or control click on Mac) action to make a file 
+     * This mixin handles right click (or control click on Mac) action to make a file
      * the "context" object for performing operations like rename.
      */
     var contextSettable = {
@@ -318,7 +318,7 @@ define(function (require, exports, module) {
         componentDidUpdate: function (prevProps, prevState) {
             var wasSelected = prevProps.entry.get("selected"),
                 isSelected  = this.props.entry.get("selected");
-            
+
             if (isSelected && !wasSelected) {
                 // TODO: This shouldn't really know about project-files-container
                 // directly. It is probably the case that our React tree should actually
@@ -330,7 +330,7 @@ define(function (require, exports, module) {
                 this.clearTimer();
             }
         },
-        
+
         clearTimer: function () {
             if (this.state.clickTimer !== null) {
                 window.clearTimeout(this.state.clickTimer);
@@ -339,7 +339,7 @@ define(function (require, exports, module) {
                 });
             }
         },
-        
+
         startRename: function () {
             if (!this.props.entry.get("rename")) {
                 this.props.actions.startRename(this.myPath());
@@ -360,7 +360,7 @@ define(function (require, exports, module) {
             if (e.button !== LEFT_MOUSE_BUTTON) {
                 return;
             }
-            
+
             if (this.props.entry.get("selected")) {
                 if (this.state.clickTimer === null && !this.props.entry.get("rename")) {
                     var timer = window.setTimeout(this.startRename, CLICK_RENAME_MINIMUM);
@@ -772,7 +772,7 @@ define(function (require, exports, module) {
                 return;
             }
 
-            node.style.top = selectedNode.offset().top - selectionViewInfo.get("offsetTop") + selectionViewInfo.get("scrollTop") + "px";
+            node.style.top = selectedNode.offset().top - selectionViewInfo.get("offsetTop") + selectionViewInfo.get("scrollTop") - selectedNode.position().top + "px";
         },
 
         render: function () {

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -24,7 +24,7 @@
 
 /* Styles for jsTree control */
 /* (these are based on jsTree's default theme .css file, so they are not very LESS-like) */
-@li-min-height: 22px;
+@li-min-height: 23px;
 
 .jstree ul, .jstree li { display:block; margin:0 0 0 0; padding:0 0 0 0; list-style-type:none; }
 .jstree li { display:block; min-height:@li-min-height; line-height:16px; white-space:nowrap; margin-left:18px; min-width:18px; }


### PR DESCRIPTION
This fixes the position of the selection `<div>` when entering the rename mode in the file tree.

CC @dangoor & @larz0, could you please verify that this works now as expected. Thanks.
