### PR TITLE
Call _enableAgents even if DOM.enable() is failing

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1052,8 +1052,7 @@ define(function LiveDevelopment(require, exports, module) {
 
         // Domains for some agents must be enabled first before loading
         var enablePromise = Inspector.Page.enable().then(function () {
-            var domEnablePromise = Inspector.DOM.enable ? Inspector.DOM.enable() : (new $.Deferred()).resolve().promise();
-            domEnablePromise.then(_enableAgents);
+            return Inspector.DOM.enable().then(_enableAgents, _enableAgents);
         });
         
         enablePromise.done(function () {


### PR DESCRIPTION
This is the same pull request as #10198, but targeting the release branch. This fixes issue #10191 for live previewing with old Chrome browsers.

cc @redmunds 
