### PR TITLE
Implement progress callback so node domains are able to notify the Brackets before they finish

### DIFF
--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -486,6 +486,12 @@ define(function (require, exports, module) {
                 delete this._pendingCommandDeferreds[m.message.id];
             }
             break;
+        case "commandProgress":
+            responseDeferred = this._pendingCommandDeferreds[m.message.id];
+            if (responseDeferred) {
+                responseDeferred.notifyWith(this, [m.message.message]);
+            }
+            break;
         case "commandError":
             responseDeferred = this._pendingCommandDeferreds[m.message.id];
             if (responseDeferred) {

--- a/test/spec/NodeConnection-test-files/TestCommandsTwo.js
+++ b/test/spec/NodeConnection-test-files/TestCommandsTwo.js
@@ -49,6 +49,24 @@
     }
     
     /**
+     * @private
+     * Handler for test.reverseAsyncWithProgress command. Reverses the specified string
+     * and then returns the result asynconously, but launches progress event before that.
+     * @param {string} s String to reverse.
+     * @param {Function} cb Callback function of the form cb(err, response)
+     * @param {Function} pcb Progress callback function of the form pcb(message)
+     */
+    function cmdTestReverseAsyncWithProgress(s, cb, pcb) {
+        var result = s.split("").reverse().join("");
+        process.nextTick(function () {
+            pcb("progress");
+            process.nextTick(function () {
+                cb(null, result);
+            });
+        });
+    }
+
+    /**
      * Initializes the test domain with an additional test command.
      * @param {DomainManager} DomainManager The DomainManager for the server
      */
@@ -63,6 +81,15 @@
             cmdTestReverseAsync,
             true,
             "reverses the specified string using an async call on the server",
+            [{name: "s", type: "string"}],
+            [{name: "reversedString", type: "string"}]
+        );
+        _domainManager.registerCommand(
+            "test",
+            "reverseAsyncWithProgress",
+            cmdTestReverseAsyncWithProgress,
+            true,
+            "reverses the specified string using an async call on the server and calls a progress event before",
             [{name: "s", type: "string"}],
             [{name: "reversedString", type: "string"}]
         );

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -192,6 +192,42 @@ define(function (require, exports, module) {
             });
         });
         
+        it("should receive progress events from asynchronous commands", function () {
+            var connection = createConnection();
+            var commandDeferred = null;
+            var result = null;
+            var progressMessage = null;
+            runConnectAndWait(connection, false);
+            runLoadDomainsAndWait(connection, ["TestCommandsTwo"], false);
+            runs(function () {
+                commandDeferred = connection.domains.test.reverseAsyncWithProgress("asdf");
+                commandDeferred.progress(function (message) {
+                    progressMessage = message;
+                });
+                commandDeferred.done(function (response) {
+                    result = response;
+                });
+            });
+            waitsFor(
+                function () {
+                    return commandDeferred && progressMessage !== null;
+                },
+                CONNECTION_TIMEOUT
+            );
+            waitsFor(
+                function () {
+                    return commandDeferred &&
+                        commandDeferred.state() === "resolved" &&
+                        result;
+                },
+                CONNECTION_TIMEOUT
+            );
+            runs(function () {
+                expect(progressMessage).toBe("progress");
+                expect(result).toBe("fdsa");
+            });
+        });
+
         it("should receive events", function () {
             var connection = createConnection();
             var spy = jasmine.createSpy();


### PR DESCRIPTION
Related PR: https://github.com/adobe/brackets-shell/pull/509
Related Issue: https://github.com/adobe/brackets/issues/7356

Please review @nethip , I'd like to get this into Brackets as this would help to improve user experience on some of my work I'm doing with extensions.
