### PR TITLE
Add CodeMirror simple-mode addon

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -52,6 +52,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/fold/xml-fold");
     require("thirdparty/CodeMirror/addon/mode/multiplex");
     require("thirdparty/CodeMirror/addon/mode/overlay");
+    require("thirdparty/CodeMirror/addon/mode/simple");
     require("thirdparty/CodeMirror/addon/scroll/scrollpastend");
     require("thirdparty/CodeMirror/addon/search/match-highlighter");
     require("thirdparty/CodeMirror/addon/search/searchcursor");


### PR DESCRIPTION
Allows extension developers to use CodeMirror's simple mode addon. Fixes #11267 and #10501 
