### PR TITLE
Highlight scrollbar tickmark for the current Find match

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -163,6 +163,7 @@ define(function (require, exports, module) {
                 }
             }
         
+            console.assert(state.matchIndex !== -1);
             if (state.matchIndex !== -1) {
                 // Convert to 1-based by adding one before showing the index.
                 findBar.showFindCount(StringUtils.format(Strings.FIND_MATCH_INDEX,
@@ -404,6 +405,7 @@ define(function (require, exports, module) {
     function clearCurrentMatchHighlight(cm, state) {
         if (state.markedCurrent) {
             state.markedCurrent.clear();
+            ScrollTrackMarkers.markCurrent(-1);
         }
     }
     
@@ -426,13 +428,28 @@ define(function (require, exports, module) {
             
             var nextMatch = _getNextMatch(editor, searchBackwards, pos);
             if (nextMatch) {
-                _updateFindBarWithMatchInfo(getSearchState(editor._codeMirror),
-                                            {from: nextMatch.start, to: nextMatch.end}, searchBackwards);
+                // Update match index indicators - only possible if we have resultSet saved (missing if FIND_MAX_FILE_SIZE threshold hit)
+                if (state.resultSet.length) {
+                    _updateFindBarWithMatchInfo(state,
+                                                {from: nextMatch.start, to: nextMatch.end}, searchBackwards);
+                    // Update current-tickmark indicator - only if highlighting enabled (disabled if FIND_HIGHLIGHT_MAX threshold hit)
+                    if (state.marked.length) {
+                        ScrollTrackMarkers.markCurrent(state.matchIndex);  // _updateFindBarWithMatchInfo() has updated this index
+                    }
+                }
+                
                 _selectAndScrollTo(editor, [nextMatch], true, preferNoScroll);
-                state.markedCurrent = cm.markText(nextMatch.start, nextMatch.end,
-                     { className: "searching-current-match", startStyle: "searching-first", endStyle: "searching-last" });
+                
+                // Only mark text with "current match" highlight if search bar still open
+                if (findBar && !findBar.isClosed()) {
+                    // If highlighting disabled, apply both match AND current-match styles for correct appearance
+                    var curentMatchClassName = state.marked.length ? "searching-current-match" : "CodeMirror-searching searching-current-match";
+                    state.markedCurrent = cm.markText(nextMatch.start, nextMatch.end,
+                         { className: curentMatchClassName, startStyle: "searching-first", endStyle: "searching-last" });
+                }
             } else {
                 cm.setCursor(editor.getCursorPos());  // collapses selection, keeping cursor in place to avoid scrolling
+                // (nothing more to do: previous highlights already cleared above)
             }
         });
     }

--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -62,6 +62,12 @@ define(function (require, exports, module) {
      */
     var marks = [];
     
+    /**
+     * Tickmark markCurrent() last called on, or null if never called / called with -1.
+     * @type {?jQueryObject}
+     */
+    var $markedTickmark;
+    
     
     function _getScrollbar(editor) {
         // Be sure to select only the direct descendant, not also elements within nested inline editors
@@ -114,6 +120,7 @@ define(function (require, exports, module) {
         if (editor) {
             $(".tickmark-track", editor.getRootElement()).empty();
             marks = [];
+            $markedTickmark = null;
         }
     }
     
@@ -168,6 +175,18 @@ define(function (require, exports, module) {
         marks = marks.concat(posArray);
         _renderMarks(posArray);
     }
+    
+    /** @param {number} index Either -1, or an index into the array passed to addTickmarks() */
+    function markCurrent(index) {
+        // Remove previous highlight first
+        if ($markedTickmark) {
+            $markedTickmark.removeClass("tickmark-current");
+            $markedTickmark = null;
+        }
+        if (index !== -1) {
+            $markedTickmark = $(".tickmark-track > .tickmark", editor.getRootElement()).eq(index).addClass("tickmark-current");
+        }
+    }
 
     // Private helper for unit tests
     function _getTickmarks() {
@@ -181,4 +200,5 @@ define(function (require, exports, module) {
     exports.clear           = clear;
     exports.setVisible      = setVisible;
     exports.addTickmarks    = addTickmarks;
+    exports.markCurrent     = markCurrent;
 });

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1715,6 +1715,12 @@ textarea.exclusions-editor {
         border-top: 1px solid #e0d123;
         border-bottom: 1px solid #d4c620;
         opacity: 0.85;  // allow thumb to show through
+        &.tickmark-current {
+            background-color: #ed9823;
+            border-top: 1px solid #dd9128;
+            border-bottom: 1px solid #cb8320;
+            z-index: 1;  // ensure this one appears above overlapping sibling highlights
+        }
     }
 }
 


### PR DESCRIPTION
Highlight scrollbar tickmark for the current Find match differently from the other matches (similar to the text highlighting within the editor: the current match is orange and the other matches are yellow).

Also, fix a bug where the wrong text highlight color was seen when a file had many search results (> `FIND_HIGHLIGHT_MAX`) or was too big to search for all matches at once (> `FIND_MAX_FILE_SIZE`): ensure `.CodeMirror-searching` is always applied to the current-match highlight, even when other matches aren't highlighted.

I thought this would be a nice enhancement to get into 1.2 :-)
