### PR TITLE
Fixed #8410: NOT_READABLE_ERR, NOT_FOUND_ERR in ./src/nls/root/strings.js corrected.

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -32,8 +32,8 @@ define({
 
     // General file io error strings
     "GENERIC_ERROR"                     : "(error {0})",
-    "NOT_FOUND_ERR"                     : "The file could not be found.",
-    "NOT_READABLE_ERR"                  : "The file could not be read.",
+    "NOT_FOUND_ERR"                     : "The file/directory could not be found.",
+    "NOT_READABLE_ERR"                  : "The file/directory could not be read.",
     "EXCEEDS_MAX_FILE_SIZE"             : "Files larger than {0} MB cannot be opened in {APP_NAME}.",
     "NO_MODIFICATION_ALLOWED_ERR"       : "The target directory cannot be modified.",
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "The permissions do not allow you to make modifications.",


### PR DESCRIPTION
Correct a typo as pointed in #8410 .

Please let me know if the string should be changed.
