### PR TITLE
Resolves issues - 11333 and 11261

### DIFF
--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -234,7 +234,13 @@ define(function (require, exports, module) {
         templateVars.Strings = Strings;
         templateVars.replaceAllLabel = (templateVars.multifile ? Strings.BUTTON_REPLACE_ALL_IN_FILES : Strings.BUTTON_REPLACE_ALL);
         
-        this._modalBar = new ModalBar(Mustache.render(_searchBarTemplate, templateVars), true);  // 2nd arg = auto-close on Esc/blur
+        ModalBar.prototype._handleFocusChange = function (e) {
+            if (this.isLockedOpen && this.isLockedOpen()) {
+                return;
+            }
+        };
+        
+        this._modalBar = new ModalBar(Mustache.render(_searchBarTemplate, templateVars), true);  // 2nd arg = auto-close on Esc
         
         // When the ModalBar closes, clean ourselves up.
         this._modalBar.on("close", function (event) {

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -239,9 +239,20 @@ define(function (require, exports, module) {
         }
     };
     
+    /**
+     * If autoClose is set, detects when something other than the modal bar is getting focus and
+     * dismisses the modal bar. DOM nodes with "attached-to" jQuery metadata referencing an element
+     * within the ModalBar are allowed to take focus without closing it.
+     */
     ModalBar.prototype._handleFocusChange = function (e) {
         if (this.isLockedOpen && this.isLockedOpen()) {
             return;
+        }
+        
+        var effectiveElem = $(e.target).data("attached-to") || e.target;
+        
+        if (!$.contains(this._$root.get(0), effectiveElem)) {
+            this.close(undefined, undefined, ModalBar.CLOSE_BLUR);
         }
     };
     

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -239,20 +239,9 @@ define(function (require, exports, module) {
         }
     };
     
-    /**
-     * If autoClose is set, detects when something other than the modal bar is getting focus and
-     * dismisses the modal bar. DOM nodes with "attached-to" jQuery metadata referencing an element
-     * within the ModalBar are allowed to take focus without closing it.
-     */
     ModalBar.prototype._handleFocusChange = function (e) {
         if (this.isLockedOpen && this.isLockedOpen()) {
             return;
-        }
-        
-        var effectiveElem = $(e.target).data("attached-to") || e.target;
-        
-        if (!$.contains(this._$root.get(0), effectiveElem)) {
-            this.close(undefined, undefined, ModalBar.CLOSE_BLUR);
         }
     };
     


### PR DESCRIPTION
11333 ( https://github.com/adobe/brackets/issues/11333 ) and 11261 ( https://github.com/adobe/brackets/issues/11261 )

Closes the modal bar only when escape is pressed and modal bar is having focus .This removes the problem in find operations as losing the focus of the bar will not close the modal bar until 'escape' key is pressed..
