### PR TITLE
Debounce calls to ProjectManager._renderTree.

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -605,6 +605,8 @@ define(function (require, exports, module) {
         return null;
     };
 
+    var _RENDER_DEBOUNCE_TIME = 100;
+
     /**
      * @private
      *
@@ -620,6 +622,8 @@ define(function (require, exports, module) {
         model.setScrollerInfo($projectTreeContainer[0].scrollWidth, $projectTreeContainer.scrollTop(), $projectTreeContainer.scrollLeft(), $projectTreeContainer.offset().top);
         FileTreeView.render(fileTreeViewContainer, model._viewModel, projectRoot, actionCreator, forceRender, brackets.platform);
     };
+
+    _renderTree = _.debounce(_renderTree, _RENDER_DEBOUNCE_TIME);
 
     /**
      * @private
@@ -1375,7 +1379,8 @@ define(function (require, exports, module) {
     
     
     // Private API helpful in testing
-    exports._actionCreator                 = actionCreator;
+    exports._actionCreator                = actionCreator;
+    exports._RENDER_DEBOUNCE_TIME         = _RENDER_DEBOUNCE_TIME;
     
     // Private API for use with SidebarView
     exports._setFileTreeSelectionWidth    = _setFileTreeSelectionWidth;

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
+/*global $, define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast, waitsForTime */
 
 define(function (require, exports, module) {
     "use strict";
@@ -373,13 +373,7 @@ define(function (require, exports, module) {
              * we'll need to wait for the next render.
              */
             function waitForRenderDebounce() {
-                runs(function () {
-                    var d = new $.Deferred();
-                    setTimeout(function () {
-                        d.resolve();
-                    }, ProjectManager._RENDER_DEBOUNCE_TIME);
-                    waitsForDone(d.promise());
-                });
+                waitsForTime(ProjectManager._RENDER_DEBOUNCE_TIME);
             }
 
             it("should deselect after opening file not rendered in tree", function () {

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
+/*global $, define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";
@@ -367,6 +367,20 @@ define(function (require, exports, module) {
                     expect($selectedItem.text().trim()).toBe(name);
                 }
             }
+            
+            /**
+             * ProjectManager pauses between renders for performance reasons. For some tests,
+             * we'll need to wait for the next render.
+             */
+            function waitForRenderDebounce() {
+                runs(function () {
+                    var d = new $.Deferred();
+                    setTimeout(function () {
+                        d.resolve();
+                    }, ProjectManager._RENDER_DEBOUNCE_TIME);
+                    waitsForDone(d.promise());
+                });
+            }
 
             it("should deselect after opening file not rendered in tree", function () {
                 var promise,
@@ -377,12 +391,14 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: exposedFile });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(exposedFile);
 
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: unexposedFile });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(null);
                 });
@@ -429,6 +445,7 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: initialFile });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(initialFile);
                     toggleFolder(folder, true);     // open folder
@@ -437,6 +454,7 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: fileInFolder });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(fileInFolder);
                     toggleFolder(folder, false);    // close folder
@@ -444,6 +462,7 @@ define(function (require, exports, module) {
                 runs(function () {
                     toggleFolder(folder, true);     // open folder again
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(fileInFolder);
                     toggleFolder(folder, false);    // close folder
@@ -460,6 +479,7 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: initialFile });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(initialFile);
                     toggleFolder(folder, true);     // open folder
@@ -471,10 +491,12 @@ define(function (require, exports, module) {
                     promise = CommandManager.execute(Commands.FILE_OPEN, { fullPath: fileInFolder });
                     waitsForDone(promise);
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(null);
                     toggleFolder(folder, true);     // open folder again
                 });
+                waitForRenderDebounce();
                 runs(function () {
                     expectSelected(fileInFolder);
                     toggleFolder(folder, false);    // close folder

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast, waitsForTime */
+/*global define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast, waits */
 
 define(function (require, exports, module) {
     "use strict";
@@ -373,7 +373,7 @@ define(function (require, exports, module) {
              * we'll need to wait for the next render.
              */
             function waitForRenderDebounce() {
-                waitsForTime(ProjectManager._RENDER_DEBOUNCE_TIME);
+                waits(ProjectManager._RENDER_DEBOUNCE_TIME);
             }
 
             it("should deselect after opening file not rendered in tree", function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -195,7 +195,7 @@ define(function (require, exports, module) {
             return promise.state() === "rejected";
         }, "failure " + operationName, timeout);
     };
-
+    
     /**
      * Get or create a NativeFileSystem rooted at the system root.
      * @return {$.Promise} A promise resolved when the native file system is found or rejected when an error occurs.

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -195,7 +195,23 @@ define(function (require, exports, module) {
             return promise.state() === "rejected";
         }, "failure " + operationName, timeout);
     };
-    
+
+    /**
+     * Utility for *rare* situations in which a test needs to pause for a *known* amount of time.
+     * Tests that sporadically fail due to timing issues can't really be fixed by this. This function
+     * was created when a debounce delay was added to updating the project tree, so we have a specific,
+     * known amount of time to pause for.
+     */
+    window.waitsForTime = function (timeout) {
+        runs(function () {
+            var d = new $.Deferred();
+            setTimeout(function () {
+                d.resolve();
+            }, timeout);
+            waitsForDone(d.promise());
+        });
+    };
+
     /**
      * Get or create a NativeFileSystem rooted at the system root.
      * @return {$.Promise} A promise resolved when the native file system is found or rejected when an error occurs.

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -197,22 +197,6 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Utility for *rare* situations in which a test needs to pause for a *known* amount of time.
-     * Tests that sporadically fail due to timing issues can't really be fixed by this. This function
-     * was created when a debounce delay was added to updating the project tree, so we have a specific,
-     * known amount of time to pause for.
-     */
-    window.waitsForTime = function (timeout) {
-        runs(function () {
-            var d = new $.Deferred();
-            setTimeout(function () {
-                d.resolve();
-            }, timeout);
-            waitsForDone(d.promise());
-        });
-    };
-
-    /**
      * Get or create a NativeFileSystem rooted at the system root.
      * @return {$.Promise} A promise resolved when the native file system is found or rejected when an error occurs.
      */

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast, waitsForTime */
+/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast, waits */
 
 define(function (require, exports, module) {
     "use strict";
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_RENAME);
             });
 
-            waitsForTime(ProjectManager._RENDER_DEBOUNCE_TIME);
+            waits(ProjectManager._RENDER_DEBOUNCE_TIME);
 
             runs(function () {
                 expect($("#project-files-container ul input").val()).toBe(fileName);

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast */
+/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast, waitsForTime */
 
 define(function (require, exports, module) {
     "use strict";
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         DocumentManager,        // Load from brackets.test
         FileViewController,     // Load from brackets.test
         MainViewManager,        // Load from brackets.test
+        ProjectManager,         // Load from brackets.test
         WorkingSetView,
         SpecRunnerUtils         = require("spec/SpecRunnerUtils");
 
@@ -74,6 +75,7 @@ define(function (require, exports, module) {
                 FileViewController  = testWindow.brackets.test.FileViewController;
                 MainViewManager     = testWindow.brackets.test.MainViewManager;
                 WorkingSetView      = testWindow.brackets.test.WorkingSetView;
+                ProjectManager      = testWindow.brackets.test.ProjectManager;
                 
                 // Open a directory
                 if (loadProject) {
@@ -254,17 +256,22 @@ define(function (require, exports, module) {
         });
         
         it("should show the file in project tree when a file is being renamed", function () {
+            var $ = testWindow.$;
+            var secondItem =  $(".open-files-container > ul").children().eq(1);
+            var fileName = secondItem.text();
+
             runs(function () {
-                var $ = testWindow.$;
-                var secondItem =  $(".open-files-container > ul").children().eq(1);
-                var fileName = secondItem.text();
                 secondItem.trigger("click");
                 
                 // Calling FILE_RENAME synchronously works fine here since the item is already visible in project file tree.
                 // However, if the selected item is not already visible in the tree, this command will complete asynchronously.
                 // In that case, waitsFor will be needed before continuing with the rest of the test.
                 CommandManager.execute(Commands.FILE_RENAME);
-                
+            });
+
+            waitsForTime(ProjectManager._RENDER_DEBOUNCE_TIME);
+
+            runs(function () {
                 expect($("#project-files-container ul input").val()).toBe(fileName);
             });
         });


### PR DESCRIPTION
This is a possible fix for #9851. In my tests, this can cause a
dramatic speed up when lots of filesystem changes cause the tree
to be continuously rerendered.

I chose 100ms as the debounce time because that seemed quick enough that
users will not be waiting for their actions to be reflected in the tree.
