### PR TITLE
Make file stats available to indexFilter

### DIFF
--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -170,9 +170,9 @@ define(function (require, exports, module) {
                 names.forEach(function (name, index) {
                     var entryPath = this.fullPath + name;
 
-                    if (this._fileSystem._indexFilter(entryPath, name)) {
-                        var entryStats = stats[index],
-                            entry;
+                    var entryStats = stats[index];
+                    if (this._fileSystem._indexFilter(entryPath, name, entryStats)) {
+                        var entry;
 
                         // Note: not all entries necessarily have associated stats.
                         if (typeof entryStats === "string") {


### PR DESCRIPTION
Small change to make the file stat information available to the file filter.

There are extensions available to extend the filtering capability, but they are all limited in that it is difficult to have custom filtering for directories or file sizes etc without more information provided to the filter.
