### PR TITLE
Map filename to language in case of dotfiles

### DIFF
--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Klikněte pro změnu typu souboru",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Klikněte pro zapnutí panelu zpráv.",
     "STATUSBAR_DEFAULT_LANG"                : "(výchozí)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Nastavit jako výchozí pro .{0} soubory",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Nastavit jako výchozí pro {0} soubory",
 
     // CodeInspection: chyby/varování
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} chyb",

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Klicken, um den Dateityp zu ändern",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Klicken, um Übersicht anzuzeigen/auszublenden.",
     "STATUSBAR_DEFAULT_LANG"                : "(Standard)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Als Standard für .{0}-Dateien festlegen",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Als Standard für {0}-Dateien festlegen",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Probleme",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -282,7 +282,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Haz clic para cambiar el tipo de archivo",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Haz clic para mostrar/ocultar el panel de reportes.",
     "STATUSBAR_DEFAULT_LANG"                : "(por defecto)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Marcar como predeterminado para los archivos .{0}",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Marcar como predeterminado para los archivos {0}",
     
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "Problemas de {0}",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "جهت تغییر نوع پرونده، کلیک کنید.",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. باز و بسته کردن پنل گزارشات.",
     "STATUSBAR_DEFAULT_LANG"                : "(پیش فرض)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : " اعمال بعنوان پیش فرض برای .{0} پرونده ها",
+    "STATUSBAR_SET_DEFAULT_LANG"            : " اعمال بعنوان پیش فرض برای {0} پرونده ها",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : " {0} خطا",

--- a/src/nls/fi/strings.js
+++ b/src/nls/fi/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Vaihda tiedostotyyppiä napsauttamalla",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Näytä tai piilota raporttipaneeli napsauttamalla.",
     "STATUSBAR_DEFAULT_LANG"                : "(oletus)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Aseta oletukseksi .{0}-tiedostoille",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Aseta oletukseksi {0}-tiedostoille",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} ongelmaa",

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -288,7 +288,7 @@ define({
 	"STATUSBAR_LANG_TOOLTIP": "Cliquez pour modifier le type de fichier",
 	"STATUSBAR_CODE_INSPECTION_TOOLTIP": "{0}. Cliquez pour afficher/masquer le panneau des rapports.",
 	"STATUSBAR_DEFAULT_LANG": "(par défaut)",
-	"STATUSBAR_SET_DEFAULT_LANG": "Utiliser par défaut pour les fichiers .{0}",
+	"STATUSBAR_SET_DEFAULT_LANG": "Utiliser par défaut pour les fichiers {0}",
 
     // CodeInspection: errors/warnings
 	"ERRORS_PANEL_TITLE_MULTIPLE": "{0} problèmes",

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -270,7 +270,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Fai click para cambiar o tipo de arquivo",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Fai click para amosar/ocultar o panel de reportes.",
     "STATUSBAR_DEFAULT_LANG"                : "(por defecto)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Marcar como predeterminado para os arquivos .{0}",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Marcar como predeterminado para os arquivos {0}",
     
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "Problemas de {0}",

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Klik untuk mengubah tipe file",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Klik untuk menampilkan/menyembunyikan panel laporan.",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Simpan sebagai Default untuk File .{0}",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Simpan sebagai Default untuk File {0}",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Masalah",

--- a/src/nls/it/strings.js
+++ b/src/nls/it/strings.js
@@ -281,7 +281,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Clicca per cambiare il tipo di file",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Clicca per attivare pannello dei report.",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Imposta come predefinito per .{0} File",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Imposta come predefinito per {0} File",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problemi",

--- a/src/nls/ja/strings.js
+++ b/src/nls/ja/strings.js
@@ -288,7 +288,7 @@ define({
 	"STATUSBAR_LANG_TOOLTIP": "クリックしてファイルタイプを変更",
 	"STATUSBAR_CODE_INSPECTION_TOOLTIP": "{0}。クリックしてレポートパネルを切り替えます。",
 	"STATUSBAR_DEFAULT_LANG": "(指定なし)",
-	"STATUSBAR_SET_DEFAULT_LANG": ".{0} ファイルのデフォルトとして設定",
+	"STATUSBAR_SET_DEFAULT_LANG": "{0} ファイルのデフォルトとして設定",
 
     // CodeInspection: errors/warnings
 	"ERRORS_PANEL_TITLE_MULTIPLE": "{0} 個の問題",

--- a/src/nls/ko/strings.js
+++ b/src/nls/ko/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "파일 종류를 변경하려면 클릭하세요",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. 클릭하면 기록 패널을 토글합니다.",
     "STATUSBAR_DEFAULT_LANG"                : "(기본값)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : ".{0} 파일에 대한 기본값으로 설정",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "{0} 파일에 대한 기본값으로 설정",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0}개의 에러",

--- a/src/nls/nl/strings.js
+++ b/src/nls/nl/strings.js
@@ -281,7 +281,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Klik om bestandstype te veranderen.",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Klik om foutenpaneel te openen.",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Standaard voor .{0} bestanden",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Standaard voor {0} bestanden",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Fouten",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Clique para alterar o tipo de arquivo",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Clique para abrir/fechar o painel de relatórios.",
     "STATUSBAR_DEFAULT_LANG"                : "(padrão)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Definir como padrão para arquivos .{0}.",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Definir como padrão para arquivos {0}.",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "Problemas de {0}",

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Clic pentru a modifica tipul fișierului",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Clic pentru a arăta / ascunde panoul de rapoarte.",
     "STATUSBAR_DEFAULT_LANG"                : "(implicit)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Setează ca implicit pentru fișierele .{0}",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Setează ca implicit pentru fișierele {0}",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} probleme",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Click to change file type",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Click to toggle report panel.",
     "STATUSBAR_DEFAULT_LANG"                : "(default)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for .{0} Files",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Set as Default for {0} Files",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} Problems",

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Кликни за измену типа датотеке",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Кликни за приказ/скривање панела са извештајима.",
     "STATUSBAR_DEFAULT_LANG"                : "(подразумевано)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Подеси као \"подразумевано\" за .{0} датотеке",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Подеси као \"подразумевано\" за {0} датотеке",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} грешака",

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -281,7 +281,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "Klicka för att byta filtyp",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}. Klicka för att visa rapportpanel.",
     "STATUSBAR_DEFAULT_LANG"                : "(standard)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "Ställ in som standard för .{0}-filer",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "Ställ in som standard för {0}-filer",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} fel",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -280,7 +280,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                    : "Натисніть, аби змінити тип файлу",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"         : "{0}. Натисніть, аби перемкнути панель повідомлень.",
     "STATUSBAR_DEFAULT_LANG"                    : "(типово)",
-    "STATUSBAR_SET_DEFAULT_LANG"                : "Встановити типовим для файлів .{0}",
+    "STATUSBAR_SET_DEFAULT_LANG"                : "Встановити типовим для файлів {0}",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"               : "{0} Помилок",

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -288,7 +288,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "点击更改文件类型",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}。点击打开关闭报告面板",
     "STATUSBAR_DEFAULT_LANG"                : "(默认)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "设置为 .{0} 的缺省",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "设置为 {0} 的缺省",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} 问题",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -287,7 +287,7 @@ define({
     "STATUSBAR_LANG_TOOLTIP"                : "按一下可以變更檔案類型",
     "STATUSBAR_CODE_INSPECTION_TOOLTIP"     : "{0}。按一下可以開啟或關閉報告面板。",
     "STATUSBAR_DEFAULT_LANG"                : "(預設)",
-    "STATUSBAR_SET_DEFAULT_LANG"            : "設定成 .{0} 檔的預設值",
+    "STATUSBAR_SET_DEFAULT_LANG"            : "設定成 {0} 檔的預設值",
 
     // CodeInspection: errors/warnings
     "ERRORS_PANEL_TITLE_MULTIPLE"           : "{0} 項問題",


### PR DESCRIPTION
`LanguageManager.getCompoundFileExtension` returns an empty string for dotfiles and extension-less files because of which the Language menu shows `Set as Default for . Files`. Clicking which adds an empty string as an extension in `"language.fileExtensions"`.

This PR will add dotfiles and extension-less files to `"language.fileNames"` instead of `"language.fileExtensions"`. The dot in extension is added dynamically now, will update it in rest of the locales once this gets reviewed.
