### PR TITLE
Adding input types to focusable elements #9476

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -409,9 +409,15 @@ define(function (require, exports, module) {
             // Text fields should always be focusable.
             var $target = $(e.target),
                 isFormElement =
-                    $target.is("input[type=text]") ||
+                    $target.is("input[type=date]") ||
+                    $target.is("input[type=email]") ||
                     $target.is("input[type=number]") ||
                     $target.is("input[type=password]") ||
+                    $target.is("input[type=search]") ||
+                    $target.is("input[type=tel]") ||
+                    $target.is("input[type=text]") ||
+                    $target.is("input[type=time]") ||
+                    $target.is("input[type=url]") ||
                     $target.is("input:not([type])") || // input with no type attribute defaults to text
                     $target.is("textarea") ||
                     $target.is("select");

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -409,16 +409,7 @@ define(function (require, exports, module) {
             // Text fields should always be focusable.
             var $target = $(e.target),
                 isFormElement =
-                    $target.is("input[type=date]") ||
-                    $target.is("input[type=email]") ||
-                    $target.is("input[type=number]") ||
-                    $target.is("input[type=password]") ||
-                    $target.is("input[type=search]") ||
-                    $target.is("input[type=tel]") ||
-                    $target.is("input[type=text]") ||
-                    $target.is("input[type=time]") ||
-                    $target.is("input[type=url]") ||
-                    $target.is("input:not([type])") || // input with no type attribute defaults to text
+                    $target.is("input") || 
                     $target.is("textarea") ||
                     $target.is("select");
 


### PR DESCRIPTION
This pull-request contains the patch to fix the issue #9476. 

Making possible to the user give focus on input fields inside elements with `no-focus` class.
