### PR TITLE
Add pref to allow indenting line comments

### DIFF
--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -213,7 +213,7 @@ define(function (require, exports, module) {
         if (containsNotLineComment) {
             // Comment out - prepend the first prefix to each line
             for (i = startLine; i <= endLine; i++) {
-                if (PreferencesManager.get("indentLineComment")) {
+                if (PreferencesManager.get("lineComment.indent")) {
                     line = doc.getLine(i);
                     commentI = Math.max(line.search(/\S/), 0);
                 } else {

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -485,6 +485,14 @@ define(function (require, exports, module) {
     Language.prototype._lineCommentSyntax = null;
     
     /**
+     * Whether or not the language requires indented line comments
+     * True if line comments must be indented, false if line comments must not
+     * be indented, or null to respect the preference
+     * @type {?boolean}
+     */
+    Language.prototype._indentLineComment = null;
+    
+    /**
      * Which language to use for what CodeMirror mode
      * @type {Object.<string,Language>}
      */
@@ -798,6 +806,22 @@ define(function (require, exports, module) {
     };
     
     /**
+     * Returns whether the line comments should start at the code indentation for this language.
+     * @return {?boolean} Whether indent line comments are required
+     */
+    Language.prototype.hasIndentLineComments = function () {
+        return this._indentLineComments;
+    };
+    
+    /**
+     * Sets or removes the requirement of indent or unindent line comments in this language.
+     * @param {?boolean} indentLineComments
+     */
+    Language.prototype.setIndentLineComments = function (indentLineComments) {
+        this._indentLineComments = indentLineComments;
+    };
+    
+    /**
      * Returns whether the block comment syntax is defined for this language.
      * @return {boolean} Whether block comments are supported
      */
@@ -967,6 +991,7 @@ define(function (require, exports, module) {
             result.reject();
             return result.promise();
         }
+        language.setIndentLineComments(definition.indentLineComments);
 
         
         if (definition.isBinary) {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -38,7 +38,8 @@
         "mode": ["stylus", "text/x-styl"],
         "fileExtensions": ["styl"],
         "blockComment": ["/*", "*/"],
-        "lineComment": ["//"]
+        "lineComment": ["//"],
+        "indentLineComments": true
     },
 
     "html": {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -729,6 +729,7 @@ define({
     "DESCRIPTION_LANGUAGE"                           : "Language specific settings",
     "DESCRIPTION_LANGUAGE_FILE_EXTENSIONS"           : "Additional mappings from file extension to language name",
     "DESCRIPTION_LANGUAGE_FILE_NAMES"                : "Additional mappings from file name to language name",
+    "DESCRIPTION_LINE_COMMENT_INDENT"                : "true to align a line comment with the line's indentation",
     "DESCRIPTION_LINTING_ENABLED"                    : "true to enable Code Inspection",
     "DESCRIPTION_ASYNC_TIMEOUT"                      : "The time in milliseconds after which asynchronous linters time out",
     "DESCRIPTION_LINTING_PREFER"                     : "Array of linters to run first",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -729,7 +729,7 @@ define({
     "DESCRIPTION_LANGUAGE"                           : "Language specific settings",
     "DESCRIPTION_LANGUAGE_FILE_EXTENSIONS"           : "Additional mappings from file extension to language name",
     "DESCRIPTION_LANGUAGE_FILE_NAMES"                : "Additional mappings from file name to language name",
-    "DESCRIPTION_LINE_COMMENT_INDENT"                : "true to align a line comment with the line's indentation",
+    "DESCRIPTION_LINE_COMMENT_INDENT"                : "true to align a line comment with the line's indentation - does not apply to all languages",
     "DESCRIPTION_LINTING_ENABLED"                    : "true to enable Code Inspection",
     "DESCRIPTION_ASYNC_TIMEOUT"                      : "The time in milliseconds after which asynchronous linters time out",
     "DESCRIPTION_LINTING_PREFER"                     : "Array of linters to run first",


### PR DESCRIPTION
Fixes #8012.
This pref is enabled by default, aligned with https://github.com/adobe/brackets/issues/8012#issuecomment-54155264.

The pref does not apply when there's no line comment syntax available and we fall back to block commenting the line.

cc @le717 @redmunds 
