### PR TITLE
Fix event chaining with .off()

### DIFF
--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -127,12 +127,12 @@ define(function (require, exports, module) {
      * @param {?function(!{type:string, target:!Object}, ...)} fn
      */
     var off = function (events, fn) {
+        if (!this._eventHandlers) {
+            return this;
+        }
+        
         var eventsList = events.split(/\s+/).map(splitNs),
             i;
-        
-        if (!this._eventHandlers) {
-            return;
-        }
         
         var removeAllMatches = function (eventRec, eventName) {
             var handlerList = this._eventHandlers[eventName],


### PR DESCRIPTION
Reported as https://github.com/zaggino/brackets-git/issues/820.
`.off()`, `.on()` and `.one()` should _always_ `return this`, but there was one case where `.off()` didn't.

Also, moved the condition a few lines - no big deal.
