### PR TITLE
node crash fix: error on live preview server creation.

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.js
@@ -131,6 +131,9 @@
                         console.error("nodeSocketTransport: Socket closed, but couldn't locate client");
                     }
                 });
+            }).on("error", function (e) {
+                // TODO: emit error event
+                console.error("nodeSocketTransport: Error on live preview server creation: " + e);
             });
         }
     }


### PR DESCRIPTION
handle error message on live preview server creation. 
Else node crashes if the port is already in use.
