### PR TITLE
Print deprecation warnings for extensions using $() on EventDispatchers

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets: true, $, window, navigator, Mustache */
+/*global define, brackets: true, $, window, navigator, Mustache, jQuery */
 
 // TODO: (issue #264) break out the definition of brackets into a separate module from the application controller logic
 
@@ -459,6 +459,27 @@ define(function (require, exports, module) {
                 throw new Error("Brackets-shell is not a secure general purpose web browser. Use NativeApp.openURLInDefaultBrowser() to open URLs in the user's main browser");
             }
             return real_windowOpen.apply(window, arguments);
+        };
+        
+        // jQuery patch to shim deprecated usage of $() on EventDispatchers
+        var DefaultCtor = jQuery.fn.init;
+        jQuery.fn.init = function (firstArg, secondArg) {
+            var jQObject = new DefaultCtor(firstArg, secondArg);
+
+            // Is this a Brackets EventDispatcher object? (not a DOM node or other object)
+            if (firstArg && firstArg._EventDispatcher) {
+                // Patch the jQ wrapper object so it calls EventDispatcher's APIs instead of jQuery's
+                jQObject.on  = firstArg.on.bind(firstArg);
+                jQObject.one = firstArg.one.bind(firstArg);
+                jQObject.off = firstArg.off.bind(firstArg);
+                // Don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
+                // shouldn't be doing that anyway since it's basically poking at private API
+
+                // Console warning, since $() is deprecated for EventDispatcher objects
+                // (pass true to only print once per caller, and index 4 since the extension caller is deeper in the stack than usual)
+                DeprecationWarning.deprecationWarning("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly on the object without a $() wrapper.", true, 4);
+            }
+            return jQObject;
         };
     }
     

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, window, brackets, navigator, jQuery */
+/*global require, define, window, brackets, navigator */
 
 /**
  * The bootstrapping module for brackets. This module sets up the require
@@ -59,33 +59,6 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
         locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
     });
 }
-
-// jQuery patch for event dispatchers
-// TODO: once all core usages fixed, we can move this into brackets.js since only extensions will need it
-(function () {
-    "use strict";
-    var DefaultCtor = jQuery.fn.init;
-
-    jQuery.fn.init = function (firstArg, secondArg) {
-        var jQObject = new DefaultCtor(firstArg, secondArg);
-        
-        // Is this a Brackets EventDispatcher object? (not a DOM node or other object)
-        if (firstArg && firstArg._EventDispatcher) {
-            // Patch the jQ wrapper object so it calls EventDispatcher's APIs instead of jQuery's
-            jQObject.on  = firstArg.on.bind(firstArg);
-            jQObject.one = firstArg.one.bind(firstArg);
-            jQObject.off = firstArg.off.bind(firstArg);
-            // Don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
-            // shouldn't be doing that anyway since it's basically poking at private API
-            
-            // Console warning, since $() is deprecated for EventDispatcher objects
-            var stack = new Error().stack.split("\n");
-            var stackStr = "\n" + stack.slice(1).join("\n");  // trim off "Error" prefix
-            console.warn("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly on the object without a $() wrapper.", stackStr);
-        }
-        return jQObject;
-    };
-}());
 
 define(function (require) {
     "use strict";

--- a/src/main.js
+++ b/src/main.js
@@ -75,24 +75,13 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
             jQObject.on  = firstArg.on.bind(firstArg);
             jQObject.one = firstArg.one.bind(firstArg);
             jQObject.off = firstArg.off.bind(firstArg);
-            // We don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
+            // Don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
             // shouldn't be doing that anyway since it's basically poking at private API
             
             // Console warning, since $() is deprecated for EventDispatcher objects
-            // Check if this is an extension vs. core - 4th line of stack trace (3rd stack frame) is $()'s caller
             var stack = new Error().stack.split("\n");
-            if (stack[3].indexOf("/dev/src/") !== -1 && stack[3].indexOf("/extensions/dev/") === -1) {
-                // Report more agressively if core code is still using deprecated $(). This detection only
-                // works in dev builds, since r.js-concatenated builds don't provide much path info in the
-                // stack trace, and we don't want an overbroad check that would flag r.js extension code too.
-                console.error("Core code should no longer be using $().on/off()!");
-                console.assert();  // force dev tools to pause
-                
-            // TODO: Enable warnings for extensions once they've had some time to update (too much spam for now)
-//            } else {
-//                var stackStr = "\n" + stack.slice(1).join("\n");  // trim off "Error" prefix
-//                console.warn("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly.", stackStr);
-            }
+            var stackStr = "\n" + stack.slice(1).join("\n");  // trim off "Error" prefix
+            console.warn("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly on the object without a $() wrapper.", stackStr);
         }
         return jQObject;
     };

--- a/src/utils/DeprecationWarning.js
+++ b/src/utils/DeprecationWarning.js
@@ -66,8 +66,10 @@ define(function (require, exports, module) {
      *     Note that setting this to true can cause a slight performance hit (because it has to generate
      *     a stack trace), so don't set this for functions that you expect to be called from performance-
      *     sensitive code (e.g. tight loops).
+     * @param {number=} callerStackPos Only used if oncePerCaller=true. Overrides the `Error().stack` depth
+     *     where the client-code caller can be found. Only needed if extra shim layers are involved.
      */
-    function deprecationWarning(message, oncePerCaller) {
+    function deprecationWarning(message, oncePerCaller, callerStackPos) {
         // If oncePerCaller isn't set, then only show the message once no matter who calls it. 
         if (!message || (!oncePerCaller && displayedWarnings[message])) {
             return;
@@ -80,7 +82,7 @@ define(function (require, exports, module) {
         // * 2 is the caller of this function (the one throwing the deprecation warning)
         // * 3 is the actual caller of the deprecated function.
         var stack = new Error().stack,
-            callerLocation = stack.split("\n")[3];
+            callerLocation = stack.split("\n")[callerStackPos || 3];
         if (oncePerCaller && displayedWarnings[message] && displayedWarnings[message][callerLocation]) {
             return;
         }


### PR DESCRIPTION
Print deprecation warnings for extensions that are still using `$()` wrapper on Brackets EventDispatcher objects. The shim still works, so extensions have more time to migrate.

Many extensions have yet to migrate, so this creates quite a bit of console spam.  ~~That makes me a _little_ hesitant to land it late-ish in the 1.2 cycle -- maybe it would be better to land early in 1.3?  Open to either option, but I'm curious to hear others' opinions...~~ It now only prints one warning per caller, so the spam seems manageable -- I'd like to land this for 1.2 if it seems safe enough to others.
