### PR TITLE
Set Bash files syntax highlighting

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -258,6 +258,7 @@
         "name": "Bash",
         "mode": ["shell", "text/x-sh"],
         "fileExtensions": ["sh", "command", "bash"],
+        "fileNames": [".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile"],
         "lineComment": ["#"]
     },
   


### PR DESCRIPTION
Syntax Highlighting for [Bash startup files](http://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html)
