### PR TITLE
jasmine.sh: add some log to say which platforms are support

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,7 +11,9 @@ Running Tests
 2 options for running tests:
 
 1. Run brackets-app and click "Run Tests" from the menu (debugging and dev tools **not** supported)
-1. Run jasmine.sh or manually run Brackets-app with the argument file://path/to/brackets/test/SpecRunner.html.
+1. Run jasmine.sh (only OSX is supported) or manually run Brackets-app with
+   the argument file://path/to/brackets/test/SpecRunner.html.
+
 
 Adding New Tests
 

--- a/test/jasmine.sh
+++ b/test/jasmine.sh
@@ -28,4 +28,20 @@ BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $BASEDIR
 
 # open the Jasmine SpecRunner
-open ${BASEDIR}/../../bin/mac/Brackets.app --args file:///${BASEDIR}/SpecRunner.html
+case $OSTYPE in
+darwin*)
+    open ${BASEDIR}/../../bin/mac/Brackets.app --args file:///${BASEDIR}/SpecRunner.html
+    ;;
+linux*)
+    echo Linux Not Yet Implemented
+    ;;
+cygwin* | msys | win32 )
+    echo Windows Not Yet Implemented
+    ;;
+freebsd*)
+    echo FreeBSD Not Yet Implemented
+    ;;
+*)
+    echo Unknown operating system $OSTYPE
+    ;;
+esac


### PR DESCRIPTION
I have some problem to run all the test suite from Brackets so I tried to run it from the command line only to found that OSX is the only platform supported.
This PR simply add some log to say it.
