### PR TITLE
Fix for error #11801

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -304,6 +304,7 @@ define(function (require, exports, module) {
 
         // Make sure that the font size is expressed in terms we can handle (px or em). If not, simply bail.
         if (fsStyle.search(validFont) === -1) {
+        	 prefs.set("fontSize", "12px");
             return false;
         }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -304,7 +304,9 @@ define(function (require, exports, module) {
 
         // Make sure that the font size is expressed in terms we can handle (px or em). If not, simply bail.
         if (fsStyle.search(validFont) === -1) {
-        	  prefs.set("fontSize", '12px');
+        	  fsAdjustment = PreferencesManager.getViewState("fontSizeAdjustment");
+   				 fsStyle = (DEFAULT_FONT_SIZE + fsAdjustment) + "px";
+                prefs.set("fontSize", fsStyle);
             return false;
         }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
 
         // Make sure that the font size is expressed in terms we can handle (px or em). If not, simply bail.
         if (fsStyle.search(validFont) === -1) {
-        	  prefs.set("fontSize", "12px");
+        	  prefs.set("fontSize", '12px');
             return false;
         }
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
 
         // Make sure that the font size is expressed in terms we can handle (px or em). If not, simply bail.
         if (fsStyle.search(validFont) === -1) {
-        	 prefs.set("fontSize", "12px");
+        	  prefs.set("fontSize", "12px");
             return false;
         }
 


### PR DESCRIPTION
This commit fixes error #11801. If  fontSize text input is invalid, then
show default 12px value in textBlock.
