### PR TITLE
Don't trigger DocumentManager.pathDeleted on document objects too soon

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -501,7 +501,7 @@ define(function (require, exports, module) {
         FileSyncManager.syncOpenDocuments(Strings.FILE_DELETED_TITLE);
         
         if (!getOpenDocumentForPath(fullPath) &&
-            !MainViewManager.findInAllWorkingSets(fullPath).length) {
+                !MainViewManager.findInAllWorkingSets(fullPath).length) {
             // For images not open in the workingset,
             // FileSyncManager.syncOpenDocuments() will 
             //  not tell us to close those views

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1095,7 +1095,7 @@ define(function (require, exports, module) {
         //        We can also remove the _fileSystemRename handler below and move
         //          it to DocumentManager
         if (removed) {
-            removed.forEach(function(file) {
+            removed.forEach(function (file) {
                 // The call to syncOpenDocuemnts above will not nofify
                 //  document manager about deleted images that are 
                 //  not in the working set -- try to clean that up here

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1088,6 +1088,20 @@ define(function (require, exports, module) {
         FileSyncManager.syncOpenDocuments();
 
         model.handleFSEvent(entry, added, removed);
+        
+        // @TODO: DocumentManager should implement its own fsChange  handler
+        //          we can clean up the calls to DocumentManager.notifyPathDeleted
+        //          and privatize DocumentManager.notifyPathDeleted as well
+        //        We can also remove the _fileSystemRename handler below and move
+        //          it to DocumentManager
+        if (removed) {
+            removed.forEach(function(file) {
+                // The call to syncOpenDocuemnts above will not nofify
+                //  document manager about deleted images that are 
+                //  not in the working set -- try to clean that up here
+                DocumentManager.notifyPathDeleted(file.fullPath);
+            });
+        }
     };
 
     /**


### PR DESCRIPTION
Squashed version of #9410

This effectively fixes issue #9400 byNot triggering the `DocumentManager.pathDeleted` event on document objects when `ProjectManager` calls `DocumentManager.notifyPathDeleted()` and the path has a `Document` object.

For `Document` objects , `FileSyncManager.syncOpenDocuements()` will call  `DocumentManager.notifyFileDeleted` for each `Document` object whose view needs to be destroyed and its file removed from the working set.

Prior versions of `DocumentManager.notifyFileDeleted` called `DocumentManager.closeFullEditor()` which called `removeFromWorkingSet()`; 

Now this is done in `Pane.handleFileDeleted` when the `DocumentManager.pathDeleted` event is handled.   The `DocumentManager.notifyPathDeleted` case which triggered `DocumentManager.pathDeleted` was handled by the Editor to close down Image Views.

This is safe as no other code uses this event. There are a few extensions using this event but the impact should be positive since we don't want to trigger the event until `FileSyncManager` notifies `DocumentManager` on actual deletions. For non-document objects (images) it should be OK to dispatch the event when we get it. This will be the only time we get a notification for non-document objects anyway so we _have_ to do dispatch the event during `DocumentObject.notifyPathDeleted` or it won't be removed from the working set and its view closed.

Recommended Test Scenarios:
- [ ] Open a file to the working set don't change it and delete it from the file tree
- [ ] Open a file to the working set, change it and delete it from the file tree
- [ ] Open a file to the working set, don't change it and delete it from Finder/Explorer
- [ ] Open a file but don't add it to the working set and delete it from the file tree
- [ ] Open a file but don't add it to the working set and delete it from Finder/Explorer
- [ ] Open an image to the working set and delete it from the file tree
- [ ] Open an image to the working set and delete it from Finder/Explorer
- [ ] Open an image but don't add it to the working set and delete it from the file tree
