### PR TITLE
adding lineEndings UI in statusbar for documents

### DIFF
--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -698,7 +698,24 @@ define(function (require, exports, module) {
     Document.prototype.isUntitled = function () {
         return this.file instanceof InMemoryFile;
     };
+
+    /**
+     * Set lineEnding of the document. Change Text in the process.
+     */
+    Document.prototype.setLineEndings = function (lineEndings) {
+        this._lineEndings = lineEndings;
+        this.setText(FileUtils.translateLineEndings(this.getText(true), lineEndings));
+    };
     
+    /**
+     * Get the current document LineEnding.
+     *
+     * @return {string} - returns the current line endings of the document.
+     */
+    Document.prototype.getLineEndings = function () {
+        return this._lineEndings;
+    };
+
     // We dispatch events from the module level, and the instance level. Instance events are wired up
     // in the Document constructor.
     EventDispatcher.makeEventDispatcher(exports);

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -704,7 +704,7 @@ define(function (require, exports, module) {
      */
     Document.prototype.setLineEndings = function (lineEndings) {
         this._lineEndings = lineEndings;
-        this.setText(FileUtils.translateLineEndings(this.getText(true), lineEndings));
+        this.isDirty = true;
     };
     
     /**

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -108,6 +108,12 @@ define(function (require, exports, module) {
      * @type {boolean}
      */
     Document.prototype.isDirty = false;
+
+    /**
+     * Whether this document has unsaved lineEndings changes or not.
+     * @type {boolean}
+     */
+    Document.prototype._lineEndingsDirty = false;
     
     /**
      * Whether this document is currently being saved.
@@ -415,7 +421,7 @@ define(function (require, exports, module) {
         if (!this._refreshInProgress) {
             // Sync isDirty from CodeMirror state
             var wasDirty = this.isDirty;
-            this.isDirty = !editor._codeMirror.isClean();
+            this.isDirty = !editor._codeMirror.isClean() || this._lineEndingsDirty;
             
             // Notify if isDirty just changed (this also auto-adds us to working set if needed)
             if (wasDirty !== this.isDirty) {
@@ -432,6 +438,7 @@ define(function (require, exports, module) {
      */
     Document.prototype._markClean = function () {
         this.isDirty = false;
+        this._lineEndingsDirty = false;
         if (this._masterEditor) {
             this._masterEditor._codeMirror.markClean();
         }
@@ -704,6 +711,7 @@ define(function (require, exports, module) {
      */
     Document.prototype.setLineEndings = function (lineEndings) {
         this._lineEndings = lineEndings;
+        this._lineEndingsDirty = true;
         this.isDirty = true;
     };
     

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -224,26 +224,7 @@ define(function (require, exports, module) {
         if (!doNotAnimate) {
             AnimationUtils.animateUsingClass($statusOverwrite[0], "flash", 1500);
         }
-    }
-
-    /**
-     * Update LineEndings label
-     * @param {Event} event (unused)
-     * @param {Editor} editor Current editor
-     * @param {boolean=} doNotAnimate True if state should not be animated
-     */
-    function _updateLineEndingsLabel(event, editor, doNotAnimate) {
-        /* Toggle text */
-        if($statusLineEndings.text() === Strings.STATUSBAR_LINE_ENDINGS_CRLF) {
-            $statusLineEndings.text(Strings.STATUSBAR_LINE_ENDINGS_LF);
-        } else {
-            $statusLineEndings.text(Strings.STATUSBAR_LINE_ENDINGS_CRLF);
-        }
-        
-        if (!doNotAnimate) {
-            AnimationUtils.animateUsingClass($statusLineEndings[0], "flash", 1500);
-        }
-    }
+    }    
 
     /**
      * Update insert/overwrite indicator
@@ -263,14 +244,21 @@ define(function (require, exports, module) {
      * @param {Event} event (unused)
      */
     function _updateLineEndings(event) {
-        var editor = EditorManager.getActiveEditor();
-        var document = editor.document;
+        var editor = EditorManager.getActiveEditor(),
+            document = editor.document,
+            currentLineEndings;
 
-        // update label with no transition
-        _updateLineEndingsLabel(event, editor, true);
-        // Update the line ending in the document if needed(label is already updated to new value).
-        if(document.getLineEndings() !== $statusLineEndings.text()) {
-            document.setLineEndings($statusLineEndings.text());
+        // update label
+        if($statusLineEndings.text() === Strings.STATUSBAR_LINE_ENDINGS_CRLF) {
+            $statusLineEndings.text(Strings.STATUSBAR_LINE_ENDINGS_LF);
+            currentLineEndings = FileUtils.LINE_ENDINGS_LF;
+        } else {
+            $statusLineEndings.text(Strings.STATUSBAR_LINE_ENDINGS_CRLF);
+            currentLineEndings = FileUtils.LINE_ENDINGS_CRLF;
+        }
+        // Update the line ending in the document if needed.
+        if(document.getLineEndings() !== currentLineEndings) {
+            document.setLineEndings(currentLineEndings);
         }
     }
     

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -281,6 +281,9 @@ define({
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Click to toggle report panel.",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
     "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for .{0} Files",
+    "STATUSBAR_LINE_ENDINGS_CRLF"           : "CRLF",
+    "STATUSBAR_LINE_ENDINGS_LF"             : "LF",
+    "STATUSBAR_LINE_ENDINGS_TOOLTIP"        : "Click to toggle between CRLF(Windows) and LF(Linux and Mac) line endings",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problems",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -283,7 +283,7 @@ define({
     "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for .{0} Files",
     "STATUSBAR_LINE_ENDINGS_CRLF"           : "CRLF",
     "STATUSBAR_LINE_ENDINGS_LF"             : "LF",
-    "STATUSBAR_LINE_ENDINGS_TOOLTIP"        : "Click to toggle between CRLF(Windows) and LF(Linux and Mac) line endings",
+    "STATUSBAR_LINE_ENDINGS_TOOLTIP"        : "Click to toggle line endings",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problems",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -271,7 +271,7 @@ a, img {
     margin-right: 3px;
 }
 
-#status-overwrite:hover, #indent-type:hover, #indent-width-label:hover {
+#status-overwrite:hover, #indent-type:hover, #indent-width-label:hover, #status-line-endings:hover {
     text-decoration: underline;
 }
 
@@ -320,6 +320,21 @@ a, img {
     background-color: rgb(120, 178, 242);
 }
 
+#status-line-endings {
+    transition: background-color 3s;
+    background-color: rgba(255, 255, 255, 0);
+    color: @bc-text;
+    cursor: pointer;
+    
+    .dark & {
+        color: @dark-bc-text;
+    }
+}
+
+#status-line-endings.flash {
+    transition: background-color 1s;
+    background-color: rgb(120, 178, 242);
+}
 
 #editor-holder {
     position: relative;

--- a/src/widgets/StatusBar.html
+++ b/src/widgets/StatusBar.html
@@ -11,6 +11,7 @@
         </div>
         <div id="status-language"></div>
         <div id="status-overwrite">{{STATUSBAR_INSERT}}</div>
+        <div id="status-line-endings">{{Strings.STATUSBAR_LINE_ENDINGS_CRLF}}</div>
         <div class="spinner"></div>
     </div>
 </div>


### PR DESCRIPTION
Fix for #10106 and #10594
Tests Done
1) All tests under Brackets->Run Tests
2) jshint tests run from grunt jshint
3) Open a file, modify the Line ending option from existing(say CRLF) to other(say LF), save file. Close the file and reopen to notice that modified LineEnding is preserved. 
Let me know if any unit tests needs to be added for the change. I couldn't find any added for other status bar options available. 
