### PR TITLE
Update the selected file if a renamed folder is a prefix of the path

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -939,8 +939,8 @@ define(function (require, exports, module) {
         
         delete this._selections.rename;
         delete this._selections.context;
-        if (this._selections.selected === oldPath) {
-            this._selections.selected = newPath;
+        if (this._selections.selected && this._selections.selected.indexOf(oldPath) === 0) {
+            this._selections.selected = newPath + this._selections.selected.slice(oldPath.length);
         }
         
         viewModel.moveMarker("rename", oldProjectPath, null);

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -939,18 +939,21 @@ define(function (require, exports, module) {
         
         delete this._selections.rename;
         delete this._selections.context;
-        if (this._selections.selected && this._selections.selected.indexOf(oldPath) === 0) {
-            this._selections.selected = newPath + this._selections.selected.slice(oldPath.length);
-        }
         
         viewModel.moveMarker("rename", oldProjectPath, null);
         viewModel.moveMarker("context", oldProjectPath, null);
         viewModel.moveMarker("creating", oldProjectPath, null);
+        
+        function finalizeRename() {
+            viewModel.renameItem(oldProjectPath, newName);
+            if (self._selections.selected && self._selections.selected.indexOf(oldPath) === 0) {
+                self._selections.selected = newPath + self._selections.selected.slice(oldPath.length);
+            }
+        }
 
         if (renameInfo.type === FILE_CREATING) {
             this.createAtPath(newPath).done(function (entry) {
-                viewModel.renameItem(oldProjectPath, newName);
-                
+                finalizeRename();
                 renameInfo.deferred.resolve(entry);
             }).fail(function (error) {
                 self._viewModel.deleteAtPath(self.makeProjectRelativeIfPossible(renameInfo.path));
@@ -958,7 +961,7 @@ define(function (require, exports, module) {
             });
         } else {
             this._renameItem(oldPath, newPath).then(function () {
-                viewModel.renameItem(oldProjectPath, newName);
+                finalizeRename();
                 renameInfo.deferred.resolve({
                     newPath: newPath
                 });

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -732,13 +732,41 @@ define(function (require, exports, module) {
                 });
                 
                 it("adjusts the selection if the renamed file was selected", function () {
+                    spyOn(model, "_renameItem").andReturn(new $.Deferred().resolve().promise());
                     model.setSelected("/foo/afile.js");
                     model.startRename("/foo/afile.js");
                     model.setRenameValue("something.js");
                     model.performRename();
                     expect(model._selections.selected).toBe("/foo/something.js");
                 });
+                
+                it("does not adjust the selection if renaming it fails", function () {
+                    spyOn(model, "_renameItem").andReturn(new $.Deferred().reject().promise());
+                    model.setSelected("/foo/afile.js");
+                    model.startRename("/foo/afile.js");
+                    model.setRenameValue("something.js");
+                    model.performRename();
+                    expect(model._selections.selected).toBe("/foo/afile.js");
+                });
 
+                it("adjusts the selection if a parent folder is renamed", function () {
+                    spyOn(model, "_renameItem").andReturn(new $.Deferred().resolve().promise());
+                    model.setSelected("/foo/afile.js");
+                    model.startRename("/foo");
+                    model.setRenameValue("bar");
+                    model.performRename();
+                    expect(model._selections.selected).toBe("/bar/afile.js");
+                });
+                
+                it("does not adjust the selection if renaming a parent folder fails", function () {
+                    spyOn(model, "_renameItem").andReturn(new $.Deferred().reject().promise());
+                    model.setSelected("/foo/afile.js");
+                    model.startRename("/foo");
+                    model.setRenameValue("bar");
+                    model.performRename();
+                    expect(model._selections.selected).toBe("/foo/afile.js");
+                });
+                
                 it("does nothing if setRenameValue is called when there's no rename in progress", function () {
                     model.setRenameValue("/foo/bar/baz");
                     expect(model._selections.rename).toBeUndefined();


### PR DESCRIPTION
This seems to fix #10527, but I don't know the code well enough to know if there would be other side-effects - I just made this fix by local inspection of the code. @dangoor could you take a look?

This fix exposes another issue, though: if you follow the steps in #10527, but rename the folder so it clashes with an existing filename, you get an error dialog, but now the selection is messed up again. The reason is that we update `this._selections.selected` before we know whether the rename was successful or not. (I think you would get a similar bug without this fix if you were just renaming an ordinary file.) So there's probably more work that would need to be done to make sure that gets updated only after we know the rename succeeded, but that looks like a more complex fix and someone who knows the code better should probably get into it :)
