### PR TITLE
Working Performance Set Improvements

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -470,6 +470,7 @@ define(function (require, exports, module) {
      * Semi-private: should only be called within this module or by Document.
      * @param {!Document} document  Document whose main/full Editor to create
      * @param {!Pane} pane  Pane in which the editor will be hosted
+     * @return {!Editor}
      */
     function _createFullEditorForDocument(document, pane) {
         // Create editor; make it initially invisible
@@ -477,6 +478,7 @@ define(function (require, exports, module) {
         editor.setVisible(false);
         pane.addView(editor);
         $(exports).triggerHandler("_fullEditorCreatedForDocument", [document, editor, pane.id]);
+        return editor;
     }
  
     
@@ -535,8 +537,6 @@ define(function (require, exports, module) {
             editor = document._masterEditor;
         
         if (!editor) {
-            createdNewEditor = true;
-
             // Performance (see #4757) Chrome wastes time messing with selection
             // that will just be changed at end, so clear it for now
             if (window.getSelection && window.getSelection().empty) {  // Chrome
@@ -544,23 +544,24 @@ define(function (require, exports, module) {
             }
             
             // Editor doesn't exist: populate a new Editor with the text
-            _createFullEditorForDocument(document, pane);
-        } else if (editor.$el.parent() !== pane.$el) {
+            editor = _createFullEditorForDocument(document, pane);
+            createdNewEditor = true;
+        } else if (editor.$el.parent()[0] !== pane.$content[0]) {
             // editor does exist but is not a child of the pane so add it to the 
             //  pane (which will switch the view's container as well)
             pane.addView(editor);
         }
 
         // show the view
-        pane.showView(document._masterEditor);
+        pane.showView(editor);
 
         if (MainViewManager.getActivePaneId() === pane.id) {
             // give it focus
-            document._masterEditor.focus();
+            editor.focus();
         }
 
         if (createdNewEditor) {
-            _restoreEditorViewState(document._masterEditor);
+            _restoreEditorViewState(editor);
         }
     }
 

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -129,8 +129,10 @@ define(function (require, exports, module) {
             return;
         }
 
-        _fileSelectionFocus = fileSelectionFocus;
-        $(exports).triggerHandler("fileViewFocusChange");
+        if (_fileSelectionFocus !== fileSelectionFocus) {
+            _fileSelectionFocus = fileSelectionFocus;
+            $(exports).triggerHandler("fileViewFocusChange");
+        }
     }
 
     /** 

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -76,6 +76,7 @@
   *         adjustScrollPos: function(state:Object=, heightDelta:number)=
   *         notifyContainerChange: function()=
   *         notifyVisibilityChange: function(boolean)=
+  *         focus:function()=
   *     }
   *  
   * When views are created they can be added to the pane by calling `pane.addView()`.  
@@ -1214,18 +1215,63 @@ define(function (require, exports, module) {
      * Gives focus to the last thing that had focus, the current view or the pane in that order
      */
     Pane.prototype.focus = function () {
-        // Blur the currently focused element which will move focus to the BODY tag
-        //  If the element we want to focus below cannot receive the input focus such as an ImageView
-        //  This will remove focus from the current view which is important if the current view is 
-        //  a codemirror view. 
-        document.activeElement.blur();
+        var current = window.document.activeElement,
+            self = this;
+
+        // Helper to focus the current view if it can
+        function tryFocusingCurrentView() {
+            if (self._currentView) {
+                if (self._currentView.focus) {
+                    //  Views can implement a focus
+                    //  method for focusing a complex
+                    //  DOM like codemirror
+                    self._currentView.focus();
+                } else {
+                    //  Otherwise, no focus method
+                    //  just try and give the DOM
+                    //  element focus
+                    self._currentView.$el.focus();
+                }
+            } else {
+                // no view so just focus the pane
+                self.$el.focus();
+            }
+        }
         
-        if (this._lastFocusedElement && $(this._lastFocusedElement).is(":visible")) {
-            $(this._lastFocusedElement).focus();
-        } else if (this._currentView) {
-            this._currentView.$el.focus();
+        // short-circuit for performance
+        if (this._lastFocusedElement === current) {
+            return;
+        }
+            
+        // If the focus was in a "textarea" and the currentView is anything other than 
+        //  a codeMirror view then we must blur the textarea to force focus to the body tag.
+        //
+        // If we don't then the focus will stay in the text-area which directs keyboard input
+        //  to the codemirror document when it shouldn't
+        //
+        // Steps: 
+        //  1. Open a js file in the left pane and an image in the right pane and
+        //  2. Focus the js file using the working-set
+        //  3. Focus the image view using the working-set.
+        //
+        // ==> Focus is still in the text area. Any keyboard input will modify the document
+        
+        if (current.tagName === "textarea" &&
+                (!this._currentView || !this._currentView._codeMirror)) {
+            current.blur();
+        }
+
+        var $lfe = $(this._lastFocusedElement);
+
+        if ($lfe.length && !$lfe.is(".view-pane") && $lfe.is(":visible")) {
+            // if we had a last focused element 
+            //  and it wasn't a pane element 
+            //  and it's still visible, focus it
+            $lfe.focus();
         } else {
-            this.$el.focus();
+            // otherwise, just try to give focus 
+            //  to the currently active view
+            tryFocusingCurrentView();
         }
     };
     


### PR DESCRIPTION
This Replaces #9493

This is for #9439 -- Clicking on items in the working set is slow.
- Don't create the drag ghost until needed
- Improve `Pane.focus`(one big drag was `currentElement.blur()` so we only need to do that if we're focusing something that isn't code mirror.
- Improve `EditorManager._showEditor()`, the UX changes for the pane DOM weren't targeting the right node to see if it needed to re-add the editor to the pane so this was happening every time the editor was shown.
- Improve `_open` and `_edit` to not activate pane until _after_ opening the document

Also Fixes #9428
