### PR TITLE
Fix src/xorigin.js to not use function statement that isn't top-level and break strict mode when minifying

### DIFF
--- a/src/xorigin.js
+++ b/src/xorigin.js
@@ -55,7 +55,7 @@
     var previousErrorHandler = window.onerror;
 
     // Our error handler
-    function handleError(message, url, line) {
+    var handleError = function(message, url, line) {
         // Ignore this error if it does not look like the rather vague cross origin error in Chrome
         // Chrome will print it to the console anyway
         if (!testCrossOriginError(message, url, line)) {
@@ -70,7 +70,7 @@
 
         // Restore the original handler for later errors
         window.onerror = previousErrorHandler;
-    }
+    };
 
     // Install our error handler
     window.onerror = handleError;


### PR DESCRIPTION
Working on getting Brackets to run well in-browser, I'm playing with various minificaiton strategies.  While doing this I hit an issue where xorigin.js was breaking strict mode.  This fixes it.

See http://whereswalden.com/2011/01/24/new-es5-strict-mode-requirement-function-statements-not-at-top-level-of-a-program-or-function-are-prohibited/ for details on why this is bad.
