### PR TITLE
Be more specific about filesystem watch error

### DIFF
--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -51,8 +51,9 @@ define(function (require, exports, module) {
         ALREADY_EXISTS              : "AlreadyExists",
         CONTENTS_MODIFIED           : "ContentsModified",
         ROOT_NOT_WATCHED            : "RootNotBeingWatched",
-        EXCEEDS_MAX_FILE_SIZE       : "ExceedsMaxFileSize"
-        
+        EXCEEDS_MAX_FILE_SIZE       : "ExceedsMaxFileSize",
+        NETWORK_DRIVE_NOT_SUPPORTED : "NetworkDriveNotSupported"
+
         // FUTURE: Add remote connection errors: timeout, not logged in, connection err, etc.
     };
 });

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -531,15 +531,17 @@ define(function (require, exports, module) {
         }
         appshell.fs.isNetworkDrive(path, function (err, isNetworkDrive) {
             if (err || isNetworkDrive) {
-                callback(FileSystemError.UNKNOWN);
+                if (isNetworkDrive) {
+                    callback(FileSystemError.NETWORK_DRIVE_NOT_SUPPORTED);
+                } else {
+                    callback(FileSystemError.UNKNOWN);
+                }
                 return;
             }
-            
             _nodeDomain.exec("watchPath", path)
                 .then(callback, callback);
         });
     }
-    
     /**
      * Stop providing change notifications for the file or directory at the
      * given path, calling back asynchronously with a possibly null FileSystemError


### PR DESCRIPTION
We shouldn't hide the fact that the user hit an unsupported use case. Let's make it crystal clear and hope that some _phantom_ issues with file watching could be resolved this way.
