### PR TITLE
Add theme option addModeClass (for language-aware themes)

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -96,10 +96,11 @@ define(function (require, exports, module) {
             options.name = options.name.toLocaleLowerCase().replace(/[\W]/g, '-');
         }
 
-        this.file        = file;
-        this.name        = options.name;
-        this.displayName = options.title || toDisplayName(fileName);
-        this.dark        = options.theme !== undefined && options.theme.dark === true;
+        this.file           = file;
+        this.name           = options.name;
+        this.displayName    = options.title || toDisplayName(fileName);
+        this.dark           = options.theme !== undefined && options.theme.dark === true;
+        this.addModeClass   = options.theme !== undefined && options.theme.addModeClass === true;
     }
 
 
@@ -249,7 +250,7 @@ define(function (require, exports, module) {
     /**
      * Refresh current theme in the editor
      *
-     * @param {boolean} force Forces a reload the current theme.  It reload the theme file.
+     * @param {boolean} force Forces a reload of the current theme.  It reloads the theme file.
      */
     function refresh(force) {
         if (force) {
@@ -264,6 +265,7 @@ define(function (require, exports, module) {
 
             var cm = editor._codeMirror;
             ThemeView.updateThemes(cm);
+            cm.setOption("addModeClass", currentTheme.addModeClass);
         });
     }
 


### PR DESCRIPTION
Adds the theme option `addModeClass`, which enables the CM option `addModeClass` if set.
When enabled, themes can apply styles language-aware with rules like `.cm-m-javascript.cm-variable`.
CMs `addModeClass` uses innerMode for class name determination, so modes like htmlmixed, php or gfm work correctly, too.

See also #8579.
cc @MiguelCastillo 
