### PR TITLE
Fix Flipview focus issues

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -776,7 +776,6 @@ define({
     "DESCRIPTION_OPEN_USER_PREFS_IN_SECOND_PANE"     : "false to open user preferences file in left/top pane",
     "DESCRIPTION_MERGE_PANES_WHEN_LAST_FILE_CLOSED"  : "true to collapse panes after the last file from the pane is closed via pane header close button",
     "DESCRIPTION_SHOW_PANE_HEADER_BUTTONS"           : "Toggle when to show the close and flip-view buttons on the header.",
-    "DESCRIPTION_RETAIN_FOCUS_AFTER_FLIP"            : "true to retain focus on the currently active pane, false to move focus to the new pane",
     "DEFAULT_PREFERENCES_JSON_HEADER_COMMENT"        : "/*\n * This is a read-only file with the preferences supported\n * by {APP_NAME}.\n * Use this file as a reference to modify your preferences\n * file \"brackets.json\" opened in the other pane.\n * For more information on how to use preferences inside\n * {APP_NAME}, refer to the web page at https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#preferences\n */",
     "DEFAULT_PREFERENCES_JSON_DEFAULT"               : "Default",
     "DESCRIPTION_PURE_CODING_SURFACE"                : "true to enable code only mode and hide all other UI elements in {APP_NAME}"

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -776,6 +776,7 @@ define({
     "DESCRIPTION_OPEN_USER_PREFS_IN_SECOND_PANE"     : "false to open user preferences file in left/top pane",
     "DESCRIPTION_MERGE_PANES_WHEN_LAST_FILE_CLOSED"  : "true to collapse panes after the last file from the pane is closed via pane header close button",
     "DESCRIPTION_SHOW_PANE_HEADER_BUTTONS"           : "Toggle when to show the close and flip-view buttons on the header.",
+    "DESCRIPTION_RETAIN_FOCUS_AFTER_FLIP"            : "true to retain focus on the currently active pane, false to move focus to the new pane",
     "DEFAULT_PREFERENCES_JSON_HEADER_COMMENT"        : "/*\n * This is a read-only file with the preferences supported\n * by {APP_NAME}.\n * Use this file as a reference to modify your preferences\n * file \"brackets.json\" opened in the other pane.\n * For more information on how to use preferences inside\n * {APP_NAME}, refer to the web page at https://github.com/adobe/brackets/wiki/How-to-Use-Brackets#preferences\n */",
     "DEFAULT_PREFERENCES_JSON_DEFAULT"               : "Default",
     "DESCRIPTION_PURE_CODING_SURFACE"                : "true to enable code only mode and hide all other UI elements in {APP_NAME}"

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -192,12 +192,6 @@ define(function (require, exports, module) {
         values: ["hover", "always", "never"]
     });
 
-    // Define retainFocusAfterFlip, which controls which pane gets focus after a pane
-    // has been flipped.
-    PreferencesManager.definePreference("pane.retainFocusAfterFlip", "boolean", false, {
-        description: Strings.DESCRIPTION_RETAIN_FOCUS_AFTER_FLIP
-    });
-
     // Define mergePanesWhenLastFileClosed, which controls if a split view pane should be
     // closed when the last file is closed, skipping the "Open a file while this pane has focus"
     // step completely.
@@ -235,7 +229,6 @@ define(function (require, exports, module) {
         // Setup the container and the element we're inserting
         var self = this,
             showPaneHeaderButtonsPref = PreferencesManager.get("pane.showPaneHeaderButtons"),
-            retainFocusAfterFlip = PreferencesManager.get("pane.retainFocusAfterFlip"),
             $el = $container.append(Mustache.render(paneTemplate, {id: id})).find("#" + id),
             $header  = $el.find(".pane-header"),
             $headerText = $header.find(".pane-header-text"),
@@ -253,11 +246,6 @@ define(function (require, exports, module) {
             var otherPaneId = self.id === FIRST_PANE ? SECOND_PANE : FIRST_PANE;
             var otherPane = MainViewManager._getPane(otherPaneId);
 
-            // currently active pane is not necessarily self.id as just clicking the button does not
-            // give focus to the pane. This way it is possible to flip multiple panes to the active one
-            // without losing focus.
-            var activePaneIdBeforeFlip = MainViewManager.getActivePaneId();
-
             MainViewManager._moveView(self.id, otherPaneId, currentFile).always(function () {
                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: currentFile.fullPath,
                                                             paneId: otherPaneId}).always(function () {
@@ -266,17 +254,8 @@ define(function (require, exports, module) {
 
                     // Defer the focusing until other focus events have occurred.
                     setTimeout(function () {
-                        if (retainFocusAfterFlip) {
-                            // Focus has most likely changed: give it back to the original pane.
-                            var activePaneBeforeFlip = MainViewManager._getPane(activePaneIdBeforeFlip);
-                            activePaneBeforeFlip.focus();
-                            self._lastFocusedElement = activePaneBeforeFlip.$el[0];
-                            MainViewManager.setActivePaneId(activePaneIdBeforeFlip);
-                        } else {
-                            // Other pane already has focus: update the Active Pane Id too.
-                            MainViewManager.setActivePaneId(otherPaneId);
-                            self._lastFocusedElement = otherPane.$el[0];
-                        }
+                        MainViewManager.setActivePaneId(otherPaneId);
+                        self._lastFocusedElement = otherPane.$el[0];
                     }, 1);
                 });
             });


### PR DESCRIPTION
This PR fixes the following `FlipView` focus issues:

> Steps: 
> 
> 1) Launch brackets and make sure the working set is empty. 
> 2) Single click on any file to have it view only. 
> 3) Enable split view. At this stage the view of the file is present in pane 1 lets assume. 
> 4) Flip view from pane 1 to pane 2. 
> 
> Issue 1( Must-fix): 
> 
> The focus remains on pane 1 which is expected but the editor in the destination pane still shows > the cursor. Ideally editor in the second pane should loose focus as the focus in in first pane. 
> 
> Issue 2( Must-fix):
> 
> If you now click on the flipped editor in the second pane, focus switch happens to second pane as  expected. But now if you try to click on the first pane focus is never retained on first pane and > immediately reverts to second pane. So at this point there is no way you can open a document in the first pane unless there is something in the working set of first pane and you click there to regain focus.

The implementation is surprisingly non-trivial due to how MainViewManager, CodeMirror and CEF in general handle their `focus` events.

This PR adds a new preference called `pane.retainFocusAfterFlip` which controls which panel gets focused after the flip. By default the setting is `false`, which makes the focus end up in the **new** panel after pressing the FlipView button; setting it `true` will make the currently active pane keep its focus. The default setting is purely out of my personal preference: the biggest reason for me needing a FlipView button was to have a quick way to move the **new** file to other pane so I can look at the one under it while I edit the new file, not the other way around. If the consensus is the other way, the default can of course be flipped.

In the implementation the focus event is deferred with `setTimeout` to happen after the other focus events have occurred: AFAIK there's no way to prevent **all** the focus/blur events that happen in editor concurrently. In the `retainFocusAfterFlip` scenario `.focus()` is also called _before_ setting the active pane Id: otherwise the editor doesn't unblur the CodeMirror-textarea for some reason, leaving the active cursor to the wrong pane.

 Another semi-interesting tidbit is the following: `activePaneIdBeforeFlip` is not always `self.id`: when the `FlipView` button has been clicked, the pane doesn't get the focus: this can actually be preferable, because this enables a fast way for flipping multiple views from the non-active view to the active one without losing the focus. Other way would be giving the pane the button belongs to focus when clicked, but this makes giving the focus to the correct pane after the switch even more confusing :confused:.

**Note that this PR is against @swmitra's `BugFixesFor1.6Beta`-branch instead of the master**

I'll make some unit tests for these next.

ping @swmitra 
