### PR TITLE
Add @rj-adobe to CLA exceptions

### DIFF
--- a/tasks/cla-exceptions.json
+++ b/tasks/cla-exceptions.json
@@ -1,8 +1,9 @@
 {
+    "albertinad": true,
     "busykai": true,
     "mjherna1": true,
-    "shahabl": true,
+    "rj-adobe": true,
     "sebaslv": true,
-    "albertinad": true,
+    "shahabl": true,
     "walfgithub": true
 }


### PR DESCRIPTION
As @rj-adobe seems to be the new ALF bot (#11355), I added him to the CLA exceptions (and also sorted them alphabetically).

@ryanstewart 
