### PR TITLE
Prevent working set from taking focus on every mousedown

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -765,6 +765,9 @@ define(function (require, exports, module) {
                 }
             }
 
+            // prevent working set from grabbing focus no matter what type of click/drag occurs
+            e.preventDefault();
+            
             // initialization
             $(window).on("mouseup.wsvdragging", function () {
                 drop();


### PR DESCRIPTION
Fixes bug #9429 and half of #9414. This is basically just restoring what we were doing before the drag & drop rewrite.

This isn't critical for the release, but if we're still open for one last PR and @JeffryBooher agrees this is safe, it would be nice to get in for 0.44 (since it's a regression).
