### PR TITLE
for #10634 Element duplication when copying root node

### DIFF
--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -604,7 +604,7 @@ define(function (require, exports, module) {
                 // because it isn't the child of any other node. The browser-side code doesn't
                 // care about parentage/positioning in this case, and will handle just setting the 
                 // ID on the existing implied HTML tag in the browser without actually creating it.
-                if (!newElement.parent ) {
+                if (!newElement.parent) {
                     edits.push({
                         type: "elementInsert",
                         tag: newElement.tag,

--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -611,19 +611,18 @@ define(function (require, exports, module) {
                         attributes: newElement.attributes
                     });
                     
+                    // Since the root <html> tag has a new tag ID if the user copies and pastes the entire document,
+                    // This checks if there is an old <root> node, and if there is, passes that node as a parameter to 
+                    // generateChildEdits instead of null.
+                    if (Object.keys(oldNodeMap).length > 0){
+                        addEdits(generateChildEdits(oldNodeMap[Object.keys(oldNodeMap)[0]], oldNodeMap, newElement, newNodeMap));
+                    } else {
+                        addEdits(generateChildEdits(null, oldNodeMap, newElement, newNodeMap));
+                    }
                     
-                }
-                
-                // Since the root <html> tag has a new tag ID if the user copies and pastes the entire document,
-                // This checks if there is an old <root> node, and if there is, passes that node as a parameter to 
-                // generateChildEdits instead of null.
-                if (Object.keys(oldNodeMap).length > 0){
-                    addEdits(generateChildEdits(oldNodeMap[Object.keys(oldNodeMap)[0]], oldNodeMap, newElement, newNodeMap));
                 } else {
                     addEdits(generateChildEdits(null, oldNodeMap, newElement, newNodeMap));
                 }
-                
-                
                 
                 
             }

--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -570,8 +570,6 @@ define(function (require, exports, module) {
         // Start at the root of the current tree.
         queue.push(newNode);
         
-        var rootElemChanged = false, deltaID;
-        
         do {
             newElement = queue.pop();
             oldElement = oldNodeMap[newElement.tagID];

--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -570,9 +570,12 @@ define(function (require, exports, module) {
         // Start at the root of the current tree.
         queue.push(newNode);
         
+        var rootElemChanged = false, deltaID;
+        
         do {
             newElement = queue.pop();
             oldElement = oldNodeMap[newElement.tagID];
+            
             
             // Do we need to compare elements?
             if (oldElement) {
@@ -601,7 +604,7 @@ define(function (require, exports, module) {
                 // because it isn't the child of any other node. The browser-side code doesn't
                 // care about parentage/positioning in this case, and will handle just setting the 
                 // ID on the existing implied HTML tag in the browser without actually creating it.
-                if (!newElement.parent) {
+                if (!newElement.parent ) {
                     edits.push({
                         type: "elementInsert",
                         tag: newElement.tag,
@@ -609,9 +612,22 @@ define(function (require, exports, module) {
                         parentID: null,
                         attributes: newElement.attributes
                     });
+                    
+                    
                 }
                 
-                addEdits(generateChildEdits(null, oldNodeMap, newElement, newNodeMap));
+                // Since the root <html> tag has a new tag ID if the user copies and pastes the entire document,
+                // This checks if there is an old <root> node, and if there is, passes that node as a parameter to 
+                // generateChildEdits instead of null.
+                if (Object.keys(oldNodeMap).length > 0){
+                    addEdits(generateChildEdits(oldNodeMap[Object.keys(oldNodeMap)[0]], oldNodeMap, newElement, newNodeMap));
+                } else {
+                    addEdits(generateChildEdits(null, oldNodeMap, newElement, newNodeMap));
+                }
+                
+                
+                
+                
             }
         } while (queue.length);
         


### PR DESCRIPTION
for #10634
fixed element duplication when copy/pasting html tag.

The issue was sending a null as the oldElement in generateChildEdits, which implies an insertion edit.
The fix was to check if there was a root node in the oldNodeMap, and passing that node as the oldElement so that generateChildEdits had a node to compare to. 
