### PR TITLE
Don't misidentify pseudo selector/element as a property while parsing CSS.

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -844,7 +844,7 @@ define(function (require, exports, module) {
 
         function _maybeProperty() {
             return (/^-(moz|ms|o|webkit)-$/.test(token) ||
-                    (state.state !== "top" && state.state !== "block" &&
+                    (state.state !== "top" && state.state !== "block" && state.state !== "pseudo" &&
                     // Has a semicolon as in "rgb(0,0,0);", but not one of those after a LESS 
                     // mixin parameter variable as in ".size(@width; @height)"
                     stream.string.indexOf(";") !== -1 && !/\([^)]+;/.test(stream.string)));

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -1298,6 +1298,27 @@ define(function (require, exports, module) {
                 expect(result.length).toBe(0);
             });
                 
+            it("should find selectors that are after a rule starting with a pseudo selector/element", function () {
+                var css = ":focus { color:red; } \n" +
+                          "div { color:blue; } \n" +
+                          "::selection { color:green; } \n" +
+                          ".Foo { color:black } \n" +
+                          "#bar { color:blue } \n" +
+                          "#baR { color:white }";
+                           
+                var result = match(css, { tag: "div" });
+                expect(result.length).toBe(1);
+
+                result = matchAgain({ clazz: "Foo" });
+                expect(result.length).toBe(1);
+                
+                result = matchAgain({ id: "bar" });
+                expect(result.length).toBe(1);
+                
+                result = matchAgain({ id: "baR" });
+                expect(result.length).toBe(1);
+            });
+            
         }); // describe("Simple selectors")
         
         


### PR DESCRIPTION
This fixes issue #9840.

@redmunds Can you review this since you're familiar with this code?
