### PR TITLE
Fix Korean translation of split-view menu items

### DIFF
--- a/src/nls/ko/strings.js
+++ b/src/nls/ko/strings.js
@@ -242,9 +242,9 @@ define({
     "RIGHT"             : "오른쪽",
 
     "CMD_SPLITVIEW_NONE"        : "나누지 않음",
-    "CMD_SPLITVIEW_VERTICAL"    : "위/아래로 분할",
-    "CMD_SPLITVIEW_HORIZONTAL"  : "왼쪽/오른쪽으로 분할",
-    "SPLITVIEW_MENU_TOOLTIP"    : "에디터를 위/아래 또는 왼쪽/오른쪽으로 분할합니다",
+    "CMD_SPLITVIEW_VERTICAL"    : "왼쪽/오른쪽으로 분할",
+    "CMD_SPLITVIEW_HORIZONTAL"  : "위/아래로 분할",
+    "SPLITVIEW_MENU_TOOLTIP"    : "에디터를 왼쪽/오른쪽 또는 위/아래로 분할합니다",
     "GEAR_MENU_TOOLTIP"         : "Configure Working Set",
 
     "SPLITVIEW_INFO_TITLE"              : "이미 열려있는 파일",


### PR DESCRIPTION
The CMD_SPLITVIEW_VERTICAL is up/down split but The (left/right) is understandable.
For example, Japanese is not a up/down but a left/right.

```
//current
"CMD_SPLITVIEW_VERTICAL"    : "위/아래로 분할",
"CMD_SPLITVIEW_HORIZONTAL"  : "왼쪽/오른쪽으로 분할",

//propose
"CMD_SPLITVIEW_VERTICAL"    : "왼쪽/오른쪽으로 분할",
"CMD_SPLITVIEW_HORIZONTAL"  : "위/아래로 분할",

//japanese==propose
"CMD_SPLITVIEW_VERTICAL": "左右分割",
"CMD_SPLITVIEW_HORIZONTAL": "上下分割",
```
