### PR TITLE
Remove even more deprecated code

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2012 Adobe Systems Incorporated. All rights reserved.
- *  
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"), 
  * to deal in the Software without restriction, including without limitation 
  * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
  * and/or sell copies of the Software, and to permit persons to whom the 
  * Software is furnished to do so, subject to the following conditions:
- *  
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *  
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,7 +18,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
  * DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 
 
@@ -175,16 +175,5 @@ define(function (require, exports, module) {
     DeprecationWarning.deprecateConstant(exports, "SORT_WORKINGSET_BY_NAME",    "CMD_WORKINGSET_SORT_BY_NAME");
     DeprecationWarning.deprecateConstant(exports, "SORT_WORKINGSET_BY_TYPE",    "CMD_WORKINGSET_SORT_BY_TYPE");
     DeprecationWarning.deprecateConstant(exports, "SORT_WORKINGSET_AUTO",       "CMD_WORKING_SORT_TOGGLE_AUTO");
-              
-    // DEPRECATED: Edit commands that were moved from the Edit Menu to the Find Menu
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND",                  "CMD_FIND");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND_IN_SELECTED",      "CMD_FIND_IN_SELECTED");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND_IN_SUBTREE",       "CMD_FIND_IN_SUBTREE");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND_NEXT",             "CMD_FIND_NEXT");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND_PREVIOUS",         "CMD_FIND_PREVIOUS");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_FIND_ALL_AND_SELECT",   "CMD_FIND_ALL_AND_SELECT");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_ADD_NEXT_MATCH",        "CMD_ADD_NEXT_MATCH");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_SKIP_CURRENT_MATCH",    "CMD_SKIP_CURRENT_MATCH");
-    DeprecationWarning.deprecateConstant(exports, "EDIT_REPLACE",               "CMD_REPLACE");
 });
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -553,7 +553,6 @@ define(function (require, exports, module) {
             menuItem,
             name,
             commandID;
-            commandID;
         
         if (!command) {
             console.error("addMenuItem(): missing required parameters: command");
@@ -710,7 +709,6 @@ define(function (require, exports, module) {
      */
     // Menu.prototype.createMenuItemsFromJSON = function (jsonStr, position, relativeID) {
     //     NOT IMPLEMENTED
-    // };
     // };
 
 

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -94,10 +94,6 @@ define(function (require, exports, module) {
         EDIT_CODE_HINTS_COMMANDS:           {sectionMarker: Commands.SHOW_CODE_HINTS},
         EDIT_TOGGLE_OPTIONS:                {sectionMarker: Commands.TOGGLE_CLOSE_BRACKETS},
         
-        // DEPRECATED: Old Edit menu sections redirected to existing Edit menu section
-        EDIT_FIND_COMMANDS:                 {sectionMarker: Commands.TOGGLE_CLOSE_BRACKETS},
-        EDIT_REPLACE_COMMANDS:              {sectionMarker: Commands.TOGGLE_CLOSE_BRACKETS},
-        
         FIND_FIND_COMMANDS:                 {sectionMarker: Commands.CMD_FIND},
         FIND_FIND_IN_COMMANDS:              {sectionMarker: Commands.CMD_FIND_IN_FILES},
         FIND_REPLACE_COMMANDS:              {sectionMarker: Commands.CMD_REPLACE},
@@ -557,14 +553,7 @@ define(function (require, exports, module) {
             menuItem,
             name,
             commandID;
-        
-        if (relativeID === MenuSection.EDIT_FIND_COMMANDS) {
-            DeprecationWarning.deprecationWarning("Add " + command + " Command to the Find Menu instead of the Edit Menu.", true);
-            DeprecationWarning.deprecationWarning("Use MenuSection.FIND_FIND_COMMANDS instead of MenuSection.EDIT_FIND_COMMANDS.", true);
-        } else if (relativeID === MenuSection.EDIT_REPLACE_COMMANDS) {
-            DeprecationWarning.deprecationWarning("Add " + command + " Command to the Find Menu instead of the Edit Menu.", true);
-            DeprecationWarning.deprecationWarning("Use MenuSection.FIND_REPLACE_COMMANDS instead of MenuSection.EDIT_REPLACE_COMMANDS.", true);
-        }
+            commandID;
         
         if (!command) {
             console.error("addMenuItem(): missing required parameters: command");
@@ -721,6 +710,7 @@ define(function (require, exports, module) {
      */
     // Menu.prototype.createMenuItemsFromJSON = function (jsonStr, position, relativeID) {
     //     NOT IMPLEMENTED
+    // };
     // };
 
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -838,7 +838,6 @@ define(function (require, exports, module) {
         
         // Redispatch these CodeMirror key events as jQuery events
         function _onKeyEvent(instance, event) {
-            $(self).triggerHandler("keyEvent", [self, event]);  // deprecated
             $(self).triggerHandler(event.type, [self, event]);
             return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
         }

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -949,10 +949,4 @@ define(function (require, exports, module) {
     exports.beginSearch             = beginSearch;
     exports.addQuickOpenPlugin      = addQuickOpenPlugin;
     exports.highlightMatch          = highlightMatch;
-    
-    // accessing these from this module will ultimately be deprecated
-    exports.stringMatch             = StringMatch.stringMatch;
-    exports.SearchResult            = StringMatch.SearchResult;
-    exports.basicMatchSort          = StringMatch.basicMatchSort;
-    exports.multiFieldSort          = StringMatch.multiFieldSort;
 });

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -145,15 +145,6 @@ define(function (require, exports, module) {
      * cancels Quick Open (via Esc), those changes are automatically reverted.
      */
     function addQuickOpenPlugin(pluginDef) {
-        // Backwards compatibility (for now) for old fileTypes field, if newer languageIds not specified
-        if (pluginDef.fileTypes && !pluginDef.languageIds) {
-            console.warn("Using fileTypes for QuickOpen plugins is deprecated. Use languageIds instead.");
-            pluginDef.languageIds = pluginDef.fileTypes.map(function (extension) {
-                return LanguageManager.getLanguageForPath("file." + extension).getId();
-            });
-            delete pluginDef.fileTypes;
-        }
-        
         plugins.push(new QuickOpenPlugin(
             pluginDef.name,
             pluginDef.languageIds,


### PR DESCRIPTION
Even more for #8751.

I did a through scrub of the code base, looking for any pre-0.41 deprecated. I found what I was looking for. 
The following is removed with this PR, listed along side the commit they were deprecated with and the release that deprecation went into effect.
- `command/Commands.js` and `command/Menus.js`: Old export redirects (56ab3e942f5b651da6d91176cd4da8b41a8c7252, Sprint 39)
- `editor/Editor.js`: jQuery `triggerHandler` for `"keyEvent"` (21bea9d143825122b8b89528e84052c132b0c64a, Sprint 38)
- `search/QuickOpen.js`: Backwards compatibility for `addQuickOpenPlugin()` (1ec5c8f8c70dc4aed5e98e3254904a2e8a55ae48, Sprint 23)
- `search/QuickOpen.js`: Old export redirects ([`7d262804728`](https://github.com/adobe/brackets/commit/57d262804728b1d179f2e1a98e6932884c37e77b), Sprint _19_!) These were technically never deprecated, but they are also not documented either.

Few notes:
- I came across this: [`672c7e`](https://github.com/adobe/brackets/commit/9672c7e19df84cc2bd84c807adc24fe870c0c042#diff-3) (`utils/StringMatch.js`), which landed in Sprint 25. I did not remove it for fear of breaking it because I do not know how that code works. Again, never deprecated, but it seems it was planned to be. @dangoor Since you made this commit, can you provide some insight here on what should be done?
- I have not checked extension compatibility yet, but all except the first item will be tricky to catch, as everything else was removing statements in the function/method, not directly access statements or APIs.
