### PR TITLE
Chain the returned promise from DOM.enable.

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1052,7 +1052,7 @@ define(function LiveDevelopment(require, exports, module) {
 
         // Domains for some agents must be enabled first before loading
         var enablePromise = Inspector.Page.enable().then(function () {
-            Inspector.DOM.enable().then(_enableAgents);
+            return Inspector.DOM.enable().then(_enableAgents, _enableAgents);
         });
         
         enablePromise.done(function () {


### PR DESCRIPTION
..This fixes issue #10191 for live previewing with old Chrome browsers.

cc @peterflynn @redmunds 
