### PR TITLE
Replace the URL in URLCodeHints even if it is the current content of …

### DIFF
--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -752,8 +752,6 @@ define(function (require, exports, module) {
                 } else if (tagInfo.position.offset === 0) {
                     completion = "\"" + completion + "\"";
                 }
-            } else if (completion === tagInfo.attr.value) {
-                shouldReplace = false;
             }
 
             if (shouldReplace) {

--- a/src/extensions/default/UrlCodeHints/testfiles/test.html
+++ b/src/extensions/default/UrlCodeHints/testfiles/test.html
@@ -23,5 +23,6 @@ body {
   <a href='/'>Site-root relative: root folder</a>
   <a href='test2.html'>Results</a>
   <video poster=''>Results</video>
+  <img src='subfolder/chevron.png'>
 </body>
 </html>

--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -620,6 +620,34 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should completely replace file in HTML", function () {
+                var pos1    = { line: 25, ch: 11 },
+                    pos2    = { line: 25, ch: 27 },
+                    pos3    = { line: 25, ch: 34 };
+
+                runs(function () {
+                    testEditor.setCursorPos(pos2);
+                    hintsObj = null;
+                    expectAsyncHints(UrlCodeHints.hintProvider);
+                });
+
+                runs(function () {
+                    expect(hintsObj).toBeTruthy();
+                    expect(hintsObj.hints).toBeTruthy();
+                    expect(hintsObj.hints.length).toBe(1);
+                    expect(hintsObj.hints[0]).toBe("subfolder/chevron.png");
+
+                    // False indicates hints were closed after insertion
+                    expect(UrlCodeHints.hintProvider.insertHint(hintsObj.hints[0])).toBe(false);
+
+                    // File name was completely replaced, not just appended to
+                    expect(testDocument.getRange(pos1, pos3)).toEqual("'subfolder/chevron.png'");
+
+                    // Cursor was moved past closing single-quote
+                    expect(testEditor.getCursorPos()).toEqual(pos3);
+                });
+            });
+
             it("should insert filtered folder in HTML", function () {
                 var pos1    = { line: 23, ch: 11 },
                     pos2    = { line: 23, ch: 14 },


### PR DESCRIPTION
…the attr

Fixes #11087. Turns out we already do what @redmunds [described in his comment](https://github.com/adobe/brackets/issues/11087#issuecomment-112203940), but only if the hinted file name is not equal to the current value.

@redmunds It looks like you added this extra condition [on purpose](https://github.com/adobe/brackets/commit/04d518efac55436a5ad7e5333d6e72e6693c1e34#diff-7d9ea0ab85fe015d47a5e38310b31226R425). Do you recall on why you did that? Was there a specific case which this was supposed to fix?

cc @redmunds 
