### PR TITLE
Add gyp and gypi file extensions to python language

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -195,7 +195,7 @@
     "python": {
         "name": "Python",
         "mode": "python",
-        "fileExtensions": ["py", "pyw", "wsgi"],
+        "fileExtensions": ["py", "pyw", "wsgi", "gyp", "gypi"],
         "lineComment": ["#"]
     },
 


### PR DESCRIPTION
The documentation here https://gyp.gsrc.io/docs/LanguageSpecification.md#Overview
says `The .gyp file syntax is a Python data structure.`
