### PR TITLE
Code folding UI & code style tweaks

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2405,6 +2405,14 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Runs callback for every Editor instance that currently exists
+     * @param {!function(!Editor)} callback
+     */
+    Editor.forEveryEditor = function (callback) {
+        _instances.forEach(callback);
+    };
+    
+    /**
      * @private
      * Toggles the left padding of all code editors.  Used to provide more
      * space between the code text and the left edge of the editor when

--- a/src/extensions/default/CodeFolding/Prefs.js
+++ b/src/extensions/default/CodeFolding/Prefs.js
@@ -19,8 +19,8 @@ define(function (require, exports, module) {
         SAVE_FOLD_STATES_HELP       = "Save fold states to disk when editor is closed and restore the folds when reopened",
         ALWAYS_USE_INDENT_FOLD      = "Always use indent fold",
         ALWAYS_USE_INDENT_FOLD_HELP = "Fall back to using level of indentation as a folding guideline if no range finder is found for the current mode.",
-        FADE_FOLD_BUTTONS           = "Fade fold buttons",
-        FADE_FOLD_BUTTONS_HELP      = "Hides the fold buttons unless the mouse is over the gutter",
+        HIDE_FOLD_BUTTONS           = "Hide fold triangles",
+        HIDE_FOLD_BUTTONS_HELP      = "Hide fold triangles unless the mouse is over the gutter",
         MAX_FOLD_LEVEL              = "Max fold level",
         MAX_FOLD_LEVEL_HELP         = "Used to limit the number of nested folds to find and collapse when View -> Collapse All is called or Alt is held down when collapsing. Should improve performance for large files.";
 
@@ -33,8 +33,8 @@ define(function (require, exports, module) {
                            {name: SAVE_FOLD_STATES, description: SAVE_FOLD_STATES_HELP});
     prefs.definePreference("alwaysUseIndentFold", "boolean", false,
                            {name: ALWAYS_USE_INDENT_FOLD, description: ALWAYS_USE_INDENT_FOLD_HELP});
-    prefs.definePreference("fadeFoldButtons", "boolean", false,
-                           {name: FADE_FOLD_BUTTONS, description: FADE_FOLD_BUTTONS_HELP});
+    prefs.definePreference("hideUntilMouseover", "boolean", false,
+                           {name: HIDE_FOLD_BUTTONS, description: HIDE_FOLD_BUTTONS_HELP});
     prefs.definePreference("maxFoldLevel", "number", 2,
                            {name: MAX_FOLD_LEVEL, description: MAX_FOLD_LEVEL_HELP});
     prefs.definePreference("folds", "object", {});
@@ -115,13 +115,8 @@ define(function (require, exports, module) {
     }
 
     module.exports.getFolds = getFolds;
-
     module.exports.setFolds = setFolds;
-
     module.exports.getSetting = getSetting;
-
     module.exports.clearAllFolds = clearAllFolds;
-
-    module.exports.prefBase = prefs;
-
+    module.exports.prefsObject = prefs;
 });

--- a/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
@@ -1,11 +1,7 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
-/**
- * Based on http://codemirror.net/addon/fold/foldcode.js
- * @author Patrick Oladimeji
- * @date 10/28/13 8:41:46 AM
- * @last modified 20 April 2014
- */
+// Based on http://codemirror.net/addon/fold/foldcode.js
+// Modified by Patrick Oladimeji for Brackets
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, brackets, document*/
 define(function (require, exports, module) {

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -1,10 +1,7 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
-/**
- * Based on http://codemirror.net/addon/fold/foldgutter.js
- * @author Patrick Oladimeji
- * @date 10/24/13 10:14:01 AM
- */
+// Based on http://codemirror.net/addon/fold/foldgutter.js
+// Modified by Patrick Oladimeji for Brackets
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define, brackets, document, window, $*/
 define(function (require, exports, module) {
@@ -45,7 +42,7 @@ define(function (require, exports, module) {
     function updateFoldInfo(cm, from, to) {
         var minFoldSize = prefs.getSetting("minFoldSize") || 2;
         var opts = cm.state.foldGutter.options;
-        var fade = prefs.getSetting("fadeFoldButtons");
+        var fade = prefs.getSetting("hideUntilMouseover");
         var gutter = $(cm.getGutterElement());
         var i = from;
 
@@ -77,7 +74,7 @@ define(function (require, exports, module) {
         /**
             This case is needed when unfolding a region that does not cause the viewport to change.
             For instance in a file with about 15 lines, if some code regions are folded and unfolded, the
-            viewport change event isnt fired by codeMirror. The setTimeout is a workaround to trigger the
+            viewport change event isn't fired by CodeMirror. The setTimeout is a workaround to trigger the
             gutter update after the viewport has been drawn.
         */
         if (i === to) {
@@ -88,19 +85,19 @@ define(function (require, exports, module) {
         }
 
         while (i < to) {
-            var sr = _isCurrentlyFolded(i),//surrounding range for the current line if one exists
+            var sr = _isCurrentlyFolded(i), // surrounding range for the current line if one exists
                 range;
             var mark = marker("CodeMirror-foldgutter-blank");
             var pos = CodeMirror.Pos(i),
                 func = opts.rangeFinder || CodeMirror.fold.auto;
-            //dont look inside collapsed ranges
+            // don't look inside collapsed ranges
             if (sr) {
                 i = sr.to.line + 1;
             } else {
                 range = cm._lineFolds[i] || (func && func(cm, pos));
                 if (!fade || (fade && gutter.is(":hover"))) {
                     if (cm.isFolded(i)) {
-                        //expand fold if invalid
+                        // expand fold if invalid
                         if (range) {
                             mark = marker(opts.indicatorFolded);
                         } else {
@@ -120,7 +117,7 @@ define(function (require, exports, module) {
     }
 
     /**
-      * Updates the fold infor in the viewport for the specifiec range
+      * Updates the fold information in the viewport for the specified range
       * @param {CodeMirror} cm the instance of the CodeMirror object
       * @param {?number} from the starting line number for the update
       * @param {?number} to the end line number for the update

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
         var minFoldSize = prefs.getSetting("minFoldSize") || 2;
         var opts = cm.state.foldGutter.options;
         var fade = prefs.getSetting("hideUntilMouseover");
-        var gutter = $(cm.getGutterElement());
+        var $gutter = $(cm.getGutterElement());
         var i = from;
 
         function isFold(m) {
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
                 i = sr.to.line + 1;
             } else {
                 range = cm._lineFolds[i] || (func && func(cm, pos));
-                if (!fade || (fade && gutter.is(":hover"))) {
+                if (!fade || (fade && $gutter.is(":hover"))) {
                     if (cm.isFolded(i)) {
                         // expand fold if invalid
                         if (range) {

--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
         ProjectManager          = brackets.getModule("project/ProjectManager"),
         KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
-        Menus					= brackets.getModule("command/Menus"),
+        Menus                   = brackets.getModule("command/Menus"),
         prefs                   = require("Prefs"),
         COLLAPSE_ALL            = "codefolding.collapse.all",
         COLLAPSE                = "codefolding.collapse",
@@ -55,14 +55,14 @@ define(function (require, exports, module) {
 
     ExtensionUtils.loadStyleSheet(module, "main.less");
     
-    //load code mirror addons
+    // Load CodeMirror addons
     brackets.getModule(["thirdparty/CodeMirror2/addon/fold/brace-fold"]);
     brackets.getModule(["thirdparty/CodeMirror2/addon/fold/comment-fold"]);
     brackets.getModule(["thirdparty/CodeMirror2/addon/fold/markdown-fold"]);
 
-    //still using slightly modified versions of the foldcode.js and foldgutter.js since we
-    //need to modify the gutter click handler to take care of some collapse and expand features
-    //e.g. collapsing all children when 'alt' key is pressed
+    // Still using slightly modified versions of the foldcode.js and foldgutter.js since we
+    // need to modify the gutter click handler to take care of some collapse and expand features
+    // e.g. collapsing all children when 'alt' key is pressed
     var foldGutter              = require("foldhelpers/foldgutter"),
         foldCode                = require("foldhelpers/foldcode"),
         indentFold              = require("foldhelpers/indentFold");

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -1,17 +1,28 @@
-@font-size: 1.2em;
-@color: #aaa;
+@font-size: 1.1em;
+@color-triangle: #ccc;
+@color-triangle-mouseover: #aaa;
+@color-triangle-collapsed: #999;
+@color-marker-bg: #ddd;
+@color-marker-border: #c3c3c3;
+@color-marker-text: #777;
 
 .CodeMirror-foldgutter {
 	&-open:after {
     	content: "\25bc";
 		font-size: @font-size;
-		color: @color;
+		color: @color-triangle;
 	}
 	&-folded:after {
     	content: "\25b6";
 		font-size: @font-size;
-		color: @color;
+		color: @color-triangle-collapsed;
 	}
+}
+
+.CodeMirror.over-gutter, .CodeMirror-activeline {
+    .CodeMirror-foldgutter-open:after {
+        color: @color-triangle-mouseover;
+    }
 }
 
 .CodeMirror-foldgutter,
@@ -19,6 +30,7 @@
 .CodeMirror-foldgutter-folded,
 .CodeMirror-foldgutter-blank {
     width: @font-size;
+    padding-top: 2px;
     cursor: default;
     line-height: 100%;
 }
@@ -27,6 +39,13 @@
     height: 100% !important;
 }
 
+.CodeMirror.folding-enabled .CodeMirror-linenumber {
+    // Normally linenumber gutter has large right-padding to separate it from the code's text. But the
+    // folding gutter provides that same separation, so we need much less padding when it's displayed.
+    padding-right: 5px;
+}
+
+
 .CodeMirror-foldmarker {
     padding-right: 5px;
     padding-left: 5px;
@@ -34,12 +53,12 @@
     margin-left: 3px;
     border-radius: 3px;
     cursor: pointer;
-	border: 1px solid lighten(@color, 10%);
-	color: darken(@color, 20%);
-	background-color: lighten(@color, 20%);
+	border: 1px solid @color-marker-border;
+	color: @color-marker-text;
+	background-color: @color-marker-bg;
     
     &:after {
-        content: "\2194";   
+        content: "\27f7";
     }
 }
 

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -7,16 +7,16 @@
 @color-marker-text: #777;
 
 .CodeMirror-foldgutter {
-	&-open:after {
-    	content: "\25bc";
-		font-size: @font-size;
-		color: @color-triangle;
-	}
-	&-folded:after {
-    	content: "\25b6";
-		font-size: @font-size;
-		color: @color-triangle-collapsed;
-	}
+    &-open:after {
+        content: "\25bc";
+        font-size: @font-size;
+        color: @color-triangle;
+    }
+    &-folded:after {
+        content: "\25b6";
+        font-size: @font-size;
+        color: @color-triangle-collapsed;
+    }
 }
 
 .CodeMirror.over-gutter, .CodeMirror-activeline {
@@ -53,21 +53,11 @@
     margin-left: 3px;
     border-radius: 3px;
     cursor: pointer;
-	border: 1px solid @color-marker-border;
-	color: @color-marker-text;
-	background-color: @color-marker-bg;
+    border: 1px solid @color-marker-border;
+    color: @color-marker-text;
+    background-color: @color-marker-bg;
     
     &:after {
         content: "\27f7";
     }
-}
-
-#code-folding-settings-dialog {
-	label {
-		width: 40%;
-		padding-right: 10px;
-	}
-	input[type=number] {
-		width: 40px;	
-	}
 }

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -47,8 +47,8 @@
 
 
 .CodeMirror-foldmarker {
-    padding-right: 5px;
-    padding-left: 5px;
+    padding-right: 3px;
+    padding-left: 3px;
     margin-right: 3px;
     margin-left: 3px;
     border-radius: 3px;
@@ -58,6 +58,9 @@
     background-color: @color-marker-bg;
     
     &:after {
-        content: "\27f7";
+        content: "...";
+        font-size: 0.9em;
+        vertical-align: top;
+        line-height: 1.0em;
     }
 }

--- a/src/extensions/default/CodeFolding/package.json
+++ b/src/extensions/default/CodeFolding/package.json
@@ -1,16 +1,7 @@
 {
     "title": "Code Folding",
     "name": "code-folding",
-    "version": "0.3.3",
     "author": "Patrick Oladimeji <patrick@dustygem.co.uk>",
-    "description": "Brackets extension that provides simple code folding for files edited in brackets. Supports brace folding, tag folding, indent folding and multi-line comment folding",
-    "homepage": "https://github.com/thehogfather/brackets-code-folding",
-    "keywords": ["code folding", "code collapsing"],
-    "categories": ["formatting", "general", "editing", "visual"],
-    "i18n": ["en", "de", "it", "es", "gl", "fr", "ru", "jp", "fi", "nl", "pt-br"],
-    "engines": {
-        "brackets": ">=1.3.0"
-    },
     "contributors": [
         {"name": "Patrick Oladimeji", "email": "thehogfather@dustygem.co.uk", "url": "https://github.com/thehogfather"},
         {"name": "Daniel Glazman", "email": "daniel@glazman.org"}

--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -157,6 +157,25 @@
     }
 }
 
+.CodeMirror-foldgutter-open:after {
+    color: #666;
+}
+.CodeMirror-foldgutter-folded:after {
+    color: #aaa;
+}
+
+.CodeMirror.over-gutter, .CodeMirror-activeline {
+    .CodeMirror-foldgutter-open:after {
+        color: #888;
+    }
+}
+
+.CodeMirror-foldmarker {
+    border-color: #999;
+    color: #ccc;
+    background-color: #808080;
+}
+
 /* Non-editor styling */
 
 .image-view,

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
     // Brackets modules
     var ColorUtils          = brackets.getModule("utils/ColorUtils"),
         CommandManager      = brackets.getModule("command/CommandManager"),
+        Commands            = brackets.getModule("command/Commands"),
         CSSUtils            = brackets.getModule("language/CSSUtils"),
         EditorManager       = brackets.getModule("editor/EditorManager"),
         ExtensionUtils      = brackets.getModule("utils/ExtensionUtils"),
@@ -774,8 +775,9 @@ define(function (require, exports, module) {
     ExtensionUtils.loadStyleSheet(module, "QuickView.less");
     
     // Register command
+    // Insert menu at specific pos since this may load before OR after code folding extension
     CommandManager.register(Strings.CMD_ENABLE_QUICK_VIEW, CMD_ENABLE_QUICK_VIEW, toggleEnableQuickView);
-    Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_ENABLE_QUICK_VIEW);
+    Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_ENABLE_QUICK_VIEW, null, Menus.AFTER, Commands.VIEW_TOGGLE_INSPECTION);
     
     // Convert old preferences
     PreferencesManager.convertPreferences(module, {

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -172,7 +172,7 @@ div.CodeMirror-cursors {
     color: @accent-comment;
     min-width: 2.5em;
     /*font-size: 0.9em;*/  /* restore after SourceCodePro font fix? */
-    padding: 0 @code-padding 0 10px;
+    padding: 0 @code-padding 0 10px;  // note: overridden if code-folding gutter is shown
 }
 .CodeMirror .CodeMirror-selected {
     background: @selection-color-unfocused;


### PR DESCRIPTION
~~We should land PR #10850 first, and then the diff for this will be simplified.~~ _(done)_

~~For now, this link previews what the diff will be after 10850 lands: https://github.com/thehogfather/brackets/compare/issue10846...adobe:pflynn/codefolding-tweaks~~

Improve visual appearance of code folding:
- Fainter, smaller gutter triangle icons
- Gutter triangle icons become less faint on mouseover (or when collapsed)
- Vertically align gutter triangle icons with text better
- Change inline collapsed placeholder to more readable arrow icon
- Better colors in dark theme
- Less horizontal gap between line numbers and triangle icons (without reducing gap between line numbers and text, if folding gutter disabled)

Usability: rename `"fadeFoldButtons"` pref to clearer `"hideUntilMouseover"`

And tweak code style issues:
- Remove most of ignored, unneeded package.json
- Preserve original CodeMirror copyright on CM-derived files
- Rename a few things for clarity
- Remove some unneeded code
- Tweak formatting & spelling in comments

**Update - adds a few more fixes/cleanups:**

More rigorous enable/disable flow for code folding: instead of piecemeal checking whether each bit has already initialized, atomically track whether init is done yet or not. Init/deinit all extant editors at once instead of doing each editor as it is activated, since splitview means editors may be already visible but not yet active. Fix listener leaks from repeated inits.

And keep menu items in a more predictable order:
- Add menu items at startup before user extensions load (at htmlReady instead of appReady), so core menu items like these don't move around as user extension load order changes
- Place QuickView menu item more explicitly, so it doesn't move unpredictably relative to Code Folding menu items (within the extensions/default folder, load order is arbitrary)
- Properly clean up menu divider, which used to get duplicated on each init pass
