### PR TITLE
FindBar not working for case insensitive values

### DIFF
--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -400,7 +400,7 @@ define(function (require, exports, module) {
     FindBar.prototype.getQueryInfo = function () {
         return {
             query:           this.$("#find-what").val() || "",
-            isCaseSensitive: this.$("#find-case-sensitive").is(".active"),
+            isCaseSensitive: this.$("#find-case-sensitive").is(".inactive"),
             isRegexp:        this.$("#find-regexp").is(".active")
         };
     };


### PR DESCRIPTION
It behaves differently from the very common searching methods. For ex- If you want to search "getResults" and you type "getresults" , it won't find anything . So , this patch actually fixes this.
