### PR TITLE
Adding fix for Issue#10370 ...Changing PrefManager to use project default path for new docs

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -192,6 +192,22 @@ define(function (require, exports, module) {
         }
         return result;
     }
+    /**
+     * Returns whether the given filePath is of an untitled File
+     * @param {!string} filePath
+     * @return {boolean} true if given filePath is of an untitled File, false otherwise
+     */
+    function isUntitledFilePath(filePath) {
+        var document,
+            isUntitled = false;
+        if (filePath) {
+            document = getOpenDocumentForPath(filePath);
+            if (document) {
+                isUntitled = true;
+            }
+        }
+        return isUntitled;
+    }
     
     
     /**
@@ -733,6 +749,7 @@ define(function (require, exports, module) {
     exports.getDocumentText             = getDocumentText;
     exports.createUntitledDocument      = createUntitledDocument;
     exports.getAllOpenDocuments         = getAllOpenDocuments;
+    exports.isUntitledFilePath          = isUntitledFilePath;
     
     // For internal use only
     exports.notifyPathNameChanged       = notifyPathNameChanged;

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -421,12 +421,7 @@ define(function (require, exports, module) {
     function _buildContext(filename, languageId) {
         var ctx = {};
         if (filename) {
-            ctx.path = filename;
-            // In case of untitled documents we want to use the project root instead of
-            // the random generated file path. This is to resolve #10370
-            if (!ProjectManager.isWithinProject(filename)) {
-                ctx.path = ProjectManager.getProjectRoot().fullPath;
-            }
+            ctx.path = ProjectManager.getPreferenceContextPath(filename);
         } else {
             ctx.path = currentFilename;
         }

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
     var OldPreferenceStorage    = require("preferences/PreferenceStorage").PreferenceStorage,
         AppInit                 = require("utils/AppInit"),
         Commands                = require("command/Commands"),
+        ProjectManager          = require("project/ProjectManager"),
         CommandManager          = require("command/CommandManager"),
         DeprecationWarning      = require("utils/DeprecationWarning"),
         FileUtils               = require("file/FileUtils"),
@@ -421,6 +422,9 @@ define(function (require, exports, module) {
         var ctx = {};
         if (filename) {
             ctx.path = filename;
+            if (!ProjectManager.isWithinProject(filename)) {
+                ctx.path = ProjectManager.getProjectRoot().fullPath;
+            }
         } else {
             ctx.path = currentFilename;
         }

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -422,6 +422,8 @@ define(function (require, exports, module) {
         var ctx = {};
         if (filename) {
             ctx.path = filename;
+            // In case of untitled documents we want to use the project root instead of
+            // the random generated file path. This is to resolve #10370
             if (!ProjectManager.isWithinProject(filename)) {
                 ctx.path = ProjectManager.getProjectRoot().fullPath;
             }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -502,6 +502,20 @@ define(function (require, exports, module) {
     function getProjectRoot() {
         return model.projectRoot;
     }
+    
+    /**
+     * Returns the path to be used for getting the preferences for this file
+     * This will return the project root for an untitled document and the regular file path for a saved file
+     * @return {Path} 
+     */
+    function getPreferenceContextPath(filePath) {
+        // In case of untitled documents we want to use the project root instead of
+        // the random generated file path. This is to resolve #10370
+        if (filePath && DocumentManager.isUntitledFilePath(filePath)) {
+            return getProjectRoot().fullPath;
+        }
+        return filePath;
+    }
 
     /**
      * @private
@@ -1397,6 +1411,7 @@ define(function (require, exports, module) {
     exports.makeProjectRelativeIfPossible = makeProjectRelativeIfPossible;
     exports.shouldShow                    = ProjectModel.shouldShow;
     exports.openProject                   = openProject;
+    exports.getPreferenceContextPath      = getPreferenceContextPath;
     exports.getSelectedItem               = getSelectedItem;
     exports.getContext                    = getContext;
     exports.getInitialProjectPath         = getInitialProjectPath;


### PR DESCRIPTION
#10370  Changed _buildContext in PreferenceManager to use the project path in case of untitled documents
