### PR TITLE
Fix bug #10411 - Unable to update extension if that extension does not have brackets min version in package.json.

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
             entry.installInfo.updateAvailable   = true;
             // Calculate updateCompatible to check if there's an update for current version of Brackets
             var lastCompatibleVersionInfo = _.findLast(entry.registryInfo.versions, function (versionInfo) {
-                return semver.satisfies(brackets.metadata.apiVersion, versionInfo.brackets);
+                return !versionInfo.brackets || semver.satisfies(brackets.metadata.apiVersion, versionInfo.brackets);
             });
             if (lastCompatibleVersionInfo && lastCompatibleVersionInfo.version && semver.lt(currentVersion, lastCompatibleVersionInfo.version)) {
                 entry.installInfo.updateCompatible        = true;


### PR DESCRIPTION
This fixes the issue with extension manager complaining about extension not being compatible if the extension's package.json does not have min version required for the extension to run in Brackets. https://github.com/adobe/brackets/issues/10411
