### PR TITLE
Shim Error.prototype.stack for browsers that lack it.

### DIFF
--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -39,4 +39,10 @@ define(function () {
         String.prototype.trimLeft = function () { return this.replace(/^\s+/, ""); };
     }
 
+    // Feature detection for Error.stack. Not all browsers expose it
+    // and Brackets assumes it will be a non-null string.
+    if (typeof (new Error()).stack === "undefined") {
+        Error.prototype.stack = "";
+    }
+
 });


### PR DESCRIPTION
In IE the deprecation warning is causing extensions to fail to load, since it tries to split `err.stack`, but it's undefined.  This shims it so that the extensions can still load.
