### PR TITLE
Use the global RequireJS config for ExtensionLoader. Fixes #1087

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -42,7 +42,7 @@ define(function (require, exports, module) {
         Async          = require("utils/Async"),
         ExtensionUtils = require("utils/ExtensionUtils"),
         UrlParams      = require("utils/UrlParams").UrlParams,
-        PathUtils              = require("thirdparty/path-utils/path-utils");
+        PathUtils      = require("thirdparty/path-utils/path-utils");
 
     // default async initExtension timeout
     var INIT_EXTENSION_TIMEOUT = 10000;

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
         FileUtils      = require("file/FileUtils"),
         Async          = require("utils/Async"),
         ExtensionUtils = require("utils/ExtensionUtils"),
-        UrlParams      = require("utils/UrlParams").UrlParams;
+        UrlParams      = require("utils/UrlParams").UrlParams,
+        PathUtils              = require("thirdparty/path-utils/path-utils");
 
     // default async initExtension timeout
     var INIT_EXTENSION_TIMEOUT = 10000;
@@ -61,10 +62,14 @@ define(function (require, exports, module) {
     // load the text and i18n modules.
     srcPath = srcPath.replace(/\/test$/, "/src"); // convert from "test" to "src"
 
-    var globalConfig = {
-            "text" : srcPath + "/thirdparty/text/text",
-            "i18n" : srcPath + "/thirdparty/i18n/i18n"
-        };
+
+    // Retrieve the global paths
+    var globalPaths = brackets._getGlobalRequireJSConfig().paths;
+
+    // Convert the relative paths to absolute
+    Object.keys(globalPaths).forEach(function (key) {
+        globalPaths[key] = PathUtils.makePathAbsolute(srcPath + "/" + globalPaths[key]);
+    });
 
     /**
      * Returns the full path of the default user extensions directory. This is in the users
@@ -157,8 +162,7 @@ define(function (require, exports, module) {
         var extensionConfig = {
             context: name,
             baseUrl: config.baseUrl,
-            /* FIXME (issue #1087): can we pass this from the global require context instead of hardcoding twice? */
-            paths: globalConfig,
+            paths: globalPaths,
             locale: brackets.getLocale()
         };
 

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -286,7 +286,7 @@ define(function (require, exports, module) {
                 var extensionRequire = brackets.libRequire.config({
                     context: name,
                     baseUrl: config.baseUrl,
-                    paths: $.extend({}, config.paths, globalConfig)
+                    paths: $.extend({}, config.paths, globalPaths)
                 });
 
                 extensionRequire([entryPoint], function () {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -121,5 +121,12 @@ define(function (require, exports, module) {
     // only be able to load modules that have already been loaded once.
     global.brackets.getModule = require;
 
+    /* API for retrieving the global RequireJS config
+     * For internal use only
+     */
+    global.brackets._getGlobalRequireJSConfig = function () {
+        return global.require.s.contexts._.config;
+    };
+    
     exports.global = global;
 });


### PR DESCRIPTION
Brackets has a long running (minor) issue #1087, where the global RequireJS path configuration is not being re-used but instead repeated in `ExtensionLoader.js`. 

This PR fixes the issue by creating a simple wrapper API around the semi-private (see [James Burkes comment here](https://groups.google.com/forum/#!topic/requirejs/Hf-qNmM0ceI)) `requirejs.s.contexts._.config` and later converts them to absolute paths in `ExtensionLoader.js`.

This same method can also be used to retrieve global modules with other modules that aren't run in the same scope as the rest of Brackets, such as WebWorkers and Node instances. For more information see my comment at: https://github.com/adobe/brackets/issues/12006#issuecomment-166005753
