### PR TITLE
Don't use null for comparefn, rely on undefined per spec http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.11

### DIFF
--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -222,8 +222,8 @@ define(function (require, exports, module) {
      * @param {string} attrName 
      * HTML attribute name
      *
-     * @return {{hints: Array.<string>|$.Deferred, sortFunc: ?Function}} 
-     * The (possibly deferred) hints and the sort function to use on thise hints.
+     * @return {!Array.<string>|$.Deferred}
+     * The (possibly deferred) hints.
      */
     AttrHints.prototype._getValueHintsForAttr = function (query, tagName, attrName) {
         // We look up attribute values with tagName plus a slash and attrName first.  
@@ -231,8 +231,7 @@ define(function (require, exports, module) {
         // of the attributes in JSON are using attribute name only as their properties, 
         // but in some cases like "type" attribute, we have different properties like 
         // "script/type", "link/type" and "button/type".
-        var hints = [],
-            sortFunc = null;
+        var hints = [];
         
         var tagPlusAttr = tagName + "/" + attrName,
             attrInfo = attributes[tagPlusAttr] || attributes[attrName];
@@ -245,7 +244,7 @@ define(function (require, exports, module) {
             }
         }
         
-        return { hints: hints, sortFunc: sortFunc };
+        return hints;
     };
     
     /**
@@ -319,10 +318,9 @@ define(function (require, exports, module) {
                 
                 // If we're at an attribute value, check if it's an attribute name that has hintable values.
                 if (this.tagInfo.attr.name) {
-                    var hintsAndSortFunc = this._getValueHintsForAttr({queryStr: query},
-                                                                      this.tagInfo.tagName,
-                                                                      this.tagInfo.attr.name);
-                    var hints = hintsAndSortFunc.hints;
+                    var hints = this._getValueHintsForAttr({queryStr: query},
+                                                           this.tagInfo.tagName,
+                                                           this.tagInfo.attr.name);
                     if (hints instanceof Array) {
                         // If we got synchronous hints, check if we have something we'll actually use
                         var i, foundPrefix = false;
@@ -416,14 +414,10 @@ define(function (require, exports, module) {
                 attrName = query.attrName,
                 filter = query.queryStr,
                 unfiltered = [],
-                hints = [],
-                sortFunc = null;
+                hints;
 
             if (attrName) {
-                var hintsAndSortFunc = this._getValueHintsForAttr(query, tagName, attrName);
-                hints = hintsAndSortFunc.hints;
-                sortFunc = hintsAndSortFunc.sortFunc;
-                
+                hints = this._getValueHintsForAttr(query, tagName, attrName);
             } else if (tags && tags[tagName] && tags[tagName].attributes) {
                 unfiltered = tags[tagName].attributes.concat(this.globalAttributes);
                 hints = $.grep(unfiltered, function (attr, i) {
@@ -437,7 +431,7 @@ define(function (require, exports, module) {
                     if (item.indexOf(filter) === 0) {
                         return item;
                     }
-                }).sort(sortFunc);
+                }).sort();
                 return {
                     hints: result,
                     match: query.queryStr,

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
      */
     UrlCodeHints.prototype._getUrlHints = function (query) {
         var hints = [],
-            sortFunc = null;
+            sortFunc;
 
         // Do not show hints after "?" in url
         if (query.queryStr.indexOf("?") === -1) {
@@ -398,7 +398,7 @@ define(function (require, exports, module) {
             cursor = this.editor.getCursorPos(),
             filter = "",
             hints = [],
-            sortFunc = null,
+            sortFunc,
             query = { queryStr: "" },
             result = [];
 


### PR DESCRIPTION
For our in browser fork, I'm getting top-level errors thrown when trying to do HTML code hints in Firefox:

```
"Exception in 'change' listener on" Object { document: Object, _handleDocumentChange: function (), _handleDocumentDeleted: function (), _handleDocumentLanguageChanged: function (), _inlineWidgets: Array[0], _inlineWidgetQueues: Object, _hideMarks: Array[0], _lastEditorWidth: 474, _$messagePopover: null, _currentOptions: Object, 6 more… } "TypeError: Not enough arguments to Console.assert." "d@http://humphd.github.io/brackets/dist/main.js:12:3893
s.prototype._handleEditorChange@http://humphd.github.io/brackets/dist/main.js:23:24680
s/<@http://humphd.github.io/brackets/dist/main.js:23:18133
d@http://humphd.github.io/brackets/dist/main.js:12:3784
s.prototype._installEditorListeners/<@http://humphd.github.io/brackets/dist/main.js:23:25373
e.signal@http://humphd.github.io/brackets/dist/main.js:8:25576
hn@http://humphd.github.io/brackets/dist/main.js:5:25993
ln@http://humphd.github.io/brackets/dist/main.js:5:23561
sn@http://humphd.github.io/brackets/dist/main.js:5:23360
Mn@http://humphd.github.io/brackets/dist/main.js:5:31075
An/<@http://humphd.github.io/brackets/dist/main.js:6:1189
"
```

The cause is the explicit use of `null` vs. `undefined` for the comparefn passed to `Array.prototype.sort`.  Leaving `sortFunc` with an implicit value of `undefined` here makes it work in all browsers.  Chrome is just a bit more permissive in what it allows in this case.
