### PR TITLE
Attach editor to LiveCSSDocument

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -312,7 +312,7 @@ define(function (require, exports, module) {
         docPromise.done(function (doc) {
             if ((_classForDocument(doc) === LiveCSSDocument) &&
                     (!_liveDocument || (doc !== _liveDocument.doc))) {
-                var liveDoc = _createLiveDocument(doc, null, roots);
+                var liveDoc = _createLiveDocument(doc, doc._masterEditor, roots);
                 if (liveDoc) {
                     _server.add(liveDoc);
                     _relatedDocuments[doc.url] = liveDoc;

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.js
@@ -72,6 +72,9 @@ define(function LiveCSSDocumentModule(require, exports, module) {
 
         this.doc.on("change.LiveCSSDocument", this.onChange);
         this.doc.on("deleted.LiveCSSDocument", this.onDeleted);
+        if (editor) {
+            this._attachToEditor(editor);
+        }
     };
     
     LiveCSSDocument.prototype = Object.create(LiveDocument.prototype);


### PR DESCRIPTION
Fixes #10516. Attach editor to `LiveCSSDocument` during its creation since `updateHighlight()` is not being evaluated when Live Preview session starts from a CSS document.
