### PR TITLE
Don't throw an exception if currentTheme is undefined

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -265,7 +265,11 @@ define(function (require, exports, module) {
 
             var cm = editor._codeMirror;
             ThemeView.updateThemes(cm);
-            cm.setOption("addModeClass", currentTheme.addModeClass);
+
+            // currentTheme can be undefined if you reloaded without extensions
+            if (currentTheme && currentTheme.addModeClass !== undefined) {
+                cm.setOption("addModeClass", currentTheme.addModeClass);
+            }
         });
     }
 


### PR DESCRIPTION
Steps to repro the issue:
1. Reload Brackets without extensions
2. Take a look at the console

Result:
At least one error saying: `Exception in 'activeEditorChange' listener on Object TypeError: Cannot read property 'addModeClass' of undefined TypeError: Cannot read property 'addModeClass' of undefined`
