### PR TITLE
Fix #10853 - Fix colour editor for use in browsers that don't use -webkit- prefix

### DIFF
--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -171,8 +171,8 @@ define(function (require, exports, module) {
         
         // Update gradients in color square & opacity slider
         this.$selectionBase.css("background-color", colorObject.toHexString());
-        this.$opacityGradient.css("background-image", "-webkit-gradient(linear, 0% 0%, 0% 100%, from(" + hueColor + "), to(transparent))");
-        
+        this.$opacityGradient.css("background-image", "linear-gradient(to bottom, " + hueColor + " 0%, rgba(0,0,0,0) 100%)");
+
         // Update slider thumb positions
         this.$hueSelector.css("bottom", (this._hsv.h / 360 * 100) + "%");
         this.$opacitySelector.css("bottom", (this._hsv.a * 100) + "%");

--- a/src/extensions/default/InlineColorEditor/css/main.less
+++ b/src/extensions/default/InlineColorEditor/css/main.less
@@ -135,10 +135,10 @@
     float: left;
 }
 .color-editor section .color-selection-field .saturation-gradient {
-    background-image: -webkit-gradient(linear, 0% 50%, 100% 50%, from(#fff), to(rgba(255,255,255,0)));
+    background-image: linear-gradient(to right, #FFFFFF 0%, rgba(255,255,255,0) 100%);
 }
 .color-editor section .color-selection-field .luminosity-gradient {
-    background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(transparent), to(#000));
+    background-image: linear-gradient(to top, #000000 0%, rgba(255,255,255,0) 100%);
 }
 .color-editor section .color-selection-field .selector-base {
     width: 12px;
@@ -200,7 +200,7 @@
     margin-right: 0px;  
 }
 .color-editor section .hue-slider {
-    background-image: -webkit-linear-gradient(top, #f00, #f0f, #00f, #0ff, #0f0, #ff0, #f00);
+    background-image: linear-gradient(to bottom, #f00, #f0f, #00f, #0ff, #0f0, #ff0, #f00);
 }
 .color-editor section footer {
     font-size: 100%;


### PR DESCRIPTION
This patch will fix https://github.com/adobe/brackets/issues/10853. It adds all other browser prefixes in addition to the `-webkit-` prefix for the color editor. Here are some screenshots of what the changes look like.

Chrome
![chrome](https://cloud.githubusercontent.com/assets/9154982/7055375/e636c14c-de10-11e4-879a-3423cefc9f87.png)

Desktop Brackets 
![desktopbrackets](https://cloud.githubusercontent.com/assets/9154982/7055383/ec574524-de10-11e4-958a-9e20d7418bad.png)

Firefox
![firefox](https://cloud.githubusercontent.com/assets/9154982/7055387/f2c5d916-de10-11e4-87a0-29376f59b146.png)

Internet Explorer 10
![ie10](https://cloud.githubusercontent.com/assets/9154982/7055391/fa891cf8-de10-11e4-9b38-936a7e9de8f8.png)

Opera
![opera](https://cloud.githubusercontent.com/assets/9154982/7055395/ff905554-de10-11e4-9cb7-011f47bd5cc4.png)

Safari
![safari](https://cloud.githubusercontent.com/assets/9154982/7055396/0528bf2e-de11-11e4-8df2-17d1d35327bf.png)
