### PR TITLE
Add ES6 keywords

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -177,10 +177,11 @@ define(function (require, exports, module) {
     }
 
     var KEYWORD_NAMES   = [
-        "break", "case", "catch", "continue", "debugger", "default", "delete",
-        "do", "else", "finally", "for", "function", "if", "in", "instanceof",
-        "new", "return", "switch", "this", "throw", "try", "typeof", "var",
-        "void", "while", "with"
+        "break", "case", "catch", "class", "const", "continue", "debugger",
+        "default", "delete", "do", "else", "export", "extends", "finally",
+        "for", "function", "if", "import", "in", "instanceof", "let", "new",
+        "return", "super", "switch", "this", "throw", "try", "typeof", "var",
+        "void", "while", "with", "yield"
     ],
         KEYWORD_TOKENS  = KEYWORD_NAMES.map(function (t) {
             return makeToken(t, []);


### PR DESCRIPTION
Part of #11644.
Keywords as per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Reserved_keywords_as_of_ECMAScript_6.

Newly added keywords: `class, const, export, extends, import, let, super, yield`
