### PR TITLE
Change 'split selection into lines' shortcut on Linux

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -71,7 +71,13 @@
         }
     ],
     "edit.splitSelIntoLines": [
-        "Ctrl-Alt-L"
+        {
+           "key": "Ctrl-Alt-L"
+        },
+        {
+           "key":"Ctrl-Shift-L",
+           "platform": "linux"
+        }
     ],
     "edit.addCursorToPrevLine": [
         {


### PR DESCRIPTION
Current combination is a system default for locking the machine/ standby. New combination follows convention used by other editors and should work without affecting any system defaults.
