### PR TITLE
Allow non-autoClose dialogs to trigger "buttonClick" more than once

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
      */
     function _dismissDialog($dlg, buttonId) {
         $dlg.data("buttonId", buttonId);
-        $dlg.modal("hide");
+        $dlg.modal("hide");  // triggers "hidden" event, excuting the listener we added below
     }
     
     /**
@@ -83,6 +83,11 @@ define(function (require, exports, module) {
      * @param {boolean} autoDismiss Whether to autodismiss the dialog on a button click.
      */
     function _processButton($dlg, buttonId, autoDismiss) {
+        if (!$dlg.data("modal").isShown) {
+            // Dialog is already playing its hide animation - don't process any more dismissal actions
+            return;
+        }
+        
         if (autoDismiss) {
             _dismissDialog($dlg, buttonId);
         } else {
@@ -341,7 +346,7 @@ define(function (require, exports, module) {
             } else if ($otherBtn.length) {
                 $otherBtn.focus();
             } else {
-                document.activeElement.blur();
+                window.document.activeElement.blur();
             }
 
             // Push our global keydown handler onto the global stack of handlers.
@@ -349,7 +354,7 @@ define(function (require, exports, module) {
         });
         
         // Click handler for buttons
-        $dlg.one("click", ".dialog-button", function (e) {
+        $dlg.on("click", ".dialog-button", function (e) {
             _processButton($dlg, $(this).attr("data-button-id"), autoDismiss);
         });
                 


### PR DESCRIPTION
Allow non-`autoClose` dialogs to trigger "buttonClick" more than once (until the dialog is actually closed). This lets clients use `autoClose=false` to do simple validation.

Presumably the `.one()` was originally intended to prevent double-clicking a button (etc.) from triggering `"buttonClick"` twice, since the dialog remains semi-visible for a beat while animating closed after the first click. But
the keydown handler had no such protections. Now anyone calling `_processButton()` is protected from calls while the dialog is already closing.

Also fixes a JSLint warning introduced back in 34b1a186.
