### PR TITLE
Cleaner fix for LiveDevMultiBrowser infinite loop

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -417,7 +417,7 @@ define(function (require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = FileUtils.getDirectoryPath(containingFolder);
+                    containingFolder = FileUtils.getDirectoryPath(FileUtils.stripTrailingSlash(containingFolder));
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -389,7 +389,7 @@ define(function (require, exports, module) {
             }
             
             var filteredFiltered = allFiles.filter(function (item) {
-                var parent = FileUtils.getDirectoryPath(item.fullPath);
+                var parent = FileUtils.getParentPath(item.fullPath);
                 
                 return (containingFolder.indexOf(parent) === 0);
             });
@@ -417,7 +417,7 @@ define(function (require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = FileUtils.getDirectoryPath(FileUtils.stripTrailingSlash(containingFolder));
+                    containingFolder = FileUtils.getParentPath(containingFolder);
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -679,16 +679,6 @@ define(function LiveDevelopment(require, exports, module) {
             refPath,
             i;
 
-        // TODO: FileUtils.getParentFolder()
-        function getParentFolder(path) {
-            return path.substring(0, path.lastIndexOf('/', path.length - 2) + 1);
-        }
-
-        function getFilenameWithoutExtension(filename) {
-            var index = filename.lastIndexOf(".");
-            return index === -1 ? filename : filename.slice(0, index);
-        }
-
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
@@ -715,14 +705,14 @@ define(function LiveDevelopment(require, exports, module) {
             }
             
             var filteredFiltered = allFiles.filter(function (item) {
-                var parent = getParentFolder(item.fullPath);
+                var parent = FileUtils.getParentPath(item.fullPath);
                 
                 return (containingFolder.indexOf(parent) === 0);
             });
             
             var filterIndexFile = function (fileInfo) {
                 if (fileInfo.fullPath.indexOf(containingFolder) === 0) {
-                    if (getFilenameWithoutExtension(fileInfo.name) === "index") {
+                    if (FileUtils.getFilenameWithoutExtension(fileInfo.name) === "index") {
                         if (hasOwnServerForLiveDevelopment) {
                             if ((FileUtils.isServerHtmlFileExt(fileInfo.name)) ||
                                     (FileUtils.isStaticHtmlFileExt(fileInfo.name))) {
@@ -743,7 +733,7 @@ define(function LiveDevelopment(require, exports, module) {
                 // We found no good match
                 if (i === -1) {
                     // traverse the directory tree up one level
-                    containingFolder = getParentFolder(containingFolder);
+                    containingFolder = FileUtils.getParentPath(containingFolder);
                     // Are we still inside the project?
                     if (containingFolder.indexOf(projectRoot) === -1) {
                         stillInProjectTree = false;

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -443,7 +443,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Get the parent directory of a file. If a directory is passed in the directory is returned.
+     * Get the parent directory of a file. If a directory is passed, the SAME directory is returned.
      * @param {string} fullPath full path to a file or directory
      * @return {string} Returns the path to the parent directory of a file or the path of a directory,
      *                  including trailing "/"
@@ -453,8 +453,22 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Get the file name without the extension.
-     * @param {string} filename File name of a file or directory
+     * Get the parent folder of the given file/folder path. Differs from getDirectoryPath() when 'fullPath'
+     * is a directory itself: returns its parent instead of the original path. (Note: if you already have a
+     * FileSystemEntry, it's faster to use entry.parentPath instead).
+     * @param {string} fullPath full path to a file or directory
+     * @return {string} Path of containing folder (including trailing "/"); or "" if path was the root
+     */
+    function getParentPath(fullPath) {
+        if (fullPath === "/") {
+            return "";
+        }
+        return fullPath.substring(0, fullPath.lastIndexOf("/", fullPath.length - 2) + 1);
+    }
+
+    /**
+     * Get the file name without the extension. Returns "" if name starts with "."
+     * @param {string} filename File name of a file or directory, without preceding path
      * @return {string} Returns the file name without the extension
      */
     function getFilenameWithoutExtension(filename) {
@@ -559,6 +573,7 @@ define(function (require, exports, module) {
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
     exports.isServerHtmlFileExt            = isServerHtmlFileExt;
     exports.getDirectoryPath               = getDirectoryPath;
+    exports.getParentPath                  = getParentPath;
     exports.getBaseName                    = getBaseName;
     exports.getRelativeFilename            = getRelativeFilename;
     exports.getFilenameWithoutExtension    = getFilenameWithoutExtension;

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -85,7 +85,30 @@ define(function (require, exports, module) {
             });
 
             it("should return the unchanged directory of a posix directory path", function () {
-                expect(FileUtils.getDirectoryPath("C:/foo/bar/")).toBe("C:/foo/bar/");
+                expect(FileUtils.getDirectoryPath("/foo/bar/")).toBe("/foo/bar/");
+            });
+            
+            it("should return the unchanged directory of a root path", function () {
+                expect(FileUtils.getDirectoryPath("C:/")).toBe("C:/");
+                expect(FileUtils.getDirectoryPath("/")).toBe("/");
+            });
+        });
+
+        describe("getParentPath", function () {
+
+            it("should get the parent directory of a normalized file path", function () {
+                expect(FileUtils.getParentPath("C:/foo/bar/baz.txt")).toBe("C:/foo/bar/");
+                expect(FileUtils.getParentPath("/foo/bar/baz.txt")).toBe("/foo/bar/");
+            });
+
+            it("should return the parent directory of a normalized directory path", function () {
+                expect(FileUtils.getParentPath("C:/foo/bar/")).toBe("C:/foo/");
+                expect(FileUtils.getParentPath("/foo/bar/")).toBe("/foo/");
+            });
+
+            it("should return '' given a root path", function () {
+                expect(FileUtils.getParentPath("C:/")).toBe("");
+                expect(FileUtils.getParentPath("/")).toBe("");
             });
         });
 
@@ -140,6 +163,17 @@ define(function (require, exports, module) {
                 expect(FileUtils.getFileExtension("C:/foo/bar/.baz/jaz.txt")).toBe("txt");
                 expect(FileUtils.getFileExtension("foo/bar/baz/.jaz.txt")).toBe("txt");
                 expect(FileUtils.getFileExtension("foo.bar.baz..jaz.txt")).toBe("txt");
+            });
+        });
+        
+        describe("getFilenameWithoutExtension", function () {
+
+            it("should remove last extension segment only", function () {
+                expect(FileUtils.getFilenameWithoutExtension("foo.txt")).toBe("foo");
+                expect(FileUtils.getFilenameWithoutExtension("foo.min.txt")).toBe("foo.min");
+                expect(FileUtils.getFilenameWithoutExtension("foo")).toBe("foo");
+                
+                expect(FileUtils.getFilenameWithoutExtension(".foo")).toBe("");
             });
         });
 

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/index.html
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/index.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>Test</title>
+        <link rel="stylesheet" href="sub/test.css" />
+    </head>
+    <body>
+        <h1>Hello</h1>
+    </body>
+</html>

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/sub/test.css
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/sub/test.css
@@ -1,0 +1,3 @@
+body { background-color: red;}
+
+h1 { color: blue; }

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -102,6 +102,18 @@ define(function (require, exports, module) {
                 });
             });
             
+            it("should find an index.html in a parent directory", function () {
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["sub/test.css"]), "SpecRunnerUtils.openProjectFiles sub/test.css", 1000);
+                });
+
+                waitsForLiveDevelopmentToOpen();
+
+                runs(function () {
+                    expect(LiveDevelopment._getCurrentLiveDoc().doc.url).toMatch(/\/index\.html$/);
+                });
+            });
+
             it("should send all external stylesheets as related docs on start-up", function () {
                 var liveDoc;
                 runs(function () {


### PR DESCRIPTION
This is for #10193. See discussion here for context: https://github.com/adobe/brackets/pull/10192#discussion_r21957109.

Move shared code into FileUtils (with unit tests) to minimize diff in the `_getInitialDocFromCurrent()` code that is duplicated between the two Live Preview impls.

Also...
- fixes an unhit edge case in getParentFolder() (now getParentDirectory()) that behaves differently across platforms
- removes duplicate copy of getFilenameWithoutExtension() in LiveDevelopment.js (copy in FileUtils was identical)
- add/fix some unit tests for two existing FileUtils APIs
