### PR TITLE
Enable stylus support

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -33,6 +33,14 @@
         "lineComment": ["//"]
     },
 
+    "stylus": {
+        "name": "Stylus",
+        "mode": ["stylus", "text/x-styl"],
+        "fileExtensions": ["styl"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
     "html": {
         "name": "HTML",
         "mode": ["htmlmixed", "text/x-brackets-html"],


### PR DESCRIPTION
Enables stylus mode which is now part of CodeMirror that is shipped with Brackets.
