### PR TITLE
Finish updating Brackets version to 0.45

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -22,8 +22,8 @@
         "build_timestamp": ""
     },
     "name": "Brackets",
-    "version": "0.44.0-0",
-    "apiVersion": "0.44.0",
+    "version": "0.45.0-0",
+    "apiVersion": "0.45.0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets/issues"


### PR DESCRIPTION
The `src/config.json` file was not updated with #9395. This simply remedies that. :)

@ingorichter 
