### PR TITLE
Use undefined instread of void. Fixes JSLint.

### DIFF
--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -180,7 +180,7 @@ define(function (require, exports, module) {
         });
     }
     // Workaround for JSHint to not complain about the unused function
-    void(_dumpMarks);
+    undefined(_dumpMarks);
 
     /**
      * Get the instrumented tagID at the specified position. Returns -1 if


### PR DESCRIPTION
Simple fix to avoid JSLint complaining about JSHint workaround (sic!).
