### PR TITLE
[HOTFIX] Only update stat and clear contents when old stat is newer than current stat.

### DIFF
--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -817,7 +817,7 @@ define(function (require, exports, module) {
             var oldStat = entry._stat;
             if (entry.isFile) {
                 // Update stat and clear contents, but only if out of date
-                if (!(stat && oldStat && stat.mtime.getTime() === oldStat.mtime.getTime())) {
+                if (!(stat && oldStat && stat.mtime.getTime() <= oldStat.mtime.getTime())) {
                     entry._clearCachedData();
                     entry._stat = stat;
                     this._fireChangeEvent(entry);


### PR DESCRIPTION
:fire: Potentially fixes #11826 :fire: 

There is a long running issue with Brackets where the async `stat` implementation for fetching the timestamp (`stat._mtime`) can cause rare :racehorse: `race conditions` :racehorse:. See this issue: https://github.com/adobe/brackets/issues/295

This is very rare and usually doesn't matter much. But it does matter when `FileSystem.js` does this:

```
      // Update stat and clear contents, but only if out of date
      if (!(stat && oldStat && stat.mtime.getTime() === oldStat.mtime.getTime())) {
         entry._clearCachedData();
         entry._stat = stat;
         this._fireChangeEvent(entry);
      }
```

Due to the race condition `stat.mtime` is sometimes older than `oldStat.mtime`, causing a change event to happen and cache get cleared, nullifying the history ->  causing #11826.
#### Q & A
##### Q: Brackets has been like that for a long time. Why did this start occurring in `1.5.`?

A: I only got speculation, but as it is a race condition, I guess increased code base plays an unfortunate part here: some additional file system operations or anything else made the race condition much more reoccurring. 
##### Q: Does this really fix #11826

A: I... don't know for sure. There's no steps to reproduce #11826 with even 1% success rate
##### Q: Why do you think it fixes #11826

A: It fixes the issue with my [corrupt-brackets-history](https://github.com/petetnt/corrupt-brackets-history) extension: I tried to save 10000 times in a row and history was kept intact. Without the fix the issue usually occurs before the 50th save.
##### Q: Does this have other side-effects

A: Not sure. Most likely not, but I am a bit worried that it might have unwanted effects on some external changes. Obviously it should be better to fix the  race condition itself, but this is just a hotfix.
##### Q: Why is the history getting reseted

A: The change event getting erroneously called eventually leads to this chain:

```
FileSyncManager#reloadChangedDocs 
-> FileSyncManager#reloadDoc
-> Document#refreshText 
-> Editor#resetText
```

`Editor#resetText` which calls:

```
 // Make sure we can't undo back to the empty state before setValue(), and mark
// the document clean.
this._codeMirror.clearHistory();
this._codeMirror.markClean();
```
