### PR TITLE
Ensure that .cm-error gets applied last

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -87,7 +87,6 @@ span.cm-comment {color: @accent-comment;}
 span.cm-string {color: @accent-string;}
 span.cm-string-2 {color: @accent-string-2;}
 span.cm-meta {color: @accent-meta;}
-span.cm-error {color: @accent-error;}
 span.cm-qualifier {color: @accent-qualifier;}
 span.cm-builtin {color: @accent-builtin;}
 span.cm-bracket {color: @accent-bracket;}
@@ -101,6 +100,7 @@ span.cm-rangeinfo {color: @accent-rangeinfo;}
 span.cm-minus {color: @accent-minus;}
 span.cm-plus {color: @accent-plus;}
 span.cm-property {color: @accent-property;} //cm-property has go after cm-string for a better JSON look.
+span.cm-error {color: @accent-error;}
 
 span.CodeMirror-matchingbracket {color: @accent-bracket !important; background-color: @matching-bracket;}
 span.CodeMirror-nonmatchingbracket {color: @accent-bracket;}


### PR DESCRIPTION
This simple PR ensures that `.cm-error` gets applied last. Fixes #11890

Before:

![image](https://cloud.githubusercontent.com/assets/7641760/10962362/3fe8c7fa-83a0-11e5-99f0-41445c5bb0db.png)

After

![image](https://cloud.githubusercontent.com/assets/7641760/10962366/4656c60a-83a0-11e5-8391-a345eb77a223.png)
