### PR TITLE
Change links to use new codemirror organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Awesome! _There are lots of ways you can help._ First read
 then learn how to [pull the repo and hack on Brackets](https://github.com/adobe/brackets/wiki/How-to-Hack-on-Brackets).
 
 The text editor inside Brackets is based on 
-[CodeMirror](http://github.com/marijnh/CodeMirror)&mdash;thanks to Marijn for
+[CodeMirror](http://github.com/codemirror/CodeMirror)&mdash;thanks to Marijn for
 taking our pull requests, implementing feature requests and fixing bugs! See 
 [Notes on CodeMirror](https://github.com/adobe/brackets/wiki/Notes-on-CodeMirror)
 for info on how we're using CodeMirror.

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
         // Update display of inline editors when the hostEditor signals a redraw
         CodeMirror.on(this.info, "redraw", function () {
             // At the point where we get the redraw, CodeMirror might not yet have actually
-            // re-added the widget to the DOM. This is filed as https://github.com/marijnh/CodeMirror/issues/1226.
+            // re-added the widget to the DOM. This is filed as https://github.com/codemirror/CodeMirror/issues/1226.
             // For now, we can work around it by doing the refresh on a setTimeout().
             window.setTimeout(function () {
                 if (self.editor) {

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
             return;
         }
         
-        // FIXME (issue #4564) Workaround https://github.com/marijnh/CodeMirror/issues/1787
+        // FIXME (issue #4564) Workaround https://github.com/codemirror/CodeMirror/issues/1787
         triggerUpdateLayout();
         
         if (!windowResizing) {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -1373,8 +1373,8 @@ define(function (require, exports, module) {
                     });
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 2));
                     
-                    // TODO: can't do our usual undo + re-check range test at the end, becuase of
-                    // marijnh/CodeMirror2 bug #487
+                    // TODO: can't do our usual undo + re-check range test at the end, because of
+                    // codemirror/CodeMirror bug #487
                 });
                 
                 


### PR DESCRIPTION
Just a minor change, nothing else.
See https://github.com/codemirror/CodeMirror/commit/50cf44c40c339db5084d79b24b973771535e0cd8
