### PR TITLE
Replace `&gt;` with right arrow (→) in Getting Started

### DIFF
--- a/samples/root/Getting Started/index.html
+++ b/samples/root/Getting Started/index.html
@@ -139,7 +139,7 @@
             In addition to all the goodness that's built into Brackets, our large and growing community of
             extension developers has built over a hundred extensions that add useful functionality. If there's
             something you need that Brackets doesn't offer, more than likely someone has built an extension for
-            it. To browse or search the list of available extensions, choose <strong>File &gt; Extension
+            it. To browse or search the list of available extensions, choose <strong>File → Extension
             Manager</strong> and click on the "Available" tab. When you find an extension you want, just click
             the "Install" button next to it.
         </p>


### PR DESCRIPTION
For the same reason as #9533 (“Replace HTML entity with literal dash in Getting Started”)
