### PR TITLE
Update Getting Started

### DIFF
--- a/samples/root/Getting Started/index.html
+++ b/samples/root/Getting Started/index.html
@@ -18,8 +18,8 @@
         -->
         
         <p>
-            Welcome to an early preview of Brackets, a new open-source editor for the next generation of
-            the web. We're big fans of standards and want to build better tooling for JavaScript, HTML and CSS 
+            Welcome to Brackets, a new open-source editor for the next generation of the web.
+            We're big fans of standards and want to build better tooling for JavaScript, HTML and CSS 
             and related open web technologies. This is our humble beginning.
         </p>
         
@@ -137,7 +137,7 @@
         <h3>Need something else? Try an extension!</h3>
         <p>
             In addition to all the goodness that's built into Brackets, our large and growing community of
-            extension developers has built over a hundred extensions that add useful functionality. If there's
+            extension developers has built hundreds of extensions that add useful functionality. If there's
             something you need that Brackets doesn't offer, more than likely someone has built an extension for
             it. To browse or search the list of available extensions, choose <strong>File &gt; Extension
             Manager</strong> and click on the "Available" tab. When you find an extension you want, just click


### PR DESCRIPTION
Bring Getting Started up-to-date

We should also remove the term "experimental" from this string in the About Dialog:

``` js
        "EXPERIMENTAL_BUILD"       : "experimental build",
```

But I wasn't sure if it's OK to just update the string, or also update the string id?
