### PR TITLE
Fix two spelling errors.

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
      *  - index.html
      *  - index.htm
      * 
-     * If the project is configured with a custom base url for live developmment, then
+     * If the project is configured with a custom base url for live development, then
      * the list of possible index files is extended to contain these index files too:
      *  - index.php
      *  - index.php3

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -648,7 +648,7 @@ define(function LiveDevelopment(require, exports, module) {
      *  - index.html
      *  - index.htm
      * 
-     * If the project is configured with a custom base url for live developmment, then
+     * If the project is configured with a custom base url for live development, then
      * the list of possible index files is extended to contain these index files too:
      *  - index.php
      *  - index.php3


### PR DESCRIPTION
Change both instances of 'developmment' -> 'development'
