### PR TITLE
Fix memory leak in Quick Open/Smart Autocomplete

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -521,6 +521,9 @@ define(function (require, exports, module) {
             }
         }, 0);
         
+        _curDialog = null;
+
+        $("input#quickOpenSearch").removeData("smart-autocomplete");
         $(".smart_autocomplete_container").remove();
 
         $(window.document).off("mousedown", this._handleDocumentMouseDown);

--- a/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
+++ b/src/thirdparty/smart-auto-complete-local/jquery.smart_autocomplete.js
@@ -494,6 +494,8 @@
         }
       });
 
+        // Brackets monkeypatch: don't bind leaky handlers to document. Brackets can detect lost focus itself.
+/*
       //check for loosing focus on smart complete field and results container
       //$(this).blur(function(ev){
       $(document).bind("focusin click", function(ev){
@@ -505,6 +507,7 @@
           $(options.context).trigger("lostFocus");
         }
       });
+*/
 
       // Brackets monkeypatch: don't trigger item focus/unfocus events on mouseenter/mouseleave, since we don't
       // want to select an item just by mousing over it. We just want an ordinary hover highlight, which we apply


### PR DESCRIPTION
Fixes the memory leak pointed out in https://groups.google.com/d/msg/brackets-dev/98FAtTKEKYw/zi5O-v2VtwQJ (~1.4MB each invocation).

I know that we won't stay with Smart Autcomplete (see #7227), but for the time being this fix is still worth it, I guess.

I didn't test everything, but at first glance I'd say "it still works".
