### PR TITLE
Convert numbers to strings, so StringMatch can match it.

### DIFF
--- a/src/extensions/default/PrefsCodeHints/main.js
+++ b/src/extensions/default/PrefsCodeHints/main.js
@@ -281,6 +281,13 @@ define(function (require, exports, module) {
                     return null;
                 }
                 
+                // Convert integers to strings, so StringMatch.stringMatch can match it.
+                if (option.type === "number" || option.valueType === "number") {
+                    values = values.map(function (val) {
+                        return val.toString();
+                    });
+                }
+
                 // filter through the values.
                 hints = $.map(values, function (value) {
                     var match = StringMatch.stringMatch(value, query, stringMatcherOptions);
@@ -332,8 +339,7 @@ define(function (require, exports, module) {
             }
             
             // Put quotes around completion.
-            completion = quoteChar + completion;
-            completion = completion + quoteChar;
+            completion = quoteChar + completion + quoteChar;
             
             // Append colon and braces, brackets and quotes.
             if (!ctxInfo.shouldReplace) {


### PR DESCRIPTION
Converts `"number"` values into strings so `StringMatch.stringMatch` can match it. 

@abose This is critical to go with the release.
