### PR TITLE
Project Preferences File Corruption Issue

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -88,6 +88,7 @@ define({
     // Application preferences corrupt error strings
     "ERROR_PREFS_CORRUPT_TITLE"         : "Error Reading Preferences",
     "ERROR_PREFS_CORRUPT"               : "Your preferences file is not valid JSON. The file will be opened so that you can correct the format. You will need to restart {APP_NAME} for the changes to take effect.",
+    "ERROR_PROJ_PREFS_CORRUPT"          : "Your project preferences file is not valid JSON. The file will be opened so that you can correct the format. You will need to reload the project for the changes to take effect.",
 
     // Application error strings
     "ERROR_IN_BROWSER_TITLE"            : "Oops! {APP_NAME} Doesn't Run in Browsers Yet.",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -821,21 +821,18 @@ define(function (require, exports, module) {
         rootPath = ProjectModel._ensureTrailingSlash(rootPath);
 
         var projectPrefFullPath = (rootPath + SETTINGS_FILENAME),
-            file   = FileSystem.getFileForPath(projectPrefFullPath),
-            result = new $.Deferred(),
-            corrupt = false;
-       
+            file   = FileSystem.getFileForPath(projectPrefFullPath);
+            
         //Verify that the project preferences file (.brackets.json) is NOT corrupted.
         //If corrupted, display the error message and open the file in editor for the user to edit.
         FileUtils.readAsText(file)
             .done(function (text) {
                 try {
                     if (text) {
-                        var json = JSON.parse(text);                        
+                        JSON.parse(text);
                     }
                 } catch (err) {
                     // Cannot parse the text read from the project preferences file.
-                    corrupt = true;
                     var info = MainViewManager.findInAllWorkingSets(projectPrefFullPath);
                     var paneId;
                     if (info.length) {
@@ -851,8 +848,7 @@ define(function (require, exports, module) {
                                 // give the focus back to the editor with the pref file
                                 MainViewManager.focusActivePane();
                             });
-                        });                        
-
+                        });
                 }
             });
 


### PR DESCRIPTION
Fix for #10757 .
Error message appears if the Global Preferences file (brackets.json) is corrupted and the file is opened in editor for editing. Added similar functionality for project level Preferences File (.brackets.json).
