### PR TITLE
Blur Current Editor when focusing Pane W/O Editor the Focus from the Global Menu

### DIFF
--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -1256,7 +1256,7 @@ define(function (require, exports, module) {
         //
         // ==> Focus is still in the text area. Any keyboard input will modify the document
         
-        if (current.tagName === "textarea" &&
+        if (current.tagName.toLowerCase() === "textarea" &&
                 (!this._currentView || !this._currentView._codeMirror)) {
             current.blur();
         }


### PR DESCRIPTION
This fixes the case where the editor should be blurred but was not because the tag name used a case sensitive compare method and didn't recognize that the editor currently had the focus because of it.

This is for #9664 
CC: @redmunds 
