### PR TITLE
Apply exclude filter when handling fs events.

### DIFF
--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -253,7 +253,9 @@ define(function (require, exports, module) {
                 try {
                     callback(null, stat);
                 } finally {
-                    this._fileSystem._fireChangeEvent(parent, added, removed);
+                    if (parent._isWatched()) {
+                        this._fileSystem._fireChangeEvent(parent, added, removed);
+                    }
                     // Unblock external change events
                     this._fileSystem._endChange();
                 }

--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -183,9 +183,12 @@ define(function (require, exports, module) {
                         // Notify the caller
                         callback(null, stat);
                     } finally {
-                        // If the write succeeded, fire a synthetic change event
-                        this._fileSystem._fireChangeEvent(parent, added, removed);
-                        
+                        if (parent._isWatched()) {
+                            // If the write succeeded and the parent directory is watched,
+                            // fire a synthetic change event
+                            this._fileSystem._fireChangeEvent(parent, added, removed);
+
+                        }
                         // Always unblock external change events
                         this._fileSystem._endChange();
                     }

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -544,7 +544,9 @@ define(function (require, exports, module) {
         
         if (!entry) {
             entry = new EntryConstructor(path, this);
-            this._index.addEntry(entry);
+            if (this._indexFilter(path, entry.name)) {
+                this._index.addEntry(entry);
+            }
         }
                 
         return entry;

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -797,7 +797,7 @@ define(function (require, exports, module) {
         path = this._normalizePath(path, false);
         
         var entry = this._index.getEntry(path);
-        if (entry) {
+        if (entry && entry._isWatched()) {
             var oldStat = entry._stat;
             if (entry.isFile) {
                 // Update stat and clear contents, but only if out of date

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -544,9 +544,7 @@ define(function (require, exports, module) {
         
         if (!entry) {
             entry = new EntryConstructor(path, this);
-            if (this._indexFilter(path, entry.name)) {
-                this._index.addEntry(entry);
-            }
+            this._index.addEntry(entry);
         }
                 
         return entry;

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -797,7 +797,7 @@ define(function (require, exports, module) {
         path = this._normalizePath(path, false);
         
         var entry = this._index.getEntry(path);
-        if (entry && entry._isWatched()) {
+        if (entry) {
             var oldStat = entry._stat;
             if (entry.isFile) {
                 // Update stat and clear contents, but only if out of date
@@ -810,10 +810,12 @@ define(function (require, exports, module) {
                 this._handleDirectoryChange(entry, function (added, removed) {
                     entry._stat = stat;
                     
-                    // We send a change even if added & removed are both zero-length. Something may still have changed,
-                    // e.g. a file may have been quickly removed & re-added before we got a chance to reread the directory
-                    // listing.
-                    this._fireChangeEvent(entry, added, removed);
+                    if (entry._isWatched()) {
+                        // We send a change even if added & removed are both zero-length. Something may still have changed,
+                        // e.g. a file may have been quickly removed & re-added before we got a chance to reread the directory
+                        // listing.
+                        this._fireChangeEvent(entry, added, removed);
+                    }
                 }.bind(this));
             }
         }

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -1143,7 +1143,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        if (!this.isWithinProject(entry) || !shouldShow(entry)) {
+        if (!this.isWithinProject(entry)) {
             return;
         }
 

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -1143,7 +1143,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        if (!this.isWithinProject(entry)) {
+        if (!this.isWithinProject(entry) || !shouldShow(entry)) {
             return;
         }
 

--- a/test/node/TestingDomain.js
+++ b/test/node/TestingDomain.js
@@ -68,6 +68,25 @@ function init(domainManager) {
             }
         ]
     );
+    domainManager.registerCommand(
+        "testing",
+        "rename",
+        fs.rename,
+        true,
+        "Rename a file or directory.",
+        [
+            {
+                name: "src",
+                type: "string",
+                description: "source path"
+            },
+            {
+                name: "dest",
+                type: "string",
+                description: "destination path"
+            }
+        ]
+    );
 }
 
 exports.init = init;

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -54,6 +54,10 @@ define(function (require, exports, module) {
             runs(function () {
                 waitsForDone(SpecRunnerUtils.copy(testPath, tempDir), "copy temp files");
             });
+            
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.rename(tempDir + "/git/", tempDir + "/.git/"), "move files");
+            });
 
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
@@ -121,60 +125,6 @@ define(function (require, exports, module) {
                 });
             });
             
-            // Issue #10183 -- Brackets writing to filtered directories could cause them to appear
-            // in the file tree
-            it("should not display excluded entry when resolved and written to", function () {
-                var opFailed = false,
-                    doneResolving = false,
-                    doneWriting = false,
-                    found = false,
-                    entry;
-                
-                runs(function () {
-                    waitsForDone(SpecRunnerUtils.copy(tempDir + "/git/", tempDir + "/.git/"), "copy git to .git");
-                });
-                
-                runs(function () {
-                    FileSystem.resolve(ProjectManager.getProjectRoot().fullPath + ".git/", function (err, e, stat) {
-                        if (err) {
-                            opFailed = true;
-                            return;
-                        }
-                        entry = e;
-                        doneResolving = true;
-                    });
-                });
-                
-                waitsFor(function () {
-                    return !opFailed && doneResolving;
-                }, "FileSystem.resolve()", 500);
-
-                runs(function () {
-                    var file = FileSystem.getFileForPath(entry.fullPath + "test");
-                    file.write("hi there!", function (err) {
-                        if (err) {
-                            opFailed = true;
-                            return;
-                        }
-                        doneWriting = true;
-                    });
-                });
-                
-                waitsFor(function () {
-                    return !opFailed && doneWriting;
-                }, "create a file under .git", 500);
-                
-                // unfortunately, this wait has to happen for the fs event to propagate to
-                // the project model
-                waits(500);
-                
-                runs(function () {
-                    found = testWindow.$(".jstree-brackets span:contains(\".git\")").length;
-                    expect(found).toBe(0);
-                });
-                
-            });
-
             it("should fail when a file already exists", function () {
                 var didCreate = false, gotError = false;
 
@@ -297,6 +247,62 @@ define(function (require, exports, module) {
                     runs(assertFile);
                 }
             });
+            
+            // Issue #10183 -- Brackets writing to filtered directories could cause them to appear
+            // in the file tree
+            it("should not display excluded entry when resolved and written to", function () {
+                var opFailed = false,
+                    doneResolving = false,
+                    doneWriting = false,
+                    entry;
+                                
+                runs(function () {
+                    var found = testWindow.$(".jstree-brackets span:contains(\".git\")").length;
+                    expect(found).toBe(0);
+                });
+                
+                runs(function () {
+                    FileSystem.resolve(ProjectManager.getProjectRoot().fullPath + ".git/", function (err, e, stat) {
+                        if (err) {
+                            opFailed = true;
+                            return;
+                        }
+                        entry = e;
+                        doneResolving = true;
+                    });
+                });
+                
+                waitsFor(function () {
+                    return !opFailed && doneResolving;
+                }, "FileSystem.resolve()", 500);
+
+                runs(function () {
+                    var file = FileSystem.getFileForPath(entry.fullPath + "test");
+                    file.write("hi there!", function (err) {
+                        if (err) {
+                            opFailed = true;
+                            return;
+                        }
+                        doneWriting = true;
+                    });
+                });
+                
+                waitsFor(function () {
+                    return !opFailed && doneWriting;
+                }, "create a file under .git", 500);
+                
+                // wait for the fs event to propagate to the project model
+                waits(500);
+                
+                runs(function () {
+                    var found = testWindow.$(".jstree-brackets span:contains(\".git\")").length,
+                        sanity = testWindow.$(".jstree-brackets span:contains(\"file\") + span:contains(\".js\")").length;
+                    expect(sanity).toBe(1);
+                    expect(found).toBe(0);
+                });
+                
+            });
+
         });
 
         describe("deleteItem", function () {

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -123,7 +123,6 @@ define(function (require, exports, module) {
             
             it("should not display excluded entry when resolved and written to", function () {
                 var opFailed = false,
-                    doneCreating = false,
                     doneResolving = false,
                     doneWriting = false,
                     doneLooking = false,
@@ -131,18 +130,8 @@ define(function (require, exports, module) {
                     entry;
                 
                 runs(function () {
-                    ProjectManager.createNewItem(ProjectManager.getProjectRoot.fullPath, ".git/", true, true)
-                        .fail(function () {
-                            opFailed = true;
-                        })
-                        .always(function () {
-                            doneCreating = true;
-                        });
+                    waitsForDone(SpecRunnerUtils.copy(tempDir + "/git/", tempDir + "/.git/"), "copy git to .git");
                 });
-                
-                waitsFor(function () {
-                    return !opFailed && doneCreating;
-                }, "create .git directory", 500);
                 
                 runs(function () {
                     FileSystem.resolve(ProjectManager.getProjectRoot().fullPath + ".git/", function (err, e, stat) {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -140,6 +140,14 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Rename a directory or file.
+     * @return {$.Promise} Resolved when the path is rename, rejected if there was a problem
+     */
+    function rename(src, dest) {
+        return testDomain().rename(src, dest);
+    }
+    
+    /**
      * Resolves a path string to a File or Directory
      * @param {!string} path Path to a file or directory
      * @return {$.Promise} A promise resolved when the file/directory is found or
@@ -1337,6 +1345,7 @@ define(function (require, exports, module) {
     exports.chmod                           = chmod;
     exports.remove                          = remove;
     exports.copy                            = copy;
+    exports.rename                          = rename;
     exports.getTestRoot                     = getTestRoot;
     exports.getTestPath                     = getTestPath;
     exports.getTempDirectory                = getTempDirectory;


### PR DESCRIPTION
This resolves the issue with `ProjectModel` not applying exclude list when handling `FileSystem` change.

~~This PR fixes [part 2](https://github.com/adobe/brackets/issues/10183#issuecomment-67237422) of the issues described in #10183.~~

EDIT:

This PR fixes #10183, see [this comment](https://github.com/adobe/brackets/issues/10183#issuecomment-67237422) for the issue definition:
- 5d181f5 fixes the part 2 -- do not allow the fs events to change the project model, apply filtering
- 6514f20 fixes the part 1 -- do not change `FileSystem._index` when the requested entry is filtered.

It might be so that 6514f20 actually draws 5d181f5 useless since no more events will be generated and the filtering will be done at `FileSystem` level, but there's no penalty on having 5d181f5 in place as well.
