### PR TITLE
Fix style sheet parsing

### DIFF
--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -166,20 +166,23 @@ define(function (require, exports, module) {
         // Check for gradient. -webkit-gradient() can have parens in parameters
         // nested 2 levels. Other gradients can only nest 1 level.
         var gradientRegEx = /-webkit-gradient\((?:[^\(]*?(?:\((?:[^\(]*?(?:\([^\)]*?\))*?)*?\))*?)*?\)|(?:(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?linear-gradient)|(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?radial-gradient))(\((?:[^\)]*?(?:\([^\)]*?\))*?)*?\))/gi,
-            colorRegEx = new RegExp(ColorUtils.COLOR_REGEX);
+            colorRegEx    = new RegExp(ColorUtils.COLOR_REGEX),
+            mode          = TokenUtils.getModeAt(editor._codeMirror, pos),
+            isStyleSheet  = (styleLanguages.indexOf(mode) !== -1);
 
         function areParensBalanced(str) {
             var i,
                 nestLevel = 0,
-                content,
                 len;
 
-            // Remove comments & strings
-            content = CSSUtils.reduceStyleSheetForRegExParsing(str);
-            len = content.length;
+            if (isStyleSheet) {
+                // Remove comments & strings from style sheets
+                str = CSSUtils.reduceStyleSheetForRegExParsing(str);
+            }
+            len = str.length;
             
             for (i = 0; i < len; i++) {
-                switch (content[i]) {
+                switch (str[i]) {
                 case "(":
                     nestLevel++;
                     break;

--- a/src/extensions/default/QuickView/unittest-files/test.css
+++ b/src/extensions/default/QuickView/unittest-files/test.css
@@ -185,3 +185,8 @@ background: -ms-linear-gradient(top,  #d2dfed 0%,#c8d7eb 26%,#bed0ea 51%,#a6c0e3
     background: url("img/don't.png");
     background:url("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg'></svg>");
 }
+
+.unbalanced-parens {
+    background-image: linear-gradient(to bottom, #333, #CCC;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(rgb(51,51,51)), to(rgb(204,204,204));
+}

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            it("Should should convert gradients arguments from pixel to percent", function () {
+            it("Should convert gradients arguments from pixel to percent", function () {
                 runs(function () {
                     // linear gradient in px
                     checkGradientAtPos("-webkit-linear-gradient(top, rgba(0,0,0,0) 0%, green 50%, red 100%)", 163, 40);
@@ -337,6 +337,14 @@ define(function (require, exports, module) {
                     checkGradientAtPos("repeating-linear-gradient(red, blue 50%, red 100%)", 164, 40);
                     // repeating radial-gradient in pixels (no prefix)
                     checkGradientAtPos("repeating-radial-gradient(red, blue 50%, red 100%)", 165, 40);
+                });
+            });
+            
+            it("Should not go into infinite loop on unbalanced parens", function () {
+                runs(function () {
+                    // no preview, and no infinite loop
+                    expectNoPreviewAtPos(189, 30);
+                    expectNoPreviewAtPos(190, 40);
                 });
             });
         });

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1659,12 +1659,12 @@ define(function (require, exports, module) {
     }
     
     /**
-     * removes strings from the content 
+     * removes strings specified with css content property (e.g. "content: '('")
      * @param {!string} content to reduce
      * @return {string} reduced content 
      */
     function _removeStrings(content) {
-        return content.replace(/[^\\]\"(.*)[^\\]\"|[^\\]\'(.*)[^\\]\'+/g, "");
+        return content.replace(/content\s*:\s*(?:[^\\]\"(.*)[^\\]\"|[^\\]\'(.*)[^\\]\')/g, "");
     }
     
     /**

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1659,12 +1659,17 @@ define(function (require, exports, module) {
     }
     
     /**
-     * removes strings specified with css content property (e.g. "content: '('")
+     * removes strings from the content
      * @param {!string} content to reduce
      * @return {string} reduced content 
      */
     function _removeStrings(content) {
-        return content.replace(/content\s*:\s*(?:[^\\]\"(.*)[^\\]\"|[^\\]\'(.*)[^\\]\')/g, "");
+        // First remove escaped quotes so we can balance unescaped quotes
+        // since JavaScript doesn't support negative lookbehind
+        var s = content.replace(/\\\"|\\\'/g, "");
+
+        // Now remove strings
+        return s.replace(/\"(.*?)\"|\'(.*?)\'/g, "");
     }
     
     /**

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -706,21 +706,17 @@ define(function (require, exports, module) {
                 var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: hsl(0, 100%, 50%); /* unbalanced paren :) */ margin: 0; } .foo { background-color: orange; /* comment */ margin: 1px; }");
                 expect(result).toEqual(".test { color: hsl(0, 100%, 50%);  margin: 0; } .foo { background-color: orange;  margin: 1px; }");
             });
-            it("should remove css content property with single quotes", function () {
-                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { content: '('; padding: 0; }");
-                expect(result).toEqual(".test { ; padding: 0; }");
+            it("should remove css string with single quotes", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { content: '('; background-image: url('bg.svg'); padding: 0; }");
+                expect(result).toEqual(".test { content: ; background-image: url(); padding: 0; }");
             });
-            it("should remove css content property with double quotes", function () {
-                var result = CSSUtils.reduceStyleSheetForRegExParsing('.test-content { border: 0; content: ">"; }');
-                expect(result).toEqual('.test-content { border: 0; ; }');
-            });
-            it("should not remove strings which are not css content property", function () {
-                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { background-image: url('bg.svg'); padding: 0; }");
-                expect(result).toEqual(".test { background-image: url('bg.svg'); padding: 0; }");
+            it("should remove css string with double quotes", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing('.test-content { border: 0; background-image: url("bg.svg"); content: ">"; }');
+                expect(result).toEqual('.test-content { border: 0; background-image: url(); content: ; }');
             });
             it("should remove both comment and css content property", function () {
                 var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: #123; /* unbalanced paren :-) */ margin: 0; content: ')'; padding: 0; }");
-                expect(result).toEqual(".test { color: #123;  margin: 0; ; padding: 0; }");
+                expect(result).toEqual(".test { color: #123;  margin: 0; content: ; padding: 0; }");
             });
             it("should otherwise not alter stylesheet text", function () {
                 var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: #1254ef; margin: 0.1em; filter: blur(); }");

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -692,6 +692,41 @@ define(function (require, exports, module) {
                 expect(selector).toEqual(".foo");
             });
         });
+        
+        describe("reduceStyleSheetForRegExParsing", function () {
+            it("should remove css comment in a line", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: #123; /* unbalanced paren :) */ margin: 0; }");
+                expect(result).toEqual(".test { color: #123;  margin: 0; }");
+            });
+            it("should remove css comment across newlines", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".foo {\n  background-color: rgb(0, 63, 255); /* start of comment\n end of comment */\n  margin: 0;\n}\n");
+                expect(result).toEqual(".foo {\n  background-color: rgb(0, 63, 255); \n  margin: 0;\n}\n");
+            });
+            it("should remove multiple css comments", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: hsl(0, 100%, 50%); /* unbalanced paren :) */ margin: 0; } .foo { background-color: orange; /* comment */ margin: 1px; }");
+                expect(result).toEqual(".test { color: hsl(0, 100%, 50%);  margin: 0; } .foo { background-color: orange;  margin: 1px; }");
+            });
+            it("should remove css content property with single quotes", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { content: '('; padding: 0; }");
+                expect(result).toEqual(".test { ; padding: 0; }");
+            });
+            it("should remove css content property with double quotes", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing('.test-content { border: 0; content: ">"; }');
+                expect(result).toEqual('.test-content { border: 0; ; }');
+            });
+            it("should not remove strings which are not css content property", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { background-image: url('bg.svg'); padding: 0; }");
+                expect(result).toEqual(".test { background-image: url('bg.svg'); padding: 0; }");
+            });
+            it("should remove both comment and css content property", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: #123; /* unbalanced paren :-) */ margin: 0; content: ')'; padding: 0; }");
+                expect(result).toEqual(".test { color: #123;  margin: 0; ; padding: 0; }");
+            });
+            it("should otherwise not alter stylesheet text", function () {
+                var result = CSSUtils.reduceStyleSheetForRegExParsing(".test { color: #1254ef; margin: 0.1em; filter: blur(); }");
+                expect(result).toEqual(".test { color: #1254ef; margin: 0.1em; filter: blur(); }");
+            });
+        });
     }); // describe("CSSUtils")
 
     


### PR DESCRIPTION
This is for #9875 .

When minimizing style sheets for parsing, limit string removal to content property.

Added unit tests to CSSUtils and Quick View.
