### PR TITLE
Escape RegExp specials in _createSpecialLineExp

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -55,17 +55,18 @@ define(function (require, exports, module) {
      * @return {RegExp}
      */
     function _createSpecialLineExp(lineSyntax, blockSyntax) {
-        var i, character,
+        var i, character, escapedCharacter,
             subExps   = [],
             prevChars = "";
         
         for (i = lineSyntax.length; i < blockSyntax.length; i++) {
             character = blockSyntax.charAt(i);
-            subExps.push(prevChars + "[^" + StringUtils.regexEscape(character) + "]");
+            escapedCharacter = StringUtils.regexEscape(character);
+            subExps.push(prevChars + "[^" + escapedCharacter + "]");
             if (prevChars) {
                 subExps.push(prevChars + "$");
             }
-            prevChars += character;
+            prevChars += escapedCharacter;
         }
         return new RegExp("^\\s*" + StringUtils.regexEscape(lineSyntax) + "($|" + subExps.join("|") + ")");
     }


### PR DESCRIPTION
Fixes #11097.

Before this, the current character was only escaped in `subExps`, but not in `prevChars`.
