### PR TITLE
Get rid of deprecation warnings in LiveDevMultiBrowser

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -698,14 +698,14 @@ define(function (require, exports, module) {
                 otherDocumentsInWorkingFiles;
 
             if (doc && !doc._masterEditor) {
-                otherDocumentsInWorkingFiles = DocumentManager.getWorkingSet().length;
-                DocumentManager.addToWorkingSet(doc.file);
+                otherDocumentsInWorkingFiles = MainViewManager.getWorkingSetSize(MainViewManager.ALL_PANES);
+                MainViewManager.addToWorkingSet(MainViewManager.ACTIVE_PANE, doc.file);
 
                 if (!otherDocumentsInWorkingFiles) {
-                    DocumentManager.setCurrentDocument(doc);
+                    MainViewManager._edit(MainViewManager.ACTIVE_PANE, doc);
                 }
             }
-
+            
             // wait for server (StaticServer, Base URL or file:)
             prepareServerPromise
                 .done(function () {

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -71,7 +71,9 @@ define(function (require, exports, module) {
     var STATUS_RELOADING     = exports.STATUS_RELOADING      =  5;
     var STATUS_RESTARTING    = exports.STATUS_RESTARTING     =  6;
 
-    var Dialogs              = require("widgets/Dialogs"),
+    var CommandManager       = require("command/CommandManager"),
+        Commands             = require("command/Commands"),
+        Dialogs              = require("widgets/Dialogs"),
         DefaultDialogs       = require("widgets/DefaultDialogs"),
         DocumentManager      = require("document/DocumentManager"),
         EditorManager        = require("editor/EditorManager"),
@@ -702,7 +704,7 @@ define(function (require, exports, module) {
                 MainViewManager.addToWorkingSet(MainViewManager.ACTIVE_PANE, doc.file);
 
                 if (!otherDocumentsInWorkingFiles) {
-                    MainViewManager._edit(MainViewManager.ACTIVE_PANE, doc);
+                    CommandManager.execute(Commands.CMD_OPEN, { fullPath: doc.file.fullPath });
                 }
             }
             

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -157,7 +157,7 @@ define(function (require, exports, module) {
      * @return {Array.<File>}
      */
     function getWorkingSet() {
-        DeprecationWarning.deprecationWarning("Use MainViewManager.getViews() instead of DocumentManager.getWorkingSet()", true);
+        DeprecationWarning.deprecationWarning("Use MainViewManager.getWorkingSet() instead of DocumentManager.getWorkingSet()", true);
         return MainViewManager.getWorkingSet(MainViewManager.ALL_PANES)
             .filter(function (file) {
                 // Legacy didn't allow for files with custom viewers


### PR DESCRIPTION
In case where the `LiveDocument` does not have a master editor, `LiveDevMultiBrowser` implementation uses deprecated methods to add it to the working set and open if there's no other documents.

CC @redmunds 
