### PR TITLE
Fix bug #9511 (Can't select text in Extension Manager anymore)

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -124,10 +124,12 @@ define(function (require, exports, module) {
                                 errorArray.forEach(function (errorObj) {
                                     ids.push(errorObj.item);
                                     if (errorObj.error && errorObj.error.forEach) {
-                                        console.error("Errors for ", errorObj.item);
+                                        console.error("Errors for", errorObj.item);
                                         errorObj.error.forEach(function (error) {
                                             console.error(Package.formatError(error));
                                         });
+                                    } else {
+                                        console.error("Error for", errorObj.item, errorObj);
                                     }
                                 });
                                 Dialogs.showModalDialog(
@@ -292,8 +294,10 @@ define(function (require, exports, module) {
         // Open the dialog
         dialog = Dialogs.showModalDialogUsingTemplate(Mustache.render(dialogTemplate, context));
         
-        // When dialog closes, dismiss models and commit changes
+        // On dialog close: clean up listeners & models, and commit changes
         dialog.done(function () {
+            $(document).off(".extensionManager");
+            
             models.forEach(function (model) {
                 model.dispose();
             });
@@ -319,8 +323,9 @@ define(function (require, exports, module) {
                 setActiveTab($(this));
             });
 
-        // navigate through tabs via Ctrl-(Shift)-Tab
-        $dlg.on("keyup", function (event) {
+        // Navigate through tabs via Ctrl-(Shift)-Tab
+        // (focus may be on document.body if text in extension listing clicked - see #9511)
+        $(document).on("keyup.extensionManager", function (event) {
             if (event.keyCode === KeyEvent.DOM_VK_TAB && event.ctrlKey) {
                 var $tabs = $(".nav-tabs a", $dlg),
                     tabIndex = _activeTabIndex;

--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -1,4 +1,4 @@
-<div class="extension-manager-dialog modal no-focus">
+<div class="extension-manager-dialog modal">
     <div class="modal-header">
         <ul class="nav nav-tabs">
             {{#showRegistry}}


### PR DESCRIPTION
Fix bug #9511 - Remove no-focus from dialog root to allow text selection. Change scope of key listener so tabbing continues to work without needing to reintroduce tabIndex on the dialog, since that triggers Bootstrap-modal problems (#9196).

Also: add an extra error logging line so that failed updates always log some error details to the console. (I think this case seemed to come up in a bug a while back, but couldn't remember which one).
