### PR TITLE
Add @sourceFontFamily LESS variable and use instead of SourceCodePro font-family

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -438,7 +438,7 @@ a, img {
             color: @bc-text-alt;
             background-color: rgba(0, 0, 0, 0.8);
             font-size: 11px;
-            font-family: SourceCodePro;
+            font-family: @sourceFontFamily;
             line-height: 13px;
             border-radius: 3px;
             box-shadow: 0 1px 3px @bc-shadow;
@@ -640,7 +640,7 @@ a, img {
 
     .line-number {
         color: @bc-text-thin-quiet;
-        font-family: SourceCodePro;
+        font-family: @sourceFontFamily;
         font-size: 11px;
         padding: 4px 0 0 15px;
         text-align: right;

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -81,4 +81,6 @@
 /* Font Stacks */
 
 @sansFontFamily: 'SourceSansPro', Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+
 @sourceFontFamily: "SourceCodePro", "Menlo Regular", Consolas, Inconsolata, "Vera Sans", "Lucida Console", Courier, fixed;
+@sourceFontFamily-Medium: "SourceCodePro-Medium", "ＭＳ ゴシック", "MS Gothic", monospace;

--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -81,3 +81,4 @@
 /* Font Stacks */
 
 @sansFontFamily: 'SourceSansPro', Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+@sourceFontFamily: "SourceCodePro", "Menlo Regular", Consolas, Inconsolata, "Vera Sans", "Lucida Console", Courier, fixed;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -132,7 +132,7 @@
         color: @dark-bc-text;
     }
 
-    font-family: "SourceCodePro-Medium", "ＭＳ ゴシック", "MS Gothic", monospace;
+    font-family: @sourceFontFamily-Medium;
 }
 
 .code-font-win() {


### PR DESCRIPTION
In my Brackets fork, I've been discussing ways to save on download size for the in-browser use case.  @peterflynn and I discussed making it easier to turn off the use of the Source Code/Sans Pro web fonts in favour of system fonts (it ends up saving me about ~300K of gzipped download, which is great), see https://github.com/humphd/brackets/issues/78.

I've made a start at this, switching all explicit uses of these `font-family`s to variables.  I'm unclear how much more I can do than this, since all of the other occurrences of these are in extension LESS/CSS files, and I don't think these have access to the variables in Brackets (correct me if I'm wrong and can change there too)?
- SourceSansPro uses - https://github.com/adobe/brackets/search?utf8=%E2%9C%93&q=sourcesanspro&type=Code
- SourceCodePro uses - https://github.com/adobe/brackets/search?utf8=%E2%9C%93&q=sourcecodepro&type=Code

Anything else I can do here?  I'm not sure how to deal with the explicit use in extensions, especially when I rip out that font-family for the in-browser case.

cc @Pomax
