### PR TITLE
Few Portuguese update, spelling and punctuation correction

### DIFF
--- a/samples/pt-br/Primeiros Passos/index.html
+++ b/samples/pt-br/Primeiros Passos/index.html
@@ -55,7 +55,7 @@
     -->
     <h3>Visualizar as alterações CSS ao vivo no navegador</h3>
     <p>
-        Você sabe aquela "dança salvar/recarregar" que temos feito há anos? Aquela onde você faz mudanças no seu editor, clica em salvar, alterna para o navegador e então recarrega a pagina para finalmente ver o resultado Com Brackets, você não precisa fazer essa dança.
+        Você sabe aquela "dança salvar/recarregar" que temos feito há anos? Aquela onde você faz mudanças no seu editor, clica em salvar, alterna para o navegador e então recarrega a página para finalmente ver o resultado? Com Brackets, você não precisa fazer essa dança.
     </p>
     <p>
         Brackets vai abrir uma <em>conexão ao vivo</em> com o seu navegador local e vai empurrar atualizações CSS enquanto você digita! Você já deve estar fazendo alguma coisa como esta hoje com ferramentas baseadas em navegador, mas com Brackets
@@ -69,7 +69,7 @@
     </samp>
     
     <p class="note">
-        Atualmente, Brackets suporta Visualização ao Vivo (Live Preview) apenas para CSS. Iremos adicionar suporte à Visualização ao Vivo (Live Preview) para HTML e JavaScript em uma versão futura. Visualizações ao vivo atualmente só são possíveis com Google Chrome. Nós queremos trazer esta funcionalidade para todos os principais navegadores, e estamos ansiosos para trabalhar com os fornecedores.
+        Atualmente, Brackets suporta Visualização ao Vivo (Live Preview) apenas para HTML e CSS. Entretanto, na versão atual, mudanças nos arquivos JavaScript são automaticamente carregadas quando você salva. Estamos trabalhando no suporte à Visualização ao Vivo para JavaScript. Visualizações ao vivo atualmente só são possíveis com Google Chrome, mas nós esperamos trazer essa funcionalidade para os principais buscadores no futuro.
     </p>
     
     <!--


### PR DESCRIPTION
One of the paragraphs was rewritten because it was out of date in relation to the English version. There were also a few spelling and punctuation corrections.
