### PR TITLE
During rename in the tree, allow only default behavior.

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -224,6 +224,7 @@ define(function (require, exports, module) {
             }
             // Return true only for mouse down in rename mode.
             if (this.props.entry.get("rename")) {
+                e.stopPropagation();
                 return true;
             }
             return false;


### PR DESCRIPTION
This fixes a problem in which you can't move the cursor or select
text during rename because the event was getting stopped by the
directory node above the entry being renamed before the default behavior
could take control.

cc @RaymondLim @peterflynn 
