### PR TITLE
Adding feature for adding own CSS to brackets GUI (#10548)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -342,6 +342,10 @@ define(function (require, exports, module) {
         // Add the platform (mac or win) to the body tag so we can have platform-specific CSS rules
         $("body").addClass("platform-" + brackets.platform);
         
+        var themePrefs = PreferencesManager.getExtensionPrefs("themes");
+        if (themePrefs.get("customCSS") === true) {
+            ExtensionUtils.addLinkedStyleSheet("custom.css");
+        }
         // Browser-hosted version may also have different CSS (e.g. since '#titlebar' is shown)
         if (brackets.inBrowser) {
             $("body").addClass("in-browser");

--- a/src/htmlContent/themes-settings.html
+++ b/src/htmlContent/themes-settings.html
@@ -40,6 +40,18 @@
                     <input type="text" data-target="fontFamily" value="{{settings.fontFamily}}">
                 </div>
             </div>
+            <div class="control-group">
+                <label class="control-label">{{Strings.USE_CUSTOM_CSS}}:</label>
+                <div class="controls">
+                    {{#settings.customCSS}}
+                        <input type="checkbox" data-target="customCSS" checked>
+                    {{/settings.customCSS}}
+                    {{^settings.customCSS}}
+                        <input type="checkbox" data-target="customCSS">
+                    {{/settings.customCSS}}
+                </div>
+            </div>
+
         </form>
     </div>
     <div class="modal-footer">

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -462,7 +462,7 @@ define({
     "FONT_SIZE"                            : "Schriftgröße",
     "FONT_FAMILY"                          : "Schriftart",
     "THEMES_SETTINGS"                      : "Design-Einstellungen",
-
+    "USE_CUSTOM_CSS"                       : "Eigene CSS Datei laden",
     // CSS Quick Edit
     "BUTTON_NEW_RULE"                      : "Neue Regel",
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -460,7 +460,7 @@ define({
     "FONT_SIZE"                            : "Font Size",
     "FONT_FAMILY"                          : "Font Family",
     "THEMES_SETTINGS"                      : "Themes Settings",
-
+    "USE_CUSTOM_CSS"                       : "Use own CSS",
     // CSS Quick Edit
     "BUTTON_NEW_RULE"                      : "New Rule",
 

--- a/src/view/ThemeSettings.js
+++ b/src/view/ThemeSettings.js
@@ -46,7 +46,8 @@ define(function (require, exports, module) {
      */
     var defaults = {
         "themeScrollbars": true,
-        "theme": "light-theme"
+        "theme": "light-theme",
+        "customCSS": false
     };
 
 
@@ -154,10 +155,12 @@ define(function (require, exports, module) {
     function restore() {
         prefs.set("theme", defaults.theme);
         prefs.set("themeScrollbars", defaults.themeScrollbars);
+        prefs.set("customCSS", defaults.customCSS);
     }
 
     prefs.definePreference("theme", "string", defaults.theme);
     prefs.definePreference("themeScrollbars", "boolean", defaults.themeScrollbars);
+    prefs.definePreference("customCSS", "boolean", defaults.customCSS);
 
     exports._setThemes = setThemes;
     exports.restore    = restore;


### PR DESCRIPTION
You can now adding own CSS declaration without using a extension.

Put an custom.css on the same level like config.json or index.html and activate it over View -> Themes

Reload the UI with F5
