### PR TITLE
Show colored swatch in CSS Code Hints

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -175,16 +175,20 @@ define(function (require, exports, module) {
         return true;
     };
 
-    /*
+    /**
      * Returns a sorted and formatted list of hints with the query substring
      * highlighted.
      * 
      * @param {Array.<Object>} hints - the list of hints to format
      * @param {string} query - querystring used for highlighting matched
-     *      poritions of each hint
+     *      portions of each hint
      * @return {Array.jQuery} sorted Array of jQuery DOM elements to insert
      */
     function formatHints(hints, query) {
+        var hasColorSwatch = hints.some(function (token) {
+            return token.color;
+        });
+
         StringMatch.basicMatchSort(hints);
         return hints.map(function (token) {
             var $hintObj = $("<span>").addClass("brackets-css-hints");
@@ -202,6 +206,10 @@ define(function (require, exports, module) {
                 });
             } else {
                 $hintObj.text(token.value);
+            }
+
+            if (hasColorSwatch) {
+                $hintObj = ColorUtils.formatColorHint($hintObj, token.color);
             }
 
             $hintObj.data("token", token);
@@ -286,13 +294,19 @@ define(function (require, exports, module) {
                 
                 valueArray = valueArray.concat(namedFlows);
             } else if (type === "color") {
-                valueArray = valueArray.concat(ColorUtils.COLOR_NAMES);
+                valueArray = valueArray.concat(ColorUtils.COLOR_NAMES.map(function (color) {
+                    return { text: color, color: color };
+                }));
                 valueArray.push("transparent", "currentColor");
             }
             
-            result = $.map(valueArray, function (pvalue, pindex) {
-                var result = StringMatch.stringMatch(pvalue, valueNeedle, stringMatcherOptions);
+            result = $.map(valueArray, function (pvalue) {
+                var result = StringMatch.stringMatch(pvalue.text || pvalue, valueNeedle, stringMatcherOptions);
                 if (result) {
+                    if (pvalue.color) {
+                        result.color = pvalue.color;
+                    }
+
                     return result;
                 }
             });

--- a/src/extensions/default/CSSCodeHints/unittest-files/regions.css
+++ b/src/extensions/default/CSSCodeHints/unittest-files/regions.css
@@ -93,3 +93,13 @@ div.layout > div {
     flow-from: content;
     flow-from: element;
 }
+
+/* colors */
+.colorful {
+    color: ;
+    background-color: ;
+    border-left-color: deep;
+    border-color: rent;
+    height: ;
+    color: transparent;
+}

--- a/src/extensions/default/SVGCodeHints/main.js
+++ b/src/extensions/default/SVGCodeHints/main.js
@@ -102,6 +102,10 @@ define(function (require, exports, module) {
      * @return {Array.jQuery} sorted Array of jQuery DOM elements to insert
      */
     function formatHints(hints, query) {
+        var hasColorSwatch = hints.some(function (token) {
+            return token.color;
+        });
+
         StringMatch.basicMatchSort(hints);
         return hints.map(function (token) {
             var $hintObj = $("<span>").addClass("brackets-svg-hints");
@@ -119,6 +123,10 @@ define(function (require, exports, module) {
                 });
             } else {
                 $hintObj.text(token.value);
+            }
+
+            if (hasColorSwatch) {
+                $hintObj = ColorUtils.formatColorHint($hintObj, token.color);
             }
 
             $hintObj.data("token", token);
@@ -210,7 +218,9 @@ define(function (require, exports, module) {
                     isMultiple = attributeData[tagInfo.attrName].multiple;
 
                     if (attributeData[tagInfo.attrName].type === "color") {
-                        options = ColorUtils.COLOR_NAMES;
+                        options = ColorUtils.COLOR_NAMES.map(function (color) {
+                            return { text: color, color: color };
+                        });
                         options = options.concat(["currentColor", "transparent"]);
                     }
                 }
@@ -223,8 +233,12 @@ define(function (require, exports, module) {
                 query = XMLUtils.getValueQuery(tagInfo);
                 hints = $.map(options, function (option) {
                     if (tagInfo.exclusionList.indexOf(option) === -1) {
-                        var match = StringMatch.stringMatch(option, query, stringMatcherOptions);
+                        var match = StringMatch.stringMatch(option.text || option, query, stringMatcherOptions);
                         if (match) {
+                            if (option.color) {
+                                match.color = option.color;
+                            }
+
                             return match;
                         }
                     }

--- a/src/extensions/default/SVGCodeHints/unittests.js
+++ b/src/extensions/default/SVGCodeHints/unittests.js
@@ -39,8 +39,8 @@ define(function (require, exports, module) {
                         "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"\n" +
                         "     width=\"200\" height=\"200\" preserveAspectRatio=\"xMinYMin meet\">\n" +
                         "    <title>Brackets SVG Code Hints</title>\n" +
-                        "    <rect width=\"200\" height=\"200\" baseline-shift=\"baseline\" alignment-baseline=\"alphabetic\" stroke-width=\"1\"></rect>\n" +
-                        "    <rect width='160' height='160' x='20' y='20' baseline-shift='super' alignment-baseline='baseline' />\n" +
+                        "    <rect width=\"200\" height=\"200\" baseline-shift=\"baseline\" alignment-baseline=\"alphabetic\" stroke-width=\"1\" color=\"\"></rect>\n" +
+                        "    <rect width='160' height='160' x='20' y='20' baseline-shift='super' alignment-baseline='baseline' color='rent' fill='transparent' />\n" +
                         "    <g>\n" +
                         "        \n" +
                         "    </g>\n" +
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // Between <rect></rect>
-                testEditor.setCursorPos({line: 4, ch: 110});
+                testEditor.setCursorPos({line: 4, ch: 119});
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // After <title>+space in <title> Brackets
@@ -216,21 +216,21 @@ define(function (require, exports, module) {
             
             it("should not hint after the closed tag", function () {
                 // After </rect>
-                testEditor.setCursorPos({line: 4, ch: 117});
+                testEditor.setCursorPos({line: 4, ch: 126});
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // After space at </rect>+space
-                testDocument.replaceRange(" ", {line: 4, ch: 117});
-                testEditor.setCursorPos({line: 4, ch: 118});
+                testDocument.replaceRange(" ", {line: 4, ch: 126});
+                testEditor.setCursorPos({line: 4, ch: 127});
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // After />
-                testEditor.setCursorPos({line: 5, ch: 104});
+                testEditor.setCursorPos({line: 5, ch: 136});
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // After space in />+space
-                testDocument.replaceRange(" ", {line: 5, ch: 104});
-                testEditor.setCursorPos({line: 5, ch: 105});
+                testDocument.replaceRange(" ", {line: 5, ch: 136});
+                testEditor.setCursorPos({line: 5, ch: 137});
                 expectNoHints(SVGCodeHints.hintProvider);
                 
                 // After </g>
@@ -453,6 +453,38 @@ define(function (require, exports, module) {
             });
         });
         
+        describe("Color names and swatches", function () {
+            it("should show color swatches", function () {
+                // After color="
+                testEditor.setCursorPos({line: 4, ch: 117});
+                var hints = expectHints(SVGCodeHints.hintProvider);
+                verifyHints(hints, "aliceblue"); // first hint should be aliceblue
+                expect(hints[0].find(".color-swatch").length).toBe(1);
+                expect(hints[0].find(".color-swatch").css("backgroundColor")).toBe("rgb(240, 248, 255)");
+            });
+
+            it("should always include transparent and currentColor and they should not have a swatch, but class no-swatch-margin", function () {
+                // After color='rent
+                testEditor.setCursorPos({line: 5, ch: 113});
+                var hints = expectHints(SVGCodeHints.hintProvider);
+                verifyHints(hints, "currentColor"); // first hint should be currentColor
+                expect(hints[0].find(".color-swatch").length).toBe(0); // no swatch for currentColor
+                expect(hints[2].find(".color-swatch").length).toBe(0); // no swatch for transparent
+                expect(hints[0].hasClass("no-swatch-margin")).toBeTruthy(); // no-swatch-margin applied to currentColor
+                expect(hints[2].hasClass("no-swatch-margin")).toBeTruthy(); // no-swatch-margin applied to transparent
+            });
+
+            it("should remove class no-swatch-margin from transparent if it's the only one in the list", function () {
+                // After fill='transparent
+                testEditor.setCursorPos({line: 5, ch: 132});
+                var hints = expectHints(SVGCodeHints.hintProvider);
+                verifyHints(hints, "transparent");
+                expect(hints.length).toBe(1); // transparent should be the only hint
+                expect(hints[0].find(".color-swatch").length).toBe(0); // no swatch for transparent
+                expect(hints[0].hasClass("no-swatch-margin")).toBeFalsy(); // no-swatch-margin not applied to transparent
+            });
+        });
+
         describe("Tag Insertion", function () {
             it("should insert if query is empty", function () {
                 // After < inside <g>

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -526,6 +526,25 @@ a:focus {
                         background-color: @dark-bc-bg-highlight;
                     }
                 }
+
+                .color-swatch {
+                    border-radius: 2px;
+                    width: 12px;
+                    height: 12px;
+                    float: left;
+                    margin: 2px -8px 0 4px;
+                    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.24);
+
+                    .dark & {
+                        box-shadow: inset 0 0 1px rgba(255, 255, 255, 0.24);
+                    }
+                }
+
+                // Used to align non-swatch items with the others. Only applied
+                // if there's at least one item with a swatch in the list
+                .no-swatch-margin {
+                    margin-left: 8px;
+                }
             }
         }
     }

--- a/src/utils/ColorUtils.js
+++ b/src/utils/ColorUtils.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
+/*global define, $ */
 
 /**
  *  Utilities functions related to color matching
@@ -48,7 +48,27 @@ define(function (require, exports, module) {
     // use RegExp.source of the RegExp literal to avoid doubled backslashes
     var COLOR_REGEX = new RegExp(/#[a-f0-9]{6}\b|#[a-f0-9]{3}\b|\brgb\(\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*,\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*,\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*\)|\brgb\(\s*(?:[0-9]{1,2}%|100%)\s*,\s*(?:[0-9]{1,2}%|100%)\s*,\s*(?:[0-9]{1,2}%|100%)\s*\)|\brgba\(\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*,\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*,\s*(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b\s*,\s*(?:1|1\.0|0|0?\.[0-9]{1,3})\s*\)|\brgba\(\s*(?:[0-9]{1,2}%|100%)\s*,\s*(?:[0-9]{1,2}%|100%)\s*,\s*(?:[0-9]{1,2}%|100%)\s*,\s*(?:1|1\.0|0|0?\.[0-9]{1,3})\s*\)|\bhsl\(\s*(?:[0-9]{1,3})\b\s*,\s*(?:[0-9]{1,2}|100)\b%\s*,\s*(?:[0-9]{1,2}|100)\b%\s*\)|\bhsla\(\s*(?:[0-9]{1,3})\b\s*,\s*(?:[0-9]{1,2}|100)\b%\s*,\s*(?:[0-9]{1,2}|100)\b%\s*,\s*(?:1|1\.0|0|0?\.[0-9]{1,3})\s*\)|\b/.source + COLOR_NAMES.join("\\b|\\b") + "\\b", "gi");
 
+    /*
+     * Adds a color swatch to code hints where this is supported.
+     * @param {!jQuery} $hintObj - list item where the swatch will be in
+     * @param {?string} color - color the swatch should have, or null to add extra left margin to
+     *      align with the other hints
+     * @return {jQuery} jQuery object with the correct class and/or style applied
+     */
+    function formatColorHint($hintObj, color) {
+        if (color) {
+            $hintObj.prepend($("<span>")
+                .addClass("color-swatch")
+                .css("backgroundColor", color));
+        } else {
+            $hintObj.addClass("no-swatch-margin");
+        }
+        return $hintObj;
+    }
+
+
     // Define public API
-    exports.COLOR_NAMES = COLOR_NAMES;
-    exports.COLOR_REGEX = COLOR_REGEX;
+    exports.COLOR_NAMES     = COLOR_NAMES;
+    exports.COLOR_REGEX     = COLOR_REGEX;
+    exports.formatColorHint = formatColorHint;
 });


### PR DESCRIPTION
(for updated screenshots scroll down)
![image](https://cloud.githubusercontent.com/assets/2641501/5837033/dce0083c-a17b-11e4-894b-3cbd5b9421f7.png)
![image](https://cloud.githubusercontent.com/assets/2641501/5837052/1271d21e-a17c-11e4-85ff-f5643da50a16.png)

I'd like to get this in Release 1.2 as well so the color support is even better ([we did great progress this Release](https://twitter.com/randyedmunds/status/557702803125469185)).
cc @redmunds 
