### PR TITLE
Replace sourceURL with real source maps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,15 +124,10 @@ module.exports = function (grunt) {
                 // Options: https://github.com/jrburke/r.js/blob/master/build/example.build.js
                 options: {
                     // `name` and `out` is set by grunt-usemin
-                    baseUrl: 'src',
-                    optimize: 'uglify2',
+                    baseUrl: "src",
                     // brackets.js should not be loaded until after polyfills defined in "utils/Compatibility"
                     // so explicitly include it in main.js 
                     include: ["utils/Compatibility", "brackets"],
-                    // TODO: Figure out how to make sourcemaps work with grunt-usemin
-                    // https://github.com/yeoman/grunt-usemin/issues/30
-                    generateSourceMaps: true,
-                    useSourceUrl: true,
                     // required to support SourceMaps
                     // http://requirejs.org/docs/errors.html#sourcemapcomments
                     preserveLicenseComments: false,
@@ -140,7 +135,18 @@ module.exports = function (grunt) {
                     // Disable closure, we want define/require to be globals
                     wrap: false,
                     exclude: ["text!config.json"],
-                    uglify2: {} // https://github.com/mishoo/UglifyJS2
+                    useSourceUrl: false,
+                    generateSourceMaps: true,
+                    optimize: "uglify2",
+                    uglify2: {
+                        output: {
+                            beautify: false,
+                            // Include comments that match this regexp
+                            comments: /license|copyright|\(c\)/i
+                        }
+                    },
+                    mangle: true,
+                    compress: true
                 }
             }
         },

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1156,14 +1156,6 @@ define(function (require, exports, module) {
             $projectTreeContainer.trigger("contentChanged");
         });
 
-        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuOpen", function () {
-            actionCreator.restoreContext();
-        });
-
-        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuClose", function () {
-            model.setContext(null, false, true);
-        });
-
         $projectTreeContainer.on("contextmenu", function () {
             forceFinishRename();
         });
@@ -1187,6 +1179,16 @@ define(function (require, exports, module) {
         _renderTree();
         
         ViewUtils.addScrollerShadow($projectTreeContainer[0]);
+    });
+
+    AppInit.appReady(function () {
+        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuOpen", function () {
+            actionCreator.restoreContext();
+        });
+
+        Menus.getContextMenu(Menus.ContextMenuIds.PROJECT_MENU).on("beforeContextMenuClose", function () {
+            model.setContext(null, false, true);
+        });
     });
 
     /**


### PR DESCRIPTION
Replaces "sourceURL" (which isn't the same as source maps http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/#toc-sourceurl) unminified build with real source maps using mangled/compressed code.

Also fixes a race condition in ProjectManager that only appears in the minified build where menus aren't initialized yet.
