### PR TITLE
Adding preference to enable/disable type details in js hinting

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
+++ b/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
@@ -22,8 +22,8 @@
  */
 
 
-span.brackets-js-hints {
-    width: 400px;
+span.brackets-js-hints-with-type-details {
+    width: 300px;
     display: inline-block;
 }
 
@@ -137,7 +137,7 @@ span.brackets-js-hints {
 }
 
 .brackets-js-hints-type-details {
-    color: #d3d3d3 !important;
+    color: #a3a3a3 !important;
     font-weight: 100;
     font-style: italic !important;
     margin-right: 5px;
@@ -146,12 +146,10 @@ span.brackets-js-hints {
 
 .jshint-description {
     display: none;
-    padding-left: 28px !important;
-    padding-right:10px !important;
     color: #d4d4d4;
     word-wrap: break-word;	
     white-space: normal;
-    width:400px;
+    width:300px;
     box-sizing: border-box;
 }
 
@@ -161,12 +159,11 @@ span.brackets-js-hints {
 
 .jshint-jsdoc {
     display: none;
-    padding-left: 28px !important;
     padding-right: 10px !important;
     color: grey;
     word-wrap: break-word;
     white-space: normal;
-    width: 400px;
+    width: 300px;
     box-sizing: border-box;
     float: left;
     clear: left;
@@ -179,24 +176,41 @@ span.brackets-js-hints {
 }
 
 .jshint-link {
-    float:right;
     display:none;
-    margin-right: 10px !important;
+    width:0px !important;
+    height:1px !important;
+    margin-left: 15px;
+    float:right;
 }
 
 .jshint-link:before {
-    float: right;
-    color: orangered !important;
-    content: '?' !important;
-    border: 1px orangered solid;
-    width: 10px;
+    position: relative;
+    float: left;
+    top:1px;
+    content: "i" !important;
+    width: 16px;
+    height: 16px;
+    margin-right:10px;
+    font-size: 14px;
+    font-weight: bold;
+    font-style: italic;
+    line-height: 15px;
     text-align: center;
-    line-height: 1em;
     visibility: visible !important;
+    font-weight: 900;
+    color: #fff;
+    background-color: #2ea56c;
+    border-color: #177F42;
+    border-radius: 16px;
+    font-family: SourceSansPro-Semibold;
+}
+
+.dark .jshint-link:before {
+    background-color: #146a41;
 }
 
 .highlight .jshint-link {
-    display:block;
+    display: inline-block !important;
 }
 
 .highlight .jshint-description {
@@ -213,11 +227,14 @@ span.brackets-js-hints {
 } 
 
 .highlight .brackets-js-hints-type-details {
-    color: #6495ed !important;
-    display: inline-block;
+    display:none;
 }
 
-.brackets-js-hints-type-details.keyword {
+.brackets-js-hints-keyword {
+    font-weight: 100;
+    font-style: italic !important;
+    margin-right: 5px;
+    float:right;
     color: #6495ed !important;
 }
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -691,6 +691,7 @@ define({
     "DESCRIPTION_ATTR_HINTS"                         : "Enable/disable HTML attribute hints",
     "DESCRIPTION_CSS_PROP_HINTS"                     : "Enable/disable CSS/LESS/SCSS property hints",
     "DESCRIPTION_JS_HINTS"                           : "Enable/disable JavaScript code hints",
+    "DESCRIPTION_JS_HINTS_TYPE_DETAILS"              : "Enable/disable datatype details in JavaScript code hints",
     "DESCRIPTION_PREF_HINTS"                         : "Enable/disable Preferences code hints",
     "DESCRIPTION_SPECIAL_CHAR_HINTS"                 : "Enable/disable HTML entity hints",
     "DESCRIPTION_SVG_HINTS"                          : "Enable/disable SVG code hints",


### PR DESCRIPTION
- Adding preference **jscodehints.typedetails** to enable/disable type details in js hinting. Default value is true. 
  . 
- Styling changes to make the addition UI more subtle ( snapshots attached for light and dark theme for reference )

![latest_light](https://cloud.githubusercontent.com/assets/12087205/11745380/be5ffcfc-a03d-11e5-9225-93aea443b1e1.png)
![latest_dark](https://cloud.githubusercontent.com/assets/12087205/11745383/c1fa4250-a03d-11e5-8fe9-1d5171d05f07.png)
