### PR TITLE
Fix unit test failure

### DIFF
--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -386,7 +386,7 @@ define(function (require, exports, module) {
         } else {
             exports.stat(path, function (_err, _stat) {
                 if (_err) {
-                    callback(_mapError(_err));
+                    callback(_err);
                 } else {
                     doReadFile(_stat);
                 }


### PR DESCRIPTION
After PR #9585, file-read wasn't always passing back correct error codes anymore. If the initial stat() fails (e.g. file doesn't exist or permission denied), we were double-converting the error code from brackets-shell format to FS impl API format, causing it to get mangled and treated as "Unknown."
