### PR TITLE
Fix for #11763

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -48,6 +48,7 @@ define({
     "FILENAMES_LEDE"                    : "Filenames",
     "FILENAME"                          : "Filename",
     "DIRECTORY_NAME"                    : "Directory Name",
+    "SAVE_FILE_BEFORE_PROCEEDING"       : "Please save the file before proceeding",
 
     // Project error strings
     "ERROR_LOADING_PROJECT"             : "Error Loading Project",
@@ -73,6 +74,7 @@ define({
     "ERROR_CREATING_FILE_TITLE"         : "Error Creating {0}",
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",
     "ERROR_MIXED_DRAGDROP"              : "Cannot open a folder at the same time as opening other files.",
+    "ERROR_PERFORMING_OPERATION"        : "Error performing this operation",
 
     // User key map error strings
     "ERROR_KEYMAP_TITLE"                : "Error Reading User Key Map",


### PR DESCRIPTION
The new created file cannot be renamed/showed in file tree/showed in
explorer with no messages if it isn't saved.

The file is checked if it is an InMemoryFile before attempting to perform
the above mentioned operations on it. If it is indeed not saved, then a
message is shown to the user to save the document to proceed. Upon
clicking 'Ok', the save dialog box opens up allowing the user to save the
file.
