### PR TITLE
Remove .jsx from Javascript file extensions and create an jsx-mode

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -65,7 +65,15 @@
     "javascript": {
         "name": "JavaScript",
         "mode": "javascript",
-        "fileExtensions": ["js", "jsx", "js.erb", "jsm", "_js"],
+        "fileExtensions": ["js", "js.erb", "jsm", "_js"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
+    "jsx": {
+        "name": "JSX",
+        "mode": "jsx",
+        "fileExtensions": ["jsx"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },


### PR DESCRIPTION
This PR removes `.jsx` from Javascript file extensions and creates an separate jsx-mode.
