### PR TITLE
Fix makeFileMostRecent API

### DIFF
--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -253,6 +253,19 @@ define(function (require, exports, module) {
     function _makeMRUListEntry(file, paneId) {
         return {file: file, paneId: paneId};
     }
+
+    /**
+     * Locates the first  MRU entry of a file
+     * @param {!File} File - the file
+     * @return {{file:File, paneId:string}}
+     * @private
+     */
+    function _findFileInMRUList(file) {
+        return _.findIndex(_mruList, function (record) {
+            return (record.file.fullPath === file.fullPath);
+        });
+    }
+
     
     /**
      * Retrieves the currently active Pane Id
@@ -321,15 +334,21 @@ define(function (require, exports, module) {
             pane.makeViewMostRecent(file);
         
             index = _.findIndex(_mruList, function (record) {
-                return (record.file === file && record.paneId === paneId);
+                return (record.file === file && record.paneId === pane.id);
             });
 
             entry = _makeMRUListEntry(file, pane.id);
 
             if (index !== -1) {
                 _mruList.splice(index, 1);
-                _mruList.unshift(entry);
             }
+
+            if (_findFileInMRUList(file) !== -1) {
+                console.log(file.fullPath + " duplicated in mru list");
+            }
+            
+            // add it to the front of the list
+            _mruList.unshift(entry);
         }
     }
 
@@ -709,11 +728,13 @@ define(function (require, exports, module) {
         } else if (result === pane.ITEM_NOT_FOUND) {
             index = pane.addToViewList(file, index);
 
-            // Add to or update the position in MRU
-            if (pane.getCurrentlyViewedFile() === file) {
-                _mruList.unshift(entry);
-            } else {
-                _mruList.push(entry);
+            if (_findFileInMRUList(file) === -1) {
+                // Add to or update the position in MRU
+                if (pane.getCurrentlyViewedFile() === file) {
+                    _mruList.unshift(entry);
+                } else {
+                    _mruList.push(entry);
+                }
             }
 
             exports.trigger("workingSetAdd", file, index, pane.id);
@@ -732,6 +753,9 @@ define(function (require, exports, module) {
         uniqueFileList = pane.addListToViewList(fileList);
         
         uniqueFileList.forEach(function (file) {
+            if (_findFileInMRUList(file) !== -1) {
+                console.log(file.fullPath + " duplicated in mru list");
+            }
             _mruList.push(_makeMRUListEntry(file, pane.id));
         });
         
@@ -1060,6 +1084,9 @@ define(function (require, exports, module) {
                                                newPane.id);
                 }
             });
+            $(newPane).on("viewDestroy.mainView", function (e, view) {
+                _removeFileFromMRU(newPane.id, view.getFile());
+            });
         }
         
         return newPane;
@@ -1253,6 +1280,10 @@ define(function (require, exports, module) {
                 });
         }
 
+        result.done(function () {
+            _makeFileMostRecent(paneId, file);
+        });
+        
         return result;
     }
     
@@ -1499,6 +1530,9 @@ define(function (require, exports, module) {
                     var fileList = pane.getViewList();
 
                     fileList.forEach(function (file) {
+                        if (_findFileInMRUList(file) !== -1) {
+                            console.log(file.fullPath + " duplicated in mru list");
+                        }
                         _mruList.push(_makeMRUListEntry(file, pane.id));
                     });
                     exports.trigger("workingSetAddList", fileList, pane.id);

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -59,8 +59,11 @@
   *  - viewListChange - Whenever there is a file change to a file in the working set.  These 2 events: `DocumentManger.pathRemove` 
   *  and `DocumentManger.fileNameChange` will cause a `viewListChange` event so the WorkingSetView can update.
   *
-  *  - currentViewChange - triggered whenever the current view changes.
+  *  - currentViewChange - Whenever the current view changes.
   *             (e, newView:View, oldView:View)
+  *
+  *  - viewDestroy - Whenever a view has been destroyed
+  *             (e, view:View)
   *
   * View Interface:  
   *
@@ -506,6 +509,7 @@ define(function (require, exports, module) {
         
         // Destroy temporary views
         _.forEach(viewsToDestroy, function (view) {
+            $(this).triggerHandler("viewDestroy", view);
             view.destroy();
         });
 
@@ -739,6 +743,7 @@ define(function (require, exports, module) {
             this._hideCurrentView();
         }
         delete this._views[view.getFile().fullPath];
+        $(this).triggerHandler("viewDestroy", view);
         view.destroy();
     };
     
@@ -1084,6 +1089,7 @@ define(function (require, exports, module) {
             var file = view.getFile(),
                 path = file && file.fullPath;
             delete this._views[path];
+            $(this).triggerHandler("viewDestroy", view);
             view.destroy();
         }
     };
@@ -1116,6 +1122,7 @@ define(function (require, exports, module) {
 
         // Now destroy the views
         views.forEach(function (_view) {
+            $(this).triggerHandler("viewDestroy", _view);
             _view.destroy();
         });
     };


### PR DESCRIPTION
Fixes #9654 

This is a squashed version of #9661

Existing File Objects are opened using CMD_OPEN_AND_ADD_TO_WORKING_SET which opens the file then adds it to the working set. The act of adding it to the working set would move it to the front of the MRU list if it was the currently viewed file (which happens in step 1 of the OPEN_AND_ADD_TO_WORKING_SET command)

We create an in-memory document to edit an untitled document and call MainViewManger._edit() on the document object. This adds the file to the working set before it has been opened which, because it wasn't the current file, means that its entry got added to the end of the MRU list.

We then call _makeFileMostRecent() which should have made the untitled document the most recent but there was were 2 flaws:

1) It was originally intended to only reorder the working set for items added to the working set (more on this later)
2) It was getting ACTIVE_PANE for untitled documents which needed to be resolved to an actual paneId. This is why untitled documents were MRU ordered last.

Because _makeFileMostRecent was not intended to work for Temporary Files but it probably should have been otherwise you could open a temporary view in the left pane and another temporary view in the right pane and never tab between them. You would have been scurried off to another document somewhere which would close the temporary view. Therefore, _makeFileMostRecent now works on temporary views and a new event is added Pane.viewDestroy to trap when temporary views are destroyed so they can be removed from the MRU list.
