### PR TITLE
Re-enable ViewCommandHandlers tests

### DIFF
--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
     require("spec/UrlParams-test");
     require("spec/ValidationUtils-test");
     require("spec/ViewFactory-test");
-    //require("spec/ViewCommandHandlers-test");
+    require("spec/ViewCommandHandlers-test");
     require("spec/ViewUtils-test");
     require("spec/WorkingSetView-test");
     require("spec/WorkingSetSort-test");


### PR DESCRIPTION
This is for #7420 

I can run all Integration Tests on Windows 7 in brackets-shell **master** branch (_not_ CEF 2171), so we might be able to just re-enable these. These also pass on Mac OS X 10.8 (but that was never a problem before).

@JeffryBooher Verify that the ViewCommandHandlers tests now pass for you when running all Integration tests
