### PR TITLE
Add build number field for release number.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Brackets",
-    "version": "0.45.0-0",
-    "apiVersion": "0.45.0",
+    "version": "1.0.0-0",
+    "apiVersion": "1.0.0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets/issues"

--- a/src/config.json
+++ b/src/config.json
@@ -22,8 +22,8 @@
         "build_timestamp": ""
     },
     "name": "Brackets",
-    "version": "0.45.0-0",
-    "apiVersion": "0.45.0",
+    "version": "1.0.0-0",
+    "apiVersion": "1.0.0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets/issues"

--- a/tasks/update-release-number.js
+++ b/tasks/update-release-number.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
             grunt.fail.fatal("Please specify a release. e.g. grunt update-release-number --release=1.1.0");
         }
 
-        packageJSON.version = release;
+        packageJSON.version = release + "-0";
         packageJSON.apiVersion = release;
 
         common.writeJSON(grunt, path, packageJSON);


### PR DESCRIPTION
Brackets won't start with a 1.0.0 version number. This also bumps the version number to 1.0.0-0.

cc @ingorichter 
