### PR TITLE
Add .webp support

### DIFF
--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -454,7 +454,7 @@ define(function (require, exports, module) {
             // Strip leading/trailing quotes, if present
             tokenString = tokenString.replace(/(^['"])|(['"]$)/g, "");
             
-            if (/^(data\:image)|(\.gif|\.png|\.jpg|\.jpeg|\.svg)$/i.test(tokenString)) {
+            if (/^(data\:image)|(\.gif|\.png|\.jpg|\.jpeg|\.webp|\.svg)$/i.test(tokenString)) {
                 var sPos, ePos;
                 var docPath = editor.document.file.fullPath;
                 var imgPath;

--- a/src/extensions/samples/InlineImageViewer/main.js
+++ b/src/extensions/samples/InlineImageViewer/main.js
@@ -110,7 +110,7 @@ define(function (require, exports, module) {
         }
         
         // Check for valid file extensions
-        if (!/(.png|.jpg|.jpeg|.gif|.svg)$/i.test(fileName)) {
+        if (!/(\.png|\.jpg|\.jpeg|\.gif|\.webp|\.svg)$/i.test(fileName)) {
             return null;
         }
 

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -255,7 +255,7 @@
   
     "image": {
         "name": "Image",
-        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp"],
+        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp", "webp"],
         "isBinary": true
     },
     


### PR DESCRIPTION
Adds support for the [.webp format](https://en.wikipedia.org/wiki/WebP).

For testing I've taken [this .webp image](https://www.gstatic.com/webp/gallery3/3_webp_ll.webp) (taken from https://developers.google.com/speed/webp/gallery2#webp_links):
![Image Preview](https://cloud.githubusercontent.com/assets/2641501/7377902/a67f9522-ede9-11e4-8882-effce0162b45.png)
![Quick View](https://cloud.githubusercontent.com/assets/2641501/7377951/1dc259d0-edea-11e4-95de-062a7c3cf317.png)
