### PR TITLE
Recognize Vagrantfile as ruby

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -165,7 +165,7 @@
         "name": "Ruby",
         "mode": "ruby",
         "fileExtensions": ["rb", "ru", "gemspec", "rake"],
-        "fileNames": ["Gemfile", "Rakefile", "Guardfile"],
+        "fileNames": ["Gemfile", "Rakefile", "Guardfile", "Vagrantfile"],
         "lineComment": ["#"]
     },
 


### PR DESCRIPTION
Small change to src/language/languages.json to add ruby syntax highlighting to Vagrantfile files.

Tested manually in Brackets : Vagrantfile was recognized
No test added, the "should map file names to languages" feature is already tested with "cakefile"
