### PR TITLE
Optimizing node for find in files

### DIFF
--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -285,7 +285,7 @@ define(function (require, exports, module) {
         
         var re = new RegExp(compiledFilter);
         return files.filter(function (f) {
-            return !f.fullPath.match(re);
+            return !re.test(f.fullPath);
         });
     }
     

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -843,8 +843,7 @@ define(function (require, exports, module) {
                 var files = fileListResult,
                     filter = FileFilters.getActiveFilter();
                 if (filter && filter.patterns.length > 0) {
-                    filter = new RegExp(FileFilters.compile(filter.patterns));
-                    files = files.filter(function (entry) { return !filter.test(entry); });
+                    files = FileFilters.filterFileList(FileFilters.compile(filter.patterns), files);
                 }
                 files = files.filter(function (entry) {
                     return entry.isFile && _isReadableText(entry.fullPath);

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -840,13 +840,17 @@ define(function (require, exports, module) {
         }
         ProjectManager.getAllFiles(filter, true, true)
             .done(function (fileListResult) {
-                var files = fileListResult
-                    .filter(function (entry) {
-                        return entry.isFile && _isReadableText(entry.fullPath);
-                    })
-                    .map(function (entry) {
-                        return entry.fullPath;
-                    });
+                var files = fileListResult,
+                    filter = FileFilters.getActiveFilter();
+                if (filter && filter.patterns.length > 0) {
+                    filter = new RegExp(FileFilters.compile(filter.patterns));
+                    files = files.filter(function (entry) { return !filter.test(entry); });
+                }
+                files = files.filter(function (entry) {
+                    return entry.isFile && _isReadableText(entry.fullPath);
+                }).map(function (entry) {
+                    return entry.fullPath;
+                });
                 FindUtils.notifyIndexingStarted();
                 searchDomain.exec("initCache", files);
             });

--- a/src/search/node/FindInFilesDomain.js
+++ b/src/search/node/FindInFilesDomain.js
@@ -32,6 +32,7 @@ maxerr: 50, node: true */
         projectCache = [],
         files,
         _domainManager,
+        MAX_FILE_SIZE_TO_INDEX = 16777216, //16MB
         MAX_DISPLAY_LENGTH = 200,
         MAX_TOTAL_RESULTS = 100000, // only 100,000 search results are supported
         MAX_RESULTS_IN_A_FILE = MAX_TOTAL_RESULTS,
@@ -187,8 +188,26 @@ maxerr: 50, node: true */
         projectCache = [];
     }
 
+
     /**
-     * Get the contents of a file given the path
+     * Gets the file size in bytes.
+     * @param   {string} fileName The name of the file to get the size
+     * @returns {Number} the file size in bytes
+     */
+    function getFilesizeInBytes(fileName) {
+        var stats = {};
+        try {
+            stats = fs.statSync(fileName);
+        } catch (ex) {
+            console.log(ex);
+            return 0;
+        }
+        return stats.size || 0;
+    }
+
+    /**
+     * Get the contents of a file from cache given the path. Also adds the file contents to cache from disk if not cached.
+     * Will not read/cache files greater than MAX_FILE_SIZE_TO_INDEX in size.
      * @param   {string} filePath full file path
      * @return {string} contents or null if no contents
      */
@@ -197,7 +216,11 @@ maxerr: 50, node: true */
             return projectCache[filePath];
         }
         try {
-            projectCache[filePath] = fs.readFileSync(filePath, 'utf8');
+            if (getFilesizeInBytes(filePath) <= MAX_FILE_SIZE_TO_INDEX) {
+                projectCache[filePath] = fs.readFileSync(filePath, 'utf8');
+            } else {
+                projectCache[filePath] = "";
+            }
         } catch (ex) {
             console.log(ex);
             projectCache[filePath] = null;
@@ -325,9 +348,8 @@ maxerr: 50, node: true */
             setTimeout(fileCrawler, 1000);
             return;
         }
-        var i = 0,
-            contents = "";
-        for (i = 0; i < 10 && currentCrawlIndex < files.length; i++) {
+        var contents = "";
+        if (currentCrawlIndex < files.length) {
             contents = getFileContentsForFile(files[currentCrawlIndex]);
             if (contents) {
                 cacheSize += contents.length;
@@ -660,7 +682,7 @@ maxerr: 50, node: true */
                 }
             ]
         );
-        setTimeout(fileCrawler, 5000);
+        setTimeout(fileCrawler, 10000);
     }
     
     exports.init = init;

--- a/src/search/node/FindInFilesDomain.js
+++ b/src/search/node/FindInFilesDomain.js
@@ -347,27 +347,23 @@ maxerr: 50, node: true */
             setTimeout(fileCrawler, 1000);
             return;
         }
+        var contents = "";
         if (currentCrawlIndex < files.length) {
-            var filePath = files[currentCrawlIndex];
-            fs.readFile(filePath, 'utf8', function (err, data) {
-                if (!err) {
-                    projectCache[filePath] = data;
-                    cacheSize += data.length;
-                }
-                currentCrawlIndex++;
-                if (currentCrawlIndex < files.length) {
-                    crawlComplete = false;
-                    setImmediate(fileCrawler);
-                } else {
-                    crawlComplete = true;
-                    if (!crawlEventSent) {
-                        crawlEventSent = true;
-                        _domainManager.emitEvent("FindInFiles", "crawlComplete", [files.length, cacheSize]);
-                    }
-                    setTimeout(fileCrawler, 1000);
-                }
-            });
+            contents = getFileContentsForFile(files[currentCrawlIndex]);
+            if (contents) {
+                cacheSize += contents.length;
+            }
+            currentCrawlIndex++;
+        }
+        if (currentCrawlIndex < files.length) {
+            crawlComplete = false;
+            setImmediate(fileCrawler);
         } else {
+            crawlComplete = true;
+            if (!crawlEventSent) {
+                crawlEventSent = true;
+                _domainManager.emitEvent("FindInFiles", "crawlComplete", [files.length, cacheSize]);
+            }
             setTimeout(fileCrawler, 1000);
         }
     }
@@ -685,7 +681,7 @@ maxerr: 50, node: true */
                 }
             ]
         );
-        setTimeout(fileCrawler, 10000);
+        setTimeout(fileCrawler, 5000);
     }
     
     exports.init = init;


### PR DESCRIPTION
- [x] Dont search in files > 16MB 
- [x] only 1 file is indexed at a time instead of 10 in batch.
- [x] File filter has to be applied to indexable files - This will impact the search performance on file filter change[but could be a lesser thig to worry abut], as that will lead to un indexed files.

Tried but not effictive and reverted

```
- [x]  async file reads- this would slow down the indexer considerabily, but might unblock node.
          Reverted to sync file reads as for the brackets project alone, sync file reads complete in ~3 secs instead of 18 secs with async - 6x performance difference. 
- [x] 10 sec delay instead of 5 secs before indexer kick in at first start
         Reverted to 5 secs as this doesn't affect any behavior or solve any problems
```
