### PR TITLE
Add "gradle" to Groovy file extensions

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -7,7 +7,7 @@
     "groovy": {
         "name": "Groovy",
         "mode": "groovy",
-        "fileExtensions": ["groovy"],
+        "fileExtensions": ["groovy", "gradle"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },


### PR DESCRIPTION
Gradle is an open source build automation system that builds upon the concepts of Apache Ant and Apache Maven and introduces a Groovy-based domain-specific language (DSL) instead of the XML form used by Apache Maven of declaring the project configuration.

Fixes #12332
