### PR TITLE
Fixing resizing performance issue in split view 

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -476,6 +476,11 @@ a, img {
             position: absolute;
             display: block;
         }
+
+        .CodeMirror.fixedWidth{
+            width:3000px!important;
+            
+        }
     }
     .pane-header {
         box-sizing: border-box;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -134,6 +134,23 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Because of the resizing performance issue we need to make the width of the codemirror 
+     *  fixed size (3000px) in each panes to prevent rendering when the user is resizing 
+     * @makeFixed  {Boolean} false if we want thenormal width
+     */
+    function makeEditorsFixedWidth( makeFixed ) {
+        var firstPane =  $('#first-pane>.pane-content>.CodeMirror');
+        var secondPane =  $('#second-pane>.pane-content>.CodeMirror');
+        if (makeFixed) {
+            firstPane.addClass('fixedWidth');
+            secondPane.addClass('fixedWidth');
+        } else {
+            firstPane.removeClass('fixedWidth');
+            secondPane.removeClass('fixedWidth');
+        }
+    }
+
+    /**
      * Adds resizing and (optionally) expand/collapse capabilities to a given html element. The element's size
      * & visibility are automatically saved & restored as a view-state preference.
      *
@@ -340,6 +357,10 @@ define(function (require, exports, module) {
         
 
         $resizer.on("mousedown.resizer", function (e) {
+        	
+        	// we change the editors' width to fixed size to prevent rendering contents
+        	makeEditorsFixedWidth(true);
+
             var $resizeShield   = $("<div class='resizing-container " + direction + "-resizing' />"),
                 startPosition   = e[directionProperty],
                 startSize       = $element.is(":visible") ? elementSizeFunction.apply($element) : 0,
@@ -438,6 +459,9 @@ define(function (require, exports, module) {
             }
             
             function endResize(e) {
+            	// restoring the width to default value
+            	makeEditorsFixedWidth(false);
+
                 if (isResizing) {
                     
                     var elementSize	= elementSizeFunction.apply($element);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -138,15 +138,15 @@ define(function (require, exports, module) {
      *  fixed size (3000px) in each panes to prevent rendering when the user is resizing 
      * @makeFixed  {Boolean} false if we want thenormal width
      */
-    function makeEditorsFixedWidth( makeFixed ) {
-        var firstPane =  $('#first-pane>.pane-content>.CodeMirror');
-        var secondPane =  $('#second-pane>.pane-content>.CodeMirror');
+    function makeEditorsFixedWidth(makeFixed) {
+        var $firstPane = $("#first-pane>.pane-content>.CodeMirror");
+        var $secondPane = $("#second-pane>.pane-content>.CodeMirror");
         if (makeFixed) {
-            firstPane.addClass('fixedWidth');
-            secondPane.addClass('fixedWidth');
+            $firstPane.addClass("fixedWidth");
+            $secondPane.addClass("fixedWidth");
         } else {
-            firstPane.removeClass('fixedWidth');
-            secondPane.removeClass('fixedWidth');
+            $firstPane.removeClass("fixedWidth");
+            $secondPane.removeClass("fixedWidth");
         }
     }
 
@@ -357,9 +357,8 @@ define(function (require, exports, module) {
         
 
         $resizer.on("mousedown.resizer", function (e) {
-        	
-        	// we change the editors' width to fixed size to prevent rendering contents
-        	makeEditorsFixedWidth(true);
+            // we change the editors' width to fixed size to prevent rendering contents
+            makeEditorsFixedWidth(true);
 
             var $resizeShield   = $("<div class='resizing-container " + direction + "-resizing' />"),
                 startPosition   = e[directionProperty],


### PR DESCRIPTION
Resizing in split view is too slow because codemirror's width is changing on resizing and it has to render it's contents every time.

We change the width to fixed size (3000px) on resizing start and restore to default at the end so codemirror doesn't render it's contents anymore :)
