### PR TITLE
Fix failing InlineEditorProvider tests

### DIFF
--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
- *
+ *  
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
  * Software is furnished to do so, subject to the following conditions:
- *
+ *  
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ *  
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
  * DEALINGS IN THE SOFTWARE.
- *
+ * 
  */
 
 
@@ -27,7 +27,7 @@
 
 define(function (require, exports, module) {
     'use strict';
-
+    
     var CommandManager,     // loaded from brackets.test
         Commands,           // loaded from brackets.test
         EditorManager,      // loaded from brackets.test
@@ -43,18 +43,18 @@ define(function (require, exports, module) {
         Strings          = require("strings");
 
     describe("InlineEditorProviders", function () {
-
+        
         this.category = "integration";
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
             tempPath = SpecRunnerUtils.getTempDirectory(),
             testWindow,
             infos = {};
-
+        
         function toRange(startLine, endLine) {
             return {startLine: startLine, endLine: endLine};
         }
-
+        
         function rewriteProject() {
             var result = new $.Deferred(),
                 options = {
@@ -68,17 +68,17 @@ define(function (require, exports, module) {
             }).fail(function () {
                 result.reject();
             });
-
+            
             return result.promise();
         }
-
+        
         /**
          * Performs setup for an inline editor test. Parses offsets (saved to infos) for all files in
          * the test project (testPath) and saves files back to disk without offset markup.
          * When finished, open an editor for the specified project relative file path
          * then attempts opens an inline editor at the given offset. Installs an after()
          * function restore all file content back to original state with offset markup.
-         *
+         * 
          * @param {string} openFile  Project relative file path to open in a main editor.
          * @param {number} openOffset  The offset index location within openFile to open an inline editor.
          * @param {boolean=} expectInline  Use false to verify that an inline editor should not be opened. Omit otherwise.
@@ -86,25 +86,25 @@ define(function (require, exports, module) {
          */
         function initInlineTest(openFile, openOffset, expectInline, documentList) {
             var editor;
-
+            
             documentList = documentList || [];
-
+            
             expectInline = (expectInline !== undefined) ? expectInline : true;
-
+            
             runs(function () {
                 documentList.push(openFile);
                 waitsForDone(SpecRunnerUtils.openProjectFiles(documentList), "FILE_OPEN timeout", 1000);
             });
-
+            
             runs(function () {
                 editor = EditorManager.getCurrentFullEditor();
-
+                
                 // open inline editor at specified offset index
                 var inlineEditorResult = SpecRunnerUtils.toggleQuickEditAtOffset(
                     editor,
                     infos[openFile].offsets[openOffset]
                 );
-
+                
                 if (expectInline) {
                     waitsForDone(inlineEditorResult, "inline editor opened", 1000);
                 } else {
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
                 if (expectInline) {
                     var inlineWidgets = editor.getInlineWidgets();
                     expect(inlineWidgets.length).toBe(1);
-
+                    
                     // By the time we're called, the content of the widget should be in the DOM and have a nontrivial height.
                     expect($.contains(testWindow.document.documentElement, inlineWidgets[0].htmlContent)).toBe(true);
                     expect(inlineWidgets[0].$htmlContent.height()).toBeGreaterThan(50);
@@ -125,16 +125,16 @@ define(function (require, exports, module) {
                 editor = null;
             });
         }
-
+        
         // Utilities for testing Editor state
         function expectText(editor) {
             return expect(editor._codeMirror.getValue());
         }
-
+        
         function expectTextToBeEqual(editor1, editor2) {
             expect(editor1._codeMirror.getValue()).toBe(editor2._codeMirror.getValue());
         }
-
+		
         function isLineHidden(cm, lineNum) {
             var markers = cm.findMarksAt({line: lineNum, pos: 0}),
                 i;
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
                 expect(popoverText).toEqual(text);
             });
         }
-
+        
         function getBounds(object, useOffset) {
             var left = (useOffset ? object.offset().left : parseInt(object.css("left"), 10)),
                 top = (useOffset ? object.offset().top : parseInt(object.css("top"), 10));
@@ -198,7 +198,7 @@ define(function (require, exports, module) {
          * These tests are primarily focused on the InlineEditorProvider module.
          */
         describe("htmlToCSSProvider", function () {
-
+            
             beforeFirst(function () {
                 SpecRunnerUtils.createTempDirectory();
 
@@ -206,11 +206,11 @@ define(function (require, exports, module) {
                 runs(function () {
                     waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                 });
-
+                
                 // Create a new window that will be shared by ALL tests in this spec.
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     testWindow = w;
-
+    
                     // Load module instances from brackets.test
                     CommandManager      = testWindow.brackets.test.CommandManager;
                     Commands            = testWindow.brackets.test.Commands;
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
                     FileViewController  = testWindow.brackets.test.FileViewController;
                 });
             });
-
+            
             afterLast(function () {
                 testWindow          = null;
                 Commands            = null;
@@ -234,7 +234,7 @@ define(function (require, exports, module) {
 
                 SpecRunnerUtils.removeTempDirectory();
             });
-
+            
             beforeEach(function () {
                 this.addMatchers({
                     toHaveInlineEditorRange: function (range) {
@@ -247,10 +247,10 @@ define(function (require, exports, module) {
                             startLine = range.startLine,
                             endLine = range.endLine,
                             visibleRangeCheck;
-
+                        
                         for (i = 0; i < lineCount; i++) {
                             hidden = isLineHidden(editor._codeMirror, i);
-
+                            
                             if (i < startLine) {
                                 if (!hidden) {
                                     shouldHide.push(i); // lines above start line should be hidden
@@ -265,44 +265,44 @@ define(function (require, exports, module) {
                                 }
                             }
                         }
-
+                        
                         visibleRangeCheck = (editor._visibleRange.startLine === startLine) &&
                             (editor._visibleRange.endLine === endLine);
-
+                        
                         this.message = function () {
                             var msg = "";
-
+                            
                             if (shouldHide.length > 0) {
                                 msg += "Expected inline editor to hide [" + shouldHide.toString() + "].\n";
                             }
-
+                            
                             if (shouldShow.length > 0) {
                                 msg += "Expected inline editor to show [" + shouldShow.toString() + "].\n";
                             }
-
+                            
                             if (!visibleRangeCheck) {
                                 msg += "Editor._visibleRange [" +
                                     editor._visibleRange.startLine + "," +
                                     editor._visibleRange.endLine + "] should be [" +
                                     startLine + "," + endLine + "].";
                             }
-
+                            
                             return msg;
                         };
-
+                        
                         return (shouldHide.length === 0) &&
                             (shouldShow.length === 0) &&
                             visibleRangeCheck;
                     }
                 });
-
+                
                 SpecRunnerUtils.loadProjectInTestWindow(tempPath);
             });
-
+    
             afterEach(function () {
                 //debug visual confirmation of inline editor
                 //waits(1000);
-
+                
                 // revert files to original content with offset markup
                 testWindow.closeAllFiles();
             });
@@ -310,40 +310,40 @@ define(function (require, exports, module) {
 
             it("should open a type selector and show correct range including the embedded php", function () {
                 initInlineTest("test1.php", 1);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position and displayed range in inline editor
                     expect(inlinePos).toEqual(infos["test1.php"].offsets[0]);
                     expect(inlineWidget.editor).toHaveInlineEditorRange(toRange(4, 8));
-
+                    
                     inlineWidget = null;
                 });
             });
-
+            
             it("should open a type selector on opening tag", function () {
                 initInlineTest("test1.html", 0);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
                     inlineWidget = null;
                 });
             });
-
+            
             it("should open a type selector on closing tag", function () {
                 initInlineTest("test1.html", 9);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
@@ -353,11 +353,11 @@ define(function (require, exports, module) {
 
             it("should open a class selector", function () {
                 initInlineTest("test1.html", 1);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
@@ -367,11 +367,11 @@ define(function (require, exports, module) {
 
             it("should also open a class selector", function () {
                 initInlineTest("test1.html", 7);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
@@ -381,11 +381,11 @@ define(function (require, exports, module) {
 
             it("should open an embedded class selector", function () {
                 initInlineTest("test1.html", 10);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.html"].offsets[11]);
 
@@ -395,11 +395,11 @@ define(function (require, exports, module) {
 
             it("should open an id selector", function () {
                 initInlineTest("test1.html", 2);
-
+                
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[2]);
 
@@ -451,36 +451,36 @@ define(function (require, exports, module) {
                     inlineWidget = null;
                 });
             });
-
-
+            
+            
             it("should close, then remove the inline widget and restore focus", function () {
                 initInlineTest("test1.html", 0);
-
+                
                 var hostEditor, inlineWidget, inlinePos, savedPos;
-
+                
                 runs(function () {
                     hostEditor =  EditorManager.getCurrentFullEditor();
                     savedPos = hostEditor.getCursorPos();
                     inlineWidget = hostEditor.getInlineWidgets()[0];
                     inlinePos = inlineWidget.editor.getCursorPos();
-
+                    
                     // verify cursor position & focus in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
                     expect(inlineWidget.hasFocus()).toEqual(true);
                     expect(hostEditor.hasFocus()).toEqual(false);
-
+                    
                     // close the editor
                     waitsForDone(EditorManager.closeInlineWidget(hostEditor, inlineWidget), "closing inline widget");
-
+                    
                 });
-
+                
                 runs(function () {
                     // verify no inline widgets in list
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
-
+                    
                     // verify that the inline widget's content has been removed from the DOM
                     expect($.contains(testWindow.document.documentElement, inlineWidget.htmlContent)).toBe(false);
-
+                    
                     // verify full editor cursor & focus restored
                     expect(savedPos).toEqual(hostEditor.getCursorPos());
                     expect(hostEditor.hasFocus()).toEqual(true);
@@ -514,7 +514,7 @@ define(function (require, exports, module) {
 
             it("should not open an inline editor when positioned on textContent", function () {
                 initInlineTest("test1.html", 3, false);
-
+                
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
@@ -529,7 +529,7 @@ define(function (require, exports, module) {
             // The call to `waits(4000)` in this test seems to dismiss the popover
             xit("should not open an inline editor when positioned on title attribute", function () {
                 initInlineTest("test1.html", 12, false);
-
+                
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
@@ -546,7 +546,7 @@ define(function (require, exports, module) {
                     var $popover = testWindow.$(".popover-message");
                     expect($popover.length).toEqual(1);
                 });
-
+                
                 runs(function () {
                     // verify popover message is automatically dismissed after 2 more seconds
                     // total delay is 5 sec + 0.5 sec fade-out transition
@@ -562,16 +562,16 @@ define(function (require, exports, module) {
 
             it("should not open an inline editor when positioned on a tag in a comment", function () {
                 initInlineTest("test1.html", 4, false);
-
+                
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
                 });
             });
-
+            
             it("should open an inline editor when positioned on the non standard html tag <to>, but no content from @keyframes", function () {
                 initInlineTest("test1.html", 18);
-
+                
                 runs(function () {
                     // verify inline editor is open for adding a new rule
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(1);
@@ -617,8 +617,8 @@ define(function (require, exports, module) {
                     expect($popover.length).toEqual(1);
                 });
             });
-
-
+            
+                        
             it("should close popover message on selection change", function () {
                 var editor,
                     openFile = "test1.html";
@@ -649,7 +649,7 @@ define(function (require, exports, module) {
                     expect($popover.length).toEqual(0);
                 });
             });
-
+            
             it("should position message popover inside left edge of window", function () {
                 var $popover;
                 initInlineTest("test1.html", 11, false);
@@ -720,49 +720,49 @@ define(function (require, exports, module) {
                     toggleOption(Commands.TOGGLE_WORD_WRAP, "Toggle word-wrap");
                 });
             });
-
+            
             it("should increase size based on content", function () {
                 initInlineTest("test1.html", 1);
-
+                
                 var inlineEditor, widgetHeight;
-
+                
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                     widgetHeight = inlineEditor.totalHeight();
-
+                    
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(25);
-
+                    
                     // change inline editor content
                     var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
-
+                    
                     // insert new lines at current cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(
                         newLines,
                         inlineEditor.getCursorPos()
                     );
-
+                    
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(30);
                     expect(inlineEditor.totalHeight()).toBeGreaterThan(widgetHeight);
-
+                    
                     inlineEditor = null;
                 });
             });
-
+            
             it("should decrease size based on content", function () {
                 initInlineTest("test1.html", 1);
-
+                
                 var inlineEditor, widgetHeight;
-
+                
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                     widgetHeight = inlineEditor.totalHeight();
-
+                    
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(25);
-
+                    
                     // replace the entire .foo rule with an empty string
                     // set text on the editor, can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(
@@ -770,7 +770,7 @@ define(function (require, exports, module) {
                         inlineEditor.getCursorPos(),
                         infos["test1.css"].offsets[3]
                     );
-
+                    
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(23);
                     expect(inlineEditor.totalHeight()).toBeLessThan(widgetHeight);
@@ -778,52 +778,52 @@ define(function (require, exports, module) {
                     inlineEditor = null;
                 });
             });
-
+            
             it("should save changes in the inline editor", function () {
                 initInlineTest("test1.html", 1);
-
+                
                 var err = false,
                     hostEditor,
                     inlineEditor,
                     newText = "\n/* jasmine was here */",
                     savedText;
-
+                
                 this.after(function () {
                     // rewrite the project after saving changes
                     runs(function () {
                         waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                     });
                 });
-
+                
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
                     inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-
+                    
                     // insert text at the inline editor's cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(newText, inlineEditor.getCursorPos());
-
+                    
                     // we're going to compare this to disk later, so pass true to get non-normalized line endings
                     newText = inlineEditor.document.getText(true);
-
+                    
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeTruthy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
-
+                    
                     // verify that the dirty dot is visible in the UI
                     expect(testWindow.$(".dirty-indicator", hostEditor.getInlineWidgets()[0].$htmlContent).width()).not.toEqual(0);
-
+                    
                     // verify focus is in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-
+                    
                     // execute file save command
                     waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-
+                
                 runs(function () {
                     // verify focus is still in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-
+                    
                     // read saved file contents
                     FileUtils.readAsText(inlineEditor.document.file).done(function (text) {
                         savedText = text;
@@ -831,26 +831,26 @@ define(function (require, exports, module) {
                         err = true;
                     });
                 });
-
+                
                 waitsFor(function () { return savedText !== undefined; }, "readAsText timeout", 1000);
-
+                
                 runs(function () {
                     expect(savedText).toEqual(newText);
-
+                    
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
 
                     // verify that the dirty dot is hidden in the UI
                     expect(testWindow.$(".dirty-indicator", hostEditor.getInlineWidgets()[0].$htmlContent).width()).toEqual(0);
-
+                    
                     inlineEditor = hostEditor = null;
                 });
             });
-
+            
             it("should not save changes in the host editor", function () {
                 initInlineTest("test1.html", 1);
-
+                
                 var err = false,
                     hostEditor,
                     inlineEditor,
@@ -858,39 +858,39 @@ define(function (require, exports, module) {
                     newHostText = "/* jasmine was here */\n",
                     savedInlineText,
                     savedHostText;
-
+                
                 this.after(function () {
                     // rewrite the project after saving changes
                     runs(function () {
                         waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                     });
                 });
-
+                
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
                     inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-
+                    
                     // insert text at the host editor's cursor position
                     hostEditor._codeMirror.replaceRange(newHostText, hostEditor.getCursorPos());
-
+                    
                     // insert text at the inline editor's cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(newInlineText, inlineEditor.getCursorPos());
-
+                    
                     // we're going to compare this to disk later, so pass true to get non-normalized line endings
                     newInlineText = inlineEditor.document.getText(true);
-
+                    
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeTruthy();
                     expect(hostEditor.document.isDirty).toBeTruthy();
-
+                    
                     // verify focus is in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-
+                    
                     // execute file save command
                     waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-
+                
                 runs(function () {
                     // read saved inline file contents
                     FileUtils.readAsText(inlineEditor.document.file).done(function (text) {
@@ -898,7 +898,7 @@ define(function (require, exports, module) {
                     }).fail(function () {
                         err = true;
                     });
-
+                    
                     // read saved host editor file contents
                     FileUtils.readAsText(hostEditor.document.file).done(function (text) {
                         savedHostText = text;
@@ -906,13 +906,13 @@ define(function (require, exports, module) {
                         err = true;
                     });
                 });
-
+                
                 waitsFor(function () { return savedInlineText !== undefined && savedHostText !== undefined; }, "readAsText timeout", 1000);
-
+                
                 runs(function () {
                     expect(savedInlineText).toEqual(newInlineText);
                     expect(savedHostText).toEqual(infos["test1.html"].text); // i.e, should be unchanged
-
+                    
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeTruthy();
@@ -920,9 +920,9 @@ define(function (require, exports, module) {
                     inlineEditor = hostEditor = null;
                 });
             });
-
+            
             describe("Inline Editor syncing from disk", function () {
-
+                
                 it("should close inline editor when file deleted on disk", function () {
                     // Create an expendable CSS file
                     var fileToWrite;
@@ -936,37 +936,37 @@ define(function (require, exports, module) {
                             .fail(function (err) {
                                 console.log(err);
                             });
-
+                        
                         waitsForDone(promise, "writeText tempCSS.css", 1000);
                     });
-
+                    
                     // Open inline editor for that file
                     runs(function () {
                         initInlineTest("test1.html", 6, true);
                     });
                     // initInlineTest() inserts a waitsFor() automatically, so must end runs() block here
-
+                    
                     runs(function () {
                         var hostEditor = EditorManager.getCurrentFullEditor();
                         expect(hostEditor.getInlineWidgets().length).toBe(1);
                     });
-
+                    
                     // Delete the file
                     runs(function () {
                         waitsForDone(SpecRunnerUtils.deletePath(fileToWrite.fullPath));
                     });
-
+                    
                     // Ping FileSyncManager to recognize the deletion
                     runs(function () {
                         FileSyncManager.syncOpenDocuments();
                     });
-
+                    
                     // Verify inline is now closed
                     waitsFor(function () {
                         var hostEditor = EditorManager.getCurrentFullEditor();
                         return (hostEditor.getInlineWidgets().length === 0);
                     }, 1000);
-
+                    
                     // Cleanup: initInlineTest() saves contents of all files in the project and rewrites
                     // them back to disk at the end (to restore any stripped offset markers). But in this
                     // case we really want the temp file to stay gone.
@@ -974,36 +974,36 @@ define(function (require, exports, module) {
                         delete infos["tempCSS.css"];
                     });
                 });
-
+                
                 // FUTURE: Eventually we'll instead want it to stay open and revert to the content on disk.
                 // Editor's syncing code can't yet handle blowing away the whole Document like that, though.
                 it("should close inline when file is closed without saving changes", function () {
                     initInlineTest("test1.html", 1);
-
+                    
                     var newText = "\n/* jasmine was here */",
                         hostEditor,
                         inlineEditor,
                         promise;
-
+                    
                     runs(function () {
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-
+                        
                         // verify inline is open
                         expect(hostEditor.getInlineWidgets().length).toBe(1);
-
+                        
                         // insert text at the inline editor's cursor position
                         inlineEditor._codeMirror.replaceRange(newText, inlineEditor.getCursorPos());
-
+                        
                         // verify isDirty flag
                         expect(inlineEditor.document.isDirty).toBe(true);
-
+                        
                         // close the main editor / working set entry for the inline's file
                         promise = testWindow.executeCommand(Commands.FILE_CLOSE, {file: inlineEditor.document.file});
-
+                        
                         // synchronously click the don't save button,
                         // asynchronously wait for the dialog to close and the Dialog's
-                        // promise to resolve.
+                        // promise to resolve. 
                         SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_DONTSAVE);
                     });
 
@@ -1013,7 +1013,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         waitsForDone(promise);
                     });
-
+                    
                     runs(function () {
                         // verify inline is closed
                         expect(hostEditor.getInlineWidgets().length).toBe(0);
@@ -1022,78 +1022,78 @@ define(function (require, exports, module) {
                     });
                 });
             });
-
-
+            
+            
             describe("Bi-directional Editor Synchronizing", function () {
                 // For these tests we *deliberately* use Editor._codeMirror instead of Document to make edits,
                 // in order to test Editor->Document syncing (instead of Document->Editor).
-
+                
                 it("should not add an inline document to the working set without being edited", function () {
                     initInlineTest("test1.html", 0);
-
+                    
                     runs(function () {
                         var i = MainViewManager.findInWorkingSet(MainViewManager.ACTIVE_PANE, infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(-1);
                     });
                 });
-
+            
                 it("should add dirty documents to the working set", function () {
                     initInlineTest("test1.html", 1);
-
+                    
                     var inlineEditor, widgetHeight;
-
+                    
                     runs(function () {
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                         widgetHeight = inlineEditor.totalHeight();
-
+                        
                         // change inline editor content
                         var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
-
+                        
                         // insert new lines at current cursor position
                         inlineEditor._codeMirror.replaceRange(
                             newLines,
                             inlineEditor.getCursorPos()
                         );
-
+                        
                         var i = MainViewManager.findInWorkingSet(MainViewManager.ACTIVE_PANE, infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(1);
 
                         inlineEditor = null;
                     });
                 });
-
+            
                 it("should sync edits between full and inline editors", function () {
                     var fullEditor,
                         inlineEditor,
                         newInlineText = "/* jasmine was inline */\n";
-
+                    
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-
+                    
                     runs(function () {
                         var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
-
+                        
                         // edit the inline editor
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                         inlineEditor._codeMirror.replaceRange(
                             newInlineText,
                             inlineEditor.getCursorPos()
                         );
-
+                        
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
-
+                        
                         // sanity check
                         expect(fullEditor).not.toBe(inlineEditor);
                         expect(fullEditor._codeMirror).not.toBe(inlineEditor._codeMirror);
-
+                        
                         // compare inline editor to full editor
                         expectTextToBeEqual(inlineEditor, fullEditor);
-
+                        
                         // make sure the text was inserted
                         expect(fullEditor._codeMirror.getValue().indexOf(newInlineText)).toBeGreaterThan(0);
-
+                        
                         // edit in the full editor and compare
                         fullEditor._codeMirror.replaceRange(
                             newInlineText,
@@ -1105,9 +1105,9 @@ define(function (require, exports, module) {
                     });
                 });
             });
-
+            
             describe("Inline Editor range updating", function () {
-
+                
                 var fullEditor,
                     hostEditor,
                     inlineEditor,
@@ -1120,20 +1120,20 @@ define(function (require, exports, module) {
                     endOfEnd,
                     after,
                     wayafter;
-
+                    
                 beforeEach(function () {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-
+                    
                     runs(function () {
                         var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-
+                        
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
-
+                        
                         // alias offsets to nice names
                         before = infos["test1.css"].offsets[4];
                         start = infos["test1.css"].offsets[1];
@@ -1151,22 +1151,22 @@ define(function (require, exports, module) {
                     hostEditor   = null;
                     inlineEditor = null;
                 });
-
+                
                 it("should insert new line at start of range, and stay open on undo", function () {
-                    // insert new line at start of inline range--the new line should be included in
+                    // insert new line at start of inline range--the new line should be included in 
                     // the inline
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
                         start
                     );
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
-
+                    
                     // undo is equivalent to deleting the first line in the range: shouldn't close the editor
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-
+                
                 it("should insert new line within first line of range, and stay open on undo", function () {
                     // insert new line in middle of first line of inline range--the new line should
                     // be included
@@ -1175,18 +1175,18 @@ define(function (require, exports, module) {
                         {line: start.line, ch: start.ch + 1}
                     );
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
-
+                
                     // Even though the edit didn't start at the beginning of the line, the undo touches
                     // the whole line; but deleting the first line still shouldn't close the editor
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-
+                
                 it("should not close inline when undoing changes to first line in range that did not include newlines", function () {
                     // undo is NOT deleting the entire first line in these cases, so the inline should be able to stay open
-
-                    // insert new text at start of inline range, without newlines--the new text should be included in
+                    
+                    // insert new text at start of inline range, without newlines--the new text should be included in 
                     // the inline
                     fullEditor._codeMirror.replaceRange(
                         ".bar, ",
@@ -1196,7 +1196,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // replace text at start of inline range with text without newlines
                     fullEditor._codeMirror.replaceRange(
                         ".bar",
@@ -1207,7 +1207,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // insert new text in middle of first line in range, without newlines
                     fullEditor._codeMirror.replaceRange(
                         "ABCD",
@@ -1218,10 +1218,10 @@ define(function (require, exports, module) {
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-
+                
                 it("should sync deletions (and their undos) on last line in range, with or without newlines", function () {
                     // undo is NOT deleting the entire last line in these cases, so the inline should be able to stay open
-
+                    
                     // insert new line in middle of last line of inline range--the new line should
                     // be included
                     fullEditor._codeMirror.replaceRange(
@@ -1232,7 +1232,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // insert new line at end of last line of inline range--the new line should
                     // be included
                     fullEditor._codeMirror.replaceRange(
@@ -1243,7 +1243,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // replace all text on last line (without replacing trailing newline)
                     fullEditor._codeMirror.replaceRange(
                         "ABCD",
@@ -1265,7 +1265,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line + 1, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // insert line within inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1274,7 +1274,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // insert line at end of inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1283,7 +1283,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // insert line below inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1293,14 +1293,14 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-
+            
                 it("should sync deletions from the full editor and update the visual range of the inline editor", function () {
                     // delete line within inline range
                     fullEditor._codeMirror.replaceRange("", middle, end);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line - 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-
+                    
                     // delete line below inline range
                     fullEditor._codeMirror.replaceRange("", after, wayafter);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
@@ -1360,8 +1360,8 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.replaceRange("", middleOfMiddle, wayafter);
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                 });
-
-
+                
+            
                 it("should sync insertions with multiple change objects in one event", function () {
                     // Insert two new lines: one at start of inline range, the other at the (newly
                     // updated) end of range. The edits are batched into just one event (so the
@@ -1380,19 +1380,19 @@ define(function (require, exports, module) {
                         );
                     });
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 2));
-
+                    
                     // TODO: can't do our usual undo + re-check range test at the end, because of
                     // codemirror/CodeMirror bug #487
                 });
-
-
+                
+                
                 it("should sync multiple edits between full and inline editors", function () {
                     var i,
                         editor,
                         text,
                         newInlineText = "/* jasmine was inline */\n",
                         newFullText = "/* full editor edit */\n";
-
+                    
                     // alternate editors while inserting new text
                     for (i = 0; i < 10; i++) {
                         editor = (i % 2 === 0) ? fullEditor : inlineEditor;
@@ -1404,25 +1404,25 @@ define(function (require, exports, module) {
                         expectTextToBeEqual(inlineEditor, fullEditor);
                     }
                 });
-
+            
                 it("should close inline if the contents of the full editor are all deleted", function () {
                     // verify inline is open
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
-
+                    
                     // delete all text via full editor
                     fullEditor._codeMirror.setValue("");
-
+                    
                     // verify inline is closed
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                 });
-
+                
                 it("should sync after undoing and redoing an edit", function () {
                     var originalText,
                         editedText,
                         newInlineText = "/* jasmine was inline */\n";
-
+                    
                     originalText = inlineEditor._codeMirror.getValue();
-
+                    
                     // edit the inline editor in the middle of the text so it doesn't
                     // run into one of the collapsing cases
                     inlineEditor._codeMirror.replaceRange(
@@ -1430,44 +1430,44 @@ define(function (require, exports, module) {
                         middle
                     );
                     editedText = inlineEditor._codeMirror.getValue();
-
+                    
                     // compare inline editor to full editor
                     expectTextToBeEqual(inlineEditor, fullEditor);
-
+                    
                     // undo the inline editor
                     inlineEditor._codeMirror.undo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(inlineEditor).toBe(originalText);
-
+                    
                     // redo the inline editor
                     inlineEditor._codeMirror.redo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(inlineEditor).toBe(editedText);
-
+                    
                     // undo the full editor
                     fullEditor._codeMirror.undo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(fullEditor).toBe(originalText);
-
+                    
                     // redo the full editor
                     fullEditor._codeMirror.redo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(fullEditor).toBe(editedText);
                 });
-
+                
             });
-
+            
             describe("Multiple inline editor interaction", function () {
                 var hostEditor, inlineEditor;
                 beforeEach(function () {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-
+                    
                     runs(function () {
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
                     });
                 });
-
+            
                 afterEach(function () {
                     hostEditor   = null;
                     inlineEditor = null;
@@ -1475,7 +1475,7 @@ define(function (require, exports, module) {
 
                 it("should keep range consistent after undo/redo (bug #1031)", function () {
                     var secondInlineOpen = false, secondInlineEditor;
-
+                    
                     // open inline editor at specified offset index
                     runs(function () {
                         hostEditor.focus();
@@ -1486,9 +1486,9 @@ define(function (require, exports, module) {
                             secondInlineOpen = isOpen;
                         });
                     });
-
+                    
                     waitsFor(function () { return secondInlineOpen; }, "second inline open timeout", 1000);
-
+                    
                     // Not sure why we have to wait in between these for the bug to occur, but we do.
                     runs(function () {
                         secondInlineEditor = hostEditor.getInlineWidgets()[1].editor;
@@ -1507,37 +1507,37 @@ define(function (require, exports, module) {
                     });
                 });
             });
-
-
+            
+            
             describe("Inline Editor range equal to file range", function () {
                 var fullEditor,
                     hostEditor,
                     inlineEditor;
-
+                    
                 beforeEach(function () {
                     initInlineTest("test1.html", 5, true, ["testOneRuleFile.css"]);
-
+                    
                     runs(function () {
                         var cssPath = infos["testOneRuleFile.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-
+                        
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
                     });
                 });
-
+                
                 afterEach(function () {
                     fullEditor   = null;
                     hostEditor   = null;
                     inlineEditor = null;
                 });
-
+                
                 it("should delete line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
-
+                    
                     // delete all of last line in range
                     fullEditor._codeMirror.replaceRange("", {line: 1, ch: 16}, {line: 2, ch: 1});
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
@@ -1546,10 +1546,10 @@ define(function (require, exports, module) {
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
                 });
-
+                
                 it("should insert new line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
-
+                    
                     // delete all of last line in range
                     fullEditor._codeMirror.replaceRange("\n/* New last line */", {line: 2, ch: 1});
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
@@ -1560,25 +1560,25 @@ define(function (require, exports, module) {
                 });
             });
         });
-
+        
         describe("InlineEditor provider prioritization", function () {
             var testWindow,
                 testDocumentManager,
                 testEditorManager,
                 testMainViewManager,
                 testDoc;
-
+            
             function getPositiveProviderCallback(widget) {
                 return function () {
                     widget.called = true;
                     return $.Deferred().resolve(widget).promise();
                 };
             }
-
+            
             function negativeProviderCallback() {
                 return null;
             }
-
+            
             beforeEach(function () {
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     var mock = SpecRunnerUtils.createMockEditor("");
@@ -1587,17 +1587,17 @@ define(function (require, exports, module) {
                     testEditorManager   = testWindow.brackets.test.EditorManager;
                     testMainViewManager = testWindow.brackets.test.MainViewManager;
                     testDocumentManager = testWindow.brackets.test.DocumentManager;
-
+                    
                     testDoc             = mock.doc;
-
+                    
                     testDocumentManager.getOpenDocumentForPath = function (fullPath) {
                         return testDoc;
                     };
-
+                    
                     testMainViewManager._edit(testMainViewManager.ACTIVE_PANE, testDoc);
                 });
             });
-
+            
             afterEach(function () {
                 SpecRunnerUtils.destroyMockEditor(testDoc);
                 SpecRunnerUtils.closeTestWindow();
@@ -1608,41 +1608,41 @@ define(function (require, exports, module) {
                 testMainViewManager = null;
                 testDocumentManager = null;
             });
-
-
+            
+            
             it("should prefer positive higher priority providers (1)", function () {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-
+                
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), 2);
-
+                                
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-
+                
                 runs(function () {
                     expect(widget0.called).toBeFalsy();
                     expect(widget1.called).toBeFalsy();
                     expect(widget2.called).toBe(true);
                 });
             });
-
+            
             it("should prefer positive higher priority providers (2)", function () {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-
+                
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), 2);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
-
+                                
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-
+                
                 runs(function () {
                     expect(widget0.called).toBeFalsy();
                     expect(widget1.called).toBeFalsy();
@@ -1655,17 +1655,17 @@ define(function (require, exports, module) {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-
+                
                 testEditorManager.registerInlineEditProvider(negativeProviderCallback, 2);
                 testEditorManager.registerInlineEditProvider(negativeProviderCallback, 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), -1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), -2);
-
+                                
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-
+                
                 runs(function () {
                     expect(widget0.called).toBe(true);
                     expect(widget1.called).toBeFalsy();
@@ -1673,7 +1673,7 @@ define(function (require, exports, module) {
                 });
 
             });
-
+            
         });
     });
 });

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -1,24 +1,24 @@
 /*
  * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -27,7 +27,7 @@
 
 define(function (require, exports, module) {
     'use strict';
-    
+
     var CommandManager,     // loaded from brackets.test
         Commands,           // loaded from brackets.test
         EditorManager,      // loaded from brackets.test
@@ -43,18 +43,18 @@ define(function (require, exports, module) {
         Strings          = require("strings");
 
     describe("InlineEditorProviders", function () {
-        
+
         this.category = "integration";
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/InlineEditorProviders-test-files"),
             tempPath = SpecRunnerUtils.getTempDirectory(),
             testWindow,
             infos = {};
-        
+
         function toRange(startLine, endLine) {
             return {startLine: startLine, endLine: endLine};
         }
-        
+
         function rewriteProject() {
             var result = new $.Deferred(),
                 options = {
@@ -68,17 +68,17 @@ define(function (require, exports, module) {
             }).fail(function () {
                 result.reject();
             });
-            
+
             return result.promise();
         }
-        
+
         /**
          * Performs setup for an inline editor test. Parses offsets (saved to infos) for all files in
          * the test project (testPath) and saves files back to disk without offset markup.
          * When finished, open an editor for the specified project relative file path
          * then attempts opens an inline editor at the given offset. Installs an after()
          * function restore all file content back to original state with offset markup.
-         * 
+         *
          * @param {string} openFile  Project relative file path to open in a main editor.
          * @param {number} openOffset  The offset index location within openFile to open an inline editor.
          * @param {boolean=} expectInline  Use false to verify that an inline editor should not be opened. Omit otherwise.
@@ -86,25 +86,25 @@ define(function (require, exports, module) {
          */
         function initInlineTest(openFile, openOffset, expectInline, documentList) {
             var editor;
-            
+
             documentList = documentList || [];
-            
+
             expectInline = (expectInline !== undefined) ? expectInline : true;
-            
+
             runs(function () {
                 documentList.push(openFile);
                 waitsForDone(SpecRunnerUtils.openProjectFiles(documentList), "FILE_OPEN timeout", 1000);
             });
-            
+
             runs(function () {
                 editor = EditorManager.getCurrentFullEditor();
-                
+
                 // open inline editor at specified offset index
                 var inlineEditorResult = SpecRunnerUtils.toggleQuickEditAtOffset(
                     editor,
                     infos[openFile].offsets[openOffset]
                 );
-                
+
                 if (expectInline) {
                     waitsForDone(inlineEditorResult, "inline editor opened", 1000);
                 } else {
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
                 if (expectInline) {
                     var inlineWidgets = editor.getInlineWidgets();
                     expect(inlineWidgets.length).toBe(1);
-                    
+
                     // By the time we're called, the content of the widget should be in the DOM and have a nontrivial height.
                     expect($.contains(testWindow.document.documentElement, inlineWidgets[0].htmlContent)).toBe(true);
                     expect(inlineWidgets[0].$htmlContent.height()).toBeGreaterThan(50);
@@ -125,16 +125,16 @@ define(function (require, exports, module) {
                 editor = null;
             });
         }
-        
+
         // Utilities for testing Editor state
         function expectText(editor) {
             return expect(editor._codeMirror.getValue());
         }
-        
+
         function expectTextToBeEqual(editor1, editor2) {
             expect(editor1._codeMirror.getValue()).toBe(editor2._codeMirror.getValue());
         }
-		
+
         function isLineHidden(cm, lineNum) {
             var markers = cm.findMarksAt({line: lineNum, pos: 0}),
                 i;
@@ -147,13 +147,21 @@ define(function (require, exports, module) {
         }
 
         function expectPopoverMessageWithText(text) {
-            var $popover  = testWindow.$(".popover-message");
-            expect($popover.length).toEqual(1);
+            var $popover;
 
-            var popoverText = $(".text", $popover).html();
-            expect(popoverText).toEqual(text);
+            runs(function () {
+                waitsFor(function () {
+                    $popover = testWindow.$(".popover-message");
+                    return $popover.length === 1;
+                }, "Expect popover window");
+            });
+
+            runs(function () {
+                var popoverText = testWindow.$(".text", $popover).html();
+                expect(popoverText).toEqual(text);
+            });
         }
-        
+
         function getBounds(object, useOffset) {
             var left = (useOffset ? object.offset().left : parseInt(object.css("left"), 10)),
                 top = (useOffset ? object.offset().top : parseInt(object.css("top"), 10));
@@ -190,7 +198,7 @@ define(function (require, exports, module) {
          * These tests are primarily focused on the InlineEditorProvider module.
          */
         describe("htmlToCSSProvider", function () {
-            
+
             beforeFirst(function () {
                 SpecRunnerUtils.createTempDirectory();
 
@@ -198,11 +206,11 @@ define(function (require, exports, module) {
                 runs(function () {
                     waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                 });
-                
+
                 // Create a new window that will be shared by ALL tests in this spec.
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     testWindow = w;
-    
+
                     // Load module instances from brackets.test
                     CommandManager      = testWindow.brackets.test.CommandManager;
                     Commands            = testWindow.brackets.test.Commands;
@@ -213,7 +221,7 @@ define(function (require, exports, module) {
                     FileViewController  = testWindow.brackets.test.FileViewController;
                 });
             });
-            
+
             afterLast(function () {
                 testWindow          = null;
                 Commands            = null;
@@ -226,7 +234,7 @@ define(function (require, exports, module) {
 
                 SpecRunnerUtils.removeTempDirectory();
             });
-            
+
             beforeEach(function () {
                 this.addMatchers({
                     toHaveInlineEditorRange: function (range) {
@@ -239,10 +247,10 @@ define(function (require, exports, module) {
                             startLine = range.startLine,
                             endLine = range.endLine,
                             visibleRangeCheck;
-                        
+
                         for (i = 0; i < lineCount; i++) {
                             hidden = isLineHidden(editor._codeMirror, i);
-                            
+
                             if (i < startLine) {
                                 if (!hidden) {
                                     shouldHide.push(i); // lines above start line should be hidden
@@ -257,44 +265,44 @@ define(function (require, exports, module) {
                                 }
                             }
                         }
-                        
+
                         visibleRangeCheck = (editor._visibleRange.startLine === startLine) &&
                             (editor._visibleRange.endLine === endLine);
-                        
+
                         this.message = function () {
                             var msg = "";
-                            
+
                             if (shouldHide.length > 0) {
                                 msg += "Expected inline editor to hide [" + shouldHide.toString() + "].\n";
                             }
-                            
+
                             if (shouldShow.length > 0) {
                                 msg += "Expected inline editor to show [" + shouldShow.toString() + "].\n";
                             }
-                            
+
                             if (!visibleRangeCheck) {
                                 msg += "Editor._visibleRange [" +
                                     editor._visibleRange.startLine + "," +
                                     editor._visibleRange.endLine + "] should be [" +
                                     startLine + "," + endLine + "].";
                             }
-                            
+
                             return msg;
                         };
-                        
+
                         return (shouldHide.length === 0) &&
                             (shouldShow.length === 0) &&
                             visibleRangeCheck;
                     }
                 });
-                
+
                 SpecRunnerUtils.loadProjectInTestWindow(tempPath);
             });
-    
+
             afterEach(function () {
                 //debug visual confirmation of inline editor
                 //waits(1000);
-                
+
                 // revert files to original content with offset markup
                 testWindow.closeAllFiles();
             });
@@ -302,40 +310,40 @@ define(function (require, exports, module) {
 
             it("should open a type selector and show correct range including the embedded php", function () {
                 initInlineTest("test1.php", 1);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position and displayed range in inline editor
                     expect(inlinePos).toEqual(infos["test1.php"].offsets[0]);
                     expect(inlineWidget.editor).toHaveInlineEditorRange(toRange(4, 8));
-                    
+
                     inlineWidget = null;
                 });
             });
-            
+
             it("should open a type selector on opening tag", function () {
                 initInlineTest("test1.html", 0);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
                     inlineWidget = null;
                 });
             });
-            
+
             it("should open a type selector on closing tag", function () {
                 initInlineTest("test1.html", 9);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
 
@@ -345,11 +353,11 @@ define(function (require, exports, module) {
 
             it("should open a class selector", function () {
                 initInlineTest("test1.html", 1);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
@@ -359,11 +367,11 @@ define(function (require, exports, module) {
 
             it("should also open a class selector", function () {
                 initInlineTest("test1.html", 7);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[1]);
 
@@ -373,11 +381,11 @@ define(function (require, exports, module) {
 
             it("should open an embedded class selector", function () {
                 initInlineTest("test1.html", 10);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.html"].offsets[11]);
 
@@ -387,11 +395,11 @@ define(function (require, exports, module) {
 
             it("should open an id selector", function () {
                 initInlineTest("test1.html", 2);
-                
+
                 runs(function () {
                     var inlineWidget = EditorManager.getCurrentFullEditor().getInlineWidgets()[0];
                     var inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[2]);
 
@@ -443,36 +451,36 @@ define(function (require, exports, module) {
                     inlineWidget = null;
                 });
             });
-            
-            
+
+
             it("should close, then remove the inline widget and restore focus", function () {
                 initInlineTest("test1.html", 0);
-                
+
                 var hostEditor, inlineWidget, inlinePos, savedPos;
-                
+
                 runs(function () {
                     hostEditor =  EditorManager.getCurrentFullEditor();
                     savedPos = hostEditor.getCursorPos();
                     inlineWidget = hostEditor.getInlineWidgets()[0];
                     inlinePos = inlineWidget.editor.getCursorPos();
-                    
+
                     // verify cursor position & focus in inline editor
                     expect(inlinePos).toEqual(infos["test1.css"].offsets[0]);
                     expect(inlineWidget.hasFocus()).toEqual(true);
                     expect(hostEditor.hasFocus()).toEqual(false);
-                    
+
                     // close the editor
                     waitsForDone(EditorManager.closeInlineWidget(hostEditor, inlineWidget), "closing inline widget");
-                    
+
                 });
-                
+
                 runs(function () {
                     // verify no inline widgets in list
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
-                    
+
                     // verify that the inline widget's content has been removed from the DOM
                     expect($.contains(testWindow.document.documentElement, inlineWidget.htmlContent)).toBe(false);
-                    
+
                     // verify full editor cursor & focus restored
                     expect(savedPos).toEqual(hostEditor.getCursorPos());
                     expect(hostEditor.hasFocus()).toEqual(true);
@@ -506,7 +514,7 @@ define(function (require, exports, module) {
 
             it("should not open an inline editor when positioned on textContent", function () {
                 initInlineTest("test1.html", 3, false);
-                
+
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
@@ -521,7 +529,7 @@ define(function (require, exports, module) {
             // The call to `waits(4000)` in this test seems to dismiss the popover
             xit("should not open an inline editor when positioned on title attribute", function () {
                 initInlineTest("test1.html", 12, false);
-                
+
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
@@ -538,7 +546,7 @@ define(function (require, exports, module) {
                     var $popover = testWindow.$(".popover-message");
                     expect($popover.length).toEqual(1);
                 });
-                
+
                 runs(function () {
                     // verify popover message is automatically dismissed after 2 more seconds
                     // total delay is 5 sec + 0.5 sec fade-out transition
@@ -554,16 +562,16 @@ define(function (require, exports, module) {
 
             it("should not open an inline editor when positioned on a tag in a comment", function () {
                 initInlineTest("test1.html", 4, false);
-                
+
                 runs(function () {
                     // verify no inline editor open
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(0);
                 });
             });
-            
+
             it("should open an inline editor when positioned on the non standard html tag <to>, but no content from @keyframes", function () {
                 initInlineTest("test1.html", 18);
-                
+
                 runs(function () {
                     // verify inline editor is open for adding a new rule
                     expect(EditorManager.getCurrentFullEditor().getInlineWidgets().length).toBe(1);
@@ -609,8 +617,8 @@ define(function (require, exports, module) {
                     expect($popover.length).toEqual(1);
                 });
             });
-            
-                        
+
+
             it("should close popover message on selection change", function () {
                 var editor,
                     openFile = "test1.html";
@@ -641,7 +649,7 @@ define(function (require, exports, module) {
                     expect($popover.length).toEqual(0);
                 });
             });
-            
+
             it("should position message popover inside left edge of window", function () {
                 var $popover;
                 initInlineTest("test1.html", 11, false);
@@ -712,49 +720,49 @@ define(function (require, exports, module) {
                     toggleOption(Commands.TOGGLE_WORD_WRAP, "Toggle word-wrap");
                 });
             });
-            
+
             it("should increase size based on content", function () {
                 initInlineTest("test1.html", 1);
-                
+
                 var inlineEditor, widgetHeight;
-                
+
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                     widgetHeight = inlineEditor.totalHeight();
-                    
+
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(25);
-                    
+
                     // change inline editor content
                     var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
-                    
+
                     // insert new lines at current cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(
                         newLines,
                         inlineEditor.getCursorPos()
                     );
-                    
+
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(30);
                     expect(inlineEditor.totalHeight()).toBeGreaterThan(widgetHeight);
-                    
+
                     inlineEditor = null;
                 });
             });
-            
+
             it("should decrease size based on content", function () {
                 initInlineTest("test1.html", 1);
-                
+
                 var inlineEditor, widgetHeight;
-                
+
                 runs(function () {
                     inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                     widgetHeight = inlineEditor.totalHeight();
-                    
+
                     // verify original line count
                     expect(inlineEditor.lineCount()).toBe(25);
-                    
+
                     // replace the entire .foo rule with an empty string
                     // set text on the editor, can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(
@@ -762,7 +770,7 @@ define(function (require, exports, module) {
                         inlineEditor.getCursorPos(),
                         infos["test1.css"].offsets[3]
                     );
-                    
+
                     // verify widget resizes when contents is changed
                     expect(inlineEditor.lineCount()).toBe(23);
                     expect(inlineEditor.totalHeight()).toBeLessThan(widgetHeight);
@@ -770,52 +778,52 @@ define(function (require, exports, module) {
                     inlineEditor = null;
                 });
             });
-            
+
             it("should save changes in the inline editor", function () {
                 initInlineTest("test1.html", 1);
-                
+
                 var err = false,
                     hostEditor,
                     inlineEditor,
                     newText = "\n/* jasmine was here */",
                     savedText;
-                
+
                 this.after(function () {
                     // rewrite the project after saving changes
                     runs(function () {
                         waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                     });
                 });
-                
+
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
                     inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-                    
+
                     // insert text at the inline editor's cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(newText, inlineEditor.getCursorPos());
-                    
+
                     // we're going to compare this to disk later, so pass true to get non-normalized line endings
                     newText = inlineEditor.document.getText(true);
-                    
+
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeTruthy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
-                    
+
                     // verify that the dirty dot is visible in the UI
                     expect(testWindow.$(".dirty-indicator", hostEditor.getInlineWidgets()[0].$htmlContent).width()).not.toEqual(0);
-                    
+
                     // verify focus is in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-                    
+
                     // execute file save command
                     waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-                
+
                 runs(function () {
                     // verify focus is still in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-                    
+
                     // read saved file contents
                     FileUtils.readAsText(inlineEditor.document.file).done(function (text) {
                         savedText = text;
@@ -823,26 +831,26 @@ define(function (require, exports, module) {
                         err = true;
                     });
                 });
-                
+
                 waitsFor(function () { return savedText !== undefined; }, "readAsText timeout", 1000);
-                
+
                 runs(function () {
                     expect(savedText).toEqual(newText);
-                    
+
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeFalsy();
 
                     // verify that the dirty dot is hidden in the UI
                     expect(testWindow.$(".dirty-indicator", hostEditor.getInlineWidgets()[0].$htmlContent).width()).toEqual(0);
-                    
+
                     inlineEditor = hostEditor = null;
                 });
             });
-            
+
             it("should not save changes in the host editor", function () {
                 initInlineTest("test1.html", 1);
-                
+
                 var err = false,
                     hostEditor,
                     inlineEditor,
@@ -850,39 +858,39 @@ define(function (require, exports, module) {
                     newHostText = "/* jasmine was here */\n",
                     savedInlineText,
                     savedHostText;
-                
+
                 this.after(function () {
                     // rewrite the project after saving changes
                     runs(function () {
                         waitsForDone(rewriteProject(), "rewriteProject timeout", 1000);
                     });
                 });
-                
+
                 runs(function () {
                     hostEditor = EditorManager.getCurrentFullEditor();
                     inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-                    
+
                     // insert text at the host editor's cursor position
                     hostEditor._codeMirror.replaceRange(newHostText, hostEditor.getCursorPos());
-                    
+
                     // insert text at the inline editor's cursor position
                     // can't mutate document directly at this point
                     inlineEditor._codeMirror.replaceRange(newInlineText, inlineEditor.getCursorPos());
-                    
+
                     // we're going to compare this to disk later, so pass true to get non-normalized line endings
                     newInlineText = inlineEditor.document.getText(true);
-                    
+
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeTruthy();
                     expect(hostEditor.document.isDirty).toBeTruthy();
-                    
+
                     // verify focus is in inline editor
                     expect(inlineEditor.hasFocus()).toBeTruthy();
-                    
+
                     // execute file save command
                     waitsForDone(testWindow.executeCommand(Commands.FILE_SAVE), "save timeout", 1000);
                 });
-                
+
                 runs(function () {
                     // read saved inline file contents
                     FileUtils.readAsText(inlineEditor.document.file).done(function (text) {
@@ -890,7 +898,7 @@ define(function (require, exports, module) {
                     }).fail(function () {
                         err = true;
                     });
-                    
+
                     // read saved host editor file contents
                     FileUtils.readAsText(hostEditor.document.file).done(function (text) {
                         savedHostText = text;
@@ -898,13 +906,13 @@ define(function (require, exports, module) {
                         err = true;
                     });
                 });
-                
+
                 waitsFor(function () { return savedInlineText !== undefined && savedHostText !== undefined; }, "readAsText timeout", 1000);
-                
+
                 runs(function () {
                     expect(savedInlineText).toEqual(newInlineText);
                     expect(savedHostText).toEqual(infos["test1.html"].text); // i.e, should be unchanged
-                    
+
                     // verify isDirty flag
                     expect(inlineEditor.document.isDirty).toBeFalsy();
                     expect(hostEditor.document.isDirty).toBeTruthy();
@@ -912,9 +920,9 @@ define(function (require, exports, module) {
                     inlineEditor = hostEditor = null;
                 });
             });
-            
+
             describe("Inline Editor syncing from disk", function () {
-                
+
                 it("should close inline editor when file deleted on disk", function () {
                     // Create an expendable CSS file
                     var fileToWrite;
@@ -928,37 +936,37 @@ define(function (require, exports, module) {
                             .fail(function (err) {
                                 console.log(err);
                             });
-                        
+
                         waitsForDone(promise, "writeText tempCSS.css", 1000);
                     });
-                    
+
                     // Open inline editor for that file
                     runs(function () {
                         initInlineTest("test1.html", 6, true);
                     });
                     // initInlineTest() inserts a waitsFor() automatically, so must end runs() block here
-                    
+
                     runs(function () {
                         var hostEditor = EditorManager.getCurrentFullEditor();
                         expect(hostEditor.getInlineWidgets().length).toBe(1);
                     });
-                    
+
                     // Delete the file
                     runs(function () {
                         waitsForDone(SpecRunnerUtils.deletePath(fileToWrite.fullPath));
                     });
-                    
+
                     // Ping FileSyncManager to recognize the deletion
                     runs(function () {
                         FileSyncManager.syncOpenDocuments();
                     });
-                    
+
                     // Verify inline is now closed
                     waitsFor(function () {
                         var hostEditor = EditorManager.getCurrentFullEditor();
                         return (hostEditor.getInlineWidgets().length === 0);
                     }, 1000);
-                    
+
                     // Cleanup: initInlineTest() saves contents of all files in the project and rewrites
                     // them back to disk at the end (to restore any stripped offset markers). But in this
                     // case we really want the temp file to stay gone.
@@ -966,36 +974,36 @@ define(function (require, exports, module) {
                         delete infos["tempCSS.css"];
                     });
                 });
-                
+
                 // FUTURE: Eventually we'll instead want it to stay open and revert to the content on disk.
                 // Editor's syncing code can't yet handle blowing away the whole Document like that, though.
                 it("should close inline when file is closed without saving changes", function () {
                     initInlineTest("test1.html", 1);
-                    
+
                     var newText = "\n/* jasmine was here */",
                         hostEditor,
                         inlineEditor,
                         promise;
-                    
+
                     runs(function () {
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-                        
+
                         // verify inline is open
                         expect(hostEditor.getInlineWidgets().length).toBe(1);
-                        
+
                         // insert text at the inline editor's cursor position
                         inlineEditor._codeMirror.replaceRange(newText, inlineEditor.getCursorPos());
-                        
+
                         // verify isDirty flag
                         expect(inlineEditor.document.isDirty).toBe(true);
-                        
+
                         // close the main editor / working set entry for the inline's file
                         promise = testWindow.executeCommand(Commands.FILE_CLOSE, {file: inlineEditor.document.file});
-                        
+
                         // synchronously click the don't save button,
                         // asynchronously wait for the dialog to close and the Dialog's
-                        // promise to resolve. 
+                        // promise to resolve.
                         SpecRunnerUtils.clickDialogButton(Dialogs.DIALOG_BTN_DONTSAVE);
                     });
 
@@ -1005,7 +1013,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         waitsForDone(promise);
                     });
-                    
+
                     runs(function () {
                         // verify inline is closed
                         expect(hostEditor.getInlineWidgets().length).toBe(0);
@@ -1014,78 +1022,78 @@ define(function (require, exports, module) {
                     });
                 });
             });
-            
-            
+
+
             describe("Bi-directional Editor Synchronizing", function () {
                 // For these tests we *deliberately* use Editor._codeMirror instead of Document to make edits,
                 // in order to test Editor->Document syncing (instead of Document->Editor).
-                
+
                 it("should not add an inline document to the working set without being edited", function () {
                     initInlineTest("test1.html", 0);
-                    
+
                     runs(function () {
                         var i = MainViewManager.findInWorkingSet(MainViewManager.ACTIVE_PANE, infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(-1);
                     });
                 });
-            
+
                 it("should add dirty documents to the working set", function () {
                     initInlineTest("test1.html", 1);
-                    
+
                     var inlineEditor, widgetHeight;
-                    
+
                     runs(function () {
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                         widgetHeight = inlineEditor.totalHeight();
-                        
+
                         // change inline editor content
                         var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";
-                        
+
                         // insert new lines at current cursor position
                         inlineEditor._codeMirror.replaceRange(
                             newLines,
                             inlineEditor.getCursorPos()
                         );
-                        
+
                         var i = MainViewManager.findInWorkingSet(MainViewManager.ACTIVE_PANE, infos["test1.css"].fileEntry.fullPath);
                         expect(i).toEqual(1);
 
                         inlineEditor = null;
                     });
                 });
-            
+
                 it("should sync edits between full and inline editors", function () {
                     var fullEditor,
                         inlineEditor,
                         newInlineText = "/* jasmine was inline */\n";
-                    
+
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-                    
+
                     runs(function () {
                         var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
-                        
+
                         // edit the inline editor
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
                         inlineEditor._codeMirror.replaceRange(
                             newInlineText,
                             inlineEditor.getCursorPos()
                         );
-                        
+
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
-                        
+
                         // sanity check
                         expect(fullEditor).not.toBe(inlineEditor);
                         expect(fullEditor._codeMirror).not.toBe(inlineEditor._codeMirror);
-                        
+
                         // compare inline editor to full editor
                         expectTextToBeEqual(inlineEditor, fullEditor);
-                        
+
                         // make sure the text was inserted
                         expect(fullEditor._codeMirror.getValue().indexOf(newInlineText)).toBeGreaterThan(0);
-                        
+
                         // edit in the full editor and compare
                         fullEditor._codeMirror.replaceRange(
                             newInlineText,
@@ -1097,9 +1105,9 @@ define(function (require, exports, module) {
                     });
                 });
             });
-            
+
             describe("Inline Editor range updating", function () {
-                
+
                 var fullEditor,
                     hostEditor,
                     inlineEditor,
@@ -1112,20 +1120,20 @@ define(function (require, exports, module) {
                     endOfEnd,
                     after,
                     wayafter;
-                    
+
                 beforeEach(function () {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-                    
+
                     runs(function () {
                         var cssPath = infos["test1.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-                        
+
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
-                        
+
                         // alias offsets to nice names
                         before = infos["test1.css"].offsets[4];
                         start = infos["test1.css"].offsets[1];
@@ -1143,22 +1151,22 @@ define(function (require, exports, module) {
                     hostEditor   = null;
                     inlineEditor = null;
                 });
-                
+
                 it("should insert new line at start of range, and stay open on undo", function () {
-                    // insert new line at start of inline range--the new line should be included in 
+                    // insert new line at start of inline range--the new line should be included in
                     // the inline
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
                         start
                     );
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
-                    
+
                     // undo is equivalent to deleting the first line in the range: shouldn't close the editor
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-                
+
                 it("should insert new line within first line of range, and stay open on undo", function () {
                     // insert new line in middle of first line of inline range--the new line should
                     // be included
@@ -1167,18 +1175,18 @@ define(function (require, exports, module) {
                         {line: start.line, ch: start.ch + 1}
                     );
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
-                
+
                     // Even though the edit didn't start at the beginning of the line, the undo touches
                     // the whole line; but deleting the first line still shouldn't close the editor
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-                
+
                 it("should not close inline when undoing changes to first line in range that did not include newlines", function () {
                     // undo is NOT deleting the entire first line in these cases, so the inline should be able to stay open
-                    
-                    // insert new text at start of inline range, without newlines--the new text should be included in 
+
+                    // insert new text at start of inline range, without newlines--the new text should be included in
                     // the inline
                     fullEditor._codeMirror.replaceRange(
                         ".bar, ",
@@ -1188,7 +1196,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // replace text at start of inline range with text without newlines
                     fullEditor._codeMirror.replaceRange(
                         ".bar",
@@ -1199,7 +1207,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // insert new text in middle of first line in range, without newlines
                     fullEditor._codeMirror.replaceRange(
                         "ABCD",
@@ -1210,10 +1218,10 @@ define(function (require, exports, module) {
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-                
+
                 it("should sync deletions (and their undos) on last line in range, with or without newlines", function () {
                     // undo is NOT deleting the entire last line in these cases, so the inline should be able to stay open
-                    
+
                     // insert new line in middle of last line of inline range--the new line should
                     // be included
                     fullEditor._codeMirror.replaceRange(
@@ -1224,7 +1232,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // insert new line at end of last line of inline range--the new line should
                     // be included
                     fullEditor._codeMirror.replaceRange(
@@ -1235,7 +1243,7 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // replace all text on last line (without replacing trailing newline)
                     fullEditor._codeMirror.replaceRange(
                         "ABCD",
@@ -1257,7 +1265,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line + 1, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // insert line within inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1266,7 +1274,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // insert line at end of inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1275,7 +1283,7 @@ define(function (require, exports, module) {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // insert line below inline range
                     fullEditor._codeMirror.replaceRange(
                         newInlineText,
@@ -1285,14 +1293,14 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
                 });
-            
+
                 it("should sync deletions from the full editor and update the visual range of the inline editor", function () {
                     // delete line within inline range
                     fullEditor._codeMirror.replaceRange("", middle, end);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line - 1));
                     fullEditor._codeMirror.undo();
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
-                    
+
                     // delete line below inline range
                     fullEditor._codeMirror.replaceRange("", after, wayafter);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line));
@@ -1352,8 +1360,8 @@ define(function (require, exports, module) {
                     fullEditor._codeMirror.replaceRange("", middleOfMiddle, wayafter);
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                 });
-                
-            
+
+
                 it("should sync insertions with multiple change objects in one event", function () {
                     // Insert two new lines: one at start of inline range, the other at the (newly
                     // updated) end of range. The edits are batched into just one event (so the
@@ -1372,19 +1380,19 @@ define(function (require, exports, module) {
                         );
                     });
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(start.line, end.line + 2));
-                    
+
                     // TODO: can't do our usual undo + re-check range test at the end, because of
                     // codemirror/CodeMirror bug #487
                 });
-                
-                
+
+
                 it("should sync multiple edits between full and inline editors", function () {
                     var i,
                         editor,
                         text,
                         newInlineText = "/* jasmine was inline */\n",
                         newFullText = "/* full editor edit */\n";
-                    
+
                     // alternate editors while inserting new text
                     for (i = 0; i < 10; i++) {
                         editor = (i % 2 === 0) ? fullEditor : inlineEditor;
@@ -1396,25 +1404,25 @@ define(function (require, exports, module) {
                         expectTextToBeEqual(inlineEditor, fullEditor);
                     }
                 });
-            
+
                 it("should close inline if the contents of the full editor are all deleted", function () {
                     // verify inline is open
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
-                    
+
                     // delete all text via full editor
                     fullEditor._codeMirror.setValue("");
-                    
+
                     // verify inline is closed
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
                 });
-                
+
                 it("should sync after undoing and redoing an edit", function () {
                     var originalText,
                         editedText,
                         newInlineText = "/* jasmine was inline */\n";
-                    
+
                     originalText = inlineEditor._codeMirror.getValue();
-                    
+
                     // edit the inline editor in the middle of the text so it doesn't
                     // run into one of the collapsing cases
                     inlineEditor._codeMirror.replaceRange(
@@ -1422,44 +1430,44 @@ define(function (require, exports, module) {
                         middle
                     );
                     editedText = inlineEditor._codeMirror.getValue();
-                    
+
                     // compare inline editor to full editor
                     expectTextToBeEqual(inlineEditor, fullEditor);
-                    
+
                     // undo the inline editor
                     inlineEditor._codeMirror.undo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(inlineEditor).toBe(originalText);
-                    
+
                     // redo the inline editor
                     inlineEditor._codeMirror.redo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(inlineEditor).toBe(editedText);
-                    
+
                     // undo the full editor
                     fullEditor._codeMirror.undo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(fullEditor).toBe(originalText);
-                    
+
                     // redo the full editor
                     fullEditor._codeMirror.redo();
                     expectTextToBeEqual(inlineEditor, fullEditor);
                     expectText(fullEditor).toBe(editedText);
                 });
-                
+
             });
-            
+
             describe("Multiple inline editor interaction", function () {
                 var hostEditor, inlineEditor;
                 beforeEach(function () {
                     initInlineTest("test1.html", 1, true, ["test1.css"]);
-                    
+
                     runs(function () {
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
                     });
                 });
-            
+
                 afterEach(function () {
                     hostEditor   = null;
                     inlineEditor = null;
@@ -1467,7 +1475,7 @@ define(function (require, exports, module) {
 
                 it("should keep range consistent after undo/redo (bug #1031)", function () {
                     var secondInlineOpen = false, secondInlineEditor;
-                    
+
                     // open inline editor at specified offset index
                     runs(function () {
                         hostEditor.focus();
@@ -1478,9 +1486,9 @@ define(function (require, exports, module) {
                             secondInlineOpen = isOpen;
                         });
                     });
-                    
+
                     waitsFor(function () { return secondInlineOpen; }, "second inline open timeout", 1000);
-                    
+
                     // Not sure why we have to wait in between these for the bug to occur, but we do.
                     runs(function () {
                         secondInlineEditor = hostEditor.getInlineWidgets()[1].editor;
@@ -1499,37 +1507,37 @@ define(function (require, exports, module) {
                     });
                 });
             });
-            
-            
+
+
             describe("Inline Editor range equal to file range", function () {
                 var fullEditor,
                     hostEditor,
                     inlineEditor;
-                    
+
                 beforeEach(function () {
                     initInlineTest("test1.html", 5, true, ["testOneRuleFile.css"]);
-                    
+
                     runs(function () {
                         var cssPath = infos["testOneRuleFile.css"].fileEntry.fullPath;
                         var cssDoc = DocumentManager.getOpenDocumentForPath(cssPath);
                         hostEditor = EditorManager.getCurrentFullEditor();
                         inlineEditor = hostEditor.getInlineWidgets()[0].editor;
-                        
+
                         // activate the full editor
                         MainViewManager._edit(MainViewManager.ACTIVE_PANE, cssDoc);
                         fullEditor = EditorManager.getCurrentFullEditor();
                     });
                 });
-                
+
                 afterEach(function () {
                     fullEditor   = null;
                     hostEditor   = null;
                     inlineEditor = null;
                 });
-                
+
                 it("should delete line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
-                    
+
                     // delete all of last line in range
                     fullEditor._codeMirror.replaceRange("", {line: 1, ch: 16}, {line: 2, ch: 1});
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
@@ -1538,10 +1546,10 @@ define(function (require, exports, module) {
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
                 });
-                
+
                 it("should insert new line at bottom and not close on undo", function () {
                     expect(inlineEditor).toHaveInlineEditorRange(toRange(0, 2));
-                    
+
                     // delete all of last line in range
                     fullEditor._codeMirror.replaceRange("\n/* New last line */", {line: 2, ch: 1});
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
@@ -1552,25 +1560,25 @@ define(function (require, exports, module) {
                 });
             });
         });
-        
+
         describe("InlineEditor provider prioritization", function () {
             var testWindow,
                 testDocumentManager,
                 testEditorManager,
                 testMainViewManager,
                 testDoc;
-            
+
             function getPositiveProviderCallback(widget) {
                 return function () {
                     widget.called = true;
                     return $.Deferred().resolve(widget).promise();
                 };
             }
-            
+
             function negativeProviderCallback() {
                 return null;
             }
-            
+
             beforeEach(function () {
                 SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                     var mock = SpecRunnerUtils.createMockEditor("");
@@ -1579,17 +1587,17 @@ define(function (require, exports, module) {
                     testEditorManager   = testWindow.brackets.test.EditorManager;
                     testMainViewManager = testWindow.brackets.test.MainViewManager;
                     testDocumentManager = testWindow.brackets.test.DocumentManager;
-                    
+
                     testDoc             = mock.doc;
-                    
+
                     testDocumentManager.getOpenDocumentForPath = function (fullPath) {
                         return testDoc;
                     };
-                    
+
                     testMainViewManager._edit(testMainViewManager.ACTIVE_PANE, testDoc);
                 });
             });
-            
+
             afterEach(function () {
                 SpecRunnerUtils.destroyMockEditor(testDoc);
                 SpecRunnerUtils.closeTestWindow();
@@ -1600,41 +1608,41 @@ define(function (require, exports, module) {
                 testMainViewManager = null;
                 testDocumentManager = null;
             });
-            
-            
+
+
             it("should prefer positive higher priority providers (1)", function () {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-                
+
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), 2);
-                                
+
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-                
+
                 runs(function () {
                     expect(widget0.called).toBeFalsy();
                     expect(widget1.called).toBeFalsy();
                     expect(widget2.called).toBe(true);
                 });
             });
-            
+
             it("should prefer positive higher priority providers (2)", function () {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-                
+
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), 2);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
-                                
+
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-                
+
                 runs(function () {
                     expect(widget0.called).toBeFalsy();
                     expect(widget1.called).toBeFalsy();
@@ -1647,17 +1655,17 @@ define(function (require, exports, module) {
                 var widget0 = new InlineWidget(),
                     widget1 = new InlineWidget(),
                     widget2 = new InlineWidget();
-                
+
                 testEditorManager.registerInlineEditProvider(negativeProviderCallback, 2);
                 testEditorManager.registerInlineEditProvider(negativeProviderCallback, 1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget0));
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget1), -1);
                 testEditorManager.registerInlineEditProvider(getPositiveProviderCallback(widget2), -2);
-                                
+
                 runs(function () {
                     testWindow.executeCommand(Commands.TOGGLE_QUICK_EDIT);
                 });
-                
+
                 runs(function () {
                     expect(widget0.called).toBe(true);
                     expect(widget1.called).toBeFalsy();
@@ -1665,7 +1673,7 @@ define(function (require, exports, module) {
                 });
 
             });
-            
+
         });
     });
 });


### PR DESCRIPTION
There is a good chance that the test doesn't find the Popup message, because of a race condition.
This fix will wait (5 secs) to let the Popup message appear.
