### PR TITLE
Fix FindReplace Integration tests

### DIFF
--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -516,17 +516,19 @@ define(function (require, exports, module) {
                 myEditor.setCursorPos(0, 0);
 
                 twCommandManager.execute(Commands.CMD_FIND);
+                // The previous search term "b" was pre-filled, so the editor was centered there already
+                expect(myEditor.centerOnCursor.calls.length).toEqual(1);
 
                 enterSearchText("foo");
                 expectHighlightedMatches(fooExpectedMatches);
                 expectSelection(fooExpectedMatches[0]);
                 expectMatchIndex(0, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(1);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(2);
 
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[1]);
                 expectMatchIndex(1, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(2);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(3);
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[2]);
                 expectMatchIndex(2, 4);
@@ -539,24 +541,26 @@ define(function (require, exports, module) {
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[0]);
                 expectMatchIndex(0, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(5);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(6);
             });
 
             it("should find all case-insensitive matches with mixed-case text", function () {
                 myEditor.setCursorPos(0, 0);
 
                 twCommandManager.execute(Commands.CMD_FIND);
+                // The previous search term "foo" was pre-filled, so the editor was centered there already
+                expect(myEditor.centerOnCursor.calls.length).toEqual(1);
 
                 enterSearchText("Foo");
                 expectHighlightedMatches(fooExpectedMatches);
                 expectSelection(fooExpectedMatches[0]);
                 expectMatchIndex(0, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(1);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(2);
 
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[1]);
                 expectMatchIndex(1, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(2);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(3);
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[2]);
                 expectMatchIndex(2, 4);
@@ -569,7 +573,7 @@ define(function (require, exports, module) {
                 twCommandManager.execute(Commands.CMD_FIND_NEXT);
                 expectSelection(fooExpectedMatches[0]);
                 expectMatchIndex(0, 4);
-                expect(myEditor.centerOnCursor.calls.length).toEqual(5);
+                expect(myEditor.centerOnCursor.calls.length).toEqual(6);
             });
 
             it("should find all case-sensitive matches with mixed-case text", function () {
@@ -637,6 +641,8 @@ define(function (require, exports, module) {
                     myEditor.setCursorPos(0, 0);
 
                     twCommandManager.execute(Commands.CMD_FIND);
+                    // The previous search term "Foo" was pre-filled, so the editor was centered there already
+                    expect(myEditor.centerOnCursor.calls.length).toEqual(1);
 
                     enterSearchText("foo");
                     pressEscape();
@@ -647,12 +653,12 @@ define(function (require, exports, module) {
 
                 runs(function () {
                     expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 8}, end: {line: LINE_FIRST_REQUIRE, ch: 11}});
-                    expect(myEditor.centerOnCursor.calls.length).toEqual(1);
+                    expect(myEditor.centerOnCursor.calls.length).toEqual(2);
 
                     // Simple linear Find Next
                     twCommandManager.execute(Commands.CMD_FIND_NEXT);
                     expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: 31}, end: {line: LINE_FIRST_REQUIRE, ch: 34}});
-                    expect(myEditor.centerOnCursor.calls.length).toEqual(2);
+                    expect(myEditor.centerOnCursor.calls.length).toEqual(3);
                     twCommandManager.execute(Commands.CMD_FIND_NEXT);
                     expectSelection({start: {line: 6, ch: 17}, end: {line: 6, ch: 20}});
                     twCommandManager.execute(Commands.CMD_FIND_NEXT);
@@ -745,13 +751,13 @@ define(function (require, exports, module) {
                 });
             });
 
-            it("shouldn't Find Next after search bar reopened", function () {
+            it("should remember the last search query", function () {
                 runs(function () {
                     myEditor.setCursorPos(0, 0);
 
                     twCommandManager.execute(Commands.CMD_FIND);
 
-                    enterSearchText("foo");
+                    enterSearchText("Foo");
                     pressEscape();
                 });
 
@@ -763,20 +769,36 @@ define(function (require, exports, module) {
                     twCommandManager.execute(Commands.CMD_FIND);
 
                     expectSearchBarOpen();
-                    expect(myEditor).toHaveCursorPosition(0, 0);
+                    expect(getSearchField().val()).toEqual("Foo");
+                    expectHighlightedMatches(capitalFooSelections);
+                    expectSelection(capitalFooSelections[0]);
+                    expectMatchIndex(0, 3);
+                    expect(myEditor.centerOnCursor.calls.length).toEqual(3);
 
                     twCommandManager.execute(Commands.CMD_FIND_NEXT);
-                    expect(myEditor).toHaveCursorPosition(0, 0);
+                    expectSelection(capitalFooSelections[1]);
+                    expectMatchIndex(1, 3);
                 });
             });
 
             it("should open search bar on Find Next with no previous search", function () {
-                myEditor.setCursorPos(0, 0);
+                runs(function () {
+                    // Make sure we have no previous query
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    enterSearchText("");
+                    pressEscape();
+                });
 
-                twCommandManager.execute(Commands.CMD_FIND_NEXT);
+                waitsForSearchBarClose();
 
-                expectSearchBarOpen();
-                expect(myEditor).toHaveCursorPosition(0, 0);
+                runs(function () {
+                    myEditor.setCursorPos(0, 0);
+
+                    twCommandManager.execute(Commands.CMD_FIND_NEXT);
+
+                    expectSearchBarOpen();
+                    expect(myEditor).toHaveCursorPosition(0, 0);
+                });
             });
 
             it("should select-all without affecting search state if Find invoked while search bar open", function () {  // #2478
@@ -855,16 +877,38 @@ define(function (require, exports, module) {
             });
 
             it("should use empty initial query for single cursor selection", function () {
-                myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START});
-                twCommandManager.execute(Commands.CMD_FIND);
-                expect(getSearchField().val()).toEqual("");
+                runs(function () {
+                    // Make sure we have no previous query
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    enterSearchText("");
+                    pressEscape();
+                });
+
+                waitsForSearchBarClose();
+
+                runs(function () {
+                    myEditor.setSelection({line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START});
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    expect(getSearchField().val()).toEqual("");
+                });
             });
 
             it("should use empty initial query for multiple cursor selection", function () {
-                myEditor.setSelections([{start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, primary: true},
-                                        {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}}]);
-                twCommandManager.execute(Commands.CMD_FIND);
-                expect(getSearchField().val()).toEqual("");
+                runs(function () {
+                    // Make sure we have no previous query
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    enterSearchText("");
+                    pressEscape();
+                });
+
+                waitsForSearchBarClose();
+
+                runs(function () {
+                    myEditor.setSelections([{start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, primary: true},
+                                            {start: {line: 1, ch: 0}, end: {line: 1, ch: 0}}]);
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    expect(getSearchField().val()).toEqual("");
+                });
             });
 
             it("should get single selection as initial query", function () {
@@ -958,6 +1002,15 @@ define(function (require, exports, module) {
         describe("Terminating search", function () {
             it("shouldn't change selection on Escape after typing text, no Find Nexts", function () {
                 runs(function () {
+                    // Make sure we have no previous query
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    enterSearchText("");
+                    pressEscape();
+                });
+
+                waitsForSearchBarClose();
+
+                runs(function () {
                     myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
 
                     twCommandManager.execute(Commands.CMD_FIND);
@@ -981,9 +1034,6 @@ define(function (require, exports, module) {
                     myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
 
                     twCommandManager.execute(Commands.CMD_FIND);
-                    expect(myEditor).toHaveCursorPosition(LINE_FIRST_REQUIRE, 0);
-
-                    enterSearchText("require");
                     expectSelection({start: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_START}, end: {line: LINE_FIRST_REQUIRE, ch: CH_REQUIRE_PAREN}});
 
                     twCommandManager.execute(Commands.CMD_FIND_NEXT);
@@ -1000,13 +1050,24 @@ define(function (require, exports, module) {
             });
 
             it("should no-op on Find Next with blank search", function () {
-                myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
+                runs(function () {
+                    // Make sure we have no previous query
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    enterSearchText("");
+                    pressEscape();
+                });
 
-                twCommandManager.execute(Commands.CMD_FIND);
-                expect(myEditor).toHaveCursorPosition(LINE_FIRST_REQUIRE, 0);
+                waitsForSearchBarClose();
 
-                twCommandManager.execute(Commands.CMD_FIND_NEXT);
-                expect(myEditor).toHaveCursorPosition(LINE_FIRST_REQUIRE, 0); // no change
+                runs(function () {
+                    myEditor.setCursorPos(LINE_FIRST_REQUIRE, 0);
+
+                    twCommandManager.execute(Commands.CMD_FIND);
+                    expect(myEditor).toHaveCursorPosition(LINE_FIRST_REQUIRE, 0);
+
+                    twCommandManager.execute(Commands.CMD_FIND_NEXT);
+                    expect(myEditor).toHaveCursorPosition(LINE_FIRST_REQUIRE, 0); // no change
+                });
 
             });
         });


### PR DESCRIPTION
Turns out we never adapted our tests for the altered behaviour introduced in #11869.
I tried my best to preserve the test cases.

cc @abose 
