### PR TITLE
apply theme to .force-syntax-highlighting

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -167,7 +167,7 @@ define(function (require, exports, module) {
             filename: fixPath(theme.file._path)
         });
 
-        parser.parse("#editor-holder {" + content + "\n}", function (err, tree) {
+        parser.parse("#editor-holder, .force-syntax-highlighting {" + content + "\n}", function (err, tree) {
             if (err) {
                 deferred.reject(err);
             } else {


### PR DESCRIPTION
I've added changed where the theme gets applied so it also applies to any element with the `.force-syntax-highlighting` class
