### PR TITLE
Ability to specify that SSL errors should be ignored ...

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
             }
             
             // Download the bits (using Node since brackets-shell doesn't support binary file IO)
-            var r = extensionManager.downloadFile(downloadId, urlInfo.url, PreferencesManager.get("proxy"));
+            var r = extensionManager.downloadFile(downloadId, urlInfo.url, PreferencesManager.get("proxy"), PreferencesManager.get("proxy.ignoreSSL"));
             r.done(function (result) {
                 d.resolve({ localPath: FileUtils.convertWindowsPathToUnixPath(result), filenameHint: urlInfo.filenameHint });
             }).fail(function (err) {


### PR DESCRIPTION
... when downloading extensions, useful when behind a corporate proxy/firewall that is doing SSL decryption as part of the company security policy. Turned on by adding the following line to the preferences file:

```
"proxy.ignoreSSL": true
```
