### PR TITLE
Fix Issue#10858

### DIFF
--- a/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
@@ -84,8 +84,9 @@ define(function (require, exports, module) {
             __isFold: true
         });
 
-        CodeMirror.on(widget, "mousedown", function () {
+        CodeMirror.on(widget, "mousedown", function (e) {
             textRange.clear();
+            e.preventDefault();
         });
 
         textRange.on("clear", function (from, to) {

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -51,6 +51,9 @@
 
 
 .CodeMirror-foldmarker {
+    // Re-enabling the pointer events for the fold marker. As pointer events are disabled for "CodeMirror-lines"
+    // to fix issue #2780.
+    pointer-events: auto;
     padding-right: 3px;
     padding-left: 3px;
     margin-right: 3px;


### PR DESCRIPTION
Fix for Issue #10858. 
Re-enabling the pointer events for the CodeMirror-foldmarker as pointer events are disabled for parent "CodeMirror-lines" to fix issue #2780. 
