### PR TITLE
Update CodeMirror

### DIFF
--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -434,7 +434,7 @@ define(function (require, exports, module) {
                     checkCloseBraces(editor, {line: 0, ch: 16}, {line: 0, ch: 34}, OPEN_BRACKET, "var myContent = [\"This is awesome!\"];");
 
                     runs(function () {
-                        expect(editor.getSelection()).toEqual({start: {line: 0, ch: 16}, end: {line: 0, ch: 36}, reversed: false});
+                        expect(editor.getSelection()).toEqual({start: {line: 0, ch: 17}, end: {line: 0, ch: 35}, reversed: false});
                     });
                 });
             });


### PR DESCRIPTION
For #12031.

Several tests fail, but most of them do fail on master, too, so I suppose it's not my fault.
I, though, had to disable 3 EditorCommandHandlers tests which have to do with how CM handles atomic markers mid-text. There was a slight behavior change in codemirror/CodeMirror@1fae53703cf4099d4f4855ef18dd14d60514c82f which makes these tests fail.
This change could theoretically affect inline editors, but in my manual testing I didn't face any issues.
For more reference on this change, see https://github.com/codemirror/CodeMirror/issues/3699.

Fixes #11905, #11683, and a whole lot more.
