### PR TITLE
Avoid "Debug > Open Brackets Source" hitting symlink bug #6692

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -256,7 +256,7 @@ define(function (require, exports, module) {
     function handleOpenBracketsSource() {
         // Brackets source dir w/o the trailing src/ folder
         var dir = FileUtils.getNativeBracketsDirectoryPath().replace(/\/[^\/]+$/, "/");
-        ProjectManager.openProject(dir);
+        brackets.app.showOSFolder(dir);
     }
 
     /* Register all the command handlers */

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -41,7 +41,6 @@ define(function (require, exports, module) {
         Strings                = brackets.getModule("strings"),
         PreferencesManager     = brackets.getModule("preferences/PreferencesManager"),
         LocalizationUtils      = brackets.getModule("utils/LocalizationUtils"),
-        ProjectManager         = brackets.getModule("project/ProjectManager"),
         ErrorNotification      = require("ErrorNotification"),
         NodeDebugUtils         = require("NodeDebugUtils"),
         PerfDialogTemplate     = require("text!htmlContent/perf-dialog.html"),


### PR DESCRIPTION
Just spotted this... the new "Open Brackets Source" command added in #8859 is somewhat dangerous, because in developer setups it'll open a symlink alias to the actual git source tree.  On Macs, this means hitting #6692 -- file watching stops working, but Brackets doesn't realize it and keeps caching files anyway.  It's a fairly nasty bug to hit in a folder where you're quite likely to have external changes (e.g. git syncing).

Proposed fix here is to open the folder as an OS folder view instead of switching projects within Brackets.  The original use case in #8795 (what #8859 was addressing) was just to be able to double-check where the 'set up for hacking' copy of the source is coming from, and I think this still covers that quite well.  (Plus it avoids any potential confusion -- the first time I clicked it, it was surprising that I was getting prompted about unsaved changes, etc., since it's not obvious that the action includes closing your current project).
