### PR TITLE
Fixing resizing performance issue in split view 

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -477,9 +477,8 @@ a, img {
             display: block;
         }
 
-        .CodeMirror.fixedWidth{
-            width:3000px!important;
-            
+        .CodeMirror.fixedWidth {
+            width: 3000px !important;
         }
     }
     .pane-header {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -476,6 +476,11 @@ a, img {
             position: absolute;
             display: block;
         }
+
+        .CodeMirror.fixedWidth{
+            width:3000px!important;
+            
+        }
     }
     .pane-header {
         box-sizing: border-box;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -458,8 +458,8 @@ define(function (require, exports, module) {
             }
             
             function endResize(e) {
-            	// restoring the width to default value
-            	makeEditorsFixedWidth(false);
+                // restoring the width to default value
+                makeEditorsFixedWidth(false);
 
                 if (isResizing) {
                     

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -134,6 +134,23 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Because of the resizing performance issue we need to make the width of the codemirror 
+     *  fixed size (3000px) in each panes to prevent rendering when the user is resizing 
+     * @makeFixed  {Boolean} false if we want thenormal width
+     */
+    function makeEditorsFixedWidth( makeFixed ) {
+        var firstPane =  $('#first-pane>.pane-content>.CodeMirror');
+        var secondPane =  $('#second-pane>.pane-content>.CodeMirror');
+        if (makeFixed) {
+            firstPane.addClass('fixedWidth');
+            secondPane.addClass('fixedWidth');
+        } else {
+            firstPane.removeClass('fixedWidth');
+            secondPane.removeClass('fixedWidth');
+        }
+    }
+
+    /**
      * Adds resizing and (optionally) expand/collapse capabilities to a given html element. The element's size
      * & visibility are automatically saved & restored as a view-state preference.
      *
@@ -340,6 +357,10 @@ define(function (require, exports, module) {
         
 
         $resizer.on("mousedown.resizer", function (e) {
+        	
+        	// we change the editors' width to fixed size to prevent rendering contents
+        	makeEditorsFixedWidth(true);
+
             var $resizeShield   = $("<div class='resizing-container " + direction + "-resizing' />"),
                 startPosition   = e[directionProperty],
                 startSize       = $element.is(":visible") ? elementSizeFunction.apply($element) : 0,
@@ -438,6 +459,9 @@ define(function (require, exports, module) {
             }
             
             function endResize(e) {
+            	// restoring the width to default value
+            	makeEditorsFixedWidth(false);
+
                 if (isResizing) {
                     
                     var elementSize	= elementSizeFunction.apply($element);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -138,15 +138,15 @@ define(function (require, exports, module) {
      *  fixed size (3000px) in each panes to prevent rendering when the user is resizing 
      * @makeFixed  {Boolean} false if we want thenormal width
      */
-    function makeEditorsFixedWidth( makeFixed ) {
-        var firstPane =  $('#first-pane>.pane-content>.CodeMirror');
-        var secondPane =  $('#second-pane>.pane-content>.CodeMirror');
+    function makeEditorsFixedWidth(makeFixed) {
+        var $firstPane = $("#first-pane>.pane-content>.CodeMirror");
+        var $secondPane = $("#second-pane>.pane-content>.CodeMirror");
         if (makeFixed) {
-            firstPane.addClass('fixedWidth');
-            secondPane.addClass('fixedWidth');
+            $firstPane.addClass("fixedWidth");
+            $secondPane.addClass("fixedWidth");
         } else {
-            firstPane.removeClass('fixedWidth');
-            secondPane.removeClass('fixedWidth');
+            $firstPane.removeClass("fixedWidth");
+            $secondPane.removeClass("fixedWidth");
         }
     }
 
@@ -357,9 +357,8 @@ define(function (require, exports, module) {
         
 
         $resizer.on("mousedown.resizer", function (e) {
-        	
-        	// we change the editors' width to fixed size to prevent rendering contents
-        	makeEditorsFixedWidth(true);
+            // we change the editors' width to fixed size to prevent rendering contents
+            makeEditorsFixedWidth(true);
 
             var $resizeShield   = $("<div class='resizing-container " + direction + "-resizing' />"),
                 startPosition   = e[directionProperty],

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -54,10 +54,13 @@ define(function (require, exports, module) {
     var POSITION_BOTTOM = "bottom";
     var POSITION_LEFT = "left";
     var POSITION_RIGHT = "right";
-	
+    
     // Minimum size (height or width) for autodiscovered resizable panels
     var DEFAULT_MIN_SIZE = 100;
     
+    // Constants for the preferences referred to in this file
+    var WORD_WRAP = "wordWrap";
+
     // Load dependent modules
     var AppInit                 = require("utils/AppInit"),
         PreferencesManager      = require("preferences/PreferencesManager");
@@ -135,10 +138,17 @@ define(function (require, exports, module) {
     
     /**
      * Because of the resizing performance issue we need to make the width of the codemirror 
-     *  fixed size (3000px) in each panes to prevent rendering when the user is resizing 
-     * @makeFixed  {Boolean} false if we want thenormal width
+     *  fixed size (3000px) in each pane to prevent rendering while resizing. 
+     * Note: Slow resizing is still there in warp mode or in horizontal split.
+     * @param {boolean} false if we want the normal width
      */
     function makeEditorsFixedWidth(makeFixed) {
+        var warpMode = PreferencesManager.get(WORD_WRAP);
+        if(warpMode) {
+            // we shouldn't fix it in warp mode
+            return;
+        }
+
         var $firstPane = $("#first-pane>.pane-content>.CodeMirror");
         var $secondPane = $("#second-pane>.pane-content>.CodeMirror");
         if (makeFixed) {
@@ -198,7 +208,7 @@ define(function (require, exports, module) {
             $resizableElement   = $($element.find(".resizable-content:first")[0]),
             $body               = $(window.document.body),
             elementID           = $element.attr("id"),
-            elementPrefs        = PreferencesManager.getViewState(elementID) || {},
+            elementPrefs        = PreferencesManager.getViewState(elementID) || {},
             animationRequest    = null,
             directionProperty   = direction === DIRECTION_HORIZONTAL ? "clientX" : "clientY",
             directionIncrement  = (position === POSITION_TOP || position === POSITION_LEFT) ? 1 : -1,
@@ -437,7 +447,7 @@ define(function (require, exports, module) {
                 }
                                    
                 e.preventDefault();
-                
+              
                 if (animationRequest === null) {
                     animationRequest = window.requestAnimationFrame(doRedraw);
                 }
@@ -463,7 +473,7 @@ define(function (require, exports, module) {
 
                 if (isResizing) {
                     
-                    var elementSize	= elementSizeFunction.apply($element);
+                    var elementSize = elementSizeFunction.apply($element);
                     if ($element.is(":visible")) {
                         elementPrefs.size = elementSize;
                         if ($resizableElement.length) {
@@ -494,7 +504,7 @@ define(function (require, exports, module) {
             
             e.preventDefault();
         });
-		
+        
         // Panel preferences initialization
         if (elementPrefs) {
             
@@ -518,7 +528,7 @@ define(function (require, exports, module) {
     // Scan DOM for horz-resizable and vert-resizable classes and make them resizable
     AppInit.htmlReady(function () {
         var minSize = DEFAULT_MIN_SIZE;
-		
+        
         $mainView = $(".main-view");
         
         $(".vert-resizable").each(function (index, element) {
@@ -526,7 +536,7 @@ define(function (require, exports, module) {
             if ($(element).data().minsize !== undefined) {
                 minSize = $(element).data().minsize;
             }
-			
+            
             if ($(element).hasClass("top-resizer")) {
                 makeResizable(element, DIRECTION_VERTICAL, POSITION_TOP, minSize, $(element).hasClass("collapsible"));
             }


### PR DESCRIPTION
Resizing in split view is too slow because the width of the codemirror editor is changing on resizing and it has to render it's contents every time.

We change the width to fixed size (3000px) on resizing start and restore to default at the end so codemirror doesn't render it's contents anymore :)

Slow resizing is still there in warp mode and horizontal split view.
