### PR TITLE
Don't retain focus on mouse down events in File tree

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -222,6 +222,11 @@ define(function (require, exports, module) {
                 this.props.actions.setContext(this.myPath());
                 return false;
             }
+            // Return true only for mouse down in rename mode.
+            if (this.props.entry.get("rename")) {
+                return true;
+            }
+            return false;
         }
     };
 


### PR DESCRIPTION
This fixes #9987 and #9414.
