### PR TITLE
Fix bug #10089 ([CEF 2171] Cannot reopen Jasmine test window after closing it)

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -81,21 +81,15 @@ define(function (require, exports, module) {
     var _testWindow = null;
     function _runUnitTests(spec) {
         var queryString = spec ? "?spec=" + spec : "";
-        if (_testWindow) {
-            try {
-                if (_testWindow.location.search !== queryString) {
-                    _testWindow.location.href = "../test/SpecRunner.html" + queryString;
-                } else {
-                    _testWindow.location.reload(true);
-                }
-            } catch (e) {
-                _testWindow = null;  // the window was probably closed
+        if (_testWindow && !_testWindow.closed) {
+            if (_testWindow.location.search !== queryString) {
+                _testWindow.location.href = "../test/SpecRunner.html" + queryString;
+            } else {
+                _testWindow.location.reload(true);
             }
-        }
-        
-        if (!_testWindow) {
+        } else {
             _testWindow = window.open("../test/SpecRunner.html" + queryString, "brackets-test", "width=" + $(window).width() + ",height=" + $(window).height());
-            _testWindow.location.reload(true); // if it was opened before, we need to reload because it will be cached
+            _testWindow.location.reload(true); // if it had been opened earlier, force a reload because it will be cached
         }
     }
     


### PR DESCRIPTION
Fix bug #10089 -- We were previously relying on access of `window.location` throwing an exception to tell that the test window was closed. In newer Chrome, it's simply stubbed out instead.

Check `window.closed` instead, which is a much more standard way to get this info.
