### PR TITLE
Fixup of 'Open Recent' strings

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -313,7 +313,7 @@ define({
     "CMD_FILE_NEW"                        : "New File",
     "CMD_FILE_NEW_FOLDER"                 : "New Folder",
     "CMD_FILE_OPEN"                       : "Open\u2026",
-    "CMD_RECENT_FILES_OPEN"               : "Open Recent",
+    "CMD_RECENT_FILES_OPEN"               : "Open Recent\u2026",
     "CMD_ADD_TO_WORKING_SET"              : "Open To Working Set",
     "CMD_OPEN_DROPPED_FILES"              : "Open Dropped Files",
     "CMD_OPEN_FOLDER"                     : "Open Folder\u2026",
@@ -676,7 +676,7 @@ define({
     // extensions/default/NavigationAndHistory
     "RECENT_FILES_DLG_HEADER"                    : "Recent Files",
     "RECENT_FILES_DLG_CLEAR_BUTTON_LABEL"        : "Clear",
-    "RECENT_FILES_DLG_CLEAR_BUTTON_TITLE"        : "Clear Files Not in WorkingSet",
+    "RECENT_FILES_DLG_CLEAR_BUTTON_TITLE"        : "Clear files not in Working Set",
 
     // Descriptions of core preferences
     "DESCRIPTION_CLOSE_BRACKETS"                     : "true to automatically close braces, brackets and parentheses",


### PR DESCRIPTION
Re line 316: It is our convention to use ellipsis if the menu item results in opening a dialog of some sort.
Re line 679: No need to use title capitalization here; "Working Set" is two words

cc @swmitra @abose @nethip 
