### PR TITLE
Reintroduce JSLint as a prefered linter

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -10,7 +10,7 @@
     "defaultExtension": "js",
     "language": {
         "javascript": {
-            "linting.prefer": ["ESLint"],
+            "linting.prefer": ["ESLint", "JSLint"],
             "linting.usePreferredOnly": true
         }
     },

--- a/.eslintrc
+++ b/.eslintrc
@@ -48,8 +48,8 @@
         "valid-jsdoc": 0,
         "valid-typeof": 2,
 
-        "no-trailing-spaces": 2,
-        "eol-last": 2
+        "no-trailing-spaces": 0,
+        "eol-last": 0
     },
     "globals": {
         "brackets": false,


### PR DESCRIPTION
and disable temporary the `no-trailing-spaces` and `eol-last` eslint rules
This is based on the discussion in: https://github.com/adobe/brackets/pull/11998

Actually the ESLint checks are ATM weaker than JSLint so there shouldn't be any problems.
