### PR TITLE
Add grunt task to check for correct nls keys

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -320,7 +320,7 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config', 'less']);
 
     // task: test
-    grunt.registerTask('test', ['jshint', 'jasmine']);
+    grunt.registerTask('test', ['jshint', 'jasmine', 'nls-check']);
 //    grunt.registerTask('test', ['jshint', 'jasmine', 'jasmine_node']);
 
     // task: set-release

--- a/src/nls/da/strings.js
+++ b/src/nls/da/strings.js
@@ -135,8 +135,6 @@ define({
     "BUTTON_NO"                         : "Nej",
         
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} resultater",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 resultat",
     "FIND_NO_RESULTS"                   : "Ingen resultater",
     "FIND_QUERY_PLACEHOLDER"            : "Søg\u2026",
     "REPLACE_PLACEHOLDER"               : "Erstat med\u2026",
@@ -327,11 +325,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Tilføj næste forekomst til markeringer",
     "CMD_SKIP_CURRENT_MATCH"              : "Spring over og tilføj næste forekomst",
     "CMD_FIND_IN_FILES"                   : "Søg i filer",
-    "CMD_FIND_IN_SELECTED"                : "Søg i valgte fil/mappe",
     "CMD_FIND_IN_SUBTREE"                 : "Søg i\u2026",
     "CMD_REPLACE"                         : "Erstat",
     "CMD_REPLACE_IN_FILES"                : "Erstat i filer",
-    "CMD_REPLACE_IN_SELECTED"             : "Erstat i valgte fil/mappe",
     "CMD_REPLACE_IN_SUBTREE"              : "Erstat i\u2026",
     
     // View menu commands
@@ -348,10 +344,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Tekstombrydning",
     "CMD_LIVE_HIGHLIGHT"                  : "Fremhæv i Live-Forhåndsvisning",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Lint filer når de gemmes",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sortér efter tilføjelse",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Sortér efter navn",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sortér efter type",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatisk sortering",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Sortér efter tilføjelse",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Sortér efter navn",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Sortér efter type",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatisk sortering",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navigér",

--- a/src/nls/el/strings.js
+++ b/src/nls/el/strings.js
@@ -60,7 +60,6 @@ define({
     "ERROR_DELETING_FILE"               : "Σφάλμα προέκυψε κατά τη διαδικασία διαγραφής του αρχείου <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Μη έγκυρο {0} όνομα",
     "INVALID_FILENAME_MESSAGE"          : "Τα όνομα αρχείων δεν μπορούν να περιέχουν τους ακόλουθους χαρακτήρες: {0} ή οποιεσδήποτε system reserved λέξεις.",
-    "FILE_ALREADY_EXISTS"               : "Το {0} <span class='dialog-filename'>{1}</span> υπάρχει ήδη.",
     "ERROR_CREATING_FILE_TITLE"         : "Σφάλμα δημιουργίας {0}",
     "ERROR_CREATING_FILE"               : "Σφάλμα προέκυψε κατά τη διαδικασία δημιουργίας του {0} <span class='dialog-filename'>{1}</span>. {2}",
 
@@ -111,15 +110,10 @@ define({
     "EXT_DELETED_MESSAGE"               : "Το <span class='dialog-filename'>{0}</span> έχει διαγραφεί στον δίσκο, αλλά έχει μη αποθηκευμένες αλλαγές στο {APP_NAME}.<br /><br />Θέλετε να κρατήσετε τις αλλαγές σας;",
     
     // Find, Replace, Find in Files
-    "SEARCH_REGEXP_INFO"                : "Χρησιμοποιήστε την σύνταξη /re/ για αναζήτηση regexp",
-    "FIND_RESULT_COUNT"                 : "{0} αποτελέσματα",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 αποτέλεσμα",
     "FIND_NO_RESULTS"                   : "Δεν βρέθηκαν αποτελέσματα",
-    "WITH"                              : "Με",
     "BUTTON_YES"                        : "Ναι",
     "BUTTON_NO"                         : "Όχι",
     "BUTTON_REPLACE_ALL"                : "Όλα\u2026",
-    "BUTTON_STOP"                       : "Διακοπή",
     "BUTTON_REPLACE"                    : "Αντικατάσταση",
             
     "BUTTON_NEXT"                       : "\u25B6",
@@ -135,13 +129,6 @@ define({
     "NO_UPDATE_TITLE"                   : "Έχετε την τελευταία έκδοση!",
     "NO_UPDATE_MESSAGE"                 : "Τρέχετε την τελευταία έκδοση του {APP_NAME}.",
 
-    "FIND_REPLACE_TITLE_PART1"          : "Αντικατάσταση \"",
-    "FIND_REPLACE_TITLE_PART2"          : "\" με \"",
-    "FIND_REPLACE_TITLE_PART3"          : "\" &mdash; {2} {0} {1}",
-
-    "FIND_IN_FILES_TITLE_PART1"         : "\"",
-    "FIND_IN_FILES_TITLE_PART2"         : "\" βρέθηκε",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} in {3} {4}",
     "FIND_IN_FILES_SCOPED"              : "στο <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "στο project",
     "FIND_IN_FILES_FILE"                : "αρχείο",
@@ -186,9 +173,6 @@ define({
     "STATUSBAR_LINE_COUNT_PLURAL"           : "\u2014 {0} Γραμμές",
 
     // CodeInspection: errors/warnings
-    "ERRORS_PANEL_TITLE"                    : "{0} Σφάλματα",
-    "ERRORS_PANEL_TITLE_SINGLE"             : "{0} Προβλήματα",
-    "ERRORS_PANEL_TITLE_MULTI"              : "Lint Προβλήματα",
     "SINGLE_ERROR"                          : "1 {0} Σφάλμα",
     "MULTIPLE_ERRORS"                       : "{1} {0} Σφάλματα",
     "NO_ERRORS"                             : "Καθόλου {0} σφάλματα - καλή δουλειά!",
@@ -272,10 +256,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Αναδίπλωση Λέξης",
     "CMD_LIVE_HIGHLIGHT"                  : "Επισήμανση Live Preview",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Lint Αρχείων κατά την Αποθήκευση",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Ταξινόμηση κατά Σειρά Προσθήκης",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Ταξινόμηση κατά Όνομα",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ταξινόμηση κατά Τύπο",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Αυτόματη Ταξινόμηση",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Ταξινόμηση κατά Σειρά Προσθήκης",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Ταξινόμηση κατά Όνομα",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Ταξινόμηση κατά Τύπο",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Αυτόματη Ταξινόμηση",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Πλοήγηση",
@@ -297,9 +281,7 @@ define({
     "HELP_MENU"                           : "Βοήθεια",
     "CMD_CHECK_FOR_UPDATE"                : "Έλεγχος για Αναβαθμίσεις",
     "CMD_HOW_TO_USE_BRACKETS"             : "Πώς να Χρησιμοποιήσετε το {APP_NAME}",
-    "CMD_FORUM"                           : "{APP_NAME} Forum",
     "CMD_RELEASE_NOTES"                   : "Release Notes",
-    "CMD_REPORT_AN_ISSUE"                 : "Αναφορά Προβλήματος",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Προβολή Φακέλου Επεκτάσεων",
     "CMD_TWITTER"                         : "{TWITTER_NAME} στο Twitter",
     "CMD_ABOUT"                           : "Σχετικά με το {APP_TITLE}",
@@ -406,11 +388,6 @@ define({
     "UNDO_REMOVE"                          : "Αναίρεση",
     "MARKED_FOR_UPDATE"                    : "Επιλεγμένο για αναβάθμιση",
     "UNDO_UPDATE"                          : "Αναίρεση",
-    "CHANGE_AND_QUIT_TITLE"                : "Αλλαγή Επεκτάσεων",
-    "CHANGE_AND_QUIT_MESSAGE"              : "Για να αναβαθμίσετε ή να καταργήσετε τις επιλεγμένες επεκτάσεις, πρέπει να κλείσετε και να επανεκκινήσετε το {APP_NAME}. Θα ερωτηθείτε για την αποθήκευση των αλλαγών.",
-    "REMOVE_AND_QUIT"                      : "Κατάργηση Επεκτάσεων και Κλείσιμο",
-    "CHANGE_AND_QUIT"                      : "Αλλαγή Επεκτάσεων και Κλείσιμο",
-    "UPDATE_AND_QUIT"                      : "Αναβάθμιση Επεκτάσεων και Κλείσιμο",
     "EXTENSION_NOT_INSTALLED"              : "Αδυναμία κατάργησης της επέκτασης {0} αφού δεν ήταν εγκατεστημένη.",
     "NO_EXTENSIONS"                        : "Δεν υπάρχουν επεκτάσεις εγκατεστημένες ακόμα.<br>Κάντε κλικ στην καρτέλα Διαθέσιμα για να ξεκινήσετε.",
     "NO_EXTENSION_MATCHES"                 : "Δεν βρέθηκαν επεκτάσεις που να ικανοποιούν τα κριτήρια αναζήτησης σας.",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -150,7 +150,7 @@ define({
     "BUTTON_NO"                         : "No",
     
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} de {1}",
+    "FIND_MATCH_INDEX"                  : "{0} de {1}",
     "FIND_NO_RESULTS"                   : "No hay resultados",
     "FIND_QUERY_PLACEHOLDER"            : "Buscar\u2026",
     "REPLACE_PLACEHOLDER"               : "Reemplazar con\u2026",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -363,11 +363,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "عبارت انطباق یافته بعدی را به انتخاب شده ها اضافه کن",
     "CMD_SKIP_CURRENT_MATCH"              : "پرش از این مورد و افزودن مورد انطباق یافته بعدی",
     "CMD_FIND_IN_FILES"                   : "جستجو در پرونده ها",
-    "CMD_FIND_IN_SELECTED"                : "جستجو در پرونده/پوشه انتخاب شده",
     "CMD_FIND_IN_SUBTREE"                 : "جستجو در\u2026",
     "CMD_REPLACE"                         : "جایگزینی",
     "CMD_REPLACE_IN_FILES"                : "جایگزینی در پرونده ها",
-    "CMD_REPLACE_IN_SELECTED"             : "جایگزینی در پرونده/پوشه های انتخاب شده",
     "CMD_REPLACE_IN_SUBTREE"              : "جایگزینی در\u2026",
 
     // View menu commands

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -38,7 +38,6 @@ define({
     "NO_MODIFICATION_ALLOWED_ERR_FILE"  : "Os permisos non permiten facer modificacións.",
     "CONTENTS_MODIFIED_ERR"             : "O arquivo foi modificado fóra de {APP_NAME}.",
     "UNSUPPORTED_ENCODING_ERR"          : "{APP_NAME} actualmente só soporta arquivos codificados como UTF-8.",
-    "UNSUPPORTED_FILE_TYPE_ERR"         : "Este tipo de arquivo non é soportado.",
     "FILE_EXISTS_ERR"                   : "O arquivo xa existe.",
     "FILE"                              : "arquivo",
     "FILE_TITLE"                        : "Arquivo",
@@ -354,11 +353,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Agregar a seguinte coincidencia á selección",
     "CMD_SKIP_CURRENT_MATCH"              : "Omitir e agregar a seguinte coincidencia",
     "CMD_FIND_IN_FILES"                   : "Buscar en arquivos",
-    "CMD_FIND_IN_SELECTED"                : "Buscar no arquivo/directorio seleccionado",
     "CMD_FIND_IN_SUBTREE"                 : "Buscar en\u2026",
     "CMD_REPLACE"                         : "Reemplazar",
     "CMD_REPLACE_IN_FILES"                : "Reemplazar en Arquivos",
-    "CMD_REPLACE_IN_SELECTED"             : "Reemplazar no Arquivo/Cartafol seleccionado",
     "CMD_REPLACE_IN_SUBTREE"              : "Reemplazar en\u2026",
     
     // View menu commands
@@ -375,10 +372,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Habilitar axuste de liña",
     "CMD_LIVE_HIGHLIGHT"                  : "Resaltado en Vista Previa en Vivo",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Inspeccionar o código ó gardar",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Ordenar por Añadido",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Ordenar por Nome",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ordenar por Tipo",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Ordenación automática",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Ordenar por Añadido",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Ordenar por Nome",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Ordenar por Tipo",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Ordenación automática",
     "CMD_THEMES"                          : "Temas\u2026",
 
     // Navigate menu Commands

--- a/src/nls/hr/strings.js
+++ b/src/nls/hr/strings.js
@@ -61,7 +61,6 @@ define({
     "ERROR_DELETING_FILE"               : "Došlo je do greške prilikom pokušaja da se obriše datoteka <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Ime {0} nije valjano",
     "INVALID_FILENAME_MESSAGE"          : "Imena datoteka ne smiju sadržavati sljedeće znakove: {0} ili riječi rezervirane za sistem.",
-    "FILE_ALREADY_EXISTS"               : "{0} <span class='dialog-filename'>{1}</span> već postoji.",
     "ERROR_CREATING_FILE_TITLE"         : "Greška pri kreiranju {0}",
     "ERROR_CREATING_FILE"               : "Došlo je do greške prilikom pokušaja da se kreira {0} <span class='dialog-filename'>{1}</span>. {2}",
 
@@ -128,9 +127,8 @@ define({
     "BUTTON_NO"                         : "Ne",
         
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} rezultata",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 rezultat",
     "FIND_NO_RESULTS"                   : "Nema rezultata",
+    "FIND_QUERY_PLACEHOLDER"            : "Nađi\u2026",
     "REPLACE_PLACEHOLDER"               : "Zamijeni sa\u2026",
     "BUTTON_REPLACE_ALL"                : "Sve\u2026",
     "BUTTON_REPLACE"                    : "Zamijeni",
@@ -149,15 +147,7 @@ define({
     "NO_UPDATE_TITLE"                   : "Imate aktualnu verziju!",
     "NO_UPDATE_MESSAGE"                 : "Trenutno koristite aktualnu verziju aplikacije {APP_NAME}.",
 
-    // Replace All (in single file)
-    "FIND_REPLACE_TITLE_PART1"          : "Zamijeni \"",
-    "FIND_REPLACE_TITLE_PART2"          : "\" sa \"",
-    "FIND_REPLACE_TITLE_PART3"          : "\" &mdash; {2} {0} {1}",
-
     // Find in Files
-    "FIND_IN_FILES_TITLE_PART1"         : "\"",
-    "FIND_IN_FILES_TITLE_PART2"         : "\" pronađen",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} in {3} {4}",
     "FIND_IN_FILES_SCOPED"              : "u <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "u projektu",
     "FIND_IN_FILES_FILE"                : "datoteci",
@@ -177,7 +167,6 @@ define({
     "EDIT_FILE_FILTER"                  : "Uredi\u2026",
     "FILE_FILTER_DIALOG"                : "Uređivački filter",
     "FILE_FILTER_INSTRUCTIONS"          : "Isključi datoteke i direktorije koji se slažu sa ijednom od sljedećih nizova / podnizova riječi ili <a href='{0}' title='{0}'>globs</a>. Unesi svaki niz u novi red.",
-    "FILE_FILTER_LIST_PREFIX"           : "osim",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "i {0} više",
 
     // Quick Edit
@@ -317,9 +306,7 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Nađi",
     "CMD_FIND"                            : "Nađi",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Nađi\u2026",
     "CMD_FIND_IN_FILES"                   : "Nađi u datotekama",
-    "CMD_FIND_IN_SELECTED"                : "Nađi u odabranoj Datoteci/Mapi",
     "CMD_FIND_IN_SUBTREE"                 : "Nađi u\u2026",
     "CMD_FIND_NEXT"                       : "Nađi sljedeće",
     "CMD_FIND_PREVIOUS"                   : "Nađi prethodno",
@@ -328,7 +315,6 @@ define({
     "CMD_SKIP_CURRENT_MATCH"              : "Preskoči i dodaj sljedeće slaganje",
     "CMD_REPLACE"                         : "Zamijeni",
     "CMD_REPLACE_IN_FILES"                : "Zamijeni u datotekama",
-    "CMD_REPLACE_IN_SELECTED"             : "Zamijeni u odabranoj datoteci/mapi",
     "CMD_REPLACE_IN_SUBTREE"              : "Zamijeni u\u2026",
     
     // View menu commands
@@ -345,10 +331,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Prijelom teksta",
     "CMD_LIVE_HIGHLIGHT"                  : "Obilježi prikaz uživo",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Prekontroliraj datoteke prilikom spremanja",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sortiraj po datumu",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Sortiraj po imenu",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sortiraj po tipu",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatsko sortiranje",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Sortiraj po datumu",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Sortiraj po imenu",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Sortiraj po tipu",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatsko sortiranje",
     "CMD_THEMES"                          : "Teme\u2026",
 
     // Navigate menu Commands
@@ -375,10 +361,8 @@ define({
     "CMD_HOW_TO_USE_BRACKETS"             : "Kako koristiti {APP_NAME}",
     "CMD_SUPPORT"                         : "{APP_NAME} Podrška (na engleskom)",
     "CMD_SUGGEST"                         : "Predloži mogućnost / značajku",
-    "CMD_FORUM"                           : "{APP_NAME} Forum",
     "CMD_RELEASE_NOTES"                   : "Bilješke o trenutnoj verziji",
     "CMD_GET_INVOLVED"                    : "Uključi se",
-    "CMD_REPORT_AN_ISSUE"                 : "Prijavi problem",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Prikaži direktorij sa ekstenzijama",
     "CMD_TWITTER"                         : "{TWITTER_NAME} na Twitteru",
     "CMD_ABOUT"                           : "O programu {APP_TITLE}",

--- a/src/nls/hu/strings.js
+++ b/src/nls/hu/strings.js
@@ -57,7 +57,6 @@ define({
     "ERROR_DELETING_FILE"               : "Hiba történt a fájl törlése közben: <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Helytelen fájlnév",
     "INVALID_FILENAME_MESSAGE"          : "A fájl neve nem tartalmazhatja a következő karaktereket: {0} és foglalt rendszer neveket.",
-    "FILE_ALREADY_EXISTS"               : "A fájl <span class='dialog-filename'>{0}</span> már létezik.",
     "ERROR_CREATING_FILE_TITLE"         : "Hiba történt a fájl létrehozása közben.",
     "ERROR_CREATING_FILE"               : "Hiba történt a fájl létrehozása közben: <span class='dialog-filename'>{0}</span>. {1}",
 
@@ -105,12 +104,8 @@ define({
     "EXT_DELETED_MESSAGE"               : "A/az <span class='dialog-filename'>{0}</span> törölve lett a lemezen, de tartalmaz nem mentet változtatásokat is a {APP_NAME}-ben.<br /><br />Meg szeretnéd tartani a változtatásokat?",
     
     // Find, Replace, Find in Files
-    "SEARCH_REGEXP_INFO"                : "Használd a  /re/ szintaxis-t a regexp kereséshez",
-    "FIND_RESULT_COUNT"                 : "{0} találat",
-    "WITH"                              : "",
     "BUTTON_YES"                        : "Igen",
     "BUTTON_NO"                         : "Nem",
-    "BUTTON_STOP"                       : "Leállítás",
 
     "OPEN_FILE"                         : "Fájl megnyitása",
     "SAVE_FILE_AS"                      : "Fájl mentése",
@@ -120,7 +115,6 @@ define({
     "NO_UPDATE_TITLE"                   : "A legfrissebb verziót használod!",
     "NO_UPDATE_MESSAGE"                 : "A legfrissebb {APP_NAME} fut.",
     
-    "FIND_IN_FILES_TITLE"               : "a \"{4}\" {5} - {0} {1} a {2} {3}-ban",
     "FIND_IN_FILES_SCOPED"              : "a <span class='dialog-filename'>{0}</span>-ban",
     "FIND_IN_FILES_NO_SCOPE"            : "a projektben",
     "FIND_IN_FILES_FILE"                : "fájl",
@@ -128,9 +122,7 @@ define({
     "FIND_IN_FILES_MATCH"               : "találat",
     "FIND_IN_FILES_MATCHES"             : "találatok",
     "FIND_IN_FILES_MORE_THAN"           : "Több mint ",
-    "FIND_IN_FILES_MAX"                 : " (az első {0} találat megjelenítése)",
     "FIND_IN_FILES_FILE_PATH"           : "Fájl: <span class='dialog-filename'>{0}</span>",
-    "FIND_IN_FILES_LINE"                : "sor:&nbsp;{0}",
 
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Hiba a frissítési infó lekérdezése közben",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Hiba történt a legfrissebb frissítési infó lekérdezése közben. Győződj meg arról hogy van internet kapcsolatod, majd próbáld meg újra.",
@@ -230,10 +222,10 @@ define({
     "CMD_TOGGLE_LINE_NUMBERS"             : "Sorok száma",
     "CMD_TOGGLE_ACTIVE_LINE"              : "Aktív sor megjelölése",
     "CMD_TOGGLE_WORD_WRAP"                : "Sortörés",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Rendezés Hozzáadás Szerint",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Rendezés Név Szerint",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Rendezés Típus Szerint",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatikus Rendezés",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Rendezés Hozzáadás Szerint",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Rendezés Név Szerint",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Rendezés Típus Szerint",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatikus Rendezés",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navigálás",
@@ -253,23 +245,14 @@ define({
     "HELP_MENU"                           : "Súgó",
     "CMD_CHECK_FOR_UPDATE"                : "Frissítések keresése",
     "CMD_HOW_TO_USE_BRACKETS"             : "{APP_NAME} használata",
-    "CMD_FORUM"                           : "{APP_NAME} Fórum",
     "CMD_RELEASE_NOTES"                   : "Kiadási megjegyzések",
-    "CMD_REPORT_AN_ISSUE"                 : "Probléma bejelentése",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Bővítmények mappa megjelenítése",
     "CMD_TWITTER"                         : "{TWITTER_NAME} a Twitter-en",
     "CMD_ABOUT"                           : "A {APP_TITLE}-ről",
 
-
-    // Special commands invoked by the native shell
-    "CMD_CLOSE_WINDOW"                    : "Ablak bezárása",
-    "CMD_ABORT_QUIT"                      : "Kilépés Megakadályozása",
-    "CMD_BEFORE_MENUPOPUP"                : "A Felugró Menüablak Előtt",
-
     // Strings for main-view.html
     "EXPERIMENTAL_BUILD"                   : "kísérleti verzió",
     "DEVELOPMENT_BUILD"                    : "fejlesztési verzió",
-    "SEARCH_RESULTS"                       : "Keresési Találatok",
     "OK"                                   : "OK",
     "DONT_SAVE"                            : "Ne Mentse",
     "SAVE"                                 : "Mentés",
@@ -360,11 +343,6 @@ define({
     "UNDO_REMOVE"                          : "Mégsem",
     "MARKED_FOR_UPDATE"                    : "Frissítéshez megjelölve",
     "UNDO_UPDATE"                          : "Mégsem",
-    "CHANGE_AND_QUIT_TITLE"                : "Bővítmények megváltoztatása",
-    "CHANGE_AND_QUIT_MESSAGE"              : "A megjelölt bővítmények frissítéséhez/eltávolításához ki kell lépni a {APP_NAME}-ből, majd újraindítani. A mentetlen változásokról meg fog jelenni egy ablak ahol elmentheted.",
-    "REMOVE_AND_QUIT"                      : "Bővítmények eltávolítása és kilépés",
-    "CHANGE_AND_QUIT"                      : "Bővítmények megváltoztatása és kilépés",
-    "UPDATE_AND_QUIT"                      : "Bővítmények frissítése és kilépés",
     "EXTENSION_NOT_INSTALLED"              : "A {0} bővítményt nem lehet eltávolítani, mert nincs telepítve.",
     "NO_EXTENSIONS"                        : "Nincs még telepített bővítmény.<br>Kattints a Telepítés URL-ről gombra a kezdéshez.",
     "NO_EXTENSION_MATCHES"                 : "Nincs bővítmény a keresett szavakra.",
@@ -404,15 +382,6 @@ define({
     
     // extensions/default/JavaScriptCodeHints
     "CMD_JUMPTO_DEFINITION"                     : "Ugrás a Definícióhoz",
-    
-    // extensions/default/JSLint
-    "CMD_JSLINT"                                : "JSLint engedélyezése",
-    "CMD_JSLINT_FIRST_ERROR"                    : "Ugrás az első JSLint Hibához",
-    "JSLINT_ERRORS"                             : "JSLint Hibák",
-    "JSLINT_ERROR_INFORMATION"                  : "1 JSLint Hiba",
-    "JSLINT_ERRORS_INFORMATION"                 : "{0} JSLint Hiba",
-    "JSLINT_NO_ERRORS"                          : "Nincs JSLint hiba - szép munka!",
-    "JSLINT_DISABLED"                           : "JSLint letiltva, vagy nem működik a jelenlegi fájlban.",
     
     // extensions/default/QuickView 
     "CMD_ENABLE_QUICK_VIEW"                     : "Gyors Nézet rámutatáskor",

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -363,11 +363,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Tambahkan Hasil Berikutnya ke Pilihan",
     "CMD_SKIP_CURRENT_MATCH"              : "Lewati dan Tambahkan Hasil Berikutnya",
     "CMD_FIND_IN_FILES"                   : "Temukan di File",
-    "CMD_FIND_IN_SELECTED"                : "Temukan di File/Folder yang Dipilih",
     "CMD_FIND_IN_SUBTREE"                 : "Temukan\u2026",
     "CMD_REPLACE"                         : "Ganti",
     "CMD_REPLACE_IN_FILES"                : "Ganti di File",
-    "CMD_REPLACE_IN_SELECTED"             : "Ganti di File/Folder yang Dipilih",
     "CMD_REPLACE_IN_SUBTREE"              : "Ganti di\u2026",
 
     // View menu commands

--- a/src/nls/it/strings.js
+++ b/src/nls/it/strings.js
@@ -305,7 +305,6 @@ define({
     "CMD_FILE_NEW"                        : "Nuovo File",
     "CMD_FILE_NEW_FOLDER"                 : "Nuova cartella",
     "CMD_FILE_OPEN"                       : "Apri\u2026",
-    "CMD_ADD_TO_WORKINGSET_AND_OPEN"      : "Aggiungi uno spazio di lavoro e apri",
     "CMD_OPEN_DROPPED_FILES"              : "Apri un file abbandonato",
     "CMD_OPEN_FOLDER"                     : "Apri cartella\u2026",
     "CMD_FILE_CLOSE"                      : "Chiudi",

--- a/src/nls/ko/strings.js
+++ b/src/nls/ko/strings.js
@@ -71,7 +71,6 @@ define({
     "INVALID_FILENAME_TITLE": "잘못된 {0}이름",
     "INVALID_FILENAME_MESSAGE": "파일 이름에는 다음 문자를 포함 할 수 없습니다: {0} 또는 시스템의 모든 예약어",
     "ENTRY_WITH_SAME_NAME_EXISTS": "<span class='dialog-filename'>{0}</span> 이름을 가진 파일 또는 디렉토리가 이미 존재합니다.",
-    "FILE_ALREADY_EXISTS": "{0} <span class='dialog-filename'>{1}</span>은 이미 존재 합니다.",
     "ERROR_CREATING_FILE_TITLE": "{0}를 만들던 중에 에러가 발생했습니다",
     "ERROR_CREATING_FILE": "{0} <span class='dialog-filename'>{1}</span>를 만들던 중에 에러가 발생했습니다.{2}",
     
@@ -364,11 +363,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "다음 일치하는 단어 찾은 후 선택영역에 추가",
     "CMD_SKIP_CURRENT_MATCH"              : "현재 영역 건너뛰고 다음 찾기",
     "CMD_FIND_IN_FILES"                   : "파일에서 찾기",
-    "CMD_FIND_IN_SELECTED"                : "선택한 파일/폴더에서 찾기",
     "CMD_FIND_IN_SUBTREE"                 : "다음에서 찾기\u2026",
     "CMD_REPLACE"                         : "바꾸기",
     "CMD_REPLACE_IN_FILES"                : "파일에서 바꾸기",
-    "CMD_REPLACE_IN_SELECTED"             : "선택한 파일/폴더에서 바꾸기",
     "CMD_REPLACE_IN_SUBTREE"              : "다음에서 바꾸기\u2026",
 
     // View menu commands
@@ -385,10 +382,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP": "자동 줄바꿈",
     "CMD_LIVE_HIGHLIGHT": "실시간 미리보기 하이라이트",
     "CMD_VIEW_TOGGLE_INSPECTION": "저장시 파일 Lint표시",
-    "CMD_SORT_WORKINGSET_BY_ADDED": "추가순으로 작업세트 정렬",
-    "CMD_SORT_WORKINGSET_BY_NAME": "이름순으로 작업세트 정렬",
-    "CMD_SORT_WORKINGSET_BY_TYPE": "타입별로 작업세트 정렬",
-    "CMD_SORT_WORKINGSET_AUTO": "자동으로 작업세트 정렬",
+    "CMD_WORKINGSET_SORT_BY_ADDED": "추가순으로 작업세트 정렬",
+    "CMD_WORKINGSET_SORT_BY_NAME": "이름순으로 작업세트 정렬",
+    "CMD_WORKINGSET_SORT_BY_TYPE": "타입별로 작업세트 정렬",
+    "CMD_WORKING_SORT_TOGGLE_AUTO": "자동으로 작업세트 정렬",
     "CMD_THEMES"                          : "테마\u2026",
 
     // Navigate menu Commands

--- a/src/nls/nb/strings.js
+++ b/src/nls/nb/strings.js
@@ -134,9 +134,8 @@ define({
     "BUTTON_NO"                         : "Nei",
 
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} resultater",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 resultat",
     "FIND_NO_RESULTS"                   : "Ingen resultater",
+    "FIND_QUERY_PLACEHOLDER"            : "Finn\u2026",
     "REPLACE_PLACEHOLDER"               : "Erstatt med\u2026",
     "BUTTON_REPLACE_ALL"                : "Alle\u2026",
     "BUTTON_REPLACE"                    : "Erstatt",
@@ -154,16 +153,8 @@ define({
     "RELEASE_NOTES"                     : "Versjonsmerknader",
     "NO_UPDATE_TITLE"                   : "Du er oppdatert!",
     "NO_UPDATE_MESSAGE"                 : "Du kjører den nyeste versjonen av {APP_NAME}.",
-    
-    // Replace All (in single file)
-    "FIND_REPLACE_TITLE_PART1"          : "Erstatt \"",
-    "FIND_REPLACE_TITLE_PART2"          : "\" med \"",
-    "FIND_REPLACE_TITLE_PART3"          : "\" &mdash; {2} {0} {1}",
 
     // Find in Files
-    "FIND_IN_FILES_TITLE_PART1"         : "\"",
-    "FIND_IN_FILES_TITLE_PART2"         : "\" funnet",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} i {3} {4}",
     "FIND_IN_FILES_SCOPED"              : "i <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "i prosjekt",
     "FIND_IN_FILES_ZERO_FILES"          : "Filter ekskluderer alle filer {0}",
@@ -183,7 +174,6 @@ define({
     "EDIT_FILE_FILTER"                  : "Rediger\u2026",
     "FILE_FILTER_DIALOG"                : "Rediger filter",
     "FILE_FILTER_INSTRUCTIONS"          : "Ekskluder filer og kataloger som er lik følgende strenger / understrenger eller <a href='{0}' title='{0}'>jokertegn</a>. Skriv inn hver streng på egen linje.",
-    "FILE_FILTER_LIST_PREFIX"           : "unntatt",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "og {0} mere",
     "FILTER_COUNTING_FILES"             : "Teller filer\u2026",
     "FILTER_FILE_COUNT"                 : "Tillater {0} av {1} filer {2}",
@@ -309,14 +299,12 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Finn",
     "CMD_FIND"                            : "Finn",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Finn\u2026",
     "CMD_FIND_NEXT"                       : "Finn neste",
     "CMD_FIND_PREVIOUS"                   : "Finn forrige",
     "CMD_FIND_ALL_AND_SELECT"             : "Finn alle og velg",
     "CMD_ADD_NEXT_MATCH"                  : "Legg til neste treff til utvalg",
     "CMD_SKIP_CURRENT_MATCH"              : "Hopp over og legg til neste treff",
     "CMD_FIND_IN_FILES"                   : "Finn i filer",
-    "CMD_FIND_IN_SELECTED"                : "Finn i valgt fil/katalog",
     "CMD_FIND_IN_SUBTREE"                 : "Finn i\u2026",
     "CMD_REPLACE"                         : "Erstatt",
 
@@ -334,10 +322,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Tekstbryting",
     "CMD_LIVE_HIGHLIGHT"                  : "Live Preview Highlight",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Lint filer ved lagring",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sorter på tilføyd",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Sorter på navn",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sorter på type",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatisk sortering",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Sorter på tilføyd",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Sorter på navn",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Sorter på type",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatisk sortering",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Naviger",

--- a/src/nls/pl/strings.js
+++ b/src/nls/pl/strings.js
@@ -62,7 +62,6 @@ define({
     "ERROR_DELETING_FILE"               : "Podczas usuwania pliku <span class='dialog-filename'>{0}</span> wystąpił błąd: {1}",
     "INVALID_FILENAME_TITLE"            : "Niewłaściwa nazwa pliku",
     "INVALID_FILENAME_MESSAGE"          : "Nazwa pliku nie może zawierać następujących znaków: {0}",
-    "FILE_ALREADY_EXISTS"               : "Plik <span class='dialog-filename'>{0}</span> już istnieje.",
     "ERROR_CREATING_FILE_TITLE"         : "Nie można utworzyć pliku",
     "ERROR_CREATING_FILE"               : "Wystąpił błąd podczas próby utworzenia pliku <span class='dialog-filename'>{0}</span>. {1}",
 
@@ -129,9 +128,8 @@ define({
     "BUTTON_NO"                         : "Nie",
 
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} wyników",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 wynik",
     "FIND_NO_RESULTS"                   : "Brak wyników",
+    "FIND_QUERY_PLACEHOLDER"            : "Znajdź\u2026",
     "REPLACE_PLACEHOLDER"               : "Zamień na\u2026",
     "BUTTON_REPLACE_ALL"                : "Wszystko\u2026",
     "BUTTON_REPLACE"                    : "Zamień",
@@ -150,15 +148,7 @@ define({
     "NO_UPDATE_TITLE"                   : "{APP_NAME} jest aktualny!",
     "NO_UPDATE_MESSAGE"                 : "Aktualnie używasz najnowszej wersji {APP_NAME}.",
 
-    // Replace All (in single file)
-    "FIND_REPLACE_TITLE_PART1"          : "Zamienianie „",
-    "FIND_REPLACE_TITLE_PART2"          : "” na „",
-    "FIND_REPLACE_TITLE_PART3"          : "” &mdash; {2} {0} {1}",
-
     // Find in Files
-    "FIND_IN_FILES_TITLE_PART1"         : "Znaleziono „",
-    "FIND_IN_FILES_TITLE_PART2"         : "” ",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} in {3} {4}",
     "FIND_IN_FILES_SCOPED"              : "w <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "w projekcie",
     "FIND_IN_FILES_ZERO_FILES"                  : "Filtr wyklucza wszystkie pliki {0}",
@@ -178,7 +168,6 @@ define({
     "EDIT_FILE_FILTER"                  : "Edytuj…",
     "FILE_FILTER_DIALOG"                : "Edytuj filtr",
     "FILE_FILTER_INSTRUCTIONS"          : "Możesz odrzucić pliki o nazwach pasujących do poniższych wzorów lub <a href='{0}' title='{0}'>masek</a>. Każdą regułę umieść w osobnej linii.",
-    "FILE_FILTER_LIST_PREFIX"           : "oprócz",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "i {0} więcej",
     "FILTER_COUNTING_FILES"             : "Kalkulowanie…",
     "FILTER_FILE_COUNT"                 : "Przeszukane zostanie {0} z {1} plików {2}",
@@ -305,14 +294,12 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Find",
     "CMD_FIND"                            : "Znajdź",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Znajdź…",
     "CMD_FIND_NEXT"                       : "Znajdź następny",
     "CMD_FIND_PREVIOUS"                   : "Znajdź poprzedni",
     "CMD_FIND_ALL_AND_SELECT"             : "Zaznacz wszystkie wystapienia",
     "CMD_ADD_NEXT_MATCH"                  : "Dodaj nastepny do zaznaczenia",
     "CMD_SKIP_CURRENT_MATCH"              : "Pomiń i dodaj następny",
     "CMD_FIND_IN_FILES"                   : "Znajdź w plikach",
-    "CMD_FIND_IN_SELECTED"                : "Find in Selected File/Folder",
     "CMD_FIND_IN_SUBTREE"                 : "Znajdź\u2026",
     "CMD_REPLACE"                         : "Zamień",
 
@@ -330,10 +317,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Zawijaj wiersze",
     "CMD_LIVE_HIGHLIGHT"                  : "Podświetlanie przy podglądzie błyskawicznym",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Sprawdzaj poprawność przy zapisywaniu",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Sortuj według dodanych",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Sortuj według nazwy",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Sortuj według typu",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatyczne sortowanie",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Sortuj według dodanych",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Sortuj według nazwy",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Sortuj według typu",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatyczne sortowanie",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Nawigacja",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -372,11 +372,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Adicionar próximo resultado à seleção",
     "CMD_SKIP_CURRENT_MATCH"              : "Pular e adicionar próximo resultado",
     "CMD_FIND_IN_FILES"                   : "Localizar em arquivos",
-    "CMD_FIND_IN_SELECTED"                : "Localizar no arquivo/diretório selecionado",
     "CMD_FIND_IN_SUBTREE"                 : "Localizar em\u2026",
     "CMD_REPLACE"                         : "Substituir",
     "CMD_REPLACE_IN_FILES"                : "Substituir em arquivos",
-    "CMD_REPLACE_IN_SELECTED"             : "Substituir no arquivo/diretório selecionado",
     "CMD_REPLACE_IN_SUBTREE"              : "Substituir em\u2026",
 
     // View menu commands
@@ -393,10 +391,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Quebra automática de linha",
     "CMD_LIVE_HIGHLIGHT"                  : "Destacar Live Preview",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Analisar arquivos ao salvar",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Ordenar por Data de Adição",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Ordenar por Nome",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ordenar por Tipo",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Ordenação automática",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Ordenar por Data de Adição",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Ordenar por Nome",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Ordenar por Tipo",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Ordenação automática",
     "CMD_THEMES"                          : "Temas\u2026",
 
     // Navigate menu Commands

--- a/src/nls/pt-pt/strings.js
+++ b/src/nls/pt-pt/strings.js
@@ -54,7 +54,6 @@ define({
     "ERROR_RENAMING_FILE"               : "Ocorreu um erro ao tentar renomear o ficheiro <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Nome do ficheiro inválido",
     "INVALID_FILENAME_MESSAGE"          : "O nome do ficheiro não pode conter os seguintes caracteres: {0}",
-    "FILE_ALREADY_EXISTS"               : "O ficheiro <span class='dialog-filename'>{0}</span> já existe.",
     "ERROR_CREATING_FILE_TITLE"         : "Erro ao criar ficheiro.",
     "ERROR_CREATING_FILE"               : "Ocorreu um erro ao tentar criar o ficheiro <span class='dialog-filename'>{0}</span>. {1}",
 
@@ -92,11 +91,8 @@ define({
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> foi apagado do disco, mas tem alterações não guardadas em {APP_NAME}.<br /><br />Quer manter as suas alterações?",
 
     // Find, Replace, Find in Files
-    "SEARCH_REGEXP_INFO"                : "Usar /re/ sintaxe para usar regexp na pesquisa",
-    "WITH"                              : "Com",
     "BUTTON_YES"                        : "Sim",
     "BUTTON_NO"                         : "Não",
-    "BUTTON_STOP"                       : "Parar",
 
     "OPEN_FILE"                         : "Abrir ficheiro",
     "CHOOSE_FOLDER"                     : "Escolha uma pasta",
@@ -105,7 +101,6 @@ define({
     "NO_UPDATE_TITLE"                   : "Está atualizado!",
     "NO_UPDATE_MESSAGE"                 : "Está a executar a versão mais recente de {APP_NAME}.",
 
-    "FIND_IN_FILES_TITLE"               : "Para \"{4}\" {5} - {0} {1} em {2} {3}",
     "FIND_IN_FILES_SCOPED"              : "em <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "no projeto",
     "FIND_IN_FILES_FILE"                : "ficheiro",
@@ -113,9 +108,7 @@ define({
     "FIND_IN_FILES_MATCH"               : "resultado",
     "FIND_IN_FILES_MATCHES"             : "resultado",
     "FIND_IN_FILES_MORE_THAN"           : "Mais que ",
-    "FIND_IN_FILES_MAX"                 : " (a mostar os primeiros {0} resultados)",
     "FIND_IN_FILES_FILE_PATH"           : "Ficheiro: <span class='dialog-filename'>{0}</span>",
-    "FIND_IN_FILES_LINE"                : "linha:&nbsp;{0}",
 
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Erro ao receber as atualizações",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Houve um problema a receber a atualização mais recente a partir do servidor. Por favor, verifique se você está conectado à Internet e tente novamente.",
@@ -144,7 +137,6 @@ define({
     "STATUSBAR_INDENT_SIZE_TOOLTIP_TABS"    : "Mudar a largura do caractere de tabulação",
     "STATUSBAR_SPACES"                      : "Espaços",
     "STATUSBAR_TAB_SIZE"                    : "Tamanho da tabulação",
-    "STATUSBAR_LINE_COUNT"                  : "{0} Linhas",
 
     /**
      * Command Name Constants
@@ -192,10 +184,10 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Aumentar tamanho da fonte",
     "CMD_DECREASE_FONT_SIZE"              : "Diminuir tamanho da fonte",
     "CMD_RESTORE_FONT_SIZE"               : "Restaurar tamanho da fonte",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Ordenar por data adicionado",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Ordenar por nome",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Ordenar por tipo",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Ordenação automática",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Ordenar por data adicionado",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Ordenar por nome",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Ordenar por tipo",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Ordenação automática",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navegar",
@@ -214,15 +206,9 @@ define({
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Mostrar pasta de extensões",
     "CMD_CHECK_FOR_UPDATE"                : "Verificar atualizações",
     "CMD_ABOUT"                           : "Sobre",
-    "CMD_FORUM"                           : "Forum do {APP_NAME}",
-
-    // Special commands invoked by the native shell
-    "CMD_CLOSE_WINDOW"                    : "Fechar a janela",
-    "CMD_ABORT_QUIT"                      : "Cancelar a saída",
 
     // Strings for main-view.html
     "EXPERIMENTAL_BUILD"                   : "Versão Experimental",
-    "SEARCH_RESULTS"                       : "Resultados da pesquisa",
     "OK"                                   : "OK",
     "DONT_SAVE"                            : "Não guardar",
     "SAVE"                                 : "Guardar",
@@ -240,7 +226,6 @@ define({
     "UPDATE_AVAILABLE_TITLE"               : "Atualização disponível",
     "UPDATE_MESSAGE"                       : "Hey, {APP_NAME} {VERSION} disponível. Aqui estão alguns dos novos recursos:",
     "GET_IT_NOW"                           : "Obter agora!",
-    "PROJECT_SETTINGS_TOOLTIP"             : "Definições do projeto",
     "PROJECT_SETTINGS_TITLE"               : "Definições do projeto para: {0}",
     "PROJECT_SETTING_BASE_URL"             : "Live Preview URL base",
     "PROJECT_SETTING_BASE_URL_HINT"        : "(deixe em branco para url do ficheiro)",
@@ -263,13 +248,5 @@ define({
     "LANGUAGE_TITLE"                       : "Mudar idioma",
     "LANGUAGE_MESSAGE"                     : "Por favor, selecione o idioma desejado na lista abaixo:",
     "LANGUAGE_SUBMIT"                      : "Recarregar {APP_NAME}",
-    "LANGUAGE_CANCEL"                      : "Cancelar",
-    
-    // extensions/default/JSLint
-    "CMD_JSLINT"                           : "Activar JSLint",
-    "JSLINT_ERRORS"                        : "Erros JSLint",
-    "JSLINT_ERROR_INFORMATION"             : "1 Erro JSLint",
-    "JSLINT_ERRORS_INFORMATION"            : "{0} Erros JSLint",
-    "JSLINT_NO_ERRORS"                     : "Sem erros JSLint - bom trabalho!",
-    "JSLINT_DISABLED"                      : "JSLint desabilitado ou não funcionando para o arquivo atual"
+    "LANGUAGE_CANCEL"                      : "Cancelar"
 });

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -362,11 +362,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Adaugă următoarea potrivire la selecție",
     "CMD_SKIP_CURRENT_MATCH"              : "Omite și adaugă următoarea potrivire",
     "CMD_FIND_IN_FILES"                   : "Caută în fișiere",
-    "CMD_FIND_IN_SELECTED"                : "Caută în fișierul/directoriul selectat",
     "CMD_FIND_IN_SUBTREE"                 : "Caută în\u2026",
     "CMD_REPLACE"                         : "Înlocuiește",
     "CMD_REPLACE_IN_FILES"                : "Înlocuiește în fișiere",
-    "CMD_REPLACE_IN_SELECTED"             : "Înlocuiește în fișierul/directoriul selecta",
     "CMD_REPLACE_IN_SUBTREE"              : "Înlocuiește în\u2026",
 
     // View menu commands

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -134,8 +134,6 @@ define({
     "BUTTON_NO"                         : "Нет",
 
     // Find, Replace, Find in Files
-    "FIND_RESULT_COUNT"                 : "{0} результатов",
-    "FIND_RESULT_COUNT_SINGLE"          : "1 результат",
     "FIND_NO_RESULTS"                   : "Не найдено",
     "FIND_QUERY_PLACEHOLDER"            : "Найти\u2026",
     "REPLACE_PLACEHOLDER"               : "Заменить на\u2026",
@@ -166,9 +164,6 @@ define({
     "FIND_TITLE_SUMMARY"                : "&mdash; {0} {1} {2} в {3}",
 
     // Find in Files
-    "FIND_IN_FILES_TITLE_PART1"         : "\"",
-    "FIND_IN_FILES_TITLE_PART2"         : "\" найдено",
-    "FIND_IN_FILES_TITLE_PART3"         : "&mdash; {0} {1} {2} в {3} {4}",
     "FIND_NUM_FILES"                    : "{0} {1}",
     "FIND_IN_FILES_SCOPED"              : "в <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "в проекте",
@@ -195,7 +190,6 @@ define({
     "FILE_FILTER_DIALOG"                : "Редактировать фильтр",
     "FILE_FILTER_INSTRUCTIONS"          : "Исключить файлы и директории содержащие любую из перечисленных строк, возможно использование <a href='{0}' title='{0}'>групповых символов</a>. Указывайте по одной строке на линию.",
     "FILTER_NAME_PLACEHOLDER"           : "Назвать этот фильтр (опционально)",
-    "FILE_FILTER_LIST_PREFIX"           : "кроме",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "и еще {0}",
 
     "FILTER_COUNTING_FILES"             : "Подсчет количества файлов\u2026",
@@ -323,18 +317,15 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Поиск",
     "CMD_FIND"                            : "Найти",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Найти\u2026",
     "CMD_FIND_NEXT"                       : "Найти след.",
     "CMD_FIND_PREVIOUS"                   : "Найти пред.",
     "CMD_FIND_ALL_AND_SELECT"             : "Найти все и выделить",
     "CMD_ADD_NEXT_MATCH"                  : "Добавить следущее найденное к выделению",
     "CMD_SKIP_CURRENT_MATCH"              : "Пропустить и добавить следующее найденное",
     "CMD_FIND_IN_FILES"                   : "Найти в файлах",
-    "CMD_FIND_IN_SELECTED"                : "Найти в выделенном файле/директории",
     "CMD_FIND_IN_SUBTREE"                 : "Найти в\u2026",
     "CMD_REPLACE"                         : "Заменить",
     "CMD_REPLACE_IN_FILES"                : "Заменить в файлах",
-    "CMD_REPLACE_IN_SELECTED"             : "Заменить в выделенном файле/директории",
     "CMD_REPLACE_IN_SUBTREE"              : "Заменить в\u2026",
 
     // View menu commands
@@ -351,10 +342,10 @@ define({
     "CMD_TOGGLE_WORD_WRAP"                : "Заворачивать строки",
     "CMD_LIVE_HIGHLIGHT"                  : "Подсвечивать в Live Preview",
     "CMD_VIEW_TOGGLE_INSPECTION"          : "Анализировать при сохранении",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Сортировать по порядку добавления",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Сортировать по имени",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Сортировать по типу",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Автоматическая сортировка",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Сортировать по порядку добавления",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Сортировать по имени",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Сортировать по типу",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Автоматическая сортировка",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Навигация",

--- a/src/nls/sk/strings.js
+++ b/src/nls/sk/strings.js
@@ -60,7 +60,6 @@ define({
     "ERROR_DELETING_FILE"               : "Nastala chyba pri zmazaní súboru <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Neplatný {0} názov",
     "INVALID_FILENAME_MESSAGE"          : "Názvy súboru nesmú obsahovať nasledujúce znaky: {0} alebo používať rezervované systémové slová.",
-    "FILE_ALREADY_EXISTS"               : "Súbor {0} <span class='dialog-filename'>{1}</span> už existuje.",
     "ERROR_CREATING_FILE_TITLE"         : "Chyba pri vytváraní súboru {0}",
     "ERROR_CREATING_FILE"               : "Nastala chyba pri vytváraní súboru {0} <span class='dialog-filename'>{1}</span>. {2}",
 
@@ -110,13 +109,8 @@ define({
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> bol zmazaný z disku, ale zmeny sa neuložili v {APP_NAME}.<br /><br />Chcete uložiť zmeny?",
     
     // Find, Replace, Find in Files
-    "SEARCH_REGEXP_INFO"                : "Použite /re/ syntax pre regexp vyhľadávanie",
-    "FIND_RESULT_COUNT"                 : "{0} výsledkov",
-    "WITH"                              : "S",
     "BUTTON_YES"                        : "Áno",
     "BUTTON_NO"                         : "Nie",
-    "BUTTON_ALL"                        : "Všetko",
-    "BUTTON_STOP"                       : "Stop",
     "BUTTON_REPLACE"                    : "Nahradiť",
 
     "OPEN_FILE"                         : "Otvoriť súbor",
@@ -127,9 +121,6 @@ define({
     "NO_UPDATE_TITLE"                   : "Všetko je aktuálne!",
     "NO_UPDATE_MESSAGE"                 : "Máte najnovšiu verziu {APP_NAME}.",
 
-    "FIND_REPLACE_TITLE"                : "Nahradiť \"{0}\" s \"{1}\" &mdash; {3} {2} zhodami",
-
-    "FIND_IN_FILES_TITLE"               : "\"{4}\" nájdený {5} &mdash; {0} {1} v {2} {3}",
     "FIND_IN_FILES_SCOPED"              : "v <span class='dialog-filename'>{0}</span>",
     "FIND_IN_FILES_NO_SCOPE"            : "v projekte",
     "FIND_IN_FILES_FILE"                : "súbor",
@@ -138,10 +129,7 @@ define({
     "FIND_IN_FILES_MATCHES"             : "zhody",
     "FIND_IN_FILES_MORE_THAN"           : "Cez ",
     "FIND_IN_FILES_PAGING"              : "{0}&mdash;{1}",
-    "FIND_IN_FILES_LESS"                : " <a href='#' class='find-less'>Menej</a>",
-    "FIND_IN_FILES_MORE"                : " <a href='#' class='find-more'>Viac</a>",
     "FIND_IN_FILES_FILE_PATH"           : "Súbor: <span class='dialog-filename'>{0}</span>",
-    "FIND_IN_FILES_LINE"                : "riadok: {0}",
 
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Problém pri získavaní informácií o aktualizácii",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Nastal problém pri získavaní aktuálnych informácií zo servera. Prosím uistite sa, že ste pripojený do internetu a skúste znovu.",
@@ -246,10 +234,10 @@ define({
     "CMD_TOGGLE_LINE_NUMBERS"             : "Čísla riadkov",
     "CMD_TOGGLE_ACTIVE_LINE"              : "Zvýrazniť aktívny riadok",
     "CMD_TOGGLE_WORD_WRAP"                : "Zalomenie riadkov",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Usporiadať podľa dátumu",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "Usporiadať podľa mena",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Usporiadať podľa typu",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Automatické usporiadanie",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Usporiadať podľa dátumu",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "Usporiadať podľa mena",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Usporiadať podľa typu",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Automatické usporiadanie",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Navigácia",
@@ -269,18 +257,10 @@ define({
     "HELP_MENU"                           : "Nápoveda",
     "CMD_CHECK_FOR_UPDATE"                : "Skontrolovať aktualizácie",
     "CMD_HOW_TO_USE_BRACKETS"             : "Ako používať {APP_NAME}",
-    "CMD_FORUM"                           : "{APP_NAME} fórum",
     "CMD_RELEASE_NOTES"                   : "Poznámky o verzii",
-    "CMD_REPORT_AN_ISSUE"                 : "Nahlásiť problém",
     "CMD_SHOW_EXTENSIONS_FOLDER"          : "Zobraziť priečinok s doplnkami",
     "CMD_TWITTER"                         : "{TWITTER_NAME} na Twitteri",
     "CMD_ABOUT"                           : "O {APP_TITLE}",
-
-
-    // Špeciálne príkazy spúšťané pomocou natívneho shellu
-    "CMD_CLOSE_WINDOW"                    : "Zatvoriť okno",
-    "CMD_ABORT_QUIT"                      : "Zrusiť ukončenie",
-    "CMD_BEFORE_MENUPOPUP"                : "Before Menu Popup",
 
     // Strings for main-view.html
     "EXPERIMENTAL_BUILD"                   : "experimentálna verzia",
@@ -379,11 +359,6 @@ define({
     "UNDO_REMOVE"                          : "Späť",
     "MARKED_FOR_UPDATE"                    : "Označené pre aktualizáciu",
     "UNDO_UPDATE"                          : "Späť",
-    "CHANGE_AND_QUIT_TITLE"                : "Zmeniť doplnky",
-    "CHANGE_AND_QUIT_MESSAGE"              : "Pre aktualizáciu alebo odstránenie označených doplnkov musíte ukončiť a reštartovať {APP_NAME}. Budete vyzvaný k uloženiu zmien.",
-    "REMOVE_AND_QUIT"                      : "Odstrániť doplnky a skončiť",
-    "CHANGE_AND_QUIT"                      : "Zmeniť doplnky a skončiť",
-    "UPDATE_AND_QUIT"                      : "Aktualizovať doplnky a skončiť",
     "EXTENSION_NOT_INSTALLED"              : "Nie je možné odstrániť doplnok {0}, pretože nebol nainštalovaný",
     "NO_EXTENSIONS"                        : "Nie sú nainštalované žiadne doplnky.<br>Click on the Available tab above to get started.",
     "NO_EXTENSION_MATCHES"                 : "Nenašiel sa žiadny doplnok.",
@@ -429,15 +404,6 @@ define({
     "CMD_JUMPTO_DEFINITION"                     : "Prejsť na definíciu",
     "CMD_SHOW_PARAMETER_HINT"                   : "Ukázať pomôcku parametra",
     "NO_ARGUMENTS"                              : "<žiadne parametre>",
-
-    // extensions/default/JSLint
-    "CMD_JSLINT"                                : "Povoliť JSLint",
-    "CMD_JSLINT_FIRST_ERROR"                    : "Prejsť na prvú JSLint chybu",
-    "JSLINT_ERRORS"                             : "JSLint chyby",
-    "JSLINT_ERROR_INFORMATION"                  : "1 JSLint chyba",
-    "JSLINT_ERRORS_INFORMATION"                 : "{0} JSLint chýb",
-    "JSLINT_NO_ERRORS"                          : "Žiadne JSLint chyby - dobrá práca!",
-    "JSLINT_DISABLED"                           : "JSLint je vypnutý, alebo nefunguje s týmto súborom.",
     
     // extensions/default/QuickView
     "CMD_ENABLE_QUICK_VIEW"                     : "Rýchly náhľad",

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -362,11 +362,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Додај следеће поклапање у селекцију",
     "CMD_SKIP_CURRENT_MATCH"              : "Прескочи и додај следеће поклапање",
     "CMD_FIND_IN_FILES"                   : "Пронађи међу датотекама",
-    "CMD_FIND_IN_SELECTED"                : "Пронађи у изабраној датотеци/директоријуму",
     "CMD_FIND_IN_SUBTREE"                 : "Пронађи у\u2026",
     "CMD_REPLACE"                         : "Замени",
     "CMD_REPLACE_IN_FILES"                : "Замени у датотекама",
-    "CMD_REPLACE_IN_SELECTED"             : "Замени у изабраној датотеци/директоријуму",
     "CMD_REPLACE_IN_SUBTREE"              : "Замени у\u2026",
 
     // View menu commands

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -364,11 +364,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                  : "Lägg nästa träff till markering",
     "CMD_SKIP_CURRENT_MATCH"              : "Hoppa över och lägg till nästa träff",
     "CMD_FIND_IN_FILES"                   : "Sök i filer",
-    "CMD_FIND_IN_SELECTED"                : "Sök i markerad fil/mapp",
     "CMD_FIND_IN_SUBTREE"                 : "Sök i\u2026",
     "CMD_REPLACE"                         : "Ersätt",
     "CMD_REPLACE_IN_FILES"                : "Ersätt i filer",
-    "CMD_REPLACE_IN_SELECTED"             : "Ersätt i markerad fil/mapp",
     "CMD_REPLACE_IN_SUBTREE"              : "Ersätt i\u2026",
     
     // View menu commands

--- a/src/nls/tr/strings.js
+++ b/src/nls/tr/strings.js
@@ -54,7 +54,6 @@ define({
     "ERROR_RENAMING_FILE"               : "<span class='dialog-filename'>{0}</span> dosyasının ismi değiştirilirken hata meydana geldi. {1}",
     "INVALID_FILENAME_TITLE"            : "Hatalı dosya ismi",
     "INVALID_FILENAME_MESSAGE"          : "Dosya isimleri yandaki karakterleri bulunduramaz: {0}",
-    "FILE_ALREADY_EXISTS"               : "<span class='dialog-filename'>{0}</span> dosyası zaten bulunmakta",
     "ERROR_CREATING_FILE_TITLE"         : "Dosya yaratılırken hata",
     "ERROR_CREATING_FILE"               : "<span class='dialog-filename'>{0}</span> dosyası yaratılırken hata meydana geldi. {1}",
 
@@ -94,11 +93,8 @@ define({
     "EXT_DELETED_MESSAGE"               : "<span class='dialog-filename'>{0}</span> dosyası hafızadan silind ama {APP_NAME} programında kaydetmediğiniz değişiklikler bulunmakta.<br /><br />Değişikliklerin kalmasını istiyor musunuz?",
     
     // Find, Replace, Find in Files
-    "SEARCH_REGEXP_INFO"                : "Regex arama yapmak için /re/ sentaksını kullanın",
-    "WITH"                              : "İle",
     "BUTTON_YES"                        : "Evet",
     "BUTTON_NO"                         : "Hayır",
-    "BUTTON_STOP"                       : "Durdur",
 
     "OPEN_FILE"                         : "Dosya Aç",
     "CHOOSE_FOLDER"                     : "Klasör Seç",
@@ -107,7 +103,6 @@ define({
     "NO_UPDATE_TITLE"                   : "En son versiyon!",
     "NO_UPDATE_MESSAGE"                 : "{APP_NAME} programının en son versiyonunu kullanıyorsunuz.",
     
-    "FIND_IN_FILES_TITLE"               : "- {2} {3} içindeki {0} {1}",
     "FIND_IN_FILES_SCOPED"              : "<span class='dialog-filename'>{0}</span> dosyası içinde",
     "FIND_IN_FILES_NO_SCOPE"            : "proje içinde",
     "FIND_IN_FILES_FILE"                : "dosya",
@@ -115,9 +110,7 @@ define({
     "FIND_IN_FILES_MATCH"               : "eşleşen",
     "FIND_IN_FILES_MATCHES"             : "eşleşenler",
     "FIND_IN_FILES_MORE_THAN"           : "Daha fazla ",
-    "FIND_IN_FILES_MAX"                 : " (ilk {0} eşlemeyi gösteriyor)",
     "FIND_IN_FILES_FILE_PATH"           : "Dosya: <b>{0}</b>",
-    "FIND_IN_FILES_LINE"                : "Satır:&nbsp;{0}",
 
     "ERROR_FETCHING_UPDATE_INFO_TITLE"  : "Versiyon bilgisi alınırken hata",
     "ERROR_FETCHING_UPDATE_INFO_MSG"    : "Sunucudan yeni versiyon bilgisi alınırken hata oluştu. Lütfen internete bağlı olduğunuzdan emin olun ve tekrar deneyin.",
@@ -147,7 +140,6 @@ define({
     "STATUSBAR_INDENT_SIZE_TOOLTIP_TABS"    : "Tab karakter genişliğini değiştirmek için tıklayın",
     "STATUSBAR_SPACES"                      : "Boşluk:",
     "STATUSBAR_TAB_SIZE"                    : "Tab Boyutu:",
-    "STATUSBAR_LINE_COUNT"                  : "{0} Satır",
 
     /**
      * Command Name Constants
@@ -201,7 +193,6 @@ define({
     // Search menu commands
     "FIND_MENU"                           : "Bul",
     "CMD_FIND"                            : "Bul",
-    "CMD_FIND_FIELD_PLACEHOLDER"          : "Bul\u2026",
     "CMD_FIND_NEXT"                       : "Sonrakini Bul",
     "CMD_FIND_PREVIOUS"                   : "Öncekini Bul",
     "CMD_FIND_ALL_AND_SELECT"             : "Hepsini Bul ve Seç",
@@ -218,10 +209,10 @@ define({
     "CMD_INCREASE_FONT_SIZE"              : "Font Boyutunu Büyült",
     "CMD_DECREASE_FONT_SIZE"              : "Font Boyutunu Küçült",
     "CMD_RESTORE_FONT_SIZE"               : "Font Boyutunu Sıfırla",
-    "CMD_SORT_WORKINGSET_BY_ADDED"        : "Eklenmeye Göre Sırala",
-    "CMD_SORT_WORKINGSET_BY_NAME"         : "İsme Göre Sırala",
-    "CMD_SORT_WORKINGSET_BY_TYPE"         : "Türüne Göre Sırala",
-    "CMD_SORT_WORKINGSET_AUTO"            : "Otomatik Sırala",
+    "CMD_WORKINGSET_SORT_BY_ADDED"        : "Eklenmeye Göre Sırala",
+    "CMD_WORKINGSET_SORT_BY_NAME"         : "İsme Göre Sırala",
+    "CMD_WORKINGSET_SORT_BY_TYPE"         : "Türüne Göre Sırala",
+    "CMD_WORKING_SORT_TOGGLE_AUTO"        : "Otomatik Sırala",
 
     // Navigate menu Commands
     "NAVIGATE_MENU"                       : "Git",
@@ -250,16 +241,10 @@ define({
     "CMD_TWITTER"                         : "{TWITTER_NAME} Twitter'da...",
     "CMD_CHECK_FOR_UPDATE"                : "Yeni Versiyon Kontrol Et",
     "CMD_ABOUT"                           : "{APP_TITLE} Hakkında",
-    "CMD_FORUM"                           : "{APP_NAME} Forum",
     "CMD_OPEN_PREFERENCES"                : "Ayarlar Dosyasını Aç",
-
-    // Special commands invoked by the native shell
-    "CMD_CLOSE_WINDOW"                    : "Ekranı Kapat",
-    "CMD_ABORT_QUIT"                      : "Çıkışı İptal Et",
 
     // Strings for main-view.html
     "EXPERIMENTAL_BUILD"                   : "Deneysel Sürüm",
-    "SEARCH_RESULTS"                       : "Arama sonuçları",
     "OK"                                   : "Tamam",
     "DONT_SAVE"                            : "Kaydetme",
     "SAVE"                                 : "Kaydet",
@@ -307,14 +292,6 @@ define({
     "LANGUAGE_MESSAGE"                     : "Lütfen aşağıdaki dillerden istediğiniz dili seçin:",
     "LANGUAGE_SUBMIT"                      : "{APP_NAME} Yenile",
     "LANGUAGE_CANCEL"                      : "İptal",
-    
-    // extensions/default/JSLint
-    "CMD_JSLINT"                           : "JSLint Aç",
-    "JSLINT_ERRORS"                        : "JSLint Hataları",
-    "JSLINT_ERROR_INFORMATION"             : "1 JSLint Hatası",
-    "JSLINT_ERRORS_INFORMATION"            : "{0} JSLint Hatası",
-    "JSLINT_NO_ERRORS"                     : "JSLint hatası bulunamadı - Mükemmel!",
-    "JSLINT_DISABLED"                      : "JSLint kapalı veya şuan ki dosyada kullanılamıyor",
 
     // extensions/default/JavaScriptCodeHints
     "CMD_JUMPTO_DEFINITION"                     : "Tanıma Atla",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -362,11 +362,9 @@ define({
     "CMD_ADD_NEXT_MATCH"                        : "Додати наступний збіг до виділення",
     "CMD_SKIP_CURRENT_MATCH"                    : "Пропустити поточний збіг",
     "CMD_FIND_IN_FILES"                         : "Знайти у файлах",
-    "CMD_FIND_IN_SELECTED"                      : "Знайти в обраному файлі/теці",
     "CMD_FIND_IN_SUBTREE"                       : "Знайти у\u2026",
     "CMD_REPLACE"                               : "Замінити",
     "CMD_REPLACE_IN_FILES"                      : "Замінити у файлах",
-    "CMD_REPLACE_IN_SELECTED"                   : "Замінити у вибраному файлі/теці",
     "CMD_REPLACE_IN_SUBTREE"                    : "Замінити\u2026",
 
     // View menu commands


### PR DESCRIPTION
This grunt task checks that all nls keys referenced in a nls file are actually present in the root file, too.
This will help us spot typos and the like.

I've dropped all the keys removed from the root file, but still present in some nls files.
