### PR TITLE
Auto-install extensions

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
     var _idsToRemove = [],
         _idsToUpdate = [];
 
-    PreferencesManager.definePreference(FOLDER_AUTOINSTALL, "object", undefined);
+    PreferencesManager.stateManager.definePreference(FOLDER_AUTOINSTALL, "object", undefined);
 
     /**
      * @private


### PR DESCRIPTION
Squashed version of #9490 

---

Automatically install extensions "bundled" with installer on startup. This feature relies on the installer putting **zip files** for "bundled" extensions into the `[install-dir]/auto-install-extensions/` folder.

This is for #9233 

---
### Testing Matrix for `auto-install-extensions` folder
#### Should fail silently
- is missing
- is empty
- contains file which has non-zip file extension
- contains file which has non-extension with zip file extension
- contains extension that is already auto-installed
- contains extension that is already manually installed
- contains extension that has a newer version auto-installed
- contains extension that has a newer version manually installed
- contains extension that was already auto-installed, then manually removed
#### Should install extension
- contains extension that is not yet installed (auto or manually)
- contains extension that has an older version auto-installed
- contains extension that has an older version manually installed
