### PR TITLE
Fix expected error string in unit test

### DIFF
--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -137,7 +137,7 @@ define(function (require, exports, module) {
         });
 
         it("should log an error if an extension fails during RequireJS loading", function () {
-            testLoadExtension("BadRequire", "rejected", /\[Extension\] failed to load.*BadRequire.* Error: Script error for: notdefined/);
+            testLoadExtension("BadRequire", "rejected", /\[Extension\] failed to load.*BadRequire.* - Module does not exist: .*BadRequire\/notdefined\.js/);
         });
 
         it("should log an error if an extension uses an invalid requirejs-config.json", function () {


### PR DESCRIPTION
Fix expected error string in unit test to reflect the improved error message in PR #9901.

My bad!  Forgot to include this update in the original PR.
