### PR TITLE
Resize the Sidebar to fill the whole window now possible (#6822)

### DIFF
--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -70,6 +70,7 @@ define(function (require, exports, module) {
     function calcAvailableHeight() {
         var availableHt = $windowContent.height();
 
+        
         $editorHolder.siblings().each(function (i, elem) {
             var $elem = $(elem);
             if ($elem.css("display") !== "none" && $elem.css("position") !== "absolute") {

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
      */
     function calcAvailableHeight() {
         var availableHt = $windowContent.height();
-        
+
         $editorHolder.siblings().each(function (i, elem) {
             var $elem = $(elem);
             if ($elem.css("display") !== "none" && $elem.css("position") !== "absolute") {
@@ -84,6 +84,18 @@ define(function (require, exports, module) {
     /** Updates panel resize limits to disallow making panels big enough to shrink editor area below 0 */
     function updateResizeLimits() {
         var editorAreaHeight = $editorHolder.height();
+   
+        // Set maxsize for sideBar
+        var $sideBar = $("#sidebar");
+        var sideBarMaxSize = $(".main-view").width() - $("#main-toolbar").width() - 1;
+        $sideBar.data("maxsize", sideBarMaxSize);
+        
+        // Adjust the sideBar's width in case it exceeds the window's width when resizing the window.
+        if ($sideBar.css("display") !== "none") {
+            $sideBar.width(Math.min(sideBarMaxSize, $sideBar.width()));
+            Resizer.resyncSizer($sideBar);
+            $windowContent.css("left", $sideBar.width());
+        }
         
         $editorHolder.siblings().each(function (i, elem) {
             var $elem = $(elem);


### PR DESCRIPTION
This change was made to avoid issue #6822. 

The user can now resize the Sidebar to fill the whole window. 

When the user resizes the Window an upper bound width (maxsize) is set for the sidebar. This upper bound is computed by taking into consideration the main-toolbar width (on the right) and also the fact of leaving enough space for the Sidebar resizer icon to appear when the user hovers over the sidebar edges.

Also important is the scenario when the Sidebar is at its maximum size (filling the whole window) and the user decreases the Window's width. In that case the Sidebar's width should also be "dragged-along" and its width should be decreased to avoid the issue #6822 all over again. The content's left position must also be adjusted in that case.
