### PR TITLE
Issue #11261: keep the search bar open

### DIFF
--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -87,6 +87,7 @@ define(function (require, exports, module) {
             this._autoClose = true;
             this._$root.on("keydown", this._handleKeydown);
             window.document.body.addEventListener("focusin", this._handleFocusChange, true);
+            window.document.body.addEventListener("keydown",this._handleKeydown,true);
                 
             // Set focus to the first input field, or the first button if there is no input field.
             // TODO: remove this logic?
@@ -252,7 +253,7 @@ define(function (require, exports, module) {
         var effectiveElem = $(e.target).data("attached-to") || e.target;
         
         if (!$.contains(this._$root.get(0), effectiveElem)) {
-            this.close(undefined, undefined, ModalBar.CLOSE_BLUR);
+            // this.close(undefined, undefined, ModalBar.CLOSE_BLUR);
         }
     };
     

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -250,11 +250,11 @@ define(function (require, exports, module) {
             return;
         }
         
-        var effectiveElem = $(e.target).data("attached-to") || e.target;
+        // var effectiveElem = $(e.target).data("attached-to") || e.target;
         
-        if (!$.contains(this._$root.get(0), effectiveElem)) {
+        // if (!$.contains(this._$root.get(0), effectiveElem)) {
             // this.close(undefined, undefined, ModalBar.CLOSE_BLUR);
-        }
+        // }
     };
     
     /**


### PR DESCRIPTION
This change fixes issue #11261. It will prevent the Search Modal Bar from closing (if open) after a left mouse click on the main editor.This is accomplished by commenting out line 253 to line 257 and added an event listener in window.document.body for the event keydown in line 90. This is necessary to handle the closing of the search bar when ESC key is pressed when the main editor window has focus. 
