### PR TITLE
Update phantomjs -> 1.9.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
-        "phantomjs": "1.9.13",
+        "phantomjs": "1.9.18",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.4.3",

--- a/src/config.json
+++ b/src/config.json
@@ -40,7 +40,7 @@
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
-        "phantomjs": "1.9.13",
+        "phantomjs": "1.9.18",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-contrib-jshint": "0.6.0",
         "grunt-contrib-watch": "0.4.3",


### PR DESCRIPTION
Adds support for io.js, so `npm install` does no longer fail when installing this package.
Still uses the same version of PhantomJS, so I don't expect any behaviour changes.
