### PR TITLE
Remove code-padding from Codemirror pre's. Fixes #12630

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -31,7 +31,7 @@
 }
 
 .show-line-padding .CodeMirror pre {
-    padding-left: @code-padding;
+    padding-left: 0;
 }
 
 .CodeMirror-scroll {


### PR DESCRIPTION
As suggested by @RaymondLim. Didn't remove the `@code-padding` altogether as it is needed elsewhere too.

Signed-off-by: petetnt pete.a.nykanen@gmail.com
