### PR TITLE
Fix bug #9451 (Dark Theme: active line w/o line numbers has wrong gutter color)

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -49,7 +49,7 @@
     background: #2f2f2f;
 }
 
-&.show-line-padding .CodeMirror-focused .CodeMirror-activeline-background {
+.show-line-padding .CodeMirror-focused .CodeMirror-activeline-background {
     box-shadow: inset 15px 0 0 0 #000;
 }
 


### PR DESCRIPTION
Fix bug #9451 -- `.show-line-padding` is now on the Pane rather than on `#editor-holder`
