### PR TITLE
Listener leak "canary" warning

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -389,13 +389,21 @@ define(function (require, exports, module) {
      *      changes
      */
     function installListeners(editor) {
-        editor.on("keydown", function (event, editor, domEvent) {
+        editor.on("keydown.ParameterHints", function (event, editor, domEvent) {
             if (domEvent.keyCode === KeyEvent.DOM_VK_ESCAPE) {
                 dismissHint();
             }
-        }).on("scroll", function () {
+        }).on("scroll.ParameterHints", function () {
             dismissHint();
         });
+    }
+    
+    /**
+     * Clean up after installListeners()
+     * @param {!Editor} editor
+     */
+    function uninstallListeners(editor) {
+        editor.off(".ParameterHints");
     }
 
     /**
@@ -429,6 +437,7 @@ define(function (require, exports, module) {
     exports.addCommands             = addCommands;
     exports.dismissHint             = dismissHint;
     exports.installListeners        = installListeners;
+    exports.uninstallListeners      = uninstallListeners;
     exports.isHintDisplayed         = isHintDisplayed;
     exports.popUpHint               = popUpHint;
     exports.popUpHintAtOpenParen    = popUpHintAtOpenParen;

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -637,6 +637,7 @@ define(function (require, exports, module) {
         function uninstallEditorListeners(editor) {
             if (editor) {
                 editor.off(HintUtils.eventName("change"));
+                ParameterHintManager.uninstallListeners(editor);
             }
         }
 

--- a/test/spec/EventDispatcher-test.js
+++ b/test/spec/EventDispatcher-test.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global jasmine, define, describe, beforeEach, it, expect */
+/*global jasmine, define, describe, beforeEach, it, expect, spyOn */
 
 define(function (require, exports, module) {
     "use strict";
@@ -428,6 +428,28 @@ define(function (require, exports, module) {
             dispatcher.trigger("foo");
             expect(fn1).toHaveBeenCalled();
             expect(fn2).toHaveBeenCalled();
+        });
+        
+        
+        it("on() should print warnings when too many listeners attached", function () {
+            function makeStubListener() {  // avoids JSLint "don't make functions in a loop" complaint
+                return function () {};
+            }
+            
+            spyOn(console, "error");
+            var i;
+            for (i = 0; i < 15; i++) {
+                dispatcher.on("foo", makeStubListener());
+            }
+            expect(console.error).not.toHaveBeenCalled();
+            
+            // Prints warnings when number of listeners exceeds 15
+            dispatcher.on("foo", fn1);
+            expect(console.error).toHaveBeenCalled();
+            
+            // ...but still attaches listener anyway
+            dispatcher.trigger("foo");
+            expect(fn1).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Print console warning when more than 15 listeners for the same event are attached to one object (likely indicating a memory leak).  NodeJS has a similar mechanism.

This PR also fixes one such leak in JS Parameter Hints that I discovered using this new warning.

Also throw an error when `on()` is called with no listener function, which may indicate mixing up `on()`/`off()` calls (it already would have thrown later, when `trigger()` is called -- but now it fails faster, giving a more useful stack).
