### PR TITLE
LiveDevMultiBrowser should properly search parent directories for an index.html

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -417,7 +417,7 @@ define(function (require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = FileUtils.getDirectoryPath(containingFolder);
+                    containingFolder = FileUtils.getDirectoryPath(FileUtils.stripTrailingSlash(containingFolder));
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -363,11 +363,6 @@ define(function (require, exports, module) {
             refPath,
             i;
 
-        // TODO: FileUtils.getParentFolder()
-        function getParentFolder(path) {
-            return path.substring(0, path.lastIndexOf('/', path.length - 2) + 1);
-        }
-
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
@@ -422,7 +417,7 @@ define(function (require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = getParentFolder(containingFolder);
+                    containingFolder = FileUtils.getParentDirectoryPath(containingFolder);
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -363,6 +363,11 @@ define(function (require, exports, module) {
             refPath,
             i;
 
+        // TODO: FileUtils.getParentFolder()
+        function getParentFolder(path) {
+            return path.substring(0, path.lastIndexOf('/', path.length - 2) + 1);
+        }
+
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
@@ -417,7 +422,7 @@ define(function (require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = FileUtils.getDirectoryPath(FileUtils.stripTrailingSlash(containingFolder));
+                    containingFolder = getParentFolder(containingFolder);
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -679,16 +679,6 @@ define(function LiveDevelopment(require, exports, module) {
             refPath,
             i;
 
-        // TODO: FileUtils.getParentFolder()
-        function getParentFolder(path) {
-            return path.substring(0, path.lastIndexOf('/', path.length - 2) + 1);
-        }
-
-        function getFilenameWithoutExtension(filename) {
-            var index = filename.lastIndexOf(".");
-            return index === -1 ? filename : filename.slice(0, index);
-        }
-
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
@@ -715,14 +705,14 @@ define(function LiveDevelopment(require, exports, module) {
             }
             
             var filteredFiltered = allFiles.filter(function (item) {
-                var parent = getParentFolder(item.fullPath);
+                var parent = FileUtils.getParentDirectoryPath(item.fullPath);
                 
                 return (containingFolder.indexOf(parent) === 0);
             });
             
             var filterIndexFile = function (fileInfo) {
                 if (fileInfo.fullPath.indexOf(containingFolder) === 0) {
-                    if (getFilenameWithoutExtension(fileInfo.name) === "index") {
+                    if (FileUtils.getFilenameWithoutExtension(fileInfo.name) === "index") {
                         if (hasOwnServerForLiveDevelopment) {
                             if ((FileUtils.isServerHtmlFileExt(fileInfo.name)) ||
                                     (FileUtils.isStaticHtmlFileExt(fileInfo.name))) {
@@ -743,7 +733,7 @@ define(function LiveDevelopment(require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = getParentFolder(containingFolder);
+                    containingFolder = FileUtils.getParentDirectoryPath(containingFolder);
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -453,6 +453,16 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Gets the parent directory of a file or a directory.
+     * @param {string} fullPath full path to a file or directory
+     * @return {string} Returns the path to the parent directory of a file or directory, including
+     *                  trailing "/"
+     */
+    function getParentDirectoryPath(fullPath) {
+        return fullPath.substring(0, fullPath.lastIndexOf('/', fullPath.length - 2) + 1);
+    }
+
+    /**
      * Get the file name without the extension.
      * @param {string} filename File name of a file or directory
      * @return {string} Returns the file name without the extension
@@ -559,6 +569,7 @@ define(function (require, exports, module) {
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
     exports.isServerHtmlFileExt            = isServerHtmlFileExt;
     exports.getDirectoryPath               = getDirectoryPath;
+    exports.getParentDirectoryPath         = getParentDirectoryPath;
     exports.getBaseName                    = getBaseName;
     exports.getRelativeFilename            = getRelativeFilename;
     exports.getFilenameWithoutExtension    = getFilenameWithoutExtension;

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -85,7 +85,26 @@ define(function (require, exports, module) {
             });
 
             it("should return the unchanged directory of a posix directory path", function () {
-                expect(FileUtils.getDirectoryPath("C:/foo/bar/")).toBe("C:/foo/bar/");
+                expect(FileUtils.getDirectoryPath("/foo/bar/")).toBe("/foo/bar/");
+            });
+        });
+
+        describe("getParentDirectoryPath", function () {
+
+            it("should get the parent directory of a normalized win file path", function () {
+                expect(FileUtils.getParentDirectoryPath("C:/foo/bar/baz.txt")).toBe("C:/foo/bar/");
+            });
+
+            it("should get the parent directory of a posix file path", function () {
+                expect(FileUtils.getParentDirectoryPath("/foo/bar/baz.txt")).toBe("/foo/bar/");
+            });
+
+            it("should return the parent directory of a normalized win directory path", function () {
+                expect(FileUtils.getParentDirectoryPath("C:/foo/bar/")).toBe("C:/foo/");
+            });
+
+            it("should return the parent directory of a posix directory path", function () {
+                expect(FileUtils.getParentDirectoryPath("/foo/bar/")).toBe("/foo/");
             });
         });
 

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/index.html
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/index.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>Test</title>
+        <link rel="stylesheet" href="sub/test.css" />
+    </head>
+    <body>
+        <h1>Hello</h1>
+    </body>
+</html>

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/sub/test.css
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/sub/test.css
@@ -1,0 +1,3 @@
+body { background-color: red;}
+
+h1 { color: blue; }

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -102,6 +102,18 @@ define(function (require, exports, module) {
                 });
             });
             
+            it("should find an index.html in a parent directory", function () {
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["sub/test.css"]), "SpecRunnerUtils.openProjectFiles sub/test.css", 1000);
+                });
+
+                waitsForLiveDevelopmentToOpen();
+
+                runs(function () {
+                    expect(LiveDevelopment._getCurrentLiveDoc().doc.url).toMatch(/\/index\.html$/);
+                });
+            });
+
             it("should send all external stylesheets as related docs on start-up", function () {
                 var liveDoc;
                 runs(function () {


### PR DESCRIPTION
Presently, LiveDevMultiBrowser gets stuck in an infinite loop trying to step into parent directories to find an initial index.html if none is present in the current directory. Without the fix, the included test will loop forever.
