### PR TITLE
Fix #9363: Code hints popup dismisses prematurely

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -160,7 +160,7 @@
 /* Non-editor styling */
 
 .image-view,
-.not-editor {
+.not-editor.not-editor {
     background-color: @background;
 }
 

--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -160,7 +160,7 @@
 /* Non-editor styling */
 
 .image-view,
-.not-editor.not-editor {
+.not-editor {
     background-color: @background;
 }
 

--- a/src/htmlContent/search-results.html
+++ b/src/htmlContent/search-results.html
@@ -4,7 +4,7 @@
         <tr class="file-section" data-file-index="{{fileIndex}}">
             {{#replace}}<td class="checkbox-column"><input type="checkbox" class="check-one-file" {{#isChecked}}checked="true"{{/isChecked}} /></td>{{/replace}}
             <td colspan="2">
-                <span class="disclosure-triangle {{#isCollapsed}}collapsed{{/isCollapsed}}{{^isCollapsed}}expanded{{/isCollapsed}}" title="{{Strings.FIND_IN_FILES_EXPAND_COLLAPSE}}"></span>
+                <span class="disclosure-triangle {{^isCollapsed}}expanded{{/isCollapsed}}" title="{{Strings.FIND_IN_FILES_EXPAND_COLLAPSE}}"></span>
                 {{{filename}}}
             </td>
         </tr>

--- a/src/htmlContent/search-results.html
+++ b/src/htmlContent/search-results.html
@@ -4,12 +4,12 @@
         <tr class="file-section" data-file-index="{{fileIndex}}">
             {{#replace}}<td class="checkbox-column"><input type="checkbox" class="check-one-file" {{#isChecked}}checked="true"{{/isChecked}} /></td>{{/replace}}
             <td colspan="2">
-                <span class="disclosure-triangle expanded" title="{{Strings.FIND_IN_FILES_EXPAND_COLLAPSE}}"></span>
+                <span class="disclosure-triangle {{#isCollapsed}}collapsed{{/isCollapsed}}{{^isCollapsed}}expanded{{/isCollapsed}}" title="{{Strings.FIND_IN_FILES_EXPAND_COLLAPSE}}"></span>
                 {{{filename}}}
             </td>
         </tr>
         {{#items}}
-        <tr data-file-index="{{fileIndex}}" data-item-index="{{itemIndex}}" data-match-index="{{matchIndex}}">
+        <tr data-file-index="{{fileIndex}}" data-item-index="{{itemIndex}}" data-match-index="{{matchIndex}}" {{#isCollapsed}}style="display:none;"{{/isCollapsed}}>
             {{#replace}}<td class="checkbox-column"><input type="checkbox" class="check-one" {{#isChecked}}checked="true"{{/isChecked}} /></td>{{/replace}}
             <td class="line-number">{{line}}</td>
             <td class="line-text">{{pre}}<span class="highlight">{{highlight}}</span>{{post}}</td>

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -601,7 +601,7 @@ define(function (require, exports, module) {
                     $selectedRow.nextUntil(".inspector-section").toggle();
 
                     var $triangle = $(".disclosure-triangle", $selectedRow);
-                    $triangle.toggleClass("expanded").toggleClass("collapsed");
+                    $triangle.toggleClass("expanded");
                 } else {
                     // This is a problem marker row, show the result on click
                     // Grab the required position data

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
             self             = this;
         
         this._showSummary();
-        this._searchList   = [];
+        this._searchList = [];
         
         // Iterates throuh the files to display the results sorted by filenamess. The loop ends as soon as
         // we filled the results for one page
@@ -427,16 +427,17 @@ define(function (require, exports, module) {
                     multiLine = match.start.line !== match.end.line;
                     
                     searchItems.push({
-                        fileIndex:  self._searchList.length,
-                        itemIndex:  searchItems.length,
-                        matchIndex: i,
-                        line:       match.start.line + 1,
-                        pre:        match.line.substr(0, match.start.ch),
-                        highlight:  match.line.substring(match.start.ch, multiLine ? undefined : match.end.ch),
-                        post:       multiLine ? "\u2026" : match.line.substr(match.end.ch),
-                        start:      match.start,
-                        end:        match.end,
-                        isChecked:  match.isChecked
+                        fileIndex:   self._searchList.length,
+                        itemIndex:   searchItems.length,
+                        matchIndex:  i,
+                        line:        match.start.line + 1,
+                        pre:         match.line.substr(0, match.start.ch),
+                        highlight:   match.line.substring(match.start.ch, multiLine ? undefined : match.end.ch),
+                        post:        multiLine ? "\u2026" : match.line.substr(match.end.ch),
+                        start:       match.start,
+                        end:         match.end,
+                        isChecked:   match.isChecked,
+                        isCollapsed: item.collapsed
                     });
                     if (!match.isChecked) {
                         allInFileChecked = false;
@@ -456,11 +457,12 @@ define(function (require, exports, module) {
                     );
 
                 self._searchList.push({
-                    fileIndex: self._searchList.length,
-                    filename:  displayFileName,
-                    fullPath:  fullPath,
-                    isChecked: allInFileChecked,
-                    items:     searchItems
+                    fileIndex:   self._searchList.length,
+                    filename:    displayFileName,
+                    fullPath:    fullPath,
+                    isChecked:   allInFileChecked,
+                    items:       searchItems,
+                    isCollapsed: item.collapsed
                 });
             }
         });
@@ -473,16 +475,7 @@ define(function (require, exports, module) {
                 replace:       this._model.isReplace,
                 searchList:    this._searchList,
                 Strings:       Strings
-            }))
-            // Restore the collapsed files
-            .find(".file-section").each(function () {
-                var fullPath = self._searchList[$(this).data("file-index")].fullPath;
-
-                if (self._model.results[fullPath].collapsed) {
-                    self._model.results[fullPath].collapsed = false;
-                    $(this).trigger("click");
-                }
-            });
+            }));
         
         if (this._$selectedRow) {
             this._$selectedRow.removeClass("selected");

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -212,7 +212,7 @@ define(function (require, exports, module) {
                             if (searchItem.collapsed !== collapsed) {
                                 searchItem.collapsed = collapsed;
                                 $(this).nextUntil(".file-section").toggle();
-                                $(this).find(".disclosure-triangle").toggleClass("expanded").toggleClass("collapsed");
+                                $(this).find(".disclosure-triangle").toggleClass("expanded");
                             }
                         });
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1327,14 +1327,11 @@ a, img {
 #problems-panel .disclosure-triangle {
     .jstree-sprite;
     display: inline-block;
+    background-position: 7px 5px;
     &.expanded {
         // Unfortunately, the way jsTree sprites are aligned within their 18px boxes doesn't look good in
         // other contexts, so we need some tweaks here instead of straight multiples of @jstree-sprite-size
-        background-position: 7px 5px;
         -webkit-transform: translateZ(0) rotate(90deg);
-    }
-    &.collapsed {
-        background-position: 7px 5px;
     }
 }
 


### PR DESCRIPTION
I moved the logic to restore the collapsed files to the template, so that we don't need to toggle them after the results UI is rendered.
