### PR TITLE
Fix 11801

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -244,7 +244,7 @@ define(function (require, exports, module) {
             if(last2digits=="px" || last2digits=="em" && !isNaN(fsizeNumeric)  ) {
              return prefs.get("fontSize");
             } else {
-              return "12px";
+              return ;
             }
     }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -246,7 +246,6 @@ define(function (require, exports, module) {
             } else {
               return "12px";
             }
-
     }
 
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -237,7 +237,16 @@ define(function (require, exports, module) {
      * @return {string} Font size with size unit as 'px' or 'em'
      */
     function getFontSize() {
-        return prefs.get("fontSize");
+        
+            var input = prefs.get("fontSize");
+            var last2digits = input.substr(input.length-2);
+            var fsizeNumeric = input.substr(0,input.length-2);
+            if(last2digits=="px" || last2digits=="em" && !isNaN(fsizeNumeric)  ) {
+             return prefs.get("fontSize");
+            } else {
+              return "12px";
+            }
+
     }
 
 


### PR DESCRIPTION
If invalid characters appear in Font Size textblock then check input,
and if is not correct show default value 12px. Changes inside function
getFontSize
