### PR TITLE
Increase timeout for deleting temp directory

### DIFF
--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -296,7 +296,7 @@ define(function (require, exports, module) {
                 console.log("boo");
             });
         
-            waitsForDone(deferred.promise(), "removeTempDirectory", 1000);
+            waitsForDone(deferred.promise(), "removeTempDirectory", 2000);
         });
     }
     


### PR DESCRIPTION
Test case - FindInFile was failing due to smaller timeout. This test case failed in some VMs.
