### PR TITLE
Fix bug #9966 ([CEF 2171] JSLint doesn't work)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/requirejs/i18n.git
 [submodule "src/extensions/default/JSLint/thirdparty/jslint"]
 	path = src/extensions/default/JSLint/thirdparty/jslint
-	url = https://github.com/douglascrockford/JSLint.git
+	url = https://github.com/peterflynn/JSLint.git


### PR DESCRIPTION
Fix bug #9966 - Switch to a private fork of JSLint with the bug fix cherry-picked in so we're not stuck upgrading to a much newer JSLint which has the fix but is significantly stricter / less configurable.

Note: you must run `git submodule sync` after syncing to this change, in order for the submodule URI change to take effect.

Here's a diff of the actual change in the fork: https://github.com/peterflynn/JSLint/compare/pflynn/fix-for-newCEF.
