### PR TITLE
Chrome 40: DOM agent must be enabled before CSS agent can be enabled

### DIFF
--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -290,6 +290,12 @@ define(function DOMAgent(require, exports, module) {
         }
     }
 
+    /** Enable the domain */
+    function enable() {
+        return Inspector.DOM.enable();
+    }
+
+
     /** Initialize the agent */
     function load() {
         _load = new $.Deferred();
@@ -315,6 +321,7 @@ define(function DOMAgent(require, exports, module) {
     EventDispatcher.makeEventDispatcher(exports);
 
     // Export private functions
+    exports.enable = enable;
     exports.nodeBeforeLocation = nodeBeforeLocation;
     exports.allNodesAtLocation = allNodesAtLocation;
     exports.nodeAtLocation = nodeAtLocation;

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -295,6 +295,11 @@ define(function DOMAgent(require, exports, module) {
         return Inspector.DOM.enable();
     }
 
+    /** Disable the domain */
+    function disable() {
+        return Inspector.DOM.disable();
+    }
+
 
     /** Initialize the agent */
     function load() {
@@ -322,6 +327,7 @@ define(function DOMAgent(require, exports, module) {
 
     // Export private functions
     exports.enable = enable;
+    exports.disable = disable;
     exports.nodeBeforeLocation = nodeBeforeLocation;
     exports.allNodesAtLocation = allNodesAtLocation;
     exports.nodeAtLocation = nodeAtLocation;

--- a/src/LiveDevelopment/Inspector/Inspector.json
+++ b/src/LiveDevelopment/Inspector/Inspector.json
@@ -1881,7 +1881,11 @@
         "commands": [
             {
                 "name": "enable",
-                "description": "Enable DOM agent."
+                "description": "Enables DOM agent for the given page."
+            },
+            {
+                "name": "disable",
+                "description": "Disables DOM agent for the given page."
             },
             {
                 "name": "getDocument",

--- a/src/LiveDevelopment/Inspector/Inspector.json
+++ b/src/LiveDevelopment/Inspector/Inspector.json
@@ -1880,6 +1880,10 @@
         ],
         "commands": [
             {
+                "name": "enable",
+                "description": "Enable DOM agent."
+            },
+            {
                 "name": "getDocument",
                 "returns": [
                     { "name": "root", "$ref": "Node", "description": "Resulting node." }

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1051,7 +1051,9 @@ define(function LiveDevelopment(require, exports, module) {
         });
 
         // Domains for some agents must be enabled first before loading
-        var enablePromise = Inspector.Page.enable().then(_enableAgents);
+        var enablePromise = Inspector.Page.enable().then(function () {
+            Inspector.DOM.enable().then(_enableAgents);
+        });
         
         enablePromise.done(function () {
             // Some agents (e.g. DOMAgent and RemoteAgent) require us to


### PR DESCRIPTION
This is for #9999 

There's a new requirement in Chrome 40 that the DOM agent must be enabled before CSS agent can be enabled. Need to add `enable()` to DOM API ([chromium 303653008](https://codereview.chromium.org/303653008)) so we can call it.
