### PR TITLE
Fix the grayscale animation in our samples

### DIFF
--- a/samples/bg/Getting Started/main.css
+++ b/samples/bg/Getting Started/main.css
@@ -39,8 +39,7 @@ samp {
 }
 
 img {
-    -webkit-animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
-            animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
+    animation: colorize 2s cubic-bezier(0, 0, .78, .36) 1;
     background: transparent;
     border: 10px solid rgba(0, 0, 0, 0.12);
     border-radius: 4px;
@@ -49,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/cs/Getting Started/main.css
+++ b/samples/cs/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/da/Kom godt i gang/main.css
+++ b/samples/da/Kom godt i gang/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/de/Erste Schritte/main.css
+++ b/samples/de/Erste Schritte/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/el/Getting Started/main.css
+++ b/samples/el/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/es/Primeros Pasos/main.css
+++ b/samples/es/Primeros Pasos/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/fa-ir/Getting Started/main.css
+++ b/samples/fa-ir/Getting Started/main.css
@@ -53,20 +53,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/fi/Aloitus/main.css
+++ b/samples/fi/Aloitus/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/fr/Premiers pas/main.css
+++ b/samples/fr/Premiers pas/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/id/Memulai/main.css
+++ b/samples/id/Memulai/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/it/Primi passi/main.css
+++ b/samples/it/Primi passi/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/ja/Getting Started/main.css
+++ b/samples/ja/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/nl/Aan-de-slag/main.css
+++ b/samples/nl/Aan-de-slag/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/pl/Szybki Start/main.css
+++ b/samples/pl/Szybki Start/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/pt-br/Primeiros Passos/main.css
+++ b/samples/pt-br/Primeiros Passos/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/pt-pt/Primeiros Passos/main.css
+++ b/samples/pt-pt/Primeiros Passos/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/root/Getting Started/main.css
+++ b/samples/root/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/ru/Getting Started/main.css
+++ b/samples/ru/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/sv/Kom igang/main.css
+++ b/samples/sv/Kom igang/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }

--- a/samples/zh-tw/Getting Started/main.css
+++ b/samples/zh-tw/Getting Started/main.css
@@ -48,20 +48,13 @@ img {
     max-width: 95%;
 }
 
-@-webkit-keyframes colorize {
-    0% {
-        -webkit-filter: grayscale(100%);
-    }
-    100% {
-        -webkit-filter: grayscale(0%);
-    }
-}
-
 @keyframes colorize {
     0% {
+        -webkit-filter: grayscale(100%);
         filter: grayscale(100%);
     }
     100% {
+        -webkit-filter: grayscale(0%);
         filter: grayscale(0%);
     }
 }


### PR DESCRIPTION
This includes two changes:
- Remove `@-webkit-keyframes`, which has the exact same browser support level as the changes in #12533 
- Add `-webkit-filter` to `@keyframes` (without prefix) so browsers (most notably, Chrome 43-52) don't ignore the unprefixed `filter`

cc @ficristo 
