### PR TITLE
Rename CodeMirror2 folder to CodeMirror

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -15,7 +15,7 @@
         }
     },
     "path": {
-        "src/thirdparty/CodeMirror2/**/*.js": {
+        "src/thirdparty/CodeMirror/**/*.js": {
             "spaceUnits": 2,
             "linting.enabled": false
         },

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "src/thirdparty/CodeMirror2"]
-	path = src/thirdparty/CodeMirror2
+[submodule "src/thirdparty/CodeMirror"]
+	path = src/thirdparty/CodeMirror
 	url = https://github.com/adobe/CodeMirror2.git
 [submodule "src/thirdparty/path-utils"]
 	path = src/thirdparty/path-utils

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,13 +93,13 @@ module.exports = function (grunt) {
                             '!extensions/default/*/thirdparty/**/*.htm{,l}',
                             'extensions/dev/*',
                             'extensions/samples/**/*',
-                            'thirdparty/CodeMirror2/addon/{,*/}*',
-                            'thirdparty/CodeMirror2/keymap/{,*/}*',
-                            'thirdparty/CodeMirror2/lib/{,*/}*',
-                            'thirdparty/CodeMirror2/mode/{,*/}*',
-                            '!thirdparty/CodeMirror2/mode/**/*.html',
-                            '!thirdparty/CodeMirror2/**/*test.js',
-                            'thirdparty/CodeMirror2/theme/{,*/}*',
+                            'thirdparty/CodeMirror/addon/{,*/}*',
+                            'thirdparty/CodeMirror/keymap/{,*/}*',
+                            'thirdparty/CodeMirror/lib/{,*/}*',
+                            'thirdparty/CodeMirror/mode/{,*/}*',
+                            '!thirdparty/CodeMirror/mode/**/*.html',
+                            '!thirdparty/CodeMirror/**/*test.js',
+                            'thirdparty/CodeMirror/theme/{,*/}*',
                             'thirdparty/i18n/*.js',
                             'thirdparty/text/*.js'
                         ]
@@ -268,11 +268,11 @@ module.exports = function (grunt) {
                 vendor : [
                     'test/polyfills.js', /* For reference to why this polyfill is needed see Issue #7951. The need for this should go away once the version of phantomjs gets upgraded to 2.0 */
                     'src/thirdparty/jquery-2.1.3.min.js',
-                    'src/thirdparty/CodeMirror2/lib/codemirror.js',
-                    'src/thirdparty/CodeMirror2/lib/util/dialog.js',
-                    'src/thirdparty/CodeMirror2/lib/util/searchcursor.js',
-                    'src/thirdparty/CodeMirror2/addon/edit/closetag.js',
-                    'src/thirdparty/CodeMirror2/addon/selection/active-line.js',
+                    'src/thirdparty/CodeMirror/lib/codemirror.js',
+                    'src/thirdparty/CodeMirror/lib/util/dialog.js',
+                    'src/thirdparty/CodeMirror/lib/util/searchcursor.js',
+                    'src/thirdparty/CodeMirror/addon/edit/closetag.js',
+                    'src/thirdparty/CodeMirror/addon/selection/active-line.js',
                     'src/thirdparty/mustache/mustache.js',
                     'src/thirdparty/path-utils/path-utils.min',
                     'src/thirdparty/less-1.7.5.min.js'

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -45,19 +45,19 @@ define(function (require, exports, module) {
     require("widgets/bootstrap-twipsy-mod");
 
     // Load CodeMirror add-ons--these attach themselves to the CodeMirror module
-    require("thirdparty/CodeMirror2/addon/edit/closebrackets");
-    require("thirdparty/CodeMirror2/addon/edit/closetag");
-    require("thirdparty/CodeMirror2/addon/edit/matchbrackets");
-    require("thirdparty/CodeMirror2/addon/edit/matchtags");
-    require("thirdparty/CodeMirror2/addon/fold/xml-fold");
-    require("thirdparty/CodeMirror2/addon/mode/multiplex");
-    require("thirdparty/CodeMirror2/addon/mode/overlay");
-    require("thirdparty/CodeMirror2/addon/scroll/scrollpastend");
-    require("thirdparty/CodeMirror2/addon/search/match-highlighter");
-    require("thirdparty/CodeMirror2/addon/search/searchcursor");
-    require("thirdparty/CodeMirror2/addon/selection/active-line");
-    require("thirdparty/CodeMirror2/addon/selection/mark-selection");
-    require("thirdparty/CodeMirror2/keymap/sublime");
+    require("thirdparty/CodeMirror/addon/edit/closebrackets");
+    require("thirdparty/CodeMirror/addon/edit/closetag");
+    require("thirdparty/CodeMirror/addon/edit/matchbrackets");
+    require("thirdparty/CodeMirror/addon/edit/matchtags");
+    require("thirdparty/CodeMirror/addon/fold/xml-fold");
+    require("thirdparty/CodeMirror/addon/mode/multiplex");
+    require("thirdparty/CodeMirror/addon/mode/overlay");
+    require("thirdparty/CodeMirror/addon/scroll/scrollpastend");
+    require("thirdparty/CodeMirror/addon/search/match-highlighter");
+    require("thirdparty/CodeMirror/addon/search/searchcursor");
+    require("thirdparty/CodeMirror/addon/selection/active-line");
+    require("thirdparty/CodeMirror/addon/selection/mark-selection");
+    require("thirdparty/CodeMirror/keymap/sublime");
 
     // Load dependent modules
     var AppInit             = require("utils/AppInit"),
@@ -104,11 +104,11 @@ define(function (require, exports, module) {
     // DEPRECATED: In future we want to remove the global CodeMirror, but for now we
     // expose our required CodeMirror globally so as to avoid breaking extensions in the
     // interim.
-    var CodeMirror = require("thirdparty/CodeMirror2/lib/codemirror");
+    var CodeMirror = require("thirdparty/CodeMirror/lib/codemirror");
 
     Object.defineProperty(window, "CodeMirror", {
         get: function () {
-            DeprecationWarning.deprecationWarning('Use brackets.getModule("thirdparty/CodeMirror2/lib/codemirror") instead of global CodeMirror.', true);
+            DeprecationWarning.deprecationWarning('Use brackets.getModule("thirdparty/CodeMirror/lib/codemirror") instead of global CodeMirror.', true);
             return CodeMirror;
         }
     });

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
         InMemoryFile        = require("document/InMemoryFile"),
         PerfUtils           = require("utils/PerfUtils"),
         LanguageManager     = require("language/LanguageManager"),
-        CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+        CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
         _                   = require("thirdparty/lodash");
     
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     
     var AnimationUtils     = require("utils/AnimationUtils"),
         Async              = require("utils/Async"),
-        CodeMirror         = require("thirdparty/CodeMirror2/lib/codemirror"),
+        CodeMirror         = require("thirdparty/CodeMirror/lib/codemirror"),
         LanguageManager    = require("language/LanguageManager"),
         EventDispatcher    = require("utils/EventDispatcher"),
         Menus              = require("command/Menus"),

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         EditorManager      = require("editor/EditorManager"),
         StringUtils        = require("utils/StringUtils"),
         TokenUtils         = require("utils/TokenUtils"),
-        CodeMirror         = require("thirdparty/CodeMirror2/lib/codemirror"),
+        CodeMirror         = require("thirdparty/CodeMirror/lib/codemirror"),
         _                  = require("thirdparty/lodash");
     
     /**

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     "use strict";
     
     // Load dependent modules
-    var CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
         EventDispatcher     = require("utils/EventDispatcher"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),

--- a/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
@@ -6,7 +6,7 @@
 /*global define, brackets, document*/
 define(function (require, exports, module) {
     "use strict";
-    var CodeMirror          = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         prefs               = require("Prefs");
 
     /**

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -6,7 +6,7 @@
 /*global define, brackets, document, window, $*/
 define(function (require, exports, module) {
     "use strict";
-    var CodeMirror      = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror      = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         prefs           = require("Prefs");
 
     function State(options) {

--- a/src/extensions/default/CodeFolding/foldhelpers/indentFold.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/indentFold.js
@@ -8,7 +8,7 @@
 
 define(function (require, exports, module) {
     "use strict";
-    var CodeMirror  = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror  = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         cols        = CodeMirror.countColumn,
         pos         = CodeMirror.Pos;
 

--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -30,7 +30,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var CodeMirror              = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror              = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         Strings                 = brackets.getModule("strings"),
         AppInit                 = brackets.getModule("utils/AppInit"),
         CommandManager          = brackets.getModule("command/CommandManager"),
@@ -56,9 +56,9 @@ define(function (require, exports, module) {
     ExtensionUtils.loadStyleSheet(module, "main.less");
     
     // Load CodeMirror addons
-    brackets.getModule(["thirdparty/CodeMirror2/addon/fold/brace-fold"]);
-    brackets.getModule(["thirdparty/CodeMirror2/addon/fold/comment-fold"]);
-    brackets.getModule(["thirdparty/CodeMirror2/addon/fold/markdown-fold"]);
+    brackets.getModule(["thirdparty/CodeMirror/addon/fold/brace-fold"]);
+    brackets.getModule(["thirdparty/CodeMirror/addon/fold/comment-fold"]);
+    brackets.getModule(["thirdparty/CodeMirror/addon/fold/markdown-fold"]);
 
     // Still using slightly modified versions of the foldcode.js and foldgutter.js since we
     // need to modify the gutter click handler to take care of some collapse and expand features

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
 
     var _ = brackets.getModule("thirdparty/lodash");
     
-    var CodeMirror          = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         DefaultDialogs      = brackets.getModule("widgets/DefaultDialogs"),
         Dialogs             = brackets.getModule("widgets/Dialogs"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
     <!-- Warn about failed cross origin requests in Chrome -->
     <script type="application/javascript" src="xorigin.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror2/lib/codemirror.css">
+    <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
     <!--(if target dev)><!-->
     <link rel="stylesheet" type="text/less" href="styles/brackets.less">
     <!--<!(endif)-->

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -31,7 +31,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
         Async               = require("utils/Async"),
         DocumentManager     = require("document/DocumentManager"),
         EditorManager       = require("editor/EditorManager"),

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -28,7 +28,7 @@
 define(function (require, exports, module) {
     "use strict";
     
-    var CodeMirror = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror = require("thirdparty/CodeMirror/lib/codemirror"),
         TokenUtils = require("utils/TokenUtils");
     
     // Constants

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
     var _ = require("thirdparty/lodash");
     
     // Load brackets modules
-    var CodeMirror              = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror              = require("thirdparty/CodeMirror/lib/codemirror"),
         Async                   = require("utils/Async"),
         DocumentManager         = require("document/DocumentManager"),
         ChangedDocumentTracker  = require("document/ChangedDocumentTracker"),

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -77,7 +77,7 @@
  *     language.addFileExtension("lhs");
  *
  * Some CodeMirror modes define variations of themselves. They are called MIME modes.
- * To find existing MIME modes, search for "CodeMirror.defineMIME" in thirdparty/CodeMirror2/mode
+ * To find existing MIME modes, search for "CodeMirror.defineMIME" in thirdparty/CodeMirror/mode
  * For instance, C++, C# and Java all use the clike (C-like) mode with different settings and a different MIME name.
  * You can refine the mode definition by specifying the MIME mode as well:
  *
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
     
     
     // Dependencies
-    var CodeMirror            = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror            = require("thirdparty/CodeMirror/lib/codemirror"),
         EventDispatcher       = require("utils/EventDispatcher"),
         Async                 = require("utils/Async"),
         FileUtils             = require("file/FileUtils"),
@@ -563,7 +563,7 @@ define(function (require, exports, module) {
      * Loads a mode and sets it for this language.
      * 
      * @param {(string|Array.<string>)} mode  CodeMirror mode (e.g. "htmlmixed"), optionally paired with a MIME mode defined by
-     *      that mode (e.g. ["clike", "text/x-c++src"]). Unless the mode is located in thirdparty/CodeMirror2/mode/<name>/<name>.js,
+     *      that mode (e.g. ["clike", "text/x-c++src"]). Unless the mode is located in thirdparty/CodeMirror/mode/<name>/<name>.js,
      *      you need to first load it yourself.
      * @return {$.Promise} A promise object that will be resolved when the mode is loaded and set
      */
@@ -613,7 +613,7 @@ define(function (require, exports, module) {
         if (CodeMirror.modes[mode]) {
             finish();
         } else {
-            require(["thirdparty/CodeMirror2/mode/" + mode + "/" + mode], finish);
+            require(["thirdparty/CodeMirror/mode/" + mode + "/" + mode], finish);
         }
         
         return result.promise();
@@ -916,7 +916,7 @@ define(function (require, exports, module) {
      * @param {Array.<string>}        definition.blockComment   Array with two entries defining the block comment prefix and suffix (e.g. ["<!--", "-->"])
      * @param {(string|Array.<string>)} definition.lineComment  Line comment prefixes (e.g. "//" or ["//", "#"])
      * @param {(string|Array.<string>)} definition.mode         CodeMirror mode (e.g. "htmlmixed"), optionally with a MIME mode defined by that mode ["clike", "text/x-c++src"]
-     *                                                          Unless the mode is located in thirdparty/CodeMirror2/mode/<name>/<name>.js, you need to first load it yourself.
+     *                                                          Unless the mode is located in thirdparty/CodeMirror/mode/<name>/<name>.js, you need to first load it yourself.
      *
      * @return {$.Promise} A promise object that will be resolved with a Language object
      **/

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,11 @@ require.config({
         // The file system implementation. Change this value to use different
         // implementations (e.g. cloud-based storage).
         "fileSystemImpl"    : "filesystem/impls/appshell/AppshellFileSystem"
+    },
+    map: {
+        "*": {
+            "thirdparty/CodeMirror2": "thirdparty/CodeMirror"
+        }
     }
 });
 

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -850,7 +850,7 @@ define(function (require, exports, module) {
      * (switching to single line comments because the glob interferes with the multiline comment):
      */
 //    "path": {
-//        "src/thirdparty/CodeMirror2/**/*.js": {
+//        "src/thirdparty/CodeMirror/**/*.js": {
 //            "spaceUnits": 2,
 //            "linting.enabled": false
 //        }

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -29,7 +29,7 @@
 /**
  * Adds Find and Replace commands
  *
- * Originally based on the code in CodeMirror2/lib/util/search.js.
+ * Originally based on the code in CodeMirror/lib/util/search.js.
  */
 define(function (require, exports, module) {
     "use strict";
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
         FindInFilesUI       = require("search/FindInFilesUI"),
         ScrollTrackMarkers  = require("search/ScrollTrackMarkers"),
         _                   = require("thirdparty/lodash"),
-        CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror");
+        CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror");
     
     /**
      * Maximum file size to search within (in chars)

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -34,7 +34,7 @@ define(function (require, exports, module) {
     "use strict";
     
     var _           = require("thirdparty/lodash"),
-        CodeMirror  = require("thirdparty/CodeMirror2/lib/codemirror");
+        CodeMirror  = require("thirdparty/CodeMirror/lib/codemirror");
     
     var cache;
     

--- a/src/view/ThemeView.js
+++ b/src/view/ThemeView.js
@@ -27,7 +27,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var CodeMirror         = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror         = require("thirdparty/CodeMirror/lib/codemirror"),
         PreferencesManager = require("preferences/PreferencesManager"),
         prefs              = PreferencesManager.getExtensionPrefs("themes");
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -83,16 +83,16 @@ define(function (require, exports, module) {
     require("test/thirdparty/jasmine-reporters/jasmine.junit_reporter");
     
     // Load CodeMirror add-ons--these attach themselves to the CodeMirror module    
-    require("thirdparty/CodeMirror2/addon/fold/xml-fold");
-    require("thirdparty/CodeMirror2/addon/edit/matchtags");
-    require("thirdparty/CodeMirror2/addon/edit/matchbrackets");
-    require("thirdparty/CodeMirror2/addon/edit/closebrackets");
-    require("thirdparty/CodeMirror2/addon/edit/closetag");
-    require("thirdparty/CodeMirror2/addon/selection/active-line");
-    require("thirdparty/CodeMirror2/addon/mode/multiplex");
-    require("thirdparty/CodeMirror2/addon/mode/overlay");
-    require("thirdparty/CodeMirror2/addon/search/searchcursor");
-    require("thirdparty/CodeMirror2/keymap/sublime");
+    require("thirdparty/CodeMirror/addon/fold/xml-fold");
+    require("thirdparty/CodeMirror/addon/edit/matchtags");
+    require("thirdparty/CodeMirror/addon/edit/matchbrackets");
+    require("thirdparty/CodeMirror/addon/edit/closebrackets");
+    require("thirdparty/CodeMirror/addon/edit/closetag");
+    require("thirdparty/CodeMirror/addon/selection/active-line");
+    require("thirdparty/CodeMirror/addon/mode/multiplex");
+    require("thirdparty/CodeMirror/addon/mode/overlay");
+    require("thirdparty/CodeMirror/addon/search/searchcursor");
+    require("thirdparty/CodeMirror/keymap/sublime");
 
     var selectedSuites,
         params          = new UrlParams(),

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
     'use strict';
     
     // Load dependent modules
-    var CodeMirror          = require("thirdparty/CodeMirror2/lib/codemirror"),
+    var CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
         LanguageManager     = require("language/LanguageManager"),
         SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         PreferencesManager  = require("preferences/PreferencesManager");


### PR DESCRIPTION
Now that we use CodeMirror 5, it's a little misleading our submodule is still called `CodeMirror2`. Thus, in this PR, I've renamed it to `CodeMirror`.

There are some things to keep in mind, though:
- While most extensions will still work through our require mapping, other ways to access `CodeMirror2` (FileSystem, node) **won't work**. Look out for those.
- We probably cannot utilize deprecation warnings.
- [ ] See if any extension accesses `CodeMirror2` through anything else than a `require` (FileSystem, node, ...)
- [ ] See if we can fire deprecation warnings
- [ ] See if it makes sense to rename our [adobe/CodeMirror2](/adobe/CodeMirror2) repo as well
