### PR TITLE
Fix unit test that broke due to Find highlighting fix in PR #10413

### DIFF
--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -352,6 +352,10 @@ define(function (require, exports, module) {
                 });
             }
             
+            // Verify number of tickmarks equals number of highlights
+            var tickmarks = tw$(".tickmark-track .tickmark", myEditor.getRootElement());
+            expect(tickmarks.length).toEqual(selections.length);
+            
             // Verify that editor UI doesn't have extra ranges left highlighted from earlier
             // (note: this only works for text that's short enough to not get virtualized)
             var lineDiv = tw$(".CodeMirror-lines .CodeMirror-code", myEditor.getRootElement());
@@ -504,7 +508,8 @@ define(function (require, exports, module) {
                 enterSearchText("b");
 
                 expectMatchIndex(0, 2430);
-                expectHighlightedMatches([]);
+                // When exceeding 2000 matches, tickmarks disabled and only the *current* editor highlight is shown
+                expectHighlightedMatches([], 1);
             });
             
             it("should find all case-insensitive matches with lowercase text", function () {

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -269,7 +269,7 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.FILE_RENAME);
             });
 
-            waits(ProjectManager._RENDER_DEBOUNCE_TIME);
+            waits(ProjectManager._RENDER_DEBOUNCE_TIME + 50);
 
             runs(function () {
                 expect($("#project-files-container ul input").val()).toBe(fileName);


### PR DESCRIPTION
Fix unit test that broke due to a side fix in PR #10413, and also:
- Enhance whole FindReplace integration suite to verify that search tickmarks are rendered.
- Bump up wait time in WorkingSetView-test that was failing sporadically. The test had zero margin for error on the wait, which may be making it fragile.
