### PR TITLE
Remove unnecessary call to EditorManager.getFocusedEditor()

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -31,7 +31,6 @@ define(function (require, exports, module) {
     var AppInit         = brackets.getModule("utils/AppInit"),
         CodeHintManager = brackets.getModule("editor/CodeHintManager"),
         CSSUtils        = brackets.getModule("language/CSSUtils"),
-        EditorManager   = brackets.getModule("editor/EditorManager"),
         FileSystem      = brackets.getModule("filesystem/FileSystem"),
         FileUtils       = brackets.getModule("file/FileUtils"),
         HTMLUtils       = brackets.getModule("language/HTMLUtils"),

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -60,7 +60,6 @@ define(function (require, exports, module) {
         var directory,
             doc,
             docDir,
-            editor,
             queryDir = "",
             queryUrl,
             result = [],
@@ -68,13 +67,7 @@ define(function (require, exports, module) {
             targetDir,
             unfiltered = [];
 
-        // get path to document in focused editor
-        editor = EditorManager.getFocusedEditor();
-        if (!editor) {
-            return result;
-        }
-
-        doc = editor.document;
+        doc = this.editor && this.editor.document;
         if (!doc || !doc.file) {
             return result;
         }


### PR DESCRIPTION
This fixes unit test failure in CEF 2171 branch reported in #9972. This also works in brackets-shell master, so this can be merged now.
