### PR TITLE
Reuse parseQueryInfo defined in FindUtils for the FindReplace feature.

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -94,24 +94,19 @@ define(function (require, exports, module) {
             findBar.showError(null);
         }
 
-        if (!queryInfo || !queryInfo.query) {
+        var parsed = FindUtils.parseQueryInfo(queryInfo);
+        if (parsed.empty === true) {
             return "";
         }
 
-        // Is it a (non-blank) regex?
-        if (queryInfo.isRegexp) {
-            try {
-                return new RegExp(queryInfo.query, queryInfo.isCaseSensitive ? "" : "i");
-            } catch (e) {
-                if (findBar) {
-                    findBar.showError(e.message);
-                }
-                return "";
+        if (!parsed.valid) {
+            if (findBar) {
+                findBar.showError(parsed.error);
             }
-
-        } else {
-            return queryInfo.query;
+            return "";
         }
+
+        return parsed.queryExpr;
     }
 
     /**

--- a/src/search/FindUtils.js
+++ b/src/search/FindUtils.js
@@ -311,8 +311,6 @@ define(function (require, exports, module) {
     function parseQueryInfo(queryInfo) {
         var queryExpr;
 
-        // TODO: only major difference between this one and the one in FindReplace is that
-        // this always returns a regexp even for simple strings. Reconcile.
         if (!queryInfo || !queryInfo.query) {
             return {empty: true};
         }


### PR DESCRIPTION
The functions weren't exactly the same so there could be a change in behaviour.
(The flags in regexp were different, and now uses always a regex to search)
