### PR TITLE
Fix Quick Open position issues (#9981)

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -746,7 +746,7 @@ define(function (require, exports, module) {
         initialString = prefix + initialString;
         
         var $field = this.$searchField;
-        $field.val(initialString);
+        $field.val(initialString).focus();
         $field.get(0).setSelectionRange(prefix.length, initialString.length);
         
         // Kick smart-autocomplete to update (it only listens for keyboard events)

--- a/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
+++ b/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
@@ -260,8 +260,7 @@
           if(options.alignResultsContainer){
             results_container.css({ 
                   position: "absolute",
-                  // Explicitly add 2 pixels to "top" for the bottom edge of the focus ring around the search field.
-                  top: function(){ return $(context).offset().top + $(context).height() + 2; }, 
+                  top: function(){ return $(context).offset().top + ($(context).height() + $(context).innerHeight()) / 2; }, 
                   left: function(){ return $(context).offset().left; }, 
                   width: function(){ return $(context).width(); }, 
                   zIndex: 1000

--- a/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
+++ b/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
@@ -260,7 +260,8 @@
           if(options.alignResultsContainer){
             results_container.css({ 
                   position: "absolute",
-                  top: function(){ return $(context).offset().top + $(context).height(); }, 
+                  // Explicitly add 2 pixels to "top" for the bottom edge of the focus ring around the search field.
+                  top: function(){ return $(context).offset().top + $(context).height() + 2; }, 
                   left: function(){ return $(context).offset().left; }, 
                   width: function(){ return $(context).width(); }, 
                   zIndex: 1000


### PR DESCRIPTION
This fixes #9981 for CEF 2171 and the following focus ring issue that is also in the release 1.0.

before 
![quickopenfocusringbeforefix](https://cloud.githubusercontent.com/assets/1542488/5151370/da81405c-7191-11e4-9b4d-7620f66f8563.png)

after
![quickopenfocusringafterfix](https://cloud.githubusercontent.com/assets/1542488/5151386/210ff6d0-7192-11e4-9088-fc4434b214c0.png)
