### PR TITLE
Fix CSSUtils detection of @import urls

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -559,7 +559,7 @@ define(function (require, exports, module) {
                 break;
             }
 
-            if (backwardCtx.token.type && backwardCtx.token.type !== "tag" && backwardCtx.token.string !== "url") {
+            if (backwardCtx.token.type && backwardCtx.token.type !== "atom" && backwardCtx.token.string !== "url") {
                 // Previous token may be white-space
                 // Otherwise, previous token may only be "url("
                 break;


### PR DESCRIPTION
The highlighting of the `url` keyword changed in https://github.com/codemirror/codemirror/commit/5e1ca4f62d7f06c95f4d847ee60dcb52cb89d9e2 and that's why UrlCodeHints didn't show Hints anymore when inside of `@import url()`.

It's kind of my fault fault as I didn't bother running Extension tests when merging that version of CodeMirror.
