### PR TITLE
Properly handle FS events for directory in the file tree.

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -1135,9 +1135,18 @@ define(function (require, exports, module) {
             ];
         } else {
             // Special case: a directory passed in without added and removed values
-            // appears to be new.
+            // needs to be updated.
             if (!added && !removed) {
-                this._viewModel.ensureDirectoryExists(this.makeProjectRelativeIfPossible(entry.fullPath));
+                entry.getContents(function (err, contents) {
+                    if (err) {
+                        console.error("Unexpected error refreshing file tree for directory", entry.fullPath, err);
+                        return;
+                    }
+                    self._viewModel.setDirectoryContents(self.makeProjectRelativeIfPossible(entry.fullPath), contents);
+                });
+                
+                // Exit early because we can't update the viewModel until we get the directory contents.
+                return;
             }
         }
 

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -1362,14 +1362,25 @@ define(function (require, exports, module) {
                 expect(model._selections.context).toBeNull();
             });
             
-            it("should see events with a directory but no added or removed as an add", function () {
+            it("should see events with a directory but no added or removed as a need to reload the directory", function () {
                 model.handleFSEvent({
                     isFile: false,
                     name: "newdir",
-                    fullPath: "/foo/newdir/"
+                    fullPath: "/foo/newdir/",
+                    getContents: function (callback) {
+                        callback(null, [
+                            {
+                                isFile: true,
+                                name: "newfile",
+                                fullPath: "/foo/newdir/newfile"
+                            }
+                        ]);
+                    }
                 });
                 expect(vm._treeData.get("newdir").toJS()).toEqual({
-                    children: null
+                    children: {
+                        newfile: {}
+                    }
                 });
             });
         });


### PR DESCRIPTION
An FS event for a directory with no "added" or "removed" means that
the directory contents should be reloaded. This change does that
and fixes #9510 and #9517.
