### PR TITLE
Add extension changelogs to the extension manager

### DIFF
--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
@@ -1,15 +1,28 @@
-/*global define*/
+/*global brackets, define, Mustache*/
 
 define(function (require, exports, module) {
     "use strict";
 
-    var ChangelogDownloader = require("./ChangelogDownloader");
+    var Dialogs                 = brackets.getModule("widgets/Dialogs");
+    var Strings                 = brackets.getModule("strings");
+    var ChangelogDownloader     = require("./ChangelogDownloader");
+    var changelogDialogTemplate = require("text!ChangelogDialogTemplate.html");
 
     function show(extensionId) {
         ChangelogDownloader.downloadChangelog(extensionId)
             .then(function (changelog) {
+
                 console.log("changelog for " + extensionId);
                 console.log(JSON.stringify(changelog, null, 4));
+
+                var compiledTemplate = Mustache.render(changelogDialogTemplate, {
+                    title: extensionId,
+                    changelog: changelog,
+                    Strings: Strings
+                });
+
+                Dialogs.showModalDialogUsingTemplate(compiledTemplate);
+
             })
             .catch(function (e) {
                 console.error(e);

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
@@ -1,0 +1,21 @@
+/*global define*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var ChangelogDownloader = require("./ChangelogDownloader");
+
+    function show(extensionId) {
+        ChangelogDownloader.downloadChangelog(extensionId)
+            .then(function (changelog) {
+                console.log("changelog for " + extensionId);
+                console.log(JSON.stringify(changelog, null, 4));
+            })
+            .catch(function (e) {
+                console.error(e);
+            });
+    }
+
+    exports.show = show;
+
+});

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
@@ -4,9 +4,14 @@ define(function (require, exports, module) {
     "use strict";
 
     var Dialogs                 = brackets.getModule("widgets/Dialogs");
+    var ExtensionManager        = brackets.getModule("extensibility/ExtensionManager");
     var Strings                 = brackets.getModule("strings");
     var ChangelogDownloader     = require("./ChangelogDownloader");
     var changelogDialogTemplate = require("text!ChangelogDialogTemplate.html");
+
+    function getExtensionTitle(extensionId) {
+        return ExtensionManager.extensions[extensionId].registryInfo.metadata.title;
+    }
 
     function show(extensionId) {
         ChangelogDownloader.downloadChangelog(extensionId)
@@ -16,7 +21,7 @@ define(function (require, exports, module) {
                 console.log(JSON.stringify(changelog, null, 4));
 
                 var compiledTemplate = Mustache.render(changelogDialogTemplate, {
-                    title: extensionId,
+                    title: getExtensionTitle(extensionId),
                     changelog: changelog,
                     Strings: Strings
                 });

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialog.js
@@ -3,6 +3,7 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var _                       = brackets.getModule("thirdparty/lodash");
     var Dialogs                 = brackets.getModule("widgets/Dialogs");
     var ExtensionManager        = brackets.getModule("extensibility/ExtensionManager");
     var Strings                 = brackets.getModule("strings");
@@ -13,12 +14,25 @@ define(function (require, exports, module) {
         return ExtensionManager.extensions[extensionId].registryInfo.metadata.title;
     }
 
+    function getCurrentVersionOfAnExtension(extensionId) {
+        var installInfo = ExtensionManager.extensions[extensionId].installInfo;
+        return installInfo ? installInfo.metadata.version : null;
+    }
+
     function show(extensionId) {
         ChangelogDownloader.downloadChangelog(extensionId)
             .then(function (changelog) {
 
                 console.log("changelog for " + extensionId);
                 console.log(JSON.stringify(changelog, null, 4));
+
+                var currentVersion = getCurrentVersionOfAnExtension(extensionId);
+                if (currentVersion) {
+                    var f = _.find(changelog, { version: currentVersion });
+                    if (f) {
+                        f.currentlyInstalled = true;
+                    }
+                }
 
                 var compiledTemplate = Mustache.render(changelogDialogTemplate, {
                     title: getExtensionTitle(extensionId),

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
@@ -5,7 +5,12 @@
     <div class="modal-body">
         <div class="dialog-message">
             {{#changelog}}
-            <h4>Version {{version}} - {{date}}</h4>
+            <h4>
+                Version {{version}} - {{date}}
+                {{#currentlyInstalled}}
+                    - {{Strings.EXTENSION_INSTALLED}}
+                {{/currentlyInstalled}}
+            </h4>
             <ul>
                 {{#lines}}
                     <li class="{{className}}">{{{escapedContent}}}</li>

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
@@ -1,4 +1,4 @@
-<div class="{{dlgClass}} template modal">
+<div class="changelog-dialog template modal">
     <div class="modal-header">
         <h1 class="dialog-title">{{{title}}}</h1>
     </div>
@@ -8,7 +8,7 @@
             <h4>Version {{version}} - {{date}}</h4>
             <ul>
                 {{#lines}}
-                <li>{{.}}</li>
+                    <li class="{{className}}">{{content}}</li>
                 {{/lines}}
             </ul>
             {{/changelog}}

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
@@ -5,10 +5,15 @@
     <div class="modal-body">
         <div class="dialog-message">
             {{#changelog}}
-                <h3>{{version}} - {{date}}</h3>
+            <h4>Version {{version}} - {{date}}</h4>
+            <ul>
                 {{#lines}}
-                    <p>{{.}}</p>
+                <li>{{.}}</li>
                 {{/lines}}
+            </ul>
+            {{/changelog}}
+            {{^changelog}}
+                {{Strings.NO_CHANGELOG_LOADED}}
             {{/changelog}}
         </div>
     </div>

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
@@ -8,7 +8,7 @@
             <h4>Version {{version}} - {{date}}</h4>
             <ul>
                 {{#lines}}
-                    <li class="{{className}}">{{content}}</li>
+                    <li class="{{className}}">{{{escapedContent}}}</li>
                 {{/lines}}
             </ul>
             {{/changelog}}

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDialogTemplate.html
@@ -1,0 +1,18 @@
+<div class="{{dlgClass}} template modal">
+    <div class="modal-header">
+        <h1 class="dialog-title">{{{title}}}</h1>
+    </div>
+    <div class="modal-body">
+        <div class="dialog-message">
+            {{#changelog}}
+                <h3>{{version}} - {{date}}</h3>
+                {{#lines}}
+                    <p>{{.}}</p>
+                {{/lines}}
+            {{/changelog}}
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button class="dialog-button btn primary" data-button-id="ok">{{Strings.OK}}</button>
+    </div>
+</div>

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -126,12 +126,8 @@ define(function (require, exports, module) {
     function getGithubDetails(extensionId) {
         var repoUrl = getGithubUrl(extensionId);
 
-        // https version
-        var m = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)/);
-        if (!m) {
-            // try ssh version
-            m = repoUrl.match(/git@github\.com:([^\/]+)\/([^\/]+)/);
-        }
+        // https/ssh version
+        var m = repoUrl.match(/github\.com[:\/]([^\/]+)\/([^\/]+)/);
 
         return {
             owner: m[1],

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -281,6 +281,17 @@ define(function (require, exports, module) {
         });
     }
 
+    // exposed for testing purposes
+    exports._getDateOfVersion               = getDateOfVersion;
+    exports._getGithubUrl                   = getGithubUrl;
+    exports._getGithubDetails               = getGithubDetails;
+    exports._createChangelogFromMarkdown    = createChangelogFromMarkdown;
+    exports._createChangelogFromCommits     = createChangelogFromCommits;
+    exports._base64toUtf8                   = base64toUtf8;
+    exports._getChangelogFromChangelogFile  = getChangelogFromChangelogFile;
+    exports._githubHtmlToCommits            = githubHtmlToCommits;
+    exports._getChangelogFromCommits        = getChangelogFromCommits;
+    // public
     exports.downloadChangelog = downloadChangelog;
 
 });

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -22,7 +22,7 @@ define(function (require, exports, module) {
         str.split("\n").forEach(function (line) {
             var target;
 
-            var versionHeader = line.match(/^#.*([0-9]+\.[0-9]+\.[0-9]+)/);
+            var versionHeader = line.match(/^[#\+].*([0-9]+\.[0-9]+\.[0-9]+)/);
             if (versionHeader) {
                 version = versionHeader[1];
                 versionPublished = getDateOfVersion(extensionId, version);
@@ -44,6 +44,9 @@ define(function (require, exports, module) {
             }
 
             line = line.trim();
+
+            // replace some leading markdown non-word characters
+            line = line.replace(/^[^0-9A-Za-z]+/, "");
 
             if (target && line) {
                 target.lines.push(line);

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -125,7 +125,14 @@ define(function (require, exports, module) {
 
     function getGithubDetails(extensionId) {
         var repoUrl = getGithubUrl(extensionId);
-        var m = repoUrl.match(/github.com\/([^\/]+)\/([^\/]+)/);
+
+        // https version
+        var m = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)/);
+        if (!m) {
+            // try ssh version
+            m = repoUrl.match(/git@github\.com:([^\/]+)\/([^\/]+)/);
+        }
+
         return {
             owner: m[1],
             repo: m[2].replace(/\.git$/, "")

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
                     resolve(createChangelogFromMarkdown(extensionId, utf8content));
                 })
                 .fail(function (response) {
-                    reject("Couldn't load changelog: " + response.statusText);
+                    reject("Couldn't load changelog from CHANGELOG.md: " + response.statusText);
                 });
         });
     }
@@ -173,7 +173,7 @@ define(function (require, exports, module) {
                     resolve(createChangelogFromCommits(extensionId, response));
                 })
                 .fail(function (response) {
-                    reject("Couldn't load changelog: " + response.statusText);
+                    reject("Couldn't load changelog from GitHub commits: " + response.statusText);
                 });
         });
     }

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -43,13 +43,20 @@ define(function (require, exports, module) {
                 }
             }
 
-            line = line.trim();
+            if (!target) {
+                return;
+            }
 
+            /* TODO: parse headers from MARKDOWN
+            line = line.trim();
             // replace some leading markdown non-word characters
             line = line.replace(/^[^0-9A-Za-z]+/, "");
+            */
 
-            if (target && line) {
-                target.lines.push(line);
+            if (line) {
+                target.lines.push({
+                    content: line
+                });
             }
         });
 
@@ -82,16 +89,25 @@ define(function (require, exports, module) {
                     target = {
                         version: version,
                         date: versionDate,
-                        lines: []
+                        lines: [{
+                            className: "header",
+                            content: "Commits"
+                        }]
                     };
                     changelog.push(target);
                 }
             }
 
+            if (!target) {
+                return;
+            }
+
             commit.message = commit.message.trim();
 
-            if (target && commit.message) {
-                target.lines.push(commit.message);
+            if (commit.message) {
+                target.lines.push({
+                    content: obj.sha.substring(0, 7) + " - " + commit.message
+                });
             }
         });
 

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -74,7 +74,7 @@ define(function (require, exports, module) {
             }
 
             // remove markdown bullet points
-            line = line.replace(/^\*\s+/, "");
+            line = line.replace(/^\s*[\*\+]\s+/, "");
 
             if (line) {
                 target.lines.push({

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -1,0 +1,99 @@
+/*global $, brackets, define, Promise*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var ExtensionManager = brackets.getModule("extensibility/ExtensionManager");
+
+    /*
+        createChangelogFromMarkdown and createChangelogFromCommits should return
+        the output in the following format:
+        [
+            {
+                title: string - description of the change
+                version: string - version number in which the change was introduced
+            }
+        ]
+    */
+    function createChangelogFromMarkdown(str) {
+        var changes = [];
+
+        // TODO:
+
+        return changes;
+    }
+
+    function createChangelogFromCommits(commits) {
+        var changes = [];
+
+        // TODO:
+
+        return changes;
+    }
+
+    // ref: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+    function base64toUtf8(str) {
+        return decodeURIComponent(window.escape(window.atob(str)));
+    }
+
+    function getGithubUrl(extensionId) {
+        var extensionInfo = ExtensionManager.extensions[extensionId];
+
+        var metadata = extensionInfo.registryInfo ? extensionInfo.registryInfo.metadata : extensionInfo.installInfo.metadata;
+
+        if (metadata.repository) {
+
+            return typeof metadata.repository === "string" ? metadata.repository : metadata.repository.url;
+
+        } else if (metadata.homepage) {
+
+            return metadata.homepage;
+
+        } else {
+
+            throw new Error("Cannot get Github url from: " + JSON.stringify(metadata));
+
+        }
+    }
+
+    function getGithubDetails(extensionId) {
+        var repoUrl = getGithubUrl(extensionId);
+        var m = repoUrl.match(/github.com\/([^\/]+)\/([^\/]+)/);
+        return {
+            owner: m[1],
+            repo: m[2].replace(/\.git$/, "")
+        };
+    }
+
+    function downloadChangelog(extensionId) {
+        return new Promise(function (resolve, reject) {
+            var githubDetails = getGithubDetails(extensionId);
+
+            function getChangelogFromCommits() {
+                $.get("https://api.github.com/repos/" + githubDetails.owner + "/" + githubDetails.repo + "/commits")
+                    .done(function (response) {
+                        resolve(createChangelogFromCommits(response));
+                    })
+                    .fail(function (response) {
+                        reject("Couldn't load changelog: " + response.statusText);
+                    });
+            }
+
+            $.get("https://api.github.com/repos/" + githubDetails.owner + "/" + githubDetails.repo + "/contents/CHANGELOG.md")
+                .done(function (response) {
+                    var utf8content = base64toUtf8(response.content);
+                    resolve(createChangelogFromMarkdown(utf8content));
+                })
+                .fail(function (response) {
+                    if (response.status === 404) {
+                        return getChangelogFromCommits();
+                    }
+                    reject("Couldn't load changelog: " + response.statusText);
+                });
+
+        });
+    }
+
+    exports.downloadChangelog = downloadChangelog;
+
+});

--- a/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/ChangelogDownloader.js
@@ -178,6 +178,13 @@ define(function (require, exports, module) {
 
     function downloadChangelog(extensionId) {
         return new Promise(function (resolve, reject) {
+
+            var isInRegistry = ExtensionManager.extensions[extensionId].registryInfo;
+            if (!isInRegistry) {
+                reject("Couldn't find " + extensionId + " in the extension registry!");
+                return;
+            }
+
             var githubDetails = getGithubDetails(extensionId);
 
             var changelogFile = null;

--- a/src/extensions/default/ExtensionUpdateNotifications/Watchers.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/Watchers.js
@@ -1,0 +1,54 @@
+/*global $, brackets, define, MutationObserver*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var _ = brackets.getModule("thirdparty/lodash");
+
+    function watchChildren(target, selector, callback, options) {
+
+        options = options || {};
+
+        // create an observer instance
+        var observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
+
+                _.toArray(mutation.addedNodes)
+                    .map(function (node) {
+                        return $(node).find(selector);
+                    })
+                    .filter(function ($result) {
+                        return $result.length > 0;
+                    })
+                    .forEach(function (match) {
+
+                        // notify callback about every match
+                        match.each(function () {
+                            callback($(this));
+                        });
+
+                        // disconnect watcher if required
+                        if (options.watchOnce) {
+                            observer.disconnect();
+                        }
+
+                    });
+
+            });
+        });
+
+        // pass in the target node, as well as the observer options
+        target = target.jquery ? target.toArray() : [target];
+        target.forEach(function (el) {
+            observer.observe(el, {
+                attributes: false,
+                childList: true,
+                characterData: false
+            });
+        });
+
+    }
+
+    exports.watchChildren = watchChildren;
+
+});

--- a/src/extensions/default/ExtensionUpdateNotifications/main.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/main.js
@@ -1,0 +1,35 @@
+/*global $, brackets, define*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var AppInit         = brackets.getModule("utils/AppInit"),
+        Strings         = brackets.getModule("strings"),
+        ChangelogDialog = require("./ChangelogDialog"),
+        Watchers        = require("./Watchers");
+
+    function onExtensionManagerOpen($modalBody) {
+
+        // wait until buttons are loaded (spinner goes away) and attach additional buttons
+        Watchers.watchChildren($modalBody, "button:not(:disabled)", function ($installBtn) {
+            $("<button>")
+                .addClass("btn btn-mini show-changelog")
+                .attr("data-extension-id", $installBtn.attr("data-extension-id"))
+                .text(Strings.SEE_CHANGELOG)
+                .appendTo($installBtn.parent());
+        }, {
+            watchOnce: true
+        });
+
+        // attach an event for the new buttons
+        $modalBody.on("click", "button.show-changelog", function () {
+            ChangelogDialog.show($(this).attr("data-extension-id"));
+        });
+
+    }
+
+    AppInit.appReady(function () {
+        Watchers.watchChildren(document.body, ".extension-manager-dialog > .modal-body", onExtensionManagerOpen);
+    });
+
+});

--- a/src/extensions/default/ExtensionUpdateNotifications/main.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/main.js
@@ -4,9 +4,12 @@ define(function (require, exports, module) {
     "use strict";
 
     var AppInit         = brackets.getModule("utils/AppInit"),
+        ExtensionUtils  = brackets.getModule("utils/ExtensionUtils"),
         Strings         = brackets.getModule("strings"),
         ChangelogDialog = require("./ChangelogDialog"),
         Watchers        = require("./Watchers");
+
+    ExtensionUtils.loadStyleSheet(module, "styles.css");
 
     function onExtensionManagerOpen($modalBody) {
 

--- a/src/extensions/default/ExtensionUpdateNotifications/main.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/main.js
@@ -11,7 +11,7 @@ define(function (require, exports, module) {
     function onExtensionManagerOpen($modalBody) {
 
         // wait until buttons are loaded (spinner goes away) and attach additional buttons
-        Watchers.watchChildren($modalBody, "button:not(:disabled)", function ($installBtn) {
+        Watchers.watchChildren($modalBody, "button.install,button.remove", function ($installBtn) {
             $("<button>")
                 .addClass("btn btn-mini show-changelog")
                 .attr("data-extension-id", $installBtn.attr("data-extension-id"))

--- a/src/extensions/default/ExtensionUpdateNotifications/styles.css
+++ b/src/extensions/default/ExtensionUpdateNotifications/styles.css
@@ -1,0 +1,4 @@
+.changelog-dialog li.header {
+    list-style: none;
+    margin-left: -1.3em;
+}

--- a/src/extensions/default/ExtensionUpdateNotifications/unittests.js
+++ b/src/extensions/default/ExtensionUpdateNotifications/unittests.js
@@ -1,0 +1,43 @@
+/*global define, brackets, it, expect, describe, beforeEach, waitsFor, runs*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var _                   = brackets.getModule("thirdparty/lodash");
+    var ExtensionManager    = brackets.getModule("extensibility/ExtensionManager");
+    var ChangelogDownloader = require("ChangelogDownloader");
+    var registryDownloaded  = false;
+
+    describe("Extension Update Notifications", function () {
+
+        beforeEach(function () {
+
+            runs(function () {
+                if (!registryDownloaded) {
+                    ExtensionManager.downloadRegistry().then(function () {
+                        registryDownloaded = true;
+                    });
+                }
+            });
+
+            waitsFor(function () {
+                return registryDownloaded;
+            });
+
+            runs(function () {
+                // check that registryInfo was really downloaded
+                expect(_.pluck(ExtensionManager.extensions, "registryInfo").length).toBeGreaterThan(0);
+            });
+
+        });
+
+        describe("ChangelogDownloader", function () {
+
+            it("getDateOfVersion should return a date when extension was published", function () {
+                expect(ChangelogDownloader._getDateOfVersion("zaggino.brackets-git", "0.14.10")).toBe("2015-02-10");
+            });
+
+        });
+
+    });
+});

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -627,6 +627,7 @@ define({
     "DOCS_MORE_LINK"                            : "Read more",
 
     // extensions/default/ExtensionUpdateNotifications
-    "SEE_CHANGELOG"                             : "See changelog"
+    "SEE_CHANGELOG"                             : "See changelog",
+    "NO_CHANGELOG_LOADED"                       : "No changelog could be loaded for this extension."
 
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -628,6 +628,7 @@ define({
 
     // extensions/default/ExtensionUpdateNotifications
     "SEE_CHANGELOG"                             : "See changelog",
-    "NO_CHANGELOG_LOADED"                       : "No changelog could be loaded for this extension."
+    "NO_CHANGELOG_LOADED"                       : "No changelog could be loaded for this extension.",
+    "COMMITS"                                   : "Commits"
 
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -624,5 +624,9 @@ define({
     "CMD_TOGGLE_RECENT_PROJECTS"                : "Recent Projects",
 
     // extensions/default/WebPlatformDocs
-    "DOCS_MORE_LINK"                            : "Read more"
+    "DOCS_MORE_LINK"                            : "Read more",
+
+    // extensions/default/ExtensionUpdateNotifications
+    "SEE_CHANGELOG"                             : "See changelog"
+
 });

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1289,6 +1289,9 @@ a[href^="http"] {
                 text-align: right;
                 vertical-align: middle;
                 width: 150px;
+                button {
+                    margin-bottom: 6px;
+                }
             }
             .load-error {
                 display: inline-block;


### PR DESCRIPTION
As discussed here: https://groups.google.com/forum/#!topic/brackets-dev/MgoqM-nFJR0
and mentioned here: https://trello.com/c/86DGrlbJ/794-extension-update-notifications

The extension adds a "See changelog" button to the current extension manager and on demand downloads information about an extension from GitHub. Result looks something like this:

![image](https://cloud.githubusercontent.com/assets/1067319/6100509/2b42a776-b065-11e4-9618-193ca93f0913.png)

Sadly, code heavily depends on GitHub not changing anything - it parses both `CHANGELOG.md` if available and first commit page of an extension which puts latest 35 commits to the generated changelog. I've tried using GitHub API but it has limit of only 60 requests per hour without authorizations which basically disables this feature after opening a few logs.

I'd appreciate some comments onto this before putting any more time into it. Thanks :)
