### PR TITLE
Add cut/copy/paste to the context menu

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -251,6 +251,12 @@ define(function (require, exports, module) {
         // editor_cmenu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_DOCS);
+        editor_cmenu.addMenuDivider();
+        editor_cmenu.addMenuItem(Commands.EDIT_CUT);
+        editor_cmenu.addMenuItem(Commands.EDIT_COPY);
+        editor_cmenu.addMenuItem(Commands.EDIT_PASTE);
+
+        editor_cmenu.addMenuDivider();
         editor_cmenu.addMenuItem(Commands.EDIT_SELECT_ALL);
 
         var inline_editor_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.INLINE_EDITOR_MENU);
@@ -279,17 +285,13 @@ define(function (require, exports, module) {
                     inlineWidget = EditorManager.getFocusedInlineWidget();
 
                 if (editor) {
-                    // If there's just an insertion point select the word token at the cursor pos so
-                    // it's more clear what the context menu applies to.
-                    if (!editor.hasSelection()) {
-                        editor.selectWordAt(editor.getCursorPos());
-
+                    //if (!editor.hasSelection()) {
                         // Prevent menu from overlapping text by moving it down a little
                         // Temporarily backout this change for now to help mitigate issue #1111,
                         // which only happens if mouse is not over context menu. Better fix
                         // requires change to bootstrap, which is too risky for now.
                         //e.pageY += 6;
-                    }
+                    //}
 
                     // Inline text editors have a different context menu (safe to assume it's not some other
                     // type of inline widget since we already know an Editor has focus)

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -1113,17 +1113,7 @@ define(function (require, exports, module) {
         return handleUndoRedo("redo");
     }
 
-    /**
-     * Special command handler that just ignores the command. This is used for Cut, Copy, and Paste.
-     * These menu items are handled natively, but need to be registered in our JavaScript code so the
-     * menu items can be created.
-     */
-    function ignoreCommand() {
-        // Do nothing. The shell will call the native handler for the command.
-        return (new $.Deferred()).reject().promise();
-    }
-
-	function _handleSelectAll() {
+    function _handleSelectAll() {
         var result = new $.Deferred(),
             editor = EditorManager.getFocusedEditor();
 
@@ -1135,6 +1125,19 @@ define(function (require, exports, module) {
         }
 
         return result.promise();
+    }
+
+    function _execCommand(cmd) {
+        window.document.execCommand(cmd);
+    }
+    function _execCommandCut() {
+        _execCommand("cut");
+    }
+    function _execCommandCopy() {
+        _execCommand("copy");
+    }
+    function _execCommandPaste() {
+        _execCommand("paste");
     }
 
     // Register commands
@@ -1155,8 +1158,8 @@ define(function (require, exports, module) {
 
     CommandManager.register(Strings.CMD_UNDO,                   Commands.EDIT_UNDO,                   handleUndo);
     CommandManager.register(Strings.CMD_REDO,                   Commands.EDIT_REDO,                   handleRedo);
-    CommandManager.register(Strings.CMD_CUT,                    Commands.EDIT_CUT,                    ignoreCommand);
-    CommandManager.register(Strings.CMD_COPY,                   Commands.EDIT_COPY,                   ignoreCommand);
-    CommandManager.register(Strings.CMD_PASTE,                  Commands.EDIT_PASTE,                  ignoreCommand);
+    CommandManager.register(Strings.CMD_CUT,                    Commands.EDIT_CUT,                    _execCommandCut);
+    CommandManager.register(Strings.CMD_COPY,                   Commands.EDIT_COPY,                   _execCommandCopy);
+    CommandManager.register(Strings.CMD_PASTE,                  Commands.EDIT_PASTE,                  _execCommandPaste);
     CommandManager.register(Strings.CMD_SELECT_ALL,             Commands.EDIT_SELECT_ALL,             _handleSelectAll);
 });


### PR DESCRIPTION
Switch cut/copy/paste to use `document.execCommand` and add them to the context menu.
Before, on right click the underline word were selected but it was counterintuitive for the context menu usage so I removed it.
We need https://github.com/adobe/brackets-shell/pull/567 to make the paste command work.
