### PR TITLE
Fix Sidebar Gap

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -98,23 +98,24 @@ a, img {
     height: 100%;
 
     .dark & {
-         background: @dark-bc-menu-bg;
+        background: @dark-bc-menu-bg;
+    }
+
+    .sidebar, .content {
+        height: 100%;
+        position: absolute;
+        top: 0;
     }
 
     .sidebar {
-        height: 100%;
         .vbox;
-        width: @sidebar-width;  // changed dynamically via Resizer
-        position: absolute;
         left: 0;
-        top: 0;
+        width: @sidebar-width;  // changed dynamically via Resizer
+        white-space: nowrap;
     }
 
     .content {
-        height: 100%;
-        position: absolute;
         padding: 0;
-        top: 0;
         left: @sidebar-width;  // changed dynamically via Resizer
         right: @main-toolbar-width;
     }
@@ -770,11 +771,6 @@ a, img {
     &:nth-child(3) .menu-name::before {
         .splitview-icon-horizontal();
     }
-}
-
-#sidebar {
-    position: absolute;
-    white-space: nowrap;
 }
 
 #sidebar-resizer {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -773,7 +773,7 @@ a, img {
 }
 
 #sidebar {
-    position: relative;
+    position: absolute;
     white-space: nowrap;
 }
 


### PR DESCRIPTION
This seems to fix #9248, but I'm not quite sure what that code was for (FWIW, it was introduced in 04848ee0a5727d43bd934203f53d9332b2eb8b78) and if anything relies on it.

I've tested an verified these scenarios are still working:
- [x] Invoking menus (context menu (Working Set and file tree), Split View Menu, Working Set sort)
- [x] Expanding/collapsing folders
- [x] Resizing the sidebar (via dragging) works fine
- [x] Hiding/showing the sidebar (via `Ctrl-Alt-H`) works fine
- [x] Hiding/showing the sidebar (via double-clicking) works fine
- [x] Hiding the sidebar by dragging all the way to the edge
- [x] Showing the sidebar by dragging to the right
- [x] Showing/hiding/resizing bottom panels
- [x] Resizing the Brackets window
- [x] Adding/Removing files to/from Working Set
- [x] Switching between Split View states (invoking, exiting)
- [x] Dragging files between Working Sets
- [x] Window-wide sidebar (+ window resizing)

Not (completely) working:
- [ ] #3376 is UTR, but the Editor itself jiggles (without persistent effects on the UI, just a single jiggle) (doesn't happen all the time)
