### PR TITLE
Modal positioning fix

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -734,11 +734,13 @@ a:focus {
 /* Dialog-related styles */
 
 .modal-wrapper {
-    width: 100%;
+    width: 100% !important;
+    max-width: 75%;
     height: 100%;
     position: absolute;
     top: 0;
     left: 0;
+    padding-left: 0;
     overflow: auto;
     display: table;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -888,6 +888,8 @@ a:focus {
 
 .dialog-title {
     color: @bc-text-thin;
+    padding-top: 10px;
+    padding-bottom: 15px !important;
     margin-bottom: 0;
     margin-top: 0;
     font-size: 22px;


### PR DESCRIPTION
Fixing my bug, Issue #10977, this properly centers modals within the Brackets window.

The old:
![centering2](https://cloud.githubusercontent.com/assets/1424353/7290302/9393b3ce-e94a-11e4-82e8-b22dc06cc2e7.PNG)

The new:
![newlook](https://cloud.githubusercontent.com/assets/1424353/7290304/98d3f31c-e94a-11e4-98ec-9be255ad3a42.PNG)

It looks so much cleaner with this fix.
