### PR TITLE
Removing the unneeded negative margin trick used to position icons.

### DIFF
--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -53,17 +53,9 @@ li.jstree-closed > ul { display:none; }
 
 @jstree-icon-backindent: 12px;
 
-/* Make the links in the JS tree the width of the container
- * by shifting the off the screen by negative margin and moving the
- * content back by pushing the padding. The icons are positioned absolute
- * relative to the containing list item so they sit above the a's background.
- * This also means we need to include the size of the sprite in the padding
- * so the text ends up back in the same spot visually
- */
 .jstree-brackets li > a {
     @jstree-icon-text-overlap: 2px;
-    padding-left: (@jstree-sprite-size - @jstree-icon-backindent - @jstree-icon-text-overlap + 10000px);
-    margin-left: -10000px;
+    padding-left: (@jstree-sprite-size - @jstree-icon-backindent - @jstree-icon-text-overlap);
     display: block;
 }
 

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -57,6 +57,10 @@ li.jstree-closed > ul { display:none; }
     @jstree-icon-text-overlap: 2px;
     padding-left: (@jstree-sprite-size - @jstree-icon-backindent - @jstree-icon-text-overlap);
     display: block;
+    
+    /* Explicitly remove the focus ring to fix https://github.com/adobe/brackets/issues/9987 */
+    box-shadow: none;
+    outline: none;
 }
 
 .jstree li {

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -57,10 +57,6 @@ li.jstree-closed > ul { display:none; }
     @jstree-icon-text-overlap: 2px;
     padding-left: (@jstree-sprite-size - @jstree-icon-backindent - @jstree-icon-text-overlap);
     display: block;
-    
-    /* Explicitly remove the focus ring to fix https://github.com/adobe/brackets/issues/9987 */
-    box-shadow: none;
-    outline: none;
 }
 
 .jstree li {


### PR DESCRIPTION
This fixes issue #9965.

I also fix #9987 in this pull request since it is showing the left edge of the focus ring with the fix for #9965.
