### PR TITLE
Show an error message when trying to rename a file outside of the project

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -65,6 +65,7 @@ define({
     "ERROR_SAVING_FILE"                 : "An error occurred when trying to save the file <span class='dialog-filename'>{0}</span>. {1}",
     "ERROR_RENAMING_FILE_TITLE"         : "Error Renaming {0}",
     "ERROR_RENAMING_FILE"               : "An error occurred when trying to rename the {2} <span class='dialog-filename'>{0}</span>. {1}",
+    "ERROR_RENAMING_NOT_IN_PROJECT"     : "The file or directory is not part of the currently opened project. Unfortunately, only project files can be renamed at this point.",
     "ERROR_DELETING_FILE_TITLE"         : "Error Deleting {0}",
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid {0}",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1323,9 +1323,14 @@ define(function (require, exports, module) {
                     if (errorInfo.type === ProjectModel.ERROR_INVALID_FILENAME) {
                         _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder, ProjectModel._invalidChars);
                     } else {
-                        var errString = errorInfo.type === FileSystemError.ALREADY_EXISTS ?
-                                Strings.FILE_EXISTS_ERR :
-                                FileUtils.getFileErrorString(errorInfo.type);
+                        var errString;
+                        if (errorInfo.type === FileSystemError.ALREADY_EXISTS) {
+                            errString = Strings.FILE_EXISTS_ERR;
+                        } else if (errorInfo.type === ProjectModel.ERROR_NOT_IN_PROJECT) {
+                            errString = Strings.ERROR_RENAMING_NOT_IN_PROJECT;
+                        } else {
+                            errString = FileUtils.getFileErrorString(errorInfo.type);
+                        }
 
                         _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, errString, errorInfo.fullPath);
                     }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1320,19 +1320,18 @@ define(function (require, exports, module) {
                 // because some errors can come up synchronously and then the dialog
                 // is not displayed.
                 window.setTimeout(function () {
-                    if (errorInfo.type === ProjectModel.ERROR_INVALID_FILENAME) {
+                    switch (errorInfo.type) {
+                    case ProjectModel.ERROR_INVALID_FILENAME:
                         _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder, ProjectModel._invalidChars);
-                    } else {
-                        var errString;
-                        if (errorInfo.type === FileSystemError.ALREADY_EXISTS) {
-                            errString = Strings.FILE_EXISTS_ERR;
-                        } else if (errorInfo.type === ProjectModel.ERROR_NOT_IN_PROJECT) {
-                            errString = Strings.ERROR_RENAMING_NOT_IN_PROJECT;
-                        } else {
-                            errString = FileUtils.getFileErrorString(errorInfo.type);
-                        }
-
-                        _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, errString, errorInfo.fullPath);
+                        break;
+                    case FileSystemError.ALREADY_EXISTS:
+                        _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, Strings.FILE_EXISTS_ERR, errorInfo.fullPath);
+                        break;
+                    case ProjectModel.ERROR_NOT_IN_PROJECT:
+                        _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, Strings.ERROR_RENAMING_NOT_IN_PROJECT, errorInfo.fullPath);
+                        break;
+                    default:
+                        _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, FileUtils.getFileErrorString(errorInfo.type), errorInfo.fullPath);
                     }
                 }, 10);
                 d.reject(errorInfo);


### PR DESCRIPTION
For #9650.

Renaming files outside of the project has never worked (see also #6896), but until now, we have just (more or less) no-oped in that case, leaving the user clueless on why the rename operation failed.
I think this is a better approach.
