### PR TITLE
Fix for Issue # 10941, 10940. 

### DIFF
--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -30,9 +30,13 @@
 .CodeMirror-foldgutter-folded,
 .CodeMirror-foldgutter-blank {
     width: @font-size;
-    padding-top: 2px;
     cursor: default;
     line-height: 100%;
+}
+
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+    padding-top: 2px;
 }
 
 .CodeMirror-gutter-elt {


### PR DESCRIPTION
Setting padding-top property to open/folded marker for Code Folding to keep it sync with line number on left gutter.
