### PR TITLE
Remove references to deprecated FileSystem APIs in SpecRunner

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -71,11 +71,6 @@ define(function (require, exports, module) {
     // extensions need these to be required up front. We need a better solution for this eventually.
     require("utils/ExtensionUtils");
     
-    // Also load compatibility shims for now, in case legacy extensions are still using old file APIs
-    require("project/FileIndexManager");
-    require("file/NativeFileSystem");
-    require("file/NativeFileError");
-    
     // Load both top-level suites. Filtering is applied at the top-level as a filter to BootstrapReporter.
     require("test/UnitTestSuite");
     require("test/PerformanceTestSuite");

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -483,12 +483,11 @@ define(function (require, exports, module) {
          * Builds a fileInfos index of the project, as required to call findMatchingFunctions(). Calls the
          * specified 'invoker' function with fileInfos, and populates the 'functions' var once it's done.
          * Does not need to be wrapped in a runs() block.
-         * @param {function(Array.<FileIndexManager.FileInfo>):$.Promise} invokeFind
+         * @param {function(Array.<File>):$.Promise} invokeFind
          */
         function indexAndFind(invokeFind) {
             runs(function () {
                 var result = new $.Deferred();
-                
                 ProjectManager.getAllFiles().done(function (files) {
                     invokeFind(files)
                         .done(function (functionsResult) { functions = functionsResult; })
@@ -503,7 +502,6 @@ define(function (require, exports, module) {
         describe("Index integrity", function () {
             it("should handle colliding with prototype properties", function () { // #2813
                 // no init() needed - don't need any editors to be open
-                
                 indexAndFind(function (fileInfos) {
                     return JSUtils.findMatchingFunctions("toString", fileInfos);
                 });


### PR DESCRIPTION
Fixes #11773. SpecRunner now working as intended again.
