### PR TITLE
Proper shortcut for reload without extensions for Mac

### DIFF
--- a/src/extensions/default/DebugCommands/keyboard.json
+++ b/src/extensions/default/DebugCommands/keyboard.json
@@ -20,6 +20,10 @@
     "reloadWithoutUserExts":  [
         {
             "key": "Shift-F5"
+        },
+        {
+            "key": "Cmd-Shift-R",
+            "platform": "mac"
         }
     ]
 }


### PR DESCRIPTION
We don't use F keys as shortcuts in Mac. So I added a new shortcut for the reload without extensions command.
