### PR TITLE
Restore the QuickOpen.basicMatchSort and friends

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -949,4 +949,10 @@ define(function (require, exports, module) {
     exports.beginSearch             = beginSearch;
     exports.addQuickOpenPlugin      = addQuickOpenPlugin;
     exports.highlightMatch          = highlightMatch;
+    
+    // accessing these from this module will ultimately be deprecated
+    exports.stringMatch             = StringMatch.stringMatch;
+    exports.SearchResult            = StringMatch.SearchResult;
+    exports.basicMatchSort          = StringMatch.basicMatchSort;
+    exports.multiFieldSort          = StringMatch.multiFieldSort;
 });

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -950,7 +950,7 @@ define(function (require, exports, module) {
     exports.addQuickOpenPlugin      = addQuickOpenPlugin;
     exports.highlightMatch          = highlightMatch;
     
-    // accessing these from this module will ultimately be deprecated
+    // Convenience exports for functions that most QuickOpen plugins would need.
     exports.stringMatch             = StringMatch.stringMatch;
     exports.SearchResult            = StringMatch.SearchResult;
     exports.basicMatchSort          = StringMatch.basicMatchSort;


### PR DESCRIPTION
```
This change broke a few extensions. Looking at the fix, it seems that all QuickOpen plugins will
likely need these functions, so we may as well re-export them as we have been doing rather than
requiring the extensions to all add another import.

If we do decide to deprecate these later, we should do so with deprecation warnings (something we
weren't doing when these were moved to the StringMatch module).

Revert "Marked as deprecated by adobe/brackets#2462 in Sprint 19"

This reverts commit 49e08274a0bc9259d6dd94c03351e4c87bf570f9.
```
