### PR TITLE
Allow JavaScript Code Hints only in its context

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -56,6 +56,8 @@ define(function (require, exports, module) {
         noHintsOnDot   = false, // preference setting to prevent hints on dot
         ignoreChange;           // can ignore next "change" event if true;
 
+    // Languages that support inline JavaScript
+    var _inlineScriptLanguages = ["html", "php"];
     
     // Define the detectedExclusions which are files that have been detected to cause Tern to run out of control.
     PreferencesManager.definePreference("jscodehints.detectedExclusions", "array", [], {
@@ -341,10 +343,11 @@ define(function (require, exports, module) {
     };
 
     /**
-     * @return {boolean} - true if the document is a html file
+     * @return {boolean} - true if the document supports inline JavaScript
      */
-    function isHTMLFile(document) {
-        return LanguageManager.getLanguageForPath(document.file.fullPath).getId() === "html";
+    function isInlineScriptSupported(document) {
+        var language = LanguageManager.getLanguageForPath(document.file.fullPath).getId();
+        return _inlineScriptLanguages.indexOf(language) !== -1;
     }
     
     function isInlineScript(editor) {
@@ -442,7 +445,7 @@ define(function (require, exports, module) {
     JSHints.prototype.hasHints = function (editor, key) {
         if (session && HintUtils.hintableKey(key, !noHintsOnDot)) {
             
-            if (isHTMLFile(session.editor.document)) {
+            if (isInlineScriptSupported(session.editor.document)) {
                 if (!isInlineScript(session.editor)) {
                     return false;
                 }


### PR DESCRIPTION
Fixes a regression I made in #11245 where JavaScript code hints were globally available in a PHP document. This will make sure they are only available inside `script` tags.
