### PR TITLE
[Fix] IDs for context menu elements don't need escaping for attributes

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -997,7 +997,7 @@ define(function (require, exports, module) {
     function ContextMenu(id) {
         Menu.apply(this, arguments);
 
-        var $newMenu = $("<li class='dropdown context-menu' id='" + StringUtils.jQueryIdEscape(id) + "'></li>"),
+        var $newMenu = $("<li class='dropdown context-menu'></li>").attr("id", id),
             $popUp = $("<ul class='dropdown-menu'></ul>"),
             $toggle = $("<a href='#' class='dropdown-toggle' data-toggle='dropdown'></a>").hide();
 


### PR DESCRIPTION
See issue https://github.com/adobe/brackets/issues/9863, when creating a context menu element, when setting the ID attribute of the menu element, you don't need to pass it through StringUtils.jQueryIdEscape, that's just for escaping selectors.

The fix also changes it so that the ID is set after creation using the .attr() command, which should prevent any escaping issues.
