### PR TITLE
When flipping views, if the doc is already open on the other view, show it without closing the original pane

### DIFF
--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -212,6 +212,23 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Ensures that the given pane is focused after other focus related events occur
+     * @params {string} paneId - paneId of the pane to focus
+     * @private
+     */
+    function _ensurePaneIsFocused(paneId) {
+        var pane = MainViewManager._getPane(paneId);
+
+        // Defer the focusing until other focus events have occurred.
+        setTimeout(function () {
+            // Focus has most likely changed: give it back to the given pane.
+            pane.focus();
+            this._lastFocusedElement = pane.$el[0];
+            MainViewManager.setActivePaneId(paneId);
+        }, 1);
+    }
+
+    /**
      * @typedef {!$el: jQuery, getFile:function():!File, updateLayout:function(forceRefresh:boolean), destroy:function(),  getScrollPos:function():?,  adjustScrollPos:function(state:Object=, heightDelta:number)=, getViewState:function():?*=, restoreViewState:function(viewState:!*)=, notifyContainerChange:function()=, notifyVisibilityChange:function(boolean)=} View
      */
 
@@ -245,9 +262,14 @@ define(function (require, exports, module) {
             var currentFile = self.getCurrentlyViewedFile();
             var otherPaneId = self.id === FIRST_PANE ? SECOND_PANE : FIRST_PANE;
             var otherPane = MainViewManager._getPane(otherPaneId);
+            var sameDocInOtherView = otherPane.getViewForPath(currentFile.fullPath);
             
-            // If the same doc view is present in the destination pane prevent flip
-            if (otherPane.getViewForPath(currentFile.fullPath)) {
+            // If the same doc view is present in the destination, show the file instead of flipping it
+            if (sameDocInOtherView) {
+                CommandManager.execute(Commands.FILE_OPEN, {fullPath: currentFile.fullPath,
+                                                            paneId: otherPaneId}).always(function () {
+                    _ensurePaneIsFocused(otherPaneId);
+                });
                 return;
             }
 
@@ -255,30 +277,14 @@ define(function (require, exports, module) {
             // give focus to the pane. This way it is possible to flip multiple panes to the active one
             // without losing focus.
             var activePaneIdBeforeFlip = MainViewManager.getActivePaneId();
-            var currentFileOnOtherPaneIndex = otherPane.findInViewList(currentFile.fullPath);
 
-            // if the currentFile is already on other pane just close the current pane
-            if (currentFileOnOtherPaneIndex  !== -1) {
-                CommandManager.execute(Commands.FILE_CLOSE, {File: currentFile, paneId: self.id});
-            }
-            
             MainViewManager._moveView(self.id, otherPaneId, currentFile).always(function () {
                 CommandManager.execute(Commands.FILE_OPEN, {fullPath: currentFile.fullPath,
                                                             paneId: otherPaneId}).always(function () {
-
-                    var activePaneBeforeFlip = MainViewManager._getPane(activePaneIdBeforeFlip);
-
                     // Trigger view list changes for both panes
                     self.trigger("viewListChange");
                     otherPane.trigger("viewListChange");
-
-                    // Defer the focusing until other focus events have occurred.
-                    setTimeout(function () {
-                        // Focus has most likely changed: give it back to the original pane.
-                        activePaneBeforeFlip.focus();
-                        self._lastFocusedElement = activePaneBeforeFlip.$el[0];
-                        MainViewManager.setActivePaneId(activePaneIdBeforeFlip);
-                    }, 1);
+                    _ensurePaneIsFocused(activePaneIdBeforeFlip);
                 });
             });
         });

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -449,6 +449,37 @@ define(function (require, exports, module) {
                     expect(MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE)).toEqual(null);
                 });
             });
+            it("should show the file instead of flipping if file is already open", function () {
+                runs(function () {
+                    MainViewManager.setLayoutScheme(1, 2);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,  { fullPath: testPath + "/test.js",
+                                                                            paneId: "first-pane" });
+                    waitsForDone(promise, Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,  { fullPath: testPath + "/test.js",
+                                                                            paneId: "second-pane" });
+                    waitsForDone(promise, Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN);
+                });
+                runs(function () {
+                    promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,  { fullPath: testPath + "/test.css",
+                                                                            paneId: "second-pane" });
+                    waitsForDone(promise, Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN);
+                });
+                runs(function () {
+                    MainViewManager._getPane("first-pane").$headerFlipViewBtn.trigger("click");
+                });
+                runs(function () {
+                    MainViewManager.setActivePaneId("first-pane");
+                    expect(MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE).name).toEqual("test.js");
+                    expect(EditorManager.getCurrentFullEditor().document.file.name).toEqual("test.js");
+                    MainViewManager.setActivePaneId("second-pane");
+                    expect(MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE).name).toEqual("test.js");
+                    expect(EditorManager.getCurrentFullEditor().document.file.name).toEqual("test.js");
+                });
+            });
             it("should merge two panes to the right", function () {
                 runs(function () {
                     MainViewManager.setLayoutScheme(1, 2);


### PR DESCRIPTION
In https://github.com/adobe/brackets/commit/d72753b6b8bcc575f6e3cbbb96b4795a037a7740 there was an hotfix that prevented flipping files that were already open in the other pane (due to issues with merging views that have inline widgets open).

This PR changes it so that flipping an view that is already on the other pane just shows the other file in the other pane, being somewhat inline with the general `split-view-same-doc` concept. PR has an test included.

Tagging @swmitra 
