### PR TITLE
Revert -webkit-font-smoothing to auto

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -54,8 +54,7 @@ html, body {
     /* And make sure we get a pointer cursor even over text */
     cursor: default;
 
-    /* Turn off subpixel antialiasing on Mac since it flickers during animations. */
-    -webkit-font-smoothing: antialiased;
+    -webkit-font-smoothing: auto;
 
     /* This is a hack to avoid flicker when animations (like inline editors) that use the GPU complete.
        It seems that we have to put it here rather than on the animated element in order to prevent the
@@ -70,8 +69,6 @@ html, body {
          color: @dark-bc-text;
     }
 }
-
-
 
 .resizing-container {
     position: absolute;


### PR DESCRIPTION
This forces proper subpixel antialiasing which looks way better on Mac. Makes no difference on other platforms.

Jagged lines with `-webkit-font-smoothing: antialised`:
![Jagged lines with -webkit-font-smoothing: antialised](https://cloud.githubusercontent.com/assets/161577/4606672/753760c2-522a-11e4-9569-3cf43310df07.png)

Proper antialiasing with `-webkit-font-smoothing: auto`:
![Proper antialiasing with -webkit-font-smoothing: auto](https://cloud.githubusercontent.com/assets/161577/4606673/78de8e44-522a-11e4-967f-45c0e6ddbc3f.png)
