### PR TITLE
Correcting the wrong initialization of the _status object (with variables as keys names)

### DIFF
--- a/src/utils/AppInit.js
+++ b/src/utils/AppInit.js
@@ -66,8 +66,12 @@ define(function (require, exports, module) {
      * @type {Object.<string, boolean>}
      * @private
      */
-    var _status      = { HTML_READY : false, APP_READY : false, EXTENSIONS_LOADED: false };
+    var _status      = {};
     
+    _status[HTML_READY]         = false;
+    _status[APP_READY]          = false;
+    _status[EXTENSIONS_LOADED]  = false;
+
     /*
      * Map of callbacks to states
      * @type {Object.<string, Array.<function()>>}


### PR DESCRIPTION
Hello all,

While trying to make mine Brackets and LivePreview work with ChromiumI went into a bit of debugging and saw one possible problem, with initialization of `_status` object.

The way it was previously done had a problem since the variable names were tried to be used as object's keys in wrong way. The way they were used, it was actually creating:
`_status["HTML_READY"] = false;`
instead of:
`_status["htmlReady"] = false;`

(The scenario with using variables for object's keys is described here: http://stackoverflow.com/a/19837961/261332)

So, when later we try to check if the wanted key's ("htmlReady") value is `true` (in `_addListener()`), it was giving false negatives, since "htmlReady" key was initially not existing in that object. What existed was "HTML_READY" key. 
Well, maybe it was really giving "good false negatives", since original value was false anyway... but why not fix it if possible.

This is my first git submit, so excuse me if I did something wrong. :) I probably did.
