### PR TITLE
Added Haskell as a language

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -277,5 +277,13 @@
             "swf", "tar", "tif", "tiff", "ttf", "woff", "xls", "xlsx", "zip"
         ],
         "isBinary": true
+    },
+
+    "haskell": {
+        "name": "Haskell",
+        "mode": "haskell",
+        "fileExtensions": ["hs"],
+        "blockComment": ["{-", "-}"],
+        "lineComment": ["--"]
     }
 }


### PR DESCRIPTION
Added at the end of the languages.json file so that Haskell will have
syntax highlighting in Brackets.
