### PR TITLE
Change "Find All and Select" shortcut to Ctrl-Alt-A

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "file.newDoc":  [
         "Ctrl-N"
     ],
@@ -185,7 +185,7 @@
     ],
     "cmd.findAllAndSelect": [
         {
-            "key": "Alt-F3"
+            "key": "Ctrl-Alt-A"
         },
         {
             "key": "Cmd-Ctrl-G",


### PR DESCRIPTION
Fixed bug #8243
