### PR TITLE
Port missing piece of the indent-wrap hack from Codemirror. Fixes #11963

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -24,6 +24,10 @@
 
 .CodeMirror pre {
     padding: 0 @code-padding 0 0;
+
+    > * {
+        text-indent: 0px;
+    }
 }
 
 .show-line-padding .CodeMirror pre {


### PR DESCRIPTION
In #11909 we added a `lineRender` hack from https://codemirror.net/demo/indentwrap.html. This hack alone works fine for files using spaces as whitespace. However, the PR was missing this additional hack from the pages stylesheet:

```
      .CodeMirror pre > * { text-indent: 0px; }
```

This PR adds that, thus fixing  #11963

@abose @stowball @rroshan1 

edit: Steps to repro:
1. Create new file foo.html
2. Set indentation to Tab size: 4 from Brackets
3. Write `<h1>Foo</h1>`
4. Try to indent it with by pressing tab
   -> Text doesn't move at all

After PR:
1. Create new file foo.html
2. Set indentation to Tab size: 4 from Brackets
3. Write `<h1>Foo</h1>`
4. Try to indent it with by pressing tab
   -> Tabs work as indented and the `indent-wrap` hack still works too
