### PR TITLE
Enable "Click Through" for the file tree shadow

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1025,6 +1025,7 @@ a, img {
     height: 5px;
     position: fixed;
     z-index: @z-index-brackets-scroller-shadow;
+    pointer-events: none; // serves as a "click through", so clicks go to the file tree behind (see #12684)
 
     &.top {
         #gradient > .vertical(rgba(0,0,0,0.1), rgba(0,0,0,0));


### PR DESCRIPTION
So the file tree is responsive to clicks that happen in the upper 5px

Fixes #12684
