### PR TITLE
Be smarter about fallback projects

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -691,9 +691,9 @@ define(function (require, exports, module) {
             deferred = new $.Deferred();
 
         // Build ordered fallback path array
-        if (recentProjects && recentProjects.length > 0) {
-            // Start with MRU project
-            fallbackPaths.push(recentProjects[0]);
+        if (recentProjects && recentProjects.length > 1) {
+            // *Most* recent project is the one that just failed to load, so use second most recent
+            fallbackPaths.push(recentProjects[1]);
         }
 
         // Next is Getting Started project

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -697,13 +697,14 @@ define(function (require, exports, module) {
         // Next is Getting Started project
         fallbackPaths.push(_getWelcomeProjectPath());
 
+        // Helper func for Async.firstSequentially()
         function processItem(path) {
             var deferred = new $.Deferred(),
                 fileEntry = FileSystem.getDirectoryForPath(path);
 
             fileEntry.exists(function (err, exists) {
                 if (!err && exists) {
-                    deferred.resolve(path);
+                    deferred.resolve();
                 } else {
                     deferred.reject();
                 }


### PR DESCRIPTION
This is for #6505 and fixes 2 problems:
A. Try to revert to previous project instead of going straight to Getting Started folder.
B. Use Brackets source folder instead of getting caught in infinite loop when Getting Started folder has been deleted.

**Proposed Flow**:
If project fails to load, we show modal error message dialog (as we always have done), and then:
1. Get previous project path from MRU list
2.  If previous project folder does not exist, the try Getting Started folder
3. If still haven't found a project path, use Brackets source folder which is guaranteed to exist.

We do not cycle through the entire project MRU list [as proposed](https://github.com/adobe/brackets/issues/6505#issuecomment-41335593) because it's asynchronous, and reverting to previous project is probably the 80-90% case. All previous projects remain in recent project list, so user can easily select any of them.

We do not explicitly prompt -- that seems to adds more complexity to code and may confuse user even more.
