### PR TITLE
Fixed a bug when there is only a linter error and it is collapsed

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -329,6 +329,7 @@ define(function (require, exports, module) {
         if (providersReportingProblems.length === 1) {
             // don't show a header if there is only one provider available for this file type
             $problemsPanelTable.find(".inspector-section").hide();
+            $problemsPanelTable.find("tr").removeClass("forced-hidden");
 
             if (numProblems === 1 && !aborted) {
                 message = StringUtils.format(Strings.SINGLE_ERROR, providersReportingProblems[0].name);


### PR DESCRIPTION
If you:
1. have multiple linters
2. you collapsed one
3. after, you have only errors relative of the collapsed one

you could end up with the panel error shown without see any error.
