### PR TITLE
Fix horizontal scrolling of code hints

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -379,6 +379,9 @@ a:focus {
         box-shadow: 0 3px 9px @bc-shadow;
         border: none;
 
+        // Fixes a problem with codehints that exceed the maximum size resulting in horizental scrollbars.
+        overflow-x: hidden;
+
         .dark & {
             background-color: @dark-bc-menu-bg;
             box-shadow: 0 3px 9px @dark-bc-shadow;


### PR DESCRIPTION
This removes the horizontal scroll bars appearing when hints exceed the size.

@abose This should get in before we add #11130 

@MarcelGerber Can you merge this branch in your local `pref-code-hints` branch and check if it works for you?
