### PR TITLE
[#10228] Cmd+Delete now triggers Don't Save in Save Changes dialog

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -179,8 +179,8 @@ define(function (require, exports, module) {
                 $focusedElement.click();
             }
         } else if (brackets.platform === "mac") {
-            // CMD+D Don't Save
-            if (e.metaKey && (which === "D")) {
+            // CMD+Backspace Don't Save
+            if (e.metaKey && (e.which === KeyEvent.DOM_VK_BACK_SPACE)) {
                 if (_hasButton(this, DIALOG_BTN_DONTSAVE)) {
                     buttonId = DIALOG_BTN_DONTSAVE;
                 }


### PR DESCRIPTION
Cmd+Delete (Mac) now triggers Don't Save in Save Changes dialog. This is the system's default behaviour (see http://support.apple.com/en-us/HT201236).

(Issue #10228)
