### PR TITLE
Send the error over to the callback if decompress-zip fails

### DIFF
--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -270,7 +270,7 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
     unzipper.on("error", function (err) {
         // General error to report for problems reading the file
         callback(null, {
-            errors: [[Errors.INVALID_ZIP_FILE, zipPath]]
+            errors: [[Errors.INVALID_ZIP_FILE, zipPath, err]]
         });
         return;
     });

--- a/src/extensibility/node/package.json
+++ b/src/extensibility/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brackets-extensibility",
   "description": "Used in the management of Brackets extensions",
-  "version": "0.45.0",
+  "version": "1.2.0",
   "dependencies": {
     "decompress-zip": "0.0.2",
     "semver": "2.x",


### PR DESCRIPTION
Required for https://github.com/adobe/brackets-registry/pull/69.
