### PR TITLE
Rework how file selection is shown

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -828,16 +828,10 @@ define(function (require, exports, module) {
                 width = selectionViewInfo.get("width"),
                 scrollWidth = selectionViewInfo.get("scrollWidth");
 
-            // Avoid endless horizontal scrolling
-            if (left + width > scrollWidth) {
-                left = scrollWidth - width;
-            }
-
             return DOM.div({
                 style: {
                     overflow: "auto",
                     left: left,
-                    width: width,
                     display: this.props.visible ? "block" : "none"
                 },
                 className: this.props.className

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1166,7 +1166,7 @@ define(function (require, exports, module) {
      */
     function _setFileTreeSelectionWidth(width) {
         model.setSelectionWidth(width);
-        _renderTree();
+        _renderTreeSync();
     }
 
     // Initialize variables and listeners that depend on the HTML DOM

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -190,14 +190,6 @@ define(function (require, exports, module) {
         $projectFilesContainer    = $sidebar.find("#project-files-container");
         $workingSetViewsContainer = $sidebar.find("#working-set-list-container");
 
-        function _resizeSidebarSelection() {
-            var $element;
-            $sidebar.find(".sidebar-selection").each(function (index, element) {
-                $element = $(element);
-                $element.width($element.parent()[0].scrollWidth);
-            });
-        }
-
         // init
         $sidebar.on("panelResizeStart", function (evt, width) {
             $sidebar.find(".sidebar-selection-extension").css("display", "none");
@@ -205,12 +197,10 @@ define(function (require, exports, module) {
         });
 
         $sidebar.on("panelResizeUpdate", function (evt, width) {
-            $sidebar.find(".sidebar-selection").width(width);
             ProjectManager._setFileTreeSelectionWidth(width);
         });
 
         $sidebar.on("panelResizeEnd", function (evt, width) {
-            _resizeSidebarSelection();
             $sidebar.find(".sidebar-selection-extension").css("display", "block").css("left", width);
             $sidebar.find(".scroller-shadow").css("display", "block");
             $projectFilesContainer.triggerHandler("scroll");
@@ -223,7 +213,6 @@ define(function (require, exports, module) {
 
         $sidebar.on("panelExpanded", function (evt, width) {
             WorkingSetView.refresh();
-            _resizeSidebarSelection();
             $sidebar.find(".scroller-shadow").css("display", "block");
             $sidebar.find(".sidebar-selection-extension").css("left", width);
             $projectFilesContainer.triggerHandler("scroll");

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -967,6 +967,7 @@ a, img {
     border-bottom: 1px solid @bc-highlight;
     box-sizing: border-box;
     height: 23px;
+    width: 100%;
     position: absolute;
 }
 
@@ -997,6 +998,7 @@ a, img {
     box-sizing: border-box;
     position: absolute;
     height: 23px;
+    width: 100%;
 }
 
 //Initially start with the open files hidden, they will get show as files are added

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -259,9 +259,6 @@ define(function (require, exports, module) {
                 // list item position is relative to scroller
                 var selectionMarkerTop = $listItem.offset().top - $scrollerElement.offset().top + $scrollerElement.get(0).scrollTop;
 
-                // force selection width to match scroller
-                $selectionMarker.width($scrollerElement.get(0).scrollWidth);
-
                 // move the selectionMarker position to align with the list item
                 $selectionMarker.css("top", selectionMarkerTop);
                 $selectionMarker.show();


### PR DESCRIPTION
This PR includes two changes:
- The dark background element behind the currently selected file in both the file tree and Working Files has his width now handled by CSS (turns out that's a whole lot easier than to have React update it on every change)
- Upon resizing the panel, the tree is rendered without delay, that is, the "selection extension" that covers the dark scrollbars is always in the right place. Fixes #11341.
