### PR TITLE
Remove some circular dependencies

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -84,6 +84,7 @@ define(function (require, exports, module) {
         ProjectManager       = require("project/ProjectManager"),
         Strings              = require("strings"),
         _                    = require("thirdparty/lodash"),
+        LiveDevelopmentUtils = require("LiveDevelopment/LiveDevelopmentUtils"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         NodeSocketTransport  = require("LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport"),
         LiveDevProtocol      = require("LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol"),
@@ -120,17 +121,6 @@ define(function (require, exports, module) {
      * @type {BaseServer}
      */
     var _server;
-    
-    /**
-     * @private
-     * Returns true if we think the given extension is for an HTML file.
-     * @param {string} ext The extension to check.
-     * @return {boolean} true if this is an HTML extension
-     */
-    function _isHtmlFileExt(ext) {
-        return (FileUtils.isStaticHtmlFileExt(ext) ||
-                (ProjectManager.getBaseUrl() && FileUtils.isServerHtmlFileExt(ext)));
-    }
 
     /** 
      * @private
@@ -143,7 +133,7 @@ define(function (require, exports, module) {
             return LiveCSSDocument;
         }
 
-        if (_isHtmlFileExt(doc.file.fullPath)) {
+        if (LiveDevelopmentUtils.isHtmlFileExt(doc.file.fullPath)) {
             return LiveHTMLDocument;
         }
 
@@ -368,7 +358,7 @@ define(function (require, exports, module) {
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
-            if (FileUtils.isStaticHtmlFileExt(refPath) || FileUtils.isServerHtmlFileExt(refPath)) {
+            if (LiveDevelopmentUtils.isStaticHtmlFileExt(refPath) || LiveDevelopmentUtils.isServerHtmlFileExt(refPath)) {
                 return new $.Deferred().resolve(doc);
             }
         }
@@ -400,11 +390,11 @@ define(function (require, exports, module) {
                 if (fileInfo.fullPath.indexOf(containingFolder) === 0) {
                     if (FileUtils.getFilenameWithoutExtension(fileInfo.name) === "index") {
                         if (hasOwnServerForLiveDevelopment) {
-                            if ((FileUtils.isServerHtmlFileExt(fileInfo.name)) ||
-                                    (FileUtils.isStaticHtmlFileExt(fileInfo.name))) {
+                            if ((LiveDevelopmentUtils.isServerHtmlFileExt(fileInfo.name)) ||
+                                    (LiveDevelopmentUtils.isStaticHtmlFileExt(fileInfo.name))) {
                                 return true;
                             }
-                        } else if (FileUtils.isStaticHtmlFileExt(fileInfo.name)) {
+                        } else if (LiveDevelopmentUtils.isStaticHtmlFileExt(fileInfo.name)) {
                             return true;
                         }
                     } else {
@@ -629,7 +619,7 @@ define(function (require, exports, module) {
 
         // Optionally prompt for a base URL if no server was found but the
         // file is a known server file extension
-        showBaseUrlPrompt = !_server && FileUtils.isServerHtmlFileExt(doc.file.fullPath);
+        showBaseUrlPrompt = !_server && LiveDevelopmentUtils.isServerHtmlFileExt(doc.file.fullPath);
 
         if (showBaseUrlPrompt) {
             // Prompt for a base URL

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -78,6 +78,7 @@ define(function LiveDevelopment(require, exports, module) {
     var STATUS_SYNC_ERROR     = exports.STATUS_SYNC_ERROR     =  5;
 
     var Async                = require("utils/Async"),
+        CSSUtils             = require("language/CSSUtils"),
         Dialogs              = require("widgets/Dialogs"),
         DefaultDialogs       = require("widgets/DefaultDialogs"),
         DocumentManager      = require("document/DocumentManager"),
@@ -86,6 +87,7 @@ define(function LiveDevelopment(require, exports, module) {
         FileServer           = require("LiveDevelopment/Servers/FileServer").FileServer,
         FileSystemError      = require("filesystem/FileSystemError"),
         FileUtils            = require("file/FileUtils"),
+        LiveDevelopmentUtils = require("LiveDevelopment/LiveDevelopmentUtils"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         MainViewManager      = require("view/MainViewManager"),
         NativeApp            = require("utils/NativeApp"),
@@ -192,11 +194,6 @@ define(function LiveDevelopment(require, exports, module) {
     function _isPromisePending(promise) {
         return promise && promise.state() === "pending";
     }
-    
-    function _isHtmlFileExt(ext) {
-        return (FileUtils.isStaticHtmlFileExt(ext) ||
-                (ProjectManager.getBaseUrl() && FileUtils.isServerHtmlFileExt(ext)));
-    }
 
     /** Get the current document from the document manager
      * _adds extension, url and root to the document
@@ -219,7 +216,7 @@ define(function LiveDevelopment(require, exports, module) {
             return exports.config.experimental ? JSDocument : null;
         }
 
-        if (_isHtmlFileExt(doc.file.fullPath)) {
+        if (LiveDevelopmentUtils.isHtmlFileExt(doc.file.fullPath)) {
             return HTMLDocument;
         }
 
@@ -683,7 +680,7 @@ define(function LiveDevelopment(require, exports, module) {
         // Is the currently opened document already a file we can use for Live Development?
         if (doc) {
             refPath = doc.file.fullPath;
-            if (FileUtils.isStaticHtmlFileExt(refPath) || FileUtils.isServerHtmlFileExt(refPath)) {
+            if (LiveDevelopmentUtils.isStaticHtmlFileExt(refPath) || LiveDevelopmentUtils.isServerHtmlFileExt(refPath)) {
                 return new $.Deferred().resolve(doc);
             }
         }
@@ -715,11 +712,11 @@ define(function LiveDevelopment(require, exports, module) {
                 if (fileInfo.fullPath.indexOf(containingFolder) === 0) {
                     if (FileUtils.getFilenameWithoutExtension(fileInfo.name) === "index") {
                         if (hasOwnServerForLiveDevelopment) {
-                            if ((FileUtils.isServerHtmlFileExt(fileInfo.name)) ||
-                                    (FileUtils.isStaticHtmlFileExt(fileInfo.name))) {
+                            if ((LiveDevelopmentUtils.isServerHtmlFileExt(fileInfo.name)) ||
+                                    (LiveDevelopmentUtils.isStaticHtmlFileExt(fileInfo.name))) {
                                 return true;
                             }
-                        } else if (FileUtils.isStaticHtmlFileExt(fileInfo.name)) {
+                        } else if (LiveDevelopmentUtils.isStaticHtmlFileExt(fileInfo.name)) {
                             return true;
                         }
                     } else {
@@ -769,7 +766,7 @@ define(function LiveDevelopment(require, exports, module) {
      */
     function onActiveEditorChange(event, current, previous) {
         if (previous && previous.document &&
-                FileUtils.isCSSPreprocessorFile(previous.document.file.fullPath)) {
+                CSSUtils.isCSSPreprocessorFile(previous.document.file.fullPath)) {
             var prevDocUrl = _server && _server.pathToUrl(previous.document.file.fullPath);
             
             if (_relatedDocuments && _relatedDocuments[prevDocUrl]) {
@@ -777,7 +774,7 @@ define(function LiveDevelopment(require, exports, module) {
             }
         }
         if (current && current.document &&
-                FileUtils.isCSSPreprocessorFile(current.document.file.fullPath)) {
+                CSSUtils.isCSSPreprocessorFile(current.document.file.fullPath)) {
             var docUrl = _server && _server.pathToUrl(current.document.file.fullPath);
             _styleSheetAdded(null, docUrl);
         }
@@ -1258,7 +1255,7 @@ define(function LiveDevelopment(require, exports, module) {
         // Optionally prompt for a base URL if no server was found but the
         // file is a known server file extension
         showBaseUrlPrompt = !exports.config.experimental && !_server &&
-            FileUtils.isServerHtmlFileExt(doc.file.fullPath);
+            LiveDevelopmentUtils.isServerHtmlFileExt(doc.file.fullPath);
 
         if (showBaseUrlPrompt) {
             // Prompt for a base URL

--- a/src/LiveDevelopment/LiveDevelopmentUtils.js
+++ b/src/LiveDevelopment/LiveDevelopmentUtils.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define */
+
+/**
+ * Set of utilities for working with files and text content.
+ */
+define(function (require, exports, module) {
+    "use strict";
+
+    var LanguageManager = require("language/LanguageManager"),
+        ProjectManager  = require("project/ProjectManager");
+
+    /**
+     * File extensions - hard-coded for now, but may want to make these preferences
+     * @const {Array.<string>}
+     */
+    var _staticHtmlFileExts = ["htm", "html", "xhtml"],
+        _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "asp", "aspx", "jsp", "jspx", "shtm", "shtml"];
+
+    /**
+     * Determine if file extension is a static html file extension.
+     * @param {string} filePath could be a path, a file name or just a file extension
+     * @return {boolean} Returns true if fileExt is in the list
+     */
+    function isStaticHtmlFileExt(filePath) {
+        if (!filePath) {
+            return false;
+        }
+
+        return (_staticHtmlFileExts.indexOf(LanguageManager.getLanguageForPath(filePath).getId()) !== -1);
+    }
+
+    /**
+     * Determine if file extension is a server html file extension.
+     * @param {string} filePath could be a path, a file name or just a file extension
+     * @return {boolean} Returns true if fileExt is in the list
+     */
+    function isServerHtmlFileExt(filePath) {
+        if (!filePath) {
+            return false;
+        }
+
+        return (_serverHtmlFileExts.indexOf(LanguageManager.getLanguageForPath(filePath).getId()) !== -1);
+    }
+
+    /**
+     * Returns true if we think the given extension is for an HTML file.
+     * @param {string} ext The extension to check.
+     * @return {boolean} true if this is an HTML extension.
+     */
+    function isHtmlFileExt(ext) {
+        return (isStaticHtmlFileExt(ext) ||
+                (ProjectManager.getBaseUrl() && isServerHtmlFileExt(ext)));
+    }
+
+    // Define public API
+    exports.isHtmlFileExt       = isHtmlFileExt;
+    exports.isStaticHtmlFileExt = isStaticHtmlFileExt;
+    exports.isServerHtmlFileExt = isServerHtmlFileExt;
+});

--- a/src/LiveDevelopment/Servers/UserServer.js
+++ b/src/LiveDevelopment/Servers/UserServer.js
@@ -27,8 +27,8 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var BaseServer  = require("LiveDevelopment/Servers/BaseServer").BaseServer,
-        FileUtils   = require("file/FileUtils");
+    var BaseServer             = require("LiveDevelopment/Servers/BaseServer").BaseServer,
+        LiveDevelopmentUtils   = require("LiveDevelopment/LiveDevelopmentUtils");
 
     /**
      * Live preview server for user specified server as defined with Live Preview Base Url
@@ -68,8 +68,8 @@ define(function (require, exports, module) {
             return false;
         }
 
-        return FileUtils.isStaticHtmlFileExt(localPath) ||
-            FileUtils.isServerHtmlFileExt(localPath);
+        return LiveDevelopmentUtils.isStaticHtmlFileExt(localPath) ||
+            LiveDevelopmentUtils.isServerHtmlFileExt(localPath);
     };
 
     exports.UserServer = UserServer;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -251,6 +251,23 @@ define(function (require, exports, module) {
             _updateTitle();
         }
     }
+    
+    /**
+     * Shows an error dialog indicating that the given file could not be opened due to the given error
+     * @param {!FileSystemError} name
+     * @return {!Dialog}
+     */
+    function showFileOpenError(name, path) {
+        return Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_ERROR,
+            Strings.ERROR_OPENING_FILE_TITLE,
+            StringUtils.format(
+                Strings.ERROR_OPENING_FILE,
+                StringUtils.breakableUrl(path),
+                FileUtils.getFileErrorString(name)
+            )
+        );
+    }
 
     /**
      * @private
@@ -288,7 +305,7 @@ define(function (require, exports, module) {
             if (silent) {
                 _cleanup(fileError, fullFilePath);
             } else {
-                FileUtils.showFileOpenError(fileError, fullFilePath).done(function () {
+                showFileOpenError(fileError, fullFilePath).done(function () {
                     _cleanup(fileError, fullFilePath);
                 });
             }
@@ -803,7 +820,7 @@ define(function (require, exports, module) {
                 if (suppressError) {
                     result.resolve();
                 } else {
-                    FileUtils.showFileOpenError(error, doc.file.fullPath)
+                    showFileOpenError(error, doc.file.fullPath)
                         .done(function () {
                             result.reject(error);
                         });
@@ -1675,6 +1692,9 @@ define(function (require, exports, module) {
     } else if (brackets.platform === "mac") {
         showInOS    = Strings.CMD_SHOW_IN_FINDER;
     }
+    
+    // Define public API
+    exports.showFileOpenError = showFileOpenError;
 
     // Deprecated commands
     CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.FILE_ADD_TO_WORKING_SET,        handleFileAddToWorkingSet);

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var BaseServer           = brackets.getModule("LiveDevelopment/Servers/BaseServer").BaseServer,
-        FileUtils            = brackets.getModule("file/FileUtils"),
+        LiveDevelopmentUtils = brackets.getModule("LiveDevelopment/LiveDevelopmentUtils"),
         PreferencesManager   = brackets.getModule("preferences/PreferencesManager");
 
     
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
         }
 
         // FUTURE: do a MIME Type lookup on file extension
-        return FileUtils.isStaticHtmlFileExt(localPath);
+        return LiveDevelopmentUtils.isStaticHtmlFileExt(localPath);
     };
 
     /**

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -26,7 +26,7 @@
 /*global define, $, brackets, unescape, window */
 
 /**
- * Set of utilites for working with files and text content.
+ * Set of utilities for working with files and text content.
  */
 define(function (require, exports, module) {
     "use strict";
@@ -34,13 +34,14 @@ define(function (require, exports, module) {
     require("utils/Global");
     
     var FileSystemError     = require("filesystem/FileSystemError"),
+        DeprecationWarning  = require("utils/DeprecationWarning"),
         LanguageManager     = require("language/LanguageManager"),
         PerfUtils           = require("utils/PerfUtils"),
-        DefaultDialogs      = require("widgets/DefaultDialogs"),
         Strings             = require("strings"),
-        StringUtils         = require("utils/StringUtils"),
-        Dialogs;            // This will be loaded asynchronously
-
+        StringUtils         = require("utils/StringUtils");
+    
+    // These will be loaded asynchronously
+    var DocumentCommandHandlers, LiveDevelopmentUtils;
     
     /**
      * @const {Number} Maximium file size (in megabytes)
@@ -197,19 +198,15 @@ define(function (require, exports, module) {
     
     /**
      * Shows an error dialog indicating that the given file could not be opened due to the given error
+     * @deprecated Use DocumentCommandHandlers.showFileOpenError() instead
+     *
      * @param {!FileSystemError} name
      * @return {!Dialog}
      */
     function showFileOpenError(name, path) {
-        return Dialogs.showModalDialog(
-            DefaultDialogs.DIALOG_ID_ERROR,
-            Strings.ERROR_OPENING_FILE_TITLE,
-            StringUtils.format(
-                Strings.ERROR_OPENING_FILE,
-                StringUtils.breakableUrl(path),
-                getFileErrorString(name)
-            )
-        );
+        DeprecationWarning.deprecationWarning("FileUtils.showFileOpenError() has been deprecated. " +
+                                              "Please use DocumentCommandHandlers.showFileOpenError() instead.");
+        return DocumentCommandHandlers.showFileOpenError(name, path);
     }
 
     /**
@@ -351,32 +348,16 @@ define(function (require, exports, module) {
      * If the only `.` in the file is the first character,
      * returns "" as this is not considered an extension.
      * This method considers known extensions which include `.` in them.
+     * @deprecated Use LanguageManager.getCompoundFileExtension() instead
      *
      * @param {string} fullPath full path to a file or directory
      * @return {string} Returns the extension of a filename or empty string if
      * the argument is a directory or a filename with no extension
      */
     function getSmartFileExtension(fullPath) {
-        var baseName = getBaseName(fullPath),
-            parts = baseName.split(".");
-
-        // get rid of file name
-        parts.shift();
-        if (baseName[0] === ".") {
-            // if starts with a `.`, then still consider it as file name
-            parts.shift();
-        }
-
-        var extension = [parts.pop()], // last part is always an extension
-            i = parts.length;
-        while (i--) {
-            if (LanguageManager.getLanguageForExtension(parts[i])) {
-                extension.unshift(parts[i]);
-            } else {
-                break;
-            }
-        }
-        return extension.join(".");
+        DeprecationWarning.deprecationWarning("FileUtils.getSmartFileExtension() has been deprecated. " +
+                                              "Please use LanguageManager.getCompoundFileExtension() instead.");
+        return LanguageManager.getCompoundFileExtension(fullPath);
     }
 
     /**
@@ -400,46 +381,14 @@ define(function (require, exports, module) {
     }
 
     /**
-     * File extensions - hard-coded for now, but may want to make these preferences
-     * @const {Array.<string>}
-     */
-    var _staticHtmlFileExts = ["htm", "html", "xhtml"],
-        _serverHtmlFileExts = ["php", "php3", "php4", "php5", "phtm", "phtml", "cfm", "cfml", "asp", "aspx", "jsp", "jspx", "shtm", "shtml"];
-
-    /**
      * Determine if file extension is a static html file extension.
      * @param {string} filePath could be a path, a file name or just a file extension
      * @return {boolean} Returns true if fileExt is in the list
      */
     function isStaticHtmlFileExt(filePath) {
-        if (!filePath) {
-            return false;
-        }
-
-        return (_staticHtmlFileExts.indexOf(getFileExtension(filePath).toLowerCase()) !== -1);
-    }
-
-    /**
-     * Determine if file extension is a server html file extension.
-     * @param {string} filePath could be a path, a file name or just a file extension
-     * @return {boolean} Returns true if fileExt is in the list
-     */
-    function isServerHtmlFileExt(filePath) {
-        if (!filePath) {
-            return false;
-        }
-
-        return (_serverHtmlFileExts.indexOf(getFileExtension(filePath).toLowerCase()) !== -1);
-    }
-    
-    /**
-     * Determines if file extension is a CSS preprocessor file extension that Brackets supports.
-     * @param {string} filePath could be a path, a file name
-     * @return {boolean} true if LanguageManager identifies filePath as less or scss language.
-     */
-    function isCSSPreprocessorFile(filePath) {
-        var languageId = LanguageManager.getLanguageForPath(filePath).getId();
-        return (languageId === "less" || languageId === "scss");
+        DeprecationWarning.deprecationWarning("FileUtils.isStaticHtmlFileExt() has been deprecated. " +
+                                              "Please use LiveDevelopmentUtils.isStaticHtmlFileExt() instead.");
+        return LiveDevelopmentUtils.isStaticHtmlFileExt(filePath);
     }
     
     /**
@@ -547,10 +496,19 @@ define(function (require, exports, module) {
         });
         return pathArray.join("/");
     }
-
-    // Asynchronously loading Dialogs to avoid the circular dependency
-    require(["widgets/Dialogs"], function (dialogsModule) {
-        Dialogs = dialogsModule;
+    
+    // Asynchronously load DocumentCommandHandlers
+    // This avoids a temporary circular dependency created
+    // by relocating showFileOpenError() until deprecation is over
+    require(["document/DocumentCommandHandlers"], function (dchModule) {
+        DocumentCommandHandlers = dchModule;
+    });
+    
+    // Asynchronously load LiveDevelopmentUtils
+    // This avoids a temporary circular dependency created
+    // by relocating isStaticHtmlFileExt() until deprecation is over
+    require(["LiveDevelopment/LiveDevelopmentUtils"], function (lduModule) {
+        LiveDevelopmentUtils = lduModule;
     });
 
     // Define public API
@@ -569,9 +527,7 @@ define(function (require, exports, module) {
     exports.getNativeBracketsDirectoryPath = getNativeBracketsDirectoryPath;
     exports.getNativeModuleDirectoryPath   = getNativeModuleDirectoryPath;
     exports.stripTrailingSlash             = stripTrailingSlash;
-    exports.isCSSPreprocessorFile          = isCSSPreprocessorFile;
     exports.isStaticHtmlFileExt            = isStaticHtmlFileExt;
-    exports.isServerHtmlFileExt            = isServerHtmlFileExt;
     exports.getDirectoryPath               = getDirectoryPath;
     exports.getParentPath                  = getParentPath;
     exports.getBaseName                    = getBaseName;

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -35,8 +35,8 @@ define(function (require, exports, module) {
         Async               = require("utils/Async"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),
-        FileUtils           = require("file/FileUtils"),
         HTMLUtils           = require("language/HTMLUtils"),
+        LanguageManager     = require("language/LanguageManager"),
         ProjectManager      = require("project/ProjectManager"),
         TokenUtils          = require("utils/TokenUtils"),
         _                   = require("thirdparty/lodash");
@@ -60,6 +60,16 @@ define(function (require, exports, module) {
                           "[": "]",
                           "(": ")" },
         _invertedBracketPairs = _.invert(_bracketPairs);
+    
+    /**
+     * Determines if the given path is a CSS preprocessor file that CSSUtils supports.
+     * @param {string} filePath Absolute path to the file.
+     * @return {boolean} true if LanguageManager identifies filePath as less or scss language.
+     */
+    function isCSSPreprocessorFile(filePath) {
+        var languageId = LanguageManager.getLanguageForPath(filePath).getId();
+        return (languageId === "less" || languageId === "scss");
+    }
     
     /**
      * @private
@@ -1497,7 +1507,7 @@ define(function (require, exports, module) {
         var cm = editor._codeMirror;
         var ctx = TokenUtils.getInitialContext(cm, $.extend({}, pos));
         var selector = "", foundChars = false;
-        var isPreprocessorDoc = FileUtils.isCSSPreprocessorFile(editor.document.file.fullPath);
+        var isPreprocessorDoc = isCSSPreprocessorFile(editor.document.file.fullPath);
         var selectorArray = [];
 
         function _skipToOpeningBracket(ctx, startChar) {
@@ -1816,6 +1826,7 @@ define(function (require, exports, module) {
     exports.consolidateRules = consolidateRules;
     exports.getRangeSelectors = getRangeSelectors;
     exports.getCompleteSelectors = getCompleteSelectors;
+    exports.isCSSPreprocessorFile = isCSSPreprocessorFile;
 
     exports.SELECTOR = SELECTOR;
     exports.PROP_NAME = PROP_NAME;

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -398,7 +398,40 @@ define(function (require, exports, module) {
     function _resetPathLanguageOverrides() {
         _filePathToLanguageMap = {};
     }
+    
+    /**
+     * Get the file extension (excluding ".") given a path OR a bare filename.
+     * Returns "" for names with no extension.
+     * If the only `.` in the file is the first character,
+     * returns "" as this is not considered an extension.
+     * This method considers known extensions which include `.` in them.
+     *
+     * @param {string} fullPath full path to a file or directory
+     * @return {string} Returns the extension of a filename or empty string if
+     * the argument is a directory or a filename with no extension
+     */
+    function getCompoundFileExtension(fullPath) {
+        var baseName = FileUtils.getBaseName(fullPath),
+            parts = baseName.split(".");
 
+        // get rid of file name
+        parts.shift();
+        if (baseName[0] === ".") {
+            // if starts with a `.`, then still consider it as file name
+            parts.shift();
+        }
+
+        var extension = [parts.pop()], // last part is always an extension
+            i = parts.length;
+        while (i--) {
+            if (getLanguageForExtension(parts[i])) {
+                extension.unshift(parts[i]);
+            } else {
+                break;
+            }
+        }
+        return extension.join(".");
+    }
 
     
 
@@ -1135,4 +1168,5 @@ define(function (require, exports, module) {
     exports.getLanguageForPath          = getLanguageForPath;
     exports.getLanguages                = getLanguages;
     exports.setLanguageOverrideForPath  = setLanguageOverrideForPath;
+    exports.getCompoundFileExtension    = getCompoundFileExtension;
 });

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
         Immutable         = require("thirdparty/immutable"),
         _                 = require("thirdparty/lodash"),
         FileUtils         = require("file/FileUtils"),
+        LanguageManager   = require("language/LanguageManager"),
         FileTreeViewModel = require("project/FileTreeViewModel"),
         ViewUtils         = require("utils/ViewUtils"),
         KeyEvent          = require("utils/KeyEvent");
@@ -178,7 +179,7 @@ define(function (require, exports, module) {
          */
         componentDidMount: function () {
             var fullname = this.props.name,
-                extension = FileUtils.getSmartFileExtension(fullname);
+                extension = LanguageManager.getCompoundFileExtension(fullname);
 
             var node = this.refs.name.getDOMNode();
             node.setSelectionRange(0, _getName(fullname, extension).length);
@@ -437,7 +438,7 @@ define(function (require, exports, module) {
 
         render: function () {
             var fullname = this.props.name,
-                extension = FileUtils.getSmartFileExtension(fullname),
+                extension = LanguageManager.getCompoundFileExtension(fullname),
                 name = _getName(fullname, extension);
 
             if (extension) {

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -28,8 +28,8 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var _         = require("thirdparty/lodash"),
-        FileUtils = require("file/FileUtils");
+    var _               = require("thirdparty/lodash"),
+        LanguageManager = require("language/LanguageManager");
     
     var SCROLL_SHADOW_HEIGHT = 5;
     
@@ -402,7 +402,7 @@ define(function (require, exports, module) {
      */
     function getFileEntryDisplay(entry) {
         var name = entry.name,
-            ext = FileUtils.getSmartFileExtension(name),
+            ext = LanguageManager.getCompoundFileExtension(name),
             i = name.lastIndexOf("." + ext);
         
         if (i > 0) {

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -177,46 +177,6 @@ define(function (require, exports, module) {
             });
         });
 
-        describe("getSmartFileExtension", function () {
-
-            it("should get the extension of a normalized win file path", function () {
-                expect(FileUtils.getSmartFileExtension("C:/foo/bar/baz.txt")).toBe("txt");
-            });
-
-            it("should get the extension of a posix file path", function () {
-                expect(FileUtils.getSmartFileExtension("/foo/bar/baz.txt")).toBe("txt");
-            });
-
-            it("should return empty extension for a normalized win directory path", function () {
-                expect(FileUtils.getSmartFileExtension("C:/foo/bar/")).toBe("");
-            });
-
-            it("should return empty extension for a posix directory path", function () {
-                expect(FileUtils.getSmartFileExtension("bar")).toBe("");
-            });
-
-            it("should return the extension of a filename containing .", function () {
-                expect(FileUtils.getSmartFileExtension("C:/foo/bar/.baz/jaz.txt")).toBe("txt");
-                expect(FileUtils.getSmartFileExtension("foo/bar/baz/.jaz.txt")).toBe("txt");
-                expect(FileUtils.getSmartFileExtension("foo.bar.baz..jaz.txt")).toBe("txt");
-            });
-
-            it("should return no extension for files with only . as a first character", function () {
-                expect(FileUtils.getSmartFileExtension("C:/foo/bar/.baz/.jaz")).toBe("");
-            });
-
-            it("should return the extension containing . for known types", function () {
-                expect(FileUtils.getSmartFileExtension("C:/foo/bar/.baz/jaz.scss.erb")).toBe("scss.erb");
-                expect(FileUtils.getSmartFileExtension("foo/bar/baz/.jaz.js.erb")).toBe("js.erb");
-            });
-
-            it("should return the extension combined from other known extensions", function () {
-                expect(FileUtils.getSmartFileExtension("foo.bar.php.js")).toBe("php.js");
-                expect(FileUtils.getSmartFileExtension("foo.bar.php.html.js")).toBe("php.html.js");
-                expect(FileUtils.getSmartFileExtension("foo.bar.php.scss.erb")).toBe("php.scss.erb");
-            });
-        });
-
         describe("encodeFilePath", function () {
 
             it("should encode symbols in path", function () {

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -885,5 +885,45 @@ define(function (require, exports, module) {
                 expect(LanguageManager.getLanguageForPath("test.abcxyz").isBinary()).toBeFalsy();
             });
         });
+        
+        describe("getCompoundFileExtension", function () {
+
+            it("should get the extension of a normalized win file path", function () {
+                expect(LanguageManager.getCompoundFileExtension("C:/foo/bar/baz.txt")).toBe("txt");
+            });
+
+            it("should get the extension of a posix file path", function () {
+                expect(LanguageManager.getCompoundFileExtension("/foo/bar/baz.txt")).toBe("txt");
+            });
+
+            it("should return empty extension for a normalized win directory path", function () {
+                expect(LanguageManager.getCompoundFileExtension("C:/foo/bar/")).toBe("");
+            });
+
+            it("should return empty extension for a posix directory path", function () {
+                expect(LanguageManager.getCompoundFileExtension("bar")).toBe("");
+            });
+
+            it("should return the extension of a filename containing .", function () {
+                expect(LanguageManager.getCompoundFileExtension("C:/foo/bar/.baz/jaz.txt")).toBe("txt");
+                expect(LanguageManager.getCompoundFileExtension("foo/bar/baz/.jaz.txt")).toBe("txt");
+                expect(LanguageManager.getCompoundFileExtension("foo.bar.baz..jaz.txt")).toBe("txt");
+            });
+
+            it("should return no extension for files with only . as a first character", function () {
+                expect(LanguageManager.getCompoundFileExtension("C:/foo/bar/.baz/.jaz")).toBe("");
+            });
+
+            it("should return the extension containing . for known types", function () {
+                expect(LanguageManager.getCompoundFileExtension("C:/foo/bar/.baz/jaz.scss.erb")).toBe("scss.erb");
+                expect(LanguageManager.getCompoundFileExtension("foo/bar/baz/.jaz.js.erb")).toBe("js.erb");
+            });
+
+            it("should return the extension combined from other known extensions", function () {
+                expect(LanguageManager.getCompoundFileExtension("foo.bar.php.js")).toBe("php.js");
+                expect(LanguageManager.getCompoundFileExtension("foo.bar.php.html.js")).toBe("php.html.js");
+                expect(LanguageManager.getCompoundFileExtension("foo.bar.php.scss.erb")).toBe("php.scss.erb");
+            });
+        });
     });
 });


### PR DESCRIPTION
(Branched off discussion in #10600)
- [x] `isCSSPreprocessorFile()` -> CSSUtils
- [x] `_isStatic/ServerHtmlFileExt()` -> LiveDevelopment
  - [x] Possibly change to be based on language id instead of file ext
- [x] `getSmartFileExtension()` -> LanguageManager, and maybe rename to something like `getCompoundFileExtension()` for clarity
- [x] Move just `showFileOpenError()` to DocumentCommandHandlers, next to `_showSaveFileError()`
- [x] Update all affected tests/JSDoc

To note, moving `showFileOpenError()` to DCH and `_isStaticHtmlFileExt()` to LiveDevelopmentUtils are creating a circular dependencies (*sigh*) during deprecation.

Once merged, I suggest these APIs are put on the fast track for removal so the cycles they will resolve (and temporarily create/prolong) are removed.

/cc @peterflynn 
