### PR TITLE
Exclude more unneeded files in dist builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
     'use strict';
 
     // load dependencies
-    require('load-grunt-tasks')(grunt, {pattern: ['grunt-contrib-*', 'grunt-targethtml', 'grunt-usemin']});
+    require('load-grunt-tasks')(grunt, {pattern: ['grunt-contrib-*', 'grunt-targethtml', 'grunt-usemin', 'grunt-cleanempty']});
     grunt.loadTasks('tasks');
 
     // Project configuration.
@@ -72,6 +72,8 @@ module.exports = function (grunt) {
                         src: [
                             'extensibility/node/**',
                             '!extensibility/node/spec/**',
+                            '!extensibility/node/node_modules/**/{test,tst}/**/*',
+                            '!extensibility/node/node_modules/**/examples/**/*',
                             'filesystem/impls/appshell/node/**',
                             '!filesystem/impls/appshell/node/spec/**'
                         ]
@@ -82,15 +84,21 @@ module.exports = function (grunt) {
                         dest: 'dist/',
                         cwd: 'src/',
                         src: [
+                            'extensions/default/**/*',
                             '!extensions/default/*/unittest-files/**/*',
                             '!extensions/default/*/unittests.js',
-                            'extensions/default/*/**/*',
+                            '!extensions/default/{*/thirdparty,**/node_modules}/**/test/**/*',
+                            '!extensions/default/{*/thirdparty,**/node_modules}/**/doc/**/*',
+                            '!extensions/default/{*/thirdparty,**/node_modules}/**/examples/**/*',
+                            '!extensions/default/*/thirdparty/**/*.htm{,l}',
                             'extensions/dev/*',
                             'extensions/samples/**/*',
                             'thirdparty/CodeMirror2/addon/{,*/}*',
                             'thirdparty/CodeMirror2/keymap/{,*/}*',
                             'thirdparty/CodeMirror2/lib/{,*/}*',
                             'thirdparty/CodeMirror2/mode/{,*/}*',
+                            '!thirdparty/CodeMirror2/mode/**/*.html',
+                            '!thirdparty/CodeMirror2/**/*test.js',
                             'thirdparty/CodeMirror2/theme/{,*/}*',
                             'thirdparty/i18n/*.js',
                             'thirdparty/text/*.js'
@@ -105,6 +113,13 @@ module.exports = function (grunt) {
                     }
                 ]
             }
+        },
+        cleanempty: {
+            options: {
+                force: true,
+                files: false
+            },
+            src: ['dist/**/*'],
         },
         less: {
             dist: {
@@ -330,6 +345,7 @@ module.exports = function (grunt) {
         /*'cssmin',*/
         /*'uglify',*/
         'copy',
+        'cleanempty',
         'usemin',
         'build-config'
     ]);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "q": "0.9.2",
         "semver": "^4.1.0",
         "jshint": "2.1.4",
-        "xmldoc": "^0.1.2"
+        "xmldoc": "^0.1.2",
+        "grunt-cleanempty": "1.0.3"
     },
     "scripts": {
         "postinstall": "grunt install",

--- a/src/config.json
+++ b/src/config.json
@@ -39,7 +39,7 @@
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
-        "phantomjs": "1.9.11",
+        "phantomjs": "1.9.13",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.4.3",
@@ -59,7 +59,8 @@
         "q": "0.9.2",
         "semver": "^4.1.0",
         "jshint": "2.1.4",
-        "xmldoc": "^0.1.2"
+        "xmldoc": "^0.1.2",
+        "grunt-cleanempty": "1.0.3"
     },
     "scripts": {
         "postinstall": "grunt install",


### PR DESCRIPTION
This Gruntfile excludes way more unnecessary files (mostly `test/`, `doc/` and `examples/`), which results in a dist folder taking up way less space than before (resulting in a smaller installer).

Disk space usage analysis (using RidNacs):
On `master`:
![image](https://cloud.githubusercontent.com/assets/2641501/5491879/ee2307ca-86dc-11e4-9322-3fb9d1fedd81.png)

On `dist-exclude`:
![image](https://cloud.githubusercontent.com/assets/2641501/5491885/f953071c-86dc-11e4-9b29-88ec1c1893e0.png)

That's 10MB less!
I haven't tested this at all, though.
