### PR TITLE
Wrap indent-key to parentheses in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
         "new-parens": 2,
         "no-new-object": 2,
         "no-invalid-this": 0,
-        indent: [0, 4],
+        "indent": [0, 4],
 
         "valid-jsdoc": 0,
         "valid-typeof": 2,


### PR DESCRIPTION
The key `indent` was missing parentheses in `.eslintrc`, rendering the file invalid JSON. 

This PR fixes that simple error.
