### PR TITLE
Change font weight of menu items to 400 instead of 200, improves readability

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -328,7 +328,6 @@ a:focus {
         padding: @menubar-top-padding @menubar-h-padding @menubar-bottom-padding;
         border: 1px solid rgba(0, 0, 0, 0); // transparent border just to hold the layout so it doesn't shift on hover
         color: fadeout(@bc-menu-text, 25%);
-        font-weight: @font-weight-light;
 
         .dark & {
             color: fadeout(@dark-bc-menu-text, 25%);


### PR DESCRIPTION
Fixes #9828.

Things to consider:
- May not be the only place in the UI that this error happens.
- Should the font weight used (400) be put into a LESS variable? If so, how should that variable be named?
  - We already have `@font-weight-semibold: 500` and `@font-weight-light: 200`.
