### PR TITLE
New, more robust event-dispatching system

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -39,7 +39,8 @@ define(function CSSAgent(require, exports, module) {
 
     var _ = require("thirdparty/lodash");
 
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
+    var Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        EventDispatcher = require("utils/EventDispatcher");
 
     /**
      * Stylesheet details
@@ -147,7 +148,7 @@ define(function CSSAgent(require, exports, module) {
         _styleSheetDetails[styleSheetId] = res.header;
         _styleSheetDetails[styleSheetId].canonicalizedURL = url; // canonicalized URL
         
-        $(exports).triggerHandler("styleSheetAdded", [url, res.header]);
+        exports.trigger("styleSheetAdded", url, res.header);
     }
     
     /**
@@ -160,7 +161,7 @@ define(function CSSAgent(require, exports, module) {
         
         delete _styleSheetDetails[res.styleSheetId];
         
-        $(exports).triggerHandler("styleSheetRemoved", [header.canonicalizedURL, header]);
+        exports.trigger("styleSheetRemoved", header.canonicalizedURL, header);
     }
     
     /**
@@ -183,7 +184,7 @@ define(function CSSAgent(require, exports, module) {
             // If we have user agent string, and Chrome is >= 34, then don't use getAllStyleSheets
             if (uaMatch && parseInt(uaMatch[1], 10) >= 34) {
                 _getAllStyleSheetsNotFound = true;
-                $(Inspector.Page).off("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
+                Inspector.Page.off("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
                 return;
             }
         }
@@ -199,7 +200,7 @@ define(function CSSAgent(require, exports, module) {
         }).fail(function (err) {
             // Disable getAllStyleSheets if the first call fails
             _getAllStyleSheetsNotFound = (err.code === -32601);
-            $(Inspector.Page).off("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
+            Inspector.Page.off("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
         });
     }
 
@@ -210,21 +211,24 @@ define(function CSSAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        $(Inspector.Page).on("frameNavigated.CSSAgent", _onFrameNavigated);
-        $(Inspector.CSS).on("styleSheetAdded.CSSAgent", _styleSheetAdded);
-        $(Inspector.CSS).on("styleSheetRemoved.CSSAgent", _styleSheetRemoved);
+        Inspector.Page.on("frameNavigated.CSSAgent", _onFrameNavigated);
+        Inspector.CSS.on("styleSheetAdded.CSSAgent", _styleSheetAdded);
+        Inspector.CSS.on("styleSheetRemoved.CSSAgent", _styleSheetRemoved);
 
         // getAllStyleSheets was deleted beginning with Chrome 34
         if (!_getAllStyleSheetsNotFound) {
-            $(Inspector.Page).on("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
+            Inspector.Page.on("frameStoppedLoading.CSSAgent", _onFrameStoppedLoading);
         }
     }
 
     /** Clean up */
     function unload() {
-        $(Inspector.Page).off(".CSSAgent");
-        $(Inspector.CSS).off(".CSSAgent");
+        Inspector.Page.off(".CSSAgent");
+        Inspector.CSS.off(".CSSAgent");
     }
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Export public functions
     exports.enable = enable;

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * ConsoleAgent forwards all console message from the remote console to the

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -85,7 +85,7 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        $(Inspector.Console)
+        Inspector.Console
             .on("messageAdded.ConsoleAgent", _onMessageAdded)
             .on("messageRepeatCountUpdated.ConsoleAgent", _onMessageRepeatCountUpdated)
             .on("messagesCleared.ConsoleAgent", _onMessagesCleared);
@@ -93,7 +93,7 @@ define(function ConsoleAgent(require, exports, module) {
 
     /** Clean up */
     function unload() {
-        $(Inspector.Console).off(".ConsoleAgent");
+        Inspector.Console.off(".ConsoleAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -38,12 +38,11 @@
 define(function DOMAgent(require, exports, module) {
     "use strict";
 
-    var $exports = $(exports);
-
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
-    var EditAgent = require("LiveDevelopment/Agents/EditAgent");
-    var DOMNode = require("LiveDevelopment/Agents/DOMNode");
-    var DOMHelpers = require("LiveDevelopment/Agents/DOMHelpers");
+    var Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        EventDispatcher = require("utils/EventDispatcher"),
+        EditAgent       = require("LiveDevelopment/Agents/EditAgent"),
+        DOMNode         = require("LiveDevelopment/Agents/DOMNode"),
+        DOMHelpers      = require("LiveDevelopment/Agents/DOMHelpers");
 
     var _load; // {$.Deferred} load promise
     var _idToNode; // {nodeId -> node}
@@ -189,7 +188,7 @@ define(function DOMAgent(require, exports, module) {
     function _onLoadEventFired(event, res) {
         // res = {timestamp}
         Inspector.DOM.getDocument(function onGetDocument(res) {
-            $exports.triggerHandler("getDocument", res);
+            exports.trigger("getDocument", res);
             // res = {root}
             _idToNode = {};
             _pendingRequests = 0;
@@ -294,10 +293,10 @@ define(function DOMAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page)
+        Inspector.Page
             .on("frameNavigated.DOMAgent", _onFrameNavigated)
             .on("loadEventFired.DOMAgent", _onLoadEventFired);
-        $(Inspector.DOM)
+        Inspector.DOM
             .on("documentUpdated.DOMAgent", _onDocumentUpdated)
             .on("setChildNodes.DOMAgent", _onSetChildNodes)
             .on("childNodeCountUpdated.DOMAgent", _onChildNodeCountUpdated)
@@ -308,9 +307,12 @@ define(function DOMAgent(require, exports, module) {
 
     /** Clean up */
     function unload() {
-        $(Inspector.Page).off(".DOMAgent");
-        $(Inspector.DOM).off(".DOMAgent");
+        Inspector.Page.off(".DOMAgent");
+        Inspector.DOM.off(".DOMAgent");
     }
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Export private functions
     exports.nodeBeforeLocation = nodeBeforeLocation;

--- a/src/LiveDevelopment/Agents/EditAgent.js
+++ b/src/LiveDevelopment/Agents/EditAgent.js
@@ -105,7 +105,7 @@ define(function EditAgent(require, exports, module) {
 
         // detach from DOM change events
         if (res.value === "0") {
-            $(Inspector.DOM).off(".EditAgent");
+            Inspector.DOM.off(".EditAgent");
             return;
         }
 
@@ -118,17 +118,17 @@ define(function EditAgent(require, exports, module) {
         _editedNode = node;
 
         // attach to character data modified events
-        $(Inspector.DOM).on("characterDataModified.EditAgent", _onCharacterDataModified);
+        Inspector.DOM.on("characterDataModified.EditAgent", _onCharacterDataModified);
     }
 
     /** Initialize the agent */
     function load() {
-        $(RemoteAgent).on("edit.EditAgent", _onRemoteEdit);
+        RemoteAgent.on("edit.EditAgent", _onRemoteEdit);
     }
 
     /** Initialize the agent */
     function unload() {
-        $(RemoteAgent).off(".EditAgent");
+        RemoteAgent.off(".EditAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/EditAgent.js
+++ b/src/LiveDevelopment/Agents/EditAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * EditAgent propagates changes from the in-document editor to the source

--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -202,14 +202,14 @@ define(function GotoAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        $(RemoteAgent)
+        RemoteAgent
             .on("showgoto.GotoAgent", _onRemoteShowGoto)
             .on("goto.GotoAgent", _onRemoteGoto);
     }
 
     /** Initialize the agent */
     function unload() {
-        $(RemoteAgent).off(".GotoAgent");
+        RemoteAgent.off(".GotoAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -35,6 +35,7 @@ define(function HighlightAgent(require, exports, module) {
     "use strict";
 
     var DOMAgent        = require("LiveDevelopment/Agents/DOMAgent"),
+        EventDispatcher = require("utils/EventDispatcher"),
         Inspector       = require("LiveDevelopment/Inspector/Inspector"),
         LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
         RemoteAgent     = require("LiveDevelopment/Agents/RemoteAgent"),
@@ -48,7 +49,7 @@ define(function HighlightAgent(require, exports, module) {
         if (res.value === "1") {
             node = DOMAgent.nodeWithId(res.nodeId);
         }
-        $(exports).triggerHandler("highlight", [node]);
+        exports.trigger("highlight", node);
     }
 
     /** Hide in-browser highlighting */
@@ -137,16 +138,19 @@ define(function HighlightAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         if (LiveDevelopment.config.experimental) {
-            $(RemoteAgent).on("highlight.HighlightAgent", _onRemoteHighlight);
+            RemoteAgent.on("highlight.HighlightAgent", _onRemoteHighlight);
         }
     }
 
     /** Clean up */
     function unload() {
         if (LiveDevelopment.config.experimental) {
-            $(RemoteAgent).off(".HighlightAgent");
+            RemoteAgent.off(".HighlightAgent");
         }
     }
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Export public functions
     exports.hide = hide;

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * HighlightAgent dispatches events for highlight requests from in-browser

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -88,15 +88,15 @@ define(function NetworkAgent(require, exports, module) {
 
     /** Initialize the agent */
     function load() {
-        $(Inspector.Page).on("frameNavigated.NetworkAgent", _onFrameNavigated);
-        $(Inspector.Network).on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
+        Inspector.Page.on("frameNavigated.NetworkAgent", _onFrameNavigated);
+        Inspector.Network.on("requestWillBeSent.NetworkAgent", _onRequestWillBeSent);
     }
 
     /** Unload the agent */
     function unload() {
         _reset();
-        $(Inspector.Page).off(".NetworkAgent");
-        $(Inspector.Network).off(".NetworkAgent");
+        Inspector.Page.off(".NetworkAgent");
+        Inspector.Network.off(".NetworkAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * NetworkAgent tracks all resources loaded by the remote debugger. Use

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -35,9 +35,8 @@
 define(function RemoteAgent(require, exports, module) {
     "use strict";
 
-    var $exports = $(exports);
-
     var LiveDevelopment = require("LiveDevelopment/LiveDevelopment"),
+        EventDispatcher = require("utils/EventDispatcher"),
         Inspector       = require("LiveDevelopment/Inspector/Inspector"),
         RemoteFunctions = require("text!LiveDevelopment/Agents/RemoteFunctions.js");
 
@@ -50,7 +49,7 @@ define(function RemoteAgent(require, exports, module) {
         // res = {nodeId, name, value}
         var matches = /^data-ld-(.*)/.exec(res.name);
         if (matches) {
-            $exports.triggerHandler(matches[1], res);
+            exports.trigger(matches[1], res);
         }
     }
 
@@ -150,20 +149,23 @@ define(function RemoteAgent(require, exports, module) {
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
-        $(Inspector.Page).on("frameNavigated.RemoteAgent", _onFrameNavigated);
-        $(Inspector.Page).on("frameStartedLoading.RemoteAgent", _stopKeepAliveInterval);
-        $(Inspector.DOM).on("attributeModified.RemoteAgent", _onAttributeModified);
+        Inspector.Page.on("frameNavigated.RemoteAgent", _onFrameNavigated);
+        Inspector.Page.on("frameStartedLoading.RemoteAgent", _stopKeepAliveInterval);
+        Inspector.DOM.on("attributeModified.RemoteAgent", _onAttributeModified);
 
         return _load.promise();
     }
 
     /** Clean up */
     function unload() {
-        $(Inspector.Page).off(".RemoteAgent");
-        $(Inspector.DOM).off(".RemoteAgent");
+        Inspector.Page.off(".RemoteAgent");
+        Inspector.DOM.off(".RemoteAgent");
         _stopKeepAliveInterval();
     }
-
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // Export public functions
     exports.call = call;
     exports.load = load;

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -139,13 +139,13 @@ define(function ScriptAgent(require, exports, module) {
             });
         });
 
-        $(Inspector.Page).on("frameNavigated.ScriptAgent", _onFrameNavigated);
-        $(DOMAgent).on("getDocument.ScriptAgent", _onGetDocument);
-        $(Inspector.Debugger)
+        Inspector.Page.on("frameNavigated.ScriptAgent", _onFrameNavigated);
+        DOMAgent.on("getDocument.ScriptAgent", _onGetDocument);
+        Inspector.Debugger
             .on("scriptParsed.ScriptAgent", _onScriptParsed)
             .on("scriptFailedToParse.ScriptAgent", _onScriptFailedToParse)
             .on("paused.ScriptAgent", _onPaused);
-        $(Inspector.DOM).on("childNodeInserted.ScriptAgent", _onChildNodeInserted);
+        Inspector.DOM.on("childNodeInserted.ScriptAgent", _onChildNodeInserted);
 
         return $.when(_load.promise(), enableResult.promise());
     }
@@ -153,10 +153,10 @@ define(function ScriptAgent(require, exports, module) {
     /** Clean up */
     function unload() {
         _reset();
-        $(Inspector.Page).off(".ScriptAgent");
-        $(DOMAgent).off(".ScriptAgent");
-        $(Inspector.Debugger).off(".ScriptAgent");
-        $(Inspector.DOM).off(".ScriptAgent");
+        Inspector.Page.off(".ScriptAgent");
+        DOMAgent.off(".ScriptAgent");
+        Inspector.Debugger.off(".ScriptAgent");
+        Inspector.DOM.off(".ScriptAgent");
     }
 
     // Export public functions

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -50,6 +50,7 @@ define(function CSSDocumentModule(require, exports, module) {
     "use strict";
 
     var _               = require("thirdparty/lodash"),
+        EventDispatcher = require("utils/EventDispatcher"),
         CSSAgent        = require("LiveDevelopment/Agents/CSSAgent"),
         CSSUtils        = require("language/CSSUtils"),
         EditorManager   = require("editor/EditorManager"),
@@ -73,17 +74,18 @@ define(function CSSDocumentModule(require, exports, module) {
         this.onChange = this.onChange.bind(this);
         this.onDeleted = this.onDeleted.bind(this);
 
-        $(this.doc).on("change.CSSDocument", this.onChange);
-        $(this.doc).on("deleted.CSSDocument", this.onDeleted);
+        this.doc.on("change.CSSDocument", this.onChange);
+        this.doc.on("deleted.CSSDocument", this.onDeleted);
         
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
-        $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
+        EditorManager.on("activeEditorChange", this.onActiveEditorChange);
         
         if (editor) {
             // Attach now
             this.attachToEditor(editor);
         }
     };
+    EventDispatcher.makeEventDispatcher(CSSDocument.prototype);
 
     /**
      * @private
@@ -125,8 +127,8 @@ define(function CSSDocumentModule(require, exports, module) {
  
     /** Close the document */
     CSSDocument.prototype.close = function close() {
-        $(this.doc).off(".CSSDocument");
-        $(EditorManager).off("activeEditorChange", this.onActiveEditorChange);
+        this.doc.off(".CSSDocument");
+        EditorManager.off("activeEditorChange", this.onActiveEditorChange);
         this.doc.releaseRef();
         this.detachFromEditor();
     };
@@ -147,8 +149,8 @@ define(function CSSDocumentModule(require, exports, module) {
         this.editor = editor;
         
         if (this.editor) {
-            $(HighlightAgent).on("highlight", this.onHighlight);
-            $(this.editor).on("cursorActivity.CSSDocument", this.onCursorActivity);
+            HighlightAgent.on("highlight", this.onHighlight);
+            this.editor.on("cursorActivity.CSSDocument", this.onCursorActivity);
             this.updateHighlight();
         }
     };
@@ -156,8 +158,8 @@ define(function CSSDocumentModule(require, exports, module) {
     CSSDocument.prototype.detachFromEditor = function () {
         if (this.editor) {
             HighlightAgent.hide();
-            $(HighlightAgent).off("highlight", this.onHighlight);
-            $(this.editor).off(".CSSDocument");
+            HighlightAgent.off("highlight", this.onHighlight);
+            this.editor.off(".CSSDocument");
             this.onHighlight();
             this.editor = null;
         }
@@ -228,7 +230,7 @@ define(function CSSDocumentModule(require, exports, module) {
 
         // shut down, since our Document is now dead
         this.close();
-        $(this).triggerHandler("deleted", [this]);
+        this.trigger("deleted", this);
     };
 
     /** Triggered when the active editor changes */

--- a/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
+++ b/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 /**
  * CSSPreprocessorDocument manages a single LESS or SASS source document

--- a/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
+++ b/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
@@ -58,14 +58,14 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
         // Add a ref to the doc since we're listening for change events
         this.doc.addRef();
         this.onActiveEditorChange = this.onActiveEditorChange.bind(this);
-        $(EditorManager).on("activeEditorChange", this.onActiveEditorChange);
+        EditorManager.on("activeEditorChange", this.onActiveEditorChange);
         this.onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
     };
 
     /** Close the document */
     CSSPreprocessorDocument.prototype.close = function close() {
-        $(this.doc).off(".CSSPreprocessorDocument");
-        $(EditorManager).off("activeEditorChange", this.onActiveEditorChange);
+        this.doc.off(".CSSPreprocessorDocument");
+        EditorManager.off("activeEditorChange", this.onActiveEditorChange);
         this.doc.releaseRef();
         this.detachFromEditor();
     };
@@ -81,7 +81,7 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
         this.editor = editor;
         
         if (this.editor) {
-            $(this.editor).on("cursorActivity.CSSPreprocessorDocument", this.onCursorActivity);
+            this.editor.on("cursorActivity.CSSPreprocessorDocument", this.onCursorActivity);
             this.updateHighlight();
         }
     };
@@ -89,7 +89,7 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
     CSSPreprocessorDocument.prototype.detachFromEditor = function () {
         if (this.editor) {
             HighlightAgent.hide();
-            $(this.editor).off(".CSSPreprocessorDocument");
+            this.editor.off(".CSSPreprocessorDocument");
             this.editor = null;
         }
     };

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * HTMLDocument manages a single HTML source document

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -45,6 +45,7 @@ define(function HTMLDocumentModule(require, exports, module) {
     "use strict";
 
     var EditorManager       = require("editor/EditorManager"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         HighlightAgent      = require("LiveDevelopment/Agents/HighlightAgent"),
         HTMLInstrumentation = require("language/HTMLInstrumentation"),
         Inspector           = require("LiveDevelopment/Inspector/Inspector"),
@@ -68,11 +69,12 @@ define(function HTMLDocumentModule(require, exports, module) {
         this._instrumentationEnabled = false;
         
         this._onActiveEditorChange = this._onActiveEditorChange.bind(this);
-        $(EditorManager).on("activeEditorChange", this._onActiveEditorChange);
+        EditorManager.on("activeEditorChange", this._onActiveEditorChange);
         
         // Attach now
         this.attachToEditor(editor);
     };
+    EventDispatcher.makeEventDispatcher(HTMLDocument.prototype);
     
     /**
      * Enable or disable instrumented HTML
@@ -116,14 +118,14 @@ define(function HTMLDocumentModule(require, exports, module) {
      */
     HTMLDocument.prototype.close = function close() {
         if (this.editor) {
-            $(this.editor).off(".HTMLDocument");
+            this.editor.off(".HTMLDocument");
         }
 
         if (this.doc) {
             this.doc.releaseRef();
         }
 
-        $(EditorManager).off("activeEditorChange", this._onActiveEditorChange);
+        EditorManager.off("activeEditorChange", this._onActiveEditorChange);
 
         // Experimental code
         if (LiveDevelopment.config.experimental) {
@@ -142,21 +144,21 @@ define(function HTMLDocumentModule(require, exports, module) {
         
         // Performance optimization to use closures instead of Function.bind()
         // to improve responsiveness during cursor movement and keyboard events
-        $(this.editor).on("cursorActivity.HTMLDocument", function (event, editor) {
+        this.editor.on("cursorActivity.HTMLDocument", function (event, editor) {
             self._onCursorActivity(event, editor);
         });
 
-        $(this.editor).on("change.HTMLDocument", function (event, editor, change) {
+        this.editor.on("change.HTMLDocument", function (event, editor, change) {
             self._onChange(event, editor, change);
         });
 
-        $(this.editor).on("beforeDestroy.HTMLDocument", function (event, editor) {
+        this.editor.on("beforeDestroy.HTMLDocument", function (event, editor) {
             self._onDestroy(event, editor);
         });
         
         // Experimental code
         if (LiveDevelopment.config.experimental) {
-            $(HighlightAgent).on("highlight.HTMLDocument", function (event, node) {
+            HighlightAgent.on("highlight.HTMLDocument", function (event, node) {
                 self._onHighlight(event, node);
             });
         }
@@ -173,7 +175,7 @@ define(function HTMLDocumentModule(require, exports, module) {
     HTMLDocument.prototype.detachFromEditor = function () {
         if (this.editor) {
             HighlightAgent.hide();
-            $(this.editor).off(".HTMLDocument");
+            this.editor.off(".HTMLDocument");
             this._removeHighlight();
             this.editor = null;
         }
@@ -317,7 +319,7 @@ define(function HTMLDocumentModule(require, exports, module) {
         }
 
         this.errors = result.errors || [];
-        $(this).triggerHandler("statusChanged", [this]);
+        this.trigger("statusChanged", this);
         
         // Debug-only: compare in-memory vs. in-browser DOM
         // edit this file or set a conditional breakpoint at the top of this function:

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -63,9 +63,9 @@ define(function JSDocumentModule(require, exports, module) {
         this.onHighlight = this.onHighlight.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onCursorActivity = this.onCursorActivity.bind(this);
-        $(HighlightAgent).on("highlight", this.onHighlight);
-        $(this.editor).on("change", this.onChange);
-        $(this.editor).on("cursorActivity", this.onCursorActivity);
+        HighlightAgent.on("highlight", this.onHighlight);
+        this.editor.on("change", this.onChange);
+        this.editor.on("cursorActivity", this.onCursorActivity);
         this.onCursorActivity();
     };
 
@@ -74,9 +74,9 @@ define(function JSDocumentModule(require, exports, module) {
         if (!this.editor) {
             return;
         }
-        $(HighlightAgent).off("highlight", this.onHighlight);
-        $(this.editor).off("change", this.onChange);
-        $(this.editor).off("cursorActivity", this.onCursorActivity);
+        HighlightAgent.off("highlight", this.onHighlight);
+        this.editor.off("change", this.onChange);
+        this.editor.off("cursorActivity", this.onCursorActivity);
         this.onHighlight();
     };
 

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*global define */
 
 /**
  * JSDocument manages a single JavaScript source document

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -83,10 +83,8 @@
 define(function Inspector(require, exports, module) {
     "use strict";
 
-    var Async = require("utils/Async");
-
-    // jQuery exports object for events
-    var $exports = $(exports);
+    var Async           = require("utils/Async"),
+        EventDispatcher = require("utils/EventDispatcher");
 
     /**
      * Map message IDs to the callback function and original JSON message
@@ -183,7 +181,7 @@ define(function Inspector(require, exports, module) {
     /** WebSocket did close */
     function _onDisconnect() {
         _socket = undefined;
-        $exports.triggerHandler("disconnect");
+        exports.trigger("disconnect");
     }
 
     /** WebSocket reported an error */
@@ -192,7 +190,7 @@ define(function Inspector(require, exports, module) {
             _connectDeferred.reject();
             _connectDeferred = null;
         }
-        $exports.triggerHandler("error", [error]);
+        exports.trigger("error", error);
     }
 
     /** WebSocket did open */
@@ -201,7 +199,7 @@ define(function Inspector(require, exports, module) {
             _connectDeferred.resolve();
             _connectDeferred = null;
         }
-        $exports.triggerHandler("connect");
+        exports.trigger("connect");
     }
 
     /** Received message from the WebSocket
@@ -227,14 +225,14 @@ define(function Inspector(require, exports, module) {
                 domain = domainAndMethod[0],
                 method = domainAndMethod[1];
 
-            $(exports[domain]).triggerHandler(method, response.params);
+            EventDispatcher.triggerWithArray(exports[domain], method, response.params);
         }
 
         // Always fire event handlers for all messages/errors
-        $exports.triggerHandler("message", [response]);
+        exports.trigger("message", response);
 
         if (response.error) {
-            $exports.triggerHandler("error", [response.error, msgText]);
+            exports.trigger("error", response.error, msgText);
         }
     }
 
@@ -266,22 +264,6 @@ define(function Inspector(require, exports, module) {
         request.send(null);
 
         return def.promise();
-    }
-
-    /** Register a handler to be called when the given event is triggered
-     * @param {string} event name
-     * @param {function} handler function
-     */
-    function on(name, handler) {
-        $exports.on(name, handler);
-    }
-
-    /** Remove the given or all event handler(s) for the given event or remove all event handlers
-     * @param {string} optional event name
-     * @param {function} optional handler function
-     */
-    function off(name, handler) {
-        $exports.off(name, handler);
     }
 
     /**
@@ -398,14 +380,19 @@ define(function Inspector(require, exports, module) {
         var i, j, domain, command;
         for (i in InspectorJSON.domains) {
             domain = InspectorJSON.domains[i];
-            exports[domain.domain] = {};
+            var exportedDomain = {};
+            exports[domain.domain] = exportedDomain;
+            EventDispatcher.makeEventDispatcher(exportedDomain);
             for (j in domain.commands) {
                 command = domain.commands[j];
-                exports[domain.domain][command.name] = _send.bind(undefined, domain.domain + "." + command.name, command.parameters);
+                exportedDomain[command.name] = _send.bind(undefined, domain.domain + "." + command.name, command.parameters);
             }
         }
     }
-
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // Export public functions
     exports.connect              = connect;
     exports.connected            = connected;
@@ -414,8 +401,6 @@ define(function Inspector(require, exports, module) {
     exports.getDebuggableWindows = getDebuggableWindows;
     exports.getUserAgent         = getUserAgent;
     exports.init                 = init;
-    exports.off                  = off;
-    exports.on                   = on;
     exports.send                 = send;
     exports.setUserAgent         = setUserAgent;
 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -81,6 +81,7 @@ define(function LiveDevelopment(require, exports, module) {
         DefaultDialogs       = require("widgets/DefaultDialogs"),
         DocumentManager      = require("document/DocumentManager"),
         EditorManager        = require("editor/EditorManager"),
+        EventDispatcher      = require("utils/EventDispatcher"),
         FileServer           = require("LiveDevelopment/Servers/FileServer").FileServer,
         FileSystemError      = require("filesystem/FileSystemError"),
         FileUtils            = require("file/FileUtils"),
@@ -286,10 +287,10 @@ define(function LiveDevelopment(require, exports, module) {
         liveDocument.close();
         
         if (liveDocument.editor) {
-            $(liveDocument.editor).off(".livedev");
+            liveDocument.editor.off(".livedev");
         }
         
-        $(liveDocument).off(".livedev");
+        liveDocument.off(".livedev");
     }
     
     /**
@@ -324,7 +325,7 @@ define(function LiveDevelopment(require, exports, module) {
         exports.status = status;
         
         var reason = status === STATUS_INACTIVE ? closeReason : null;
-        $(exports).triggerHandler("statusChange", [status, reason]);
+        exports.trigger("statusChange", status, reason);
     }
     
     /**
@@ -402,7 +403,7 @@ define(function LiveDevelopment(require, exports, module) {
             return null;
         }
 
-        $(liveDocument).on("statusChanged.livedev", function () {
+        liveDocument.on("statusChanged.livedev", function () {
             _handleLiveDocumentStatusChanged(liveDocument);
         });
 
@@ -506,7 +507,7 @@ define(function LiveDevelopment(require, exports, module) {
                     _server.add(liveDoc);
                     _relatedDocuments[doc.url] = liveDoc;
 
-                    $(liveDoc).on("deleted.livedev", function (event, liveDoc) {
+                    liveDoc.on("deleted.livedev", function (event, liveDoc) {
                         _closeRelatedDocument(liveDoc);
                     });
                 }
@@ -803,10 +804,10 @@ define(function LiveDevelopment(require, exports, module) {
             deferred    = new $.Deferred(),
             connected   = Inspector.connected();
 
-        $(EditorManager).off("activeEditorChange", onActiveEditorChange);
+        EditorManager.off("activeEditorChange", onActiveEditorChange);
         
-        $(Inspector.Page).off(".livedev");
-        $(Inspector).off(".livedev");
+        Inspector.Page.off(".livedev");
+        Inspector.off(".livedev");
 
         // Wait if agents are loading
         if (_loadAgentsPromise) {
@@ -1087,10 +1088,10 @@ define(function LiveDevelopment(require, exports, module) {
     /** Triggered by Inspector.connect */
     function _onConnect(event) {
         // When the browser navigates away from the primary live document
-        $(Inspector.Page).on("frameNavigated.livedev", _onFrameNavigated);
+        Inspector.Page.on("frameNavigated.livedev", _onFrameNavigated);
 
         // When the Inspector WebSocket disconnects unexpectedely
-        $(Inspector).on("disconnect.livedev", _onDisconnect);
+        Inspector.on("disconnect.livedev", _onDisconnect);
 		
         _waitForInterstitialPageLoad()
             .fail(function () {
@@ -1237,7 +1238,7 @@ define(function LiveDevelopment(require, exports, module) {
         _server.start();
 
         // Install a one-time event handler when connected to the launcher page
-        $(Inspector).one("connect", _onConnect);
+        Inspector.one("connect", _onConnect);
         
         // open browser to the interstitial page to prepare for loading agents
         _openInterstitialPage();
@@ -1247,7 +1248,7 @@ define(function LiveDevelopment(require, exports, module) {
             // Setup activeEditorChange event listener so that we can track cursor positions in
             // CSS preprocessor files and perform live preview highlighting on all elements with
             // the current selector in the preprocessor file.
-            $(EditorManager).on("activeEditorChange", onActiveEditorChange);
+            EditorManager.on("activeEditorChange", onActiveEditorChange);
 
             // Explicitly trigger onActiveEditorChange so that live preview highlighting
             // can be set up for the preprocessor files.
@@ -1470,19 +1471,19 @@ define(function LiveDevelopment(require, exports, module) {
     function init(theConfig) {
         exports.config = theConfig;
         
-        $(Inspector).on("error", _onError);
-        $(Inspector.Inspector).on("detached", _onDetached);
+        Inspector.on("error", _onError);
+        Inspector.Inspector.on("detached", _onDetached);
 
         // Only listen for styleSheetAdded
         // We may get interim added/removed events when pushing incremental updates
-        $(CSSAgent).on("styleSheetAdded.livedev", _styleSheetAdded);
+        CSSAgent.on("styleSheetAdded.livedev", _styleSheetAdded);
         
-        $(MainViewManager)
+        MainViewManager
             .on("currentFileChange", _onFileChanged);
-        $(DocumentManager)
+        DocumentManager
             .on("documentSaved", _onDocumentSaved)
             .on("dirtyFlagChange", _onDirtyFlagChange);
-        $(ProjectManager)
+        ProjectManager
             .on("beforeProjectClose beforeAppClose", close);
         
         // Register user defined server provider
@@ -1501,8 +1502,9 @@ define(function LiveDevelopment(require, exports, module) {
         return _server && _server.getBaseUrl();
     }
 
-
-
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // For unit testing
     exports.launcherUrl               = launcherUrl;
     exports._getServer                = _getServer;

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -177,7 +177,7 @@ define(function main(require, exports, module) {
         _$btnGoLive.click(function onGoLive() {
             _handleGoLiveCommand();
         });
-        $(LiveDevelopment).on("statusChange", function statusChange(event, status, reason) {
+        LiveDevelopment.on("statusChange", function statusChange(event, status, reason) {
             // status starts at -1 (error), so add one when looking up name and style
             // See the comments at the top of LiveDevelopment.js for details on the
             // various status codes.
@@ -194,7 +194,7 @@ define(function main(require, exports, module) {
     
     /** Maintains state of the Live Preview menu item */
     function _setupGoLiveMenu() {
-        $(LiveDevelopment).on("statusChange", function statusChange(event, status) {
+        LiveDevelopment.on("statusChange", function statusChange(event, status) {
             // Update the checkmark next to 'Live Preview' menu item
             // Add checkmark when status is STATUS_ACTIVE; otherwise remove it
             CommandManager.get(Commands.FILE_LIVE_FILE_PREVIEW).setChecked(status === LiveDevelopment.STATUS_ACTIVE);

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -36,6 +36,9 @@
 define(function (require, exports, module) {
     "use strict";
     
+    var EventDispatcher = require("utils/EventDispatcher");
+    
+    
     /**
      * Map of all registered global commands
      * @type {Object.<commandID: string, Command>}
@@ -71,6 +74,7 @@ define(function (require, exports, module) {
         this._checked = undefined;
         this._enabled = true;
     }
+    EventDispatcher.makeEventDispatcher(Command.prototype);
 
     /**
      * Get command id
@@ -118,7 +122,7 @@ define(function (require, exports, module) {
         this._enabled = enabled;
 
         if (changed) {
-            $(this).triggerHandler("enabledStateChange");
+            this.trigger("enabledStateChange");
         }
     };
 
@@ -132,7 +136,7 @@ define(function (require, exports, module) {
         this._checked = checked;
 
         if (changed) {
-            $(this).triggerHandler("checkedStateChange");
+            this.trigger("checkedStateChange");
         }
     };
 
@@ -159,7 +163,7 @@ define(function (require, exports, module) {
         this._name = name;
 
         if (changed) {
-            $(this).triggerHandler("nameChange");
+            this.trigger("nameChange");
         }
     };
 
@@ -199,7 +203,7 @@ define(function (require, exports, module) {
         var command = new Command(name, id, commandFn);
         _commands[id] = command;
         
-        $(exports).triggerHandler("commandRegistered", [command]);
+        exports.trigger("commandRegistered", command);
         
         return command;
     }
@@ -229,7 +233,7 @@ define(function (require, exports, module) {
         var command = new Command(null, id, commandFn);
         _commands[id] = command;
         
-        $(exports).triggerHandler("commandRegistered", [command]);
+        exports.trigger("commandRegistered", command);
         
         return command;
     }
@@ -279,7 +283,7 @@ define(function (require, exports, module) {
         
         if (command) {
             try {
-                $(exports).triggerHandler("beforeExecuteCommand", id);
+                exports.trigger("beforeExecuteCommand", id);
             } catch (err) {
                 console.error(err);
             }
@@ -289,6 +293,8 @@ define(function (require, exports, module) {
             return (new $.Deferred()).reject().promise();
         }
     }
+    
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Define public API
     exports.register            = register;

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -38,6 +38,7 @@ define(function (require, exports, module) {
         Commands            = require("command/Commands"),
         CommandManager      = require("command/CommandManager"),
         DefaultDialogs      = require("widgets/DefaultDialogs"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         FileSystem          = require("filesystem/FileSystem"),
         FileSystemError     = require("filesystem/FileSystemError"),
         FileUtils           = require("file/FileUtils"),
@@ -1183,15 +1184,8 @@ define(function (require, exports, module) {
         });
     }
     
-    AppInit.htmlReady(function () {
-        // Due to circular dependencies, not safe to attach event handlers until all modules loaded
-        CommandManager.on("commandRegistered", _handleCommandRegistered);
-        
-        // Some commands may have been registered already though, so process those now:
-        CommandManager.getAll().forEach(function (commandId) {
-            _handleCommandRegistered(null, CommandManager.get(commandId));
-        });
-    });
+    // Due to circular dependencies, not safe to call on() directly
+    EventDispatcher.on_duringInit(CommandManager, "commandRegistered", _handleCommandRegistered);
     CommandManager.register(Strings.CMD_OPEN_KEYMAP, Commands.FILE_OPEN_KEYMAP, _openUserKeyMap);
 
     // Asynchronously loading DocumentManager to avoid the circular dependency

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
 
     // Load dependent modules
     var Commands            = require("command/Commands"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         KeyBindingManager   = require("command/KeyBindingManager"),
         StringUtils         = require("utils/StringUtils"),
         CommandManager      = require("command/CommandManager"),
@@ -309,7 +310,7 @@ define(function (require, exports, module) {
             this._keyBindingRemoved = this._keyBindingRemoved.bind(this);
 
             this._command = command;
-            $(this._command)
+            this._command
                 .on("enabledStateChange", this._enabledChanged)
                 .on("checkedStateChange", this._checkedChanged)
                 .on("nameChange", this._nameChanged)
@@ -990,6 +991,7 @@ define(function (require, exports, module) {
      *
      * Events:
      * - beforeContextMenuOpen
+     * - beforeContextMenuClose
      *
      * @constructor
      * @extends {Menu}
@@ -1020,6 +1022,7 @@ define(function (require, exports, module) {
     ContextMenu.prototype = Object.create(Menu.prototype);
     ContextMenu.prototype.constructor = ContextMenu;
     ContextMenu.prototype.parentClass = Menu.prototype;
+    EventDispatcher.makeEventDispatcher(ContextMenu.prototype);
 
 
     /**
@@ -1051,7 +1054,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        $(this).triggerHandler("beforeContextMenuOpen");
+        this.trigger("beforeContextMenuOpen");
 
         // close all other dropdowns
         closeAll();
@@ -1086,7 +1089,7 @@ define(function (require, exports, module) {
      * Closes the context menu.
      */
     ContextMenu.prototype.close = function () {
-        $(this).triggerHandler("beforeContextMenuClose");
+        this.trigger("beforeContextMenuClose");
         $("#" + StringUtils.jQueryIdEscape(this.id)).removeClass("open");
     };
 

--- a/src/document/ChangedDocumentTracker.js
+++ b/src/document/ChangedDocumentTracker.js
@@ -52,14 +52,14 @@ define(function (require, exports, module) {
         this._onChange = this._onChange.bind(this);
         this._onWindowFocus = this._onWindowFocus.bind(this);
 
-        $(DocumentManager).on("afterDocumentCreate", function (event, doc) {
+        DocumentManager.on("afterDocumentCreate", function (event, doc) {
             // Only track documents in the current project
             if (ProjectManager.isWithinProject(doc.file.fullPath)) {
                 self._addListener(doc);
             }
         });
 
-        $(DocumentManager).on("beforeDocumentDelete", function (event, doc) {
+        DocumentManager.on("beforeDocumentDelete", function (event, doc) {
             // In case a document somehow remains loaded after its project
             // has been closed, unconditionally attempt to remove the listener.
             self._removeListener(doc);
@@ -73,14 +73,14 @@ define(function (require, exports, module) {
      * Assumes all files are changed when the window loses and regains focus.
      */
     ChangedDocumentTracker.prototype._addListener = function (doc) {
-        $(doc).on("change", this._onChange);
+        doc.on("change", this._onChange);
     };
 
     /**
      * @private
      */
     ChangedDocumentTracker.prototype._removeListener = function (doc) {
-        $(doc).off("change", this._onChange);
+        doc.off("change", this._onChange);
     };
 
     /**

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var EditorManager       = require("editor/EditorManager"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         FileUtils           = require("file/FileUtils"),
         InMemoryFile        = require("document/InMemoryFile"),
         PerfUtils           = require("utils/PerfUtils"),
@@ -75,9 +76,7 @@ define(function (require, exports, module) {
      * @param {!string} rawText  Text content of the file.
      */
     function Document(file, initialTimestamp, rawText) {
-        if (!(this instanceof Document)) {  // error if constructor called without 'new'
-            throw new Error("Document constructor must be called with 'new'");
-        }
+        EventDispatcher.makeEventDispatcher(this);
         
         this.file = file;
         this._updateLanguage();
@@ -166,7 +165,7 @@ define(function (require, exports, module) {
         
         if (this._refCount === 0) {
             //console.log("+++ adding to open list");
-            if ($(exports).triggerHandler("_afterDocumentCreate", this)) {
+            if (exports.trigger("_afterDocumentCreate", this)) {
                 return;
             }
         }
@@ -183,7 +182,7 @@ define(function (require, exports, module) {
         }
         if (this._refCount === 0) {
             //console.log("--- removing from open list");
-            if ($(exports).triggerHandler("_beforeDocumentDelete", this)) {
+            if (exports.trigger("_beforeDocumentDelete", this)) {
                 return;
             }
         }
@@ -285,8 +284,8 @@ define(function (require, exports, module) {
      * @param {Object} changeList Changelist in CodeMirror format
      */
     Document.prototype._notifyDocumentChange = function (changeList) {
-        $(this).triggerHandler("change", [this, changeList]);
-        $(exports).triggerHandler("documentChange", [this, changeList]);
+        this.trigger("change", this, changeList);
+        exports.trigger("documentChange", this, changeList);
     };
     
     /**
@@ -335,7 +334,7 @@ define(function (require, exports, module) {
             this._lineEndings = FileUtils.getPlatformLineEndings();
         }
         
-        $(exports).triggerHandler("_documentRefreshed", this);
+        exports.trigger("_documentRefreshed", this);
 
         PerfUtils.addMeasurement(perfTimerName);
     };
@@ -420,7 +419,7 @@ define(function (require, exports, module) {
             
             // Notify if isDirty just changed (this also auto-adds us to working set if needed)
             if (wasDirty !== this.isDirty) {
-                $(exports).triggerHandler("_dirtyFlagChange", [this]);
+                exports.trigger("_dirtyFlagChange", this);
             }
         }
         
@@ -436,7 +435,7 @@ define(function (require, exports, module) {
         if (this._masterEditor) {
             this._masterEditor._codeMirror.markClean();
         }
-        $(exports).triggerHandler("_dirtyFlagChange", this);
+        exports.trigger("_dirtyFlagChange", this);
     };
     
     /**
@@ -467,7 +466,7 @@ define(function (require, exports, module) {
             } else {
                 console.log("Error updating timestamp after saving file: " + thisDoc.file.fullPath);
             }
-            $(exports).triggerHandler("_documentSaved", thisDoc);
+            exports.trigger("_documentSaved", thisDoc);
         });
     };
     
@@ -681,7 +680,7 @@ define(function (require, exports, module) {
         var oldLanguage = this.language;
         this.language = LanguageManager.getLanguageForPath(this.file.fullPath);
         if (oldLanguage && oldLanguage !== this.language) {
-            $(this).triggerHandler("languageChanged", [oldLanguage, this.language]);
+            this.trigger("languageChanged", oldLanguage, this.language);
         }
     };
     
@@ -699,6 +698,10 @@ define(function (require, exports, module) {
     Document.prototype.isUntitled = function () {
         return this.file instanceof InMemoryFile;
     };
+    
+    // We dispatch events from the module level, and the instance level. Instance events are wired up
+    // in the Document constructor.
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Define public API
     exports.Document = Document;

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -200,7 +200,7 @@ define(function (require, exports, module) {
         } else {
             this._text = null;
             this._masterEditor = masterEditor;
-            $(masterEditor).on("change", this._handleEditorChange.bind(this));
+            masterEditor.on("change", this._handleEditorChange.bind(this));
         }
     };
     

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -76,12 +76,12 @@ define(function (require, exports, module) {
      * @param {!string} rawText  Text content of the file.
      */
     function Document(file, initialTimestamp, rawText) {
-        EventDispatcher.makeEventDispatcher(this);
-        
         this.file = file;
         this._updateLanguage();
         this.refreshText(rawText, initialTimestamp, true);
     }
+    
+    EventDispatcher.makeEventDispatcher(Document.prototype);
     
     /**
      * Number of clients who want this Document to stay alive. The Document is listed in

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1333,7 +1333,7 @@ define(function (require, exports, module) {
                 // Give everyone a chance to save their state - but don't let any problems block
                 // us from quitting
                 try {
-                    $(ProjectManager).triggerHandler("beforeAppClose");
+                    ProjectManager.trigger("beforeAppClose");
                 } catch (ex) {
                     console.error(ex);
                 }
@@ -1363,7 +1363,7 @@ define(function (require, exports, module) {
      * Implementation for native APP_BEFORE_MENUPOPUP callback to trigger beforeMenuPopup event
      */
     function handleBeforeMenuPopup() {
-        $(PopUpManager).triggerHandler("beforeMenuPopup");
+        PopUpManager.trigger("beforeMenuPopup");
     }
 
     /** 
@@ -1561,7 +1561,7 @@ define(function (require, exports, module) {
             // Give everyone a chance to save their state - but don't let any problems block
             // us from quitting
             try {
-                $(ProjectManager).triggerHandler("beforeAppClose");
+                ProjectManager.trigger("beforeAppClose");
             } catch (ex) {
                 console.error(ex);
             }
@@ -1703,10 +1703,10 @@ define(function (require, exports, module) {
     CommandManager.registerInternal(Commands.APP_RELOAD_WITHOUT_EXTS,   handleReloadWithoutExts);
 
     // Listen for changes that require updating the editor titlebar
-    $(DocumentManager).on("dirtyFlagChange", handleDirtyChange);
-    $(DocumentManager).on("fileNameChange", handleCurrentFileChange);
-    $(MainViewManager).on("currentFileChange", handleCurrentFileChange);
+    DocumentManager.on("dirtyFlagChange", handleDirtyChange);
+    DocumentManager.on("fileNameChange", handleCurrentFileChange);
+    MainViewManager.on("currentFileChange", handleCurrentFileChange);
 
     // Reset the untitled document counter before changing projects
-    $(ProjectManager).on("beforeProjectClose", function () { _nextUntitledIndexToUse = 1; });
+    ProjectManager.on("beforeProjectClose", function () { _nextUntitledIndexToUse = 1; });
 });

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -677,7 +677,7 @@ define(function (require, exports, module) {
         PreferencesManager.fileChanged(doc.file.fullPath);
     });
     
-    $(MainViewManager).on("currentFileChange", function (e, newFile, newPaneId, oldFile) {
+    MainViewManager.on("currentFileChange", function (e, newFile, newPaneId, oldFile) {
         var newDoc = null,
             oldDoc = null;
 
@@ -737,6 +737,6 @@ define(function (require, exports, module) {
     PerfUtils.createPerfMeasurement("DOCUMENT_MANAGER_GET_DOCUMENT_FOR_PATH", "DocumentManager.getDocumentForPath()");
 
     // Handle Language change events
-    $(LanguageManager).on("languageAdded", _handleLanguageAdded);
-    $(LanguageManager).on("languageModified", _handleLanguageModified);
+    LanguageManager.on("languageAdded", _handleLanguageAdded);
+    LanguageManager.on("languageModified", _handleLanguageModified);
 });

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -23,12 +23,15 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 /**
  */
 define(function (require, exports, module) {
     "use strict";
+    
+    var EventDispatcher = require("utils/EventDispatcher");
+    
     
     /**
      * Stores a range of lines that is automatically maintained as the Document changes. The range
@@ -65,16 +68,18 @@ define(function (require, exports, module) {
         // store this-bound versions of listeners so we can remove them later
         this._handleDocumentChange = this._handleDocumentChange.bind(this);
         this._handleDocumentDeleted = this._handleDocumentDeleted.bind(this);
-        $(document).on("change", this._handleDocumentChange);
-        $(document).on("deleted", this._handleDocumentDeleted);
+        document.on("change", this._handleDocumentChange);
+        document.on("deleted", this._handleDocumentDeleted);
     }
+    EventDispatcher.makeEventDispatcher(TextRange.prototype);
+    
     
     /** Detaches from the Document. The TextRange will no longer update or send change events */
     TextRange.prototype.dispose = function (editor, change) {
         // Disconnect from Document
         this.document.releaseRef();
-        $(this.document).off("change", this._handleDocumentChange);
-        $(this.document).off("deleted", this._handleDocumentDeleted);
+        this.document.off("change", this._handleDocumentChange);
+        this.document.off("deleted", this._handleDocumentDeleted);
     };
     
     
@@ -181,16 +186,16 @@ define(function (require, exports, module) {
             
             // If we lost sync with the range, just bail now
             if (this.startLine === null || this.endLine === null) {
-                $(this).triggerHandler("lostSync");
+                this.trigger("lostSync");
                 break;
             }
         }
         
         if (hasChanged) {
-            $(this).triggerHandler("change");
+            this.trigger("change");
         }
         if (hasContentChanged) {
-            $(this).triggerHandler("contentChange");
+            this.trigger("contentChange");
         }
     };
     
@@ -199,7 +204,7 @@ define(function (require, exports, module) {
     };
     
     TextRange.prototype._handleDocumentDeleted = function (event) {
-        $(this).triggerHandler("lostSync");
+        this.trigger("lostSync");
     };
     
     

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -304,12 +304,12 @@ define(function (require, exports, module) {
                 cssInlineEditor.$htmlContent
                     .on("focusin", _updateCommands)
                     .on("focusout", _updateCommands);
-                $(cssInlineEditor).on("add", function () {
+                cssInlineEditor.on("add", function () {
                     inlineEditorDeferred.resolve();
                 });
-                $(cssInlineEditor).on("close", function () {
+                cssInlineEditor.on("close", function () {
                     newRuleButton.closeDropdown();
-                    $(hostEditor).off("scroll", _onHostEditorScroll);
+                    hostEditor.off("scroll", _onHostEditorScroll);
                 });
 
                 var $header = $(".inline-editor-header", cssInlineEditor.$htmlContent);
@@ -319,7 +319,7 @@ define(function (require, exports, module) {
                 $header.append(newRuleButton.$button);
                 _newRuleHandlers.push({inlineEditor: cssInlineEditor, handler: _handleNewRuleClick});
                 
-                $(hostEditor).on("scroll", _onHostEditorScroll);
+                hostEditor.on("scroll", _onHostEditorScroll);
                 
                 result.resolve(cssInlineEditor);
                 
@@ -352,7 +352,7 @@ define(function (require, exports, module) {
                             } else {
                                 // Fill out remaining dropdown attributes otherwise
                                 newRuleButton.items = cssFileInfos;
-                                $(newRuleButton).on("select", _onDropdownSelect);
+                                newRuleButton.on("select", _onDropdownSelect);
                             }
                         }
                         

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 /*
  * __CodeHintManager Overview:__
@@ -582,10 +582,10 @@ define(function (require, exports, module) {
     /**
      * Handle a selection change event in the editor. If the selection becomes a
      * multiple selection, end our current session.
-     * @param {Event} jqEvent
+     * @param {BracketsEvent} event
      * @param {Editor} editor
      */
-    function _handleCursorActivity(jqEvent, editor) {
+    function _handleCursorActivity(event, editor) {
         if (_inSession(editor)) {
             if (editor.getSelections().length > 1) {
                 _endSession();

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -668,32 +668,32 @@ define(function (require, exports, module) {
 
     function activeEditorChangeHandler(event, current, previous) {
         if (current) {
-            $(current).on("editorChange", _handleChange);
-            $(current).on("keydown",  _handleKeydownEvent);
-            $(current).on("keypress", _handleKeypressEvent);
-            $(current).on("keyup",    _handleKeyupEvent);
-            $(current).on("cursorActivity", _handleCursorActivity);
+            current.on("editorChange", _handleChange);
+            current.on("keydown",  _handleKeydownEvent);
+            current.on("keypress", _handleKeypressEvent);
+            current.on("keyup",    _handleKeyupEvent);
+            current.on("cursorActivity", _handleCursorActivity);
         }
 
         if (previous) {
             //Removing all old Handlers
-            $(previous).off("editorChange", _handleChange);
-            $(previous).off("keydown",  _handleKeydownEvent);
-            $(previous).off("keypress", _handleKeypressEvent);
-            $(previous).off("keyup",    _handleKeyupEvent);
-            $(previous).off("cursorActivity", _handleCursorActivity);
+            previous.off("editorChange", _handleChange);
+            previous.off("keydown",  _handleKeydownEvent);
+            previous.off("keypress", _handleKeypressEvent);
+            previous.off("keyup",    _handleKeyupEvent);
+            previous.off("cursorActivity", _handleCursorActivity);
         }
     }
 
     activeEditorChangeHandler(null, EditorManager.getActiveEditor(), null);
 
-    $(EditorManager).on("activeEditorChange", activeEditorChangeHandler);
+    EditorManager.on("activeEditorChange", activeEditorChangeHandler);
 
     // Dismiss code hints before executing any command since the command
     // may make the current hinting session irrevalent after execution.
     // For example, when the user hits Ctrl+K to open Quick Doc, it is
     // pointless to keep the hint list since the user wants to view the Quick Doc.
-    $(CommandManager).on("beforeExecuteCommand", _endSession);
+    CommandManager.on("beforeExecuteCommand", _endSession);
 
     CommandManager.register(Strings.CMD_SHOW_CODE_HINTS, Commands.SHOW_CODE_HINTS, _startNewSession);
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -60,8 +60,8 @@
  * The Editor also dispatches "change" events internally, but you should listen for those on
  * Documents, not Editors.
  *
- * These are jQuery events, so to listen for them you do something like this:
- *     `$(editorInstance).on("eventname", handler);`
+ * To listen for events, do something like this: (see EventDispatcher for details on this pattern)
+ *     `editorInstance.on("eventname", handler);`
  */
 define(function (require, exports, module) {
     "use strict";
@@ -69,6 +69,7 @@ define(function (require, exports, module) {
     var AnimationUtils     = require("utils/AnimationUtils"),
         Async              = require("utils/Async"),
         CodeMirror         = require("thirdparty/CodeMirror2/lib/codemirror"),
+        EventDispatcher    = require("utils/EventDispatcher"),
         Menus              = require("command/Menus"),
         PerfUtils          = require("utils/PerfUtils"),
         PopUpManager       = require("widgets/PopUpManager"),
@@ -226,9 +227,9 @@ define(function (require, exports, module) {
         this._handleDocumentChange = this._handleDocumentChange.bind(this);
         this._handleDocumentDeleted = this._handleDocumentDeleted.bind(this);
         this._handleDocumentLanguageChanged = this._handleDocumentLanguageChanged.bind(this);
-        $(document).on("change", this._handleDocumentChange);
-        $(document).on("deleted", this._handleDocumentDeleted);
-        $(document).on("languageChanged", this._handleDocumentLanguageChanged);
+        document.on("change", this._handleDocumentChange);
+        document.on("deleted", this._handleDocumentDeleted);
+        document.on("languageChanged", this._handleDocumentLanguageChanged);
 
         var mode = this._getModeFromDocument();
         
@@ -316,13 +317,13 @@ define(function (require, exports, module) {
         
         this._installEditorListeners();
         
-        $(this).on("cursorActivity", function (jqEvent, editor) {
+        this.on("cursorActivity", function (jqEvent, editor) {
             self._handleCursorActivity(jqEvent);
         });
-        $(this).on("keypress", function (jqEvent, editor, cmEvent) {
+        this.on("keypress", function (jqEvent, editor, cmEvent) {
             self._handleKeypressEvents(cmEvent);
         });
-        $(this).on("change", function (jqEvent, editor, changeList) {
+        this.on("change", function (jqEvent, editor, changeList) {
             self._handleEditorChange(changeList);
         });
         
@@ -360,13 +361,15 @@ define(function (require, exports, module) {
         });
     }
     
+    EventDispatcher.makeEventDispatcher(Editor.prototype);
+    
     /**
      * Removes this editor from the DOM and detaches from the Document. If this is the "master"
      * Editor that is secretly providing the Document's backing state, then the Document reverts to
      * a read-only string-backed mode.
      */
     Editor.prototype.destroy = function () {
-        $(this).triggerHandler("beforeDestroy", [this]);
+        this.trigger("beforeDestroy", this);
 
         // CodeMirror docs for getWrapperElement() say all you have to do is "Remove this from your
         // tree to delete an editor instance."
@@ -376,9 +379,9 @@ define(function (require, exports, module) {
         
         // Disconnect from Document
         this.document.releaseRef();
-        $(this.document).off("change", this._handleDocumentChange);
-        $(this.document).off("deleted", this._handleDocumentDeleted);
-        $(this.document).off("languageChanged", this._handleDocumentLanguageChanged);
+        this.document.off("change", this._handleDocumentChange);
+        this.document.off("deleted", this._handleDocumentDeleted);
+        this.document.off("languageChanged", this._handleDocumentLanguageChanged);
         
         if (this._visibleRange) {   // TextRange also refs the Document
             this._visibleRange.dispose();
@@ -710,7 +713,7 @@ define(function (require, exports, module) {
         // it to lose sync. If so, our whole view is stale - signal our owner to close us.
         if (this._visibleRange) {
             if (this._visibleRange.startLine === null || this._visibleRange.endLine === null) {
-                $(this).triggerHandler("lostContent");
+                this.trigger("lostContent");
                 return;
             }
         }
@@ -781,7 +784,7 @@ define(function (require, exports, module) {
         // whereas the "change" event should be listened to on the document. Also the
         // Editor dispatches a change event before this event is dispatched, because
         // CodeHintManager needs to hook in here when other things are already done.
-        $(this).triggerHandler("editorChange", [this, changeList]);
+        this.trigger("editorChange", this, changeList);
     };
     
     /**
@@ -818,7 +821,7 @@ define(function (require, exports, module) {
      */
     Editor.prototype._handleDocumentDeleted = function (event) {
         // Pass the delete event along as the cause (needed in MultiRangeInlineEditor)
-        $(this).triggerHandler("lostContent", [event]);
+        this.trigger("lostContent", event);
     };
     
     /**
@@ -838,8 +841,8 @@ define(function (require, exports, module) {
         
         // Redispatch these CodeMirror key events as jQuery events
         function _onKeyEvent(instance, event) {
-            $(self).triggerHandler("keyEvent", [self, event]);  // deprecated
-            $(self).triggerHandler(event.type, [self, event]);
+            self.trigger("keyEvent", self, event);  // deprecated
+            self.trigger(event.type, self, event);
             return event.defaultPrevented;   // false tells CodeMirror we didn't eat the event
         }
         this._codeMirror.on("keydown",  _onKeyEvent);
@@ -852,13 +855,13 @@ define(function (require, exports, module) {
         // Also, note that we use the new "changes" event in v4, which provides an array of
         // change objects. Our own event is still called just "change".
         this._codeMirror.on("changes", function (instance, changeList) {
-            $(self).triggerHandler("change", [self, changeList]);
+            self.trigger("change", self, changeList);
         });
         this._codeMirror.on("beforeChange", function (instance, changeObj) {
-            $(self).triggerHandler("beforeChange", [self, changeObj]);
+            self.trigger("beforeChange", self, changeObj);
         });
         this._codeMirror.on("cursorActivity", function (instance) {
-            $(self).triggerHandler("cursorActivity", [self]);
+            self.trigger("cursorActivity", self);
         });
         this._codeMirror.on("scroll", function (instance) {
             // If this editor is visible, close all dropdowns on scroll.
@@ -868,25 +871,25 @@ define(function (require, exports, module) {
                 Menus.closeAll();
             }
 
-            $(self).triggerHandler("scroll", [self]);
+            self.trigger("scroll", self);
         });
 
         // Convert CodeMirror onFocus events to EditorManager activeEditorChanged
         this._codeMirror.on("focus", function () {
             self._focused = true;
-            $(self).triggerHandler("focus", [self]);
+            self.trigger("focus", self);
         });
         
         this._codeMirror.on("blur", function () {
             self._focused = false;
-            $(self).triggerHandler("blur", [self]);
+            self.trigger("blur", self);
         });
 
         this._codeMirror.on("update", function (instance) {
-            $(self).triggerHandler("update", [self]);
+            self.trigger("update", self);
         });
         this._codeMirror.on("overwriteToggle", function (instance, newstate) {
-            $(self).triggerHandler("overwriteToggle", [self, newstate]);
+            self.trigger("overwriteToggle", self, newstate);
         });
     };
     
@@ -1663,7 +1666,7 @@ define(function (require, exports, module) {
             POPOVER_ARROW_HALF_BASE = POPOVER_ARROW_HALF_WIDTH + 3; // 3 is border radius
 
         function _removeListeners() {
-            $(self).off(".msgbox");
+            self.off(".msgbox");
         }
 
         // PopUpManager.removePopUp() callback
@@ -1684,7 +1687,7 @@ define(function (require, exports, module) {
         }
 
         function _addListeners() {
-            $(self)
+            self
                 .on("blur.msgbox",           _removeMessagePopover)
                 .on("change.msgbox",         _removeMessagePopover)
                 .on("cursorActivity.msgbox", _removeMessagePopover)
@@ -1767,7 +1770,7 @@ define(function (require, exports, module) {
 
                 // Don't add scroll listeners until open so we don't get event
                 // from scrolling cursor into view
-                $(self).on("scroll.msgbox", _removeMessagePopover);
+                self.on("scroll.msgbox", _removeMessagePopover);
 
                 // Animate closed -- which includes delay to show message
                 AnimationUtils.animateUsingClass(self._$messagePopover[0], "animateClose", 6000)
@@ -2190,7 +2193,7 @@ define(function (require, exports, module) {
                 this._codeMirror.setOption(cmOptions[prefName], newValue);
             }
             
-            $(this).triggerHandler("optionChange", [prefName, newValue]);
+            this.trigger("optionChange", prefName, newValue);
         }
     };
     

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -317,13 +317,13 @@ define(function (require, exports, module) {
         
         this._installEditorListeners();
         
-        this.on("cursorActivity", function (jqEvent, editor) {
-            self._handleCursorActivity(jqEvent);
+        this.on("cursorActivity", function (event, editor) {
+            self._handleCursorActivity(event);
         });
-        this.on("keypress", function (jqEvent, editor, cmEvent) {
-            self._handleKeypressEvents(cmEvent);
+        this.on("keypress", function (event, editor, domEvent) {
+            self._handleKeypressEvents(domEvent);
         });
-        this.on("change", function (jqEvent, editor, changeList) {
+        this.on("change", function (event, editor, changeList) {
             self._handleEditorChange(changeList);
         });
         
@@ -362,6 +362,7 @@ define(function (require, exports, module) {
     }
     
     EventDispatcher.makeEventDispatcher(Editor.prototype);
+    EventDispatcher.markDeprecated(Editor.prototype, "keyEvent", "'keydown/press/up'");
     
     /**
      * Removes this editor from the DOM and detaches from the Document. If this is the "master"
@@ -839,7 +840,7 @@ define(function (require, exports, module) {
     Editor.prototype._installEditorListeners = function () {
         var self = this;
         
-        // Redispatch these CodeMirror key events as jQuery events
+        // Redispatch these CodeMirror key events as Editor events
         function _onKeyEvent(instance, event) {
             self.trigger("keyEvent", self, event);  // deprecated
             self.trigger(event.type, self, event);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -40,9 +40,9 @@
  * but this is considered deprecated and may go away.
  *
  * The Editor object dispatches the following events:
- *    - keyEvent -- When any key event happens in the editor (whether it changes the text or not).
- *      Event handlers are passed `({Editor}, {KeyboardEvent})`. The 2nd arg is the raw DOM event.
- *      Note: most listeners will only want to respond when `event.type === "keypress"`.
+ *    - keydown, keypress, keyup -- When any key event happens in the editor (whether it changes the
+ *      text or not). Handlers are passed `(BracketsEvent, Editor, KeyboardEvent)`. The 3nd arg is the
+ *      raw DOM event. Note: most listeners will only want to listen for "keypress".
  *    - cursorActivity -- When the user moves the cursor or changes the selection, or an edit occurs.
  *      Note: do not listen to this in order to be generally informed of edits--listen to the
  *      "change" event on Document instead.

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -197,7 +197,7 @@ define(function (require, exports, module) {
         var editor = new Editor(doc, makeMasterEditor, container, range);
 
         $(editor).on("focus", function () {
-            _notifyActiveEditorChanged(this);
+            _notifyActiveEditorChanged(editor);
         });
         
         $(editor).on("beforeDestroy", function () {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -58,6 +58,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var Commands            = require("command/Commands"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         WorkspaceManager    = require("view/WorkspaceManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         CommandManager      = require("command/CommandManager"),
@@ -161,7 +162,7 @@ define(function (require, exports, module) {
         var previous = _lastFocusedEditor;
         _lastFocusedEditor = current;
         
-        $(exports).triggerHandler("activeEditorChange", [current, previous]);
+        exports.trigger("activeEditorChange", current, previous);
     }
 	
     /**
@@ -196,11 +197,11 @@ define(function (require, exports, module) {
     function _createEditorForDocument(doc, makeMasterEditor, container, range) {
         var editor = new Editor(doc, makeMasterEditor, container, range);
 
-        $(editor).on("focus", function () {
+        editor.on("focus", function () {
             _notifyActiveEditorChanged(editor);
         });
         
-        $(editor).on("beforeDestroy", function () {
+        editor.on("beforeDestroy", function () {
             if (editor.$el.is(":visible")) {
                 _saveEditorViewState(editor);
             }
@@ -477,7 +478,7 @@ define(function (require, exports, module) {
         var editor = _createEditorForDocument(document, true, pane.$content);
         editor.setVisible(false);
         pane.addView(editor);
-        $(exports).triggerHandler("_fullEditorCreatedForDocument", [document, editor, pane.id]);
+        exports.trigger("_fullEditorCreatedForDocument", document, editor, pane.id);
         return editor;
     }
  
@@ -767,8 +768,11 @@ define(function (require, exports, module) {
     }
 
     
+    // Set up event dispatching
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // File-based preferences handling
-    $(exports).on("activeEditorChange", function (e, current) {
+    exports.on("activeEditorChange", function (e, current) {
         if (current && current.document && current.document.file) {
             PreferencesManager._setCurrentEditingFile(current.document.file.fullPath);
         }
@@ -786,8 +790,8 @@ define(function (require, exports, module) {
     // Create PerfUtils measurement
     PerfUtils.createPerfMeasurement("JUMP_TO_DEFINITION", "Jump-To-Definiiton");
 
-    $(MainViewManager).on("currentFileChange", _handleCurrentFileChange);
-    $(MainViewManager).on("workingSetRemove workingSetRemoveList", _handleRemoveFromPaneView);
+    MainViewManager.on("currentFileChange", _handleCurrentFileChange);
+    MainViewManager.on("workingSetRemove workingSetRemoveList", _handleRemoveFromPaneView);
 
     
     // For unit tests and internal use only

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -255,8 +255,8 @@ define(function (require, exports, module) {
      */
     function _onActiveEditorChange(event, current, previous) {
         if (previous) {
-            $(previous).off(".statusbar");
-            $(previous.document).off(".statusbar");
+            previous.off(".statusbar");
+            previous.document.off(".statusbar");
             previous.document.releaseRef();
         }
         
@@ -266,19 +266,19 @@ define(function (require, exports, module) {
             var fullPath = current.document.file.fullPath;
             StatusBar.showAllPanes();
             
-            $(current).on("cursorActivity.statusbar", _updateCursorInfo);
-            $(current).on("optionChange.statusbar", function () {
+            current.on("cursorActivity.statusbar", _updateCursorInfo);
+            current.on("optionChange.statusbar", function () {
                 _updateIndentType(fullPath);
                 _updateIndentSize(fullPath);
             });
-            $(current).on("change.statusbar", function () {
+            current.on("change.statusbar", function () {
                 // async update to keep typing speed smooth
                 window.setTimeout(function () { _updateFileInfo(current); }, 0);
             });
-            $(current).on("overwriteToggle.statusbar", _updateOverwriteLabel);
+            current.on("overwriteToggle.statusbar", _updateOverwriteLabel);
             
             current.document.addRef();
-            $(current.document).on("languageChanged.statusbar", function () {
+            current.document.on("languageChanged.statusbar", function () {
                 _updateLanguageInfo(current);
             });
             
@@ -378,7 +378,7 @@ define(function (require, exports, module) {
         $indentWidthInput.focus(function () { $indentWidthInput.select(); });
 
         // Language select change handler
-        $(languageSelect).on("select", function (e, lang) {
+        languageSelect.on("select", function (e, lang) {
             var document = EditorManager.getActiveEditor().document,
                 fullPath = document.file.fullPath;
             
@@ -400,13 +400,13 @@ define(function (require, exports, module) {
     }
 
     // Initialize: status bar focused listener
-    $(EditorManager).on("activeEditorChange", _onActiveEditorChange);
+    EditorManager.on("activeEditorChange", _onActiveEditorChange);
     
     AppInit.htmlReady(_init);
     AppInit.appReady(function () {
         // Populate language switcher with all languages after startup; update it later if this set changes
         _populateLanguageDropdown();
-        $(LanguageManager).on("languageAdded languageModified", _populateLanguageDropdown);
+        LanguageManager.on("languageAdded languageModified", _populateLanguageDropdown);
         _onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
         StatusBar.show();
     });

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
         });
         
         // make sure we always show the right file name
-        DocumentManager.on("fileNameChange", _.bind(this._onFilenameChange, this));
+        DocumentManager.on("fileNameChange.ImageView", _.bind(this._onFilenameChange, this));
        
         this.$imageTip.hide();
         this.$imageGuides.hide();
@@ -384,7 +384,7 @@ define(function (require, exports, module) {
      */
     ImageView.prototype.destroy = function () {
         delete _viewers[this.file.fullPath];
-        DocumentManager.off("fileNameChange", _.bind(this._onFilenameChange, this));
+        DocumentManager.off(".ImageView");
         this.$image.off(".ImageView");
         this.$el.remove();
     };

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
         });
         
         // make sure we always show the right file name
-        $(DocumentManager).on("fileNameChange", _.bind(this._onFilenameChange, this));
+        DocumentManager.on("fileNameChange", _.bind(this._onFilenameChange, this));
        
         this.$imageTip.hide();
         this.$imageGuides.hide();
@@ -384,7 +384,7 @@ define(function (require, exports, module) {
      */
     ImageView.prototype.destroy = function () {
         delete _viewers[this.file.fullPath];
-        $(DocumentManager).off("fileNameChange", _.bind(this._onFilenameChange, this));
+        DocumentManager.off("fileNameChange", _.bind(this._onFilenameChange, this));
         this.$image.off(".ImageView");
         this.$el.remove();
     };

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -216,7 +216,7 @@ define(function (require, exports, module) {
         
         // Destroy the previous editor if we had one and clear out the filename info.
         if (this.editor) {
-            $(this.editor).off(".InlineTextEditor");
+            this.editor.off(".InlineTextEditor");
             this.editor.destroy(); // remove from DOM and release ref on Document
             this.editor = null;
             this.$filename.off(".InlineTextEditor")
@@ -264,14 +264,14 @@ define(function (require, exports, module) {
 
         // Always update the widget height when an inline editor completes a
         // display update
-        $(this.editor).on("update.InlineTextEditor", function (event, editor) {
+        this.editor.on("update.InlineTextEditor", function (event, editor) {
             self.sizeInlineWidgetToContents();
         });
 
         // Size editor to content whenever text changes (via edits here or any
         // other view of the doc: Editor fires "change" any time its text
         // changes, regardless of origin)
-        $(this.editor).on("change.InlineTextEditor", function (event, editor) {
+        this.editor.on("change.InlineTextEditor", function (event, editor) {
             if (self.hostEditor.isFullyVisible()) {
                 self.sizeInlineWidgetToContents();
                 self._updateLineRange(editor);
@@ -279,7 +279,7 @@ define(function (require, exports, module) {
         });
         
         // If Document's file is deleted, or Editor loses sync with Document, delegate to this._onLostContent()
-        $(this.editor).on("lostContent.InlineTextEditor", function () {
+        this.editor.on("lostContent.InlineTextEditor", function () {
             self._onLostContent.apply(self, arguments);
         });
         

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -30,7 +30,8 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var AppInit             = require("utils/AppInit"),
+        CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
         CommandManager      = require("command/CommandManager"),
@@ -337,8 +338,11 @@ define(function (require, exports, module) {
         this.close();
     };
     
-    // consolidate all dirty document updates
-    $(DocumentManager).on("dirtyFlagChange", _dirtyFlagChangeHandler);
+    // Attach listeners late due to circular references
+    AppInit.htmlReady(function () {
+        // consolidate all dirty document updates
+        DocumentManager.on("dirtyFlagChange", _dirtyFlagChangeHandler);
+    });
 
     exports.InlineTextEditor = InlineTextEditor;
 

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -30,8 +30,8 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var AppInit             = require("utils/AppInit"),
-        CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
         CommandManager      = require("command/CommandManager"),
@@ -338,11 +338,10 @@ define(function (require, exports, module) {
         this.close();
     };
     
-    // Attach listeners late due to circular references
-    AppInit.htmlReady(function () {
-        // consolidate all dirty document updates
-        DocumentManager.on("dirtyFlagChange", _dirtyFlagChangeHandler);
-    });
+    
+    // Consolidate all dirty document updates
+    // Due to circular dependencies, not safe to call on() directly
+    EventDispatcher.on_duringInit(DocumentManager, "dirtyFlagChange", _dirtyFlagChangeHandler);
 
     exports.InlineTextEditor = InlineTextEditor;
 

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
 
     // Load dependent modules
     var EditorManager       = require("editor/EditorManager"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         KeyEvent            = require("utils/KeyEvent");
     
     /**
@@ -64,6 +65,7 @@ define(function (require, exports, module) {
     InlineWidget.prototype.$htmlContent = null;
     InlineWidget.prototype.id = null;
     InlineWidget.prototype.hostEditor = null;
+    EventDispatcher.makeEventDispatcher(InlineWidget.prototype);
 
     /**
      * Initial height of inline widget in pixels. Can be changed later via hostEditor.setInlineWidgetHeight()
@@ -93,7 +95,7 @@ define(function (require, exports, module) {
      * Called any time inline is closed, whether manually or automatically.
      */
     InlineWidget.prototype.onClosed = function () {
-        $(this).triggerHandler("close");
+        this.trigger("close");
     };
 
     /**
@@ -104,7 +106,7 @@ define(function (require, exports, module) {
      * set the initial height (required to animate it open). The widget will never open otherwise.
      */
     InlineWidget.prototype.onAdded = function () {
-        $(this).triggerHandler("add");
+        this.trigger("add");
     };
 
     /**

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -324,14 +324,14 @@ define(function (require, exports, module) {
         var self = this;
         this._ranges.forEach(function (range, index) {
             // Update list item as TextRange changes
-            $(range.textRange).on("change", function () {
+            range.textRange.on("change", function () {
                 _updateRangeLabel(range.$listItem, range);
             }).on("contentChange", function () {
                 _updateRangeLabel(range.$listItem, range, self._labelCB);
             });
             
             // If TextRange lost sync, remove it from the list (and close the widget if no other ranges are left)
-            $(range.textRange).on("lostSync", function () {
+            range.textRange.on("lostSync", function () {
                 self._removeRange(range);
             });
         });
@@ -415,7 +415,7 @@ define(function (require, exports, module) {
         
         // Clear our listeners on the previous editor since it'll be destroyed in setInlineContent().
         if (this.editor) {
-            $(this.editor).off(".MultiRangeInlineEditor");
+            this.editor.off(".MultiRangeInlineEditor");
         }
 
         this._selectedRangeIndex = newIndex;
@@ -449,7 +449,7 @@ define(function (require, exports, module) {
             this.editor.refresh();
             
             // Ensure the cursor position is visible in the host editor as the user is arrowing around.
-            $(this.editor).on("cursorActivity.MultiRangeInlineEditor", this._ensureCursorVisible.bind(this));
+            this.editor.on("cursorActivity.MultiRangeInlineEditor", this._ensureCursorVisible.bind(this));
             
             // ensureVisibility is set to false because we don't want to scroll the main editor when the user selects a view
             this.sizeInlineWidgetToContents();

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var _                   = require("thirdparty/lodash"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         Package             = require("extensibility/Package"),
         AppInit             = require("utils/AppInit"),
         Async               = require("utils/Async"),
@@ -148,7 +149,7 @@ define(function (require, exports, module) {
             }
         }
 
-        $(exports).triggerHandler("registryUpdate", [id]);
+        exports.trigger("registryUpdate", id);
     }
 
 
@@ -216,7 +217,7 @@ define(function (require, exports, module) {
                     extensions[id].registryInfo = data[id];
                     synchronizeEntry(id);
                 });
-                $(exports).triggerHandler("registryDownload");
+                exports.trigger("registryDownload");
                 pendingDownloadRegistry.resolve();
             })
             .fail(function () {
@@ -267,7 +268,7 @@ define(function (require, exports, module) {
             };
             synchronizeEntry(id);
             loadTheme(id);
-            $(exports).triggerHandler("statusChange", [id]);
+            exports.trigger("statusChange", id);
         }
 
         ExtensionUtils.loadPackageJson(path)
@@ -385,7 +386,7 @@ define(function (require, exports, module) {
                 .done(function () {
                     extensions[id].installInfo = null;
                     result.resolve();
-                    $(exports).triggerHandler("statusChange", [id]);
+                    exports.trigger("statusChange", id);
                 })
                 .fail(function (err) {
                     result.reject(err);
@@ -447,7 +448,7 @@ define(function (require, exports, module) {
         } else {
             delete _idsToRemove[id];
         }
-        $(exports).triggerHandler("statusChange", [id]);
+        exports.trigger("statusChange", id);
     }
 
     /**
@@ -486,7 +487,7 @@ define(function (require, exports, module) {
             var id = installationResult.name;
             delete _idsToRemove[id];
             _idsToUpdate[id] = installationResult;
-            $(exports).triggerHandler("statusChange", [id]);
+            exports.trigger("statusChange", id);
         }
     }
 
@@ -504,7 +505,7 @@ define(function (require, exports, module) {
             FileSystem.getFileForPath(installationResult.localPath).unlink();
         }
         delete _idsToUpdate[id];
-        $(exports).triggerHandler("statusChange", [id]);
+        exports.trigger("statusChange", id);
     }
 
     /**
@@ -759,9 +760,12 @@ define(function (require, exports, module) {
     });
 
     // Listen to extension load and loadFailed events
-    $(ExtensionLoader)
+    ExtensionLoader
         .on("load", _handleExtensionLoad)
         .on("loadFailed", _handleExtensionLoad);
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
 
     // Public exports
     exports.downloadRegistry        = downloadRegistry;

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -296,7 +296,7 @@ define(function (require, exports, module) {
         
         // On dialog close: clean up listeners & models, and commit changes
         dialog.done(function () {
-            $(document).off(".extensionManager");
+            $(window.document).off(".extensionManager");
             
             models.forEach(function (model) {
                 model.dispose();
@@ -325,7 +325,7 @@ define(function (require, exports, module) {
 
         // Navigate through tabs via Ctrl-(Shift)-Tab
         // (focus may be on document.body if text in extension listing clicked - see #9511)
-        $(document).on("keyup.extensionManager", function (event) {
+        $(window.document).on("keyup.extensionManager", function (event) {
             if (event.keyCode === KeyEvent.DOM_VK_TAB && event.ctrlKey) {
                 var $tabs = $(".nav-tabs a", $dlg),
                     tabIndex = _activeTabIndex;
@@ -365,7 +365,7 @@ define(function (require, exports, module) {
                 updateNotificationIcon(index);
             });
             
-            $(model).on("change", function () {
+            model.on("change", function () {
                 if (lastNotifyCount !== model.notifyCount) {
                     lastNotifyCount = model.notifyCount;
                     updateNotificationIcon(index);
@@ -413,7 +413,7 @@ define(function (require, exports, module) {
             
             // Disable the search field when there are no items in the model
             models.forEach(function (model, index) {
-                $(model).on("change", function () {
+                model.on("change", function () {
                     if (_activeTabIndex === index) {
                         updateSearchDisabled();
                     }
@@ -428,7 +428,7 @@ define(function (require, exports, module) {
             }
         });
     
-        // Handle the install button.
+        // Handle the 'Install from URL' button.
         $(".extension-manager-dialog .install-from-url")
             .click(function () {
                 InstallExtensionDialog.showDialog().done(ExtensionManager.updateFromDownload);

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var Strings                   = require("strings"),
+        EventDispatcher           = require("utils/EventDispatcher"),
         StringUtils               = require("utils/StringUtils"),
         ExtensionManager          = require("extensibility/ExtensionManager"),
         registry_utils            = require("extensibility/registry_utils"),
@@ -43,6 +44,7 @@ define(function (require, exports, module) {
      */
     function ExtensionManagerView() {
     }
+    EventDispatcher.makeEventDispatcher(ExtensionManagerView.prototype);
     
     /**
      * Initializes the view to show a set of extensions.
@@ -144,7 +146,7 @@ define(function (require, exports, module) {
         var self = this;
 
         // Listen for model data and filter changes.
-        $(this.model)
+        this.model
             .on("filter", function () {
                 self._render();
             })
@@ -364,7 +366,7 @@ define(function (require, exports, module) {
             $item.appendTo(self._$table);
         });
         
-        $(this).triggerHandler("render");
+        this.trigger("render");
     };
     
     /**

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
     
     var ExtensionManager = require("extensibility/ExtensionManager"),
         registry_utils   = require("extensibility/registry_utils"),
+        EventDispatcher = require("utils/EventDispatcher"),
         Strings          = require("strings");
 
     /**
@@ -56,10 +57,11 @@ define(function (require, exports, module) {
         this._handleStatusChange = this._handleStatusChange.bind(this);
         
         // Listen for extension status changes.
-        $(ExtensionManager)
+        ExtensionManager
             .on("statusChange." + this.source, this._handleStatusChange)
             .on("registryUpdate." + this.source, this._handleStatusChange);
     }
+    EventDispatcher.makeEventDispatcher(ExtensionManagerViewModel.prototype);
     
     /**
      * @type {string}
@@ -138,7 +140,7 @@ define(function (require, exports, module) {
      * Unregisters listeners when we're done.
      */
     ExtensionManagerViewModel.prototype.dispose = function () {
-        $(ExtensionManager).off("." + this.source);
+        ExtensionManager.off("." + this.source);
     };
     
     /**
@@ -148,7 +150,7 @@ define(function (require, exports, module) {
     ExtensionManagerViewModel.prototype._setInitialFilter = function () {
         // Initial filtered list is the same as the sorted list.
         this.filterSet = _.clone(this.sortedFullSet);
-        $(this).triggerHandler("filter");
+        this.trigger("filter");
     };
     
     /**
@@ -179,7 +181,7 @@ define(function (require, exports, module) {
      * @param {string} id The id of the extension whose status changed.
      */
     ExtensionManagerViewModel.prototype._handleStatusChange = function (e, id) {
-        $(this).triggerHandler("change", id);
+        this.trigger("change", id);
     };
     
     /**
@@ -226,7 +228,7 @@ define(function (require, exports, module) {
 
         this._updateMessage();
 
-        $(this).triggerHandler("filter");
+        this.trigger("filter");
     };
 
     /**
@@ -376,7 +378,7 @@ define(function (require, exports, module) {
 
         // when registry is downloaded, sort extensions again - those with updates will be before others
         var self = this;
-        $(ExtensionManager).on("registryDownload", function () {
+        ExtensionManager.on("registryDownload", function () {
             self._sortFullSet();
             self._setInitialFilter();
         });

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -387,7 +387,7 @@ define(function (require, exports, module) {
         this.$browseExtensionsButton.on("click", function () {
             NativeApp.openURLInDefaultBrowser(brackets.config.extension_listing_url);
         });
-        $(document.body).on("keyup.installDialog", this._handleKeyUp.bind(this));
+        $(window.document.body).on("keyup.installDialog", this._handleKeyUp.bind(this));
         
         this._enterState(STATE_START);
         if (urlToInstall) {

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
     initializeCommands();
 
     // Add a context menu open handler
-    $(workingSetListCmenu).on("beforeContextMenuOpen", contextMenuOpenHandler);
+    workingSetListCmenu.on("beforeContextMenuOpen", contextMenuOpenHandler);
 
     prefs.on("change", prefChangeHandler);
 });

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
+/*global define, brackets */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/DebugCommands/NodeDebugUtils.js
+++ b/src/extensions/default/DebugCommands/NodeDebugUtils.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
+/*global define, brackets */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/DebugCommands/NodeDebugUtils.js
+++ b/src/extensions/default/DebugCommands/NodeDebugUtils.js
@@ -124,7 +124,7 @@ define(function (require, exports, module) {
     
     // TODO: It would be nice to add a menu item that allows the user
     // to enable/disable forwarding of node logs to the console.
-    $(_nodeConnection).on("base.log", handleLogEvent);
+    _nodeConnection.on("base:log", handleLogEvent);
     
     exports.logNodeState = logNodeState;
     exports.restartNode = restartNode;

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
         
         var doc = this.hostEditor.document;
         doc.addRef();
-        $(doc).on("change", this._handleHostDocumentChange);
+        doc.on("change", this._handleHostDocumentChange);
         
         this.hostEditor.setInlineWidgetHeight(this, this.colorEditor.getRootElement().outerHeight(), true);
         
@@ -210,7 +210,7 @@ define(function (require, exports, module) {
         }
 
         var doc = this.hostEditor.document;
-        $(doc).off("change", this._handleHostDocumentChange);
+        doc.off("change", this._handleHostDocumentChange);
         doc.releaseRef();
     };
 

--- a/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $, window */
+/*global define, brackets, window */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
@@ -206,7 +206,7 @@ define(function (require, exports, module) {
         
         var doc = this.hostEditor.document;
         doc.addRef();
-        $(doc).on("change", this._handleHostDocumentChange);
+        doc.on("change", this._handleHostDocumentChange);
         
         this.hostEditor.setInlineWidgetHeight(this, this.timingFunctionEditor.getRootElement().outerHeight(), true);
         
@@ -230,7 +230,7 @@ define(function (require, exports, module) {
         }
 
         var doc = this.hostEditor.document;
-        $(doc).off("change", this._handleHostDocumentChange);
+        doc.off("change", this._handleHostDocumentChange);
         doc.releaseRef();
     };
 

--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -389,9 +389,8 @@ define(function (require, exports, module) {
      *      changes
      */
     function installListeners(editor) {
-
-        $(editor).on("keydown", function (jqEvent, editor, event) {
-            if (event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+        editor.on("keydown", function (event, editor, domEvent) {
+            if (domEvent.keyCode === KeyEvent.DOM_VK_ESCAPE) {
                 dismissHint();
             }
         }).on("scroll", function () {

--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
             $hintContainer.hide();
             $hintContent.empty();
             hintState = {};
-            $(session.editor).off("cursorActivity", handleCursorActivity);
+            session.editor.off("cursorActivity", handleCursorActivity);
 
             if (!preserveHintStack) {
                 clearFunctionHintStack();
@@ -285,7 +285,7 @@ define(function (require, exports, module) {
             hintState.visible = true;
             hintState.fnType = fnType;
 
-            $(session.editor).on("cursorActivity", handleCursorActivity);
+            session.editor.on("cursorActivity", handleCursorActivity);
             $deferredPopUp.resolveWith(null);
         }).fail(function () {
             hintState = {};
@@ -358,7 +358,7 @@ define(function (require, exports, module) {
      * @param {Session} session - session to start cursor tracking on.
      */
     function startCursorTracking(session) {
-        $(session.editor).on("cursorActivity", handleCursorActivity);
+        session.editor.on("cursorActivity", handleCursorActivity);
     }
 
     /**
@@ -369,7 +369,7 @@ define(function (require, exports, module) {
      * @param {Session} session - session to stop cursor tracking on.
      */
     function stopCursorTracking(session) {
-        $(session.editor).off("cursorActivity", handleCursorActivity);
+        session.editor.off("cursorActivity", handleCursorActivity);
     }
 
     /**
@@ -414,7 +414,7 @@ define(function (require, exports, module) {
 
         // Close the function hint when commands are executed, except for the commands
         // to show function hints for code hints.
-        $(CommandManager).on("beforeExecuteCommand", function (jqEvent, commandId) {
+        CommandManager.on("beforeExecuteCommand", function (event, commandId) {
             if (commandId !== SHOW_PARAMETER_HINT_CMD_ID &&
                     commandId !== Commands.SHOW_CODE_HINTS) {
                 dismissHint();

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -614,7 +614,7 @@ define(function (require, exports, module) {
             
             if (editor && HintUtils.isSupportedLanguage(LanguageManager.getLanguageForPath(editor.document.file.fullPath).getId())) {
                 initializeSession(editor, previousEditor);
-                $(editor)
+                editor
                     .on(HintUtils.eventName("change"), function (event, editor, changeList) {
                         if (!ignoreChange) {
                             ScopeManager.handleFileChange(changeList);
@@ -636,8 +636,7 @@ define(function (require, exports, module) {
          */
         function uninstallEditorListeners(editor) {
             if (editor) {
-                $(editor)
-                    .off(HintUtils.eventName("change"));
+                editor.off(HintUtils.eventName("change"));
             }
         }
 
@@ -653,11 +652,11 @@ define(function (require, exports, module) {
         function handleActiveEditorChange(event, current, previous) {
             // Uninstall "languageChanged" event listeners on previous editor's document & put them on current editor's doc
             if (previous) {
-                $(previous.document)
+                previous.document
                     .off(HintUtils.eventName("languageChanged"));
             }
             if (current) {
-                $(current.document)
+                current.document
                     .on(HintUtils.eventName("languageChanged"), function () {
                         // If current doc's language changed, reset our state by treating it as if the user switched to a
                         // different document altogether
@@ -828,15 +827,14 @@ define(function (require, exports, module) {
         ExtensionUtils.loadStyleSheet(module, "styles/brackets-js-hints.css");
         
         // uninstall/install change listener as the active editor changes
-        $(EditorManager)
-            .on(HintUtils.eventName("activeEditorChange"),
+        EditorManager.on(HintUtils.eventName("activeEditorChange"),
                 handleActiveEditorChange);
         
-        $(ProjectManager).on("beforeProjectClose", function () {
+        ProjectManager.on("beforeProjectClose", function () {
             ScopeManager.handleProjectClose();
         });
 
-        $(ProjectManager).on("projectOpen", function () {
+        ProjectManager.on("projectOpen", function () {
             ScopeManager.handleProjectOpen();
         });
 

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -702,11 +702,11 @@ define(function (require, exports, module) {
         hidePreview();
 
         if (previous && previous.document) {
-            $(previous.document).off("change", hidePreview);
+            previous.document.off("change", hidePreview);
         }
 
         if (current && current.document) {
-            $(current.document).on("change", hidePreview);
+            current.document.on("change", hidePreview);
         }
     }
 
@@ -728,7 +728,7 @@ define(function (require, exports, module) {
 
                 // Setup doc "change" listener
                 onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
-                $(EditorManager).on("activeEditorChange", onActiveEditorChange);
+                EditorManager.on("activeEditorChange", onActiveEditorChange);
 
             } else {
                 editorHolder.removeEventListener("mousemove", handleMouseMove, true);
@@ -737,7 +737,7 @@ define(function (require, exports, module) {
 
                 // Cleanup doc "change" listener
                 onActiveEditorChange(null, null, EditorManager.getActiveEditor());
-                $(EditorManager).off("activeEditorChange", onActiveEditorChange);
+                EditorManager.off("activeEditorChange", onActiveEditorChange);
 
                 hidePreview();
             }

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -264,7 +264,6 @@ define(function (require, exports, module) {
     function cleanupDropdown() {
         $("html").off("click", closeDropdown);
         $("#project-files-container").off("scroll", closeDropdown);
-        $(SidebarView).off("hide", closeDropdown);
         $("#titlebar .nav").off("click", closeDropdown);
         $dropdown = null;
 
@@ -404,10 +403,9 @@ define(function (require, exports, module) {
         // We should fix this when the popup handling is centralized in PopupManager, as well
         // as making Esc close the dropdown. See issue #1381.
         $("#project-files-container").on("scroll", closeDropdown);
-
-        // Hide the menu if the sidebar is hidden.
-        // TODO: Is there some more general way we could handle this for dropdowns?
-        $(SidebarView).on("hide", closeDropdown);
+        
+        // Note: PopUpManager will automatically hide the sidebar in other cases, such as when a
+        // command is run, Esc is pressed, or the menu is focused.
 
         // Hacky: if we detect a click in the menubar, close ourselves.
         // TODO: again, we should have centralized popup management.
@@ -453,8 +451,8 @@ define(function (require, exports, module) {
     AppInit.appReady(function () {
         ExtensionUtils.loadStyleSheet(module, "styles/styles.less");
 
-        $(ProjectManager).on("projectOpen", add);
-        $(ProjectManager).on("beforeProjectClose", add);
+        ProjectManager.on("projectOpen", add);
+        ProjectManager.on("beforeProjectClose", add);
     });
 
     AppInit.htmlReady(function () {

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
      * Live preview server that uses a built-in HTTP server to serve static
      * and instrumented files.
      *
-     * @param {!{baseUrl: string, root: string, pathResolver: function(string), nodeConnection: NodeConnection}} config
+     * @param {!{baseUrl: string, root: string, pathResolver: function(string), nodeDomain: NodeDomain}} config
      *    Configuration parameters for this server:
      *        baseUrl        - Optional base URL (populated by the current project)
      *        pathResolver   - Function to covert absolute native paths to project relative paths
@@ -221,14 +221,14 @@ define(function (require, exports, module) {
      * See BaseServer#start. Starts listenting to StaticServerDomain events.
      */
     StaticServer.prototype.start = function () {
-        $(this._nodeDomain).on("requestFilter", this._onRequestFilter);
+        this._nodeDomain.on("requestFilter", this._onRequestFilter);
     };
 
     /**
      * See BaseServer#stop. Remove event handlers from StaticServerDomain.
      */
     StaticServer.prototype.stop = function () {
-        $(this._nodeDomain).off("requestFilter", this._onRequestFilter);
+        this._nodeDomain.off("requestFilter", this._onRequestFilter);
     };
 
     module.exports = StaticServer;

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -61,11 +61,11 @@ define(function (require, exports, module) {
                         nodeDomain = main._nodeDomain;
                         nodeConnection = nodeDomain.connection;
 
-                        waitsFor(function () { return nodeDomain.ready(); }, "NodeConnection connected", CONNECT_TIMEOUT);
+                        waitsFor(function () { return nodeDomain.ready(); }, "NodeDomain connected", CONNECT_TIMEOUT);
                     });
 
                     runs(function () {
-                        $(nodeConnection).on("base.log", function (event, level, timestamp, message) {
+                        nodeConnection.on("base:log", function (event, level, timestamp, message) {
                             logs.push({level: level, message: message});
                         });
                     });
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
 
             function onRequestFilter(callback) {
                 // only handle the first event
-                $(nodeConnection).one("staticServer.requestFilter", function cb(event, request) {
+                nodeConnection.one("staticServer:requestFilter", function cb(event, request) {
                     callback(request);
                 });
             }
@@ -637,7 +637,7 @@ define(function (require, exports, module) {
             });
             
             it("should decline serving if not connected to node", function () {
-                // mock NodeConnection state to be disconnected
+                // mock NodeDomain state to be disconnected
                 config.nodeDomain = { ready: function () { return false; } };
 
                 var server = new StaticServer(config);

--- a/src/extensions/samples/ContextMenuTest/main.js
+++ b/src/extensions/samples/ContextMenuTest/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
+/*global define, brackets */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/samples/ContextMenuTest/main.js
+++ b/src/extensions/samples/ContextMenuTest/main.js
@@ -79,7 +79,7 @@ define(function (require, exports, module) {
         command3.setEnabled(editor && editor.getSelectedText() !== "");
     };
     var editor_cmenu = Menus.getContextMenu(Menus.ContextMenuIds.EDITOR_MENU);
-    $(editor_cmenu).on("beforeContextMenuOpen", updateEnabledState);
+    editor_cmenu.on("beforeContextMenuOpen", updateEnabledState);
 
     
     // Add the Commands as MenuItems of the Editor context menu

--- a/src/extensions/samples/TypingSpeedLogger/main.js
+++ b/src/extensions/samples/TypingSpeedLogger/main.js
@@ -101,13 +101,13 @@ define(function (require, exports, module) {
         
             var onChangeHandler = function (event, editor, change) {
                 PerfUtils.addMeasurement(STRING_ONCHANGE);
-                $(editor).off("change.typingSpeedLogger", onChangeHandler);
+                editor.off("change.typingSpeedLogger", onChangeHandler);
 
                 requestAnimFrame(repaintAfterChangeHandler);
             };
             
             requestAnimFrame(repaintBeforeChangeHandler);
-            $(editor).on("change.typingSpeedLogger", onChangeHandler);
+            editor.on("change.typingSpeedLogger", onChangeHandler);
         };
 
         var updateFocusedEditor = function (focusedEditor) {
@@ -125,7 +125,7 @@ define(function (require, exports, module) {
             }
         };
         
-        $(EditorManager).on("activeEditorChange", function (event, focusedEditor) {
+        EditorManager.on("activeEditorChange", function (event, focusedEditor) {
             updateFocusedEditor(focusedEditor);
         });
         updateFocusedEditor(EditorManager.getFocusedEditor());

--- a/src/extensions/samples/TypingSpeedLogger/main.js
+++ b/src/extensions/samples/TypingSpeedLogger/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window */
+/*global define, brackets, window */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 /**
  * FileSystem is a model object representing a complete file system. This object creates

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -96,7 +96,8 @@ define(function (require, exports, module) {
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
         FileSystemError = require("filesystem/FileSystemError"),
-        WatchedRoot     = require("filesystem/WatchedRoot");
+        WatchedRoot     = require("filesystem/WatchedRoot"),
+        EventDispatcher = require("utils/EventDispatcher");
     
     /**
      * The FileSystem is not usable until init() signals its callback.
@@ -115,6 +116,7 @@ define(function (require, exports, module) {
         // Initialize the queue of pending external changes
         this._externalChanges = [];
     }
+    EventDispatcher.makeEventDispatcher(FileSystem.prototype);
     
     /**
      * The low-level file system implementation used by this object. 
@@ -669,7 +671,7 @@ define(function (require, exports, module) {
      * @param {string} newPath The entry's current fullPath
      */
     FileSystem.prototype._fireRenameEvent = function (oldPath, newPath) {
-        $(this).trigger("rename", [oldPath, newPath]);
+        this.trigger("rename", oldPath, newPath);
     };
 
     /**
@@ -682,7 +684,7 @@ define(function (require, exports, module) {
      *      is a set of removed entries from the directory.
      */
     FileSystem.prototype._fireChangeEvent = function (entry, added, removed) {
-        $(this).trigger("change", [entry, added, removed]);
+        this.trigger("change", entry, added, removed);
     };
     
     /**
@@ -989,7 +991,7 @@ define(function (require, exports, module) {
      * @param {function} handler The handler for the event
      */
     exports.on = function (event, handler) {
-        $(_instance).on(event, handler);
+        _instance.on(event, handler);
     };
     
     /**
@@ -999,7 +1001,7 @@ define(function (require, exports, module) {
      * @param {function} handler The handler for the event
      */
     exports.off = function (event, handler) {
-        $(_instance).off(event, handler);
+        _instance.off(event, handler);
     };
     
     // Export the FileSystem class as "private" for unit testing only.

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
     
     
     // If the connection closes, notify the FileSystem that watchers have gone offline.
-    $(_nodeDomain.connection).on("close", function (event, promise) {
+    _nodeDomain.connection.on("close", function (event, promise) {
         if (_offlineCallback) {
             _offlineCallback();
         }
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
     }
 
     // Setup the change handler. This only needs to happen once.
-    $(_nodeDomain).on("change", _fileWatcherChange);
+    _nodeDomain.on("change", _fileWatcherChange);
 
     /**
      * Convert appshell error codes to FileSystemError values.

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, appshell, $, window */
+/*global define, appshell, window */
 
 define(function (require, exports, module) {
     "use strict";
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
         _domainPath     = [_bracketsPath, _modulePath, _nodePath].join("/"),
         _nodeDomain     = new NodeDomain("fileWatcher", _domainPath);
     
-    var _isRunningOnWindowsXP = navigator.userAgent.indexOf("Windows NT 5.") >= 0;
+    var _isRunningOnWindowsXP = window.navigator.userAgent.indexOf("Windows NT 5.") >= 0;
     
     
     // If the connection closes, notify the FileSystem that watchers have gone offline.

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -474,11 +474,11 @@ define(function (require, exports, module) {
     function updateListeners() {
         if (_enabled) {
             // register our event listeners
-            $(MainViewManager)
+            MainViewManager
                 .on("currentFileChange.codeInspection", function () {
                     run();
                 });
-            $(DocumentManager)
+            DocumentManager
                 .on("currentDocumentLanguageChanged.codeInspection", function () {
                     run();
                 })
@@ -488,8 +488,8 @@ define(function (require, exports, module) {
                     }
                 });
         } else {
-            $(DocumentManager).off(".codeInspection");
-            $(MainViewManager).off(".codeInspection");
+            DocumentManager.off(".codeInspection");
+            MainViewManager.off(".codeInspection");
         }
     }
 

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
     function _removeDocFromCache(evt, document) {
         if (_cachedValues.hasOwnProperty(document.file.fullPath)) {
             delete _cachedValues[document.file.fullPath];
-            $(document).off(".htmlInstrumentation");
+            document.off(".htmlInstrumentation");
         }
     }
     
@@ -678,7 +678,7 @@ define(function (require, exports, module) {
         };
     }
     
-    $(DocumentManager).on("beforeDocumentDelete", _removeDocFromCache);
+    DocumentManager.on("beforeDocumentDelete", _removeDocFromCache);
     
     /**
      * Parses the document, returning an HTMLSimpleDOM structure and caching it as the
@@ -694,7 +694,7 @@ define(function (require, exports, module) {
      */
     function scanDocument(doc) {
         if (!_cachedValues.hasOwnProperty(doc.file.fullPath)) {
-            $(doc).on("change.htmlInstrumentation", function () {
+            doc.on("change.htmlInstrumentation", function () {
                 if (_cachedValues[doc.file.fullPath]) {
                     _cachedValues[doc.file.fullPath].dirty = true;
                 }

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -133,6 +133,7 @@ define(function (require, exports, module) {
     
     // Dependencies
     var CodeMirror            = require("thirdparty/CodeMirror2/lib/codemirror"),
+        EventDispatcher       = require("utils/EventDispatcher"),
         Async                 = require("utils/Async"),
         FileUtils             = require("file/FileUtils"),
         _defaultLanguagesJSON = require("text!language/languages.json"),
@@ -357,7 +358,7 @@ define(function (require, exports, module) {
     function _triggerLanguageAdded(language) {
         // finally, store language to _language map
         _languages[language.getId()] = language;
-        $(exports).triggerHandler("languageAdded", [language]);
+        exports.trigger("languageAdded", language);
     }
 
     /**
@@ -366,7 +367,7 @@ define(function (require, exports, module) {
      * @param {!Language} language The modified language
      */
     function _triggerLanguageModified(language) {
-        $(exports).triggerHandler("languageModified", [language]);
+        exports.trigger("languageModified", language);
     }
     
     /**
@@ -1056,6 +1057,8 @@ define(function (require, exports, module) {
     }
     
    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // Prevent modes from being overwritten by extensions
     _patchCodeMirror();
     

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, window, brackets, navigator */
+/*global require, define, window, brackets, navigator, jQuery */
 
 /**
  * The bootstrapping module for brackets. This module sets up the require
@@ -59,6 +59,22 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
         locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
     });
 }
+
+// jQuery patch for event dispatchers
+// TODO: once all core usages fixed, we can move this into brackets.js since only extensions will need it
+(function () {
+    "use strict";
+    var DefaultCtor = jQuery.fn.init;
+
+    jQuery.fn.init = function (firstArg, secondArg) {
+        var jQObject = new DefaultCtor(firstArg, secondArg);
+        if (firstArg && firstArg._EventDispatcher) {
+            jQObject.on  = firstArg.on.bind(firstArg);
+            jQObject.off = firstArg.off.bind(firstArg);
+        }
+        return jQObject;
+    };
+}());
 
 define(function (require) {
     "use strict";

--- a/src/main.js
+++ b/src/main.js
@@ -79,10 +79,12 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
             // shouldn't be doing that anyway since it's basically poking at private API
             
             // Console warning, since $() is deprecated for EventDispatcher objects
-            // Check if this is an extension vs. core - 4th line of stack trace is $()'s caller
+            // Check if this is an extension vs. core - 4th line of stack trace (3rd stack frame) is $()'s caller
             var stack = new Error().stack.split("\n");
-            if (stack[3].indexOf("/extensions/") === -1 || stack[3].indexOf("/extensions/default/") !== -1) {
-                // Report more agressively if core code is still using deprecated $()
+            if (stack[3].indexOf("/dev/src/") !== -1 && stack[3].indexOf("/extensions/dev/") === -1) {
+                // Report more agressively if core code is still using deprecated $(). This detection only
+                // works in dev builds, since r.js-concatenated builds don't provide much path info in the
+                // stack trace, and we don't want an overbroad check that would flag r.js extension code too.
                 console.error("Core code should no longer be using $().on/off()!");
                 console.assert();  // force dev tools to pause
                 

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,7 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
             if (stack[3].indexOf("/extensions/") === -1 || stack[3].indexOf("/extensions/default/") !== -1) {
                 // Report more agressively if core code is still using deprecated $()
                 console.error("Core code should no longer be using $().on/off()!");
-                console.assert(false);  // force dev tools to pause
+                console.assert();  // force dev tools to pause
                 
             // TODO: Enable warnings for extensions once they've had some time to update (too much spam for now)
 //            } else {

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,8 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
         if (firstArg && firstArg._EventDispatcher) {
             jQObject.on  = firstArg.on.bind(firstArg);
             jQObject.off = firstArg.off.bind(firstArg);
+            // We don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
+            // shouldn't be doing that anyway since it's basically poking at private API
         }
         return jQObject;
     };

--- a/src/main.js
+++ b/src/main.js
@@ -68,11 +68,29 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
 
     jQuery.fn.init = function (firstArg, secondArg) {
         var jQObject = new DefaultCtor(firstArg, secondArg);
+        
+        // Is this a Brackets EventDispatcher object? (not a DOM node or other object)
         if (firstArg && firstArg._EventDispatcher) {
+            // Patch the jQ wrapper object so it calls EventDispatcher's APIs instead of jQuery's
             jQObject.on  = firstArg.on.bind(firstArg);
+            jQObject.one = firstArg.one.bind(firstArg);
             jQObject.off = firstArg.off.bind(firstArg);
             // We don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
             // shouldn't be doing that anyway since it's basically poking at private API
+            
+            // Console warning, since $() is deprecated for EventDispatcher objects
+            // Check if this is an extension vs. core - 4th line of stack trace is $()'s caller
+            var stack = new Error().stack.split("\n");
+            if (stack[3].indexOf("/extensions/") === -1 || stack[3].indexOf("/extensions/default/") !== -1) {
+                // Report more agressively if core code is still using deprecated $()
+                console.error("Core code should no longer be using $().on/off()!");
+                console.assert(false);  // force dev tools to pause
+                
+            // TODO: Enable warnings for extensions once they've had some time to update (too much spam for now)
+//            } else {
+//                var stackStr = "\n" + stack.slice(1).join("\n");  // trim off "Error" prefix
+//                console.warn("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly.", stackStr);
+            }
         }
         return jQObject;
     };

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
 
     var Immutable           = require("thirdparty/immutable"),
         _                   = require("thirdparty/lodash"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         FileUtils           = require("file/FileUtils");
 
     // Constants
@@ -56,12 +57,16 @@ define(function (require, exports, module) {
      *
      * Contains the treeData used to generate the file tree and methods used to update that
      * treeData.
+     * 
+     * Instances dispatch the following events:
+     * - "change" (FileTreeViewModel.EVENT_CHANGE constant): Fired any time there's a change that should be reflected in the view.
      */
     function FileTreeViewModel() {
         // For convenience in callbacks, make a bound version of this method so that we can
         // just refer to it as this._commit when passing in a callback.
         this._commit = this._commit.bind(this);
     }
+    EventDispatcher.makeEventDispatcher(FileTreeViewModel.prototype);
 
     /**
      * @type {boolean}
@@ -149,7 +154,7 @@ define(function (require, exports, module) {
             changed = true;
         }
         if (changed) {
-            $(this).trigger(EVENT_CHANGE);
+            this.trigger(EVENT_CHANGE);
         }
     };
 
@@ -1083,7 +1088,7 @@ define(function (require, exports, module) {
     FileTreeViewModel.prototype.setSortDirectoriesFirst = function (sortDirectoriesFirst) {
         if (sortDirectoriesFirst !== this.sortDirectoriesFirst) {
             this.sortDirectoriesFirst = sortDirectoriesFirst;
-            $(this).trigger(EVENT_CHANGE);
+            this.trigger(EVENT_CHANGE);
         }
     };
     
@@ -1122,25 +1127,6 @@ define(function (require, exports, module) {
         // Does not emit change event. See SPECIAL CASE NOTE in docstring above.
     };
     
-    /**
-     * Listen for events. Currently a wrapper around jQuery's event system. See jQuery's .on
-     * documentation.
-     *
-     * Events published by the FileTreeViewModel:
-     *
-     * * change (EVENT_CHANGE constant in the module): fired any time there's a change that should be reflected in the view.
-     */
-    FileTreeViewModel.prototype.on = function (event, handler) {
-        $(this).on(event, handler);
-    };
-
-    /**
-     * Stop listening for events. See jQuery's .off documentation.
-     */
-    FileTreeViewModel.prototype.off = function (event, handler) {
-        $(this).off(event, handler);
-    };
-
     // Private API
     exports.EVENT_CHANGE          = EVENT_CHANGE;
     exports._filePathToObjectPath = _filePathToObjectPath;

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global define, $*/
+/*global define */
 /*unittests: FileTreeViewModel*/
 
 /**

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -38,8 +38,8 @@
  *    - projectRefresh     -- when project tree is re-rendered for a reason other than
  *      a project being opened (e.g. from the Refresh command)
  *
- * These are jQuery events, so to listen for them you do something like this:
- *    $(ProjectManager).on("eventname", handler);
+ * To listen for events, do something like this: (see EventDispatcher for details on this pattern)
+ *    ProjectManager.on("eventname", handler);
  */
 define(function (require, exports, module) {
     "use strict";
@@ -59,6 +59,7 @@ define(function (require, exports, module) {
         Commands            = require("command/Commands"),
         Dialogs             = require("widgets/Dialogs"),
         DefaultDialogs      = require("widgets/DefaultDialogs"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         LanguageManager     = require("language/LanguageManager"),
         Menus               = require("command/Menus"),
         StringUtils         = require("utils/StringUtils"),
@@ -820,7 +821,7 @@ define(function (require, exports, module) {
 
             // About to close current project (if any)
             if (model.projectRoot) {
-                $(exports).triggerHandler("beforeProjectClose", model.projectRoot);
+                exports.trigger("beforeProjectClose", model.projectRoot);
             }
 
             // close all the old files
@@ -831,7 +832,7 @@ define(function (require, exports, module) {
                 if (model.projectRoot) {
                     LanguageManager._resetPathLanguageOverrides();
                     PreferencesManager._reloadUserPrefs(model.projectRoot);
-                    $(exports).triggerHandler("projectClose", model.projectRoot);
+                    exports.trigger("projectClose", model.projectRoot);
                 }
 
                 startLoad.resolve();
@@ -881,11 +882,10 @@ define(function (require, exports, module) {
 
                             if (projectRootChanged) {
                                 // Allow asynchronous event handlers to finish before resolving result by collecting promises from them
-                                var promises = [];
-                                $(exports).triggerHandler({ type: "projectOpen", promises: promises }, [model.projectRoot]);
-                                $.when.apply($, promises).then(result.resolve, result.reject);
+                                exports.trigger("projectOpen", model.projectRoot);
+                                result.resolve();
                             } else {
-                                $(exports).triggerHandler("projectRefresh", model.projectRoot);
+                                exports.trigger("projectRefresh", model.projectRoot);
                                 result.resolve();
                             }
                             PerfUtils.addMeasurement(perfTimerName);
@@ -1136,6 +1136,11 @@ define(function (require, exports, module) {
     
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
+        // Due to circular dependencies, can't attach event handlers until all modules loaded
+        FileViewController.on("documentSelectionFocusChange", _documentSelectionFocusChange);
+        FileViewController.on("fileViewFocusChange", _fileViewControllerChange);
+        MainViewManager.on("currentFileChange", _currentFileChange);
+        
         $projectTreeContainer = $("#project-files-container");
         $projectTreeContainer.addClass("jstree jstree-brackets");
         $projectTreeContainer.css("overflow", "auto");
@@ -1156,11 +1161,11 @@ define(function (require, exports, module) {
             $projectTreeContainer.trigger("contentChanged");
         });
 
-        $(Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU)).on("beforeContextMenuOpen", function () {
+        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuOpen", function () {
             actionCreator.restoreContext();
         });
 
-        $(Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU)).on("beforeContextMenuClose", function () {
+        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuClose", function () {
             model.setContext(null, false, true);
         });
 
@@ -1220,6 +1225,9 @@ define(function (require, exports, module) {
         return null;
     }
 
+    
+    EventDispatcher.makeEventDispatcher(exports);
+
     // Init default project path to welcome project
     PreferencesManager.stateManager.definePreference("projectPath", "string", _getWelcomeProjectPath());
 
@@ -1230,14 +1238,9 @@ define(function (require, exports, module) {
         "projectBaseUrl_": "user"
     }, true, _checkPreferencePrefix);
 
-    $(exports).on("projectOpen", _reloadProjectPreferencesScope);
-    $(exports).on("projectOpen", _saveProjectPath);
-
-    // Event Handlers
-    $(FileViewController).on("documentSelectionFocusChange", _documentSelectionFocusChange);
-    $(FileViewController).on("fileViewFocusChange", _fileViewControllerChange);
-    $(MainViewManager).on("currentFileChange", _currentFileChange);
-    $(exports).on("beforeAppClose", _unwatchProjectRoot);
+    exports.on("projectOpen", _reloadProjectPreferencesScope);
+    exports.on("projectOpen", _saveProjectPath);
+    exports.on("beforeAppClose", _unwatchProjectRoot);
 
     // Commands
     CommandManager.register(Strings.CMD_OPEN_FOLDER,      Commands.FILE_OPEN_FOLDER,      openProject);
@@ -1376,7 +1379,8 @@ define(function (require, exports, module) {
     function rerenderTree() {
         _renderTree(true);
     }
-
+    
+    
     // Private API helpful in testing
     exports._actionCreator                 = actionCreator;
     

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1136,11 +1136,6 @@ define(function (require, exports, module) {
     
     // Initialize variables and listeners that depend on the HTML DOM
     AppInit.htmlReady(function () {
-        // Due to circular dependencies, can't attach event handlers until all modules loaded
-        FileViewController.on("documentSelectionFocusChange", _documentSelectionFocusChange);
-        FileViewController.on("fileViewFocusChange", _fileViewControllerChange);
-        MainViewManager.on("currentFileChange", _currentFileChange);
-        
         $projectTreeContainer = $("#project-files-container");
         $projectTreeContainer.addClass("jstree jstree-brackets");
         $projectTreeContainer.css("overflow", "auto");
@@ -1242,6 +1237,11 @@ define(function (require, exports, module) {
     exports.on("projectOpen", _saveProjectPath);
     exports.on("beforeAppClose", _unwatchProjectRoot);
 
+    // Due to circular dependencies, not safe to call on() directly for other modules' events
+    EventDispatcher.on_duringInit(FileViewController, "documentSelectionFocusChange", _documentSelectionFocusChange);
+    EventDispatcher.on_duringInit(FileViewController, "fileViewFocusChange", _fileViewControllerChange);
+    EventDispatcher.on_duringInit(MainViewManager, "currentFileChange", _currentFileChange);
+    
     // Commands
     CommandManager.register(Strings.CMD_OPEN_FOLDER,      Commands.FILE_OPEN_FOLDER,      openProject);
     CommandManager.register(Strings.CMD_PROJECT_SETTINGS, Commands.FILE_PROJECT_SETTINGS, _projectSettings);
@@ -1383,7 +1383,6 @@ define(function (require, exports, module) {
     
     // Private API helpful in testing
     exports._actionCreator                 = actionCreator;
-    
     
     // Private API for use with SidebarView
     exports._setFileTreeSelectionWidth    = _setFileTreeSelectionWidth;

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var InMemoryFile        = require("document/InMemoryFile"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         FileUtils           = require("file/FileUtils"),
         _                   = require("thirdparty/lodash"),
         FileSystem          = require("filesystem/FileSystem"),
@@ -207,6 +208,12 @@ define(function (require, exports, module) {
      *
      * The ProjectModel provides methods for accessing information about the current open project.
      * It also manages the view model to display a FileTreeView of the project.
+     * 
+     * Events:
+     * - EVENT_CHANGE (`change`) - Fired when there's a change that should refresh the UI
+     * - EVENT_SHOULD_SELECT (`select`) - Fired when a selection has been made in the file tree and the file tree should be selected
+     * - EVENT_SHOULD_FOCUS (`focus`)
+     * - ERROR_CREATION (`creationError`) - Triggered when there's a problem creating a file
      */
     function ProjectModel(initial) {
         initial = initial || {};
@@ -219,10 +226,11 @@ define(function (require, exports, module) {
         }
         this._viewModel = new FileTreeViewModel.FileTreeViewModel();
         this._viewModel.on(FileTreeViewModel.EVENT_CHANGE, function () {
-            $(this).trigger(EVENT_CHANGE);
+            this.trigger(EVENT_CHANGE);
         }.bind(this));
         this._selections = {};
     }
+    EventDispatcher.makeEventDispatcher(ProjectModel.prototype);
 
     /**
      * @type {Directory}
@@ -477,26 +485,6 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Adds an event listener for this ProjectModel. See jQuery's documentation for .on.
-     *
-     * Available events:
-     *
-     * * EVENT_CHANGE (`change`) - Fired when there's a change that should refresh the UI
-     * * EVENT_SHOULD_SELECT (`select`) - Specifies that a selection has been made in the file tree and that the file tree should be selected
-     * * ERROR_CREATION (`creationError`) - Triggered when there is a problem creating a file.
-     */
-    ProjectModel.prototype.on = function (event, handler) {
-        $(this).on(event, handler);
-    };
-
-    /**
-     * Removes an event listener for this ProjectModel. See jQuery's documentation for .off.
-     */
-    ProjectModel.prototype.off = function (event, handler) {
-        $(this).off(event, handler);
-    };
-
-    /**
      * Sets the project root (effectively resetting this ProjectModel).
      *
      * @param {Directory} projectRoot new project root
@@ -668,14 +656,14 @@ define(function (require, exports, module) {
 
         if (path) {
             if (!doNotOpen) {
-                $(this).trigger(EVENT_SHOULD_SELECT, {
+                this.trigger(EVENT_SHOULD_SELECT, {
                     path: path,
                     previousPath: previousSelection,
                     hadFocus: this._focused
                 });
             }
             
-            $(this).trigger(EVENT_SHOULD_FOCUS);
+            this.trigger(EVENT_SHOULD_FOCUS);
         }
     };
     
@@ -704,7 +692,7 @@ define(function (require, exports, module) {
      */
     ProjectModel.prototype.selectInWorkingSet = function (path) {
         this.performRename();
-        $(this).trigger(EVENT_SHOULD_SELECT, {
+        this.trigger(EVENT_SHOULD_SELECT, {
             path: path,
             add: true
         });
@@ -973,7 +961,7 @@ define(function (require, exports, module) {
                 self.selectInWorkingSet(entry.fullPath);
             }
         }).fail(function (error) {
-            $(self).trigger(ERROR_CREATION, {
+            self.trigger(ERROR_CREATION, {
                 type: error,
                 name: name,
                 isFolder: isFolder

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -238,15 +238,15 @@ define(function (require, exports, module) {
         }
         
         // wire up an event handler to monitor when panes are created
-        $(MainViewManager).on("paneCreate", function (evt, paneId) {
+        MainViewManager.on("paneCreate", function (evt, paneId) {
             WorkingSetView.createWorkingSetViewForPane($workingSetViewsContainer, paneId);
         });
         
-        $(MainViewManager).on("paneLayoutChange", function () {
+        MainViewManager.on("paneLayoutChange", function () {
             _updateUIStates();
         });
         
-        $(MainViewManager).on("workingSetAdd workingSetAddList workingSetRemove workingSetRemoveList workingSetUpdate", function () {
+        MainViewManager.on("workingSetAdd workingSetAddList workingSetRemove workingSetRemoveList workingSetUpdate", function () {
             _updateWorkingSetState();
         });
         
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
         $splitViewMenu.attr("title", Strings.SPLITVIEW_MENU_TOOLTIP);
     });
     
-    $(ProjectManager).on("projectOpen", _updateProjectTitle);
+    ProjectManager.on("projectOpen", _updateProjectTitle);
     
     /**
      * Register Command Handlers

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
      * @private
      */
     function _removeListeners() {
-        $(MainViewManager).off(".sort");
+        MainViewManager.off(".sort");
     }
     
     /**
@@ -173,7 +173,7 @@ define(function (require, exports, module) {
      */
     function _addListeners() {
         if (_automaticSort && _currentSort && _currentSort.getEvents()) {
-            $(MainViewManager)
+            MainViewManager
                 .on(_currentSort.getEvents(), function () {
                     _currentSort.sort();
                 })

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 /**
  * Manages the workingSetList sort methods.

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -1364,18 +1364,18 @@ define(function (require, exports, module) {
         this.$openFilesList = this.$el.find("ul");
         
         // Register listeners
-        $(MainViewManager).on(this._makeEventName("workingSetAdd"), _.bind(this._handleFileAdded, this));
-        $(MainViewManager).on(this._makeEventName("workingSetAddList"), _.bind(this._handleFileListAdded, this));
-        $(MainViewManager).on(this._makeEventName("workingSetRemove"), _.bind(this._handleFileRemoved, this));
-        $(MainViewManager).on(this._makeEventName("workingSetRemoveList"), _.bind(this._handleRemoveList, this));
-        $(MainViewManager).on(this._makeEventName("workingSetSort"), _.bind(this._handleWorkingSetSort, this));
-        $(MainViewManager).on(this._makeEventName("activePaneChange"), _.bind(this._handleActivePaneChange, this));
-        $(MainViewManager).on(this._makeEventName("paneLayoutChange"), _.bind(this._handlePaneLayoutChange, this));
-        $(MainViewManager).on(this._makeEventName("workingSetUpdate"), _.bind(this._handleWorkingSetUpdate, this));
+        MainViewManager.on(this._makeEventName("workingSetAdd"), _.bind(this._handleFileAdded, this));
+        MainViewManager.on(this._makeEventName("workingSetAddList"), _.bind(this._handleFileListAdded, this));
+        MainViewManager.on(this._makeEventName("workingSetRemove"), _.bind(this._handleFileRemoved, this));
+        MainViewManager.on(this._makeEventName("workingSetRemoveList"), _.bind(this._handleRemoveList, this));
+        MainViewManager.on(this._makeEventName("workingSetSort"), _.bind(this._handleWorkingSetSort, this));
+        MainViewManager.on(this._makeEventName("activePaneChange"), _.bind(this._handleActivePaneChange, this));
+        MainViewManager.on(this._makeEventName("paneLayoutChange"), _.bind(this._handlePaneLayoutChange, this));
+        MainViewManager.on(this._makeEventName("workingSetUpdate"), _.bind(this._handleWorkingSetUpdate, this));
 
-        $(DocumentManager).on(this._makeEventName("dirtyFlagChange"), _.bind(this._handleDirtyFlagChanged, this));
+        DocumentManager.on(this._makeEventName("dirtyFlagChange"), _.bind(this._handleDirtyFlagChanged, this));
 
-        $(FileViewController).on(this._makeEventName("documentSelectionFocusChange") + " " + this._makeEventName("fileViewFocusChange"), _.bind(this._updateListSelection, this));
+        FileViewController.on(this._makeEventName("documentSelectionFocusChange") + " " + this._makeEventName("fileViewFocusChange"), _.bind(this._updateListSelection, this));
         
         // Show scroller shadows when open-files-container scrolls
         ViewUtils.addScrollerShadow(this.$openFilesContainer[0], null, true);
@@ -1398,15 +1398,15 @@ define(function (require, exports, module) {
         ViewUtils.removeScrollerShadow(this.$openFilesContainer[0], null);
         this.$openFilesContainer.off(".workingSetView");
         this.$el.remove();
-        $(MainViewManager).off(this._makeEventName(""));
-        $(DocumentManager).off(this._makeEventName(""));
-        $(FileViewController).off(this._makeEventName(""));
+        MainViewManager.off(this._makeEventName(""));
+        DocumentManager.off(this._makeEventName(""));
+        FileViewController.off(this._makeEventName(""));
     };
     
     /**
      * paneDestroy event handler
      */
-    $(MainViewManager).on("paneDestroy", function (e, paneId) {
+    MainViewManager.on("paneDestroy", function (e, paneId) {
         var view = _views[paneId];
         delete _views[view.paneId];
         view.destroy();

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -487,9 +487,9 @@ define(function (require, exports, module) {
         _picker.$button.addClass("file-filter-picker no-focus");
         
         // Set up mouse click event listeners for 'Delete' and 'Edit' buttons
-        $(_picker).on("listRendered", _handleListRendered);
+        _picker.on("listRendered", _handleListRendered);
         
-        $(_picker).on("select", function (event, item, itemIndex) {
+        _picker.on("select", function (event, item, itemIndex) {
             if (itemIndex === 0) {
                 // Close the dropdown first before opening the edit filter dialog 
                 // so that it will restore focus to the DOM element that has focus

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var _                  = require("thirdparty/lodash"),
+        EventDispatcher    = require("utils/EventDispatcher"),
         Commands           = require("command/Commands"),
         KeyBindingManager  = require("command/KeyBindingManager"),
         KeyEvent           = require("utils/KeyEvent"),
@@ -84,6 +85,7 @@ define(function (require, exports, module) {
         this._closed = false;
         this._enabled = true;
     }
+    EventDispatcher.makeEventDispatcher(FindBar.prototype);
     
     /*
      * Global FindBar functions for making sure only one is open at a time.
@@ -235,14 +237,14 @@ define(function (require, exports, module) {
         this._modalBar = new ModalBar(Mustache.render(_searchBarTemplate, templateVars), true);  // 2nd arg = auto-close on Esc/blur
         
         // When the ModalBar closes, clean ourselves up.
-        $(this._modalBar).on("close", function (event) {
+        this._modalBar.on("close", function (event) {
             // Hide error popup, since it hangs down low enough to make the slide-out look awkward
             self.showError(null);
             self._modalBar = null;
             self._closed = true;
             FindBar._removeFindBar(self);
             MainViewManager.focusActivePane();
-            $(self).trigger("close");
+            self.trigger("close");
         });
         
         FindBar._addFindBar(this);
@@ -250,12 +252,12 @@ define(function (require, exports, module) {
         var $root = this._modalBar.getRoot();
         $root
             .on("input", "#find-what", function () {
-                $(self).triggerHandler("queryChange");
+                self.trigger("queryChange");
             })
             .on("click", "#find-case-sensitive, #find-regexp", function (e) {
                 $(e.currentTarget).toggleClass("active");
                 self._updatePrefsFromSearchBar();
-                $(self).triggerHandler("queryChange");
+                self.trigger("queryChange");
             })
             .on("keydown", "#find-what, #replace-with", function (e) {
                 if (e.keyCode === KeyEvent.DOM_VK_RETURN) {
@@ -268,15 +270,15 @@ define(function (require, exports, module) {
                                 self.focusReplace();
                             } else {
                                 // Trigger a Find (which really means "Find All" in this context).
-                                $(self).triggerHandler("doFind");
+                                self.trigger("doFind");
                             }
                         } else {
-                            $(self).triggerHandler("doReplaceAll");
+                            self.trigger("doReplaceAll");
                         }
                     } else {
                         // In the single file case, we just want to trigger a Find Next (or Find Previous
                         // if Shift is held down).
-                        $(self).triggerHandler("doFind", [e.shiftKey]);
+                        self.trigger("doFind", e.shiftKey);
                     }
                 }
             });
@@ -286,10 +288,10 @@ define(function (require, exports, module) {
             this._addShortcutToTooltip($("#find-prev"), Commands.CMD_FIND_PREVIOUS);
             $root
                 .on("click", "#find-next", function (e) {
-                    $(self).triggerHandler("doFind", false);
+                    self.trigger("doFind", false);
                 })
                 .on("click", "#find-prev", function (e) {
-                    $(self).triggerHandler("doFind", true);
+                    self.trigger("doFind", true);
                 });
         }
         
@@ -297,10 +299,10 @@ define(function (require, exports, module) {
             this._addShortcutToTooltip($("#replace-yes"), Commands.CMD_REPLACE);
             $root
                 .on("click", "#replace-yes", function (e) {
-                    $(self).triggerHandler("doReplace");
+                    self.trigger("doReplace");
                 })
                 .on("click", "#replace-all", function (e) {
-                    $(self).triggerHandler("doReplaceAll");
+                    self.trigger("doReplaceAll");
                 })
                 // One-off hack to make Find/Replace fields a self-contained tab cycle
                 // TODO: remove once https://trello.com/c/lTSJgOS2 implemented

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -61,9 +61,9 @@ define(function (require, exports, module) {
     
     /** Remove the listeners that were tracking potential search result changes */
     function _removeListeners() {
-        $(DocumentModule).off("documentChange", _documentChangeHandler);
+        DocumentModule.off("documentChange", _documentChangeHandler);
         FileSystem.off("change", _fileSystemChangeHandler);
-        $(DocumentManager).off("fileNameChange", _fileNameChangeHandler);
+        DocumentManager.off("fileNameChange", _fileNameChangeHandler);
     }
     
     /** Add listeners to track events that might change the search result set */
@@ -72,9 +72,9 @@ define(function (require, exports, module) {
             // Avoid adding duplicate listeners - e.g. if a 2nd search is run without closing the old results panel first
             _removeListeners();
         
-            $(DocumentModule).on("documentChange", _documentChangeHandler);
+            DocumentModule.on("documentChange", _documentChangeHandler);
             FileSystem.on("change", _fileSystemChangeHandler);
-            $(DocumentManager).on("fileNameChange",  _fileNameChangeHandler);
+            DocumentManager.on("fileNameChange",  _fileNameChangeHandler);
         }
     }
     

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -201,7 +201,7 @@ define(function (require, exports, module) {
             startSearch(_findBar.getReplaceText());
         }
         
-        $(_findBar)
+        _findBar
             .on("doFind.FindInFiles", function () {
                 // Subtle issue: we can't just pass startSearch directly as the handler, because
                 // we don't want it to get the event object as an argument.
@@ -209,14 +209,14 @@ define(function (require, exports, module) {
             })
             .on("queryChange.FindInFiles", handleQueryChange)
             .on("close.FindInFiles", function (e) {
-                $(_findBar).off(".FindInFiles");
+                _findBar.off(".FindInFiles");
                 _findBar = null;
             });
         
         if (showReplace) {
             // We shouldn't get a "doReplace" in this case, since the Replace button
             // is hidden when we set options.multifile.
-            $(_findBar).on("doReplaceAll.FindInFiles", startReplace);
+            _findBar.on("doReplaceAll.FindInFiles", startReplace);
         }
         
         var oldModalBarHeight = _findBar._modalBar.height();
@@ -369,7 +369,7 @@ define(function (require, exports, module) {
     AppInit.htmlReady(function () {
         var model = FindInFiles.searchModel;
         _resultsView = new SearchResultsView(model, "find-in-files-results", "find-in-files.results");
-        $(_resultsView)
+        _resultsView
             .on("replaceAll", function () {
                 _finishReplaceAll(model);
             })
@@ -379,7 +379,7 @@ define(function (require, exports, module) {
     });
     
     // Initialize: register listeners
-    $(ProjectManager).on("beforeProjectClose", function () { _resultsView.close(); });
+    ProjectManager.on("beforeProjectClose", function () { _resultsView.close(); });
     
     // Initialize: command handlers
     CommandManager.register(Strings.CMD_FIND_IN_FILES,       Commands.CMD_FIND_IN_FILES,       _showFindBar);

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -611,7 +611,7 @@ define(function (require, exports, module) {
         });
         findBar.open();
 
-        $(findBar)
+        findBar
             .on("queryChange.FindReplace", function (e) {
                 handleQueryChange(editor, state);
             })
@@ -625,7 +625,7 @@ define(function (require, exports, module) {
                 // Dispose highlighting UI (important to restore normal selection color as soon as focus goes back to the editor)
                 toggleHighlighting(editor, false);
 
-                $(findBar).off(".FindReplace");
+                findBar.off(".FindReplace");
                 findBar = null;
             });
         
@@ -689,7 +689,7 @@ define(function (require, exports, module) {
         
         openSearchBar(editor, true);
         
-        $(findBar)
+        findBar
             .on("doReplace.FindReplace", function (e) {
                 doReplace(editor, false);
             })
@@ -728,7 +728,7 @@ define(function (require, exports, module) {
         }
     }
 
-    $(MainViewManager).on("currentFileChange", _handleFileChanged);
+    MainViewManager.on("currentFileChange", _handleFileChanged);
 
     CommandManager.register(Strings.CMD_FIND,                   Commands.CMD_FIND,                  _launchFind);
     CommandManager.register(Strings.CMD_FIND_NEXT,              Commands.CMD_FIND_NEXT,             _findNext);

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -937,7 +937,7 @@ define(function (require, exports, module) {
     }
     
     // Listen for a change of project to invalidate our file list
-    $(ProjectManager).on("projectOpen", function () {
+    ProjectManager.on("projectOpen", function () {
         fileList = null;
     });
 

--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -140,7 +140,7 @@ define(function (require, exports, module) {
             _calcScaling();
             
             // Update tickmarks during editor resize (whenever resizing has paused/stopped for > 1/3 sec)
-            $(WorkspaceManager).on("workspaceUpdateLayout.ScrollTrackMarkers", _.debounce(function () {
+            WorkspaceManager.on("workspaceUpdateLayout.ScrollTrackMarkers", _.debounce(function () {
                 if (marks.length) {
                     _calcScaling();
                     $(".tickmark-track", editor.getRootElement()).empty();
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
             $(".tickmark-track", curEditor.getRootElement()).remove();
             editor = null;
             marks = [];
-            $(WorkspaceManager).off("workspaceUpdateLayout.ScrollTrackMarkers");
+            WorkspaceManager.off("workspaceUpdateLayout.ScrollTrackMarkers");
         }
     }
     

--- a/src/search/SearchModel.js
+++ b/src/search/SearchModel.js
@@ -21,12 +21,13 @@
  * 
  */
 
-/*global define, $ */
+/*global define */
 
 define(function (require, exports, module) {
     "use strict";
     
     var FileUtils   = require("file/FileUtils"),
+        EventDispatcher = require("utils/EventDispatcher"),
         FindUtils   = require("search/FindUtils");
 
     /**
@@ -39,6 +40,7 @@ define(function (require, exports, module) {
     function SearchModel() {
         this.clear();
     }
+    EventDispatcher.makeEventDispatcher(SearchModel.prototype);
 
     /** @const Constant used to define the maximum results found. 
      *  Note that this is a soft limit - we'll likely go slightly over it since
@@ -223,9 +225,9 @@ define(function (require, exports, module) {
      *      often, meaning that the view should buffer updates.
      */
     SearchModel.prototype.fireChanged = function (quickChange) {
-        $(this).triggerHandler("change", quickChange);
+        this.trigger("change", quickChange);
     };
-
+    
     // Public API
     exports.SearchModel = SearchModel;
 });

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var CommandManager        = require("command/CommandManager"),
+        EventDispatcher       = require("utils/EventDispatcher"),
         Commands              = require("command/Commands"),
         DocumentManager       = require("document/DocumentManager"),
         EditorManager         = require("editor/EditorManager"),
@@ -80,6 +81,7 @@ define(function (require, exports, module) {
         this._$table   = this._panel.$panel.find(".table-container");
         this._model    = model;
     }
+    EventDispatcher.makeEventDispatcher(SearchResultsView.prototype);
     
     /** @type {SearchModel} The search results model we're viewing. */
     SearchResultsView.prototype._model = null;
@@ -323,7 +325,7 @@ define(function (require, exports, module) {
                     e.stopPropagation();
                 })
                 .on("click.searchResults", ".replace-checked", function (e) {
-                    $(self).triggerHandler("replaceAll");
+                    self.trigger("replaceAll");
                 });
         }
     };
@@ -549,7 +551,7 @@ define(function (require, exports, module) {
         
         // Listen for user interaction events with the panel and change events from the model.
         this._addPanelListeners();
-        $(this._model).on("change.SearchResultsView", this._handleModelChange.bind(this));
+        this._model.on("change.SearchResultsView", this._handleModelChange.bind(this));
     };
     
     /**
@@ -560,8 +562,8 @@ define(function (require, exports, module) {
             this._$table.empty();
             this._panel.hide();
             this._panel.$panel.off(".searchResults");
-            $(this._model).off("change.SearchResultsView");
-            $(this).triggerHandler("close");
+            this._model.off("change.SearchResultsView");
+            this.trigger("close");
         }
     };
     

--- a/src/utils/AppInit.js
+++ b/src/utils/AppInit.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
             // add callbacks to this, we need to be robust to exceptions
             handler();
         } catch (e) {
-            console.error("Exception when calling a 'brackets done loading' handler:");
+            console.error("Exception when calling a 'brackets done loading' handler: " + e);
             console.log(e.stack);
         }
     }

--- a/src/utils/DeprecationWarning.js
+++ b/src/utils/DeprecationWarning.js
@@ -97,8 +97,8 @@ define(function (require, exports, module) {
      * Show a deprecation warning if there are listeners for the event
      * 
      * ```
-     *    DeprecationWarning.deprecateEvent($(exports), 
-     *                                      $(MainViewManager), 
+     *    DeprecationWarning.deprecateEvent(exports, 
+     *                                      MainViewManager, 
      *                                      "workingSetAdd", 
      *                                      "workingSetAdd", 
      *                                      "DocumentManager.workingSetAdd", 
@@ -117,9 +117,9 @@ define(function (require, exports, module) {
         EventDispatcher.markDeprecated(outbound, oldEventName, canonicalInboundName);
         
         // create an event handler for the new event to listen for 
-        $(inbound).on(newEventName, function () {
+        inbound.on(newEventName, function () {
             // Dispatch the event in case anyone is still listening
-            $(outbound).trigger(oldEventName, Array.prototype.slice.call(arguments, 1));
+            EventDispatcher.triggerWithArray(outbound, oldEventName, Array.prototype.slice.call(arguments, 1));
         });
     }
     

--- a/src/utils/DeprecationWarning.js
+++ b/src/utils/DeprecationWarning.js
@@ -21,7 +21,7 @@
  * 
  */
 
-/*global define, console, $ */
+/*global define, console */
 
 /**
  *  Utilities functions to display deprecation warning in the console.

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -260,6 +260,24 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Utility for attaching an event handler to an object that has not YET had makeEventDispatcher() called
+     * on it, but will in the future. Once 'futureDispatcher' becomes a real event dispatcher, any handlers
+     * attached here will be retained.
+     * 
+     * Useful with core modules that have circular dependencies (one module initially gets an empty copy of the
+     * other, with no on() API present yet). Unlike other strategies like waiting for htmlReady(), this helper
+     * guarantees you won't miss any future events, regardless of how soon the other module finishes init and
+     * starts calling trigger().
+     * 
+     * @param {!Object} futureDispatcher
+     * @param {string} events
+     * @param {?function(!{type:string, target:!Object}, ...)} fn
+     */
+    function on_duringInit(futureDispatcher, events, fn) {
+        on.call(futureDispatcher, events, fn);
+    }
+    
+    /**
      * Mark a given event name as deprecated, such that on() will emit warnings when called with it.
      * May be called before makeEventDispatcher(). May be called on a prototype where makeEventDispatcher()
      * is called separately per instance (i.e. in the constructor).
@@ -278,5 +296,6 @@ define(function (require, exports, module) {
     
     exports.makeEventDispatcher = makeEventDispatcher;
     exports.triggerWithArray    = triggerWithArray;
+    exports.on_duringInit       = on_duringInit;
     exports.markDeprecated      = markDeprecated;
 });

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -61,8 +61,9 @@ define(function (require, exports, module) {
 
     
     /**
-     * @param {string} eventName Event name, optionally with trailing ".namespace" part
-     * @return {!{event:string, ns:string}} Record containing separate event name and namespace
+     * Split "event.namespace" string into its two parts; both parts are optional.
+     * @param {string} eventName Event name and/or trailing ".namespace"
+     * @return {!{event:string, ns:string}} Uses "" for missing parts.
      */
     function splitNs(eventStr) {
         var dot = eventStr.indexOf(".");
@@ -94,7 +95,7 @@ define(function (require, exports, module) {
                 if (deprecation) {
                     var message = "Registering for deprecated event '" + eventsList[i].eventName + "'.";
                     if (typeof deprecation === "string") {
-                        message += " Use " + deprecation + " instead.";
+                        message += " Instead, use " + deprecation + ".";
                     }
                     console.warn(message, new Error().stack);
                 }
@@ -208,7 +209,7 @@ define(function (require, exports, module) {
             return;
         }
         
-        // Use a clone of the list so we're frozen in the face of concurrent on()/off() calls
+        // Use a clone of the list in case handlers call on()/off() while we're still in the loop
         handlerList = handlerList.slice();
 
         // Pass 'event' object followed by any additional args trigger() was given
@@ -221,7 +222,7 @@ define(function (require, exports, module) {
                 handlerList[i].handler.apply(null, applyArgs);
             } catch (err) {
                 console.error("Exception in '" + eventName + "' listener on", this, String(err), err.stack);
-                console.assert(false);  // causes dev tools to break, just like an uncaught exception
+                console.assert();  // causes dev tools to pause, just like an uncaught exception
             }
         }
     };

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
     /**
      * Adds the given handler function to 'events': a space-separated list of one or more event names, each
      * with an optional ".namespace" (used by off() - see below). If the handler is already listening to this
-     * event, another copy is added.
+     * event, a duplicate copy is added.
      * @param {string} events
      * @param {!function(!{type:string, target:!Object}, ...)} fn
      */
@@ -122,8 +122,7 @@ define(function (require, exports, module) {
      * Removes one or more handler functions based on the space-separated 'events' list. Each item in
      * 'events' can be: bare event name, bare .namespace, or event.namespace pair. This yields a set of
      * matching handlers. If 'fn' is ommitted, all these handlers are removed. If 'fn' is provided,
-     * only handlers exactly equal to 'fn' are removed (there may still be >1, if duplicates were
-     * added).
+     * only handlers exactly equal to 'fn' are removed (there may still be >1, if duplicates were added).
      * @param {string} events
      * @param {?function(!{type:string, target:!Object}, ...)} fn
      */
@@ -144,9 +143,10 @@ define(function (require, exports, module) {
             
             // Walk backwards so it's easy to remove items
             for (k = handlerList.length - 1; k >= 0; k--) {
-                // Look at ns & fn only - caller has already taken care of eventName
+                // Look at ns & fn only - doRemove() has already taken care of eventName
                 if (!eventRec.ns || eventRec.ns === handlerList[k].ns) {
-                    if (!fn || fn === handlerList[k].handler) {
+                    var handler = handlerList[k].handler;
+                    if (!fn || fn === handler || fn._eventOnceWrapper === handler) {
                         handlerList.splice(k, 1);
                     }
                 }
@@ -183,7 +183,7 @@ define(function (require, exports, module) {
      * @param {?function(!{type:string, target:!Object}, ...)} fn
      */
     var one = function (events, fn) {
-        // Tie wrapper uniqueness to fn uniqueness, so ...
+        // Wrap fn in a self-detaching handler; saved on the original fn so off() can detect it later
         if (!fn._eventOnceWrapper) {
             fn._eventOnceWrapper = function (event) {
                 // Note: this wrapper is reused for all attachments of the same fn, so it shouldn't reference

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -119,7 +119,7 @@ define(function (require, exports, module) {
     
     /**
      * Removes one or more handler functions based on the space-separated 'events' list. Each item in
-     * 'events' can be: bare event name, bare namespace, or event.namespace pair. This yields a set of
+     * 'events' can be: bare event name, bare .namespace, or event.namespace pair. This yields a set of
      * matching handlers. If 'fn' is ommitted, all these handlers are removed. If 'fn' is provided,
      * only handlers exactly equal to 'fn' are removed (there may still be >1, if duplicates were
      * added).
@@ -228,8 +228,8 @@ define(function (require, exports, module) {
     
     
     /**
-     * Adds the EventDispatcher APIs to the given object. May also be called on a prototype object,
-     * in which case each instance will behave independently.
+     * Adds the EventDispatcher APIs to the given object: on(), one(), off(), and trigger(). May also be
+     * called on a prototype object - each instance will still behave independently.
      * @param {!Object} obj Object to add event-dispatch methods to
      */
     function makeEventDispatcher(obj) {
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
     /**
      * Mark a given event name as deprecated, such that on() will emit warnings when called with it.
      * May be called before makeEventDispatcher(). May be called on a prototype where makeEventDispatcher()
-     * is called separately per instance (in the ctor).
+     * is called separately per instance (i.e. in the constructor).
      * @param {!Object} obj Event dispatcher object
      * @param {string} eventName Name of deprecated event
      * @param {string=} insteadStr Suggested thing to use instead

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014 Adobe Systems Incorporated. All rights reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, jQuery */
+
+/**
+ * Implements a jQuery-like event dispatch pattern for non-DOM objects:
+ *  - Listeners are attached via on() & detached via off()
+ *  - Listeners can use namespaces for easy removal
+ *  - Events are fired via trigger()
+ * 
+ * But it has some important differences from jQuery's non-DOM event mechanism:
+ *  - More robust to listeners that throw exceptions
+ *  - Events can be marked deprecated, causing on() to issue warnings
+ *  - trigger() uses a simpler argument-list signature (like Promise APIs), rather than requiring
+ *    an Array arg and ignoring additional args
+ * 
+ * For now, Brackets uses a jQuery patch to ensure $(obj).on() and obj.on() (etc.) are identical
+ * for any obj that has the EventDispatcher pattern. In the future, this may be deprecated.
+ * 
+ * To add EventDispatcher methods to any object, call EventDispatcher.makeEventDispatcher(obj).
+ */
+define(function (require, exports, module) {
+    "use strict";
+    
+    /** Return just the event name, sans any trailing ".namespace" part */
+    function stripNs(eventName) {
+        var dot = eventName.indexOf(".");
+        return dot === -1 ? eventName : eventName.substring(0, dot);
+    }
+    
+    
+    // These functions are added as mixins to any object by makeEventDispatcher()
+    
+    var on = function (events, fn) {
+        // Check for deprecation warnings
+        if (this._deprecatedEvents) {
+            var eventsList = events.split(/\s+/);
+            var i;
+            for (i = 0; i < eventsList.length; i++) {
+                var eventName = stripNs(eventsList[i]);
+                if (this._deprecatedEvents[eventName]) {
+                    var message = "Registering for deprecated event '" + eventName + "'.";
+                    if (typeof this._deprecatedEvents[eventName] === "string") {
+                        message += " Use " + this._deprecatedEvents[eventName] + " instead.";
+                    }
+                    console.warn(message, new Error().stack);
+                }
+            }
+        }
+        
+        // Attach listener
+        var proxy = $(this._EventDispatcher);
+        return proxy.on.apply(proxy, arguments);  // important to return value for chaining
+    };
+    
+    var off = function (events, fn) {
+        // Detach listener
+        var proxy = $(this._EventDispatcher);
+        return proxy.off.apply(proxy, arguments);  // important to return value for chaining
+    };
+    
+    var trigger = function (event) {
+        var proxy = $(this._EventDispatcher);
+        try {
+            // Convert from 'args...' to '[args]' format
+            var eventArgs = Array.prototype.slice.call(arguments, 1);
+            var applyArgs = [event, eventArgs]; // jQuery wants triggerHandler("eventName", [arg1, arg2, ...]), so we need a nested array for eventArgs
+            
+            // Dispatch event
+            return proxy.triggerHandler.apply(proxy, applyArgs);
+        } catch (err) {
+            console.error("Exception in '" + event + "' listener on", this, String(err), err.stack);
+        }
+    };
+    
+    
+    /**
+     * @param {!Object} obj Object to add event-dispatch methods to
+     */
+    function makeEventDispatcher(obj) {
+        $.extend(obj, {
+            on: on,
+            off: off,
+            trigger: trigger,
+            _EventDispatcher: {}
+        });
+    }
+    
+    /**
+     * Mark a given event name as deprecated, such that on() will emit warnings when called with it.
+     * May be called before makeEventDispatcher(). May be called on a prototype where makeEventDispatcher()
+     * is called separately per instance (in the ctor).
+     * @param {!Object} obj Event dispatcher object
+     * @param {string} event Name of deprecated event
+     * @param {string=} insteadStr Suggested thing to use instead
+     */
+    function markDeprecated(obj, event, insteadStr) {
+        // Mark event as deprecated - on() will emit warnings when called with this event
+        if (!obj._deprecatedEvents) {
+            obj._deprecatedEvents = {};
+        }
+        obj._deprecatedEvents[event] = insteadStr || true;
+    }
+    
+    
+    exports.makeEventDispatcher = makeEventDispatcher;
+    exports.markDeprecated      = markDeprecated;
+});

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -281,7 +281,8 @@ define(function (require, exports, module) {
     /**
      * Mark a given event name as deprecated, such that on() will emit warnings when called with it.
      * May be called before makeEventDispatcher(). May be called on a prototype where makeEventDispatcher()
-     * is called separately per instance (i.e. in the constructor).
+     * is called separately per instance (i.e. in the constructor). Should be called before clients have
+     * a chance to start calling on().
      * @param {!Object} obj Event dispatcher object
      * @param {string} eventName Name of deprecated event
      * @param {string=} insteadStr Suggested thing to use instead

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -28,13 +28,26 @@
  * Implements a jQuery-like event dispatch pattern for non-DOM objects:
  *  - Listeners are attached via on() & detached via off()
  *  - Listeners can use namespaces for easy removal
+ *  - Listeners can attach to multiple events at once via a space-separated list
  *  - Events are fired via trigger()
+ *  - The same listener can be attached twice, and will be called twice; but off() will detach all
+ *    duplicate copies at once ('duplicate' means '===' equality - see http://jsfiddle.net/bf4p29g5/1/)
  * 
  * But it has some important differences from jQuery's non-DOM event mechanism:
- *  - More robust to listeners that throw exceptions
+ *  - More robust to listeners that throw exceptions (other listeners will still be called, and
+ *    trigger() will still return control to its caller).
  *  - Events can be marked deprecated, causing on() to issue warnings
- *  - trigger() uses a simpler argument-list signature (like Promise APIs), rather than requiring
- *    an Array arg and ignoring additional args
+ *  - Easier to debug, since the dispatch code is much simpler
+ *  - Faster, for the same reason
+ *  - Uses less memory, since $(nonDOMObj).on() leaks memory in jQuery
+ *  - API is simplified:
+ *      - Event handlers do not have 'this' set to the event dispatcher object
+ *      - Event object passed to handlers only has 'type' and 'target' fields
+ *      - trigger() uses a simpler argument-list signature (like Promise APIs), rather than requiring
+ *        an Array arg and ignoring additional args
+ *      - trigger() does not support namespaces
+ *      - For simplicity, on() does not accept a map of multiple events -> multiple handlers, nor a
+ *        missing arg standing in for a bare 'return false' handler.
  * 
  * For now, Brackets uses a jQuery patch to ensure $(obj).on() and obj.on() (etc.) are identical
  * for any obj that has the EventDispatcher pattern. In the future, this may be deprecated.
@@ -44,59 +57,158 @@
 define(function (require, exports, module) {
     "use strict";
     
-    /** Return just the event name, sans any trailing ".namespace" part */
-    function stripNs(eventName) {
-        var dot = eventName.indexOf(".");
-        return dot === -1 ? eventName : eventName.substring(0, dot);
+    var _ = require("thirdparty/lodash");
+
+    
+    /**
+     * @param {string} eventName Event name, optionally with trailing ".namespace" part
+     * @return {!{event:string, ns:string}} Record containing separate event name and namespace
+     */
+    function splitNs(eventStr) {
+        var dot = eventStr.indexOf(".");
+        if (dot === -1) {
+            return { eventName: eventStr };
+        } else {
+            return { eventName: eventStr.substring(0, dot), ns: eventStr.substring(dot) };
+        }
     }
     
     
     // These functions are added as mixins to any object by makeEventDispatcher()
     
+    /**
+     * Adds the given handler function to 'events': a space-separated list of one or more event names, each
+     * with an optional ".namespace" (used by off() - see below). If the handler is already listening to this
+     * event, another copy is added.
+     * @param {string} events
+     * @param {!function(!{type:string, target:!Object}, ...)} fn
+     */
     var on = function (events, fn) {
+        var eventsList = events.split(/\s+/).map(splitNs),
+            i;
+        
         // Check for deprecation warnings
         if (this._deprecatedEvents) {
-            var eventsList = events.split(/\s+/);
-            var i;
             for (i = 0; i < eventsList.length; i++) {
-                var eventName = stripNs(eventsList[i]);
-                if (this._deprecatedEvents[eventName]) {
-                    var message = "Registering for deprecated event '" + eventName + "'.";
-                    if (typeof this._deprecatedEvents[eventName] === "string") {
-                        message += " Use " + this._deprecatedEvents[eventName] + " instead.";
+                var deprecation = this._deprecatedEvents[eventsList[i].eventName];
+                if (deprecation) {
+                    var message = "Registering for deprecated event '" + eventsList[i].eventName + "'.";
+                    if (typeof deprecation === "string") {
+                        message += " Use " + deprecation + " instead.";
                     }
                     console.warn(message, new Error().stack);
                 }
             }
         }
         
-        // Attach listener
-        var proxy = $(this._EventDispatcher);
-        return proxy.on.apply(proxy, arguments);  // important to return value for chaining
+        // Attach listener for each event clause
+        for (i = 0; i < eventsList.length; i++) {
+            var eventName = eventsList[i].eventName;
+            if (!this._eventHandlers) {
+                this._eventHandlers = {};
+            }
+            if (!this._eventHandlers[eventName]) {
+                this._eventHandlers[eventName] = [];
+            }
+            eventsList[i].handler = fn;
+            this._eventHandlers[eventName].push(eventsList[i]);
+        }
+        
+        return this;  // for chaining
     };
     
+    /**
+     * Removes one or more handler functions based on the space-separated 'events' list. Each item in
+     * 'events' can be: bare event name, bare namespace, or event.namespace pair. This yields a set of
+     * matching handlers. If 'fn' is ommitted, all these handlers are removed. If 'fn' is provided,
+     * only handlers exactly equal to 'fn' are removed (there may still be >1, if duplicates were
+     * added).
+     * @param {string} events
+     * @param {?function(!{type:string, target:!Object}, ...)} fn
+     */
     var off = function (events, fn) {
-        // Detach listener
-        var proxy = $(this._EventDispatcher);
-        return proxy.off.apply(proxy, arguments);  // important to return value for chaining
+        var eventsList = events.split(/\s+/).map(splitNs),
+            i;
+        
+        if (!this._eventHandlers) {
+            return;
+        }
+        
+        var removeAllMatches = function (eventRec, eventName) {
+            var handlerList = this._eventHandlers[eventName],
+                k;
+            if (!handlerList) {
+                return;
+            }
+            
+            // Walk backwards so it's easy to remove items
+            for (k = handlerList.length - 1; k >= 0; k--) {
+                // Look at ns & fn only - caller has already taken care of eventName
+                if (!eventRec.ns || eventRec.ns === handlerList[k].ns) {
+                    if (!fn || fn === handlerList[k].handler) {
+                        handlerList.splice(k, 1);
+                    }
+                }
+            }
+            if (!handlerList.length) {
+                delete this._eventHandlers[eventName];
+            }
+        }.bind(this);
+        
+        var doRemove = function (eventRec) {
+            if (eventRec.eventName) {
+                // If arg calls out an event name, look at that handler list only
+                removeAllMatches(eventRec, eventRec.eventName);
+            } else {
+                // If arg only gives a namespace, look at handler lists for all events
+                _.forEach(this._eventHandlers, function (handlerList, eventName) {
+                    removeAllMatches(eventRec, eventName);
+                });
+            }
+        }.bind(this);
+        
+        // Detach listener for each event clause
+        // Each clause may be: bare eventname, bare .namespace, full eventname.namespace
+        for (i = 0; i < eventsList.length; i++) {
+            doRemove(eventsList[i]);
+        }
+        
+        return this;  // for chaining
     };
     
-    var trigger = function (event) {
-        var proxy = $(this._EventDispatcher);
-        try {
-            // Convert from 'args...' to '[args]' format
-            var eventArgs = Array.prototype.slice.call(arguments, 1);
-            var applyArgs = [event, eventArgs]; // jQuery wants triggerHandler("eventName", [arg1, arg2, ...]), so we need a nested array for eventArgs
-            
-            // Dispatch event
-            return proxy.triggerHandler.apply(proxy, applyArgs);
-        } catch (err) {
-            console.error("Exception in '" + event + "' listener on", this, String(err), err.stack);
+    /**
+     * Invokes all handlers for the given event (in the order they were added).
+     * @param {string} eventName
+     * @param {*} ... Any additional args are passed to the event handler after the event object
+     */
+    var trigger = function (eventName) {
+        var event = { type: eventName, target: this },
+            handlerList = this._eventHandlers && this._eventHandlers[eventName],
+            i;
+        
+        if (!handlerList) {
+            return;
+        }
+
+        // Pass 'event' object followed by any additional args trigger() was given
+        var applyArgs = Array.prototype.slice.call(arguments, 1);
+        applyArgs.unshift(event);
+
+        for (i = 0; i < handlerList.length; i++) {
+            try {
+                // Call one handler
+                handlerList[i].handler.apply(null, applyArgs);
+            } catch (err) {
+                console.error("Exception in '" + eventName + "' listener on", this, String(err), err.stack);
+                console.assert(false);  // causes dev tools to break, just like an uncaught exception
+            }
         }
     };
     
     
     /**
+     * Adds the EventDispatcher APIs to the given object. May also be called on a prototype object,
+     * in which case each instance will behave independently.
      * @param {!Object} obj Object to add event-dispatch methods to
      */
     function makeEventDispatcher(obj) {
@@ -104,8 +216,13 @@ define(function (require, exports, module) {
             on: on,
             off: off,
             trigger: trigger,
-            _EventDispatcher: {}
+            _EventDispatcher: true
         });
+        // Later, on() may add _eventHandlers: Object.<string, Array.<{event:string, namespace:?string,
+        //   handler:!function(!{type:string, target:!Object}, ...)}>> - map from eventName to an array
+        //   of handler records
+        // Later, markDeprecated() may add _deprecatedEvents: Object.<string, string|boolean> - map from
+        //   eventName to deprecation warning info
     }
     
     /**
@@ -113,15 +230,15 @@ define(function (require, exports, module) {
      * May be called before makeEventDispatcher(). May be called on a prototype where makeEventDispatcher()
      * is called separately per instance (in the ctor).
      * @param {!Object} obj Event dispatcher object
-     * @param {string} event Name of deprecated event
+     * @param {string} eventName Name of deprecated event
      * @param {string=} insteadStr Suggested thing to use instead
      */
-    function markDeprecated(obj, event, insteadStr) {
+    function markDeprecated(obj, eventName, insteadStr) {
         // Mark event as deprecated - on() will emit warnings when called with this event
         if (!obj._deprecatedEvents) {
             obj._deprecatedEvents = {};
         }
-        obj._deprecatedEvents[event] = insteadStr || true;
+        obj._deprecatedEvents[eventName] = insteadStr || true;
     }
     
     

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
     require("utils/Global");
 
     var _              = require("thirdparty/lodash"),
+        EventDispatcher = require("utils/EventDispatcher"),
         FileSystem     = require("filesystem/FileSystem"),
         FileUtils      = require("file/FileUtils"),
         Async          = require("utils/Async"),
@@ -247,9 +248,9 @@ define(function (require, exports, module) {
                 return loadExtensionModule(name, config, entryPoint);
             })
             .then(function () {
-                $(exports).triggerHandler("load", config.baseUrl);
+                exports.trigger("load", config.baseUrl);
             }, function (err) {
-                $(exports).triggerHandler("loadFailed", config.baseUrl);
+                exports.trigger("loadFailed", config.baseUrl);
             });
     }
 
@@ -429,6 +430,9 @@ define(function (require, exports, module) {
         return promise;
     }
 
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     // unit tests
     exports._setInitExtensionTimeout = _setInitExtensionTimeout;
     exports._getInitExtensionTimeout = _getInitExtensionTimeout;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -60,6 +60,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var AppInit                 = require("utils/AppInit"),
+        EventDispatcher         = require("utils/EventDispatcher"),
         PreferencesManager      = require("preferences/PreferencesManager");
     
     var $mainView;
@@ -244,7 +245,7 @@ define(function (require, exports, module) {
         // Detect legacy cases where panels in the editor area are created without using WorkspaceManager APIs
         if ($parent[0] && $parent.is(".content") && !createdByWorkspaceManager) {
             console.warn("Deprecated: resizable panels should be created via WorkspaceManager.createBottomPanel(). Using Resizer directly will stop working in the future. \nElement:", element);
-            $(exports).triggerHandler("deprecatedPanelAdded", [$element]);
+            exports.trigger("deprecatedPanelAdded", $element);
         }
         
         function adjustSibling(size) {
@@ -546,6 +547,8 @@ define(function (require, exports, module) {
     }
     
     PreferencesManager.convertPreferences(module, {"panelState": "user"}, true, _isPanelPreferences);
+    
+    EventDispatcher.makeEventDispatcher(exports);
     
     exports.makeResizable   = makeResizable;
     exports.removeSizable   = removeSizable;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -227,6 +227,11 @@ define(function (require, exports, module) {
             console.error("Resizable panels must have a DOM id to use as a preferences key:", element);
             return;
         }
+        // Detect legacy cases where panels in the editor area are created without using WorkspaceManager APIs
+        if ($parent[0] && $parent.is(".content") && !createdByWorkspaceManager) {
+            console.error("Resizable panels within the editor area should be created via WorkspaceManager.createBottomPanel(). \nElement:", element);
+            return;
+        }
         
         if (minSize === undefined) {
             minSize = DEFAULT_MIN_SIZE;
@@ -241,12 +246,6 @@ define(function (require, exports, module) {
         }
         // Important so min/max sizes behave predictably
         $element.css("box-sizing", "border-box");
-        
-        // Detect legacy cases where panels in the editor area are created without using WorkspaceManager APIs
-        if ($parent[0] && $parent.is(".content") && !createdByWorkspaceManager) {
-            console.warn("Deprecated: resizable panels should be created via WorkspaceManager.createBottomPanel(). Using Resizer directly will stop working in the future. \nElement:", element);
-            exports.trigger("deprecatedPanelAdded", $element);
-        }
         
         function adjustSibling(size) {
             if (forceLeft !== undefined) {

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -442,7 +442,7 @@ define(function (require, exports, module) {
     }
 
     // Events listeners
-    $(ExtensionManager).on("registryDownload", _onRegistryDownloaded);
+    ExtensionManager.on("registryDownload", _onRegistryDownloaded);
 
     // Define public API
     exports.launchAutomaticUpdate = launchAutomaticUpdate;

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1639,13 +1639,13 @@ define(function (require, exports, module) {
      */
     AppInit.htmlReady(function () {
         _initialize($("#editor-holder"));
+        
+        // Event handlers - attach late due to circular references
+        $(ProjectManager).on("projectOpen",                       _loadViewState);
+        $(ProjectManager).on("beforeProjectClose beforeAppClose", _saveViewState);
+        $(EditorManager).on("activeEditorChange",                 _activeEditorChange);
+        DocumentManager.on("pathDeleted",                         _removeDeletedFileFromMRU);
     });
-    
-    // Event handlers
-    $(ProjectManager).on("projectOpen",                       _loadViewState);
-    $(ProjectManager).on("beforeProjectClose beforeAppClose", _saveViewState);
-    $(EditorManager).on("activeEditorChange",                 _activeEditorChange);
-    $(DocumentManager).on("pathDeleted",                      _removeDeletedFileFromMRU);
     
     
     // Unit Test Helpers

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -72,14 +72,14 @@
  *    - _workingSetDisableAutoSort -- When the working set is reordered by manually dragging a file. 
  *          (e, paneId:string) For Internal Use Only.
  *
- * These are jQuery events, so to listen for them you do something like this:
- *    `$(MainViewManager).on("eventname", handler);`
- *
+ * To listen for events, do something like this: (see EventDispatcher for details on this pattern)
+ *    `MainViewManager.on("eventname", handler);`
  */
 define(function (require, exports, module) {
     "use strict";
     
     var _                   = require("thirdparty/lodash"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         Strings             = require("strings"),
         AppInit             = require("utils/AppInit"),
         CommandManager      = require("command/CommandManager"),
@@ -363,11 +363,11 @@ define(function (require, exports, module) {
             
             _activePaneId = newPaneId;
             
-            $(exports).triggerHandler("activePaneChange", [newPaneId, oldPaneId]);
-            $(exports).triggerHandler("currentFileChange", [_getPane(ACTIVE_PANE).getCurrentlyViewedFile(),
+            exports.trigger("activePaneChange", newPaneId, oldPaneId);
+            exports.trigger("currentFileChange", _getPane(ACTIVE_PANE).getCurrentlyViewedFile(),
                                                             newPaneId,
                                                             oldPane.getCurrentlyViewedFile(),
-                                                            oldPaneId]);
+                                                            oldPaneId);
             
             _makePaneMostRecent(_activePaneId);
             focusActivePane();
@@ -704,7 +704,7 @@ define(function (require, exports, module) {
         //  the same location in the working set as the file that was renamed
         if (result === pane.ITEM_FOUND_NEEDS_SORT) {
             console.warn("pane.reorderItem returned pane.ITEM_FOUND_NEEDS_SORT which shouldn't happen " + file);
-            $(exports).triggerHandler("workingSetSort", [pane.id]);
+            exports.trigger("workingSetSort", pane.id);
         } else if (result === pane.ITEM_NOT_FOUND) {
             index = pane.addToViewList(file, index);
 
@@ -715,7 +715,7 @@ define(function (require, exports, module) {
                 _mruList.push(entry);
             }
 
-            $(exports).triggerHandler("workingSetAdd", [file, index, pane.id]);
+            exports.trigger("workingSetAdd", file, index, pane.id);
         }
     }
 
@@ -734,7 +734,7 @@ define(function (require, exports, module) {
             _mruList.push(_makeMRUListEntry(file, pane.id));
         });
         
-        $(exports).triggerHandler("workingSetAddList", [uniqueFileList, pane.id]);
+        exports.trigger("workingSetAddList", uniqueFileList, pane.id);
         
         //  find all of the files that could be added but were not 
         var unsolvedList = fileList.filter(function (item) {
@@ -784,7 +784,7 @@ define(function (require, exports, module) {
 
         if (pane.removeView(file)) {
             _removeFileFromMRU(pane.id, file);
-            $(exports).triggerHandler("workingSetRemove", [file, suppressRedraw, pane.id]);
+            exports.trigger("workingSetRemove", file, suppressRedraw, pane.id);
         }
     }
     
@@ -813,7 +813,7 @@ define(function (require, exports, module) {
                     return true;
                 });
             
-                $(exports).triggerHandler("workingSetMove", [file, sourcePane.id, destinationPane.id]);
+                exports.trigger("workingSetMove", file, sourcePane.id, destinationPane.id);
                 result.resolve();
             });
         
@@ -853,7 +853,7 @@ define(function (require, exports, module) {
     function _sortWorkingSet(paneId, compareFn) {
         _forEachPaneOrPanes(paneId, function (pane) {
             pane.sortViewList(compareFn);
-            $(exports).triggerHandler("workingSetSort", [pane.id]);
+            exports.trigger("workingSetSort", pane.id);
         });
     }
     
@@ -869,8 +869,8 @@ define(function (require, exports, module) {
         var pane = _getPane(paneId);
 
         pane.moveWorkingSetItem(fromIndex, toIndex);
-        $(exports).triggerHandler("workingSetSort", [pane.id]);
-        $(exports).triggerHandler("_workingSetDisableAutoSort", [pane.id]);
+        exports.trigger("workingSetSort", pane.id);
+        exports.trigger("_workingSetDisableAutoSort", pane.id);
     }
 
     /**
@@ -884,8 +884,8 @@ define(function (require, exports, module) {
         var pane = _getPane(paneId);
 
         pane.swapViewListIndexes(index1, index2);
-        $(exports).triggerHandler("workingSetSort", [pane.id]);
-        $(exports).triggerHandler("_workingSetDisableAutoSort", [pane.id]);
+        exports.trigger("workingSetSort", pane.id);
+        exports.trigger("_workingSetDisableAutoSort", pane.id);
     }
     
     /**
@@ -1040,23 +1040,23 @@ define(function (require, exports, module) {
             newPane = new Pane(paneId, _$el);
             _panes[paneId] = newPane;
             
-            $(exports).triggerHandler("paneCreate", [newPane.id]);
+            exports.trigger("paneCreate", newPane.id);
             
             newPane.$el.on("click.mainview dragover.mainview", function () {
                 setActivePaneId(newPane.id);
             });
 
-            $(newPane).on("viewListChange.mainview", function () {
+            newPane.on("viewListChange.mainview", function () {
                 _updatePaneHeaders();
-                $(exports).triggerHandler("workingSetUpdate", [newPane.id]);
+                exports.trigger("workingSetUpdate", newPane.id);
             });
-            $(newPane).on("currentViewChange.mainview", function (e, newView, oldView) {
+            newPane.on("currentViewChange.mainview", function (e, newView, oldView) {
                 _updatePaneHeaders();
                 if (_activePaneId === newPane.id) {
-                    $(exports).triggerHandler("currentFileChange",
-                                              [newView && newView.getFile(),
+                    exports.trigger("currentFileChange",
+                                               newView && newView.getFile(),
                                                newPane.id, oldView && oldView.getFile(),
-                                               newPane.id]);
+                                               newPane.id);
                 }
             });
         }
@@ -1110,7 +1110,7 @@ define(function (require, exports, module) {
         //  the percentages are reset as well
         _initialLayout();
         
-        $(exports).triggerHandler("paneLayoutChange", [_orientation]);
+        exports.trigger("paneLayoutChange", _orientation);
         
         // if new pane was created, and original pane is not empty, make new pane the active pane
         if (newPane && getCurrentlyViewedFile(firstPane.id)) {
@@ -1270,17 +1270,17 @@ define(function (require, exports, module) {
             Resizer.removeSizable(firstPane.$el);
             firstPane.mergeFrom(secondPane);
         
-            $(exports).triggerHandler("workingSetRemoveList", [fileList, secondPane.id]);
+            exports.trigger("workingSetRemoveList", fileList, secondPane.id);
 
             setActivePaneId(firstPane.id);
             
             secondPane.$el.off(".mainview");
-            $(secondPane).off(".mainview");
+            secondPane.off(".mainview");
 
             secondPane.destroy();
             delete _panes[SECOND_PANE];
-            $(exports).triggerHandler("paneDestroy", secondPane.id);
-            $(exports).triggerHandler("workingSetAddList", [fileList, firstPane.id]);
+            exports.trigger("paneDestroy", secondPane.id);
+            exports.trigger("workingSetAddList", fileList, firstPane.id);
 
             _mruList.forEach(function (record) {
                 if (record.paneId === secondPane.id) {
@@ -1293,7 +1293,7 @@ define(function (require, exports, module) {
             // this will set the remaining pane to 100%
             _initialLayout();
             
-            $(exports).triggerHandler("paneLayoutChange", [_orientation]);
+            exports.trigger("paneLayoutChange", _orientation);
 
             // if the current view before the merger was in the pane
             //  that went away then reopen it so that it's now the current view again
@@ -1315,7 +1315,7 @@ define(function (require, exports, module) {
         _forEachPaneOrPanes(paneId, function (pane) {
             if (pane.removeView(file, options.noOpenNextFile)) {
                 _removeFileFromMRU(pane.id, file);
-                $(exports).triggerHandler("workingSetRemove", [file, false, pane.id]);
+                exports.trigger("workingSetRemove", file, false, pane.id);
                 return false;
             }
         });
@@ -1334,7 +1334,7 @@ define(function (require, exports, module) {
                 _removeFileFromMRU(pane.id, file);
             });
 
-            $(exports).triggerHandler("workingSetRemoveList", [closedList, pane.id]);
+            exports.trigger("workingSetRemoveList", closedList, pane.id);
         });
     }
     
@@ -1351,7 +1351,7 @@ define(function (require, exports, module) {
             });
 
             pane._reset();
-            $(exports).triggerHandler("workingSetRemoveList", [closedList, pane.id]);
+            exports.trigger("workingSetRemoveList", closedList, pane.id);
         });
     }
 
@@ -1491,7 +1491,7 @@ define(function (require, exports, module) {
                 
                 if (_orientation) {
                     _$el.addClass("split-" + _orientation.toLowerCase());
-                    $(exports).triggerHandler("paneLayoutChange", _orientation);
+                    exports.trigger("paneLayoutChange", _orientation);
                 }
 
                 _.forEach(_panes, function (pane) {
@@ -1500,7 +1500,7 @@ define(function (require, exports, module) {
                     fileList.forEach(function (file) {
                         _mruList.push(_makeMRUListEntry(file, pane.id));
                     });
-                    $(exports).triggerHandler("workingSetAddList", [fileList, pane.id]);
+                    exports.trigger("workingSetAddList", fileList, pane.id);
                 });
                 
                 promises = [];
@@ -1590,7 +1590,7 @@ define(function (require, exports, module) {
         // This ensures that unit tests that use this function 
         //  get an event handler for workspace events and we don't listen
         //  to the event before we've been initialized
-        $(WorkspaceManager).on("workspaceUpdateLayout", _updateLayout);
+        WorkspaceManager.on("workspaceUpdateLayout", _updateLayout);
     }
     
     /** 
@@ -1641,12 +1641,14 @@ define(function (require, exports, module) {
         _initialize($("#editor-holder"));
         
         // Event handlers - attach late due to circular references
-        $(ProjectManager).on("projectOpen",                       _loadViewState);
-        $(ProjectManager).on("beforeProjectClose beforeAppClose", _saveViewState);
-        $(EditorManager).on("activeEditorChange",                 _activeEditorChange);
-        DocumentManager.on("pathDeleted",                         _removeDeletedFileFromMRU);
+        ProjectManager.on("projectOpen",                       _loadViewState);
+        ProjectManager.on("beforeProjectClose beforeAppClose", _saveViewState);
+        EditorManager.on("activeEditorChange",                 _activeEditorChange);
+        DocumentManager.on("pathDeleted",                      _removeDeletedFileFromMRU);
     });
     
+    
+    EventDispatcher.makeEventDispatcher(exports);
     
     // Unit Test Helpers
     exports._initialize                   = _initialize;

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1634,18 +1634,19 @@ define(function (require, exports, module) {
         return result;
     }
     
+    
     /** 
      * Setup a ready event to initialize ourself
      */
     AppInit.htmlReady(function () {
         _initialize($("#editor-holder"));
-        
-        // Event handlers - attach late due to circular references
-        ProjectManager.on("projectOpen",                       _loadViewState);
-        ProjectManager.on("beforeProjectClose beforeAppClose", _saveViewState);
-        EditorManager.on("activeEditorChange",                 _activeEditorChange);
-        DocumentManager.on("pathDeleted",                      _removeDeletedFileFromMRU);
     });
+    
+    // Event handlers - not safe to call on() directly, due to circular dependencies
+    EventDispatcher.on_duringInit(ProjectManager, "projectOpen",                       _loadViewState);
+    EventDispatcher.on_duringInit(ProjectManager, "beforeProjectClose beforeAppClose", _saveViewState);
+    EventDispatcher.on_duringInit(EditorManager, "activeEditorChange",                 _activeEditorChange);
+    EventDispatcher.on_duringInit(DocumentManager, "pathDeleted",                      _removeDeletedFileFromMRU);
     
     
     EventDispatcher.makeEventDispatcher(exports);

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -153,6 +153,7 @@ define(function (require, exports, module) {
     "use strict";
         
     var _                   = require("thirdparty/lodash"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         FileSystem          = require("filesystem/FileSystem"),
         InMemoryFile        = require("document/InMemoryFile"),
         ViewStateManager    = require("view/ViewStateManager"),
@@ -253,15 +254,15 @@ define(function (require, exports, module) {
         this.updateHeaderText();
 
         // Listen to document events so we can update ourself
-        $(DocumentManager).on(this._makeEventName("fileNameChange"),  _.bind(this._handleFileNameChange, this));
-        $(DocumentManager).on(this._makeEventName("pathDeleted"), _.bind(this._handleFileDeleted, this));
-        $(MainViewManager).on(this._makeEventName("activePaneChange"), _.bind(this._handleActivePaneChange, this));
-        $(MainViewManager).on(this._makeEventName("workingSetAdd"), _.bind(this.updateHeaderText, this));
-        $(MainViewManager).on(this._makeEventName("workingSetRemove"), _.bind(this.updateHeaderText, this));
-        $(MainViewManager).on(this._makeEventName("workingSetAddList"), _.bind(this.updateHeaderText, this));
-        $(MainViewManager).on(this._makeEventName("workingSetRemoveList"), _.bind(this.updateHeaderText, this));
-        
+        DocumentManager.on(this._makeEventName("fileNameChange"),  _.bind(this._handleFileNameChange, this));
+        DocumentManager.on(this._makeEventName("pathDeleted"), _.bind(this._handleFileDeleted, this));
+        MainViewManager.on(this._makeEventName("activePaneChange"), _.bind(this._handleActivePaneChange, this));
+        MainViewManager.on(this._makeEventName("workingSetAdd"), _.bind(this.updateHeaderText, this));
+        MainViewManager.on(this._makeEventName("workingSetRemove"), _.bind(this.updateHeaderText, this));
+        MainViewManager.on(this._makeEventName("workingSetAddList"), _.bind(this.updateHeaderText, this));
+        MainViewManager.on(this._makeEventName("workingSetRemoveList"), _.bind(this.updateHeaderText, this));
     }
+    EventDispatcher.makeEventDispatcher(Pane.prototype);
 
     /**
      * id of the pane
@@ -526,8 +527,8 @@ define(function (require, exports, module) {
 
         this._reset();
         
-        $(DocumentManager).off(this._makeEventName(""));
-        $(MainViewManager).off(this._makeEventName(""));
+        DocumentManager.off(this._makeEventName(""));
+        MainViewManager.off(this._makeEventName(""));
 
         this.$el.off(".pane");
         this.$el.remove();
@@ -721,7 +722,7 @@ define(function (require, exports, module) {
     Pane.prototype._notifyCurrentViewChange = function (newView, oldView) {
         this.updateHeaderText();
         
-        $(this).triggerHandler("currentViewChange", [newView, oldView]);
+        this.trigger("currentViewChange", newView, oldView);
     };
     
     
@@ -898,7 +899,7 @@ define(function (require, exports, module) {
         
         // dispatch the change event
         if (dispatchEvent) {
-            $(this).triggerHandler("viewListChange");
+            this.trigger("viewListChange");
         }
     };
 
@@ -910,7 +911,7 @@ define(function (require, exports, module) {
      */
     Pane.prototype._handleFileDeleted = function (e, fullPath) {
         if (this.removeView({fullPath: fullPath})) {
-            $(this).triggerHandler("viewListChange");
+            this.trigger("viewListChange");
         }
     };
     

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var WorkspaceManager        = require("view/WorkspaceManager"),
+        EventDispatcher         = require("utils/EventDispatcher"),
         DeprecationWarning      = require("utils/DeprecationWarning");
     
     /**
@@ -54,5 +55,6 @@ define(function (require, exports, module) {
     };
     
     // Deprecated PanelManager events
+    EventDispatcher.makeEventDispatcher(exports);
     _deprecateEvent("editorAreaResize", "workspaceUpdateLayout");
 });

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var _                  = require("thirdparty/lodash"),
+        EventDispatcher    = require("utils/EventDispatcher"),
         FileSystem         = require("filesystem/FileSystem"),
         FileUtils          = require("file/FileUtils"),
         EditorManager      = require("editor/EditorManager"),
@@ -330,7 +331,7 @@ define(function (require, exports, module) {
         ThemeView.updateScrollbars(getCurrentTheme());
 
         // Expose event for theme changes
-        $(exports).trigger("themeChange", getCurrentTheme());
+        exports.trigger("themeChange", getCurrentTheme());
     });
 
     prefs.on("change", "themeScrollbars", function () {
@@ -350,11 +351,13 @@ define(function (require, exports, module) {
         }
     });
 
-    $(EditorManager).on("activeEditorChange", function () {
+    EditorManager.on("activeEditorChange", function () {
         refresh();
     });
 
-
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     exports.refresh         = refresh;
     exports.loadFile        = loadFile;
     exports.loadPackage     = loadPackage;

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var Commands            = require("command/Commands"),
+        EventDispatcher     = require("utils/EventDispatcher"),
         CommandManager      = require("command/CommandManager"),
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils"),
@@ -213,7 +214,7 @@ define(function (require, exports, module) {
             }
         });
 
-        $(exports).triggerHandler("fontSizeChange", [fontSize, oldValue]);
+        exports.trigger("fontSizeChange", fontSize, oldValue);
         prefs.set("fontSize", fontSize);
     }
 
@@ -243,7 +244,7 @@ define(function (require, exports, module) {
             _addDynamicFontFamily(fontFamily);
         }
 
-        $(exports).triggerHandler("fontFamilyChange", [fontFamily, oldValue]);
+        exports.trigger("fontFamilyChange", fontFamily, oldValue);
         prefs.set("fontFamily", fontFamily);
 
         if (editor) {
@@ -491,11 +492,14 @@ define(function (require, exports, module) {
     prefs.definePreference("fontFamily", "string", DEFAULT_FONT_FAMILY);
 
     // Update UI when opening or closing a document
-    $(MainViewManager).on("currentFileChange", _updateUI);
+    MainViewManager.on("currentFileChange", _updateUI);
 
     // Update UI when Brackets finishes loading
     AppInit.appReady(init);
-
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
+    
     exports.restoreFontSize = restoreFontSize;
     exports.restoreFonts    = restoreFonts;
     exports.getFontSize     = getFontSize;

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -252,13 +252,6 @@ define(function (require, exports, module) {
         $editorHolder = $mockEditorHolder;
     }
     
-    /* If someone adds a panel in the .content stack the old way, make sure we still listen for resize/show/hide
-     * (Resizer emits a deprecation warning for us - no need to log anything here) 
-     */
-    Resizer.on("deprecatedPanelAdded", function (event, $panel) {
-        listenToResize($panel);
-    });
-    
     /* Add this as a capture handler so we're guaranteed to run it before the editor does its own
      * refresh on resize.
      */

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var AppInit                 = require("utils/AppInit"),
+        EventDispatcher         = require("utils/EventDispatcher"),
         Resizer                 = require("utils/Resizer");
     
     
@@ -108,7 +109,7 @@ define(function (require, exports, module) {
         $editorHolder.height(editorAreaHeight);  // affects size of "not-editor" placeholder as well
         
         // Resize editor to fill the space
-        $(exports).trigger("workspaceUpdateLayout", [editorAreaHeight, refreshHint]);
+        exports.trigger("workspaceUpdateLayout", editorAreaHeight, refreshHint);
     }
     
     
@@ -254,7 +255,7 @@ define(function (require, exports, module) {
     /* If someone adds a panel in the .content stack the old way, make sure we still listen for resize/show/hide
      * (Resizer emits a deprecation warning for us - no need to log anything here) 
      */
-    $(Resizer).on("deprecatedPanelAdded", function (event, $panel) {
+    Resizer.on("deprecatedPanelAdded", function (event, $panel) {
         listenToResize($panel);
     });
     
@@ -263,6 +264,8 @@ define(function (require, exports, module) {
      */
     window.addEventListener("resize", handleWindowResize, true);
     
+    
+    EventDispatcher.makeEventDispatcher(exports);
     
     // Define public API
     exports.createBottomPanel    = createBottomPanel;

--- a/src/widgets/DropdownButton.js
+++ b/src/widgets/DropdownButton.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var DropdownEventHandler    = require("utils/DropdownEventHandler").DropdownEventHandler,
+        EventDispatcher         = require("utils/EventDispatcher"),
         WorkspaceManager        = require("view/WorkspaceManager"),
         Menus                   = require("command/Menus"),
         ViewUtils               = require("utils/ViewUtils"),
@@ -76,6 +77,7 @@ define(function (require, exports, module) {
             .text(label)
             .on("click", this._onClick);
     }
+    EventDispatcher.makeEventDispatcher(DropdownButton.prototype);
     
     /**
      * Items in dropdown list - may be changed any time dropdown isn't open
@@ -180,7 +182,7 @@ define(function (require, exports, module) {
         
         // Also trigger listRendered handler so that custom event handlers can be
         // set up for any custom UI in the list.
-        $(this).triggerHandler("listRendered", [parent]);
+        this.trigger("listRendered", parent);
         
         // Also need to re-register mouse event handlers with the updated list.
         if (this._dropdownEventHandler) {
@@ -277,7 +279,7 @@ define(function (require, exports, module) {
         this._dropdownEventHandler.open();
 
         window.document.body.addEventListener("mousedown", this._onClickOutside, true);
-        $(WorkspaceManager).on("workspaceUpdateLayout", this.closeDropdown);
+        WorkspaceManager.on("workspaceUpdateLayout", this.closeDropdown);
         
         // Manage focus
         this._lastFocus = window.document.activeElement;
@@ -291,7 +293,7 @@ define(function (require, exports, module) {
      */
     DropdownButton.prototype._onDropdownClose = function () {
         window.document.body.removeEventListener("mousedown", this._onClickOutside, true);
-        $(WorkspaceManager).off("workspaceUpdateLayout", this.closeDropdown);
+        WorkspaceManager.off("workspaceUpdateLayout", this.closeDropdown);
         
         // Restore focus to old pos, unless "select" handler changed it
         if (window.document.activeElement === this.$dropdown[0]) {
@@ -341,7 +343,7 @@ define(function (require, exports, module) {
      */
     DropdownButton.prototype._onSelect = function ($link) {
         var itemIndex = Number($link.data("index"));
-        $(this).triggerHandler("select", [this.items[itemIndex], itemIndex]);
+        this.trigger("select", this.items[itemIndex], itemIndex);
     };
     
     

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var MainViewManager  = require("view/MainViewManager"),
+        EventDispatcher  = require("utils/EventDispatcher"),
         KeyEvent         = require("utils/KeyEvent"),
         AnimationUtils   = require("utils/AnimationUtils"),
         WorkspaceManager = require("view/WorkspaceManager");
@@ -101,6 +102,7 @@ define(function (require, exports, module) {
         WorkspaceManager.recomputeLayout();  // changes available ht for editor area
         MainViewManager.restoreAdjustedScrollState(MainViewManager.ALL_PANES, this.height());
     }
+    EventDispatcher.makeEventDispatcher(ModalBar.prototype);
     
     /**
      * A jQuery object containing the root node of the ModalBar.
@@ -200,7 +202,7 @@ define(function (require, exports, module) {
             window.document.body.removeEventListener("focusin", this._handleFocusChange, true);
         }
 
-        $(this).triggerHandler("close");
+        this.trigger("close");
         
         function doRemove() {
             self._$root.remove();

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var AppInit         = require("utils/AppInit"),
+        EventDispatcher = require("utils/EventDispatcher"),
         CommandManager  = require("command/CommandManager"),
         KeyEvent        = require("utils/KeyEvent");
     
@@ -153,19 +154,22 @@ define(function (require, exports, module) {
      * @param {ContextMenu} contextMenu
      */
     function listenToContextMenu(contextMenu) {
-        $(contextMenu).on("beforeContextMenuOpen", _beforeMenuPopup);
+        contextMenu.on("beforeContextMenuOpen", _beforeMenuPopup);
     }
 
     AppInit.htmlReady(function () {
         // Register for events
         window.document.body.addEventListener("keydown", _keydownCaptureListener, true);
-        $(exports).on("beforeMenuPopup", _beforeMenuPopup);
+        exports.on("beforeMenuPopup", _beforeMenuPopup);
         
         // Close all popups when a command is executed
-        $(CommandManager).on("beforeExecuteCommand", function (jqEvent, commandId) {
+        CommandManager.on("beforeExecuteCommand", function (jqEvent, commandId) {
             removeCurrentPopUp();
         });
     });
+    
+    
+    EventDispatcher.makeEventDispatcher(exports);
     
     exports.addPopUp            = addPopUp;
     exports.removePopUp         = removePopUp;

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -163,7 +163,7 @@ define(function (require, exports, module) {
         exports.on("beforeMenuPopup", _beforeMenuPopup);
         
         // Close all popups when a command is executed
-        CommandManager.on("beforeExecuteCommand", function (jqEvent, commandId) {
+        CommandManager.on("beforeExecuteCommand", function (event, commandId) {
             removeCurrentPopUp();
         });
     });

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
     require("spec/EditorCommandHandlers-test");
     require("spec/EditorOptionHandlers-test");
     require("spec/EditorManager-test");
+    require("spec/EventDispatcher-test");
     require("spec/ExtensionInstallation-test");
     require("spec/ExtensionLoader-test");
     require("spec/ExtensionManager-test");

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -509,7 +509,7 @@ define(function (require, exports, module) {
                     expect(asyncProvider.filesCalledOn).toEqual([noErrorsJS]);
                     
                     // "Modify" the file
-                    $(DocumentManager).triggerHandler("documentSaved", DocumentManager.getCurrentDocument());
+                    DocumentManager.trigger("documentSaved", DocumentManager.getCurrentDocument());
                     expect(asyncProvider.futures[noErrorsJS].length).toBe(2);
                     
                     // Finish old (stale) linting session - verify results not shown
@@ -538,7 +538,7 @@ define(function (require, exports, module) {
                     expect(asyncProvider.filesCalledOn).toEqual([noErrorsJS]);
                     
                     // "Modify" the file
-                    $(DocumentManager).triggerHandler("documentSaved", DocumentManager.getCurrentDocument());
+                    DocumentManager.trigger("documentSaved", DocumentManager.getCurrentDocument());
                     expect(asyncProvider.futures[noErrorsJS].length).toBe(2);
                     
                     // Finish new (current) linting session - verify results are shown

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect, $ */
+/*global define, describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
         it("set enabled state and trigger enabledStateChange", function () {
             var eventTriggered = false;
             var command = CommandManager.register("test command", commandID, testCommandFn);
-            $(command).on("enabledStateChange", function () {
+            command.on("enabledStateChange", function () {
                 eventTriggered = true;
             });
             command.setEnabled(false);
@@ -93,7 +93,7 @@ define(function (require, exports, module) {
         it("set checked state and trigger checkedStateChange", function () {
             var eventTriggered = false;
             var command = CommandManager.register("test command", commandID, testCommandFn);
-            $(command).on("checkedStateChange", function () {
+            command.on("checkedStateChange", function () {
                 eventTriggered = true;
             });
             command.setChecked(true);
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
         it("rename command trigger nameChange", function () {
             var eventTriggered = false;
             var command = CommandManager.register("test command", commandID, testCommandFn);
-            $(command).on("nameChange", function () {
+            command.on("nameChange", function () {
                 eventTriggered = true;
             });
             command.setName("newName");

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -253,7 +253,7 @@ define(function (require, exports, module) {
 
             runs(function () {
                 expect(DocumentManager.getAllOpenDocuments().length).toBe(0);
-                $(DocumentModule).off(".docTest");
+                DocumentModule.off(".docTest");
             });
         });
         
@@ -269,14 +269,14 @@ define(function (require, exports, module) {
                 var dirtyFlagListener = jasmine.createSpy();
                 
                 runs(function () {
-                    $(DocumentManager).on("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.on("dirtyFlagChange", dirtyFlagListener);
                     
                     promise = DocumentManager.getDocumentForPath(JS_FILE);
                     waitsForDone(promise, "Create Document");
                 });
                 runs(function () {
                     expect(dirtyFlagListener.callCount).toBe(0);
-                    $(DocumentManager).off("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.off("dirtyFlagChange", dirtyFlagListener);
                 });
             });
             
@@ -284,7 +284,7 @@ define(function (require, exports, module) {
                 var dirtyFlagListener = jasmine.createSpy();
                 
                 runs(function () {
-                    $(DocumentManager).on("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.on("dirtyFlagChange", dirtyFlagListener);
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: JS_FILE});
                     waitsForDone(promise, "Open file");
@@ -306,7 +306,7 @@ define(function (require, exports, module) {
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1); // still has undo history
                     expect(dirtyFlagListener.callCount).toBe(2);
                     
-                    $(DocumentManager).off("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.off("dirtyFlagChange", dirtyFlagListener);
                 });
             });
             
@@ -315,14 +315,14 @@ define(function (require, exports, module) {
                     changeListener    = jasmine.createSpy();
                 
                 runs(function () {
-                    $(DocumentManager).on("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.on("dirtyFlagChange", dirtyFlagListener);
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: JS_FILE});
                     waitsForDone(promise, "Open file");
                 });
                 runs(function () {
                     var doc = DocumentManager.getOpenDocumentForPath(JS_FILE);
-                    $(doc).on("change", changeListener);
+                    doc.on("change", changeListener);
                     
                     expect(doc.isDirty).toBe(false);
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(0);
@@ -341,8 +341,8 @@ define(function (require, exports, module) {
                     expect(dirtyFlagListener.callCount).toBe(2);
                     expect(changeListener.callCount).toBe(2);
                     
-                    $(doc).off("change", changeListener);
-                    $(DocumentManager).off("dirtyFlagChange", dirtyFlagListener);
+                    doc.off("change", changeListener);
+                    DocumentManager.off("dirtyFlagChange", dirtyFlagListener);
                 });
             });
             
@@ -351,14 +351,14 @@ define(function (require, exports, module) {
                     changeListener    = jasmine.createSpy();
                 
                 runs(function () {
-                    $(DocumentManager).on("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.on("dirtyFlagChange", dirtyFlagListener);
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: JS_FILE});
                     waitsForDone(promise, "Open file");
                 });
                 runs(function () {
                     var doc = DocumentManager.getOpenDocumentForPath(JS_FILE);
-                    $(doc).on("change", changeListener);
+                    doc.on("change", changeListener);
                     
                     expect(doc.isDirty).toBe(false);
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(0);
@@ -369,8 +369,8 @@ define(function (require, exports, module) {
                     expect(dirtyFlagListener.callCount).toBe(0);  // isDirty hasn't changed
                     expect(changeListener.callCount).toBe(1);     // but still counts as a content change
                     
-                    $(doc).off("change", changeListener);
-                    $(DocumentManager).off("dirtyFlagChange", dirtyFlagListener);
+                    doc.off("change", changeListener);
+                    DocumentManager.off("dirtyFlagChange", dirtyFlagListener);
                 });
             });
             
@@ -380,14 +380,14 @@ define(function (require, exports, module) {
                     doc;
                 
                 runs(function () {
-                    $(DocumentManager).on("dirtyFlagChange", dirtyFlagListener);
+                    DocumentManager.on("dirtyFlagChange", dirtyFlagListener);
                     
                     promise = DocumentManager.getDocumentForPath(JS_FILE)
                         .done(function (result) { doc = result; });
                     waitsForDone(promise, "Create Document");
                 });
                 runs(function () {
-                    $(doc).on("change", changeListener);
+                    doc.on("change", changeListener);
                     
                     expect(doc._masterEditor).toBeFalsy();
                     expect(doc.isDirty).toBe(false);
@@ -397,8 +397,8 @@ define(function (require, exports, module) {
                     expect(dirtyFlagListener.callCount).toBe(0);
                     expect(changeListener.callCount).toBe(1);   // resetting text is still a content change
                     
-                    $(doc).off("change", changeListener);
-                    $(DocumentManager).off("dirtyFlagChange", dirtyFlagListener);
+                    doc.off("change", changeListener);
+                    DocumentManager.off("dirtyFlagChange", dirtyFlagListener);
                     doc = null;
                 });
             });
@@ -427,8 +427,8 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    $(DocumentModule).on("documentChange.docTest", docChangeListener);
-                    $(doc).on("change", changeListener);
+                    DocumentModule.on("documentChange.docTest", docChangeListener);
+                    doc.on("change", changeListener);
                     
                     expect(doc._masterEditor).toBeFalsy();
 
@@ -452,8 +452,8 @@ define(function (require, exports, module) {
                     doc.setText("first edit");
                     expect(doc._masterEditor).toBeTruthy();
                     
-                    $(DocumentModule).on("documentChange.docTest", docChangeListener);
-                    $(doc).on("change", changeListener);
+                    DocumentModule.on("documentChange.docTest", docChangeListener);
+                    doc.on("change", changeListener);
 
                     doc.refreshText("New content", Date.now());
                     
@@ -464,7 +464,7 @@ define(function (require, exports, module) {
             
             it("should *not* fire documentChange when a document is first created", function () {
                 runs(function () {
-                    $(DocumentModule).on("documentChange.docTest", docChangeListener);
+                    DocumentModule.on("documentChange.docTest", docChangeListener);
                     waitsForDone(DocumentManager.getDocumentForPath(JS_FILE));
                 });
                 

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -1286,8 +1286,8 @@ define(function (require, exports, module) {
                     activeEditorChangeListener = jasmine.createSpy();
 
                 runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.on("currentDocumentChange", docChangeListener);
+                    EditorManager.on("activeEditorChange", activeEditorChangeListener);
                     
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/test.js" });
@@ -1305,8 +1305,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(docChangeListener.callCount).toBe(2);
                     expect(activeEditorChangeListener.callCount).toBe(2);
-                    _$(DocumentManager).off("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).off("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.off("currentDocumentChange", docChangeListener);
+                    EditorManager.off("activeEditorChange", activeEditorChangeListener);
                 });
             });
             
@@ -1316,8 +1316,8 @@ define(function (require, exports, module) {
                     activeEditorChangeListener = jasmine.createSpy();
 
                 runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.on("currentDocumentChange", docChangeListener);
+                    EditorManager.on("activeEditorChange", activeEditorChangeListener);
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/couz.png" });
                     waitsForDone(promise, Commands.FILE_OPEN);
@@ -1334,8 +1334,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(docChangeListener.callCount).toBe(0);
                     expect(activeEditorChangeListener.callCount).toBe(0);
-                    _$(DocumentManager).off("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).off("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.off("currentDocumentChange", docChangeListener);
+                    EditorManager.off("activeEditorChange", activeEditorChangeListener);
                 });
     
             });
@@ -1346,8 +1346,8 @@ define(function (require, exports, module) {
                     activeEditorChangeListener = jasmine.createSpy();
 
                 runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.on("currentDocumentChange", docChangeListener);
+                    EditorManager.on("activeEditorChange", activeEditorChangeListener);
                     
                     
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: testPath + "/test.js" });
@@ -1365,8 +1365,8 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(docChangeListener.callCount).toBe(2);
                     expect(activeEditorChangeListener.callCount).toBe(2);
-                    _$(DocumentManager).off("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).off("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.off("currentDocumentChange", docChangeListener);
+                    EditorManager.off("activeEditorChange", activeEditorChangeListener);
                 });
             });
             

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, $, jasmine */
+/*global define, describe, it, expect, beforeEach, afterEach, jasmine */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -98,7 +98,7 @@ define(function (require, exports, module) {
             it("should trigger a synchronous Document change event when an edit is performed", function () {
                 var changeFired = false;
                 function changeHandler(event, doc, changeList) {
-                    $(myDocument).off("change", changeHandler);
+                    myDocument.off("change", changeHandler);
                     changeFired = true;
                     expect(doc).toBe(myDocument);
                     expect(changeList.length).toBe(1);
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
                     expect(changeList[0].to).toEqual({line: 1, ch: 0});
                     expect(changeList[0].text).toEqual(["new content"]);
                 }
-                $(myDocument).on("change", changeHandler);
+                myDocument.on("change", changeHandler);
                 myEditor._codeMirror.setValue("new content");
                 expect(changeFired).toBe(true);
             });
@@ -114,7 +114,7 @@ define(function (require, exports, module) {
             it("should send an array of multiple change records for an operation", function () {
                 var cm = myEditor._codeMirror,
                     changeHandler = jasmine.createSpy();
-                $(myDocument).on("change", changeHandler);
+                myDocument.on("change", changeHandler);
                 cm.operation(function () {
                     cm.replaceRange("inserted", {line: 1, ch: 0});
                     cm.replaceRange("", {line: 0, ch: 0}, {line: 0, ch: 4});

--- a/test/spec/EventDispatcher-test.js
+++ b/test/spec/EventDispatcher-test.js
@@ -385,5 +385,20 @@ define(function (require, exports, module) {
             EventDispatcher.triggerWithArray(dispatcher, "foo", [42, "bar"]);
             expect(fn1).toHaveBeenCalledWith(jasmine.any(Object), 42, "bar");
         });
+        
+        it("on_duringInit() attaches listeners before makeEventDispatcher()", function () {
+            dispatcher = {};
+            EventDispatcher.on_duringInit(dispatcher, "foo", fn1);
+            
+            EventDispatcher.makeEventDispatcher(dispatcher);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            
+            fn1.reset();
+            dispatcher.on("foo", fn2);  // add 2nd listener the normal way - shouldn't disrupt original listener
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+        });
     });
 });

--- a/test/spec/EventDispatcher-test.js
+++ b/test/spec/EventDispatcher-test.js
@@ -379,6 +379,30 @@ define(function (require, exports, module) {
             expect(fn1).not.toHaveBeenCalled();
         });
         
+        it("duplicate one() listeners both run and both detach first time", function () {
+            dispatcher.one("foo", fn1).one("foo", fn1);
+            
+            dispatcher.trigger("foo");
+            expect(fn1.callCount).toBe(2);
+            dispatcher.trigger("foo");
+            expect(fn1.callCount).toBe(2);
+        });
+        
+        it("off() given a function should work with one()", function () {
+            dispatcher.one("foo", fn1).one("foo", fn2);
+            dispatcher.off("foo", fn1);
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();  // ensure other fn's one() wrappers remain unaffected
+        });
+        
+        it("off() given a namespace should work with one()", function () {
+            dispatcher.one("foo.1", fn1);
+            dispatcher.off(".1");
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+        });
+        
         
         it("triggerWithArray() util accepts an array of event arguments", function () {
             dispatcher.on("foo", fn1);

--- a/test/spec/EventDispatcher-test.js
+++ b/test/spec/EventDispatcher-test.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global jasmine, define, describe, beforeEach, it, expect */
+
+define(function (require, exports, module) {
+    "use strict";
+    
+    var EventDispatcher = require("utils/EventDispatcher");
+    
+    describe("EventDispatcher", function () {
+        var dispatcher,
+            fn1,
+            fn2,
+            fn3,
+            fn4;
+        
+        beforeEach(function () {
+            dispatcher = {};
+            EventDispatcher.makeEventDispatcher(dispatcher);
+            
+            fn1 = jasmine.createSpy();
+            fn2 = jasmine.createSpy();
+            fn3 = jasmine.createSpy();
+            fn4 = jasmine.createSpy();
+        });
+        
+        it("should dispatch when no handlers for any event", function () {
+            dispatcher.trigger("foo");  // shouldn't throw
+        });
+        
+        it("should dispatch when no handlers for this event", function () {
+            dispatcher.on("bar", fn1);
+            dispatcher.trigger("foo");  // shouldn't throw
+        });
+        
+        it("should attach handlers that receive events", function () {
+            dispatcher.on("foo", fn1).on("foo", fn2);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+            
+            expect(fn1.mostRecentCall.args[0]).toEqual({ type: "foo", target: dispatcher });
+        });
+        
+        it("should receive events with arguments", function () {
+            dispatcher.on("foo", fn1).on("foo", fn2);
+            dispatcher.trigger("foo", 42, "bar");
+            expect(fn1).toHaveBeenCalledWith(jasmine.any(Object), 42, "bar");
+            expect(fn2).toHaveBeenCalledWith(jasmine.any(Object), 42, "bar");
+        });
+        
+        it("should separate handlers by event", function () {
+            dispatcher.on("foo", fn1).on("bar", fn2);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).not.toHaveBeenCalled();
+            
+            fn1.reset();
+            fn2.reset();
+            dispatcher.trigger("bar");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+        });
+        
+        
+        it("should detach handlers by function", function () {
+            dispatcher.on("foo", fn1).on("foo", fn2).on("foo", fn3).on("foo", fn4);
+            
+            dispatcher.off("foo", fn2).off("foo", fn4);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).not.toHaveBeenCalled();
+            expect(fn3).toHaveBeenCalled();
+            expect(fn4).not.toHaveBeenCalled();
+        });
+        
+        it("should detach handlers by event alone", function () {
+            dispatcher.on("foo", fn1).on("bar", fn2);
+            dispatcher.off("foo");
+            
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).not.toHaveBeenCalled();
+            
+            dispatcher.trigger("bar");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+        });
+        
+        it("should detach handlers by namespace alone", function () {
+            dispatcher.on("foo.1", fn1).on("foo.2", fn2).on("foo", fn3).on("bar.1", fn4);
+            dispatcher.off(".1");
+            
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+            expect(fn3).toHaveBeenCalled();
+            
+            dispatcher.trigger("bar");
+            expect(fn4).not.toHaveBeenCalled();
+        });
+        
+        it("should detach handlers by event.namespace", function () {
+            dispatcher.on("foo.1", fn1).on("foo.2", fn2).on("bar", fn3).on("bar.2", fn4);
+            dispatcher.off("bar.2");
+            
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+            
+            dispatcher.trigger("bar");
+            expect(fn3).toHaveBeenCalled();
+            expect(fn4).not.toHaveBeenCalled();
+        });
+        
+        
+        it("should no-op detach by event alone when no handlers for any event", function () {
+            dispatcher.off("foo");  // shouldn't throw
+        });
+        
+        it("should no-op detach by event alone when no handlers for this event", function () {
+            dispatcher.on("foo", fn1);
+            dispatcher.off("bar");  // shouldn't throw
+        });
+        
+        it("should no-op detach by function when that function not attached", function () {
+            dispatcher.on("foo", fn1);
+            dispatcher.off("foo", fn2);  // shouldn't throw
+            
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+        });
+        
+        it("should no-op detach by namespace alone when that namespace not used", function () {
+            dispatcher.on("foo.1", fn1);
+            dispatcher.off(".2");  // shouldn't throw
+            
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+        });
+        
+        it("should no-op detach by event.namespace when that pairing not used", function () {
+            dispatcher.on("foo.1", fn1);
+            dispatcher.off("bar.1");  // shouldn't throw
+            
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            
+            fn1.reset();
+            dispatcher.off("foo.4");  // shouldn't throw
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+        });
+        
+        it("should dispatch when no handlers after removing handlers", function () {
+            dispatcher.on("foo", fn1).on("foo", fn2);
+            dispatcher.off("foo", fn1).off("foo", fn2);
+            
+            dispatcher.trigger("foo");  // shouldn't throw
+        });
+        
+        
+        it("should attach to multiple space-separated events", function () {
+            dispatcher.on("foo bar", fn1);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            
+            fn1.reset();
+            dispatcher.trigger("bar");
+            expect(fn1).toHaveBeenCalled();
+        });
+        
+        it("should attach to multiple space-separated events with namespaces", function () {
+            dispatcher.on("foo.1 bar.2", fn1);
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            
+            fn1.reset();
+            dispatcher.trigger("bar");
+            expect(fn1).toHaveBeenCalled();
+            
+            fn1.reset();
+            dispatcher.off(".1");
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+            dispatcher.trigger("bar");
+            expect(fn1).toHaveBeenCalled();
+        });
+
+        it("should detach from multiple space-separated events", function () {
+            dispatcher.on("foo", fn1).on("bar", fn1);
+            dispatcher.off("foo bar", fn1);
+            dispatcher.trigger("foo");
+            dispatcher.trigger("bar");
+            expect(fn1).not.toHaveBeenCalled();
+        });
+        
+        it("should detach from multiple space-separated namespaces", function () {
+            dispatcher.on("foo.1", fn1).on("bar.2", fn1);
+            dispatcher.off(".1 .2", fn1);
+            dispatcher.trigger("foo");
+            dispatcher.trigger("bar");
+            expect(fn1).not.toHaveBeenCalled();
+        });
+        
+        it("should detach from multiple space-separated events with namespaces", function () {
+            dispatcher.on("foo.1", fn1).on("bar.2", fn1);
+            dispatcher.off("foo.1 bar.2", fn1);
+            dispatcher.trigger("foo");
+            dispatcher.trigger("bar");
+            expect(fn1).not.toHaveBeenCalled();
+        });
+        
+        
+        it("handlers should be independent per-instance even when attached to prototype", function () {
+            function SomeClass() {}
+            EventDispatcher.makeEventDispatcher(SomeClass.prototype);
+            
+            var sc1 = new SomeClass();
+            var sc2 = new SomeClass();
+            sc1.on("foo", fn1);
+            sc2.on("foo", fn2);
+            
+            sc1.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
+            expect(fn2).not.toHaveBeenCalled();
+            
+            fn1.reset();
+            fn2.reset();
+            sc1.off("foo");
+            sc2.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+            expect(fn2).toHaveBeenCalled();
+        });
+        
+        
+        it("attaching handler multiple times should call it multiple times", function () {
+            dispatcher.on("foo", fn1).on("foo", fn1);
+            dispatcher.trigger("foo");
+            expect(fn1.callCount).toBe(2);
+        });
+        
+        it("duplicate handlers should all be detached at once", function () {
+            dispatcher.on("foo", fn1).on("foo", fn1);
+            dispatcher.off("foo", fn1);
+            dispatcher.trigger("foo");
+            expect(fn1).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
         afterEach(function () {
             $.mockjaxClear(mockId);
             ExtensionManager._reset();
-            $(ExtensionManager).off(".unit-test");
+            ExtensionManager.off(".unit-test");
             brackets.config.extension_registry = origRegistryURL;
             brackets.config.extension_url = origExtensionUrl;
         });
@@ -107,13 +107,13 @@ define(function (require, exports, module) {
         function mockLoadExtensions(names, fail) {
             var numStatusChanges = 0;
             runs(function () {
-                $(ExtensionManager).on("statusChange.mock-load", function () {
+                ExtensionManager.on("statusChange.mock-load", function () {
                     numStatusChanges++;
                 });
                 var mockPath = SpecRunnerUtils.getTestPath("/spec/ExtensionManager-test-files");
                 names = names || ["default/mock-extension-1", "dev/mock-extension-2", "user/mock-legacy-extension"];
                 names.forEach(function (name) {
-                    $(ExtensionLoader).triggerHandler(fail ? "loadFailed" : "load", mockPath + "/" + name);
+                    ExtensionLoader.trigger(fail ? "loadFailed" : "load", mockPath + "/" + name);
                 });
             });
             
@@ -121,7 +121,7 @@ define(function (require, exports, module) {
             waitsFor(function () { return numStatusChanges === names.length; }, "ExtensionManager status changes");
             
             runs(function () {
-                $(ExtensionManager).off(".mock-load");
+                ExtensionManager.off(".mock-load");
             });
         }
         
@@ -223,7 +223,7 @@ define(function (require, exports, module) {
                 var registryUpdateSpy;
                 runs(function () {
                     registryUpdateSpy = jasmine.createSpy();
-                    $(ExtensionManager).on("registryUpdate", registryUpdateSpy);
+                    ExtensionManager.on("registryUpdate", registryUpdateSpy);
                     waitsForDone(ExtensionManager.downloadRegistry(), "fetching registry");
                 });
                 mockLoadExtensions();
@@ -321,7 +321,7 @@ define(function (require, exports, module) {
             it("should raise a statusChange event when an extension is loaded", function () {
                 var spy = jasmine.createSpy();
                 runs(function () {
-                    $(ExtensionManager).on("statusChange.unit-test", spy);
+                    ExtensionManager.on("statusChange.unit-test", spy);
                     mockLoadExtensions(["default/mock-extension-1"]);
                 });
                 runs(function () {
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
             it("should raise a statusChange event when a legacy extension is loaded, with its path as the id", function () {
                 var spy = jasmine.createSpy();
                 runs(function () {
-                    $(ExtensionManager).on("statusChange.unit-test", spy);
+                    ExtensionManager.on("statusChange.unit-test", spy);
                     mockLoadExtensions(["user/mock-legacy-extension"]);
                 });
                 runs(function () {
@@ -346,7 +346,7 @@ define(function (require, exports, module) {
                     mockLoadExtensions(["user/mock-extension-3"]);
                 });
                 runs(function () {
-                    $(ExtensionManager).on("statusChange.unit-test", spy);
+                    ExtensionManager.on("statusChange.unit-test", spy);
                     waitsForDone(ExtensionManager.remove("mock-extension-3"));
                 });
                 runs(function () {
@@ -703,7 +703,7 @@ define(function (require, exports, module) {
                 
                 it("should trigger filter event when filter changes", function () {
                     var gotEvent = false;
-                    $(model).on("filter", function () {
+                    model.on("filter", function () {
                         gotEvent = true;
                     });
                     model.filter("uniq1");
@@ -778,7 +778,7 @@ define(function (require, exports, module) {
                 it("should raise an event when an extension is installed", function () {
                     var calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                     });
@@ -800,7 +800,7 @@ define(function (require, exports, module) {
                 it("should raise an event when an extension is removed", function () {
                     var calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         waitsForDone(ExtensionManager.remove("registered-extension"));
@@ -813,7 +813,7 @@ define(function (require, exports, module) {
                 it("should mark an extension for removal and raise an event without actually removing it", function () {
                     var id = "registered-extension", calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         ExtensionManager.markForRemoval(id, true);
@@ -828,7 +828,7 @@ define(function (require, exports, module) {
                     var id = "registered-extension", calledId;
                     runs(function () {
                         ExtensionManager.markForRemoval(id, true);
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         ExtensionManager.markForRemoval(id, false);
@@ -843,7 +843,7 @@ define(function (require, exports, module) {
                     runs(function () {
                         ExtensionManager.markForRemoval("registered-extension", true);
                         ExtensionManager.markForRemoval("Z-capital-extension", false);
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             removedIds[id] = true;
                             removedPaths[removedPath] = true;
                         });
@@ -863,7 +863,7 @@ define(function (require, exports, module) {
                 it("should mark an extension for update and raise an event", function () {
                     var id = "registered-extension", calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         ExtensionManager.updateFromDownload({
@@ -883,7 +883,7 @@ define(function (require, exports, module) {
                         file = FileSystem.getFileForPath(filename),
                         calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         ExtensionManager.updateFromDownload({
@@ -903,7 +903,7 @@ define(function (require, exports, module) {
                 it("should change an extension marked for removal to update raise an event", function () {
                     var id = "registered-extension", calledId;
                     runs(function () {
-                        $(model).on("change", function (e, id) {
+                        model.on("change", function (e, id) {
                             calledId = id;
                         });
                         ExtensionManager.markForRemoval(id, true);

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -385,7 +385,7 @@ define(function (require, exports, module) {
                     cb = errorCallback();
                 
                 runs(function () {
-                    $(fileSystem).one("rename", spy);
+                    fileSystem.one("rename", spy);
                     file.rename(newPath, cb);
                 });
                 waitsFor(function () { return cb.wasCalled && spy.wasCalled; });
@@ -835,7 +835,7 @@ define(function (require, exports, module) {
                     // Delay impl callback to happen after impl watcher notification
                     MockFileSystemImpl.when(implOpName, entry.fullPath, delay(250));
                     
-                    $(fileSystem).on(eventName, function (evt, entry) {
+                    fileSystem.on(eventName, function (evt, entry) {
                         expect(opDone).toBe(true);  // this is the important check: callback should have already run!
                         eventDone = true;
                     });
@@ -903,7 +903,7 @@ define(function (require, exports, module) {
                     MockFileSystemImpl.when("writeFile", "/file1.txt", delay(cb1Delay));
                     MockFileSystemImpl.when("writeFile", "/file2.txt", delay(cb2Delay));
                     
-                    $(fileSystem).on("change", function (evt, entry) {
+                    fileSystem.on("change", function (evt, entry) {
                         // change for file N should not precede write callback for write to N
                         expect(write1Done || entry.fullPath !== "/file1.txt").toBe(true);
                         expect(write2Done || entry.fullPath !== "/file2.txt").toBe(true);
@@ -1174,7 +1174,7 @@ define(function (require, exports, module) {
                     
                     savedHash = file._hash;
                     
-                    $(fileSystem).on("change", function (event, filename) {
+                    fileSystem.on("change", function (event, filename) {
                         fileChanged = true;
                     });
                     
@@ -1246,7 +1246,7 @@ define(function (require, exports, module) {
                     
                     savedHash = file._hash;
                     
-                    $(fileSystem).on("change", function (event, filename) {
+                    fileSystem.on("change", function (event, filename) {
                         fileChanged = true;
                     });
                     
@@ -1517,7 +1517,7 @@ define(function (require, exports, module) {
                 changeDone = false;
                 
                 runs(function () {
-                    $(fileSystem).on("change", function (event, entry, added, removed) {
+                    fileSystem.on("change", function (event, entry, added, removed) {
                         changedEntry = entry;
                         addedEntries = added;
                         removedEntries = removed;

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -769,7 +769,7 @@ define(function (require, exports, module) {
                 gotChange = false;
                 oldResults = null;
                 wasQuickChange = false;
-                $(FindInFiles.searchModel).on("change.FindInFilesTest", function (event, quickChange) {
+                FindInFiles.searchModel.on("change.FindInFilesTest", function (event, quickChange) {
                     gotChange = true;
                     wasQuickChange = quickChange;
                 });
@@ -785,7 +785,7 @@ define(function (require, exports, module) {
             });
             
             afterEach(function () {
-                $(FindInFiles.searchModel).off(".FindInFilesTest");
+                FindInFiles.searchModel.off(".FindInFilesTest");
                 waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }), "close all files");
             });
             

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -914,7 +914,7 @@ define(function (require, exports, module) {
                     editor = SpecRunnerUtils.createMockEditor(docText, "html").editor;
                     expect(editor).toBeTruthy();
 
-                    $(editor).on("change.instrtest", function (event, editor, change) {
+                    editor.on("change.instrtest", function (event, editor, change) {
                         changeList = change;
                     });
                     

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -506,8 +506,7 @@ define(function (require, exports, module) {
                 var DocumentManager,
                     FileSystem,
                     LanguageManager,
-                    MainViewManager,
-                    _$;
+                    MainViewManager;
                 
                 SpecRunnerUtils.createTempDirectory();
                 
@@ -517,7 +516,6 @@ define(function (require, exports, module) {
                     LanguageManager = w.brackets.test.LanguageManager;
                     DocumentManager = w.brackets.test.DocumentManager;
                     MainViewManager = w.brackets.test.MainViewManager;
-                    _$ = w.$;
                 });
                 
                 var writeDeferred = $.Deferred();

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -554,8 +554,8 @@ define(function (require, exports, module) {
                     doc.addRef();
 
                     // listen for event
-                    _$(doc).on("languageChanged", spy);
-                    _$(DocumentManager).on("currentDocumentLanguageChanged", dmspy);
+                    doc.on("languageChanged", spy);
+                    DocumentManager.on("currentDocumentLanguageChanged", dmspy);
                     
                     // trigger a rename
                     oldFile.rename(newFilename, function (err) {
@@ -605,7 +605,7 @@ define(function (require, exports, module) {
                     
                     // listen for event
                     spy = jasmine.createSpy("languageChanged event handler");
-                    $(doc).on("languageChanged", spy);
+                    doc.on("languageChanged", spy);
                     
                     // sanity check language
                     expect(doc.getLanguage()).toBe(unknown);
@@ -657,7 +657,7 @@ define(function (require, exports, module) {
                 
                 // listen for event
                 spy = jasmine.createSpy("languageChanged event handler");
-                $(doc).on("languageChanged", spy);
+                doc.on("languageChanged", spy);
                 
                 // sanity check language
                 expect(doc.getLanguage()).toBe(unknown);
@@ -693,7 +693,7 @@ define(function (require, exports, module) {
                 
                 // listen for event
                 spy = jasmine.createSpy("languageChanged event handler");
-                $(doc).on("languageChanged", spy);
+                doc.on("languageChanged", spy);
                 
                 // sanity check language
                 expect(doc.getLanguage()).toBe(unknownLang);
@@ -734,7 +734,7 @@ define(function (require, exports, module) {
                 
                 // listen for event
                 spy = jasmine.createSpy("languageChanged event handler");
-                $(doc).on("languageChanged", spy);
+                doc.on("languageChanged", spy);
                 
                 // sanity check language
                 expect(doc.getLanguage()).toBe(unknownLang);

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -89,11 +89,11 @@ define(function (require, exports, module) {
         // documentSaved is fired async after the FILE_SAVE command completes.
         // Instead of waiting for the FILE_SAVE promise, we listen to the
         // inspector connection to confirm that the page reload occurred
-        testWindow.$(Inspector.Page).on("loadEventFired", deferred.resolve);
+        Inspector.Page.on("loadEventFired", deferred.resolve);
         
         // remove event listener after timeout fires
         deferred.always(function () {
-            testWindow.$(Inspector.Page).off("loadEventFired", deferred.resolve);
+            Inspector.Page.off("loadEventFired", deferred.resolve);
         });
         
         // save the file
@@ -993,7 +993,7 @@ define(function (require, exports, module) {
 
                 runs(function () {
                     // Install statusChange callback
-                    testWindow.$(LiveDevelopment).one("statusChange", spy);
+                    LiveDevelopment.one("statusChange", spy);
                     op.call();
                 });
 
@@ -1082,7 +1082,7 @@ define(function (require, exports, module) {
 
                     // Save the document and see if "scanDocument" (which reparses the page) is called.
                     spyOn(testWindow.brackets.test.HTMLInstrumentation, "scanDocument").andCallThrough();
-                    testWindow.$(DocumentManager).one("documentSaved", function (e, savedDoc) {
+                    DocumentManager.one("documentSaved", function (e, savedDoc) {
                         expect(savedDoc === doc);
                         saveDeferred.resolve();
                     });

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -242,8 +242,8 @@ define(function (require, exports, module) {
                     activeEditorChangeListener = jasmine.createSpy();
 
                 runs(function () {
-                    _$(DocumentManager).on("currentDocumentChange", docChangeListener);
-                    _$(EditorManager).on("activeEditorChange", activeEditorChangeListener);
+                    DocumentManager.on("currentDocumentChange", docChangeListener);
+                    EditorManager.on("activeEditorChange", activeEditorChangeListener);
                 });
                 runs(function () {
                     promise = new $.Deferred();
@@ -266,7 +266,7 @@ define(function (require, exports, module) {
                 var currentFileChangeListener = jasmine.createSpy();
 
                 runs(function () {
-                    _$(MainViewManager).on("currentFileChange", currentFileChangeListener);
+                    MainViewManager.on("currentFileChange", currentFileChangeListener);
                     expect(currentFileChangeListener.callCount).toBe(0);
                     promise = MainViewManager._open(MainViewManager.ACTIVE_PANE, { fullPath: testPath + "/test.js" });
                     waitsForDone(promise, "MainViewManager.doOpen");
@@ -278,7 +278,7 @@ define(function (require, exports, module) {
                     MainViewManager._closeAll(MainViewManager.ALL_PANES);
                     expect(currentFileChangeListener.callCount).toBe(2);
                     expect(currentFileChangeListener.calls[1].args[1]).toEqual(null);
-                    _$(MainViewManager).off("currentFileChange", currentFileChangeListener);
+                    MainViewManager.off("currentFileChange", currentFileChangeListener);
                 });
             });
             it("DocumentManager should listen to currentFileChange events", function () {
@@ -312,8 +312,8 @@ define(function (require, exports, module) {
                     paneLayoutChangeListener = jasmine.createSpy();
                     
                 runs(function () {
-                    _$(MainViewManager).on("paneCreate", paneCreateListener);
-                    _$(MainViewManager).on("paneLayoutChange", paneLayoutChangeListener);
+                    MainViewManager.on("paneCreate", paneCreateListener);
+                    MainViewManager.on("paneLayoutChange", paneLayoutChangeListener);
                 });
                 runs(function () {
                     MainViewManager.setLayoutScheme(1, 2);
@@ -331,8 +331,8 @@ define(function (require, exports, module) {
                     expect(paneLayoutChangeListener.calls[0].args[1]).toEqual("VERTICAL");
                 });
                 runs(function () {
-                    _$(MainViewManager).off("paneCreate", paneCreateListener);
-                    _$(MainViewManager).off("paneLayoutChange", paneLayoutChangeListener);
+                    MainViewManager.off("paneCreate", paneCreateListener);
+                    MainViewManager.off("paneLayoutChange", paneLayoutChangeListener);
                 });
             });
             it("should should show interstitial page", function () {
@@ -351,8 +351,8 @@ define(function (require, exports, module) {
                     paneLayoutChangeListener = jasmine.createSpy();
                     
                 runs(function () {
-                    _$(MainViewManager).on("paneDestroy", paneDestroyListener);
-                    _$(MainViewManager).on("paneLayoutChange", paneLayoutChangeListener);
+                    MainViewManager.on("paneDestroy", paneDestroyListener);
+                    MainViewManager.on("paneLayoutChange", paneLayoutChangeListener);
                 });
                 runs(function () {
                     MainViewManager.setLayoutScheme(1, 2);
@@ -377,8 +377,8 @@ define(function (require, exports, module) {
                     expect(paneLayoutChangeListener.calls[1].args[1]).toBeFalsy();
                 });
                 runs(function () {
-                    _$(MainViewManager).off("paneDestroy", paneDestroyListener);
-                    _$(MainViewManager).off("paneLayoutChange", paneLayoutChangeListener);
+                    MainViewManager.off("paneDestroy", paneDestroyListener);
+                    MainViewManager.off("paneLayoutChange", paneLayoutChangeListener);
                 });
             });
             it("should show two files", function () {
@@ -472,7 +472,7 @@ define(function (require, exports, module) {
                     };
                 
                 runs(function () {
-                    _$(EditorManager).on("_fullEditorCreatedForDocument", handler);
+                    EditorManager.on("_fullEditorCreatedForDocument", handler);
                     MainViewManager.setLayoutScheme(1, 2);
                 });
                 runs(function () {
@@ -493,7 +493,7 @@ define(function (require, exports, module) {
                 });
                 runs(function () {
                     editors = null;
-                    _$(EditorManager).off("_fullEditorCreatedForDocument", handler);
+                    EditorManager.off("_fullEditorCreatedForDocument", handler);
                 });
             });
             it("should activate pane when inline editor gains focus", function () {
@@ -504,7 +504,7 @@ define(function (require, exports, module) {
                     };
                 
                 runs(function () {
-                    _$(EditorManager).on("_fullEditorCreatedForDocument", handler);
+                    EditorManager.on("_fullEditorCreatedForDocument", handler);
                     MainViewManager.setLayoutScheme(1, 2);
                 });
                 runs(function () {
@@ -536,7 +536,7 @@ define(function (require, exports, module) {
                 var activePaneChangeListener = jasmine.createSpy();
                 
                 runs(function () {
-                    _$(MainViewManager).on("activePaneChange", activePaneChangeListener);
+                    MainViewManager.on("activePaneChange", activePaneChangeListener);
                 });
                 runs(function () {
                     MainViewManager.setLayoutScheme(1, 2);
@@ -550,7 +550,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(activePaneChangeListener.callCount).toBe(2);
                 });
-                _$(MainViewManager).off("activePaneChange", activePaneChangeListener);
+                MainViewManager.off("activePaneChange", activePaneChangeListener);
             });
             it("should enforce bounds", function () {
                 runs(function () {
@@ -568,7 +568,7 @@ define(function (require, exports, module) {
                 var paneLayoutChangeListener = jasmine.createSpy();
                 
                 runs(function () {
-                    _$(MainViewManager).on("paneLayoutChange", paneLayoutChangeListener);
+                    MainViewManager.on("paneLayoutChange", paneLayoutChangeListener);
                 });
                 runs(function () {
                     MainViewManager.setLayoutScheme(1, 2);
@@ -593,7 +593,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     expect(paneLayoutChangeListener.callCount).toBe(2);
                 });
-                _$(MainViewManager).off("paneLayoutChange", paneLayoutChangeListener);
+                MainViewManager.off("paneLayoutChange", paneLayoutChangeListener);
             });
         });
         describe("Targeted Pane API tests", function () {

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -184,7 +184,7 @@ define(function (require, exports, module) {
                     CommandManager.register("Brackets Test Command Custom 51", "Menu-test.command51", function () {});
                     cmenu.addMenuItem("Menu-test.command51");
 
-                    testWindow.$(cmenu).on("beforeContextMenuOpen", function () {
+                    cmenu.on("beforeContextMenuOpen", function () {
                         openEvent = true;
                     });
 
@@ -955,7 +955,7 @@ define(function (require, exports, module) {
                     CommandManager.register("Brackets Test Command Custom 51", "Menu-test.command51", function () {});
                     cmenu.addMenuItem("Menu-test.command51");
 
-                    testWindow.$(cmenu).on("beforeContextMenuOpen", function () {
+                    cmenu.on("beforeContextMenuOpen", function () {
                         openEvent = true;
                     });
 

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -233,7 +233,7 @@ define(function (require, exports, module) {
         _changeCallback = null;
         _offlineCallback = null;
 
-        $(_model).on("change", function (event, path) {
+        _model.on("change", function (event, path) {
             if (_changeCallback) {
                 var cb = _getCallback("change", path, _changeCallback);
                 cb(path, _model.stat(path));

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*global define */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/MockFileSystemModel.js
+++ b/test/spec/MockFileSystemModel.js
@@ -27,7 +27,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var FileSystemStats = require("filesystem/FileSystemStats");
+    var FileSystemStats = require("filesystem/FileSystemStats"),
+        EventDispatcher = require("utils/EventDispatcher");
     
     // Initial file system data. 
     var _initialData = {
@@ -88,6 +89,7 @@ define(function (require, exports, module) {
         $.extend(this._data, _initialData);
         this._watchedPaths = {};
     }
+    EventDispatcher.makeEventDispatcher(MockFileSystemModel.prototype);
 
     MockFileSystemModel.prototype.stat = function (path) {
         var entry = this._data[path];
@@ -116,7 +118,7 @@ define(function (require, exports, module) {
     
     MockFileSystemModel.prototype._sendWatcherNotification = function (path) {
         if (this._isPathWatched(path)) {
-            $(this).triggerHandler("change", path);
+            this.trigger("change", path);
         }
     };
     

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -107,7 +107,7 @@ define(function (require, exports, module) {
         
         afterEach(function () {
             _connectionsToAutoDisconnect.forEach(function (c) {
-                $(c).off("close");
+                c.off("close");
                 c.disconnect();
             });
         });
@@ -195,7 +195,7 @@ define(function (require, exports, module) {
         it("should receive events", function () {
             var connection = createConnection();
             var spy = jasmine.createSpy();
-            $(connection).one(
+            connection.one(
                 "test:eventOne",
                 spy
             );
@@ -364,7 +364,7 @@ define(function (require, exports, module) {
             );
             
             var reconnectResolved = false, closeHandlerCalled = false;
-            $(connectionOne).on("close", function (e, reconnectPromise) {
+            connectionOne.on("close", function (e, reconnectPromise) {
                 closeHandlerCalled = true;
                 reconnectPromise.then(function () {
                     reconnectResolved = true;

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -24,7 +24,7 @@
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true,
 indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, $, ArrayBuffer, DataView, jasmine */
+/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, ArrayBuffer, DataView, jasmine */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/Pane-test.js
+++ b/test/spec/Pane-test.js
@@ -457,19 +457,19 @@ define(function (require, exports, module) {
             it("should dispatch events when a file is removed", function () {
                 var eventHandler = jasmine.createSpy();
                 
-                $(myPane).on("viewListChange.test", eventHandler);
+                myPane.on("viewListChange.test", eventHandler);
                 
                 myPane.addToViewList(myView.getFile());
                 myPane.showView(myView);
                 myPane._handleFileDeleted(undefined, myView.getFullPath());
 
                 expect(eventHandler).toHaveBeenCalled();
-                $(myPane).off(".test");
+                myPane.off(".test");
             });
             it("should dispatch events when file is renamed", function () {
                 var eventHandler = jasmine.createSpy();
                 
-                $(myPane).on("viewListChange.test", eventHandler);
+                myPane.on("viewListChange.test", eventHandler);
                 
                 myPane.addToViewList(myView.getFile());
                 myPane.showView(myView);
@@ -480,30 +480,30 @@ define(function (require, exports, module) {
                 myPane._handleFileNameChange(undefined, oldPath, myView.getFullPath());
 
                 expect(eventHandler).toHaveBeenCalled();
-                $(myPane).off(".test");
+                myPane.off(".test");
             });
             it("should dispatch events when the view has changed", function () {
                 var eventHandler = jasmine.createSpy();
                 
-                $(myPane).on("currentViewChange.test", eventHandler);
+                myPane.on("currentViewChange.test", eventHandler);
                 
                 myPane.addToViewList(myView.getFile());
                 myPane.showView(myView);
 
                 expect(eventHandler).toHaveBeenCalled();
-                $(myPane).off(".test");
+                myPane.off(".test");
             });
             it("should dispatch events when all views are closed", function () {
                 var eventHandler = jasmine.createSpy();
                 
-                $(myPane).on("currentViewChange.test", eventHandler);
+                myPane.on("currentViewChange.test", eventHandler);
                 
                 myPane.addToViewList(myView.getFile());
                 myPane.showView(myView);
                 myPane._reset();
 
                 expect(eventHandler.callCount).toBe(2);
-                $(myPane).off(".test");
+                myPane.off(".test");
             });
         });
     });

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -511,7 +511,7 @@ define(function (require, exports, module) {
                 
                 storage.data = data2;
                 var events = [];
-                $(scope).on("change", function (e, data) {
+                scope.on("change", function (e, data) {
                     events.push(data);
                 });
                 scope.load();

--- a/test/spec/TextRange-test.js
+++ b/test/spec/TextRange-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, $ */
+/*global define, describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/TextRange-test.js
+++ b/test/spec/TextRange-test.js
@@ -52,7 +52,7 @@ define(function (require, exports, module) {
             gotLostSync = false;
 
             range = new TextRange(doc, 4, 6);
-            $(range).on("change.unittest", function () {
+            range.on("change.unittest", function () {
                 expect(gotChange).toBe(false);
                 gotChange = true;
             }).on("contentChange.unittest", function () {
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
         afterEach(function () {
             SpecRunnerUtils.destroyMockEditor(doc);
             doc = null;
-            $(range).off(".unittest");
+            range.off(".unittest");
             range.dispose();
             range = null;
         });

--- a/test/spec/WorkingSetSort-test.js
+++ b/test/spec/WorkingSetSort-test.js
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
             
             runs(function () {
                 // Initialize: register listeners
-                testWindow.$(MainViewManager).on("workingSetAdd", function (event, addedFile) {
+                MainViewManager.on("workingSetAdd", function (event, addedFile) {
                     workingSetListItemCount++;
                 });
             });

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
             
             runs(function () {
                 // Initialize: register listeners
-                testWindow.$(MainViewManager).on("workingSetAdd", function (event, addedFile) {
+                MainViewManager.on("workingSetAdd", function (event, addedFile) {
                     workingSetListItemCount++;
                 });
             });
@@ -225,7 +225,7 @@ define(function (require, exports, module) {
                 expect(closeIcon.length).toBe(1);
                 
                 // simulate click
-                $(MainViewManager).on("workingSetRemove", function (event, removedFile) {
+                MainViewManager.on("workingSetRemove", function (event, removedFile) {
                     didClose = true;
                 });
 


### PR DESCRIPTION
(from backlog card [Event Infrastructure Improvements](https://trello.com/c/ogaZoRHJ/1377-events-infrastructure-improvements))

Instead of jQuery, use our own simpler event system for non-DOM objects.
- Includes shim so legacy `$().on()/off()` code still works
- It's easy to make any object into an event dispatcher: just call `EventDispatcher.makeEventDispatcher()` on any object or any class prototype.
- More robust to listeners that throw exceptions -- other listeners will still be called, and `trigger()` will still return control to its caller.  This is important for reducing how frequently core features break due to buggy extensions.
- Events can be marked deprecated, causing `on()` to issue warnings -- this provides much more specific feedback than our current deprecation warnings, at dispatch time.  (In the future, we could also issue warnings when `on()` is called for an event that the object doesn't actually support).
- Easier to debug, since the dispatch code is much simpler.
- Event dispatching is 11x faster (although the overhead was not huge to begin with).
- Uses less memory, since `$(nonDOMObj).on()` leaks memory in jQuery
- The API is a bit simpler, eliminating some pitfalls (e.g. jQuery lets you pass single handler arguments directly, but multiple arguments must be wrapped in an array; here we just use varargs instead).

This initial demonstration converts Document & DocumentManager to use the new system, plus unit tests to verify more of its functionality.

CC @dangoor -- this was the experiment I mentioned back at MAX.
