### PR TITLE
Only add padding-left to main tree UL. Fix padding-bottom assignment since React was introduced

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -917,13 +917,10 @@ a, img {
 #project-files-container {
     .box-flex(1);
 
-    ul {
+    div > ul {
+        padding-bottom: 24px;
         padding-left: 8px;
     }
-
-    > ul {
-        padding-bottom: 24px;
-    }    
 }
 
 .scroller-shadow {


### PR DESCRIPTION
Nested lists in the `#project-files-container` are unnecessarily (accidentally?) indented because of the greedy `ul` rule, and since React was introduced, `> ul` no longer matched, so the `padding-bottom` wasn't being applied
