### PR TITLE
Faster version of compareFilenames()

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -426,12 +426,36 @@ define(function (require, exports, module) {
     }
     
     /**
+     * @private
+     * OS-specific helper for `compareFilenames()`
+     * @param {string} filename1
+     * @param {string} filename2
+     * @param {string} lang Locale
+     * @return {number} The result of the compare function
+     */
+    var _cmpNames = (function (filename1, filename2, lang) {
+        if (brackets.platform === "win") {
+            // Use this function on Windows
+            return function (filename1, filename2, lang) {
+                var f1 = getFilenameWithoutExtension(filename1),
+                    f2 = getFilenameWithoutExtension(filename2);
+                return f1.localeCompare(f2, lang, {numeric: true});
+            };
+        }
+        
+        // Use this function other OSes
+        return function (filename1, filename2, lang) {
+            return filename1.localeCompare(filename2, lang, {numeric: true});
+        };
+    }());
+    
+    /**
      * Compares 2 filenames in lowercases. In Windows it compares the names without the
      * extension first and then the extensions to fix issue #4409
      * @param {string} filename1
      * @param {string} filename2
      * @param {boolean} extFirst If true it compares the extensions first and then the file names.
-     * @return {number} The result of the local compare function
+     * @return {number} The result of the compare function
      */
     function compareFilenames(filename1, filename2, extFirst) {
         var lang = brackets.getLocale();
@@ -446,12 +470,7 @@ define(function (require, exports, module) {
         }
         
         function cmpNames() {
-            if (brackets.platform === "win") {
-                var f1 = getFilenameWithoutExtension(filename1),
-                    f2 = getFilenameWithoutExtension(filename2);
-                return f1.localeCompare(f2, lang, {numeric: true});
-            }
-            return filename1.localeCompare(filename2, lang, {numeric: true});
+            return _cmpNames(filename1, filename2, lang);
         }
         
         return extFirst ? (cmpExt() || cmpNames()) : (cmpNames() || cmpExt());

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -428,12 +428,9 @@ define(function (require, exports, module) {
     /**
      * @private
      * OS-specific helper for `compareFilenames()`
-     * @param {string} filename1
-     * @param {string} filename2
-     * @param {string} lang Locale
-     * @return {number} The result of the compare function
+     * @return {Function} The OS-specific compare function
      */
-    var _cmpNames = (function (filename1, filename2, lang) {
+    var _cmpNames = (function () {
         if (brackets.platform === "win") {
             // Use this function on Windows
             return function (filename1, filename2, lang) {

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -436,24 +436,27 @@ define(function (require, exports, module) {
     function compareFilenames(filename1, filename2, extFirst) {
         var lang = brackets.getLocale();
         
+        filename1 = filename1.toLocaleLowerCase();
+        filename2 = filename2.toLocaleLowerCase();
+        
         function cmpExt() {
             var ext1 = getFileExtension(filename1),
                 ext2 = getFileExtension(filename2);
-            return ext1.toLocaleLowerCase().localeCompare(ext2.toLocaleLowerCase(), lang, {numeric: true});
+            return ext1.localeCompare(ext2, lang, {numeric: true});
         }
         
         function cmpNames() {
             if (brackets.platform === "win") {
                 var f1 = getFilenameWithoutExtension(filename1),
                     f2 = getFilenameWithoutExtension(filename2);
-                return f1.toLocaleLowerCase().localeCompare(f2.toLocaleLowerCase(), lang, {numeric: true});
+                return f1.localeCompare(f2, lang, {numeric: true});
             }
-            return filename1.toLocaleLowerCase().localeCompare(filename2.toLocaleLowerCase(), lang, {numeric: true});
+            return filename1.localeCompare(filename2, lang, {numeric: true});
         }
         
         return extFirst ? (cmpExt() || cmpNames()) : (cmpNames() || cmpExt());
     }
-    
+
     /**
      * Compares two paths segment-by-segment, used for sorting. When two files share a path prefix,
      * the less deeply nested one is sorted earlier in the list. Sorts files within the same parent

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -434,19 +434,24 @@ define(function (require, exports, module) {
      * @return {number} The result of the local compare function
      */
     function compareFilenames(filename1, filename2, extFirst) {
-        var ext1   = getFileExtension(filename1),
-            ext2   = getFileExtension(filename2),
-            lang   = brackets.getLocale(),
-            cmpExt = ext1.toLocaleLowerCase().localeCompare(ext2.toLocaleLowerCase(), lang, {numeric: true}),
-            cmpNames;
+        var lang = brackets.getLocale();
         
-        if (brackets.platform === "win") {
-            filename1 = getFilenameWithoutExtension(filename1);
-            filename2 = getFilenameWithoutExtension(filename2);
+        function cmpExt() {
+            var ext1 = getFileExtension(filename1),
+                ext2 = getFileExtension(filename2);
+            return ext1.toLocaleLowerCase().localeCompare(ext2.toLocaleLowerCase(), lang, {numeric: true});
         }
-        cmpNames = filename1.toLocaleLowerCase().localeCompare(filename2.toLocaleLowerCase(), lang, {numeric: true});
         
-        return extFirst ? (cmpExt || cmpNames) : (cmpNames || cmpExt);
+        function cmpNames() {
+            if (brackets.platform === "win") {
+                var f1 = getFilenameWithoutExtension(filename1),
+                    f2 = getFilenameWithoutExtension(filename2);
+                return f1.toLocaleLowerCase().localeCompare(f2.toLocaleLowerCase(), lang, {numeric: true});
+            }
+            return filename1.toLocaleLowerCase().localeCompare(filename2.toLocaleLowerCase(), lang, {numeric: true});
+        }
+        
+        return extFirst ? (cmpExt() || cmpNames()) : (cmpNames() || cmpExt());
     }
     
     /**


### PR DESCRIPTION
The `compareFilenames()` function can sort files by either name first (then extension) or extension first (and then name). Old code executes _both_ comparisons and then only uses the results that it needs. The vast majority of comparisons only need either name comparison or extension comparison (not _both_).

This code now breaks the 2 search types into sub-functions which has these 2 benefits:
1. Only execute comparisons needed
2. `var` storage is function scope, so it's not allocated unless it's used.

For file tree (name-first) comparison, my measurements on Win7 indicate that this function uses **~40% less time**.
