### PR TITLE
Enable setting the LivePreview server address in Brackets preferences.

### DIFF
--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -46,6 +46,10 @@ define(function (require, exports, module) {
         description: Strings.DESCRIPTION_STATIC_SERVER_PORT
     });
 
+    _prefs.definePreference("address", "string", "127.0.0.1", {
+        description: Strings.DESCRIPTION_STATIC_SERVER_ADDRESS
+    });
+
     /**
      * @constructor
      * @extends {BaseServer}
@@ -135,8 +139,11 @@ define(function (require, exports, module) {
         }
 
         var port = sanitizePort(_prefs.get("port"));
+        var address = _prefs.get("address");
 
-        this._nodeDomain.exec("getServer", self._root, port)
+        console.error('addresssssss', address);
+
+        this._nodeDomain.exec("getServer", self._root, address, port)
             .done(function (address) {
 
                 // If the port returned wasn't what was requested, then the preference has
@@ -144,7 +151,7 @@ define(function (require, exports, module) {
                 if (address.port !== port && port > 0) {
                     return self._nodeDomain.exec("closeServer", self._root)
                         .done(function () {
-                            return self._nodeDomain.exec("getServer", self._root, port)
+                            return self._nodeDomain.exec("getServer", self._root, address, port)
                                 .done(onSuccess)
                                 .fail(onFailure);
                         })

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -112,27 +112,28 @@
      * @private
      * Helper function to create a new server.
      * @param {string} path The absolute path that should be the document root
+     * @param {string} address The IP address of the server that is created
      * @param {function(?string, ?httpServer)} cb Callback function that receives
      *    an error (or null if there was no error) and the server (or null if there
      *    was an error). 
      */
     function _createServer(path, address, port, createCompleteCallback) {
         var server,
+            serverAddress,
             app,
-            address,
             pathKey = getPathKey(path);
 
         // create a new map for this server's requests
         _requests[pathKey] = {};
         
         function requestRoot(server, cb) {
-            address = server.address();
+            serverAddress = server.address();
             
             // Request the root file from the project in order to ensure that the
             // server is actually initialized. If we don't do this, it seems like
             // connect takes time to warm up the server.
             var req = http.get(
-                {host: address.address, port: address.port},
+                {host: serverAddress.address, port: serverAddress.port},
                 function (res) {
                     cb(null, res);
                 }
@@ -196,8 +197,8 @@
                 resume(!resData.body);
             };
 
-            location.hostname = address.address;
-            location.port = address.port;
+            location.hostname = serverAddress.address;
+            location.port = serverAddress.port;
             location.root = path;
 
             var request = {
@@ -393,7 +394,7 @@
                 {
                     name: "address",
                     type: "string",
-                    description: "Address to use for HTTP server. Defaults to 127.0.0.1."
+                    description: "Address to use for HTTP server."
                 },
                 {
                     name: "port",

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -116,7 +116,7 @@
      *    an error (or null if there was no error) and the server (or null if there
      *    was an error). 
      */
-    function _createServer(path, port, createCompleteCallback) {
+    function _createServer(path, address, port, createCompleteCallback) {
         var server,
             app,
             address,
@@ -240,13 +240,13 @@
         // If the given port/address is in use then use a random port
         server.on("error", function (e) {
             if (e.code === "EADDRINUSE") {
-                server.listen(0, "127.0.0.1");
+                server.listen(0, address);
             } else {
                 throw e;
             }
         });
 
-        server.listen(port, "127.0.0.1");
+        server.listen(port, address);
     }
     
     /**
@@ -262,13 +262,13 @@
      *    The "family" property of the address indicates whether the address is,
      *    for example, IPv4, IPv6, or a UNIX socket.
      */
-    function _cmdGetServer(path, port, cb) {
+    function _cmdGetServer(path, address, port, cb) {
         // Make sure the key doesn't conflict with some built-in property of Object.
         var pathKey = getPathKey(path);
         if (_servers[pathKey]) {
             cb(null, _servers[pathKey].address());
         } else {
-            _createServer(path, port, function (err, server) {
+            _createServer(path, address, port, function (err, server) {
                 if (err) {
                     cb(err, null);
                 } else {
@@ -389,6 +389,11 @@
                     name: "path",
                     type: "string",
                     description: "Absolute filesystem path for root of server."
+                },
+                {
+                    name: "address",
+                    type: "string",
+                    description: "Address to use for HTTP server. Defaults to 127.0.0.1."
                 },
                 {
                     name: "port",

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
             it("should start a static server on the given folder", function () {
                 var serverInfo, path = testFolder + "/folder1";
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
                     path = testFolder + "/folder1";
 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 54321)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 54321)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -131,11 +131,11 @@ define(function (require, exports, module) {
                     path1 = testFolder + "/folder1", path2 = testFolder + "/folder2";
 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path1, 54321)
+                    nodeConnection.domains.staticServer.getServer(path1, "127.0.0.1", 54321)
                         .done(function (info) {
                             serverInfo1 = info;
                         });
-                    nodeConnection.domains.staticServer.getServer(path2, 54321)
+                    nodeConnection.domains.staticServer.getServer(path2, "127.0.0.1", 54321)
                         .done(function (info) {
                             serverInfo2 = info;
                         });
@@ -155,10 +155,30 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should start the server on the given address", function () {
+                var serverInfo,
+                    path = testFolder + "/folder1";
+
+                runs(function () {
+                    nodeConnection.domains.staticServer.getServer(path, "0.0.0.0", 0)
+                        .done(function (info) {
+                            serverInfo = info;
+                        });
+                });
+
+                waitsFor(function () { return serverInfo; }, "waiting for static server to start");
+                runs(function () {
+                    expect(serverInfo.address).toBe("0.0.0.0");
+
+                    waitsForDone(nodeConnection.domains.staticServer.closeServer(path),
+                                 "waiting for static server to close");
+                });
+            });
+
             it("should serve the text of a file in the given folder", function () {
                 var serverInfo, text, path = testFolder + "/folder1";
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -186,11 +206,11 @@ define(function (require, exports, module) {
                 var serverInfo1, serverInfo2,
                     path1 = testFolder + "/folder1", path2 = testFolder + "/folder2";
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path1, 0)
+                    nodeConnection.domains.staticServer.getServer(path1, null, 0)
                         .done(function (info) {
                             serverInfo1 = info;
                         });
-                    nodeConnection.domains.staticServer.getServer(path2, 0)
+                    nodeConnection.domains.staticServer.getServer(path2, null, 0)
                         .done(function (info) {
                             serverInfo2 = info;
                         });
@@ -213,11 +233,11 @@ define(function (require, exports, module) {
                     path1 = testFolder + "/folder1", path2 = testFolder + "/folder2",
                     text1, text2;
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path1, 0)
+                    nodeConnection.domains.staticServer.getServer(path1, null, 0)
                         .done(function (info) {
                             serverInfo1 = info;
                         });
-                    nodeConnection.domains.staticServer.getServer(path2, 0)
+                    nodeConnection.domains.staticServer.getServer(path2, null, 0)
                         .done(function (info) {
                             serverInfo2 = info;
                         });
@@ -257,7 +277,7 @@ define(function (require, exports, module) {
                     timeout = 500;
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -313,7 +333,7 @@ define(function (require, exports, module) {
                     requestId;
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -363,7 +383,7 @@ define(function (require, exports, module) {
                     requestId;
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -410,7 +430,7 @@ define(function (require, exports, module) {
                     requestId;
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -472,7 +492,7 @@ define(function (require, exports, module) {
                 });
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });
@@ -528,7 +548,7 @@ define(function (require, exports, module) {
                     timeout = 500;
                 
                 runs(function () {
-                    nodeConnection.domains.staticServer.getServer(path, 0)
+                    nodeConnection.domains.staticServer.getServer(path, "127.0.0.1", 0)
                         .done(function (info) {
                             serverInfo = info;
                         });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -732,6 +732,7 @@ define({
     "DESCRIPTION_SORT_DIRECTORIES_FIRST"             : "True to sort the directories first in the project tree",
     "DESCRIPTION_SPACE_UNITS"                        : "Number of spaces to use for space-based indentation",
     "DESCRIPTION_STATIC_SERVER_PORT"                 : "Port number that the built-in server should use for Live Preview",
+    "DESCRIPTION_STATIC_SERVER_ADDRESS"              : "The address that the built-in server should use for Live Preview",
     "DESCRIPTION_STYLE_ACTIVE_LINE"                  : "True to highlight background color of the line the cursor is on",
     "DESCRIPTION_TAB_SIZE"                           : "Number of spaces to display for tabs",
     "DESCRIPTION_USE_TAB_CHAR"                       : "True to use tabs instead of spaces",


### PR DESCRIPTION
Add functionality to configure the LiveServer address in Brackets preferences file. This enables setting like this to let you access the LiveServer across a local network:

```
"staticserver.address": "0.0.0.0"
```

Addresses #6424
