### PR TITLE
Resolve Brackets freezing/crashing on windows on reload.

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1637,7 +1637,7 @@ define(function (require, exports, module) {
                 // Defer for a more successful reload.
                 setTimeout(function(){
                     window.location.href = href;    
-                },1000)
+                },1000);
                 
             });
         }).fail(function () {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1634,8 +1634,11 @@ define(function (require, exports, module) {
                 if (fragment !== -1) {
                     href = href.substr(0, fragment);
                 }
-
-                window.location.href = href;
+                // Defer for a more successful reload.
+                setTimeout(function(){
+                    window.location.href = href;    
+                },1000)
+                
             });
         }).fail(function () {
             _isReloading = false;


### PR DESCRIPTION
Workaround to resolve brackets freezing and crashing on some windows OS on installing/uninstalling extensions and on reload. 
Issue Reference: https://github.com/adobe/brackets/issues/11477
