### PR TITLE
Disabling drag and drop of CM by default as it was leading to some defec...

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -128,7 +128,7 @@ define(function (require, exports, module) {
     
     PreferencesManager.definePreference(CLOSE_BRACKETS,     "boolean", false);
     PreferencesManager.definePreference(CLOSE_TAGS,         "Object", { whenOpening: true, whenClosing: true, indentTags: [] });
-    PreferencesManager.definePreference(DRAG_DROP,          "boolean", true);
+    PreferencesManager.definePreference(DRAG_DROP,          "boolean", false);
     PreferencesManager.definePreference(HIGHLIGHT_MATCHES,  "boolean", false);
     PreferencesManager.definePreference(SCROLL_PAST_END,    "boolean", false);
     PreferencesManager.definePreference(SHOW_CURSOR_SELECT, "boolean", false);


### PR DESCRIPTION
...ts.

The following are the defects that got introduced because of CM drag and drop on Mac.

https://github.com/adobe/brackets/issues/10590
https://github.com/adobe/brackets/issues/10617

User still has the ability to enable this features through the preference "dragDropText": true.
