### PR TITLE
Remove dropshadow from flip-view-buttons

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -513,8 +513,6 @@ a, img {
             background-origin: content-box;
             -webkit-transform: translateZ(0); // forces GPU mode for better filter rendering on retina
             transform: translateZ(0); // future proofing
-            -webkit-filter: drop-shadow(0 1px 0 rgba(0,0,0,0.36));
-            filter: drop-shadow(0 1px 0 rgba(0,0,0,0.36));
             z-index: 1;
             vertical-align: middle;
 


### PR DESCRIPTION
Fixes #12119 

The drop shadows work nicely on the working set, but not so much with the header bar, especially with light themes. There's an additional issue where the shadow filter is much further away from the origin on HiDPI displays, making the buttons look rather blurry.
