### PR TITLE
Require PathUtils instead of using the global one

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,6 @@
 
         "require": false,
         "define": false,
-        "$": false,
-        "PathUtils": false
+        "$": false
     }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -274,7 +274,6 @@ module.exports = function (grunt) {
                     'src/thirdparty/CodeMirror/lib/util/searchcursor.js',
                     'src/thirdparty/CodeMirror/addon/edit/closetag.js',
                     'src/thirdparty/CodeMirror/addon/selection/active-line.js',
-                    'src/thirdparty/path-utils/path-utils.min',
                     'src/thirdparty/less-2.5.1.min.js'
                 ],
                 helpers : [

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, PathUtils */
+/*global define, $ */
 
 /**
  * CSSAgent keeps track of loaded style sheets and allows reloading them
@@ -35,12 +35,11 @@
 define(function CSSAgent(require, exports, module) {
     "use strict";
 
-    require("thirdparty/path-utils/path-utils.min");
-
     var _ = require("thirdparty/lodash");
 
     var Inspector       = require("LiveDevelopment/Inspector/Inspector"),
-        EventDispatcher = require("utils/EventDispatcher");
+        EventDispatcher = require("utils/EventDispatcher"),
+        PathUtils       = require("thirdparty/path-utils/path-utils");
 
     /**
      * Stylesheet details

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -39,7 +39,6 @@ define(function (require, exports, module) {
     "use strict";
 
     // Load dependent non-module scripts
-    require("thirdparty/path-utils/path-utils.min");
     require("widgets/bootstrap-dropdown");
     require("widgets/bootstrap-modal");
     require("widgets/bootstrap-twipsy-mod");
@@ -124,6 +123,18 @@ define(function (require, exports, module) {
         get: function () {
             DeprecationWarning.deprecationWarning('Use brackets.getModule("thirdparty/mustache/mustache") instead of global Mustache.', true);
             return Mustache;
+        }
+    });
+
+    // DEPRECATED: In future we want to remove the global PathUtils, but for now we
+    // expose our required PathUtils globally so as to avoid breaking extensions in the
+    // interim.
+    var PathUtils = require("thirdparty/path-utils/path-utils");
+
+    Object.defineProperty(window, "PathUtils", {
+        get: function () {
+            DeprecationWarning.deprecationWarning('Use brackets.getModule("thirdparty/path-utils/path-utils") instead of global PathUtils.', true);
+            return PathUtils;
         }
     });
 

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -24,7 +24,7 @@
 
 /*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true,
 indent: 4, maxerr: 50 */
-/*global define, $, brackets, PathUtils */
+/*global define, $, brackets */
 
 /**
  * Functions for working with extension packages
@@ -39,7 +39,8 @@ define(function (require, exports, module) {
         Strings              = require("strings"),
         ExtensionLoader      = require("utils/ExtensionLoader"),
         NodeConnection       = require("utils/NodeConnection"),
-        PreferencesManager   = require("preferences/PreferencesManager");
+        PreferencesManager   = require("preferences/PreferencesManager"),
+        PathUtils            = require("thirdparty/path-utils/path-utils");
 
     PreferencesManager.definePreference("proxy", "string", undefined, {
         description: Strings.DESCRIPTION_PROXY

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window, PathUtils */
+/*global define, brackets, $, window */
 
 define(function (require, exports, module) {
     "use strict";
@@ -40,7 +40,8 @@ define(function (require, exports, module) {
         LanguageManager     = brackets.getModule("language/LanguageManager"),
         Strings             = brackets.getModule("strings"),
         ViewUtils           = brackets.getModule("utils/ViewUtils"),
-        TokenUtils          = brackets.getModule("utils/TokenUtils");
+        TokenUtils          = brackets.getModule("utils/TokenUtils"),
+        PathUtils           = brackets.getModule("thirdparty/path-utils/path-utils");
 
     var previewContainerHTML       = require("text!QuickViewTemplate.html");
 

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         ProjectManager      = brackets.getModule("project/ProjectManager"),
         StringUtils         = brackets.getModule("utils/StringUtils"),
+        PathUtils           = brackets.getModule("thirdparty/path-utils/path-utils"),
         Strings             = brackets.getModule("strings"),
         Data                = require("text!data.json"),
 
@@ -80,7 +81,7 @@ define(function (require, exports, module) {
         docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
 
         // get relative path from query string
-        queryUrl = window.PathUtils.parseUrl(query.queryStr);
+        queryUrl = PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;
         }

--- a/src/preferences/PreferencesDialogs.js
+++ b/src/preferences/PreferencesDialogs.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, PathUtils */
+/*global define */
 
 /**
  * PreferencesDialogs
@@ -32,14 +32,13 @@
 define(function (require, exports, module) {
     "use strict";
 
-    require("thirdparty/path-utils/path-utils.min");
-
     var Dialogs                = require("widgets/Dialogs"),
         ProjectManager         = require("project/ProjectManager"),
         StringUtils            = require("utils/StringUtils"),
         Strings                = require("strings"),
         SettingsDialogTemplate = require("text!htmlContent/project-settings-dialog.html"),
-        Mustache               = require("thirdparty/mustache/mustache");
+        Mustache               = require("thirdparty/mustache/mustache"),
+        PathUtils              = require("thirdparty/path-utils/path-utils");
 
     /**
      * Validate that text string is a valid base url which should map to a server folder

--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, less, PathUtils */
+/*global define, $, brackets, less */
 
 /**
  * ExtensionUtils defines utility methods for implementing extensions.
@@ -33,7 +33,8 @@ define(function (require, exports, module) {
 
     var Async      = require("utils/Async"),
         FileSystem = require("filesystem/FileSystem"),
-        FileUtils  = require("file/FileUtils");
+        FileUtils  = require("file/FileUtils"),
+        PathUtils  = require("thirdparty/path-utils/path-utils");
 
     /**
      * Appends a <style> tag to the document's head.

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -36,10 +36,9 @@
   <!-- Pre-load third party scripts that cannot be async loaded. -->
   <!-- Keep in sync with Gruntfile.js jasmine vendor dependencies -->
   <script src="../src/thirdparty/jquery-2.1.3.min.js"></script>
-  <script src="../src/thirdparty/path-utils/path-utils.js"></script>
   <script src="../src/thirdparty/less-2.5.1.min.js"></script>
   <script src="thirdparty/bootstrap2/js/bootstrap.min.js"></script>
-    
+
   <!-- All other scripts are loaded through require. -->
   <script src="../src/thirdparty/requirejs/require.js" data-main="SpecRunner"></script>
 


### PR DESCRIPTION
Actually I decided to try again: similarly to https://github.com/adobe/brackets/pull/11734 but this time using the submodule.
