### PR TITLE
Fix #10142. LiveDev2: Firefox highlight does not have fade-away effect.

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -308,7 +308,7 @@ function RemoteFunctions(experimental) {
                 
                 window.setTimeout(function () {
                     _setStyleValues(animateEndValues, highlight.style);
-                }, 0);
+                }, 20);
             }
         
             window.document.body.appendChild(highlight);


### PR DESCRIPTION
Fixes #10142.

Wait a little longer for the highlight element to take it's initial state. If
the element is not yet in its initial state, the transition does not happen. It
seems like on Firefox/Gecko it takes longer than on Chrome/Webkit.

This is a quote from [MDN article on subject](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transitions):

> Care should also be taken when using a transition immediately after adding the element to the DOM using .appendChild() or removing its display: none; property. This is seen as if the initial state had never occurred and the element was always in its final state. The easy way to overcome this limitation is to apply a window.setTimeout() of a handful of milliseconds before changing the CSS property you intend to transition to.

CC: @dangoor, @redmunds 
