### PR TITLE
Loosen restrictions on window.open about:blank

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -447,7 +447,7 @@ define(function (require, exports, module) {
         var real_windowOpen = window.open;
         window.open = function (url) {
             // Allow file:// URLs, relative URLs (implicitly file: also), and about:blank
-            if (!url.match(/^file:\/\//) && url !== "about:blank" && url.indexOf(":") !== -1) {
+            if (!url.match(/^file:\/\//) && !url.match(/^about:blank/) && url.indexOf(":") !== -1) {
                 throw new Error("Brackets-shell is not a secure general purpose web browser. Use NativeApp.openURLInDefaultBrowser() to open URLs in the user's main browser");
             }
             return real_windowOpen.apply(window, arguments);


### PR DESCRIPTION
Partial fix for #8768. brackets-shell fix to parse only `about:blank` URLs for sizing is pending.
