### PR TITLE
Semi-fix bug #10013 (CSS Quick Edit provider does not respond if project contains any non-UTF8 CSS/LESS/SCSS files)

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -359,8 +359,8 @@ define(function (require, exports, module) {
                         _updateCommands();
                     });
             })
-            .fail(function () {
-                console.log("Error in findMatchingRules()");
+            .fail(function (error) {
+                console.warn("Error in findMatchingRules()", error);
                 result.reject();
             });
         

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1401,7 +1401,8 @@ define(function (require, exports, module) {
                     oneFileResult.resolve();
                 })
                 .fail(function (error) {
-                    oneFileResult.reject(error);
+                    console.warn("Unable to read " + fullPath + " during CSS rule search: " + error);
+                    oneFileResult.resolve();  // still resolve, so the overall result doesn't reject
                 });
         
             return oneFileResult.promise();

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -1401,7 +1401,7 @@ define(function (require, exports, module) {
                     oneFileResult.resolve();
                 })
                 .fail(function (error) {
-                    console.warn("Unable to read " + fullPath + " during CSS rule search: " + error);
+                    console.warn("Unable to read " + fullPath + " during CSS rule search:", error);
                     oneFileResult.resolve();  // still resolve, so the overall result doesn't reject
                 });
         

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, beforeFirst, afterLast */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast, spyOn */
 
 define(function (require, exports, module) {
     "use strict";
@@ -77,13 +77,12 @@ define(function (require, exports, module) {
             spec.addMatchers({toMatchSelector: toMatchSelector});
 
             runs(function () {
-                FileUtils.readAsText(fileEntry)
+                var promise = FileUtils.readAsText(fileEntry)
                     .done(function (text) {
                         spec.fileContent = text;
                     });
+                waitsForDone(promise);
             });
-            
-            waitsFor(function () { return (spec.fileContent !== null); }, 1000);
         }
     }
     
@@ -725,6 +724,7 @@ define(function (require, exports, module) {
         });
     }); // describe("CSSUtils")
 
+    
     
     describe("CSS Parsing", function () {
         
@@ -1864,7 +1864,8 @@ define(function (require, exports, module) {
                 expectCompleteSelectors(result[1], ".sidebar / a / &:hover");
             });
         }); // describe("Nested rules following an @include block")
-
+        
+        
         describe("CSS Intgration Tests", function () {
             this.category = "integration";
             
@@ -1905,10 +1906,10 @@ define(function (require, exports, module) {
                 it("should include comment preceding selector (issue #403)", function () {
                     var rules;
                     runs(function () {
-                        CSSUtils.findMatchingRules("#issue403")
+                        var promise = CSSUtils.findMatchingRules("#issue403")
                             .done(function (result) { rules = result; });
+                        waitsForDone(promise, "CSSUtils.findMatchingRules()");
                     });
-                    waitsFor(function () { return rules !== undefined; }, "CSSUtils.findMatchingRules() timeout", 1000);
                     
                     runs(function () {
                         expect(rules.length).toBe(1);
@@ -1916,21 +1917,30 @@ define(function (require, exports, module) {
                         expect(rules[0].lineEnd).toBe(7);
                     });
                 });
+                
+                it("should continue search despite unreadable files (issue #10013)", function () {
+                    var rules;
+                    runs(function () {
+                        // Add a nonexistent CSS file to the ProjectManager.getAllFiles() result, which will force a file IO error
+                        // when we try to read the file later. Similar errors may arise in real-world for non-UTF files, etc.
+                        SpecRunnerUtils.injectIntoGetAllFiles(testWindow, testPath + "/doesNotExist.css");
+                        
+                        var promise = CSSUtils.findMatchingRules("html");
+                        promise.done(function (result) {
+                            expect(result.length).toBeGreaterThan(0);
+                        });
+                        waitsForDone(promise, "CSSUtils.findMatchingRules()");
+                    });
+                });
             });
             
             describe("Working with unsaved changes", function () {
                 
                 it("should return the correct offsets if the file has changed", function () {
-                    var didOpen = false,
-                        gotError = false;
-                    
                     runs(function () {
-                        FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
-                            .done(function () { didOpen = true; })
-                            .fail(function () { gotError = true; });
+                        var promise = FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER);
+                        waitsForDone(promise, "FileViewController.openAndSelectDocument()");
                     });
-                    
-                    waitsFor(function () { return didOpen && !gotError; }, "FileViewController.openAndSelectDocument() timeout", 1000);
                     
                     var rules = null;
                     
@@ -1941,13 +1951,12 @@ define(function (require, exports, module) {
                         doc.setText("\n\n\n\n" + doc.getText());
                         
                         // Look for ".FIRSTGRADE"
-                        CSSUtils.findMatchingRules(".FIRSTGRADE")
+                        var promise = CSSUtils.findMatchingRules(".FIRSTGRADE")
                             .done(function (result) { rules = result; });
+                        waitsForDone(promise, "CSSUtils.findMatchingRules()");
                         
                         doc = null;
                     });
-                    
-                    waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
                     
                     runs(function () {
                         expect(rules.length).toBe(1);
@@ -1957,16 +1966,10 @@ define(function (require, exports, module) {
                 });
                 
                 it("should return a newly created rule in an unsaved file", function () {
-                    var didOpen = false,
-                        gotError = false;
-                    
                     runs(function () {
-                        FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER)
-                            .done(function () { didOpen = true; })
-                            .fail(function () { gotError = true; });
+                        var promise = FileViewController.openAndSelectDocument(testPath + "/simple.css", FileViewController.PROJECT_MANAGER);
+                        waitsForDone(promise, "FileViewController.openAndSelectDocument()");
                     });
-                    
-                    waitsFor(function () { return didOpen && !gotError; }, "FileViewController.openAndSelectDocument() timeout", 1000);
                     
                     var rules = null;
                     
@@ -1977,13 +1980,12 @@ define(function (require, exports, module) {
                         doc.setText(doc.getText() + "\n\n.TESTSELECTOR {\n    font-size: 12px;\n}\n");
                         
                         // Look for the selector we just created
-                        CSSUtils.findMatchingRules(".TESTSELECTOR")
+                        var promise = CSSUtils.findMatchingRules(".TESTSELECTOR")
                             .done(function (result) { rules = result; });
+                        waitsForDone(promise, "CSSUtils.findMatchingRules()");
     
                         doc = null;
                     });
-                    
-                    waitsFor(function () { return rules !== null; }, "CSSUtils.findMatchingRules() timeout", 1000);
                     
                     runs(function () {
                         expect(rules.length).toBe(1);
@@ -1995,6 +1997,8 @@ define(function (require, exports, module) {
         });
         
     }); //describe("CSS Parsing")
+    
+    
     
     describe("CSSUtils - Other", function () {
         function doAddRuleTest(options) {
@@ -2142,7 +2146,9 @@ define(function (require, exports, module) {
             range.dispose();
         });
     });
-
+    
+    
+    
     // Unit Tests: "HTMLUtils (css)"
     describe("HTMLUtils InlineEditorProviders", function () {
         var editor;
@@ -2181,6 +2187,8 @@ define(function (require, exports, module) {
             });
         });
     });
+    
+    
     
     // These tests are based on the implementation spec at https://github.com/adobe/brackets/wiki/CSS-Context-API-implementation-spec.
     describe("CSS Context Info", function () {
@@ -2588,6 +2596,7 @@ define(function (require, exports, module) {
             });
         });
         
+        
         describe("quoting", function () {
             
             it("should properly parse a value with single quotes", function () {
@@ -2658,6 +2667,8 @@ define(function (require, exports, module) {
             });
         });
     });
+    
+    
     
     // These are tests related to Shapes editor requirements for determining the start/end range of a css property
     describe("CSS Context Info Ranges", function () {
@@ -2747,6 +2758,8 @@ define(function (require, exports, module) {
             });
         });
     });
+    
+    
     
     describe("CSS Regions", function () {
         beforeEach(function () {

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast, spyOn */
+/*global define, describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";
@@ -1866,7 +1866,7 @@ define(function (require, exports, module) {
         }); // describe("Nested rules following an @include block")
         
         
-        describe("CSS Intgration Tests", function () {
+        describe("CSS Integration Tests", function () {
             this.category = "integration";
             
             var testPath = SpecRunnerUtils.getTestPath("/spec/CSSUtils-test-files"),
@@ -1919,7 +1919,6 @@ define(function (require, exports, module) {
                 });
                 
                 it("should continue search despite unreadable files (issue #10013)", function () {
-                    var rules;
                     runs(function () {
                         // Add a nonexistent CSS file to the ProjectManager.getAllFiles() result, which will force a file IO error
                         // when we try to read the file later. Similar errors may arise in real-world for non-UTF files, etc.

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -292,7 +292,7 @@ define(function (require, exports, module) {
                 });
             });
 
-            it("should ignore binary files", function () {
+            it("should ignore known binary file types", function () {
                 var $dlg, actualMessage, expectedMessage,
                     exists = false,
                     done = false,
@@ -347,6 +347,19 @@ define(function (require, exports, module) {
                 runs(function () {
                     // Set project back to main test folder
                     SpecRunnerUtils.loadProjectInTestWindow(testPath);
+                });
+            });
+
+            it("should ignore unreadable files", function () {
+                // Add a nonexistent file to the ProjectManager.getAllFiles() result, which will force a file IO error
+                // when we try to read the file later. Similar errors may arise in real-world for non-UTF files, etc.
+                SpecRunnerUtils.injectIntoGetAllFiles(testWindow, testPath + "/doesNotExist.txt");
+                
+                openSearchBar();
+                executeSearch("foo");
+
+                runs(function () {
+                    expect(Object.keys(FindInFiles.searchModel.results).length).toBe(3);
                 });
             });
 


### PR DESCRIPTION
Semi-fix for bug #10013 -- Silently ignore files that can't be read, and continue the search anyway (warning logged to console, but no user-visible error shown). Similar to what we've always done for Find in Files.

With unit test, and matching test for the pre-existing same behavior in Find in Files. Also clean up dated use of `waitsFor()` in the CSSUtils test spec.
