### PR TITLE
After fresh install health data should always return an empty object if not already defined.

### DIFF
--- a/src/utils/HealthLogger.js
+++ b/src/utils/HealthLogger.js
@@ -60,7 +60,8 @@ define(function (require, exports, module) {
      * @return {Object} Health Data aggregated till now
      */
     function getStoredHealthData() {
-        return PreferencesManager.getViewState(HEALTH_DATA_STATE_KEY);
+        var storedData = PreferencesManager.getViewState(HEALTH_DATA_STATE_KEY) || {};
+        return storedData;
     }
 
     /**


### PR DESCRIPTION
After fresh install health data should always return an empty object if not already defined.
