### PR TITLE
added Slack channel and re-ordered contact order

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Not sure you needed the exclamation point there, but we like your enthusiasm.
 
 #### Contact info
 
+* **Slack:** [Brackets on Slack](https://brackets.slack.com)
+* **Developers mailing list:** http://groups.google.com/group/brackets-dev
 * **Twitter:** [@brackets](https://twitter.com/brackets)
 * **Blog:** http://blog.brackets.io/
 * **IRC:** [#brackets on freenode](http://webchat.freenode.net/?channels=brackets)
-* **Developers mailing list:** http://groups.google.com/group/brackets-dev
+


### PR DESCRIPTION
re-ordered the list to reflect the best chance of actually receiving help.

Should we remove the IRC link? It seems to be not well-populated anymore and is redundant based on Slack usage.
