### PR TITLE
Using error notification when code errors

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
      * @param {Array.<{name:string, scanFileAsync:?function(string, string):!{$.Promise}, scanFile:?function(string, string):Object}>} providersReportingProblems - providers that reported problems
      * @param {boolean} aborted - true if any provider returned a result with the 'aborted' flag set
      */
-    function updatePanelTitleAndStatusBar(numProblems, providersReportingProblems, aborted) {
+    function updatePanelTitleAndStatusBar(numProblems, providersReportingProblems, hasError, aborted) {
         var message, tooltip;
 
         if (providersReportingProblems.length === 1) {
@@ -302,7 +302,7 @@ define(function (require, exports, module) {
 
         $problemsPanel.find(".title").text(message);
         tooltip = StringUtils.format(Strings.STATUSBAR_CODE_INSPECTION_TOOLTIP, message);
-        StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-errors", tooltip);
+        StatusBar.updateIndicator(INDICATOR_ID, true, hasError ? "inspection-errors" : "inspection-warnings", tooltip);
     }
 
     /**
@@ -360,6 +360,8 @@ define(function (require, exports, module) {
 
                 var perfTimerDOM = PerfUtils.markStart("ProblemsPanel render:\t" + currentDoc.file.fullPath);
                 
+                var hasError = false;
+                
                 // Augment error objects with additional fields needed by Mustache template
                 results.forEach(function (inspectionResult) {
                     var provider = inspectionResult.provider;
@@ -377,6 +379,8 @@ define(function (require, exports, module) {
                             if (error.type !== Type.META) {
                                 numProblems++;
                             }
+                            
+                            hasError = hasError || error.type === Type.ERROR;
                         });
 
                         // if the code inspector was unable to process the whole file, we keep track to show a different status
@@ -407,7 +411,7 @@ define(function (require, exports, module) {
                     Resizer.show($problemsPanel);
                 }
 
-                updatePanelTitleAndStatusBar(numProblems, providersReportingProblems, aborted);
+                updatePanelTitleAndStatusBar(numProblems, providersReportingProblems, hasError, aborted);
                 setGotoEnabled(true);
 
                 PerfUtils.addMeasurement(perfTimerDOM);

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1948,8 +1948,12 @@ textarea.exclusions-editor {
     background: url(images/topcoat-inactive-15.svg) 9px 5px no-repeat;
 }
 
-.inspection-errors {
+.inspection-warnings {
     background: url(images/topcoat-warning-15.svg) 9px 5px no-repeat;
+}
+
+.inspection-errors {
+    background: url(images/topcoat-error-15.svg) 9px 5px no-repeat;
 }
 
 .inspection-errors:hover {

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -786,56 +786,56 @@ define(function (require, exports, module) {
                 });
             });
 
-	    it("should show warning icon in inspector icon when only warnings", function () {
-            var lintResult = {
-                errors: [
-                    {
-                        pos: { line: 1, ch: 3 },
-                        message: "Some errors here and there",
-                        type: CodeInspection.Type.WARNING
-                    }
-                ]
-            };
-            
-            
-            var codeInspector = createCodeInspector("javascript linter", lintResult);
-            CodeInspection.register("javascript", codeInspector);
-            
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
-		  
-            runs(function () {
-                var $statusBar = $("#status-inspection");
-                expect($statusBar.is(":visible")).toBe(true);
-                expect($statusBar.attr("class")).toBe('inspection-warnings');
-            });
-        });
+            it("should show warning icon in inspector icon when only warnings", function () {
+                var lintResult = {
+                    errors: [
+                        {
+                            pos: { line: 1, ch: 3 },
+                            message: "Some errors here and there",
+                            type: CodeInspection.Type.WARNING
+                        }
+                    ]
+                };
 
-        it("should show error icon in inspector icon when has errors", function () {
-            var lintResult = {
-                errors: [
-                    {
-                        pos: { line: 1, ch: 3 },
-                        message: "Some errors here and there",
-                        type: CodeInspection.Type.WARNING
-                    },
-                    {
-                        pos: { line: 1, ch: 5 },
-                        message: "Some errors there and there and over there",
-                        type: CodeInspection.Type.ERROR
-                    }
-                ]
-            };
-            var codeInspector = createCodeInspector("javascript linter", lintResult);
-            CodeInspection.register("javascript", codeInspector);
+                var codeInspector = createCodeInspector("javascript linter", lintResult);
+                CodeInspection.register("javascript", codeInspector);
 
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
-            
-            runs(function () {
-                var $statusBar = $("#status-inspection");
-                expect($statusBar.is(":visible")).toBe(true);
-                expect($statusBar.attr("class")).toBe('inspection-errors');
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+
+                runs(function () {
+                    var $statusBar = $("#status-inspection");
+                    expect($statusBar.is(":visible")).toBe(true);
+                    expect($statusBar.attr("class")).toBe('inspection-warnings');
+                });
             });
-        });
+
+            it("should show error icon in inspector icon when has errors", function () {
+                var lintResult = {
+                    errors: [
+                        {
+                            pos: { line: 1, ch: 3 },
+                            message: "Some errors here and there",
+                            type: CodeInspection.Type.WARNING
+                        },
+                        {
+                            pos: { line: 1, ch: 5 },
+                            message: "Some errors there and there and over there",
+                            type: CodeInspection.Type.ERROR
+                        }
+                    ]
+                };
+                
+                var codeInspector = createCodeInspector("javascript linter", lintResult);
+                CodeInspection.register("javascript", codeInspector);
+
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+
+                runs(function () {
+                    var $statusBar = $("#status-inspection");
+                    expect($statusBar.is(":visible")).toBe(true);
+                    expect($statusBar.attr("class")).toBe('inspection-errors');
+                });
+            });
 
             it("should show the generic panel title if more than one inspector reported problems", function () {
                 var lintResult = failLintResult();

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -786,6 +786,57 @@ define(function (require, exports, module) {
                 });
             });
 
+	    it("should show warning icon in inspector icon when only warnings", function () {
+            var lintResult = {
+                errors: [
+                    {
+                        pos: { line: 1, ch: 3 },
+                        message: "Some errors here and there",
+                        type: CodeInspection.Type.WARNING
+                    }
+                ]
+            };
+            
+            
+            var codeInspector = createCodeInspector("javascript linter", lintResult);
+            CodeInspection.register("javascript", codeInspector);
+            
+            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+		  
+            runs(function () {
+                var $statusBar = $("#status-inspection");
+                expect($statusBar.is(":visible")).toBe(true);
+                expect($statusBar.attr("class")).toBe('inspection-warnings');
+            });
+        });
+
+        it("should show error icon in inspector icon when has errors", function () {
+            var lintResult = {
+                errors: [
+                    {
+                        pos: { line: 1, ch: 3 },
+                        message: "Some errors here and there",
+                        type: CodeInspection.Type.WARNING
+                    },
+                    {
+                        pos: { line: 1, ch: 5 },
+                        message: "Some errors there and there and over there",
+                        type: CodeInspection.Type.ERROR
+                    }
+                ]
+            };
+            var codeInspector = createCodeInspector("javascript linter", lintResult);
+            CodeInspection.register("javascript", codeInspector);
+
+            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+            
+            runs(function () {
+                var $statusBar = $("#status-inspection");
+                expect($statusBar.is(":visible")).toBe(true);
+                expect($statusBar.attr("class")).toBe('inspection-errors');
+            });
+        });
+
             it("should show the generic panel title if more than one inspector reported problems", function () {
                 var lintResult = failLintResult();
 

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                 errors: [
                     {
                         pos: { line: 1, ch: 3 },
-                        message: "Some errors here and there",
+                        message: "Some warnings here and there",
                         type: CodeInspection.Type.WARNING
                     }
                 ]
@@ -580,7 +580,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 1, ch: 3 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         },
                         {
@@ -757,7 +757,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 1, ch: 3 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         },
                         {
@@ -791,7 +791,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 1, ch: 3 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         }
                     ]
@@ -814,7 +814,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 1, ch: 3 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         },
                         {
@@ -913,7 +913,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 1, ch: 3 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         }
                     ]
@@ -922,7 +922,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: 0, ch: 2 },
-                            message: "Different error",
+                            message: "Different warning",
                             type: CodeInspection.Type.WARNING
                         }
                     ]
@@ -945,7 +945,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: -1, ch: 0 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         }
                     ]
@@ -955,7 +955,7 @@ define(function (require, exports, module) {
                     errors: [
                         {
                             pos: { line: "all", ch: 0 },
-                            message: "Some errors here and there",
+                            message: "Some warnings here and there",
                             type: CodeInspection.Type.WARNING
                         }
                     ]


### PR DESCRIPTION
Currently brackets only shows the warning style notify icon when there the `CodeInspector` finds problems with the code. This change means it will now show the error icon if any of the errors have the `error.type = Type.ERROR`

Not the worlds biggest fan of the icon but it was already present. If you'd like it changing for a different one let me know. 

![image](https://cloud.githubusercontent.com/assets/2362687/5047869/362a11b2-6c11-11e4-9590-57d6f8a99d1e.png)

This is particularly useful for my Omnisharp plugin :)
