### PR TITLE
Refresh editor when reloading file to avoid scroll area getting out of sync

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -931,6 +931,7 @@ define(function (require, exports, module) {
         
         // This *will* fire a change event, but we clear the undo immediately afterward
         this._codeMirror.setValue(text);
+        this._codeMirror.refresh();
         
         // Make sure we can't undo back to the empty state before setValue(), and mark
         // the document clean.


### PR DESCRIPTION
This is a possible fix for #9632. My suspicion is that without this refresh, CodeMirror's idea of the scroll area size gets out of sync somehow if the text has a significantly different number of lines. It's not clear why this should be necessary - there might be some bug in CodeMirror - but it seems like a fairly straightforward workaround.

With this change in place I haven't seen the bug in #9632 at all today, whereas it shows up pretty often for me on master. It seems like a relatively harmless change, although it could add some small delay when switching documents.

@peterflynn any thoughts?
