### PR TITLE
Make language names localizable

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
         // Setting Untitled documents to non-text mode isn't supported yet, so disable the switcher in that case for now
         languageSelect.$button.prop("disabled", doc.isUntitled());
         // Show the current language as button title
-        languageSelect.$button.text(lang.getName());
+        languageSelect.$button.text(lang.getLocalizedName());
     }
     
     /**
@@ -301,7 +301,7 @@ define(function (require, exports, module) {
         
         // sort dropdown alphabetically
         languages.sort(function (a, b) {
-            return a.getName().toLowerCase().localeCompare(b.getName().toLowerCase());
+            return a.getLocalizedName().toLowerCase().localeCompare(b.getLocalizedName().toLowerCase());
         });
         
         languageSelect.items = languages;
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
                 return { html: label, enabled: document.getLanguage() !== defaultLang };
             }
             
-            var html = _.escape(item.getName());
+            var html = _.escape(item.getLocalizedName());
             
             // Show indicators for currently selected & default languages for the current file
             if (item === defaultLang) {

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -456,7 +456,7 @@ define(function (require, exports, module) {
             Resizer.hide($problemsPanel);
             var language = currentDoc && LanguageManager.getLanguageForPath(currentDoc.file.fullPath);
             if (language) {
-                StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-disabled", StringUtils.format(Strings.NO_LINT_AVAILABLE, language.getName()));
+                StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-disabled", StringUtils.format(Strings.NO_LINT_AVAILABLE, language.getLocalizedName()));
             } else {
                 StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-disabled", Strings.NOTHING_TO_LINT);
             }

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -118,7 +118,7 @@
  *         name: "Audio",
  *         fileExtensions: ["mp3", "wav", "aif", "aiff", "ogg"],
  *         isBinary: true    
- *     }); 
+ *     });
  * 
  * 
  * LanguageManager dispatches two events:
@@ -136,6 +136,7 @@ define(function (require, exports, module) {
         EventDispatcher       = require("utils/EventDispatcher"),
         Async                 = require("utils/Async"),
         FileUtils             = require("file/FileUtils"),
+        Strings               = require("strings"),
         _defaultLanguagesJSON = require("text!language/languages.json"),
         _                     = require("thirdparty/lodash"),
         
@@ -460,6 +461,12 @@ define(function (require, exports, module) {
     Language.prototype._name = null;
     
     /**
+     * Localized, human-readable name
+     * @type {string}
+     */
+    Language.prototype._localizedName = null;
+
+    /**
      * CodeMirror mode for this language
      * @type {string}
      */
@@ -551,6 +558,23 @@ define(function (require, exports, module) {
         return true;
     };
     
+    /**
+     * Returns the human-readable, localized name of this language.
+     * Falls back to the normal name if no localized one was given.
+     * @return {string} The (possibly localized) name
+     */
+    Language.prototype.getLocalizedName = function () {
+        return this._localizedName || this.getName();
+    };
+
+    /**
+     * Sets the human-readable, localized name of this language.
+     * @param {string} localizedName The localized name
+     */
+    Language.prototype._setLocalizedName = function (localizedName) {
+        this._localizedName = localizedName;
+    };
+
     /**
      * Returns the CodeMirror mode for this language.
      * @return {string} The mode
@@ -956,6 +980,13 @@ define(function (require, exports, module) {
             
             language._setBinary(!!definition.isBinary);
             
+            if (definition.localizedName) {
+                language._setLocalizedName(definition.localizedName);
+            } else if (definition.translationKey) {
+                // for internal use in languages.json only
+                language._setLocalizedName(Strings[definition.translationKey]);
+            }
+
             // store language to language map
             _languages[language.getId()] = language;
         }

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -120,6 +120,15 @@
  *         isBinary: true    
  *     });
  * 
+ * You can also specify a localized name using the localizedName field.
+ * It will then be used in some places and can be accessed through language.getLocalizedName().
+ * 
+ *     LanguageManager.defineLanguage("image", {
+ *         name: "Image",
+ *         localizedName: "Bild",
+ *         isBinary: true
+ *     });
+ * 
  * 
  * LanguageManager dispatches two events:
  * 

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -246,23 +246,34 @@
         "lineComment": ["//"]
     },
 
+    "haskell": {
+        "name": "Haskell",
+        "mode": "haskell",
+        "fileExtensions": ["hs"],
+        "blockComment": ["{-", "-}"],
+        "lineComment": ["--"]
+    },
+
     "bash": {
         "name": "Bash",
         "mode": ["shell", "text/x-sh"],
         "fileExtensions": ["sh", "command", "bash"],
         "lineComment": ["#"]
     },
+
   
     "image": {
         "name": "Image",
         "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp", "webp"],
-        "isBinary": true
+        "isBinary": true,
+        "translationKey": "LANGUAGE_IMAGE"
     },
     
     "audio": {
         "name": "Audio",
         "fileExtensions": ["mp3", "wav", "aif", "aiff", "ogg"],
-        "isBinary": true
+        "isBinary": true,
+        "translationKey": "LANGUAGE_AUDIO"
     },
     
     "binary": {
@@ -276,14 +287,7 @@
             "pdi", "ppt", "pptx", "psd", "rar", "sdf", "so", "sqlite", "suo", "svgz",
             "swf", "tar", "tif", "tiff", "ttf", "woff", "xls", "xlsx", "zip"
         ],
-        "isBinary": true
-    },
-
-    "haskell": {
-        "name": "Haskell",
-        "mode": "haskell",
-        "fileExtensions": ["hs"],
-        "blockComment": ["{-", "-}"],
-        "lineComment": ["--"]
+        "isBinary": true,
+        "translationKey": "LANGUAGE_OTHER_BINARY"
     }
 }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -283,6 +283,13 @@ define({
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
     "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for .{0} Files",
 
+    /**
+     * LanguageManager localized language names
+     */
+    "LANGUAGE_IMAGE"                        : "Image",
+    "LANGUAGE_AUDIO"                        : "Audio",
+    "LANGUAGE_OTHER_BINARY"                 : "Other Binary",
+
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problems",
     "SINGLE_ERROR"                          : "1 {0} Problem",

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -93,6 +93,12 @@ define(function (require, exports, module) {
             } else {
                 expect(actual.hasLineCommentSyntax()).toBe(false);
             }
+
+            if (expected.localizedName) {
+                expect(actual.getLocalizedName()).toBe(expected.localizedName);
+            } else {
+                expect(actual.getLocalizedName()).toBe(expected.name);
+            }
         }
         
         describe("built-in languages", function () {
@@ -485,6 +491,19 @@ define(function (require, exports, module) {
                     // confirm the mode is loaded in CodeMirror
                     expect(CodeMirror.modes[id]).not.toBe(undefined);
                 });
+            });
+
+            it("should define a language with a localized name", function () {
+                var language,
+                    promise,
+                    def = { id: "six", name: "Six", localizedName: "Xis", mode: ["null", "text/plain"] };
+
+                // mode already exists, this test is completely synchronous
+                promise = defineLanguage(def).done(function (lang) {
+                    language = lang;
+                });
+
+                validateLanguage(def, language);
             });
             
         });


### PR DESCRIPTION
For #10964.

Adds a new method to language objects, `getLocalizedName`.

The name can be set via the `translationKey` property (only meant for use in `languages.json`) or via a `localizedName` field.
