### PR TITLE
HealthDataRefactoring

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -101,21 +101,9 @@ define(function (require, exports, module) {
     var extensions = {};
     
     /**
-     * @private
-     * @type {Object.<string, {metadata: Object, path: string, status: string}>}
-     * The set of all extensions (in registry and locally installed) present in user location.
-     * The fields of each record are:
-     *     installInfo: object containing the info for a locally-installed extension:
-     *         metadata: the package metadata loaded from the local package.json, or null if it's a legacy extension.
-     *         path: the local path to the extension folder on disk
-     *         status: the current status, one of the status constants above
+     * Check if we have updated registry object  
      */
-    var userExtensions = {};
-    
-    /**
-     * Registry object container  
-     */
-    var registryObject = {};
+    var isRegistryObjectUpdated = false;
 
     /**
      * Requested changes to the installed extensions.
@@ -227,7 +215,7 @@ define(function (require, exports, module) {
             cache: false
         })
             .done(function (data) {
-                exports.registryObject = data;
+                exports.isRegistryObjectUpdated = true;
                 Object.keys(data).forEach(function (id) {
                     if (!extensions[id]) {
                         extensions[id] = {};
@@ -284,18 +272,6 @@ define(function (require, exports, module) {
                 locationType: locationType,
                 status: (e.type === "loadFailed" ? START_FAILED : ENABLED)
             };
-            
-            if (locationType === LOCATION_USER) {
-                if (!userExtensions[id]) {
-                    userExtensions[id] = {};
-                }
-                
-                userExtensions[id].installInfo = {
-                    metadata: metadata,
-                    path: path,
-                    status: (e.type === "loadFailed" ? START_FAILED : ENABLED)
-                };
-            }
 
             synchronizeEntry(id);
             loadTheme(id);
@@ -416,9 +392,6 @@ define(function (require, exports, module) {
             Package.remove(extensions[id].installInfo.path)
                 .done(function () {
                     extensions[id].installInfo = null;
-                    if (userExtensions[id] && userExtensions[id].installInfo) {
-                        userExtensions[id].installInfo = null;
-                    }
                     result.resolve();
                     exports.trigger("statusChange", id);
                 })
@@ -808,7 +781,6 @@ define(function (require, exports, module) {
     exports.remove                  = remove;
     exports.update                  = update;
     exports.extensions              = extensions;
-    exports.userExtensions          = userExtensions;
     exports.cleanupUpdates          = cleanupUpdates;
     exports.markForRemoval          = markForRemoval;
     exports.isMarkedForRemoval      = isMarkedForRemoval;
@@ -822,9 +794,8 @@ define(function (require, exports, module) {
     exports.updateExtensions        = updateExtensions;
     exports.getAvailableUpdates     = getAvailableUpdates;
     exports.cleanAvailableUpdates   = cleanAvailableUpdates;
-
-    exports.registryObject          = registryObject;
-
+    exports.isRegistryObjectUpdated = isRegistryObjectUpdated;
+    
     exports.ENABLED       = ENABLED;
     exports.START_FAILED  = START_FAILED;
 
@@ -832,7 +803,7 @@ define(function (require, exports, module) {
     exports.LOCATION_DEV      = LOCATION_DEV;
     exports.LOCATION_USER     = LOCATION_USER;
     exports.LOCATION_UNKNOWN  = LOCATION_UNKNOWN;
-
+    
     // For unit testing only
     exports._getAutoInstallFiles    = _getAutoInstallFiles;
     exports._reset                  = _reset;

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -99,11 +99,6 @@ define(function (require, exports, module) {
      *         status: the current status, one of the status constants above
      */
     var extensions = {};
-    
-    /**
-     * Check if we have updated registry object  
-     */
-    var isRegistryObjectUpdated = false;
 
     /**
      * Requested changes to the installed extensions.
@@ -794,7 +789,7 @@ define(function (require, exports, module) {
     exports.updateExtensions        = updateExtensions;
     exports.getAvailableUpdates     = getAvailableUpdates;
     exports.cleanAvailableUpdates   = cleanAvailableUpdates;
-    exports.isRegistryObjectUpdated = isRegistryObjectUpdated;
+    exports.isRegistryObjectUpdated = false;
     
     exports.ENABLED       = ENABLED;
     exports.START_FAILED  = START_FAILED;

--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
         window.clearTimeout(timeoutVar);
         if (isHDTracking && notificationDialogShown) {
             var lastTimeSent = PreferencesManager.getViewState("lastTimeSentHealthData"),
-                currentTime = (new Date()).getTime();
+                currentTime = Date.now();
 
             if (!lastTimeSent || (currentTime >= lastTimeSent + ONE_DAY)) {
                 // Setting the time here to avoid any chance of sending data before ONE_DAY. Whether or not the request to the server is successful, we will be sending the data only after ONE_DAY has passed.

--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -58,14 +58,14 @@ define(function (require, exports, module) {
         }
 
         oneTimeHealthData.uuid = userUuid;
-        oneTimeHealthData.snapshotTime = (new Date()).getTime();
+        oneTimeHealthData.snapshotTime = Date.now();
         oneTimeHealthData.os = brackets.platform;
         oneTimeHealthData.userAgent = navigator.userAgent;
         oneTimeHealthData.osLanguage = brackets.app.language;
         oneTimeHealthData.bracketsLanguage = brackets.getLocale();
         oneTimeHealthData.bracketsVersion = brackets.metadata.version;
 
-        HealthDataUtils.getInstalledExtensions()
+        HealthDataUtils.getUserInstalledExtensions()
             .done(function (userInstalledExtensions) {
                 oneTimeHealthData.installedExtensions = userInstalledExtensions;
             })
@@ -122,12 +122,12 @@ define(function (require, exports, module) {
         
         window.clearTimeout(timeoutVar);
         if (isHDTracking && notificationDialogShown) {
-            var lastTimeSent = PreferencesManager.getViewState("lastTimeSentData"),
+            var lastTimeSent = PreferencesManager.getViewState("lastTimeSentHealthData"),
                 currentTime = (new Date()).getTime();
 
             if (!lastTimeSent || (currentTime >= lastTimeSent + ONE_DAY)) {
                 // Setting the time here to avoid any chance of sending data before ONE_DAY. Whether or not the request to the server is successful, we will be sending the data only after ONE_DAY has passed.
-                PreferencesManager.setViewState("lastTimeSentData", (new Date()).getTime());
+                PreferencesManager.setViewState("lastTimeSentHealthData", Date.now());
                 sendHealthDataToServer()
                     .done(function () {
                         result.resolve();

--- a/src/extensions/default/HealthData/HealthDataNotification.js
+++ b/src/extensions/default/HealthData/HealthDataNotification.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
     AppInit.appReady(function () {
         params.parse();
         // Check whether the notification dialog should be shown. It will be shown one time. Does not check in testing environment.
-        if (!params.get("skipHealthDataNotification")) {
+        if (!params.get("testEnvironment")) {
             var isShown = PreferencesManager.getViewState("healthDataNotificationShown");
 
             if (!isShown) {

--- a/src/extensions/default/HealthData/HealthDataUtils.js
+++ b/src/extensions/default/HealthData/HealthDataUtils.js
@@ -29,48 +29,43 @@ define(function (require, exports, module) {
     
     var ExtensionManager = brackets.getModule("extensibility/ExtensionManager"),
         _                = brackets.getModule("thirdparty/lodash");
-    
+   
+
     /**
      * @private
-     * For each user installed extension, check if it's present in the registry.
-     * @param {Object} object that contains information about extensions fetched from registry
-     * @param {Object} all user installed extensions
+     * Check for the extensions whether it is user installed and present in the registry.
+     * @param {Object} extensions synchronized with registry object
      * return {Array} userInstalledExtensions
-     */
-    function getUserExtensionsInRegistry(registryObject, userExtensions) {
+    */
+    function getUserExtensionsPresentInRegistry(extensions) {
         var userInstalledExtensions = [];
-        
-        _.forEach(userExtensions, function (extension, extensionId) {
-            var registryExtension = registryObject[extensionId];
-            if (extension && extension.installInfo && registryExtension) {
+        _.forEach(extensions, function (extension, extensionId) {
+            if (extension && extension.installInfo && extension.installInfo.locationType === "user" && extension.registryInfo) {
                 userInstalledExtensions.push({"name" : extensionId, "version" : extension.installInfo.metadata.version});
             }
         });
         
         return userInstalledExtensions;
     }
-   
     /**
      * Utility function to get the user installed extension which are present in the registry
      */
-    function getInstalledExtensions() {
+    function getUserInstalledExtensions() {
         var result = new $.Deferred();
-        var registryExtensions = ExtensionManager.registryObject,
-            userExtensions = ExtensionManager.userExtensions;
-        
-        if (Object.keys(registryExtensions).length === 0) {
+
+        if (!ExtensionManager.isRegistryObjectUpdated) {
             ExtensionManager.downloadRegistry().done(function () {
-                result.resolve(getUserExtensionsInRegistry(ExtensionManager.registryObject, userExtensions));
+                result.resolve(getUserExtensionsPresentInRegistry(ExtensionManager.extensions));
             })
                 .fail(function () {
                     result.resolve([]);
                 });
         } else {
-            result.resolve(getUserExtensionsInRegistry(registryExtensions, userExtensions));
+            result.resolve(getUserExtensionsPresentInRegistry(ExtensionManager.extensions));
         }
         
         return result.promise();
     }
     
-    exports.getInstalledExtensions   = getInstalledExtensions;
+    exports.getUserInstalledExtensions   = getUserInstalledExtensions;
 });

--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -65,14 +65,14 @@ define(function (require, exports, module) {
             });
 
             it("should send data to server", function () {
-                PreferencesManager.setViewState("lastTimeSendHealthData", (new Date()).getTime() - ONE_DAY);
+                PreferencesManager.setViewState("lastTimeSentHealthData", (new Date()).getTime() - ONE_DAY);
                 PreferencesManager.setViewState("healthDataNotificationShown", true);
                 var promise = HealthDataManager.checkHealthDataSend();
                 waitsForDone(promise, "Send Data to Server", 4000);
             });
 
             it("should not send data to server", function () {
-                PreferencesManager.setViewState("lastTimeSendHealthData", (new Date()).getTime() - ONE_DAY);
+                PreferencesManager.setViewState("lastTimeSentHealthData", (new Date()).getTime() - ONE_DAY);
                 prefs.set("healthDataTracking", false);
                 var promise = HealthDataManager.checkHealthDataSend();
                 waitsForFail(promise, "Send Data to Server", 4000);

--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         beforeEach(function () {
             SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
                 testWindow = w;
-            }, {"params" : {"skipHealthDataNotification": true}});
+            });
 
         });
 

--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -65,14 +65,14 @@ define(function (require, exports, module) {
             });
 
             it("should send data to server", function () {
-                PreferencesManager.setViewState("lastTimeSentHealthData", (new Date()).getTime() - ONE_DAY);
+                PreferencesManager.setViewState("lastTimeSentHealthData", Date.now() - ONE_DAY);
                 PreferencesManager.setViewState("healthDataNotificationShown", true);
                 var promise = HealthDataManager.checkHealthDataSend();
                 waitsForDone(promise, "Send Data to Server", 4000);
             });
 
             it("should not send data to server", function () {
-                PreferencesManager.setViewState("lastTimeSentHealthData", (new Date()).getTime() - ONE_DAY);
+                PreferencesManager.setViewState("lastTimeSentHealthData", Date.now() - ONE_DAY);
                 prefs.set("healthDataTracking", false);
                 var promise = HealthDataManager.checkHealthDataSend();
                 waitsForFail(promise, "Send Data to Server", 4000);


### PR DESCRIPTION
1. Checking with testEnvironment so as to avoid collision with other unittest cases.
2. Making the preference name more clear
3. Using Date.now() instead of new Date().getTime()
4. Remove separate object to store userExtensions instead using ExtensionManager.extensions
5. Change function name to be more clear
