### PR TITLE
Moved padding-bottom to container so lists can't be horizontally scrolled

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -706,7 +706,7 @@ a, img {
 
 #working-set-list-container {
     background: @bc-sidebar-bg;
-    padding-bottom: 21px; // Adds working set bottom padding to the last UL.
+    padding-bottom: 21px; // Adds bottom padding to the working set.
 }
 
 .working-set-header {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -706,10 +706,7 @@ a, img {
 
 #working-set-list-container {
     background: @bc-sidebar-bg;
-    
-    > div:last-child ul { 
-        padding-bottom: 21px; // Adds working set bottom padding to the last UL.
-    }
+    padding-bottom: 21px; // Adds working set bottom padding to the last UL.
 }
 
 .working-set-header {


### PR DESCRIPTION
If the sidebar is narrower than the list of open files, the user could click and drag right on the padding-bottom beneath the working set to scroll the file names over. The user could not click and drag back though.

This fix puts the padding on the container instead, so the overflow has no effect.
