### PR TITLE
Move most inline jslint directives to config files

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -2,10 +2,28 @@
     "jslint.options": {
         "vars": true,
         "plusplus": true,
+        "browser": false,
         "devel": true,
         "nomen": true,
+        "indent": 4,
         "maxerr": 50,
-        "es5": true
+        "es5": true,
+        "predef": [
+            "brackets",
+
+            "require",
+            "define",
+            "$",
+
+            "window",
+            "setTimeout",
+            "clearTimeout",
+
+            "ArrayBuffer",
+            "XMLHttpRequest",
+            "Uint32Array",
+            "WebSocket"
+        ]
     },
     "defaultExtension": "js",
     "language": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,15 +54,17 @@
     "globals": {
         "brackets": false,
 
-        "window": false,
-        "alert": false,
-        "document": false,
-        "localStorage": false,
-        "navigator": false,
-        "setTimeout": false,
-
         "require": false,
         "define": false,
-        "$": false
+        "$": false,
+
+        "window": false,
+        "setTimeout": false,
+        "clearTimeout": false,
+
+        "ArrayBuffer": false,
+        "XMLHttpRequest": false,
+        "Uint32Array": false,
+        "WebSocket": false
     }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*global module, require*/
+
+/*jslint node: true */
+
 module.exports = function (grunt) {
     'use strict';
 

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint forin: true */
 
 /**
  * CSSAgent keeps track of loaded style sheets and allows reloading them

--- a/src/LiveDevelopment/Agents/ConsoleAgent.js
+++ b/src/LiveDevelopment/Agents/ConsoleAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * ConsoleAgent forwards all console message from the remote console to the
  * local console.

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, XMLHttpRequest */
-
 /**
  * DOMAgent constructs and maintains a tree of {DOMNode}s that represents the
  * rendered DOM tree in the remote browser. Nodes can be accessed by id or

--- a/src/LiveDevelopment/Agents/DOMHelpers.js
+++ b/src/LiveDevelopment/Agents/DOMHelpers.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
+/*jslint regexp: true */
 
 /**
  * DOMHelpers is a collection of functions used by the DOMAgent exports `eachNode(src, callback)`

--- a/src/LiveDevelopment/Agents/DOMNode.js
+++ b/src/LiveDevelopment/Agents/DOMNode.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint forin: true */
 
 /**
  * DOMNode represents a node in the DOM tree. It is constructed from a payload

--- a/src/LiveDevelopment/Agents/EditAgent.js
+++ b/src/LiveDevelopment/Agents/EditAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * EditAgent propagates changes from the in-document editor to the source
  * document.

--- a/src/LiveDevelopment/Agents/GotoAgent.js
+++ b/src/LiveDevelopment/Agents/GotoAgent.js
@@ -22,8 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, brackets, $, window */
+/*jslint forin: true, regexp: true */
 
 /**
  * GotoAgent constructs and responds to the in-browser goto dialog.

--- a/src/LiveDevelopment/Agents/HighlightAgent.js
+++ b/src/LiveDevelopment/Agents/HighlightAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * HighlightAgent dispatches events for highlight requests from in-browser
  * highlight requests, and allows highlighting nodes and rules in the browser.

--- a/src/LiveDevelopment/Agents/NetworkAgent.js
+++ b/src/LiveDevelopment/Agents/NetworkAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * NetworkAgent tracks all resources loaded by the remote debugger. Use
  * `wasURLRequested(url)` to query whether a resource was loaded.

--- a/src/LiveDevelopment/Agents/RemoteAgent.js
+++ b/src/LiveDevelopment/Agents/RemoteAgent.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, window */
+/*jslint regexp: true */
 
 /**
  * RemoteAgent defines and provides an interface for custom remote functions

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -21,10 +21,8 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, browser: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*jshint unused: false */
-/*global window, navigator, Node, console */
+/*jslint forin: true */
+/*global Node */
 /*theseus instrument: false */
 
 /**
@@ -47,7 +45,7 @@ function RemoteFunctions(experimental) {
 
     // determine whether an event should be processed for Live Development
     function _validEvent(event) {
-        if (navigator.platform.substr(0, 3) === "Mac") {
+        if (window.navigator.platform.substr(0, 3) === "Mac") {
             // Mac
             return event.metaKey;
         } else {
@@ -127,7 +125,7 @@ function RemoteFunctions(experimental) {
                 y = offset.top + this.element.offsetHeight;
 
             // create the container
-            this.body = document.createElement("div");
+            this.body = window.document.createElement("div");
             this.body.style.setProperty("z-index", 2147483647);
             this.body.style.setProperty("position", "absolute");
             this.body.style.setProperty("left", x + "px");
@@ -143,7 +141,7 @@ function RemoteFunctions(experimental) {
         },
 
         addItem: function (target) {
-            var item = document.createElement("div");
+            var item = window.document.createElement("div");
             item.style.setProperty("padding", "2px 6px");
             if (this.body.childNodes.length > 0) {
                 item.style.setProperty("border-top", "1px solid #ccc");
@@ -154,7 +152,7 @@ function RemoteFunctions(experimental) {
             item.addEventListener("click", this.onClick.bind(this, target.url));
 
             if (target.file) {
-                var file = document.createElement("i");
+                var file = window.document.createElement("i");
                 file.style.setProperty("float", "right");
                 file.style.setProperty("margin-left", "12px");
                 file.innerHTML = " " + target.file;
@@ -168,16 +166,16 @@ function RemoteFunctions(experimental) {
                 this.body = this.createBody();
             }
             if (!this.body.parentNode) {
-                document.body.appendChild(this.body);
+                window.document.body.appendChild(this.body);
             }
-            document.addEventListener("click", this.remove);
+            window.document.addEventListener("click", this.remove);
         },
 
         remove: function () {
             if (this.body && this.body.parentNode) {
-                document.body.removeChild(this.body);
+                window.document.body.removeChild(this.body);
             }
-            document.removeEventListener("click", this.remove);
+            window.document.removeEventListener("click", this.remove);
         }
 
     };
@@ -315,7 +313,7 @@ function RemoteFunctions(experimental) {
         },
 
         add: function (element, doAnimation) {
-            if (this._elementExists(element) || element === document) {
+            if (this._elementExists(element) || element === window.document) {
                 return;
             }
             if (this.trigger) {
@@ -395,7 +393,7 @@ function RemoteFunctions(experimental) {
 
     function onMouseMove(event) {
         onMouseOver(event);
-        document.removeEventListener("mousemove", onMouseMove);
+        window.document.removeEventListener("mousemove", onMouseMove);
     }
 
     function onClick(event) {
@@ -412,11 +410,11 @@ function RemoteFunctions(experimental) {
 
     function onKeyUp(event) {
         if (_setup && !_validEvent(event)) {
-            document.removeEventListener("keyup", onKeyUp);
-            document.removeEventListener("mouseover", onMouseOver);
-            document.removeEventListener("mouseout", onMouseOut);
-            document.removeEventListener("mousemove", onMouseMove);
-            document.removeEventListener("click", onClick);
+            window.document.removeEventListener("keyup", onKeyUp);
+            window.document.removeEventListener("mouseover", onMouseOver);
+            window.document.removeEventListener("mouseout", onMouseOut);
+            window.document.removeEventListener("mousemove", onMouseMove);
+            window.document.removeEventListener("click", onClick);
             _localHighlight.clear();
             _localHighlight = undefined;
             _setup = false;
@@ -425,11 +423,11 @@ function RemoteFunctions(experimental) {
 
     function onKeyDown(event) {
         if (!_setup && _validEvent(event)) {
-            document.addEventListener("keyup", onKeyUp);
-            document.addEventListener("mouseover", onMouseOver);
-            document.addEventListener("mouseout", onMouseOut);
-            document.addEventListener("mousemove", onMouseMove);
-            document.addEventListener("click", onClick);
+            window.document.addEventListener("keyup", onKeyUp);
+            window.document.addEventListener("mouseover", onMouseOver);
+            window.document.addEventListener("mouseout", onMouseOut);
+            window.document.addEventListener("mousemove", onMouseMove);
+            window.document.addEventListener("click", onClick);
             _localHighlight = new Highlight("#ecc", true);
             _setup = true;
         }
@@ -479,7 +477,7 @@ function RemoteFunctions(experimental) {
     // highlight a rule
     function highlightRule(rule) {
         hideHighlight();
-        var i, nodes = document.querySelectorAll(rule);
+        var i, nodes = window.document.querySelectorAll(rule);
         for (i = 0; i < nodes.length; i++) {
             highlight(nodes[i]);
         }
@@ -500,7 +498,7 @@ function RemoteFunctions(experimental) {
     function _scrollHandler(e) {
         // Document scrolls can be updated immediately. Any other scrolls
         // need to be updated on a timer to ensure the layout is correct.
-        if (e.target === document) {
+        if (e.target === window.document) {
             redrawHighlights();
         } else {
             if (_remoteHighlight || _localHighlight) {
@@ -817,7 +815,7 @@ function RemoteFunctions(experimental) {
     }
 
     function getSimpleDOM() {
-        return JSON.stringify(_domElementToJSON(document.documentElement));
+        return JSON.stringify(_domElementToJSON(window.document.documentElement));
     }
 
     // init

--- a/src/LiveDevelopment/Agents/ScriptAgent.js
+++ b/src/LiveDevelopment/Agents/ScriptAgent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
-
 /**
  * ScriptAgent tracks all executed scripts, defines internal breakpoints, and
  * interfaces with the remote debugger.

--- a/src/LiveDevelopment/Documents/CSSDocument.js
+++ b/src/LiveDevelopment/Documents/CSSDocument.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint forin: true */
 
 /**
  * CSSDocument manages a single CSS source document

--- a/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
+++ b/src/LiveDevelopment/Documents/CSSPreprocessorDocument.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * CSSPreprocessorDocument manages a single LESS or SASS source document
  *

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * HTMLDocument manages a single HTML source document
  *

--- a/src/LiveDevelopment/Documents/JSDocument.js
+++ b/src/LiveDevelopment/Documents/JSDocument.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
+/*jslint forin: true */
 
 /**
  * JSDocument manages a single JavaScript source document

--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -21,10 +21,8 @@
  *
  */
 
-
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, WebSocket, FileError, XMLHttpRequest */
+/*jslint forin: true */
+/*global FileError */
 
  /**
  * Inspector manages the connection to Chrome/Chromium's remote debugger.

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
-
 /**
  * LiveDevelopment allows Brackets to launch a browser with a "live preview" that's
  * connected to the current editor.

--- a/src/LiveDevelopment/LiveDevServerManager.js
+++ b/src/LiveDevelopment/LiveDevServerManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * LiveDevServerManager Overview:
  *

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, brackets, window, open */
+/*global open */
 
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument

--- a/src/LiveDevelopment/LiveDevelopmentUtils.js
+++ b/src/LiveDevelopment/LiveDevelopmentUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Set of utilities for working with files and text content.
  */

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
-
 /**
  * LiveCSSDocument manages a single CSS source document
  *

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveDocument.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * LiveHTMLDocument manages a single HTML source document. Edits to the HTML are applied live in
  * the browser, and the DOM node corresponding to the selection is highlighted.

--- a/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: HTML Instrumentation*/
 
 /**

--- a/src/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: HTML Instrumentation*/
 
 define(function (require, exports, module) {

--- a/src/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.js
@@ -21,10 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, node: true */
+/*jslint node: true */
 
 (function () {
     "use strict";

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
-
 /**
  * Provides the protocol that Brackets uses to talk to a browser instance for live development.
  * Protocol methods are converted to a JSON message format, which is then sent over a provided

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
@@ -21,7 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*global setInterval, clearInterval */
 
 (function (global) {
@@ -84,8 +83,8 @@
             }
         };
         //iterate on document.stylesheets (StyleSheetList doesn't provide forEach iterator).
-        for (j = 0; j < document.styleSheets.length; j++) {
-            s = document.styleSheets[j];
+        for (j = 0; j < window.document.styleSheets.length; j++) {
+            s = window.document.styleSheets[j];
             traverseRules(s, s.href);
         }
         return rel;
@@ -141,8 +140,8 @@
                 // TODO: This is just a temporary 'cross-browser' solution, it needs optimization.
                 var loadInterval = setInterval(function () {
                     var i;
-                    for (i = 0; i < document.styleSheets.length; i++) {
-                        if (document.styleSheets[i].href === href) {
+                    for (i = 0; i < window.document.styleSheets.length; i++) {
+                        if (window.document.styleSheets[i].href === href) {
                             //clear interval
                             clearInterval(loadInterval);
                             // notify stylesheets added
@@ -155,7 +154,7 @@
 
             onStylesheetRemoved : function (url) {
                 // get style node created when setting new text for stylesheet.
-                var s = document.getElementById(url);
+                var s = window.document.getElementById(url);
                 // remove
                 if (s && s.parentNode && s.parentNode.removeChild) {
                     s.parentNode.removeChild(s);
@@ -285,10 +284,10 @@
             });
         } else {
             // use MutationEvents as fallback
-            document.addEventListener('DOMNodeInserted', function niLstnr(e) {
+            window.document.addEventListener('DOMNodeInserted', function niLstnr(e) {
                 _onNodesAdded([e.target]);
             });
-            document.addEventListener('DOMNodeRemoved', function nrLstnr(e) {
+            window.document.addEventListener('DOMNodeRemoved', function nrLstnr(e) {
                 _onNodesRemoved([e.target]);
             });
         }

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
@@ -21,7 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
 /*jslint evil: true */
 
 // This is the script that Brackets live development injects into HTML pages in order to
@@ -165,14 +164,14 @@
             var i,
                 node;
 
-            var head = document.getElementsByTagName('head')[0];
+            var head = window.document.getElementsByTagName('head')[0];
             // create an style element to replace the one loaded with <link>
-            var s = document.createElement('style');
+            var s = window.document.createElement('style');
             s.type = 'text/css';
-            s.appendChild(document.createTextNode(msg.params.text));
+            s.appendChild(window.document.createTextNode(msg.params.text));
 
-            for (i = 0; i < document.styleSheets.length; i++) {
-                node = document.styleSheets[i];
+            for (i = 0; i < window.document.styleSheets.length; i++) {
+                node = window.document.styleSheets[i];
                 if (node.ownerNode.id === msg.params.url) {
                     head.insertBefore(s, node.ownerNode); // insert the style element here
                     // now can remove the style element previously created (if any)
@@ -195,8 +194,8 @@
             var i,
                 sheet,
                 text = "";
-            for (i = 0; i < document.styleSheets.length; i++) {
-                sheet = document.styleSheets[i];
+            for (i = 0; i < window.document.styleSheets.length; i++) {
+                sheet = window.document.styleSheets[i];
                 // if it was already 'reloaded'
                 if (sheet.ownerNode.id ===  msg.params.url) {
                     text = sheet.ownerNode.textContent;
@@ -207,7 +206,7 @@
                     // Deal with Firefox's SecurityError when accessing sheets
                     // from other domains, and Chrome returning `undefined`.
                     try {
-                        rules = document.styleSheets[i].cssRules;
+                        rules = window.document.styleSheets[i].cssRules;
                     } catch (e) {
                         if (e.name !== "SecurityError") {
                             throw e;
@@ -286,10 +285,10 @@
         },
 
         onClose: function () {
-            var body = document.getElementsByTagName("body")[0],
-                overlay = document.createElement("div"),
-                background = document.createElement("div"),
-                status = document.createElement("div");
+            var body = window.document.getElementsByTagName("body")[0],
+                overlay = window.document.createElement("div"),
+                background = window.document.createElement("div"),
+                status = window.document.createElement("div");
 
             overlay.style.width = "100%";
             overlay.style.height = "100%";
@@ -321,7 +320,7 @@
             body.appendChild(overlay);
 
             // change the title as well
-            document.title = "(Brackets Live Preview: closed) " + document.title;
+            window.document.title = "(Brackets Live Preview: closed) " + window.document.title;
         },
 
         setDocumentObserver: function (documentOberver) {

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 // This transport provides a WebSocket connection between Brackets and a live browser preview.
 // This is just a thin wrapper around the Node extension (NodeSocketTransportDomain) that actually
 // provides the WebSocket server and handles the communication. We also rely on an injected script in

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/node/NodeSocketTransportDomain.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, node: true */
+/*jslint node: true */
 
 (function () {
     "use strict";

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/remote/NodeSocketTransportRemote.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/remote/NodeSocketTransportRemote.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint browser: true, vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global WebSocket */
-
 // This is a transport injected into the browser via a script that handles the low
 // level communication between the live development protocol handlers on both sides.
 // This transport provides a web socket mechanism. It's injected separately from the

--- a/src/LiveDevelopment/Servers/BaseServer.js
+++ b/src/LiveDevelopment/Servers/BaseServer.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/LiveDevelopment/Servers/FileServer.js
+++ b/src/LiveDevelopment/Servers/FileServer.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/LiveDevelopment/Servers/UserServer.js
+++ b/src/LiveDevelopment/Servers/UserServer.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, forin: true, maxerr: 50, regexp: true */
-/*global define, $, less, window */
+/*global less */
 
 /**
  * main integrates LiveDevelopment into Brackets

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets: true, $, window, navigator, jQuery */
+/*global jQuery */
 
 // TODO: (issue #264) break out the definition of brackets into a separate module from the application controller logic
 
@@ -244,7 +242,7 @@ define(function (require, exports, module) {
         // Use quiet scrollbars if we aren't on Lion. If we're on Lion, only
         // use native scroll bars when the mouse is not plugged in or when
         // using the "Always" scroll bar setting.
-        var osxMatch = /Mac OS X 10\D([\d+])\D/.exec(navigator.userAgent);
+        var osxMatch = /Mac OS X 10\D([\d+])\D/.exec(window.navigator.userAgent);
         if (osxMatch && osxMatch[1] && Number(osxMatch[1]) >= 7) {
             // test a scrolling div for scrollbars
             var $testDiv = $("<div style='position:fixed;left:-50px;width:50px;height:50px;overflow:auto;'><div style='width:100px;height:100px;'/></div>").appendTo(window.document.body);

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
  /**
   * Manages global application commands that can be called from menu items, key bindings, or subparts
   * of the application.

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, window */
-
 /**
  * Initializes the default brackets menu items.
  */

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, window */
+/*jslint regexp: true */
 /*unittests: KeyBindingManager */
 
 /**

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, evil:true */
-/*global window, document */
-
 /**
  * Check for missing dependencies
  */
@@ -48,6 +45,6 @@ window.setTimeout(function () {
                   "<p>If you're still having problems, please contact us via one of the channels mentioned at the bottom of the <a target=\"blank\" href=\"../README.md\">README</a>.</p>" +
                   "<p><a href=\"#\" onclick=\"window.location.reload()\">Reload Brackets</a></p>";
 
-        document.write(str);
+        window.document.write(str);
     }
 }, 1000);

--- a/src/document/ChangedDocumentTracker.js
+++ b/src/document/ChangedDocumentTracker.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Defines a ChangedDocumentTracker class to monitor changes to files in the current project.
  */

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, window, WebSocket */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * DocumentManager maintains a list of currently 'open' Documents. The DocumentManager is responsible
  * for coordinating document operations and dispatching certain document events.

--- a/src/document/InMemoryFile.js
+++ b/src/document/InMemoryFile.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Represents a file that will never exist on disk - a placeholder backing file for untitled Documents. NO ONE
  * other than DocumentManager should create instances of InMemoryFile. It is valid to test for one (`instanceof

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  */
 define(function (require, exports, module) {

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint regexp: true, vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /*
  * __CodeHintManager Overview:__
  *

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Editor is a 1-to-1 wrapper for a CodeMirror editor instance. It layers on Brackets-specific
  * functionality and provides APIs that cleanly pass through the bits of CodeMirror that the rest

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -21,10 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
-
 /**
  * Text-editing commands that apply to whichever Editor is currently focused
  */
@@ -210,7 +206,7 @@ define(function (require, exports, module) {
             line = doc.getLine(startLine);
             var originalCursorPosition = line.search(/\S|$/);
             
-            var firstCharPosition,cursorPosition = originalCursorPosition;
+            var firstCharPosition, cursorPosition = originalCursorPosition;
             
             for (i = startLine; i <= endLine; i++) {
                 //check if preference for indent line comment is available otherwise go back to default indentation
@@ -227,7 +223,7 @@ define(function (require, exports, module) {
                         cursorPosition = originalCursorPosition;
                     }
                     
-                    editGroup.push({text: prefixes[0], start: {line: i, ch: cursorPosition}}); 
+                    editGroup.push({text: prefixes[0], start: {line: i, ch: cursorPosition}});
                 } else {
                     editGroup.push({text: prefixes[0], start: {line: i, ch: 0}});
                 }

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * EditorManager owns the UI for the editor area. This essentially mirrors the 'current document'
  * property maintained by DocumentManager's model.

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Manages parts of the status bar related to the current editor's state.
  */

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/editor/InlineTextEditor.js
+++ b/src/editor/InlineTextEditor.js
@@ -23,8 +23,6 @@
 
 
 // FUTURE: Merge part (or all) of this class with MultiRangeInlineEditor
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/editor/InlineWidget.js
+++ b/src/editor/InlineWidget.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/editor/MultiRangeInlineEditor.js
+++ b/src/editor/MultiRangeInlineEditor.js
@@ -23,9 +23,6 @@
 
 // FUTURE: Merge part (or all) of this class with InlineTextEditor
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * An inline editor for displaying and editing multiple text ranges. Each range corresponds to a
  * contiguous set of lines in a file.

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
+/*jslint regexp: true */
 /*unittests: ExtensionManager*/
 
 /**

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global brackets, define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, Mustache, PathUtils */
 /*unittests: ExtensionManager*/
 
 define(function (require, exports, module) {
@@ -44,7 +42,7 @@ define(function (require, exports, module) {
     /**
      * Create a detached link element, so that we can use it later to extract url details like 'protocol'
      */
-    var _tmpLink = document.createElement('a');
+    var _tmpLink = window.document.createElement('a');
 
     /**
      * Creates a view enabling the user to install and manage extensions. Must be initialized

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $ */
 /*unittests: ExtensionManager*/
 
 define(function (require, exports, module) {

--- a/src/extensibility/InstallExtensionDialog.js
+++ b/src/extensibility/InstallExtensionDialog.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, window, $, brackets, document */
 /*unittests: Install Extension Dialog*/
 
 define(function (require, exports, module) {
@@ -260,7 +258,7 @@ define(function (require, exports, module) {
             break;
 
         case STATE_CLOSED:
-            $(document.body).off(".installDialog");
+            $(window.document.body).off(".installDialog");
 
            // Only resolve as successful if we actually installed something.
             Dialogs.cancelModalDialogIfOpen("install-extension-dialog");

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -21,10 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true,
-indent: 4, maxerr: 50 */
-/*global define, $, brackets */
+/*jslint regexp: true */
 
 /**
  * Functions for working with extension packages

--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
-indent: 4, maxerr: 50 */
+/*jslint node: true */
 
 "use strict";
 

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
-indent: 4, maxerr: 50, regexp: true */
+/*jslint node: true, regexp: true */
 
 "use strict";
 

--- a/src/extensibility/node/spec/Installation.spec.js
+++ b/src/extensibility/node/spec/Installation.spec.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
-indent: 4, maxerr: 50 */
+/*jslint node: true */
 /*global expect, describe, it, beforeEach, afterEach */
 
 "use strict";

--- a/src/extensibility/node/spec/Validation.spec.js
+++ b/src/extensibility/node/spec/Validation.spec.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
-indent: 4, maxerr: 50 */
+/*jslint node: true */
 /*global expect, describe, it, afterEach */
 
 "use strict";

--- a/src/extensibility/registry_utils.js
+++ b/src/extensibility/registry_utils.js
@@ -29,9 +29,6 @@
  * In the future, we should have a better mechanism for sharing code between the two.
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, indent: 4, maxerr: 50 */
-/*global brackets, define*/
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, brackets, $ */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, $, brackets */
+/*global describe, it, xit, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CloseOthers/unittests.js
+++ b/src/extensions/default/CloseOthers/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, runs, brackets, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/CodeFolding/Prefs.js
+++ b/src/extensions/default/CodeFolding/Prefs.js
@@ -4,8 +4,7 @@
  * @author Patrick Oladimeji
  * @date 3/22/14 20:39:53 PM
  */
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets*/
+
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CodeFolding/foldhelpers/foldSelected.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldSelected.js
@@ -3,7 +3,7 @@
  * @author Patrick Oladimeji
  * @date 31/07/2015 00:11:53
  */
-/*global define*/
+
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
@@ -2,8 +2,7 @@
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 // Based on http://codemirror.net/addon/fold/foldcode.js
 // Modified by Patrick Oladimeji for Brackets
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, document*/
+
 define(function (require, exports, module) {
     "use strict";
     var CodeMirror          = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
@@ -60,7 +59,7 @@ define(function (require, exports, module) {
         }
 
         function makeWidget() {
-            var widget = document.createElement("span");
+            var widget = window.document.createElement("span");
             widget.className = "CodeMirror-foldmarker";
             return widget;
         }

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -2,8 +2,7 @@
 // Distributed under an MIT license: http://codemirror.net/LICENSE
 // Based on http://codemirror.net/addon/fold/foldgutter.js
 // Modified by Patrick Oladimeji for Brackets
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, document, window, $*/
+
 define(function (require, exports, module) {
     "use strict";
     var CodeMirror      = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
@@ -28,7 +27,7 @@ define(function (require, exports, module) {
       * @return {HTMLElement} a htmlelement representing the fold marker
       */
     function marker(spec) {
-        var elt = document.createElement("div");
+        var elt = window.document.createElement("div");
         elt.className = spec;
         return elt;
     }

--- a/src/extensions/default/CodeFolding/foldhelpers/indentFold.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/indentFold.js
@@ -3,8 +3,6 @@
  * @author Patrick Oladimeji
  * @date 12/27/13 21:54:41 PM
  */
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets*/
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -25,8 +25,7 @@
  * @author Patrick Oladimeji
  * @date 10/24/13 9:35:26 AM
  */
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets*/
+
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CodeFolding/unittests.js
+++ b/src/extensions/default/CodeFolding/unittests.js
@@ -3,7 +3,9 @@
  * @author Patrick Oladimeji
  * @date 01/08/2015 18:34
  */
-/*global define, brackets, describe, beforeEach, afterEach, it, expect, runs, waitsForDone, waitsFor*/
+
+/*global describe, beforeEach, afterEach, it, expect, runs, waitsForDone, waitsFor*/
+
 define(function (require, exports, module) {
     "use strict";
     var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),

--- a/src/extensions/default/CommandLineTool/main.js
+++ b/src/extensions/default/CommandLineTool/main.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, appshell */
+/*global appshell */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/DebugCommands/ErrorNotification.js
+++ b/src/extensions/default/DebugCommands/ErrorNotification.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/DebugCommands/NodeDebugUtils.js
+++ b/src/extensions/default/DebugCommands/NodeDebugUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -68,7 +65,7 @@ define(function (require, exports, module) {
         try {
             _nodeConnection.domains.base.restartNode();
         } catch (e) {
-            alert("Failed trying to restart Node: " + e.message);
+            window.alert("Failed trying to restart Node: " + e.message);
         }
     }
 
@@ -79,7 +76,7 @@ define(function (require, exports, module) {
         try {
             _nodeConnection.domains.base.enableDebugger();
         } catch (e) {
-            alert("Failed trying to enable Node debugger: " + e.message);
+            window.alert("Failed trying to enable Node debugger: " + e.message);
         }
     }
 

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, window*/
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, $, brackets */
+/*global describe, it, xit, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/HandlebarsSupport/main.js
+++ b/src/extensions/default/HandlebarsSupport/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, console */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -66,7 +63,7 @@ define(function (require, exports, module) {
         oneTimeHealthData.uuid = userUuid;
         oneTimeHealthData.snapshotTime = Date.now();
         oneTimeHealthData.os = brackets.platform;
-        oneTimeHealthData.userAgent = navigator.userAgent;
+        oneTimeHealthData.userAgent = window.navigator.userAgent;
         oneTimeHealthData.osLanguage = brackets.app.language;
         oneTimeHealthData.bracketsLanguage = brackets.getLocale();
         oneTimeHealthData.bracketsVersion = brackets.metadata.version;

--- a/src/extensions/default/HealthData/HealthDataNotification.js
+++ b/src/extensions/default/HealthData/HealthDataNotification.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/HealthDataPopup.js
+++ b/src/extensions/default/HealthData/HealthDataPopup.js
@@ -21,11 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global brackets, define, $*/
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/HealthDataPreview.js
+++ b/src/extensions/default/HealthData/HealthDataPreview.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/HealthDataUtils.js
+++ b/src/extensions/default/HealthData/HealthDataUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/main.js
+++ b/src/extensions/default/HealthData/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets*/
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, describe, runs, beforeEach, it, afterEach, expect, waitsForDone, waitsForFail */
+/*global describe, runs, beforeEach, it, afterEach, expect, waitsForDone, waitsForFail */
 /*unittests: HealthData*/
 
 define(function (require, exports, module) {

--- a/src/extensions/default/HtmlEntityCodeHints/main.js
+++ b/src/extensions/default/HtmlEntityCodeHints/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HtmlEntityCodeHints/unittests.js
+++ b/src/extensions/default/HtmlEntityCodeHints/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, brackets */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/InlineColorEditor/ColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/ColorEditor.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $, window */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/InlineColorEditor/InlineColorEditor.js
+++ b/src/extensions/default/InlineColorEditor/InlineColorEditor.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineColorEditor/main.js
+++ b/src/extensions/default/InlineColorEditor/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, runs, $, brackets, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, waits, runs, waitsForDone, spyOn */
 
 define(function (require, exports, module) {
     "use strict";
@@ -357,7 +355,7 @@ define(function (require, exports, module) {
              * @param {boolean=} hide Whether to hide the color picker; default is true.
              */
             function makeUI(initialColor, callback, swatches, hide) {
-                colorEditor = new ColorEditor($(document.body),
+                colorEditor = new ColorEditor($(window.document.body),
                                               initialColor,
                                               callback || function () { },
                                               swatches || defaultSwatches);

--- a/src/extensions/default/InlineTimingFunctionEditor/BezierCurveEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/BezierCurveEditor.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/InlineTimingFunctionEditor.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineTimingFunctionEditor/StepEditor.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/StepEditor.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/TimingFunctionUtils.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
+/*jslint regexp: true */
 
 /**
  *  Utilities functions related to color matching

--- a/src/extensions/default/InlineTimingFunctionEditor/main.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/main.js
@@ -40,9 +40,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineTimingFunctionEditor/unittests.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, runs, $, brackets, waitsForDone */
+/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";
@@ -503,7 +502,7 @@ define(function (require, exports, module) {
              *     callback. If none is supplied, a dummy function is passed.
              */
             function makeTimingFuncUI(initialTimingFunction, callback) {
-                var parent = $(document.body),
+                var parent = $(window.document.body),
                     match = TimingFunctionUtils.timingFunctionMatch(initialTimingFunction, true),
                     cb = callback || function () { };
 

--- a/src/extensions/default/JSLint/main.js
+++ b/src/extensions/default/JSLint/main.js
@@ -21,8 +21,7 @@
  *
  */
 
-
-/*global define, JSLINT, brackets */
+/*global JSLINT */
 
 /**
  * Provides JSLint results via the core linting extension point

--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, runs, brackets, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptCodeHints/HintUtils.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptCodeHints/HintUtils2.js
+++ b/src/extensions/default/JavaScriptCodeHints/HintUtils2.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define */
-
 /**
  * HintUtils2 was created as a place to put utilities that do not require third party dependencies so
  * they can be used by tern-worker.js and other JS files.

--- a/src/extensions/default/JavaScriptCodeHints/MessageIds.js
+++ b/src/extensions/default/JavaScriptCodeHints/MessageIds.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ParameterHintManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/JavaScriptCodeHints/Preferences.js
+++ b/src/extensions/default/JavaScriptCodeHints/Preferences.js
@@ -60,8 +60,7 @@
 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, brackets */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -28,8 +28,7 @@
  * from an outer scope.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, Worker, setTimeout */
+/*global Worker */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, brackets, $ */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -21,7 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
 /*global self, importScripts, require */
 
 importScripts("thirdparty/requirejs/require.js");

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, brackets, waitsForDone, beforeFirst, afterLast */
+/*jslint regexp: true */
+/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptQuickEdit/main.js
+++ b/src/extensions/default/JavaScriptQuickEdit/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone */
+/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/LESSSupport/main.js
+++ b/src/extensions/default/LESSSupport/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, nomen: true, regexp: true, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/NavigationAndHistory/main.js
+++ b/src/extensions/default/NavigationAndHistory/main.js
@@ -21,11 +21,6 @@
  * 
  */
 
-/*jslint vars: true, plusplus: true, devel: true, regexp: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, brackets */
-
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/NoDistractions/main.js
+++ b/src/extensions/default/NoDistractions/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/PrefsCodeHints/main.js
+++ b/src/extensions/default/PrefsCodeHints/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $*/
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/PrefsCodeHints/unittests.js
+++ b/src/extensions/default/PrefsCodeHints/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, describe, beforeEach, afterEach, it, expect*/
+/*global describe, beforeEach, afterEach, it, expect*/
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/QuickOpenCSS/main.js
+++ b/src/extensions/default/QuickOpenCSS/main.js
@@ -21,11 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -21,10 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, regexp: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
-
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -21,11 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, runs, brackets, waitsForDone */
+/*global describe, it, expect, beforeEach, runs, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";
@@ -475,7 +474,7 @@ define(function (require, exports, module) {
                 checkImageDataAtPos("data:image/svg+xml;utf8, <svg version='1.1' xmlns='http://www.w3.org/2000/svg'></svg>", 185, 26);  // data url("") containing '
             });
 
-            it("Should show image preview for URLs with known image extensions", function() {
+            it("Should show image preview for URLs with known image extensions", function () {
                 checkImageDataAtPos("http://example.com/image.gif", 194, 20);
                 checkImageDataAtPos("http://example.com/image.png", 195, 20);
                 checkImageDataAtPos("http://example.com/image.jpe", 196, 20);
@@ -486,7 +485,7 @@ define(function (require, exports, module) {
                 checkImageDataAtPos("http://example.com/image.svg", 201, 20);
             });
 
-            it("Should show image preview for extensionless URLs (with protocol) with pref set", function() {
+            it("Should show image preview for extensionless URLs (with protocol) with pref set", function () {
                 // Flip the pref on and restore when done
                 var original = prefs.get("extensionlessImagePreview");
                 prefs.set("extensionlessImagePreview", true);
@@ -498,7 +497,7 @@ define(function (require, exports, module) {
                 prefs.set("extensionlessImagePreview", original);
             });
 
-            it("Should not show image preview for extensionless URLs (with protocol) without pref set", function() {
+            it("Should not show image preview for extensionless URLs (with protocol) without pref set", function () {
                 // Flip the pref off and restore when done
                 var original = prefs.get("extensionlessImagePreview");
                 prefs.set("extensionlessImagePreview", false);
@@ -510,7 +509,7 @@ define(function (require, exports, module) {
                 prefs.set("extensionlessImagePreview", original);
             });
 
-            it("Should ignore URLs for common non-image extensions", function() {
+            it("Should ignore URLs for common non-image extensions", function () {
                 expectNoPreviewAtPos(209, 20); // .html
                 expectNoPreviewAtPos(210, 20); // .css
                 expectNoPreviewAtPos(211, 20); // .js

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, window, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/RecentProjects/unittests.js
+++ b/src/extensions/default/RecentProjects/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeFirst, afterLast, runs, brackets, waitsFor, spyOn */
+/*global describe, it, expect, beforeFirst, afterLast, runs, waitsFor, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/SVGCodeHints/main.js
+++ b/src/extensions/default/SVGCodeHints/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/SVGCodeHints/unittests.js
+++ b/src/extensions/default/SVGCodeHints/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, describe, beforeEach, afterEach, it, expect */
+/*global describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/StaticServer/StaticServer.js
+++ b/src/extensions/default/StaticServer/StaticServer.js
@@ -21,11 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
-maxerr: 50, browser: true */
-/*global $, define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/StaticServer/main.js
+++ b/src/extensions/default/StaticServer/main.js
@@ -21,11 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
-maxerr: 50, browser: true */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/StaticServer/node/StaticServerDomain.js
+++ b/src/extensions/default/StaticServer/node/StaticServerDomain.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, node: true */
+/*jslint node: true */
 
 (function () {
     "use strict";

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, $, brackets, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, waitsForDone, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/UrlCodeHints/main.js
+++ b/src/extensions/default/UrlCodeHints/main.js
@@ -20,10 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true,  regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window */
-
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, brackets, waitsForDone */
+/*global describe, it, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
+++ b/src/extensions/default/WebPlatformDocs/InlineDocsViewer.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window */
-
 /**
  * Inline widget to display WebPlatformDocs JSON data nicely formatted
  */

--- a/src/extensions/default/WebPlatformDocs/main.js
+++ b/src/extensions/default/WebPlatformDocs/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/WebPlatformDocs/unittests.js
+++ b/src/extensions/default/WebPlatformDocs/unittests.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, waitsForFail */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, waitsForFail */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/samples/BracketsConfigCentral/main.js
+++ b/src/extensions/samples/BracketsConfigCentral/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/samples/ContextMenuTest/main.js
+++ b/src/extensions/samples/ContextMenuTest/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -46,21 +42,21 @@ define(function (require, exports, module) {
 
         var checked = command1.getChecked();
         if (checked) {
-            alert("Unchecking self. Disabling next.");
+            window.alert("Unchecking self. Disabling next.");
             command2.setEnabled(false);
         } else {
-            alert("Checking self. Enabling next.");
+            window.alert("Checking self. Enabling next.");
             command2.setEnabled(true);
         }
         command1.setChecked(!checked);
     }
 
     function TestCommand2() {
-        alert("Executing command 2");
+        window.alert("Executing command 2");
     }
 
     function TestCommand3() {
-        alert("Executing command 3");
+        window.alert("Executing command 3");
     }
 
     // Register the functions as commands

--- a/src/extensions/samples/InlineImageViewer/InlineImageViewer.js
+++ b/src/extensions/samples/InlineImageViewer/InlineImageViewer.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, window */
-
 define(function (require, exports, module) {
     'use strict';
 

--- a/src/extensions/samples/InlineImageViewer/main.js
+++ b/src/extensions/samples/InlineImageViewer/main.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
+/*jslint regexp: true */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/samples/LocalizationExample/main.js
+++ b/src/extensions/samples/LocalizationExample/main.js
@@ -21,11 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, require */
-
-
 require.config({
     paths: {
         "text" : "lib/text",
@@ -56,7 +51,7 @@ define(function (require, exports, module) {
     // This sample command first shows an alert passing in a localized
     // string in JavaScript then it shows a localized HTML dialog.
     function testCommand() {
-        alert(Strings.ALERT_MESSAGE);
+        window.alert(Strings.ALERT_MESSAGE);
 
         // Localize the dialog using Strings as the datasource and use it as the dialog template
         var localizedTemplate = Mustache.render(browserWrapperHtml, Strings);

--- a/src/extensions/samples/LocalizationExample/nls/fr/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/fr/strings.js
@@ -23,10 +23,6 @@
 
 // French Translation
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
-
 define({
     "COMMAND_NAME"      : "Ma nouvelle commande",
     "ALERT_MESSAGE"     : "Ceci est un exemple d'alerte",

--- a/src/extensions/samples/LocalizationExample/nls/root/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/root/strings.js
@@ -23,9 +23,6 @@
 
 // English - root strings
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     "COMMAND_NAME"      : "My New Command",
     "ALERT_MESSAGE"     : "This is a sample alert message",

--- a/src/extensions/samples/LocalizationExample/nls/strings.js
+++ b/src/extensions/samples/LocalizationExample/nls/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
 
     'use strict';

--- a/src/extensions/samples/LocalizationExample/strings.js
+++ b/src/extensions/samples/LocalizationExample/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * This file provides the interface to user visible strings in Brackets. Code that needs
  * to display strings should should load this module by calling var Strings = require("strings").

--- a/src/extensions/samples/TypingSpeedLogger/main.js
+++ b/src/extensions/samples/TypingSpeedLogger/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/samples/circular_dependency_test/main.js
+++ b/src/extensions/samples/circular_dependency_test/main.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/samples/circular_dependency_test/secondary.js
+++ b/src/extensions/samples/circular_dependency_test/secondary.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -21,9 +21,8 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, unescape, window */
+/*jslint regexp: true */
+/*global unescape */
 
 /**
  * Set of utilities for working with files and text content.

--- a/src/filesystem/Directory.js
+++ b/src/filesystem/Directory.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/filesystem/FileIndex.js
+++ b/src/filesystem/FileIndex.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * FileIndex is an internal module used by FileSystem to maintain an index of all files and directories.
  *

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * FileSystem is a model object representing a complete file system. This object creates
  * and manages File and Directory instances, dispatches events when the file system changes,

--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /*
  * To ensure cache coherence, current and future asynchronous state-changing
  * operations of FileSystemEntry and its subclasses should implement the

--- a/src/filesystem/FileSystemError.js
+++ b/src/filesystem/FileSystemError.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * FileSystemError describes the errors that can occur when using the FileSystem, File,
  * and Directory modules.

--- a/src/filesystem/FileSystemStats.js
+++ b/src/filesystem/FileSystemStats.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * The FileSystemStats represents a particular FileSystemEntry's stats.
  */

--- a/src/filesystem/WatchedRoot.js
+++ b/src/filesystem/WatchedRoot.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, appshell, window */
+/*global appshell */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -21,8 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true, indent: 4, maxerr: 50 */
+/*jslint node: true */
 
 "use strict";
 

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $ */
+/*jslint regexp: true */
 
 /**
  * Set of utilities for simple parsing of CSS text.

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4 */
-/*global define, $, brackets */
-
 /**
  * Manages linters and other code inspections on a per-language basis. Provides a UI and status indicator for
  * the resulting errors/warnings.

--- a/src/language/HTMLDOMDiff.js
+++ b/src/language/HTMLDOMDiff.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: HTML Instrumentation*/
 
 define(function (require, exports, module) {

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: HTML Instrumentation*/
 
 /**

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: HTML Instrumentation*/
 
 define(function (require, exports, module) {

--- a/src/language/HTMLTokenizer.js
+++ b/src/language/HTMLTokenizer.js
@@ -24,8 +24,8 @@
 // A simple HTML tokenizer, originally adapted from https://github.com/fb55/htmlparser2
 // (MIT-licensed), but with significant customizations for use in HTML live development.
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, continue: true */
-/*global define */
+/*jslint continue: true */
+
 /*unittests: HTML Tokenizer*/
 
 define(function (require, exports, module) {

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/language/JSONUtils.js
+++ b/src/language/JSONUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $*/
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
+/*jslint regexp: true */
 
 /**
  * Set of utilities for simple parsing of JS text.

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: LanguageManager*/
 
 /**

--- a/src/language/XMLUtils.js
+++ b/src/language/XMLUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/main.js
+++ b/src/main.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, window, brackets, navigator */
-
 /**
  * The bootstrapping module for brackets. This module sets up the require
  * configuration and loads the brackets module.
@@ -63,7 +60,7 @@ if (window.location.search.indexOf("testEnvironment") > -1) {
      * extension).
      */
     require.config({
-        locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : navigator.language)
+        locale: window.localStorage.getItem("locale") || (typeof (brackets) !== "undefined" ? brackets.app.language : window.navigator.language)
     });
 }
 

--- a/src/nls/bg/strings.js
+++ b/src/nls/bg/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/bg/urls.js
+++ b/src/nls/bg/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "bg/Getting Started",

--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/cs/urls.js
+++ b/src/nls/cs/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "cs/Getting Started",

--- a/src/nls/da/strings.js
+++ b/src/nls/da/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/da/urls.js
+++ b/src/nls/da/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "da/Kom godt i gang"

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/de/urls.js
+++ b/src/nls/de/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "de/Erste Schritte",

--- a/src/nls/el/strings.js
+++ b/src/nls/el/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/el/urls.js
+++ b/src/nls/el/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "el/Ξεκινώντας",

--- a/src/nls/en-gb/strings.js
+++ b/src/nls/en-gb/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
 });

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/es/urls.js
+++ b/src/nls/es/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "es/Primeros Pasos",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**
@@ -596,7 +593,7 @@ define({
     "INLINE_TIMING_EDITOR_PROGRESSION"          : "پیشرفت",
     "BEZIER_EDITOR_INFO"                        : "<kbd>↑</kbd><kbd>↓</kbd><kbd>←</kbd><kbd>→</kbd> انتخاب حرکت نشانگر<br><kbd class='text'>شیفت</kbd>حرکت با ده واحد<br><kbd class='text'>تب</kbd> نقاط تغییر",
     "STEPS_EDITOR_INFO"                         : "<kbd>↑</kbd><kbd>↓</kbd>افزایش و یا کاهش گام<br><kbd>←</kbd><kbd>→</kbd> 'شروع' or 'پایان'",
-    "INLINE_TIMING_EDITOR_INVALID"              :"مقدار سابق <code>{0}</code> دیگر معتبر نمی باشد, زیرا تابع نمایش به مقدار <code>{1}</code> تغییر یافته. سند در اولین ویرایش بروزرسانی خواهد شد.",
+    "INLINE_TIMING_EDITOR_INVALID"              : "مقدار سابق <code>{0}</code> دیگر معتبر نمی باشد, زیرا تابع نمایش به مقدار <code>{1}</code> تغییر یافته. سند در اولین ویرایش بروزرسانی خواهد شد.",
 
     // extensions/default/InlineColorEditor
     "COLOR_EDITOR_CURRENT_COLOR_SWATCH_TIP"     : "رنگ فعلی",

--- a/src/nls/fa-ir/urls.js
+++ b/src/nls/fa-ir/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "fa-ir/Getting Started",

--- a/src/nls/fi/strings.js
+++ b/src/nls/fi/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/fi/urls.js
+++ b/src/nls/fi/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "fi/Aloitus",

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/fr/urls.js
+++ b/src/nls/fr/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "fr/Premiers pas",

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/hr/strings.js
+++ b/src/nls/hr/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/hr/urls.js
+++ b/src/nls/hr/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "ADOBE_THIRD_PARTY" : "http://www.adobe.com/go/thirdparty/",

--- a/src/nls/hu/strings.js
+++ b/src/nls/hu/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/id/urls.js
+++ b/src/nls/id/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "id/Memulai",

--- a/src/nls/it/strings.js
+++ b/src/nls/it/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/it/urls.js
+++ b/src/nls/it/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "it/Primi passi",

--- a/src/nls/ja/strings.js
+++ b/src/nls/ja/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/ja/urls.js
+++ b/src/nls/ja/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "ja/Getting Started",

--- a/src/nls/ko/strings.js
+++ b/src/nls/ko/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/ko/urls.js
+++ b/src/nls/ko/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty_kr/",

--- a/src/nls/lv/strings.js
+++ b/src/nls/lv/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/nb/strings.js
+++ b/src/nls/nb/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/nb/urls.js
+++ b/src/nls/nb/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty/",

--- a/src/nls/nl/strings.js
+++ b/src/nls/nl/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/nl/urls.js
+++ b/src/nls/nl/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "nl/Aan-de-slag",

--- a/src/nls/pl/strings.js
+++ b/src/nls/pl/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**
@@ -84,7 +81,7 @@ define({
     "ERROR_MULTIPLE_SHORTCUTS"          : "Próbujesz przypisać kilka skrótów do następujących komend: {0}",
     "ERROR_DUPLICATE_SHORTCUTS"         : "Upewnij się, że następujące skróty są unikalne (nie nadpisują się): {0}",
     "ERROR_INVALID_SHORTCUTS"           : "Podane skróty są nieprawidłowe: {0}",
-    "ERROR_NONEXISTENT_COMMANDS"        : "Próbujesz przypisać skróty do niestniejących komend: {0}",    
+    "ERROR_NONEXISTENT_COMMANDS"        : "Próbujesz przypisać skróty do niestniejących komend: {0}",
 
     // Application preferences corrupt error strings
     "ERROR_PREFS_CORRUPT_TITLE"         : "Błąd podczas wczytywania ustawień",

--- a/src/nls/pl/urls.js
+++ b/src/nls/pl/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "pl/Szybki Start",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/pt-br/urls.js
+++ b/src/nls/pt-br/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"   : "pt-br/Primeiros Passos"

--- a/src/nls/pt-pt/strings.js
+++ b/src/nls/pt-pt/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     /**
      * Errors

--- a/src/nls/pt-pt/urls.js
+++ b/src/nls/pt-pt/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"   : "pt-pt/Primeiros Passos"

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/root/strings-app.js
+++ b/src/nls/root/strings-app.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // product-specific strings
     "APP_NAME"                             : "Brackets",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/root/urls.js
+++ b/src/nls/root/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "root/Getting Started",

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/ru/urls.js
+++ b/src/nls/ru/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "ru/Getting Started",

--- a/src/nls/sk/strings.js
+++ b/src/nls/sk/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/sr/strings-app.js
+++ b/src/nls/sr/strings-app.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // product-specific strings
     "APP_NAME"                             : "Заграде"

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/strings-app.js
+++ b/src/nls/strings-app.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
 
     "use strict";

--- a/src/nls/strings.js
+++ b/src/nls/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
 
     "use strict";

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/sv/urls.js
+++ b/src/nls/sv/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "sv/Kom igang",

--- a/src/nls/tr/strings.js
+++ b/src/nls/tr/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     /**
      * Errors

--- a/src/nls/tr/urls.js
+++ b/src/nls/tr/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty_tr/",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/urls.js
+++ b/src/nls/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
 
     "use strict";

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/zh-cn/urls.js
+++ b/src/nls/zh-cn/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty/",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
 
     /**

--- a/src/nls/zh-tw/urls.js
+++ b/src/nls/zh-tw/urls.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "zh-tw/Getting Started",

--- a/src/preferences/PreferenceStorage.js
+++ b/src/preferences/PreferenceStorage.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * PreferenceStorage defines an interface for persisting preference data as
  * name/value pairs for a module or plugin.

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global define, $, console, appshell */
+/*global appshell */
 /*unittests: Preferences Base */
 
 /**

--- a/src/preferences/PreferencesDialogs.js
+++ b/src/preferences/PreferencesDialogs.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * PreferencesDialogs
  *

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*global define, $, brackets */
-
 /**
  * Generates the fully configured preferences systems used throughout Brackets. This is intended
  * to be essentially private implementation that can be overridden for tests.

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -21,8 +21,6 @@
  *
  */
 
-
-/*global define, localStorage, console */
 /*unittests: Preferences Manager */
 
 /**
@@ -196,7 +194,7 @@ define(function (require, exports, module) {
 
     // Check localStorage for a preferencesKey. Production and unit test keys
     // are used to keep preferences separate within the same storage implementation.
-    preferencesKey = localStorage.getItem("preferencesKey");
+    preferencesKey = window.localStorage.getItem("preferencesKey");
 
     if (!preferencesKey) {
         // use default key if none is found
@@ -204,11 +202,11 @@ define(function (require, exports, module) {
         doLoadPreferences = true;
     } else {
         // using a non-default key, check for additional settings
-        doLoadPreferences = !!(localStorage.getItem("doLoadPreferences"));
+        doLoadPreferences = !!(window.localStorage.getItem("doLoadPreferences"));
     }
 
     // Use localStorage by default
-    _initStorage(localStorage);
+    _initStorage(window.localStorage);
 
 
     // Public API

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * FileSyncManager is a set of utilities to help track external modifications to the files and folders
  * in the currently open project.

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -21,7 +21,6 @@
  *
  */
 
-/*global define, $*/
 /*unittests: FileTreeView*/
 
 /**

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -21,7 +21,6 @@
  *
  */
 
-/*global define */
 /*unittests: FileTreeViewModel*/
 
 /**

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, event */
-
 /**
  * Responsible for coordinating file selection between views by permitting only one view
  * to show the current file selection at a time. Currently, only WorkingSetView and
@@ -152,14 +149,14 @@ define(function (require, exports, module) {
         function _getDerivedPaneContext() {
 
             function _secondPaneContext() {
-                return (event.ctrlKey || event.metaKey) && event.altKey ? MainViewManager.SECOND_PANE : null;
+                return (window.event.ctrlKey || window.event.metaKey) && window.event.altKey ? MainViewManager.SECOND_PANE : null;
             }
 
             function _firstPaneContext() {
-                return (event.ctrlKey || event.metaKey) ? MainViewManager.FIRST_PANE : null;
+                return (window.event.ctrlKey || window.event.metaKey) ? MainViewManager.FIRST_PANE : null;
             }
 
-            return event && (_secondPaneContext() || _firstPaneContext());
+            return window.event && (_secondPaneContext() || _firstPaneContext());
         }
 
         if (fileSelectionFocus !== PROJECT_MANAGER && fileSelectionFocus !== WORKING_SET_VIEW) {

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 /**
  * ProjectManager glues together the project model and file tree view and integrates as needed with other parts
  * of Brackets. It is responsible for creating and updating the project tree when projects are opened

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -22,7 +22,6 @@
  */
 
 /* unittests: ProjectModel */
-/*global define, brackets, $ */
 
 /**
  * Provides the data source for a project and manages the view model for the FileTreeView.

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * The view that controls the showing and hiding of the sidebar.
  *

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Manages the workingSetList sort methods.
  */

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window, brackets */
-
 /**
  * WorkingSetView generates the UI for the list of the files user is editing based on the model provided by EditorManager.
  * The UI allows the user to see what files are open/dirty and allows them to close files and specify the current editor.

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 /**
  * Utilities for managing file-set filters, as used in Find in Files.
  * Includes both UI for selecting/editing filters, as well as the actual file-filtering implementation.

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /*
  * UI for the Find/Replace and Find in Files modal bar.
  */

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /*
  * The core search functionality used by Find in Files and single-file Replace Batch.
  */

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /*
  * UI and controller logic for find/replace across multiple files within the project.
  *

--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -21,10 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: FindReplace*/
-
 
 /**
  * Adds Find and Replace commands

--- a/src/search/FindUtils.js
+++ b/src/search/FindUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
 /*unittests: QuickOpen*/
 
 /*

--- a/src/search/QuickOpenHelper.js
+++ b/src/search/QuickOpenHelper.js
@@ -21,11 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
-
-
 define(function (require, exports, module) {
     "use strict";
     

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -21,10 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, setTimeout */
-
-
 /*
  * Text field with attached dropdown list that is updated (based on a provider) whenever the text changes.
  *

--- a/src/search/ScrollTrackMarkers.js
+++ b/src/search/ScrollTrackMarkers.js
@@ -21,10 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
-
 /**
  * Manages tickmarks shown along the scrollbar track.
  * NOT yet intended for use by anyone other than the FindReplace module.

--- a/src/search/SearchModel.js
+++ b/src/search/SearchModel.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*global define, $, window */
-
 /*
  * Panel showing search results for a Find/Replace in Files operation.
  */

--- a/src/search/node/FindInFilesDomain.js
+++ b/src/search/node/FindInFilesDomain.js
@@ -21,9 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
-maxerr: 50, node: true */
-/*global setImmediate*/
+/*jslint node: true */
+/*global setImmediate */
 
 (function () {
     "use strict";

--- a/src/strings.js
+++ b/src/strings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, brackets, window */
-
 /**
  * This file provides the interface to user visible strings in Brackets. Code that needs
  * to display strings should should load this module by calling `var Strings = require("strings")`.

--- a/src/utils/AnimationUtils.js
+++ b/src/utils/AnimationUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * Utilities for dealing with animations in the UI.
  */
@@ -40,7 +36,7 @@ define(function (require, exports, module) {
      * @return {string} The supported transitionend event name.
      */
     function _detectTransitionEvent() {
-        var event, el = document.createElement("fakeelement");
+        var event, el = window.document.createElement("fakeelement");
 
         var transitions = {
             "OTransition"     : "oTransitionEnd",

--- a/src/utils/AppInit.js
+++ b/src/utils/AppInit.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Defines hooks to assist with module initialization.
  *

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Utilities for working with Deferred, Promise, and other asynchronous processes.
  */

--- a/src/utils/BuildInfoUtils.js
+++ b/src/utils/BuildInfoUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
 /**
  * Utilities for determining the git SHA from an optional repository or from the
  * installed copy of Brackets.

--- a/src/utils/ColorUtils.js
+++ b/src/utils/ColorUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  *  Utilities functions related to color matching
  *

--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Compatibility shims for running Brackets in various environments, browsers.
  */

--- a/src/utils/DeprecationWarning.js
+++ b/src/utils/DeprecationWarning.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*global define, console */
-
 /**
  *  Utilities functions to display deprecation warning in the console.
  *

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/EventDispatcher.js
+++ b/src/utils/EventDispatcher.js
@@ -20,10 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * Implements a jQuery-like event dispatch pattern for non-DOM objects:
  *  - Listeners are attached via on()/one() & detached via off()

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets */
-
 /**
  * ExtensionLoader searches the filesystem for extensions, then creates a new context for each one and loads it.
  * This module dispatches the following events:

--- a/src/utils/ExtensionUtils.js
+++ b/src/utils/ExtensionUtils.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, less */
+/*global less */
 
 /**
  * ExtensionUtils defines utility methods for implementing extensions.

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either

--- a/src/utils/HealthLogger.js
+++ b/src/utils/HealthLogger.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $*/
-
 /**
  *  Utilities functions related to Health Data logging
  */

--- a/src/utils/KeyEvent.js
+++ b/src/utils/KeyEvent.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define  */
-
 /**
  * Utilities module to provide constants for keyCodes
  */

--- a/src/utils/LocalizationUtils.js
+++ b/src/utils/LocalizationUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  *  Utilities functions related to localization/i18n
  */

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50*/
-/*global $, define, brackets */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -21,11 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
-maxerr: 50, browser: true */
-/*global $, define, brackets, WebSocket, ArrayBuffer, Uint32Array */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/NodeDomain.js
+++ b/src/utils/NodeDomain.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
-
 /**
  * This is a collection of utility functions for gathering performance data.
  */

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Resizer is a Module utility to inject resizing capabilities to any element
  * inside Brackets.

--- a/src/utils/ShellAPI.js
+++ b/src/utils/ShellAPI.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
  /**
   * This is JavaScript API exposed to the native shell when Brackets is run in a native shell rather than a browser.
   */

--- a/src/utils/StringMatch.js
+++ b/src/utils/StringMatch.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
 /*unittests: StringMatch */
 
 define(function (require, exports, module) {

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -25,8 +25,7 @@
    @CC wiki attribution: esmiralha
 */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50, bitwise: true */
-/*global define, brackets */
+/*jslint bitwise: true */
 
 /**
  *  Utilities functions related to string manipulation

--- a/src/utils/TokenUtils.js
+++ b/src/utils/TokenUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * Functions for iterating through tokens in the current editor buffer. Useful for doing
  * light parsing that can rely purely on information gathered by the code coloring mechanism.

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 /**
  *  Utilities functions for displaying update notifications
  *

--- a/src/utils/UrlParams.js
+++ b/src/utils/UrlParams.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/ValidationUtils.js
+++ b/src/utils/ValidationUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/utils/ViewUtils.js
+++ b/src/utils/ViewUtils.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/view/MainViewFactory.js
+++ b/src/view/MainViewFactory.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * MainViewFactory is a singleton for managing view factories.
  *

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 /**
  * MainViewManager manages the arrangement of all open panes as well as provides the controller
  * logic behind all views in the MainView (e.g. ensuring that a file doesn't appear in 2 lists)

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
  /**
   * Pane objects host views of files, editors, etc... Clients cannot access
   * Pane objects directly. Instead the implementation is protected by the

--- a/src/view/PanelManager.js
+++ b/src/view/PanelManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 /**
  * @deprecated This module provided for backwards compatibility.  Use WorkspaceManager instead.
  */

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, regexp: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, less */
+/*jslint regexp: true */
+/*global less */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/view/ThemeSettings.js
+++ b/src/view/ThemeSettings.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/view/ThemeView.js
+++ b/src/view/ThemeView.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets: false, $ */
-
 /**
  * The ViewCommandHandlers object dispatches the following event(s):
  *    - fontSizeChange -- Triggered when the font size is changed via the

--- a/src/view/ViewStateManager.js
+++ b/src/view/ViewStateManager.js
@@ -20,8 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
 
 /**
  * ViewStateManager is a singleton for views to park their global viwe state. The state is saved

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, window, $ */
-
 /**
 * Manages layout of panels surrounding the editor area, and size of the editor area (but not its contents).
  *

--- a/src/widgets/DefaultDialogs.js
+++ b/src/widgets/DefaultDialogs.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 /**
  * Utilities for creating and managing standard modal dialogs.
  */
@@ -342,7 +338,7 @@ define(function (require, exports, module) {
             } else if ($otherBtn.length) {
                 $otherBtn.focus();
             } else {
-                document.activeElement.blur();
+                window.document.activeElement.blur();
             }
 
             // Push our global keydown handler onto the global stack of handlers.

--- a/src/widgets/DropdownButton.js
+++ b/src/widgets/DropdownButton.js
@@ -20,10 +20,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 /**
  * Button that opens a dropdown list when clicked. More akin to a popup menu than a combobox. Compared to a
  * simple <select> element:

--- a/src/widgets/ModalBar.js
+++ b/src/widgets/ModalBar.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, brackets, window */
-
 /**
  * A "modal bar" component. This is a lightweight replacement for modal dialogs that
  * appears at the top of the editor area for operations like Find and Quick Open.

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, window, $, brackets */
-
 /**
  * Utilities for managing pop-ups.
  */

--- a/src/widgets/StatusBar.js
+++ b/src/widgets/StatusBar.js
@@ -21,10 +21,6 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, document */
-
 /**
  * A status bar with support for file information and busy and status indicators. This is a semi-generic
  * container; for the code that decides what content appears in the status bar, see client modules like
@@ -109,7 +105,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        indicator = indicator || document.createElement("div");
+        indicator = indicator || window.document.createElement("div");
         tooltip = tooltip || "";
         style = style || "";
         id = id.replace(_indicatorIDRegexp, "-") || "";

--- a/src/xorigin.js
+++ b/src/xorigin.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global brackets: true, navigator:true, document:true, window:true */
-
 /**
  * Function to test whether a given error represents an illegal cross origin access
  */
@@ -32,12 +29,12 @@
 
     var testCrossOriginError;
 
-    if (navigator.userAgent.search(" Chrome/") !== -1) {
+    if (window.navigator.userAgent.search(" Chrome/") !== -1) {
         // Chrome support
         testCrossOriginError = function (message, url, line) {
             return url === "" && line === 0 && message === "Script error.";
         };
-    } else if (navigator.userAgent.slice(0, 6) === 'Opera/') {
+    } else if (window.navigator.userAgent.slice(0, 6) === 'Opera/') {
         // Opera support
         testCrossOriginError = function (message, url, line) {
             return message === "Uncaught exception: DOMException: NETWORK_ERR";
@@ -46,7 +43,7 @@
 
     // Abort if running in the shell, running on a server or not running in a supported and affected browser
     if (typeof (brackets) !== "undefined" ||
-            document.location.href.substr(0, 7) !== "file://" ||
+            window.document.location.href.substr(0, 7) !== "file://" ||
             !testCrossOriginError) {
         return;
     }
@@ -66,7 +63,7 @@
         }
 
         // Show an error message
-        alert("Oops! This application doesn't run in browsers yet.\n\nIt is built in HTML, but right now it runs as a desktop app so you can use it to edit local files. Please use the application shell in the following repo to run this application:\n\ngithub.com/adobe/brackets-shell");
+        window.alert("Oops! This application doesn't run in browsers yet.\n\nIt is built in HTML, but right now it runs as a desktop app so you can use it to edit local files. Please use the application shell in the following repo to run this application:\n\ngithub.com/adobe/brackets-shell");
 
         // Restore the original handler for later errors
         window.onerror = previousErrorHandler;

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*jslint regexp:true*/
-/*global module, require, process*/
+
+/*jslint node: true, regexp: true */
 
 module.exports = function (grunt) {
     "use strict";

--- a/tasks/lib/common.js
+++ b/tasks/lib/common.js
@@ -20,8 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*jslint nomen:true */
-/*global module, require, process */
+
+/*jslint node: true */
+
 module.exports = function (grunt) {
     "use strict";
 

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -20,7 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*global module, require, process*/
+
+/*jslint node: true */
 
 module.exports = function (grunt) {
     "use strict";

--- a/tasks/update-release-number.js
+++ b/tasks/update-release-number.js
@@ -20,7 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*global module, require*/
+
+/*jslint node: true */
 
 module.exports = function (grunt) {
     "use strict";

--- a/tasks/write-config.js
+++ b/tasks/write-config.js
@@ -20,7 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-/*global module, require, process*/
+
+/*jslint node: true */
+
 module.exports = function (grunt) {
     "use strict";
 

--- a/test/BootstrapReporterView.js
+++ b/test/BootstrapReporterView.js
@@ -21,15 +21,15 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true, forin: true */
-/*global $, define, document */
+/*jslint regexp: true */
+
 define(function (require, exports, module) {
     'use strict';
 
     var _ = require("thirdparty/lodash");
 
     var BootstrapReporterView = function (doc, reporter) {
-        doc = doc || document;
+        doc = doc || window.document;
 
         $(reporter)
             .on("runnerStart", this._handleRunnerStart.bind(this))

--- a/test/PerformanceTestSuite.js
+++ b/test/PerformanceTestSuite.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
 define(function (require, exports, module) {
     'use strict';
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global require, define, $, beforeEach, afterEach, beforeFirst, afterLast, jasmine, brackets */
+/*global beforeEach, afterEach, beforeFirst, afterLast, jasmine */
 
 // Set the baseUrl to brackets/src
 require.config({
@@ -265,11 +264,11 @@ define(function (require, exports, module) {
         // Initiailize unit test preferences for each spec
         beforeEach(function () {
             // Unique key for unit testing
-            localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
+            window.localStorage.setItem("preferencesKey", SpecRunnerUtils.TEST_PREFERENCES_KEY);
 
             // Reset preferences from previous test runs
-            localStorage.removeItem("doLoadPreferences");
-            localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
+            window.localStorage.removeItem("doLoadPreferences");
+            window.localStorage.removeItem(SpecRunnerUtils.TEST_PREFERENCES_KEY);
 
             SpecRunnerUtils.runBeforeFirst();
         });
@@ -277,7 +276,7 @@ define(function (require, exports, module) {
         // Revert unit test preferences after each spec
         afterEach(function () {
             // Clean up preferencesKey
-            localStorage.removeItem("preferencesKey");
+            window.localStorage.removeItem("preferencesKey");
 
             SpecRunnerUtils.runAfterLast();
         });
@@ -294,7 +293,7 @@ define(function (require, exports, module) {
     }
 
     function init() {
-        selectedSuites = (params.get("suite") || localStorage.getItem("SpecRunner.suite") || "unit").split(",");
+        selectedSuites = (params.get("suite") || window.localStorage.getItem("SpecRunner.suite") || "unit").split(",");
 
         // Create a top-level filter to show/hide performance and extensions tests
         var runAll = (selectedSuites.indexOf("all") >= 0);
@@ -365,10 +364,10 @@ define(function (require, exports, module) {
             // Jasmine this is part of the reporter, but we separate them out so that
             // we can more easily grab just the model data for output during automatic
             // testing.)
-            reporterView = new BootstrapReporterView(document, reporter);
+            reporterView = new BootstrapReporterView(window.document, reporter);
 
             // remember the suite for the next unit test window launch
-            localStorage.setItem("SpecRunner.suite", selectedSuites);
+            window.localStorage.setItem("SpecRunner.suite", selectedSuites);
 
             $(window.document).ready(_documentReadyHandler);
         });

--- a/test/TestPreferencesImpl.js
+++ b/test/TestPreferencesImpl.js
@@ -21,9 +21,6 @@
  *
  */
 
-
-/*global define, $ */
-
 /**
  * Generates the fully configured preferences systems used IN TESTING. This configuration does
  * not manipulate the user's preferences.

--- a/test/UnitTestReporter.js
+++ b/test/UnitTestReporter.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, forin: true */
-/*global $, define, brackets */
-
 /**
  * A Jasmine reporter that summarizes test results data:
  *  - summarizes the results for each top-level suite (instead of flattening out all suites)

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
 define(function (require, exports, module) {
     "use strict";
 

--- a/test/node/TestingDomain.js
+++ b/test/node/TestingDomain.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, node: true, nomen: true,
-indent: 4, maxerr: 50 */
+/*jslint node: true */
 
 "use strict";
 

--- a/test/perf/OpenFile-perf-files/InlineWidget.js
+++ b/test/perf/OpenFile-perf-files/InlineWidget.js
@@ -21,10 +21,6 @@
  * 
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, window */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/test/perf/Performance-test.js
+++ b/test/perf/Performance-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, waitsForDone */
+/*global describe, beforeEach, afterEach, it, runs, waitsForDone */
 
 // TODO: Eventually we should have a brackets performance test suite that is separate from the unit tests
 

--- a/test/spec/Async-test.js
+++ b/test/spec/Async-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, it, runs, waitsFor, waitsForDone, waitsForFail, expect, $  */
+/*global describe, beforeEach, it, runs, waitsFor, waitsForDone, waitsForFail, expect */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CSSInlineEdit-test.js
+++ b/test/spec/CSSInlineEdit-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast */
+/*global describe, it, expect, beforeEach, afterEach, waitsForDone, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, waitsForDone, expect, $, beforeFirst, afterLast */
+/*global describe, beforeEach, afterEach, it, runs, waitsForDone, expect, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CodeHintUtils-test.js
+++ b/test/spec/CodeHintUtils-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect, $ */
+/*global describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, beforeFirst, afterEach, afterLast, waits, runs, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, beforeFirst, afterEach, afterLast, waits, runs, waitsForDone, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect */
+/*global describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, jasmine, describe, beforeFirst, afterLast, beforeEach, afterEach, it, runs, expect, waitsForDone */
+/*global jasmine, describe, beforeFirst, afterLast, beforeEach, afterEach, it, runs, expect, waitsForDone */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, expect, brackets, waitsForDone, waitsForFail, spyOn, beforeFirst, afterLast, jasmine, xit */
+/*global describe, beforeEach, afterEach, it, runs, expect, waitsForDone, waitsForFail, spyOn, beforeFirst, afterLast, jasmine, xit */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/DocumentManager-test.js
+++ b/test/spec/DocumentManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
+/*global describe, beforeEach, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/DragAndDrop-test.js
+++ b/test/spec/DragAndDrop-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
+/*global describe, beforeEach, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, jasmine, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, jasmine, spyOn */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, runs, waitsForDone, beforeFirst, afterLast */
+/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';
@@ -215,7 +214,7 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor();
-                PreferencesManager.set("indentLineComment",true);
+                PreferencesManager.set("indentLineComment", true);
             });
 
             afterEach(function () {
@@ -490,7 +489,7 @@ define(function (require, exports, module) {
             describe("with multiple selections", function () {
                 it("should toggle comments on separate lines with cursor selections", function () {
 
-                   myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
+                    myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 4}},
                                         {start: {line: 3, ch: 4}, end: {line: 3, ch: 4}}]);
 
                     var lines = defaultContent.split("\n");
@@ -555,9 +554,9 @@ define(function (require, exports, module) {
                                         {start: {line: 3, ch: 6}, end: {line: 3, ch: 8}, reversed: true}]);
 
                     var lines = defaultContent.split("\n");
-                    lines[1]= "    //function bar() {";
-                    lines[2]= "    //    ";
-                    lines[3]= "        //a();";
+                    lines[1] = "    //function bar() {";
+                    lines[2] = "    //    ";
+                    lines[3] = "        //a();";
 
 
                     var expectedText = lines.join("\n");
@@ -622,7 +621,7 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor();
-                PreferencesManager.set("indentLineComment",false);
+                PreferencesManager.set("indentLineComment", false);
             });
 
             afterEach(function () {
@@ -2148,7 +2147,7 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor(htmlContent, "html");
-                PreferencesManager.set("indentLineComment",false);
+                PreferencesManager.set("indentLineComment", false);
             });
 
             afterEach(function () {
@@ -2231,7 +2230,7 @@ define(function (require, exports, module) {
             describe("with multiple selections", function () {
                 
                 beforeEach(function () {
-                    PreferencesManager.set("indentLineComment",false);
+                    PreferencesManager.set("indentLineComment", false);
                 });
 
                 afterEach(function () {
@@ -2316,7 +2315,7 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor(htmlContent, "html");
-                PreferencesManager.set("indentLineComment",true);
+                PreferencesManager.set("indentLineComment", true);
             });
 
             afterEach(function () {
@@ -2346,7 +2345,7 @@ define(function (require, exports, module) {
             describe("with multiple selections", function () {
                 
                 beforeEach(function () {
-                    PreferencesManager.set("indentLineComment",true);
+                    PreferencesManager.set("indentLineComment", true);
                 });
 
                 afterEach(function () {

--- a/test/spec/EditorManager-test.js
+++ b/test/spec/EditorManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, spyOn, expect, beforeEach, afterEach, $ */
+/*global describe, it, spyOn, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     'use strict';
@@ -40,7 +38,7 @@ define(function (require, exports, module) {
             // hold the height, and we'll place the editor holder in it.
             $fakeContentDiv = $("<div class='content'/>")
                 .css("height", "200px")
-                .appendTo(document.body);
+                .appendTo(window.document.body);
 
             $fakeHolder = SpecRunnerUtils.createMockElement()
                                         .css("width", "1000px")
@@ -111,7 +109,7 @@ define(function (require, exports, module) {
             // hold the height, and we'll place the editor holder in it.
             $fakeContentDiv = $("<div class='content'/>")
                 .css("height", "200px")
-                .appendTo(document.body);
+                .appendTo(window.document.body);
 
             $fakeHolder = SpecRunnerUtils.createMockElement()
                                         .css("width", "1000px")

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
+/*global describe, afterEach, it, runs, expect, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/EditorRedraw-test.js
+++ b/test/spec/EditorRedraw-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, spyOn, expect, beforeEach, afterEach, $ */
+/*global describe, it, spyOn, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/EventDispatcher-test.js
+++ b/test/spec/EventDispatcher-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global jasmine, define, describe, beforeEach, it, expect, spyOn */
+/*global jasmine, describe, beforeEach, it, expect, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -21,10 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true,
-indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, runs, $, waitsForDone */
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, runs, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/ExtensionLoader-test.js
+++ b/test/spec/ExtensionLoader-test.js
@@ -21,9 +21,8 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define: false, describe: false, it: false, expect: false, spyOn: false, runs: false, waitsForDone: false, waitsForFail: false, beforeEach: false, afterEach: false */
+/*jslint regexp: true */
+/*global describe, it, expect, spyOn, runs, waitsForDone, waitsForFail, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -21,10 +21,8 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true,
-indent: 4, maxerr: 50, regexp: true */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, $, brackets, waitsForDone, spyOn, jasmine */
+/*jslint regexp: true */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, spyOn, jasmine */
 /*unittests: ExtensionManager*/
 
 define(function (require, exports, module) {
@@ -216,7 +214,7 @@ define(function (require, exports, module) {
                 model = new ModelClass();
                 modelDisposed = false;
                 waitsForDone(view.initialize(model), "view initializing");
-                view.$el.appendTo(document.body);
+                view.$el.appendTo(window.document.body);
             });
             runs(function () {
                 spyOn(view.model, "dispose").andCallThrough();
@@ -1579,7 +1577,7 @@ define(function (require, exports, module) {
                         spyOn(NativeApp, "openURLInDefaultBrowser");
 
                         var event = new window.Event("click", { bubbles: false, cancelable: true });
-                        document.querySelector("a[href='https://github.com/someuser']").dispatchEvent(event);
+                        window.document.querySelector("a[href='https://github.com/someuser']").dispatchEvent(event);
 
                         expect(NativeApp.openURLInDefaultBrowser).toHaveBeenCalledWith("https://github.com/someuser");
                         expect(window.location.href).toBe(origHref);

--- a/test/spec/ExtensionUtils-test.js
+++ b/test/spec/ExtensionUtils-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, expect, runs, waitsForDone, waitsForFail, beforeFirst, afterLast */
+/*global describe, it, expect, runs, waitsForDone, waitsForFail, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/FileFilters-test.js
+++ b/test/spec/FileFilters-test.js
@@ -20,8 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, waitsForDone, waits, runs */
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, waitsForDone, waits, runs */
 /*unittests: FileFilters*/
 
 define(function (require, exports, module) {

--- a/test/spec/FileSystem-test.js
+++ b/test/spec/FileSystem-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, $, window, jasmine, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, jasmine, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/FileTreeView-test.js
+++ b/test/spec/FileTreeView-test.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global $, define, describe, it, expect, jasmine */
+/*global describe, it, expect, jasmine */
 /*unittests: FileTreeView*/
 
 define(function (require, exports, module) {
@@ -559,7 +559,7 @@ define(function (require, exports, module) {
 
         describe("render", function () {
             it("should render into the given element", function () {
-                var el = document.createElement("div"),
+                var el = window.document.createElement("div"),
                     viewModel = new FileTreeViewModel.FileTreeViewModel();
                 viewModel._treeData = new Immutable.Map({
                     "subdir": twoLevel.getIn(["children", "subdir"])

--- a/test/spec/FileTreeViewModel-test.js
+++ b/test/spec/FileTreeViewModel-test.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global define, describe, it, beforeEach, expect */
+/*global describe, it, beforeEach, expect */
 /*unittests: FileTreeViewModel*/
 
 define(function (require, exports, module) {

--- a/test/spec/FileUtils-test.js
+++ b/test/spec/FileUtils-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, brackets, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, spyOn */
 /*unittests: FileUtils*/
 
 define(function (require, exports, module) {

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, spyOn */
+/*jslint regexp: true */
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, spyOn */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, $, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, waitsForDone, runs, jasmine */
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, waitsForDone, runs, jasmine */
 /*unittests: FindReplace*/
 
 define(function (require, exports, module) {

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -21,9 +21,8 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50, evil: true */
-/*global define, $, describe, beforeEach, afterEach, it, runs, expect, spyOn, jasmine, Node */
+/*jslint evil: true, regexp: true */
+/*global describe, beforeEach, afterEach, it, runs, expect, spyOn, jasmine, Node */
 /*unittests: HTML Instrumentation*/
 
 define(function (require, exports, module) {
@@ -68,7 +67,7 @@ define(function (require, exports, module) {
         }
     }
 
-    var entityParsingNode = document.createElement("div");
+    var entityParsingNode = window.document.createElement("div");
 
     /**
      * domFeatures is a prototype object that augments a SimpleDOM object to have more of the

--- a/test/spec/HTMLSimpleDOM-test.js
+++ b/test/spec/HTMLSimpleDOM-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50, evil: true */
-/*global define, describe, it, expect, jasmine */
+/*global describe, it, expect, jasmine */
 /*unittests: HTML SimpleDOM*/
 
 define(function (require, exports, module) {

--- a/test/spec/HTMLTokenizer-test.js
+++ b/test/spec/HTMLTokenizer-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect */
+/*global describe, it, expect */
 /*unittests: HTML Tokenizer*/
 
 define(function (require, exports, module) {

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, waitsForFail, runs, $, beforeFirst, afterLast */
+/*global describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, waitsForFail, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/InstallExtensionDialog-test.js
+++ b/test/spec/InstallExtensionDialog-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, $, spyOn, beforeFirst, afterLast, brackets */
+/*global describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, spyOn, beforeFirst, afterLast */
 /*unittests: Install Extension Dialog*/
 
 define(function (require, exports, module) {

--- a/test/spec/JSONUtils-test.js
+++ b/test/spec/JSONUtils-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect */
+/*global describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, $, waitsForDone */
+/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect, brackets, spyOn, runs, waits */
+/*global describe, beforeEach, afterEach, it, expect, spyOn, runs, waits */
 /*unittests: KeyBindingManager */
 
 define(function (require, exports, module) {

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, jasmine, beforeEach, afterEach, it, runs, waitsFor, expect, waitsForDone, spyOn */
+/*global describe, jasmine, beforeEach, afterEach, it, runs, waitsFor, expect, waitsForDone, spyOn */
 /*unittests: LanguageManager */
 
 define(function (require, exports, module) {

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global brackets, $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine, beforeFirst, afterLast */
+/*jslint regexp: true */
+/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, waitsForFail, runs, spyOn, jasmine, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global define, describe, beforeEach, runs, afterEach, waitsFor, it, xit, waitsForDone, expect */
+/*global describe, beforeEach, runs, afterEach, waitsFor, it, xit, waitsForDone, expect */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define: false, describe: false, it: false, expect: false, beforeEach: false, afterEach: false, waitsFor: false, waitsForDone: false, runs: false, brackets: false */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/MainViewFactory-test.js
+++ b/test/spec/MainViewFactory-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, runs, expect, waitsForDone */
+/*global describe, beforeEach, afterEach, it, runs, expect, waitsForDone */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/MainViewManager-test.js
+++ b/test/spec/MainViewManager-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $, describe, beforeEach, afterEach, it, runs, expect, waitsForDone, spyOn, jasmine */
+/*global describe, beforeEach, afterEach, it, runs, expect, waitsForDone, spyOn, jasmine */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, runs, $, beforeFirst, afterLast */
+/*global describe, it, expect, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/MockFileSystemImpl.js
+++ b/test/spec/MockFileSystemImpl.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/test/spec/MockFileSystemModel.js
+++ b/test/spec/MockFileSystemModel.js
@@ -21,9 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, $ */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/test/spec/MultiRangeInlineEditor-test.js
+++ b/test/spec/MultiRangeInlineEditor-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, runs, $, HTMLElement, beforeFirst, afterLast, waitsForDone */
+/*global describe, it, expect, beforeEach, afterEach, runs, HTMLElement, beforeFirst, afterLast, waitsForDone */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, runs, brackets */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, runs */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/NodeConnection-test.js
+++ b/test/spec/NodeConnection-test.js
@@ -21,10 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true,
-indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, ArrayBuffer, DataView, jasmine */
+/*global describe, it, expect, beforeEach, afterEach, waits, waitsFor, runs, ArrayBuffer, DataView, jasmine */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/Pane-test.js
+++ b/test/spec/Pane-test.js
@@ -22,8 +22,7 @@
  */
 
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, $, jasmine, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, jasmine, spyOn */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/PhantomHelper.js
+++ b/test/spec/PhantomHelper.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-
 // Polyfill for Phantom.js
 
 (function () {

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst */
 /*unittests: Preferences Base*/
 
 define(function (require, exports, module) {

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, runs, beforeFirst, afterLast, spyOn, waitsForDone */
+/*global describe, it, expect, beforeEach, runs, beforeFirst, afterLast, spyOn, waitsForDone */
+
 define(function (require, exports, module) {
     'use strict';
 

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast, waits */
+/*global describe, it, expect, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast, waits */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -21,8 +21,8 @@
  *
  */
 
-/* unittests: ProjectModel */
-/*global $, define, describe, it, expect, beforeEach, waitsForDone, waitsForFail, runs, spyOn, jasmine */
+/*global describe, it, expect, beforeEach, waitsForDone, waitsForFail, runs, spyOn, jasmine */
+/*unittests: ProjectModel */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/QuickOpen-test.js
+++ b/test/spec/QuickOpen-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs */
+/*global describe, it, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs */
 /*unittests: QuickOpen*/
 
 define(function (require, exports, module) {

--- a/test/spec/QuickSearchField-test.js
+++ b/test/spec/QuickSearchField-test.js
@@ -20,9 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, maxerr: 50 */
-/*global $, jasmine, define, describe, it, expect, beforeEach, afterEach, runs, waitsFor */
+/*global jasmine, describe, it, expect, beforeEach, afterEach, runs, waitsFor */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/RemoteFunctions-test.js
+++ b/test/spec/RemoteFunctions-test.js
@@ -21,8 +21,8 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50, evil: true */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, window */
+/*jslint evil: true */
+/*global describe, it, xit, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -21,9 +21,8 @@
  *
  */
 
+/*global jasmine, expect, beforeEach, waitsFor, waitsForDone, runs, spyOn */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, brackets, jasmine, expect, beforeEach, waitsFor, waitsForDone, runs, spyOn */
 define(function (require, exports, module) {
     'use strict';
 

--- a/test/spec/StringMatch-test.js
+++ b/test/spec/StringMatch-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach, jasmine */
+/*global describe, it, expect, beforeEach, afterEach, jasmine */
 /*unittests: StringMatch */
 
 define(function (require, exports, module) {

--- a/test/spec/StringUtils-test.js
+++ b/test/spec/StringUtils-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect */
+/*global describe, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/TextRange-test.js
+++ b/test/spec/TextRange-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, beforeEach, afterEach */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/ThemeManager-test.js
+++ b/test/spec/ThemeManager-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, waitsForDone */
+/*global describe, it, expect, waitsForDone */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/UpdateNotification-test.js
+++ b/test/spec/UpdateNotification-test.js
@@ -21,9 +21,8 @@
  *
  */
 
+/*global describe, it, expect, beforeEach, afterEach, waitsForDone, waitsForFail, spyOn, runs */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50, regexp: true */
-/*global define, $, describe, it, expect, beforeEach, afterEach, waitsForDone, waitsForFail, spyOn, runs */
 define(function (require, exports, module) {
     "use strict";
 

--- a/test/spec/UrlParams-test.js
+++ b/test/spec/UrlParams-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect */
+/*global describe, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/ValidationUtils-test.js
+++ b/test/spec/ValidationUtils-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect */
+/*global describe, it, expect */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/ViewCommandHandlers-test.js
+++ b/test/spec/ViewCommandHandlers-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, runs, expect, waitsForDone, beforeFirst, afterLast */
+/*global describe, it, runs, expect, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/ViewFactory-test.js
+++ b/test/spec/ViewFactory-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, runs, spyOn */
+/*global describe, it, expect, runs, spyOn */
 
 define(function (require, exports, module) {
     'use strict';

--- a/test/spec/ViewUtils-test.js
+++ b/test/spec/ViewUtils-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, $, beforeEach, afterEach, it, expect */
+/*global describe, beforeEach, afterEach, it, expect */
 /*unittests: ViewUtils*/
 
 define(function (require, exports, module) {
@@ -48,7 +47,7 @@ define(function (require, exports, module) {
                 /* 100% x 100px scroller with 100px x 1000px content */
                 $fixture = $("<div style='overflow:auto;height:100px'><div id='content' style='width:100px;height:1000px'></div></div>");
                 fixture = $fixture[0];
-                $(document.body).append($fixture);
+                $(window.document.body).append($fixture);
             });
 
             afterEach(function () {

--- a/test/spec/WorkingSetSort-test.js
+++ b/test/spec/WorkingSetSort-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, it, expect, waitsFor, runs, beforeFirst, afterLast */
+/*global describe, it, expect, waitsFor, runs, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/test/spec/WorkingSetView-test.js
+++ b/test/spec/WorkingSetView-test.js
@@ -21,9 +21,7 @@
  *
  */
 
-
-/*jslint vars: true, plusplus: true, devel: true, browser: true, nomen: true, indent: 4, maxerr: 50 */
-/*global $, define, describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast, waits */
+/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, waitsForDone, runs, beforeFirst, afterLast, waits */
 
 define(function (require, exports, module) {
     "use strict";
@@ -166,12 +164,12 @@ define(function (require, exports, module) {
             // force the test window to initialize to unit test preferences
             // for just this test
             runs(function () {
-                localStorage.setItem("doLoadPreferences", true);
+                window.localStorage.setItem("doLoadPreferences", true);
             });
 
             // remove temporary unit test preferences with a single-spec after()
             this.after(function () {
-                localStorage.removeItem("doLoadPreferences");
+                window.localStorage.removeItem("doLoadPreferences");
             });
 
             // close test window while working set has 2 files (see beforeEach())

--- a/test/spec/XMLUtils-test.js
+++ b/test/spec/XMLUtils-test.js
@@ -21,8 +21,7 @@
  *
  */
 
-/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, describe, beforeEach, afterEach, it, expect */
+/*global describe, beforeEach, afterEach, it, expect */
 
 define(function (require, exports, module) {
     "use strict";


### PR DESCRIPTION
Move most of the inline jslint directives inside `.brackets.json` and `.eslintrc.json`.
I've removed the `browser` directive too and so this PR supersedes #8658
I left some directive like `regexp, forin` or some globals like `appshell, less` inline because seemed better for now.
