### PR TITLE
Fix bug #9978 (CEF 2171: Significant decrease in font quality on Windows).

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -57,13 +57,15 @@ html, body {
     /* Turn off subpixel antialiasing on Mac since it flickers during animations. */
     -webkit-font-smoothing: antialiased;
 
-    /* This is a hack to avoid flicker when animations (like inline editors) that use the GPU complete.
-       It seems that we have to put it here rather than on the animated element in order to prevent the
-       entire window from flashing.
-       See: http://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform
-    */
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
+    // This is a hack to avoid flicker when animations (like inline editors) that use the GPU complete.
+    // It seems that we have to put it here rather than on the animated element in order to prevent the
+    // entire window from flashing.
+    // See: http://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform
+    // Mac-only though, since this would turn off subpixel antialiasing (ClearType) on Windows
+    &.platform-mac {
+        -webkit-backface-visibility: hidden;
+        backface-visibility: hidden;
+    }
 
     .dark,
     &.dark {


### PR DESCRIPTION
Fix bug #9978 -- Disable Mac-specific `backface-visibility` styles that cause Windows text rendering to stop doing subpixel antialiasing (aka ClearType) anywhere in the UI, on newer Chromiums.

Note: there are a lot of `-webkit-font-smoothing: antialiased;` rules that seem like they might cause similar problems on Win, but actually that CSS property is specific to Apple text rendering, and does nothing on other platforms.
