### PR TITLE
Use an unused shortcut for Reload without Extensions

### DIFF
--- a/src/extensions/default/DebugCommands/keyboard.json
+++ b/src/extensions/default/DebugCommands/keyboard.json
@@ -22,7 +22,7 @@
             "key": "Shift-F5"
         },
         {
-            "key": "Cmd-Shift-R",
+            "key": "Cmd-Ctrl-R",
             "platform": "mac"
         }
     ]


### PR DESCRIPTION
@ingorichter I changed the command to `Cmd-Ctrl-R` since both `Cmd-Shift-R` and `Cmd-Alt-R` are already used in Brackets.
