### PR TITLE
Don't trigger DocumentManager.pathDeleted on document objects too soon

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -497,8 +497,17 @@ define(function (require, exports, module) {
         /* FileSyncManager.syncOpenDocuments() does all the work of closing files
            in the working set and notifying the user of any unsaved changes. */
         FileSyncManager.syncOpenDocuments(Strings.FILE_DELETED_TITLE);
-        // Send a "pathDeleted" event. This will trigger the views to update.
-        $(exports).triggerHandler("pathDeleted", path);
+        
+        if (!getOpenDocumentForPath(path)) {
+            // The file syncManager will sync open documents and delete
+            //  those by calling DocumentManager.notifyFileDeleted when 
+            //  a file has been deleted and it's time to close the view
+            //  of the file. 
+            // For non-document files we don't get such notification
+            //  so we need to cleanup any views and remove the file from
+            //  all Working Sets
+            $(exports).triggerHandler("pathDeleted", path);
+        }
     }
 
     /**

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -716,8 +716,11 @@ define(function (require, exports, module) {
     exports.createUntitledDocument      = createUntitledDocument;
     exports.getAllOpenDocuments         = getAllOpenDocuments;
     exports.notifyFileDeleted           = notifyFileDeleted;
+    
+    // For internal use only
     exports.notifyPathNameChanged       = notifyPathNameChanged;
     exports.notifyPathDeleted           = notifyPathDeleted;
+    exports._handleFileDeleted          = _handleFileDeleted;
 
     // Performance measurements
     PerfUtils.createPerfMeasurement("DOCUMENT_MANAGER_GET_DOCUMENT_FOR_PATH", "DocumentManager.getDocumentForPath()");

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -504,7 +504,7 @@ define(function (require, exports, module) {
             !MainViewManager.findInAllWorkingSets(fullPath).length) {
             // For images not open in the workingset,
             // FileSyncManager.syncOpenDocuments() will 
-            //  not close tell us to close those views
+            //  not tell us to close those views
             $(exports).triggerHandler("pathDeleted", fullPath);
         }
     }
@@ -708,11 +708,11 @@ define(function (require, exports, module) {
     exports.getDocumentText             = getDocumentText;
     exports.createUntitledDocument      = createUntitledDocument;
     exports.getAllOpenDocuments         = getAllOpenDocuments;
-    exports.notifyFileDeleted           = notifyFileDeleted;
     
     // For internal use only
     exports.notifyPathNameChanged       = notifyPathNameChanged;
     exports.notifyPathDeleted           = notifyPathDeleted;
+    exports.notifyFileDeleted           = notifyFileDeleted;
 
     // Performance measurements
     PerfUtils.createPerfMeasurement("DOCUMENT_MANAGER_GET_DOCUMENT_FOR_PATH", "DocumentManager.getDocumentForPath()");

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -485,7 +485,7 @@ define(function (require, exports, module) {
         // At this point, all those other views SHOULD have released the Doc
         if (doc && doc._refCount > 0) {
             console.warn("Deleted " + file.fullPath + " Document still has " + doc._refCount + " references. Did someone addRef() without listening for 'deleted'?");
-        }  
+        }
     }
 
     /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1096,14 +1096,10 @@ define(function (require, exports, module) {
         //          it to DocumentManager
         if (removed) {
             removed.forEach(function(file) {
-                // The call to syncOpenDocuemnts above will remove any deleted files
-                //  in the working set, we just need to handle the case of files not
-                //  in the working set. to optimize this: call the internal handler
-                //  directly so we're not searching the working set twice or call
-                //  syncOpenDocuments again (DocumentManager.notifyPathDeleted will do this)
-                if (!MainViewManager.findInAllWorkingSets(file.fullPath).length) {
-                    DocumentManager._handleFileDeleted(file.fullPath);
-                }
+                // The call to syncOpenDocuemnts above will not nofify
+                //  document manager about deleted images that are 
+                //  not in the working set -- try to clean that up here
+                DocumentManager.notifyPathDeleted(file.fullPath);
             });
         }
     };

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1096,7 +1096,14 @@ define(function (require, exports, module) {
         //          it to DocumentManager
         if (removed) {
             removed.forEach(function(file) {
-                DocumentManager.notifyPathDeleted(file.fullPath);
+                // The call to syncOpenDocuemnts above will remove any deleted files
+                //  in the working set, we just need to handle the case of files not
+                //  in the working set. to optimize this: call the internal handler
+                //  directly so we're not searching the working set twice or call
+                //  syncOpenDocuments again (DocumentManager.notifyPathDeleted will do this)
+                if (!MainViewManager.findInAllWorkingSets(file.fullPath).length) {
+                    DocumentManager._handleFileDeleted(file.fullPath);
+                }
             });
         }
     };

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1088,6 +1088,17 @@ define(function (require, exports, module) {
         FileSyncManager.syncOpenDocuments();
 
         model.handleFSEvent(entry, added, removed);
+        
+        // @TODO: DocumentManager should implement its own fsChange  handler
+        //          we can clean up the calls to DocumentManager.notifyPathDeleted
+        //          and privatize DocumentManager.notifyPathDeleted as well
+        //        We can also remove the _fileSystemRename handler below and move
+        //          it to DocumentManager
+        if (removed) {
+            removed.forEach(function(file) {
+                DocumentManager.notifyPathDeleted(file.fullPath);
+            });
+        }
     };
 
     /**


### PR DESCRIPTION
This effectively fixes issue #9400 byNot triggering the `DocumentManager.pathDeleted` event on document objects when `ProjectManager` calls `DocumentManager.notifyPathDeleted()` and the path has a `Document` object.

For `Document` objects , `FileSyncManager.syncOpenDocuements()` will call  `DocumentManager.notifyFileDeleted` for each `Document` object whose view needs to be destroyed and its file removed from the working set.

Prior versions of `DocumentManager.notifyFileDeleted` called `DocumentManager.closeFullEditor()` which called `removeFromWorkingSet()`; 

Now this is done in `Pane.handleFileDeleted` when the `DocumentManager.pathDeleted` event is handled.   The `DocumentManager.notifyPathDeleted` case which triggered `DocumentManager.pathDeleted` was handled by the Editor to close down Image Views.

This is safe as no other code uses this event. There are a few extensions using this event but the impact should be positive since we don't want to trigger the event until `FileSyncManager` notifies `DocumentManager` on actual deletions. For non-document objects (images) it should be OK to dispatch the event when we get it. This will be the only time we get a notification for non-document objects anyway so we _have_ to do dispatch the event during `DocumentObject.notifyPathDeleted` or it won't be removed from the working set and its view closed.

Recommended Test Scenarios:
- [ ] Open a file to the working set don't change it and delete it from the file tree
- [ ] Open a file to the working set, change it and delete it from the file tree
- [ ] Open a file to the working set, don't change it and delete it from Finder/Explorer
- [ ] Open a file but don't add it to the working set and delete it from the file tree
- [ ] Open a file but don't add it to the working set and delete it from Finder/Explorer
- [ ] Open an image to the working set and delete it from the file tree
- [ ] Open an image to the working set and delete it from Finder/Explorer
- [ ] Open an image but don't add it to the working set and delete it from the file tree
- [ ] Open an image but don't add it to the working set and delete it from Finder/Explorer
