### PR TITLE
Remove a warning when reloading the app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
 
     <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
     <!--(if target dev)><!-->
-    <link rel="stylesheet" type="text/less" href="styles/brackets.less">
+    <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">
     <!--<!(endif)-->
     <!--(if target dist)>
     <link rel="stylesheet" type="text/css" href="styles/brackets.min.css">


### PR DESCRIPTION
The warning was the following:
`Resource interpreted as Stylesheet but transferred with MIME type text/plain ...`
