### PR TITLE
Fix bug #10200 (Live Preview throws errors on pages with dynamic LESS)

### DIFF
--- a/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
+++ b/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
@@ -38,6 +38,7 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
     "use strict";
 
     var _               = require("thirdparty/lodash"),
+        EventDispatcher = require("utils/EventDispatcher"),
         CSSUtils        = require("language/CSSUtils"),
         EditorManager   = require("editor/EditorManager"),
         HighlightAgent  = require("LiveDevelopment/Agents/HighlightAgent"),
@@ -62,6 +63,9 @@ define(function CSSPreprocessorDocumentModule(require, exports, module) {
         this.onActiveEditorChange(null, EditorManager.getActiveEditor(), null);
     };
 
+    // CSSPreprocessorDocument doesn't dispatch events, but the "live document" interface requires an on() API
+    EventDispatcher.makeEventDispatcher(CSSPreprocessorDocument.prototype);
+    
     /** Close the document */
     CSSPreprocessorDocument.prototype.close = function close() {
         this.doc.off(".CSSPreprocessorDocument");

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -45,9 +45,10 @@
 define(function JSDocumentModule(require, exports, module) {
     "use strict";
 
-    var Inspector = require("LiveDevelopment/Inspector/Inspector");
-    var ScriptAgent = require("LiveDevelopment/Agents/ScriptAgent");
-    var HighlightAgent = require("LiveDevelopment/Agents/HighlightAgent");
+    var EventDispatcher = require("utils/EventDispatcher"),
+        Inspector       = require("LiveDevelopment/Inspector/Inspector"),
+        ScriptAgent     = require("LiveDevelopment/Agents/ScriptAgent"),
+        HighlightAgent  = require("LiveDevelopment/Agents/HighlightAgent");
 
     /**
      * @constructor
@@ -68,6 +69,9 @@ define(function JSDocumentModule(require, exports, module) {
         this.editor.on("cursorActivity", this.onCursorActivity);
         this.onCursorActivity();
     };
+    
+    // JSDocument doesn't dispatch events, but the "live document" interface requires having an on() API
+    EventDispatcher.makeEventDispatcher(JSDocument.prototype);
 
     /** Close the document */
     JSDocument.prototype.close = function close() {


### PR DESCRIPTION
Fix bug #10200 -- Make sure every "live document" type implements the same interface, including the EventDispatcher APIs.
