### PR TITLE
Restore editor keyEvent.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -838,6 +838,7 @@ define(function (require, exports, module) {
         
         // Redispatch these CodeMirror key events as jQuery events
         function _onKeyEvent(instance, event) {
+            $(self).triggerHandler("keyEvent", [self, event]);  // deprecated
             $(self).triggerHandler(event.type, [self, event]);
             return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
         }


### PR DESCRIPTION
This one wasn't fully deprecated (no warning in console, still in documentation) and there
are still a number of extensions that depend upon it.

Revert "Deprecated by adobe/brackets#6787"

This reverts commit 2e7bc6ab049b5fc50915b54f77e8c1c2b1239845.
