### PR TITLE
UI Fixes

### DIFF
--- a/src/extensions/default/InlineColorEditor/css/main.less
+++ b/src/extensions/default/InlineColorEditor/css/main.less
@@ -334,7 +334,7 @@
 
 // Dark UI theme
 
-@dark-bc-bg-highlight: #005ecc;
+@dark-bc-bg-highlight: #2a3b50;
 @dark-bc-highlight: rgba(255, 255, 255, 0.06);
 @dark-bc-text: #ccc;
 @dark-bc-text-alt: #fff;

--- a/src/extensions/default/InlineTimingFunctionEditor/main.less
+++ b/src/extensions/default/InlineTimingFunctionEditor/main.less
@@ -301,7 +301,7 @@
 
 /* Dark UI theme */
 
-@dark-bc-bg-highlight: #005ecc;
+@dark-bc-bg-highlight: #2a3b50;
 @dark-bc-highlight: rgba(255, 255, 255, 0.06);
 @dark-bc-text: #ccc;
 @dark-bc-text-alt: #fff;

--- a/src/extensions/default/RecentProjects/styles/styles.less
+++ b/src/extensions/default/RecentProjects/styles/styles.less
@@ -4,7 +4,7 @@
 @bc-text-thin:                  #000;
 @bc-text-thin-quiet:            #777;
 
-@dark-bc-bg-highlight:          #005ecc;
+@dark-bc-bg-highlight:          #2a3b50;
 @dark-bc-menu-text:             #fff;
 @dark-bc-text-quiet:            #aaa;
 @dark-bc-text-thin:             #fff;

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -126,7 +126,7 @@
 /* Dark Core UI variables -----------------------------------------------------------------------------*/
 
 // General
-@dark-bc-bg-highlight:               #2a3b50;
+@dark-bc-bg-highlight:               #284160;
 @dark-bc-bg-inline-widget:           #1b1b1b;
 @dark-bc-bg-tool-bar:                #5D5F60;
 @dark-bc-bg-status-bar:              #1c1c1e;

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -126,7 +126,7 @@
 /* Dark Core UI variables -----------------------------------------------------------------------------*/
 
 // General
-@dark-bc-bg-highlight:               #005ecc;
+@dark-bc-bg-highlight:               #2a3b50;
 @dark-bc-bg-inline-widget:           #1b1b1b;
 @dark-bc-bg-tool-bar:                #5D5F60;
 @dark-bc-bg-status-bar:              #1c1c1e;
@@ -180,7 +180,7 @@
 
 // Default Button
 @dark-bc-btn-bg:                     #3f3f3f;
-@dark-bc-btn-bg-down:                #222;
+@dark-bc-btn-bg-down:                #383838;
 @dark-bc-btn-bg-down-alt:            #404141;
 @dark-bc-btn-border:                 #202020;
 @dark-bc-btn-border-error:           #fa689d;

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -172,7 +172,7 @@
 @dark-bc-panel-bg-alt:               #313131;
 @dark-bc-panel-bg-promoted:          #222;
 @dark-bc-panel-bg-hover:             rgba(255, 255, 255, 0.12);
-@dark-bc-panel-bg-hover-alt:         rgba(0, 0, 0, 0.04);
+@dark-bc-panel-bg-hover-alt:         rgba(0, 0, 0, 0.1);
 @dark-bc-panel-bg-selected:          #3d3e40;
 @dark-bc-panel-bg-text-highlight:    #000;
 @dark-bc-panel-border:               #000;


### PR DESCRIPTION
- Fixed #9404 
- Fixed #9359 
- Made dark theme highlight less obnoxious. Areas affected: Quick Open Highlight, Code Hint Highlight, Inline Color Editor "On" toggle, Find Option toggle, Project Dropdown Highlight.
