### PR TITLE
bump phantomjs version to 1.9.11 to avoid errors building brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
-        "phantomjs": "1.9.0-1",
+        "phantomjs": "1.9.11",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.4.3",


### PR DESCRIPTION
This fix will bump up the phantomjs dependency to 1.9.11 to avoid the issue mentioned in #9630
