### PR TITLE
Add Case Boost to StringMatch

### DIFF
--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -59,9 +59,12 @@ define(function (require, exports, module) {
         
         describe("_generateMatchList", function () {
             var fSC = StringMatch._findSpecialCharacters;
+            
             var generateMatchList = StringMatch._generateMatchList;
+            
             var SpecialMatch = StringMatch._SpecialMatch;
             var NormalMatch = StringMatch._NormalMatch;
+            var CaseMatch = StringMatch._CaseMatch;
             
             beforeEach(function () {
                 SpecialMatch.prototype.type = "special";
@@ -75,85 +78,88 @@ define(function (require, exports, module) {
             
             var path = "src/document/DocumentCommandHandler.js";
             var specialsInfo = fSC(path);
-            path = path.toLowerCase();
+            var pathLower = path.toLowerCase();
             
             it("should return undefined for no matches", function () {
-                var result = generateMatchList("foo", path, specialsInfo.specials, 0);
+                var result = generateMatchList("foo", pathLower, "foo", path, specialsInfo.specials, 0);
                 expect(result).toEqual(null);
             });
             
             it("should return an array with specials matches", function () {
-                var result = generateMatchList("d", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                var result = generateMatchList("d", pathLower, "d", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
                 expect(result).toEqual([new SpecialMatch(13)]);
                 
-                result = generateMatchList("ch", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                result = generateMatchList("ch", pathLower, "ch", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
                 expect(result).toEqual([new SpecialMatch(21), new SpecialMatch(28)]);
             });
             
             it("should try contiguous matches as well, but prefer specials", function () {
-                var result = generateMatchList("do", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
-                expect(result).toEqual([new SpecialMatch(13), new NormalMatch(14)]);
+                var result = generateMatchList("do", pathLower, "do", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                expect(result).toEqual([new SpecialMatch(13), new CaseMatch(14)]);
                 
-                result = generateMatchList("doc", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
-                expect(result).toEqual([new SpecialMatch(13), new NormalMatch(14), new SpecialMatch(21)]);
+                result = generateMatchList("doc", pathLower, "doc", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                expect(result).toEqual([new SpecialMatch(13), new CaseMatch(14), new SpecialMatch(21)]);
                 
-                result = generateMatchList("doch", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
-                expect(result).toEqual([new SpecialMatch(13), new NormalMatch(14), new SpecialMatch(21), new SpecialMatch(28)]);
+                result = generateMatchList("doch", pathLower, "doch", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                expect(result).toEqual([new SpecialMatch(13), new CaseMatch(14), new SpecialMatch(21), new SpecialMatch(28)]);
             });
             
             it("should handle contiguous matches that stand alone", function () {
-                var result = generateMatchList("o", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
-                expect(result).toEqual([new NormalMatch(14)]);
+                var result = generateMatchList("o", pathLower, "o", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                expect(result).toEqual([new CaseMatch(14)]);
             });
             
             it("should recognize non-matches", function () {
-                var result = generateMatchList("ham", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                var result = generateMatchList("ham", pathLower, "ham", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
                 expect(result).toEqual(null);
             });
             
             it("should backtrack as needed", function () {
-                var result = generateMatchList("cu", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
-                expect(result).toEqual([new NormalMatch(15), new NormalMatch(16)]);
+                var result = generateMatchList("cu", pathLower, "cu", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                expect(result).toEqual([new CaseMatch(15), new CaseMatch(16)]);
                 
-                result = generateMatchList("dcho", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
+                result = generateMatchList("dcho", pathLower, "dcho", path, specialsInfo.specials, specialsInfo.lastSegmentSpecialsIndex);
                 expect(result).toEqual(null);
                 
                 var btpath = "MamoMeMiMoMu";
                 var btspecials = fSC(btpath);
-                btpath = btpath.toLowerCase();
+                var btpathLower = btpath.toLowerCase();
                 
-                result = generateMatchList("m", btpath, btspecials.specials, 0);
+                result = generateMatchList("m", btpathLower, "m", btpath, btspecials.specials, 0);
                 expect(result).toEqual([new SpecialMatch(0)]);
                 
-                result = generateMatchList("mu", btpath, btspecials.specials, 0);
-                expect(result).toEqual([new SpecialMatch(0), new NormalMatch(11)]);
+                result = generateMatchList("mu", btpathLower, "mu", btpath, btspecials.specials, 0);
+                expect(result).toEqual([new SpecialMatch(0), new CaseMatch(11)]);
                 
-                result = generateMatchList("mamo", btpath, btspecials.specials, 0);
-                expect(result).toEqual([new SpecialMatch(0), new NormalMatch(1), new SpecialMatch(4), new NormalMatch(9)]);
+                result = generateMatchList("mamo", btpathLower, "mamo", btpath, btspecials.specials, 0);
+                expect(result).toEqual([new SpecialMatch(0), new CaseMatch(1), new SpecialMatch(4), new CaseMatch(9)]);
                 
                 btpath = "AbcdefzBcdefCdefDefEfF";
                 btspecials = fSC(btpath);
-                btpath = btpath.toLowerCase();
+                btpathLower = btpath.toLowerCase();
                 
-                result = generateMatchList("f", btpath, btspecials.specials, 0);
+                result = generateMatchList("f", btpathLower, "f", btpath, btspecials.specials, 0);
                 expect(result).toEqual([new SpecialMatch(21)]);
                 
-                result = generateMatchList("abcdefz", btpath, btspecials.specials, 0);
+                result = generateMatchList("abcdefz", btpathLower, "abcdefz", btpath, btspecials.specials, 0);
+                expect(result).toEqual([new SpecialMatch(0), new CaseMatch(1), new CaseMatch(2), new CaseMatch(3), new CaseMatch(4), new CaseMatch(5), new CaseMatch(6)]);
+
+                result = generateMatchList("abcdefz", btpathLower, "ABCDEFZ", btpath, btspecials.specials, 0);
                 expect(result).toEqual([new SpecialMatch(0), new NormalMatch(1), new NormalMatch(2), new NormalMatch(3), new NormalMatch(4), new NormalMatch(5), new NormalMatch(6)]);
                 
-                result = generateMatchList("abcdefe", btpath, btspecials.specials, 0);
-                expect(result).toEqual([new SpecialMatch(0), new SpecialMatch(7), new SpecialMatch(12), new SpecialMatch(16), new NormalMatch(17), new NormalMatch(18), new SpecialMatch(19)]);
+                result = generateMatchList("abcdefe", btpathLower, "abcdefe", btpath, btspecials.specials, 0);
+                expect(result).toEqual([new SpecialMatch(0), new SpecialMatch(7), new SpecialMatch(12), new SpecialMatch(16), new CaseMatch(17), new CaseMatch(18), new SpecialMatch(19)]);
                 
                 var str = "_computeRangesAndScore";
                 var strSpecials = fSC(str);
-                str = str.toLowerCase();
-                result = generateMatchList("_computerangesa", str, strSpecials.specials, 0);
+                var strLower = str.toLowerCase();
+                result = generateMatchList("_computerangesa", strLower, "_computerangesa", str, strSpecials.specials, 0);
                 expect(result).toEqual([
-                    new SpecialMatch(0), new SpecialMatch(1), new NormalMatch(2),
-                    new NormalMatch(3), new NormalMatch(4), new NormalMatch(5),
-                    new NormalMatch(6), new NormalMatch(7), new SpecialMatch(8),
-                    new NormalMatch(9), new NormalMatch(10), new NormalMatch(11),
-                    new NormalMatch(12), new NormalMatch(13), new SpecialMatch(14)
+                    new SpecialMatch(0), new SpecialMatch(1), new CaseMatch(2),
+                    new CaseMatch(3), new CaseMatch(4), new CaseMatch(5),
+                    new CaseMatch(6), new CaseMatch(7), new SpecialMatch(8),
+                    new CaseMatch(9), new CaseMatch(10), new CaseMatch(11),
+                    new CaseMatch(12), new CaseMatch(13), new SpecialMatch(14)
                 ]);
             });
                 
@@ -191,14 +197,17 @@ define(function (require, exports, module) {
         describe("_lastSegmentSearch", function () {
             var SpecialMatch = StringMatch._SpecialMatch;
             var NormalMatch = StringMatch._NormalMatch;
+            var CaseMatch = StringMatch._CaseMatch;
             beforeEach(function () {
                 SpecialMatch.prototype.type = "special";
                 NormalMatch.prototype.type = "normal";
+                CaseMatch.prototype.type = "case";
             });
             
             afterEach(function () {
                 delete SpecialMatch.prototype.type;
                 delete NormalMatch.prototype.type;
+                delete CaseMatch.prototype.type;
             });
             
             it("should compare results in the final segment properly", function () {
@@ -206,93 +215,102 @@ define(function (require, exports, module) {
                 var comparePath = path.toLowerCase();
                 var _lastSegmentSearch = StringMatch._lastSegmentSearch;
                 var sc = StringMatch._findSpecialCharacters(path);
-                expect(_lastSegmentSearch("d", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("d", comparePath, "d", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("do", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("do", comparePath, "do", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14)
+                        new CaseMatch(14)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("doc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("doc", comparePath, "doc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14),
+                        new CaseMatch(14),
                         new SpecialMatch(21)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("docc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("docc", comparePath, "docc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14),
-                        new NormalMatch(15),
+                        new CaseMatch(14),
+                        new CaseMatch(15),
                         new SpecialMatch(21)
                     ]
                 });
 
-                expect(_lastSegmentSearch("docch", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("docch", comparePath, "docch", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14),
-                        new NormalMatch(15),
+                        new CaseMatch(14),
+                        new CaseMatch(15),
                         new SpecialMatch(21),
                         new SpecialMatch(28)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("docch.js", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("docch.js", comparePath, "docch.js", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14),
-                        new NormalMatch(15),
+                        new CaseMatch(14),
+                        new CaseMatch(15),
                         new SpecialMatch(21),
                         new SpecialMatch(28),
                         new SpecialMatch(35),
                         new SpecialMatch(36),
-                        new NormalMatch(37)
+                        new CaseMatch(37)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("ocu", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("ocu", comparePath, "ocu", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
-                        new NormalMatch(14),
-                        new NormalMatch(15),
-                        new NormalMatch(16)
+                        new CaseMatch(14),
+                        new CaseMatch(15),
+                        new CaseMatch(16)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("ocuha", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("ocuha", comparePath, "ocuha", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "",
+                    originalRemainder: "",
                     matchList: [
-                        new NormalMatch(14),
-                        new NormalMatch(15),
-                        new NormalMatch(16),
+                        new CaseMatch(14),
+                        new CaseMatch(15),
+                        new CaseMatch(16),
                         new SpecialMatch(28),
-                        new NormalMatch(29)
+                        new CaseMatch(29)
                     ]
                 });
                 
-                expect(_lastSegmentSearch("z", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
-                expect(_lastSegmentSearch("ocuz", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
+                expect(_lastSegmentSearch("z", comparePath, "z", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
+                expect(_lastSegmentSearch("ocuz", comparePath, "ocuz", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
                 
-                expect(_lastSegmentSearch("sdoc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
+                expect(_lastSegmentSearch("sdoc", comparePath, "sdoc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual({
                     remainder: "s",
+                    originalRemainder: "s",
                     matchList: [
                         new SpecialMatch(13),
-                        new NormalMatch(14),
+                        new CaseMatch(14),
                         new SpecialMatch(21)
                     ]
                 });
@@ -306,7 +324,7 @@ define(function (require, exports, module) {
                 var comparePath = path.toLowerCase();
                 var _lastSegmentSearch = StringMatch._lastSegmentSearch;
                 var sc = StringMatch._findSpecialCharacters(path);
-                expect(_lastSegmentSearch("ocud", comparePath, sc.specials, 0)).toEqual(null);
+                expect(_lastSegmentSearch("ocud", comparePath, "ocud", path, sc.specials, 0)).toEqual(null);
             });
             
             it("should compare matches that don't fit in just the final segment", function () {
@@ -317,32 +335,32 @@ define(function (require, exports, module) {
                 
                 var comparePath = path.toLowerCase();
                 
-                expect(wholeStringSearch("sdoc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("sdoc", comparePath, "sdoc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(0),
                     new SpecialMatch(13),
-                    new NormalMatch(14),
+                    new CaseMatch(14),
                     new SpecialMatch(21)
                 ]);
                 
-                expect(wholeStringSearch("doc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("doc", comparePath, "doc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(13),
-                    new NormalMatch(14),
+                    new CaseMatch(14),
                     new SpecialMatch(21)
                 ]);
                 
-                expect(wholeStringSearch("z", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
+                expect(wholeStringSearch("z", comparePath, "z", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
                 
-                expect(wholeStringSearch("docdoc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("docdoc", comparePath, "docdoc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(4),
-                    new NormalMatch(5),
-                    new NormalMatch(6),
+                    new CaseMatch(5),
+                    new CaseMatch(6),
                     new SpecialMatch(13),
-                    new NormalMatch(14),
+                    new CaseMatch(14),
                     new SpecialMatch(21)
                 ]);
                 
                 // test for a suspected bug where specials are matched out of order.
-                expect(wholeStringSearch("hc", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
+                expect(wholeStringSearch("hc", comparePath, "hc", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual(null);
             });
             
             it("should handle matches that don't fit at all in the final segment", function () {
@@ -353,39 +371,39 @@ define(function (require, exports, module) {
                 
                 var comparePath = path.toLowerCase();
                 
-                expect(wholeStringSearch("quick", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("quick", comparePath, "quick", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(23),
-                    new NormalMatch(24),
-                    new NormalMatch(25),
-                    new NormalMatch(26),
-                    new NormalMatch(27)
+                    new CaseMatch(24),
+                    new CaseMatch(25),
+                    new CaseMatch(26),
+                    new CaseMatch(27)
                 ]);
                 
-                expect(wholeStringSearch("quickopen", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("quickopen", comparePath, "quickopen", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(23),
-                    new NormalMatch(24),
-                    new NormalMatch(25),
-                    new NormalMatch(26),
-                    new NormalMatch(27),
+                    new CaseMatch(24),
+                    new CaseMatch(25),
+                    new CaseMatch(26),
+                    new CaseMatch(27),
                     new SpecialMatch(28),
-                    new NormalMatch(29),
-                    new NormalMatch(30),
-                    new NormalMatch(39)
+                    new CaseMatch(29),
+                    new CaseMatch(30),
+                    new CaseMatch(39)
                 ]);
                                 
-                expect(wholeStringSearch("quickopenain", comparePath, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
+                expect(wholeStringSearch("quickopenain", comparePath, "quickopenain", path, sc.specials, sc.lastSegmentSpecialsIndex)).toEqual([
                     new SpecialMatch(23),
-                    new NormalMatch(24),
-                    new NormalMatch(25),
-                    new NormalMatch(26),
-                    new NormalMatch(27),
+                    new CaseMatch(24),
+                    new CaseMatch(25),
+                    new CaseMatch(26),
+                    new CaseMatch(27),
                     new SpecialMatch(28),
-                    new NormalMatch(29),
-                    new NormalMatch(30),
-                    new NormalMatch(31),
-                    new NormalMatch(37),
-                    new NormalMatch(38),
-                    new NormalMatch(39)
+                    new CaseMatch(29),
+                    new CaseMatch(30),
+                    new CaseMatch(31),
+                    new CaseMatch(37),
+                    new CaseMatch(38),
+                    new CaseMatch(39)
                 ]);
             });
         });
@@ -475,7 +493,7 @@ define(function (require, exports, module) {
                 expect(stringMatch("stringTimeRing", "STR", {
                     preferPrefixMatches: true
                 })).toEqual({
-                    matchGoodness: -Number.MAX_VALUE,
+                    matchGoodness: -Number.MAX_VALUE * 0.5,
                     label: "stringTimeRing",
                     stringRanges: [
                         { text: "str", matched: true, includesLastSegment: true },
@@ -486,7 +504,7 @@ define(function (require, exports, module) {
                 expect(stringMatch("STRINGTimeRing", "str", {
                     preferPrefixMatches: true
                 })).toEqual({
-                    matchGoodness: -Number.MAX_VALUE,
+                    matchGoodness: -Number.MAX_VALUE * 0.5,
                     label: "STRINGTimeRing",
                     stringRanges: [
                         { text: "STR", matched: true, includesLastSegment: true },


### PR DESCRIPTION
This is for #3971 (replaces #9512)

CC: @dangoor 

Adds greater weight to case matches in `StringMatch` so they are presented first.
