### PR TITLE
Fix for #10715 

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -454,6 +454,8 @@ define(function (require, exports, module) {
             now = new Date(),
             file = new InMemoryFile(fullPath, FileSystem);
         
+        FileSystem.addEntryForPathIfRequired(file, fullPath);
+
         return new DocumentModule.Document(file, now, "");
     }
     

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -526,6 +526,22 @@ define(function (require, exports, module) {
     };
 
     /**
+     * This method adds an entry for a file in the file Index. Files on disk are added
+     * to the file index either on load or on open. This method is primarily needed to add
+     * in memory files to the index
+     *
+     * @param {File} The fileEntry which needs to be added
+     * @param {String} The full path to the file
+     */
+    FileSystem.prototype.addEntryForPathIfRequired = function (fileEntry, path) {
+        var entry = this._index.getEntry(path);
+
+        if (!entry) {
+            this._index.addEntry(fileEntry);
+        }
+    };
+
+    /**
      * Return a (strict subclass of a) FileSystemEntry object for the specified
      * path using the provided constuctor. For now, the provided constructor
      * should be either File or Directory.
@@ -970,6 +986,7 @@ define(function (require, exports, module) {
     exports.close = _wrap(FileSystem.prototype.close);
     exports.shouldShow = _wrap(FileSystem.prototype.shouldShow);
     exports.getFileForPath = _wrap(FileSystem.prototype.getFileForPath);
+    exports.addEntryForPathIfRequired = _wrap(FileSystem.prototype.addEntryForPathIfRequired);
     exports.getDirectoryForPath = _wrap(FileSystem.prototype.getDirectoryForPath);
     exports.resolve = _wrap(FileSystem.prototype.resolve);
     exports.showOpenDialog = _wrap(FileSystem.prototype.showOpenDialog);


### PR DESCRIPTION
Fixes #10715 Untitled documents aren't added to MRU until visited a 2nd time.

The issue is that no file Entry is added to File Index for Untitled documents. This causes a second file entry to be created and returned for untitled files from File System on File open (also on save of untitled file). Duplicate file entries for the same file in the MRU order causes the issue.
