### PR TITLE
Ensures fold gutter is always added after line numbers 

### DIFF
--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -26,10 +26,10 @@
  * @date 10/24/13 9:35:26 AM
  */
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets*/
+/*global define, $, brackets, MutationObserver*/
 define(function (require, exports, module) {
     "use strict";
-    
+
     var CodeMirror              = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
         Strings                 = brackets.getModule("strings"),
         AppInit                 = brackets.getModule("utils/AppInit"),
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
         expandAllKeyMac         = "Cmd-Shift-1";
 
     ExtensionUtils.loadStyleSheet(module, "main.less");
-    
+
     // Load CodeMirror addons
     brackets.getModule(["thirdparty/CodeMirror/addon/fold/brace-fold"]);
     brackets.getModule(["thirdparty/CodeMirror/addon/fold/comment-fold"]);
@@ -68,11 +68,12 @@ define(function (require, exports, module) {
     var foldGutter              = require("foldhelpers/foldgutter"),
         foldCode                = require("foldhelpers/foldcode"),
         indentFold              = require("foldhelpers/indentFold");
-    
-    
+
+
     /** Set to true when init() has run; set back to false after deinit() has run */
-    var _isInitialized = false;
-    
+    var _isInitialized = false,
+        gutterObservers = {};
+
     /**
       * Restores the linefolds in the editor using values fetched from the preference store
       * Checks the document to ensure that changes have not been made (e.g., in a different editor)
@@ -211,7 +212,7 @@ define(function (require, exports, module) {
 
     /**
       * Initialises and creates the code-folding gutter.
-      * @param {Editor} editor the editor on which to initialise the fold gutter
+      * @param {Editor}  editor the editor on which to initialise the fold gutter
       */
     function createGutter(editor) {
         var cm = editor._codeMirror;
@@ -223,6 +224,9 @@ define(function (require, exports, module) {
         // Reuse any existing fold gutter
         if (gutters.indexOf(GUTTER_NAME) < 0) {
             var lnIndex = gutters.indexOf("CodeMirror-linenumbers");
+            if (lnIndex < 0) {
+                $(editor.getRootElement()).addClass("linenumber-disabled");
+            }
             $(editor.getRootElement()).addClass("folding-enabled");
             gutters.splice(lnIndex + 1, 0, GUTTER_NAME);
             cm.setOption("gutters",  gutters);
@@ -262,12 +266,45 @@ define(function (require, exports, module) {
         cm.refresh();  // force recomputing gutter width - .folding-enabled class affected linenumbers gutter
         CodeMirror.defineOption("foldGutter", false, null);
     }
-    
+
     /** Add gutter and restore saved expand/collapse state */
     function enableFoldingInEditor(editor) {
         if (editor._codeMirror.getOption("gutters").indexOf(GUTTER_NAME) === -1) {
             createGutter(editor);
             restoreLineFolds(editor);
+            //watch mutations on code mirror gutters and ensure line numbers are added before fold gutter
+            var config = {childList: true};
+            var gutters,
+                lineNumberIndex,
+                foldGutterIndex,
+                cm = editor._codeMirror,
+                guttersContainer = $(".CodeMirror-gutters", editor.getRootElement()),
+                observer = new MutationObserver(function (mutations) {
+                    observer.disconnect();
+                    //ensure fold-gutter appears after line numbers
+                    gutters = cm.getOption("gutters").slice(0);
+                    lineNumberIndex = gutters.indexOf("CodeMirror-linenumbers");
+                    foldGutterIndex = gutters.indexOf(GUTTER_NAME);
+                    if (lineNumberIndex > -1 && foldGutterIndex < lineNumberIndex) {
+                        gutters.splice(foldGutterIndex, 1);
+                        lineNumberIndex = gutters.indexOf("CodeMirror-linenumbers");
+                        gutters.splice(lineNumberIndex + 1, 0, GUTTER_NAME);
+                    }
+
+                    if (lineNumberIndex < 0) {
+                        $(editor.getRootElement()).addClass("linenumber-disabled");
+                    } else {
+                        $(editor.getRootElement()).removeClass("linenumber-disabled");
+                    }
+                    $(editor.getRootElement()).addClass("folding-enabled");
+                    cm.setOption("gutters", gutters);
+                    cm.refresh();
+                    createGutter(editor);
+                    //reconnect the observer
+                    observer.observe(guttersContainer[0], config);
+                });
+            observer.observe(guttersContainer[0], config);
+            gutterObservers[editor.document.file.fullPath] = observer;
         }
     }
 
@@ -300,7 +337,7 @@ define(function (require, exports, module) {
      */
     function deinit() {
         _isInitialized = false;
-        
+
         KeyBindingManager.removeBinding(collapseKey);
         KeyBindingManager.removeBinding(expandKey);
         KeyBindingManager.removeBinding(collapseAllKey);
@@ -314,7 +351,7 @@ define(function (require, exports, module) {
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).removeMenuItem(EXPAND);
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).removeMenuItem(COLLAPSE_ALL);
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).removeMenuItem(EXPAND_ALL);
-        
+
         EditorManager.off(".CodeFolding");
         DocumentManager.off(".CodeFolding");
         ProjectManager.off(".CodeFolding");
@@ -323,18 +360,23 @@ define(function (require, exports, module) {
         Editor.forEveryEditor(function (editor) {
             CodeMirror.commands.unfoldAll(editor._codeMirror);
             removeGutter(editor);
+            //disconnect any mutation observers on the gutter
+            if (gutterObservers[editor.document.file.fullPath]) {
+                gutterObservers[editor.document.file.fullPath].disconnect();
+                delete gutterObservers[editor.document.file.fullPath];
+            }
         });
     }
-    
+
     /**
      * Enable code-folding functionality
      */
     function init() {
         _isInitialized = true;
-        
+
         foldCode.init();
         foldGutter.init();
-        
+
         // Many CodeMirror modes specify which fold helper should be used for that language. For a few that
         // don't, we register helpers explicitly here. We also register a global helper for generic indent-based
         // folding, which cuts across all languages if enabled via preference.
@@ -358,7 +400,7 @@ define(function (require, exports, module) {
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(EXPAND_ALL);
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(COLLAPSE);
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(EXPAND);
-        
+
         //register keybindings
         KeyBindingManager.addBinding(COLLAPSE_ALL, [ {key: collapseAllKey}, {key: collapseAllKeyMac, platform: "mac"} ]);
         KeyBindingManager.addBinding(EXPAND_ALL, [ {key: expandAllKey}, {key: expandAllKeyMac, platform: "mac"} ]);
@@ -370,7 +412,7 @@ define(function (require, exports, module) {
             enableFoldingInEditor(editor);
         });
     }
-    
+
     /**
       * Register change listener for the preferences file.
       */
@@ -394,7 +436,7 @@ define(function (require, exports, module) {
         CommandManager.register(Strings.EXPAND_ALL, EXPAND_ALL, expandAll);
         CommandManager.register(Strings.COLLAPSE_CURRENT, COLLAPSE, collapseCurrent);
         CommandManager.register(Strings.EXPAND_CURRENT, EXPAND, expandCurrent);
-        
+
         if (prefs.getSetting("enabled")) {
             init();
         }

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -49,6 +49,24 @@
     padding-right: 5px;
 }
 
+// If line numbers are not shown and codefolding is enabled we remove the left padding.
+// We add the same padding below to the fold gutter
+.show-line-padding {
+    .folding-enabled.linenumber-disabled pre{
+        padding-left: 0;
+    }
+}
+
+.CodeMirror.linenumber-disabled {
+    // When there are no line numbers, .show-line-padding class adds 15px left padding to line numbers.
+    // Here we compensate for that gap by adding the same padding to the folding gutter.
+    .CodeMirror-foldgutter,
+    .CodeMirror-foldgutter-open,
+    .CodeMirror-foldgutter-folded,
+    .CodeMirror-foldgutter-blank{
+        padding-left: 15px;
+    }
+}
 
 .CodeMirror-foldmarker {
     // Re-enabling the pointer events for the fold marker. As pointer events are disabled for "CodeMirror-lines"
@@ -63,7 +81,7 @@
     border: 1px solid @color-marker-border;
     color: @color-marker-text;
     background-color: @color-marker-bg;
-    
+
     &:after {
         content: "...";
         font-size: 1em;


### PR DESCRIPTION
This addresses #11577 - where code folding gutter is not displayed nicely when line numbers are disabled. Also addresses #10864 where toggling the display of line numbers while code-folding is enabled causes fold gutters to be rendered before line numbers.
