### PR TITLE
add typescript and tsx definitions to language.json

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -78,6 +78,22 @@
         "lineComment": ["//"]
     },
 
+    "typescript": {
+        "name": "TypeScript",
+        "mode": ["javascript", "text/typescript"],
+        "fileExtensions": ["ts"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
+    "tsx": {
+        "name": "TSX",
+        "mode": ["javascript", "text/typescript"],
+        "fileExtensions": ["tsx"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
     "dart": {
         "name": "Dart",
         "mode": ["dart", "application/dart"],


### PR DESCRIPTION
note: there's currently no mime for typescript with jsx, that should be altered later ref: https://github.com/codemirror/CodeMirror/issues/3893
