### PR TITLE
Improve JS Code Hints performance in minified files

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
     "use strict";
 
     var StringMatch     = brackets.getModule("utils/StringMatch"),
+        TokenUtils      = brackets.getModule("utils/TokenUtils"),
         LanguageManager = brackets.getModule("language/LanguageManager"),
         HTMLUtils       = brackets.getModule("language/HTMLUtils"),
         HintUtils       = require("HintUtils"),
@@ -130,9 +131,9 @@ define(function (require, exports, module) {
         var cm = this.editor._codeMirror;
 
         if (cursor) {
-            return cm.getTokenAt(cursor);
+            return TokenUtils.getTokenAt(cm, cursor);
         } else {
-            return cm.getTokenAt(this.getCursor());
+            return TokenUtils.getTokenAt(cm, this.getCursor());
         }
     };
 

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -62,7 +62,7 @@ define(function (require, exports, module) {
                 cm: cm,
                 line: line,
                 timeStamp: Date.now(),
-                tokens: tokens,
+                tokens: tokens
             };
             cm.off("changes", _clearCache);
             cm.on("changes", _clearCache);


### PR DESCRIPTION
Use caching for JS Code Hints to improve performance in minified files.
Better, but still not perfect.

The [CodeMirror.copyState](https://github.com/codemirror/CodeMirror/blob/de9a6b9ac70334e31d643e0f667346b0e1e14d60/lib/codemirror.js#L5463-L5473) method takes most of the time. It would be great if someone could submit a speed improvement upstream.
