### PR TITLE
Consolidate code handling file-rename path fixups

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -65,10 +65,10 @@
  *      not just full-sized editors) or MainViewManager currentFileChange (which covers full-sized views
  *      only, but is also triggered for non-editor views e.g. image files).
  *
- *    - fileNameChange -- When the name of a file or folder has changed. The 2nd arg is the old name.
- *      The 3rd arg is the new name.  Generally, however, file objects have already been changed by the 
- *      time this event is dispatched so code that relies on matching the filename to a file object 
- *      will need to compare the newname.
+ *    - fileNameChange -- After the name of a file or folder has changed. The 2nd arg is the old full path.
+ *      The 3rd arg is the new full path. Generally, file objects have already been changed by the time
+ *      this event is dispatched. Use FileUtils.adjustForRename() to help map affected files (including
+ *      children of a renamed folder) to their correct new path.
  * 
  *    - pathDeleted -- When a file or folder has been deleted. The 2nd arg is the path that was deleted.
  *
@@ -514,10 +514,10 @@ define(function (require, exports, module) {
      * Called after a file or folder name has changed. This function is responsible
      * for updating underlying model data and notifying all views of the change.
      *
-     * @param {string} oldName The old name of the file/folder
-     * @param {string} newName The new name of the file/folder
+     * @param {string} oldPath The old path of the file/folder
+     * @param {string} newPath The new path of the file/folder
      */
-    function notifyPathNameChanged(oldName, newName) {
+    function notifyPathNameChanged(oldPath, newPath) {
         // Notify all open documents 
         _.forEach(_openDocuments, function (doc) {
             // TODO: Only notify affected documents? For now _notifyFilePathChange 
@@ -527,7 +527,7 @@ define(function (require, exports, module) {
         });
         
         // Send a "fileNameChange" event. This will trigger the views to update.
-        exports.trigger("fileNameChange", oldName, newName);
+        exports.trigger("fileNameChange", oldPath, newPath);
     }
     
     

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -41,6 +41,11 @@ define(function (require, exports, module) {
         StringUtils         = require("utils/StringUtils"),
         Dialogs;            // This will be loaded asynchronously
 
+    // Asynchronously loading Dialogs to avoid the circular dependency
+    require(["widgets/Dialogs"], function (dialogsModule) {
+        Dialogs = dialogsModule;
+    });
+
     
     /**
      * @const {Number} Maximium file size (in megabytes)
@@ -547,11 +552,23 @@ define(function (require, exports, module) {
         });
         return pathArray.join("/");
     }
-
-    // Asynchronously loading Dialogs to avoid the circular dependency
-    require(["widgets/Dialogs"], function (dialogsModule) {
-        Dialogs = dialogsModule;
-    });
+    
+    /**
+     * If 'pathToAdjust' is affected by renaming oldPath->newPath, returns the path pathToAdjust would be transformed
+     * to after the rename. Works if oldPath is a parent directory of pathToAdjust, or if pathToAdjust == oldPath.
+     * @param {string} pathToAdjust
+     * @param {string} oldPath Original full path of renamed file/dir
+     * @param {string} newPath New full path of renamed file/dir
+     * @return {string} What pathToAdjust maps to after the rename (unchanged if rename does not affect it).
+     */
+    function adjustForRename(pathToAdjust, oldPath, newPath) {
+        if (pathToAdjust === oldPath) {
+            return newPath;
+        } else if (oldPath[oldPath.length - 1] === "/" && pathToAdjust.indexOf(oldPath) === 0) {
+            return newPath + pathToAdjust.slice(oldPath.length);
+        }
+        return pathToAdjust;
+    }
 
     // Define public API
     exports.LINE_ENDINGS_CRLF              = LINE_ENDINGS_CRLF;
@@ -583,4 +600,5 @@ define(function (require, exports, module) {
     exports.comparePaths                   = comparePaths;
     exports.MAX_FILE_SIZE                  = MAX_FILE_SIZE;
     exports.encodeFilePath                 = encodeFilePath;
+    exports.adjustForRename                = adjustForRename;
 });

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -73,10 +73,10 @@
  *
  * __rename__ - Sent whenever a File or Directory is renamed. All affected File and Directory
  *   objects have been updated to reflect the new path by the time this event is dispatched.
- *   This event should be used to trigger any UI updates that may need to occur when a path
- *   has changed. Note that these events will only be sent for rename operations that happen
- *   within the filesystem. If a file is renamed externally, a change event on the parent
- *   directory will be sent instead.
+ *   Note that these events will only be sent for rename operations that happen within the
+ *   filesystem. If a file is renamed externally, a change event on the parent directory will
+ *   be sent instead. Passed two extra arguments: the original fullPath and new fullPath of the
+ *   renamed entry.
  * 
  * FileSystem may perform caching. But it guarantees:
  *    * File contents & metadata - reads are guaranteed to be up to date (cached data is not used

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1111,10 +1111,10 @@ define(function (require, exports, module) {
      * @private
      * Respond to a FileSystem rename event.
      */
-    _fileSystemRename = function (event, oldName, newName) {
+    _fileSystemRename = function (event, oldPath, newPath) {
         // Tell the document manager about the name change. This will update
         // all of the model information and send notification to all views
-        DocumentManager.notifyPathNameChanged(oldName, newName);
+        DocumentManager.notifyPathNameChanged(oldPath, newPath);
     };
 
     /**

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -869,22 +869,22 @@ define(function (require, exports, module) {
      * Rename a file/folder. This will update the project tree data structures
      * and send notifications about the rename.
      *
-     * @param {string} oldName Old item name
-     * @param {string} newName New item name
+     * @param {string} oldPath Old item full path
+     * @param {string} newPath New item full path
      * @param {boolean} isFolder True if item is a folder; False if it is a file.
      * @return {$.Promise} A promise object that will be resolved or rejected when
      *   the rename is finished.
      */
-    function _renameItem(oldName, newName, isFolder) {
+    function _renameItem(oldPath, newPath, isFolder) {
         var result = new $.Deferred();
 
-        if (oldName === newName) {
+        if (oldPath === newPath) {
             result.resolve();
-        } else if (!isValidFilename(FileUtils.getBaseName(newName), _invalidChars)) {
+        } else if (!isValidFilename(FileUtils.getBaseName(newPath), _invalidChars)) {
             result.reject(ERROR_INVALID_FILENAME);
         } else {
-            var entry = isFolder ? FileSystem.getDirectoryForPath(oldName) : FileSystem.getFileForPath(oldName);
-            entry.rename(newName, function (err) {
+            var entry = isFolder ? FileSystem.getDirectoryForPath(oldPath) : FileSystem.getFileForPath(oldPath);
+            entry.rename(newPath, function (err) {
                 if (err) {
                     result.reject(err);
                 } else {
@@ -901,11 +901,11 @@ define(function (require, exports, module) {
      *
      * Renames the item at the old path to the new name provided.
      *
-     * @param {string} oldPath full path to the current location of file or directory (should include trailing slash for directory)
-     * @param {string} newName new name for the file or directory
+     * @param {string} oldPath full path to the current location of file or directory (must include trailing slash if directory)
+     * @param {string} newPath full path to the new location
      */
-    ProjectModel.prototype._renameItem = function (oldPath, newName) {
-        return _renameItem(oldPath, newName, !_pathIsFile(oldPath));
+    ProjectModel.prototype._renameItem = function (oldPath, newPath) {
+        return _renameItem(oldPath, newPath, !_pathIsFile(oldPath));
     };
 
     /**
@@ -946,8 +946,8 @@ define(function (require, exports, module) {
         
         function finalizeRename() {
             viewModel.renameItem(oldProjectPath, newName);
-            if (self._selections.selected && self._selections.selected.indexOf(oldPath) === 0) {
-                self._selections.selected = newPath + self._selections.selected.slice(oldPath.length);
+            if (self._selections.selected) {
+                self._selections.selected = FileUtils.adjustForRename(self._selections.selected, oldPath, newPath);
             }
         }
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
         FileFilters           = require("search/FileFilters"),
         Async                 = require("utils/Async"),
         StringUtils           = require("utils/StringUtils"),
+        FileUtils             = require("file/FileUtils"),
         ProjectManager        = require("project/ProjectManager"),
         DocumentModule        = require("document/Document"),
         DocumentManager       = require("document/DocumentManager"),
@@ -511,17 +512,18 @@ define(function (require, exports, module) {
      * @private
      * Moves the search results from the previous path to the new one and updates the results list, if required
      * @param {$.Event} event
-     * @param {string} oldName
-     * @param {string} newName
+     * @param {string} oldPath
+     * @param {string} newPath
      */
-    _fileNameChangeHandler = function (event, oldName, newName) {
+    _fileNameChangeHandler = function (event, oldPath, newPath) {
         var resultsChanged = false;
         
-            // Update the search results
+        // Update the search results
         _.forEach(searchModel.results, function (item, fullPath) {
-            if (fullPath.indexOf(oldName) === 0) {
+            var adjustedPath = FileUtils.adjustForRename(fullPath, oldPath, newPath);
+            if (fullPath !== adjustedPath) {
                 searchModel.removeResults(fullPath);
-                searchModel.setResults(fullPath.replace(oldName, newName), item);
+                searchModel.setResults(adjustedPath, item);
                 resultsChanged = true;
             }
         });

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -250,5 +250,34 @@ define(function (require, exports, module) {
                 expect(FileUtils.compareFilenames("Xavier", "Äckerman", false)).toBeLessThan(0);
             });
         });
+        
+        describe("adjustForRename", function () {
+
+            it("should adjust paths for file rename", function () {
+                // pathToAdjust was renamed
+                expect(FileUtils.adjustForRename("/foo/aaa.txt", "/foo/aaa.txt", "/foo/bbb.txt")).toBe("/foo/bbb.txt");
+                
+                // pathToAdjust was not renamed
+                expect(FileUtils.adjustForRename("/foo/test.txt",    "/foo/aaa.txt", "/foo/bbb.txt")).toBe("/foo/test.txt");
+                expect(FileUtils.adjustForRename("/foo/aaa.txt2",    "/foo/aaa.txt", "/foo/bbb.txt")).toBe("/foo/aaa.txt2");
+                expect(FileUtils.adjustForRename("/pre/foo/aaa.txt", "/foo/aaa.txt", "/foo/bbb.txt")).toBe("/pre/foo/aaa.txt");
+            });
+            
+            it("should adjust paths for folder rename", function () {
+                // pathToAdjust was affected by rename
+                expect(FileUtils.adjustForRename("/foo/aaa/",                 "/foo/aaa/", "/foo/bbb/")).toBe("/foo/bbb/");
+                expect(FileUtils.adjustForRename("/foo/aaa/test.txt",         "/foo/aaa/", "/foo/bbb/")).toBe("/foo/bbb/test.txt");
+                expect(FileUtils.adjustForRename("/foo/aaa/xxx/yyy/test.txt", "/foo/aaa/", "/foo/bbb/")).toBe("/foo/bbb/xxx/yyy/test.txt");
+                expect(FileUtils.adjustForRename("/foo/aaa/foo/test.txt",     "/foo/aaa/foo/", "/foo/aaa/bbb/")).toBe("/foo/aaa/bbb/test.txt");
+                
+                // pathToAdjust was affected by rename
+                expect(FileUtils.adjustForRename("/foo/test.txt",      "/foo/aaa/", "/foo/bbb/")).toBe("/foo/test.txt");
+                expect(FileUtils.adjustForRename("/foo/aaa.txt",       "/foo/aaa/", "/foo/bbb/")).toBe("/foo/aaa.txt");
+                expect(FileUtils.adjustForRename("/foo/aaa2/",         "/foo/aaa/", "/foo/bbb/")).toBe("/foo/aaa2/");
+                expect(FileUtils.adjustForRename("/foo/aaa2/test.txt", "/foo/aaa/", "/foo/bbb/")).toBe("/foo/aaa2/test.txt");
+                expect(FileUtils.adjustForRename("/pre/foo/aaa/",      "/foo/aaa/", "/foo/bbb/")).toBe("/pre/foo/aaa/");
+                expect(FileUtils.adjustForRename("/pre/foo/aaa/X.txt", "/foo/aaa/", "/foo/bbb/")).toBe("/pre/foo/aaa/X.txt");
+            });
+        });
     });
 });

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -819,7 +819,7 @@ define(function (require, exports, module) {
 
                 it("should handle a folder change", function () {
                     runs(function () {
-                        FindInFiles._fileNameChangeHandler(null, fullTestPath("css"), fullTestPath("newcss"));
+                        FindInFiles._fileNameChangeHandler(null, fullTestPath("css/"), fullTestPath("newcss/"));
                     });
                     waitsFor(function () { return gotChange; }, "model change event");
                     runs(function () {


### PR DESCRIPTION
Consolidate code among places that handle file-rename path fixups, which tends to be bug-prone:
- Find in Files rename handling - had a subtle bug with superset filenames similar to #9904
- File tree rename handling - see recent fix #10527, and has same #9904-like bug
- Pane rename handling - did not work for any folder rename (discovered while testing #10527)

Added unit tests for Pane and for the new shared FileUtils code.

Fix a bunch of misleading var names & docs related to the arguments
passed to rename event handlers. And clarify some other docs in Pane.

_Not_ needed for 1.2 -- all of the edge-case bugs fixed here have been around for months already.  This is more about improving maintainability going forward.
