### PR TITLE
Extension manager now scrolls to top when search filters are added/removed

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -337,6 +337,7 @@ define(function (require, exports, module) {
             $search.val("");
             views.forEach(function (view, index) {
                 view.filter("");
+                $(".modal-body", $dlg).scrollTop(0);
             });
 
             if (!updateSearchDisabled()) {
@@ -456,7 +457,9 @@ define(function (require, exports, module) {
                 var query = $(this).val();
                 views.forEach(function (view) {
                     view.filter(query);
+                    $(".modal-body", $dlg).scrollTop(0);
                 });
+
             }).on("click", ".search-clear", clearSearch);
             
             // Disable the search field when there are no items in the model


### PR DESCRIPTION
In reference to bug #10611:

I took into account the feedback on the previous attempt to fix this bug (#11178) and implemented the suggested changes (i.e. added `$(".modal-body", $dlg).scrollTop(0);` below both calls to `view.filter(...)`). All unit tests pass and the feature works as intended when search filters are added/removed.
