### PR TITLE
Add GitHub Flavored Markdown mode, Add some more Markdown fileExtensions

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -207,7 +207,13 @@
     "markdown": {
         "name": "Markdown",
         "mode": "markdown",
-        "fileExtensions": ["md", "markdown"],
+        "fileExtensions": ["md", "markdown", "mdown", "mkdn"],
+        "blockComment": ["<!--", "-->"]
+    },
+
+    "gfm": {
+        "name": "GitHub Flavored Markdown",
+        "mode": "gfm",
         "blockComment": ["<!--", "-->"]
     },
 

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -212,9 +212,8 @@
     },
 
     "gfm": {
-        "name": "GitHub Flavored Markdown",
-        "mode": "gfm",
-        "blockComment": ["<!--", "-->"]
+        "name": "Markdown (GitHub)",
+        "mode": "gfm"
     },
 
     "yaml": {


### PR DESCRIPTION
Note you can only ever get into GFM mode using the Language Switcher.
Also added some more `fileExtensions` for Markdown. Source: https://github.com/github/markup#markups
