### PR TITLE
Fix memory leak in CSS & SVG Code Hints

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -212,8 +212,6 @@ define(function (require, exports, module) {
                 $hintObj = ColorUtils.formatColorHint($hintObj, token.color);
             }
 
-            $hintObj.data("token", token);
-
             return $hintObj;
         });
     }

--- a/src/extensions/default/SVGCodeHints/main.js
+++ b/src/extensions/default/SVGCodeHints/main.js
@@ -129,8 +129,6 @@ define(function (require, exports, module) {
                 $hintObj = ColorUtils.formatColorHint($hintObj, token.color);
             }
 
-            $hintObj.data("token", token);
-
             return $hintObj;
         });
     }


### PR DESCRIPTION
This darn thing was a copy & paste leftover from JS Code Hints.
It leaked `SearchResult`s for some reason, and we don't rely on it anywhere. May also improve performance a little.
