### PR TITLE
Fix #7459 -- allow parallel timers of the same name.

### DIFF
--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -280,7 +280,10 @@ define(function (require, exports, module) {
         // Appropriate timer is used, and the other is discarded.
         var timerBuildFull = "HTMLInstr. Build DOM Full";
         var timerBuildPart = "HTMLInstr. Build DOM Partial";
-        PerfUtils.markStart([timerBuildFull, timerBuildPart]);
+        var timers; // timer handles
+        timers = PerfUtils.markStart([timerBuildFull, timerBuildPart]);
+        timerBuildFull = timers[0];
+        timerBuildPart = timers[1];
         
         function closeTag(endIndex, endPos) {
             lastClosedTag = stack[stack.length - 1];

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -63,16 +63,17 @@ define(function (require, exports, module) {
     var updatableTests = {};
     
     /**
+     * @private
      * Keeps the track of measurements sequence number for re-entrant sequences with
      * the same name currently running. Entries are created and deleted as needed.
      */
-    var testSequenceIds = {};
+    var _reentTests = {};
     
     /**
      * @private
      * A unique key to log performance data
      *
-     * @param {!string} id Unique ID for this measurement name
+     * @param {(string|undefined)} id Unique ID for this measurement name
      * @param {!string} name A short name for this measurement
      * @param {?number} reent Sequence identifier for parallel tests of the same name
      */
@@ -119,12 +120,12 @@ define(function (require, exports, module) {
         var i;
         for (i = 0; i < id.length; i++) {
             if (!(id[i] instanceof PerfMeasurement)) {
-                if (testSequenceIds[id[i]] === undefined) {
-                    testSequenceIds[id[i]] = 0;
+                if (_reentTests[id[i]] === undefined) {
+                    _reentTests[id[i]] = 0;
                 } else {
-                    testSequenceIds[id[i]]++;
+                    _reentTests[id[i]]++;
                 }
-                id[i] = new PerfMeasurement(undefined, id[i], testSequenceIds[id[i]]);
+                id[i] = new PerfMeasurement(undefined, id[i], _reentTests[id[i]]);
             }
         }
         return id;
@@ -214,10 +215,10 @@ define(function (require, exports, module) {
         }
         
         if (id.reent !== undefined) {
-            if (testSequenceIds[id] === 0) {
-                delete testSequenceIds[id];
+            if (_reentTests[id] === 0) {
+                delete _reentTests[id];
             } else {
-                testSequenceIds[id]--;
+                _reentTests[id]--;
             }
         }
 
@@ -302,9 +303,9 @@ define(function (require, exports, module) {
     }
 
     /**
-      * Returns the performance data as a tab deliminted string
-      * @return {string}
-      */
+     * Returns the performance data as a tab deliminted string
+     * @return {string}
+     */
     function getDelimitedPerfData() {
         var getValue = function (entry) {
             // return single value, or tab deliminted values for an array
@@ -364,7 +365,7 @@ define(function (require, exports, module) {
         perfData = {};
         activeTests = {};
         updatableTests = {};
-        testSequenceIds = {};
+        _reentTests = {};
     }
     
     // create performance measurement constants

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
      */
     function _markStart(id, time) {
         if (activeTests[id]) {
-            console.error("Recursive tests with the same name are not supported. Timer name: " + name);
+            console.error("Recursive tests with the same name are not supported. Timer name: " + id.name);
         }
         
         activeTests[id] = { startTime: time };

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -63,11 +63,6 @@ define(function (require, exports, module) {
     var updatableTests = {};
     
     /**
-     * Hash of measurement IDs
-     */
-    var perfMeasurementIds = {};
-    
-    /**
      * @private
      * A unique key to log performance data
      *
@@ -87,9 +82,6 @@ define(function (require, exports, module) {
      * @param {!name} name A short name for this measurement
      */
     function createPerfMeasurement(id, name) {
-        if (perfMeasurementIds[id]) {
-            console.error("Performance measurement " + id + " is already defined");
-        }
         
         var pm = new PerfMeasurement(id, name);
         exports[id] = pm;
@@ -189,9 +181,6 @@ define(function (require, exports, module) {
         } else {
             perfData[name] = elapsedTime;
         }
-
-        // Real time logging
-        //console.log(name + " " + elapsedTime);
     }
 
     /**

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -77,13 +77,13 @@ define(function (require, exports, module) {
      * @param {?number} reent Sequence identifier for parallel tests of the same name
      */
     function PerfMeasurement(id, name, reent) {
+        this.name = name;
+        this.reent = reent;
         if (id) {
             this.id = id;
         } else {
             this.id = (reent) ? "[reent " + this.reent + "] " + name : name;
         }
-        this.name = name;
-        this.reent = reent;
     }
     
     /**
@@ -150,10 +150,9 @@ define(function (require, exports, module) {
      * this name will appear as an entry in the performance report. 
      * For example: "Open file: /Users/brackets/src/ProjectManager.js"
      *
-     * Multiple timers can be opened simultaneously, but all open timers must have
-     * a unique name.
+     * Multiple timers can be opened simultaneously.
      * 
-     * Returns an opaque set of timer ids which can be store and used for calling
+     * Returns an opaque set of timer ids which can be stored and used for calling
      * addMeasurement(). Since name is often creating via concatenating strings this
      * return value allows clients to construct the name once.
      *


### PR DESCRIPTION
Fix #7459.

Keep track of the measurements of the same name started in parallel: assign them different tracking ids, but report them under the same name. All the measurements are now `PerfMeasurement` objects. Also, code cleanup.

CC: @redmunds, @peterflynn -- please take a look if this change is a good idea.
