### PR TITLE
turtle support added

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -293,5 +293,12 @@
         "fileExtensions": ["hs"],
         "blockComment": ["{-", "-}"],
         "lineComment": ["--"]
+    },
+    
+    "turtle": {
+        "name": "RDF Turtle",
+        "mode": "turtle",
+        "fileExtensions": ["ttl"],
+        "lineComment": ["#"]
     }
 }


### PR DESCRIPTION
A web development oriented editor should support RDF and hence Turtle as the broadly used and most human-readable RDF format.
