### PR TITLE
Remove basePadding from indentwrap hack

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1038,10 +1038,10 @@ define(function (require, exports, module) {
         });
         // For word wrap. Code adapted from https://codemirror.net/demo/indentwrap.html#
         this._codeMirror.on("renderLine", function (cm, line, elt) {
-            var charWidth = self._codeMirror.defaultCharWidth(), basePadding = 4;
+            var charWidth = self._codeMirror.defaultCharWidth();
             var off = CodeMirror.countColumn(line.text, null, cm.getOption("tabSize")) * charWidth;
             elt.style.textIndent = "-" + off + "px";
-            elt.style.paddingLeft = (basePadding + off) + "px";
+            elt.style.paddingLeft = off + "px";
         });
     };
 


### PR DESCRIPTION
As noted by @redmunds on Slack there's an slightly ankward gap between the gutters and the text

![image](https://cloud.githubusercontent.com/assets/7641760/12463477/582e466a-bfcc-11e5-9037-fab4c2c8db47.png)

This is due to the indent-wrap hack in https://github.com/adobe/brackets/pull/11909: the texts are pushed 4 pixels back by the hack. This PR compensates for that by pulling the editor back -4 pixels:

![image](https://cloud.githubusercontent.com/assets/7641760/12463789/43f72e94-bfce-11e5-99e9-81889fd6b453.png)
