### PR TITLE
Replace HTML entity with literal dash in Getting Started

### DIFF
--- a/samples/root/Getting Started/index.html
+++ b/samples/root/Getting Started/index.html
@@ -47,7 +47,7 @@
             <kbd>Cmd/Ctrl + E</kbd> shortcut to open a quick inline editor that displays all the related CSS.
             Make a tweak to your CSS, hit <kbd>ESC</kbd> and you're back to editing HTML, or just leave the
             CSS rules open and they'll become part of your HTML editor. If you hit <kbd>ESC</kbd> outside of
-            a quick inline editor, they'll all collapse.  Quick Edit will also find rules defined in LESS and 
+            a quick inline editor, they'll all collapse. Quick Edit will also find rules defined in LESS and 
             SCSS files, including nested rules.
         </p>
 
@@ -66,8 +66,8 @@
         </a>
         
         <p>
-            You can use the same shortcut to edit other things as well &ndash; like functions in JavaScript,
-            colors, and animation timing functions &ndash; and we're adding more and more all the time. 
+            You can use the same shortcut to edit other things as well - like functions in JavaScript,
+            colors, and animation timing functions - and we're adding more and more all the time. 
         </p>
         <p>
             For now inline editors cannot be nested, so you can only use Quick Edit while the cursor


### PR DESCRIPTION
Fixup for https://github.com/adobe/brackets/pull/8886/files#r16854363 and https://github.com/adobe/brackets/pull/8886/files#r16854679.
As the text is supposed to be read in the editor, a literal dash is way more legible.
I'm not sure, though, whether to use `-` or `—`.
