### PR TITLE
Use Ctrl+PageUp/PageDown to traverse files in list order

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "file.newDoc":  [
         "Ctrl-N"
     ],
@@ -317,6 +317,16 @@
         {
             "key": "Cmd-Shift-[",
             "platform": "mac"
+        }
+    ],
+    "navigate.nextDocListOrder":  [
+        {
+            "key": "Ctrl-PageDown"
+        }
+    ],
+    "navigate.prevDocListOrder":  [
+        {
+            "key": "Ctrl-PageUp"
         }
     ],
     "navigate.toggleQuickEdit":  [

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -121,6 +121,8 @@ define(function (require, exports, module) {
     // NAVIGATE
     exports.NAVIGATE_NEXT_DOC           = "navigate.nextDoc";           // DocumentCommandHandlers.js   handleGoNextDoc()
     exports.NAVIGATE_PREV_DOC           = "navigate.prevDoc";           // DocumentCommandHandlers.js   handleGoPrevDoc()
+    exports.NAVIGATE_NEXT_DOC_LIST_ORDER    = "navigate.nextDocListOrder";           // DocumentCommandHandlers.js   handleGoNextDocListOrder()
+    exports.NAVIGATE_PREV_DOC_LIST_ORDER    = "navigate.prevDocListOrder";           // DocumentCommandHandlers.js   handleGoPrevDocListOrder()
     exports.NAVIGATE_SHOW_IN_FILE_TREE  = "navigate.showInFileTree";    // DocumentCommandHandlers.js   handleShowInTree()
     exports.NAVIGATE_SHOW_IN_OS         = "navigate.showInOS";          // DocumentCommandHandlers.js   handleShowInOS()
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";         // QuickOpen.js                 doFileSearch()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -150,6 +150,8 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC);
+        menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC_LIST_ORDER);
+        menu.addMenuItem(Commands.NAVIGATE_PREV_DOC_LIST_ORDER);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_SHOW_IN_FILE_TREE);
         menu.addMenuDivider();

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1471,35 +1471,7 @@ define(function (require, exports, module) {
      */
     function findNextPrevDoc(inc, listOrder) {
         if (listOrder) {
-            var allFiles = MainViewManager.getWorkingSet(MainViewManager.ALL_PANES);
-            if (!allFiles.length) {
-                // No files in any working set, so we cannot switch to one
-                return null;
-            }
-
-            var curFile = MainViewManager.getCurrentlyViewedFile(),
-                curFileIndex = _.findIndex(allFiles, curFile);
-
-            curFileIndex += inc;
-            curFileIndex = (curFileIndex + allFiles.length) % allFiles.length;
-
-            var newFile = allFiles[curFileIndex],
-                paneId;
-
-            // Given the index, find the pane our file is in
-            MainViewManager.getPaneIdList().some(function (curPaneId) {
-                var workingSetSize = MainViewManager.getWorkingSetSize(curPaneId);
-                if (workingSetSize <= curFileIndex) {
-                    curFileIndex -= workingSetSize;
-                } else {
-                    paneId = curPaneId;
-                    return true; // break the loop now that we have our paneId
-                }
-            });
-            return {
-                file: newFile,
-                paneId: paneId
-            };
+            return MainViewManager.traverseToNextViewInListOrder(inc);
         } else {
             return MainViewManager.traverseToNextViewByMRU(inc);
         }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1463,27 +1463,18 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Finds the next/previous document in MRU or list order
-     * @param {!number} inc Delta indicating in which direction we're going
-     * @param {?boolean} listOrder Whether to navigate using MRU or list order. Defaults to MRU order
-     * @return {?{file:File, paneId:string}} The File object of the next item in the travesal order or null if there aren't any files to traverse.
-     *                                       May return current file if there are no other files to traverse.
-     */
-    function findNextPrevDoc(inc, listOrder) {
-        if (listOrder) {
-            return MainViewManager.traverseToNextViewInListOrder(inc);
-        } else {
-            return MainViewManager.traverseToNextViewByMRU(inc);
-        }
-    }
-
-    /**
      * Navigate to the next/previous (MRU or list order) document. Don't update MRU order yet
      * @param {!number} inc Delta indicating in which direction we're going
      * @param {?boolean} listOrder Whether to navigate using MRU or list order. Defaults to MRU order
      */
     function goNextPrevDoc(inc, listOrder) {
-        var result = findNextPrevDoc(inc, listOrder);
+        var result;
+        if (listOrder) {
+            result = MainViewManager.traverseToNextViewInListOrder(inc);
+        } else {
+            result = MainViewManager.traverseToNextViewByMRU(inc);
+        }
+
         if (result) {
             var file = result.file,
                 paneId = result.paneId;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1462,9 +1462,56 @@ define(function (require, exports, module) {
         }
     }
 
-    /** Navigate to the next/previous (MRU) document. Don't update MRU order yet */
-    function goNextPrevDoc(inc) {
-        var result = MainViewManager.traverseToNextViewByMRU(inc);
+    /**
+     * Finds the next/previous document in MRU or list order
+     * @param {!number} inc Delta indicating in which direction we're going
+     * @param {?boolean} listOrder Whether to navigate using MRU or list order. Defaults to MRU order
+     * @return {?{file:File, paneId:string}} The File object of the next item in the travesal order or null if there aren't any files to traverse.
+     *                                       May return current file if there are no other files to traverse.
+     */
+    function findNextPrevDoc(inc, listOrder) {
+        if (listOrder) {
+            var allFiles = MainViewManager.getWorkingSet(MainViewManager.ALL_PANES);
+            if (!allFiles.length) {
+                // No files in any working set, so we cannot switch to one
+                return null;
+            }
+
+            var curFile = MainViewManager.getCurrentlyViewedFile(),
+                curFileIndex = _.findIndex(allFiles, curFile);
+
+            curFileIndex += inc;
+            curFileIndex = (curFileIndex + allFiles.length) % allFiles.length;
+
+            var newFile = allFiles[curFileIndex],
+                paneId;
+
+            // Given the index, find the pane our file is in
+            MainViewManager.getPaneIdList().some(function (curPaneId) {
+                var workingSetSize = MainViewManager.getWorkingSetSize(curPaneId);
+                if (workingSetSize <= curFileIndex) {
+                    curFileIndex -= workingSetSize;
+                } else {
+                    paneId = curPaneId;
+                    return true; // break the loop now that we have our paneId
+                }
+            });
+            return {
+                file: newFile,
+                paneId: paneId
+            };
+        } else {
+            return MainViewManager.traverseToNextViewByMRU(inc);
+        }
+    }
+
+    /**
+     * Navigate to the next/previous (MRU or list order) document. Don't update MRU order yet
+     * @param {!number} inc Delta indicating in which direction we're going
+     * @param {?boolean} listOrder Whether to navigate using MRU or list order. Defaults to MRU order
+     */
+    function goNextPrevDoc(inc, listOrder) {
+        var result = findNextPrevDoc(inc, listOrder);
         if (result) {
             var file = result.file,
                 paneId = result.paneId;
@@ -1481,14 +1528,24 @@ define(function (require, exports, module) {
         }
     }
 
-    /** Next Doc command handler **/
+    /** Next Doc command handler (MRU order) **/
     function handleGoNextDoc() {
         goNextPrevDoc(+1);
-
     }
-    /** Previous Doc command handler **/
+
+    /** Previous Doc command handler (MRU order) **/
     function handleGoPrevDoc() {
         goNextPrevDoc(-1);
+    }
+
+    /** Next Doc command handler (list order) **/
+    function handleGoNextDocListOrder() {
+        goNextPrevDoc(+1, true);
+    }
+
+    /** Previous Doc command handler (list order) **/
+    function handleGoPrevDocListOrder() {
+        goNextPrevDoc(-1, true);
     }
 
     /** Show in File Tree command handler **/
@@ -1724,6 +1781,9 @@ define(function (require, exports, module) {
     // Traversal
     CommandManager.register(Strings.CMD_NEXT_DOC,                    Commands.NAVIGATE_NEXT_DOC,              handleGoNextDoc);
     CommandManager.register(Strings.CMD_PREV_DOC,                    Commands.NAVIGATE_PREV_DOC,              handleGoPrevDoc);
+
+    CommandManager.register(Strings.CMD_NEXT_DOC_LIST_ORDER,         Commands.NAVIGATE_NEXT_DOC_LIST_ORDER,   handleGoNextDocListOrder);
+    CommandManager.register(Strings.CMD_PREV_DOC_LIST_ORDER,         Commands.NAVIGATE_PREV_DOC_LIST_ORDER,   handleGoPrevDocListOrder);
 
     // Special Commands
     CommandManager.register(showInOS,                                Commands.NAVIGATE_SHOW_IN_OS,            handleShowInOS);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -402,6 +402,8 @@ define({
     "CMD_CSS_QUICK_EDIT_NEW_RULE"         : "New Rule",
     "CMD_NEXT_DOC"                        : "Next Document",
     "CMD_PREV_DOC"                        : "Previous Document",
+    "CMD_NEXT_DOC_LIST_ORDER"             : "Next Document (List Order)",
+    "CMD_PREV_DOC_LIST_ORDER"             : "Previous Document (List Order)",
     "CMD_SHOW_IN_TREE"                    : "Show in File Tree",
     "CMD_SHOW_IN_EXPLORER"                : "Show in Explorer",
     "CMD_SHOW_IN_FINDER"                  : "Show in Finder",

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -25,12 +25,12 @@
 /*global define, $ */
 
 /**
- * MainViewManager Manages the arrangement of all open panes as well as provides the controller
+ * MainViewManager manages the arrangement of all open panes as well as provides the controller
  * logic behind all views in the MainView (e.g. ensuring that a file doesn't appear in 2 lists)
  *
  * Each pane contains one or more views wich are created by a view factory and inserted into a pane list. 
- * There may be several panes managed  by the MainViewManager with each pane containing a list of views.  
- * The panes are always visible and  the layout is determined by the MainViewManager and the user.  
+ * There may be several panes managed by the MainViewManager with each pane containing a list of views.
+ * The panes are always visible and the layout is determined by the MainViewManager and the user.
  *
  * Currently we support only 2 panes.
  *
@@ -354,7 +354,7 @@ define(function (require, exports, module) {
 
     /**
      * Makes the Pane's current file the most recent
-     * @param {!string} paneId - id of the pane to mae th file most recent or ACTIVE_PANE
+     * @param {!string} paneId - id of the pane to make the file most recent, or ACTIVE_PANE
      * @param {!File} file - File object to make most recent
      * @private
      */
@@ -367,7 +367,7 @@ define(function (require, exports, module) {
     }
     
     /**
-     * Switch active pane to the specified pane Id (or ACTIVE_PANE/ALL_PANES, in which case this
+     * Switch active pane to the specified pane id (or ACTIVE_PANE/ALL_PANES, in which case this
      * call does nothing).
      * @param {!string} paneId - the id of the pane to activate
      */
@@ -515,7 +515,7 @@ define(function (require, exports, module) {
         
     
     /**
-     * Retrieves the WorkingSet for the given PaneId not including temporary views
+     * Retrieves the WorkingSet for the given paneId not including temporary views
      * @param {!string} paneId - id of the pane in which to get the view list, ALL_PANES or ACTIVE_PANE
      * @return {Array.<File>}
      */
@@ -532,7 +532,7 @@ define(function (require, exports, module) {
     
     
     /**
-     * Retrieves the list of all open files inlcuding temporary views
+     * Retrieves the list of all open files including temporary views
      * @return {array.<File>} the list of all open files in all open panes
      */
     function getAllOpenFiles() {
@@ -916,8 +916,8 @@ define(function (require, exports, module) {
     /**
      * Get the next or previous file in the MRU list.
      * @param {!number} direction - Must be 1 or -1 to traverse forward or backward
-     * @return {?{file:File, paneId:string}} The File object of the next item in the travesal order or null if there aren't any files to traverse.
-     *                                        may return current file if there are no other files to traverse.
+     * @return {?{file:File, paneId:string}} The File object of the next item in the traversal order or null if there aren't any files to traverse.
+     *                                       May return current file if there are no other files to traverse.
      */
     function traverseToNextViewByMRU(direction) {
         var file = getCurrentlyViewedFile(),

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -930,6 +930,32 @@ define(function (require, exports, module) {
     }
     
     /**
+     * Get the next or previous file in list order.
+     * @param {!number} direction - Must be 1 or -1 to traverse forward or backward
+     * @return {?{file:File, paneId:string}} The File object of the next item in the traversal order or null if there aren't any files to traverse.
+     *                                       May return current file if there are no other files to traverse.
+     */
+    function traverseToNextViewInListOrder(direction) {
+        var file = getCurrentlyViewedFile(),
+            curPaneId = getActivePaneId(),
+            allFiles = [],
+            index;
+
+        getPaneIdList().forEach(function (paneId) {
+            var paneFiles = getWorkingSet(paneId).map(function (file) {
+                return { file: file, pane: paneId };
+            });
+            allFiles = allFiles.concat(paneFiles);
+        });
+
+        index = _.findIndex(allFiles, function (record) {
+            return (record.file === file && record.pane === curPaneId);
+        });
+
+        return ViewUtils.traverseViewArray(allFiles, index, direction);
+    }
+
+    /**
      * Indicates that traversal has begun. 
      * Can be called any number of times.
      */
@@ -1726,6 +1752,7 @@ define(function (require, exports, module) {
     exports.beginTraversal                = beginTraversal;
     exports.endTraversal                  = endTraversal;
     exports.traverseToNextViewByMRU       = traverseToNextViewByMRU;
+    exports.traverseToNextViewInListOrder = traverseToNextViewInListOrder;
     
     // PaneView Attributes
     exports.getActivePaneId               = getActivePaneId;

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -1042,6 +1042,25 @@ define(function (require, exports, module) {
                     expect(traverseResult.pane).toEqual("first-pane");
                 });
             });
+
+            it("should traverse between panes in reverse list order", function () {
+                runs(function () {
+                    // Make test.js the active file
+                    promise = new $.Deferred();
+                    DocumentManager.getDocumentForPath(testPath + "/test.js")
+                        .done(function (doc) {
+                            MainViewManager._edit("first-pane", doc);
+                            promise.resolve();
+                        });
+                    waitsForDone(promise, "MainViewManager._edit");
+                });
+                runs(function () {
+                    var traverseResult = MainViewManager.traverseToNextViewInListOrder(-1);
+
+                    expect(traverseResult.file).toEqual(getFileObject("test.html"));
+                    expect(traverseResult.pane).toEqual("second-pane");
+                });
+            });
         });
     });
 });

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -969,5 +969,78 @@ define(function (require, exports, module) {
                 });
             });
         });
+        
+        describe("Traversing Files", function () {
+            beforeEach(function () {
+                runs(function () {
+                    MainViewManager.setLayoutScheme(1, 2);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.js",
+                                                                            paneId: "first-pane" });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.css",
+                                                                            paneId: "first-pane" });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.html",
+                                                                            paneId: "second-pane" });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+                runs(function () {
+                    MainViewManager.addToWorkingSet("first-pane", getFileObject("test.js"));
+                    MainViewManager.addToWorkingSet("first-pane", getFileObject("test.css"));
+                    MainViewManager.addToWorkingSet("second-pane", getFileObject("test.html"));
+                });
+            });
+            
+            it("should traverse in list order", function () {
+                runs(function () {
+                    MainViewManager.setActivePaneId("first-pane");
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.js",
+                                                                            paneId: "first-pane" });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+                runs(function () {
+                    var traverseResult = MainViewManager.traverseToNextViewInListOrder(1);
+                    
+                    expect(traverseResult.file).toEqual(getFileObject("test.css"));
+                    expect(traverseResult.pane).toEqual("first-pane");
+                });
+            });
+            
+            it("should traverse between panes in list order", function () {
+                runs(function () {
+                    MainViewManager.setActivePaneId("second-pane");
+                    
+                    var traverseResult = MainViewManager.traverseToNextViewInListOrder(1);
+                    
+                    expect(traverseResult.file).toEqual(getFileObject("test.js"));
+                    expect(traverseResult.pane).toEqual("first-pane");
+                });
+            });
+            
+            it("should traverse to the first Working Set item if a file not in the Working Set is being viewed", function () {
+                runs(function () {
+                    CommandManager.execute(Commands.FILE_CLOSE, { file: getFileObject("test.js") });
+                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.js",
+                                                                            paneId: "first-pane" });
+                    waitsForDone(promise, Commands.FILE_OPEN);
+                });
+                runs(function () {
+                    MainViewManager.setActivePaneId("first-pane");
+                    
+                    var traverseResult = MainViewManager.traverseToNextViewInListOrder(1);
+                    
+                    expect(traverseResult.file).toEqual(getFileObject("test.css"));
+                    expect(traverseResult.pane).toEqual("first-pane");
+                });
+            });
+        });
     });
 });

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -999,12 +999,14 @@ define(function (require, exports, module) {
             
             it("should traverse in list order", function () {
                 runs(function () {
-                    MainViewManager.setActivePaneId("first-pane");
-                });
-                runs(function () {
-                    promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.js",
-                                                                            paneId: "first-pane" });
-                    waitsForDone(promise, Commands.FILE_OPEN);
+                    // Make test.js the active file
+                    promise = new $.Deferred();
+                    DocumentManager.getDocumentForPath(testPath + "/test.js")
+                        .done(function (doc) {
+                            MainViewManager._edit("first-pane", doc);
+                            promise.resolve();
+                        });
+                    waitsForDone(promise, "MainViewManager._edit");
                 });
                 runs(function () {
                     var traverseResult = MainViewManager.traverseToNextViewInListOrder(1);
@@ -1016,8 +1018,6 @@ define(function (require, exports, module) {
             
             it("should traverse between panes in list order", function () {
                 runs(function () {
-                    MainViewManager.setActivePaneId("second-pane");
-                    
                     var traverseResult = MainViewManager.traverseToNextViewInListOrder(1);
                     
                     expect(traverseResult.file).toEqual(getFileObject("test.js"));
@@ -1027,6 +1027,7 @@ define(function (require, exports, module) {
             
             it("should traverse to the first Working Set item if a file not in the Working Set is being viewed", function () {
                 runs(function () {
+                    // Close test.js to then reopen it without being in the Working Set
                     CommandManager.execute(Commands.FILE_CLOSE, { file: getFileObject("test.js") });
                     promise = CommandManager.execute(Commands.FILE_OPEN,  { fullPath: testPath + "/test.js",
                                                                             paneId: "first-pane" });


### PR DESCRIPTION
For #6273.

This adds a shortcut (Ctrl/Cmd + PageUp/PageDown) to traverse your open files (in all panes) in list order. The shortcut itself is pretty much universal and I found it working like this in Google Chrome, Sublime Text 3 and Notepad++ (all on Windows).
If users want, they can remap the existing Ctrl + (Shift) + Tab shortcuts to invoke these new commands.

The command goes through all panes (unlike @peterflynn's extension).

cc @peterflynn (you wrote the original extension) @fgimian (you made me do this)
