### PR TITLE
Make update-release-number task support post-1.0 releases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "grunt-usemin": "0.1.11",
         "load-grunt-tasks": "0.2.0",
         "q": "0.9.2",
+        "semver": "^4.1.0",
         "jshint": "2.1.4",
         "xmldoc": "^0.1.2"
     },

--- a/src/config.json
+++ b/src/config.json
@@ -39,7 +39,7 @@
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
-        "phantomjs": "1.9.0-1",
+        "phantomjs": "1.9.11",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.4.3",
@@ -57,6 +57,7 @@
         "grunt-usemin": "0.1.11",
         "load-grunt-tasks": "0.2.0",
         "q": "0.9.2",
+        "semver": "^4.1.0",
         "jshint": "2.1.4",
         "xmldoc": "^0.1.2"
     },

--- a/tasks/update-release-number.js
+++ b/tasks/update-release-number.js
@@ -25,22 +25,22 @@
 module.exports = function (grunt) {
     "use strict";
 
-    var common = require("./lib/common")(grunt);
+    var common = require("./lib/common")(grunt),
+        semver = require("semver");
 
     // task: update-release-number
     // Updates the version property in package.json
     grunt.registerTask('update-release-number', function () {
         var path        = "package.json",
             packageJSON = grunt.file.readJSON(path),
-            release     = grunt.option("release") || 0,
-            versionNumberRegexp = /([0-9]+\.)([0-9]+)([\.\-a-zA-Z0-9]*)?/;
+            release     = grunt.option("release") || "";
 
-        if (!release) {
-            grunt.fail.fatal("Please specify a release. e.g. grunt update-release-number --release=40");
+        if (!release || !semver.valid(release)) {
+            grunt.fail.fatal("Please specify a release. e.g. grunt update-release-number --release=1.1.0");
         }
 
-        packageJSON.version = packageJSON.version.replace(versionNumberRegexp, "$1" + release + "$3");
-        packageJSON.apiVersion = packageJSON.apiVersion.replace(versionNumberRegexp, "$1" + release + "$3");
+        packageJSON.version = release;
+        packageJSON.apiVersion = release;
 
         common.writeJSON(grunt, path, packageJSON);
     });


### PR DESCRIPTION
Fix for #9690.
