### PR TITLE
Implement zooming by Ctrl + mouse wheel

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -308,6 +308,18 @@ define(function (require, exports, module) {
         setFontSize(DEFAULT_FONT_SIZE + "px");
     }
 
+    /** Zooming by mouse wheel */
+    window.addEventListener("wheel", function(e) {
+        // Detect Ctrl key on Linux and Windows, or Cmd key on Mac
+        if (e.ctrlKey || e.metaKey) {
+            if (e.deltaY < 0) {
+                _handleIncreaseFontSize();
+            } else {
+                _handleDecreaseFontSize();
+            }
+        }
+    });
+
     /**
      * @private
      * Updates the user interface appropriately based on whether or not a document is

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -308,10 +308,10 @@ define(function (require, exports, module) {
         setFontSize(DEFAULT_FONT_SIZE + "px");
     }
 
-    /** Zooming by mouse wheel */
+    /** Increase or decrease font size with the mouse wheel */
     window.addEventListener("wheel", function(e) {
-        // Detect Ctrl key, or Cmd key on Mac
-        if (e.ctrlKey || e.metaKey) {
+        // Detect the Ctrl key on Linux and Windows, or the Alt key on Mac
+        if ((brackets.platform !== "mac" && e.ctrlKey) || (brackets.platform === "mac" && e.altKey)) {
             if (e.deltaY < 0) {
                 _handleIncreaseFontSize();
             } else {

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -310,7 +310,7 @@ define(function (require, exports, module) {
 
     /** Zooming by mouse wheel */
     window.addEventListener("wheel", function(e) {
-        // Detect Ctrl key on Linux and Windows, or Cmd key on Mac
+        // Detect Ctrl key, or Cmd key on Mac
         if (e.ctrlKey || e.metaKey) {
             if (e.deltaY < 0) {
                 _handleIncreaseFontSize();


### PR DESCRIPTION
This PR implements zooming by Ctrl + mouse wheel feature. Works also by pinching a touchpad.

~~There’s an possible issue: the font size changes by 2, not 1.~~
