### PR TITLE
Fix bug #9179 (New Untitled documents have wrong line endings on Windows)

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -873,7 +873,7 @@ define(function (require, exports, module) {
             // explictly allow "blind" writes to the filesystem in this case,
             // ignoring warnings about the contents being modified outside of
             // the editor.
-            FileUtils.writeText(newFile, doc.getText(), true)
+            FileUtils.writeText(newFile, doc.getText(true), true)
                 .done(function () {
                     // If there were unsaved changes before Save As, they don't stay with the old
                     // file anymore - so must revert the old doc to match disk content.

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1334,7 +1334,8 @@ define(function (require, exports, module) {
     /**
      * Returns an Array of all files for this project, optionally including
      * files in the working set that are *not* under the project root. Files are
-     * filtered out by ProjectModel.shouldShow().
+     * filtered first by ProjectModel.shouldShow(), then by the custom filter
+     * argument (if one was provided). The list is unsorted.
      *
      * @param {function (File, number):boolean=} filter Optional function to filter
      *          the file list (does not filter directory traversal). API matches Array.filter().


### PR DESCRIPTION
Fix bug #9179 -- Use correct form of `Document.getText()` in Save As, like in Save. Plus unit test (had time to write one after all!).
