### PR TITLE
Fix12131: release refresh 1.6: added one more shortcut ctrl+shift+1  to toggle panels

### DIFF
--- a/src/extensions/default/NoDistractions/main.js
+++ b/src/extensions/default/NoDistractions/main.js
@@ -47,8 +47,10 @@ define(function (require, exports, module) {
     //key binding keys
     var togglePureCodeKey         = "Ctrl-Shift-2",
         togglePureCodeKeyMac      = "Cmd-Shift-2",
-        togglePanelsKey           = "Ctrl-Shift-`",
-        togglePanelsKeyMac        = "Cmd-Shift-`";
+        togglePanelsKey           = "Ctrl-Shift-1",
+        togglePanelsKeyMac        = "Cmd-Shift-1",
+        togglePanelsKey_EN        = "Ctrl-Shift-`",
+        togglePanelsKeyMac_EN     = "Cmd-Shift-`";
 
     //locals
     var _previouslyOpenPanelIDs = [],
@@ -160,7 +162,11 @@ define(function (require, exports, module) {
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PURE_CODE, "", Menus.AFTER, CMD_TOGGLE_PANELS);
 
         KeyBindingManager.addBinding(CMD_TOGGLE_PURE_CODE, [ {key: togglePureCodeKey}, {key: togglePureCodeKeyMac, platform: "mac"} ]);
+
+        //default toggle panel shortcut was ctrl+shift+` as it is present in one vertical line in the keyboard. However, we later learnt
+        //from IQE team than non-English keyboards does not have the ` char. So added one more shortcut ctrl+shift+1 which will be preferred
         KeyBindingManager.addBinding(CMD_TOGGLE_PANELS, [ {key: togglePanelsKey}, {key: togglePanelsKeyMac, platform: "mac"} ]);
+        KeyBindingManager.addBinding(CMD_TOGGLE_PANELS, [ {key: togglePanelsKey_EN}, {key: togglePanelsKeyMac_EN, platform: "mac"} ]);
     }
 
     initializeCommands();


### PR DESCRIPTION
default toggle panel shortcut was ctrl+shift+` as it is present in one vertical line in the keyboard. However, we later learnt from IQE team than non-English keyboards does not have the ` char. So added one more shortcut ctrl+shift+1 which will be preferred.

Long term solution for locale specific shortcuts maybe to have a locale filter just like the os filter we have while registering shortcuts. As we have already shipped with ctrl+shift+` removing that didn't look like a good idea, so maintained both.
