### PR TITLE
Fix failing QuickOpen unit tests

### DIFF
--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -229,7 +229,7 @@ define(function (require, exports, module) {
     };
     
     /**
-     * If autoClose is set, handles the RETURN/ESC keys in the input field.
+     * If autoClose is set, close the bar when Escape is pressed
      */
     ModalBar.prototype._handleKeydown = function (e) {
         if (e.keyCode === KeyEvent.DOM_VK_ESCAPE) {

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -80,6 +80,7 @@ define(function (require, exports, module) {
             
             testWindow.setTimeout(function () {
                 getSearchField().val(str);
+                getSearchField().trigger("input");
             }, timeoutLength);
         }
         
@@ -88,7 +89,7 @@ define(function (require, exports, module) {
             
             // Using keyup here because of inside knowledge of how the events are processed
             // on the QuickOpen input.
-            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keyup", getSearchField()[0]);
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", getSearchField()[0]);
         }
         
         /**


### PR DESCRIPTION
Fix QuickOpen unit tests after introduction of QuickSearchField - listens for Enter on keydown, not keyup; expects an "input" event to follow every text change (Enter key processing now waits until text change events have caught up so Enter key never takes effect if change event never comes)
