### PR TITLE
Append remote script to the end of the doc in case no "head" tag is present

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
@@ -739,6 +739,7 @@ define(function (require, exports, module) {
             orig = doc.getText(),
             gen = "",
             lastIndex = 0,
+            remoteScriptInserted = false,
             markCache;
         
         if (!dom) {
@@ -787,11 +788,11 @@ define(function (require, exports, module) {
                 
                 // If we have a script to inject and this is the head tag, inject it immediately
                 // after the open tag.
-                // TODO: handle cases where explicit html/head are missing
-                if (remoteScript && node.tag === "head") {
+                if (remoteScript && !remoteScriptInserted && node.tag === "head") {
                     insertIndex = node.openEnd;
                     gen += orig.substr(lastIndex, insertIndex - lastIndex) + remoteScript;
                     lastIndex = insertIndex;
+                    remoteScriptInserted = true;
                 }
             }
             
@@ -803,6 +804,12 @@ define(function (require, exports, module) {
         walk(dom);
         gen += orig.substr(lastIndex);
         
+        if (remoteScript && !remoteScriptInserted) {
+            // if the remote script couldn't be injected before (e.g. due to missing "head" tag),
+            // append it at the end
+            gen += remoteScript;
+        }
+
         return gen;
     }
     

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/withoutHead.html
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/withoutHead.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="UTF-8">
+<title>Simple Test</title>
+<link rel="stylesheet" href="simpleShared.css">
+<link rel="stylesheet" href="simple1.css">
+
+<p id="testId" class="testClass">Brackets is awesome!</p>
+<p id ="testId2" class="testClass2" >Red is bad. Green is good.</p>

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -102,6 +102,19 @@ define(function (require, exports, module) {
                 });
             });
             
+            it("should establish a browser connection for an opened html file that has no 'head' tag", function () {
+                //open a file
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["withoutHead.html"]), "SpecRunnerUtils.openProjectFiles withoutHead.html", 1000);
+                });
+                
+                waitsForLiveDevelopmentToOpen();
+
+                runs(function () {
+                    expect(LiveDevelopment.status).toBe(LiveDevelopment.STATUS_ACTIVE);
+                });
+            });
+            
             it("should find an index.html in a parent directory", function () {
                 runs(function () {
                     waitsForDone(SpecRunnerUtils.openProjectFiles(["sub/test.css"]), "SpecRunnerUtils.openProjectFiles sub/test.css", 1000);


### PR DESCRIPTION
For MultiBrowser Live Preview. Fixes #10815.

I decided to append the remote script in this case. We can, of course, also prepend it.

cc @sebaslv @busykai 
