### PR TITLE
Fix memory leak in ExtensionManagerViewModel

### DIFF
--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -378,7 +378,7 @@ define(function (require, exports, module) {
 
         // when registry is downloaded, sort extensions again - those with updates will be before others
         var self = this;
-        ExtensionManager.on("registryDownload", function () {
+        ExtensionManager.on("registryDownload." + this.source, function () {
             self._sortFullSet();
             self._setInitialFilter();
         });


### PR DESCRIPTION
Fixes the memory leak pointed out in https://groups.google.com/d/msg/brackets-dev/98FAtTKEKYw/zi5O-v2VtwQJ (~0.3MB each invocation).
