### PR TITLE
Move resizer element higher in DOM for SplitView

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -169,8 +169,10 @@ define(function (require, exports, module) {
      * @param {?boolean} createdByWorkspaceManager For internal use only
      * @param {?boolean} usePercentages Maintain the size of the element as a percentage of its parent
      *                          the default is to maintain the size of the element in pixels
+     * @param {?boolean} attachToParent Attaches the resizer element to parent of the element rather than
+     *                          to element itself.
      */
-    function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages) {
+    function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages, attachToParent) {
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),
             $element            = $(element),
             $parent             = $element.parent(),
@@ -229,8 +231,11 @@ define(function (require, exports, module) {
 
         collapsible = collapsible || false;
         
-        $element.prepend($resizer);
-        
+        if (attachToParent) {
+            $parent.prepend($resizer);
+        } else {
+            $element.prepend($resizer);
+        }
         // Important so min/max sizes behave predictably
         $element.css("box-sizing", "border-box");
         
@@ -291,8 +296,11 @@ define(function (require, exports, module) {
             elementPrefs.visible = true;
             
             if (collapsible) {
-                $element.prepend($resizer);
-                
+                if (attachToParent) {
+                    $parent.prepend($resizer);
+                } else {
+                    $element.prepend($resizer);
+                }
                 if (position === POSITION_TOP) {
                     $resizer.css(resizerCSSPosition, "");
                 } else if (position === POSITION_RIGHT) {

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -169,13 +169,12 @@ define(function (require, exports, module) {
      * @param {?boolean} createdByWorkspaceManager For internal use only
      * @param {?boolean} usePercentages Maintain the size of the element as a percentage of its parent
      *                          the default is to maintain the size of the element in pixels
-     * @param {?boolean} attachToParent Attaches the resizer element to parent of the element rather than
-     *                          to element itself.
-     *                   attach the resizer to the parent *ONLY* if element has the same offset as parent
-     *                          otherwise the resizer will be incorrectly positioned. This means that
-     *                          once splitview has more than 2 panes we will need to find another solution
+     * @param {?boolean} _attachToParent Attaches the resizer element to parent of the element rather than
+     *                          to element itself. Attach the resizer to the parent *ONLY* if element has the
+     *                          same offset as parent otherwise the resizer will be incorrectly positioned. 
+     *                          FOR INTERNAL USE ONLY
      */
-    function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages, attachToParent) {
+    function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages, _attachToParent) {
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),
             $element            = $(element),
             $parent             = $element.parent(),
@@ -234,7 +233,7 @@ define(function (require, exports, module) {
 
         collapsible = collapsible || false;
         
-        if (attachToParent) {
+        if (_attachToParent) {
             $parent.prepend($resizer);
         } else {
             $element.prepend($resizer);
@@ -299,7 +298,7 @@ define(function (require, exports, module) {
             elementPrefs.visible = true;
             
             if (collapsible) {
-                if (attachToParent) {
+                if (_attachToParent) {
                     $parent.prepend($resizer);
                 } else {
                     $element.prepend($resizer);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -171,6 +171,9 @@ define(function (require, exports, module) {
      *                          the default is to maintain the size of the element in pixels
      * @param {?boolean} attachToParent Attaches the resizer element to parent of the element rather than
      *                          to element itself.
+     *                   attach the resizer to the parent *ONLY* if element has the same offset as parent
+     *                          otherwise the resizer will be incorrectly positioned. This means that
+     *                          once splitview has more than 2 panes we will need to find another solution
      */
     function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages, attachToParent) {
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1073,7 +1073,7 @@ define(function (require, exports, module) {
         Resizer.makeResizable(firstPane.$el,
                               _orientation === HORIZONTAL ? Resizer.DIRECTION_VERTICAL : Resizer.DIRECTION_HORIZONTAL,
                               _orientation === HORIZONTAL ? Resizer.POSITION_BOTTOM : Resizer.POSITION_RIGHT,
-                              MIN_PANE_SIZE, false, false, false, true);
+                              MIN_PANE_SIZE, false, false, false, true, true);
         
         firstPane.$el.on("panelResizeUpdate", function () {
             _updateLayout();


### PR DESCRIPTION
This is for #9706

This PR moves the resizer div out of the left pane and into parent DIV which puts the resizer DIV above both panes in the DOM so that it is always accessible.  By design, the resizer attaches it self to one edge of the thing it's resizing but, in this case, we want it above the container.
