### PR TITLE
#10574  Adjust file tree click behavior, don't collapse parent folder

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -609,7 +609,7 @@ define(function (require, exports, module) {
          * If you click on a directory, it will toggle between open and closed.
          */
         handleClick: function (event) {
-            if (event.button !== LEFT_MOUSE_BUTTON) {
+            if (event.button !== LEFT_MOUSE_BUTTON || event.target.localName === "ul") {
                 return;
             }
 


### PR DESCRIPTION
Issue #10574 - Clicking to the left of filename can collapse parent folder

Observed that clicking in the padding of a parent ul tag (positioned to the left of the span/a/ins tags containing filenames/icons) would collapse the parent folder.

Solution: Ignore ul tag clicks. When a user intends to click on a parent folder, clicks are sent from span/a/ins tags.

Test Cases:
[action] --> [result]

click parent folder icon --> toggles open/close
click parent folder title --> toggles open/close
click nested folder icon --> toggles open/close
click nested folder title --> toggles open/close
click to the left of nested folder icon --> no result action (previous behavior would close parent folder)
click filename --> select file
click to the left of filename --> no result action (previous behavior would close parent folder)
