### PR TITLE
Make it possible to set languages defined by an extension as default …

### DIFF
--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -134,6 +134,7 @@ define(function (require, exports, module) {
     // Dependencies
     var CodeMirror            = require("thirdparty/CodeMirror/lib/codemirror"),
         EventDispatcher       = require("utils/EventDispatcher"),
+        AppInit               = require("utils/AppInit"),
         Async                 = require("utils/Async"),
         FileUtils             = require("file/FileUtils"),
         Strings               = require("strings"),
@@ -1168,6 +1169,11 @@ define(function (require, exports, module) {
             });
             _updateFromPrefs(_EXTENSION_MAP_PREF);
             _updateFromPrefs(_NAME_MAP_PREF);
+
+            AppInit.extensionsLoaded(function () {
+                _updateFromPrefs(_EXTENSION_MAP_PREF);
+                _updateFromPrefs(_NAME_MAP_PREF);
+            });
         });
     });
     

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1042,11 +1042,22 @@ define(function (require, exports, module) {
      */
     function _updateFromPrefs(pref) {
         var newMapping = PreferencesManager.get(pref),
-            newNames = Object.keys(newMapping),
+            newNames,
             state = _prefState[pref],
             last = state.last,
             overridden = state.overridden;
         
+        // Filter out the languages that are not (yet) defined.
+        // Important to be able to add extensions to languages defined by extensions.
+        newMapping = _.reduce(newMapping, function (result, languageId, ext) {
+            if (getLanguage(languageId)) {
+                result[ext] = languageId;
+            }
+            return result;
+        }, {});
+
+        newNames = Object.keys(newMapping);
+
         // Look for added and changed names (extensions or filenames)
         newNames.forEach(function (name) {
             var language;

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -134,7 +134,6 @@ define(function (require, exports, module) {
     // Dependencies
     var CodeMirror            = require("thirdparty/CodeMirror/lib/codemirror"),
         EventDispatcher       = require("utils/EventDispatcher"),
-        AppInit               = require("utils/AppInit"),
         Async                 = require("utils/Async"),
         FileUtils             = require("file/FileUtils"),
         Strings               = require("strings"),
@@ -178,6 +177,10 @@ define(function (require, exports, module) {
         remove: "removeFileName",
         get: "getLanguageForPath"
     };
+    
+    // Set to true after the preference mappings have been loaded.
+    // All languages registered afterwards need to also call _updateFromPrefs again.
+    var prefsLoaded = false;
     
     // Helper functions
     
@@ -433,6 +436,110 @@ define(function (require, exports, module) {
             }
         }
         return extension.join(".");
+    }
+    
+    /**
+     * @private
+     * 
+     * If a default file extension or name was overridden by a pref, restore it.
+     * 
+     * @param {string} name Extension or filename that should be restored
+     * @param {{overridden: string, add: string}} prefState object for the pref that is currently being updated
+     */
+    function _restoreOverriddenDefault(name, state) {
+        if (state.overridden[name]) {
+            var language = getLanguage(state.overridden[name]);
+            language[state.add](name);
+            delete state.overridden[name];
+        }
+    }
+    
+    /**
+     * @private
+     * 
+     * Updates extension and filename mappings from languages based on the current preferences values.
+     * 
+     * The preferences look like this in a prefs file:
+     * 
+     * Map *.foo to javascript, *.vm to html
+     * 
+     *     "language.fileExtensions": {
+     *         "foo": "javascript",
+     *         "vm": "html"
+     *     }
+     * 
+     * Map "Gemfile" to ruby:
+     * 
+     *     "language.fileNames": {
+     *         "Gemfile": "ruby"
+     *     }
+     */
+    function _updateFromPrefs(pref) {
+        if (!pref) {
+            // When called without a pref defined, update from both the extension map and name map
+            _updateFromPrefs(_EXTENSION_MAP_PREF);
+            _updateFromPrefs(_NAME_MAP_PREF);
+            return;
+        }
+        
+        var newMapping = PreferencesManager.get(pref),
+            newNames,
+            state = _prefState[pref],
+            last = state.last,
+            overridden = state.overridden;
+        
+        // Filter out the languages that are not (yet) defined.
+        // Important to be able to add extensions to languages defined by extensions.
+        newMapping = _.reduce(newMapping, function (result, languageId, ext) {
+            if (getLanguage(languageId)) {
+                result[ext] = languageId;
+            }
+            return result;
+        }, {});
+
+        newNames = Object.keys(newMapping);
+
+        // Look for added and changed names (extensions or filenames)
+        newNames.forEach(function (name) {
+            var language;
+            if (newMapping[name] !== last[name]) {
+                if (last[name]) {
+                    language = getLanguage(last[name]);
+                    if (language) {
+                        language[state.remove](name);
+                        
+                        // If this name that was previously mapped was overriding a default
+                        // restore it now.
+                        _restoreOverriddenDefault(name, state);
+                    }
+                }
+                
+                language = exports[state.get](name);
+                if (language) {
+                    language[state.remove](name);
+                    
+                    // We're removing a name that was defined in Brackets or an extension,
+                    // so keep track of how it used to be mapped.
+                    if (!overridden[name]) {
+                        overridden[name] = language.getId();
+                    }
+                }
+                language = getLanguage(newMapping[name]);
+                if (language) {
+                    language[state.add](name);
+                }
+            }
+        });
+        
+        // Look for removed names (extensions or filenames)
+        _.difference(Object.keys(last), newNames).forEach(function (name) {
+            var language = getLanguage(last[name]);
+            if (language) {
+                language[state.remove](name);
+                _restoreOverriddenDefault(name, state);
+            }
+        });
+        state.last = newMapping;
     }
 
     
@@ -960,6 +1067,11 @@ define(function (require, exports, module) {
             
             // store language to language map
             _languages[language.getId()] = language;
+            
+            if (prefsLoaded) {
+                // Language mappings have already been loaded, so update them
+                _updateFromPrefs();
+            }
         }
         
         if (!language._setId(id) || !language._setName(name) ||
@@ -1003,103 +1115,6 @@ define(function (require, exports, module) {
         }
         
         return result.promise();
-    }
-    
-    /**
-     * @private
-     * 
-     * If a default file extension or name was overridden by a pref, restore it.
-     * 
-     * @param {string} name Extension or filename that should be restored
-     * @param {{overridden: string, add: string}} prefState object for the pref that is currently being updated
-     */
-    function _restoreOverriddenDefault(name, state) {
-        if (state.overridden[name]) {
-            var language = getLanguage(state.overridden[name]);
-            language[state.add](name);
-            delete state.overridden[name];
-        }
-    }
-    
-    /**
-     * @private
-     * 
-     * Updates extension and filename mappings from languages based on the current preferences values.
-     * 
-     * The preferences look like this in a prefs file:
-     * 
-     * Map *.foo to javascript, *.vm to html
-     * 
-     *     "language.fileExtensions": {
-     *         "foo": "javascript",
-     *         "vm": "html"
-     *     }
-     * 
-     * Map "Gemfile" to ruby:
-     * 
-     *     "language.fileNames": {
-     *         "Gemfile": "ruby"
-     *     }
-     */
-    function _updateFromPrefs(pref) {
-        var newMapping = PreferencesManager.get(pref),
-            newNames,
-            state = _prefState[pref],
-            last = state.last,
-            overridden = state.overridden;
-        
-        // Filter out the languages that are not (yet) defined.
-        // Important to be able to add extensions to languages defined by extensions.
-        newMapping = _.reduce(newMapping, function (result, languageId, ext) {
-            if (getLanguage(languageId)) {
-                result[ext] = languageId;
-            }
-            return result;
-        }, {});
-
-        newNames = Object.keys(newMapping);
-
-        // Look for added and changed names (extensions or filenames)
-        newNames.forEach(function (name) {
-            var language;
-            if (newMapping[name] !== last[name]) {
-                if (last[name]) {
-                    language = getLanguage(last[name]);
-                    if (language) {
-                        language[state.remove](name);
-                        
-                        // If this name that was previously mapped was overriding a default
-                        // restore it now.
-                        _restoreOverriddenDefault(name, state);
-                    }
-                }
-                
-                language = exports[state.get](name);
-                if (language) {
-                    language[state.remove](name);
-                    
-                    // We're removing a name that was defined in Brackets or an extension,
-                    // so keep track of how it used to be mapped.
-                    if (!overridden[name]) {
-                        overridden[name] = language.getId();
-                    }
-                }
-                language = getLanguage(newMapping[name]);
-                if (language) {
-                    language[state.add](name);
-                }
-            }
-        });
-        
-        // Look for removed names (extensions or filenames)
-        _.difference(Object.keys(last), newNames).forEach(function (name) {
-            var language = getLanguage(last[name]);
-            if (language) {
-                language[state.remove](name);
-                _restoreOverriddenDefault(name, state);
-            }
-        });
-        state.last = newMapping;
     }
     
    
@@ -1167,13 +1182,9 @@ define(function (require, exports, module) {
             }).on("change", function () {
                 _updateFromPrefs(_NAME_MAP_PREF);
             });
-            _updateFromPrefs(_EXTENSION_MAP_PREF);
-            _updateFromPrefs(_NAME_MAP_PREF);
-
-            AppInit.extensionsLoaded(function () {
-                _updateFromPrefs(_EXTENSION_MAP_PREF);
-                _updateFromPrefs(_NAME_MAP_PREF);
-            });
+            _updateFromPrefs();
+            
+            prefsLoaded = true;
         });
     });
     

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -31,7 +31,6 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
-        AppInit             = require("utils/AppInit"),
         LanguageManager     = require("language/LanguageManager"),
         SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         PreferencesManager  = require("preferences/PreferencesManager");
@@ -859,10 +858,9 @@ define(function (require, exports, module) {
                 });
                 var language = LanguageManager.getLanguageForExtension("test");
                 expect(language).toBeUndefined();
-                defineLanguage({ id: "six", name: "Six", mode: ["null", "text/plain"] });
                 
-                // simulate an extensionsLoaded event, which causes LanguageManager to reload its mapping
-                AppInit._dispatchReady(AppInit.EXTENSIONS_LOADED);
+                // This defineLanguage is enough to re-read the preferences and update the mappings
+                defineLanguage({ id: "six", name: "Six", mode: ["null", "text/plain"] });
                 
                 language = LanguageManager.getLanguageForExtension("test");
                 expect(language.getId()).toBe("six");

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
     
     // Load dependent modules
     var CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
+        AppInit             = require("utils/AppInit"),
         LanguageManager     = require("language/LanguageManager"),
         SpecRunnerUtils     = require("spec/SpecRunnerUtils"),
         PreferencesManager  = require("preferences/PreferencesManager");
@@ -850,6 +851,21 @@ define(function (require, exports, module) {
                 PreferencesManager.set(LanguageManager._NAME_MAP_PREF, { });
                 language = LanguageManager.getLanguageForPath("Gemfile");
                 expect(language.getId()).toBe("ruby");
+            });
+            
+            it("should manage languages which are not defined yet", function () {
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, {
+                    test: "six"
+                });
+                var language = LanguageManager.getLanguageForExtension("test");
+                expect(language).toBeUndefined();
+                defineLanguage({ id: "six", name: "Six", mode: ["null", "text/plain"] });
+                
+                // simulate an extensionsLoaded event, which causes LanguageManager to reload its mapping
+                AppInit._dispatchReady(AppInit.EXTENSIONS_LOADED);
+                
+                language = LanguageManager.getLanguageForExtension("test");
+                expect(language.getId()).toBe("six");
             });
         });
 


### PR DESCRIPTION
…for a file extension

Filtering out languages which are not currently defined (because they are probably defined by an extension later on) fixes the case described in #11252.

[Already done] ~~Currently, it seems to be working _miraculously_ as the pref change handler fires late enough, but I think I should add an additional `AppInit.extensionsLoaded` callback just to be safe. (Does anyone know why the change handler is called so late? I don't think that's the intended behavior...)~~
