### PR TITLE
Rename CONFIRM_FOLDER_DELETE_TITLE -> CONFIRM_DELETE_TITLE

### DIFF
--- a/src/nls/bg/strings.js
+++ b/src/nls/bg/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Искате ли да запазите промените, които направихте в документа <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Искате ли да запазите промените си в следните файлове?",
     "EXT_MODIFIED_TITLE"                : "Външни промени",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Потвърждаване на изтриването",
+    "CONFIRM_DELETE_TITLE"       : "Потвърждаване на изтриването",
     "CONFIRM_FOLDER_DELETE"             : "Наистина ли искате да изтриете папката <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Изтрит файл",
     "EXT_MODIFIED_WARNING"              : "Файлът <span class='dialog-filename'>{0}</span> беше променен извън {APP_NAME}.<br /><br />Искате ли да запазите файла и да презапишете промените му?",

--- a/src/nls/bg/strings.js
+++ b/src/nls/bg/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Искате ли да запазите промените, които направихте в документа <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Искате ли да запазите промените си в следните файлове?",
     "EXT_MODIFIED_TITLE"                : "Външни промени",
-    "CONFIRM_DELETE_TITLE"       : "Потвърждаване на изтриването",
+    "CONFIRM_DELETE_TITLE"              : "Потвърждаване на изтриването",
     "CONFIRM_FOLDER_DELETE"             : "Наистина ли искате да изтриете папката <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Изтрит файл",
     "EXT_MODIFIED_WARNING"              : "Файлът <span class='dialog-filename'>{0}</span> беше променен извън {APP_NAME}.<br /><br />Искате ли да запазите файла и да презапишете промените му?",

--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Chcete uložit změny v souboru <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Chcete uložit změny v následujících souborech?",
     "EXT_MODIFIED_TITLE"                : "Externí změny",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Potvrdit smazání",
+    "CONFIRM_DELETE_TITLE"       : "Potvrdit smazání",
     "CONFIRM_FOLDER_DELETE"             : "Opravdu chcete smazat složku <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Soubor smazán",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> byl změněn mimo {APP_NAME}.<br /><br />Chcete uložit soubor a přepsat tyto změny?",

--- a/src/nls/cs/strings.js
+++ b/src/nls/cs/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Chcete uložit změny v souboru <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Chcete uložit změny v následujících souborech?",
     "EXT_MODIFIED_TITLE"                : "Externí změny",
-    "CONFIRM_DELETE_TITLE"       : "Potvrdit smazání",
+    "CONFIRM_DELETE_TITLE"              : "Potvrdit smazání",
     "CONFIRM_FOLDER_DELETE"             : "Opravdu chcete smazat složku <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Soubor smazán",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> byl změněn mimo {APP_NAME}.<br /><br />Chcete uložit soubor a přepsat tyto změny?",

--- a/src/nls/da/strings.js
+++ b/src/nls/da/strings.js
@@ -112,7 +112,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Ønsker du at gemme ændringerne i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Ønsker du at gemme ændringerne i følgende filer?",
     "EXT_MODIFIED_TITLE"                : "Eksterne ændringer",
-    "CONFIRM_DELETE_TITLE"       : "Bekræft sletning",
+    "CONFIRM_DELETE_TITLE"              : "Bekræft sletning",
     "CONFIRM_FOLDER_DELETE"             : "Er du sikker på at du vil slette mappen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fil slettet",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> er blevet ændret på disken.<br /><br />Ønsker du at gemme filen og overskrive disse ændringer?",

--- a/src/nls/da/strings.js
+++ b/src/nls/da/strings.js
@@ -112,7 +112,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Ønsker du at gemme ændringerne i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Ønsker du at gemme ændringerne i følgende filer?",
     "EXT_MODIFIED_TITLE"                : "Eksterne ændringer",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Bekræft sletning",
+    "CONFIRM_DELETE_TITLE"       : "Bekræft sletning",
     "CONFIRM_FOLDER_DELETE"             : "Er du sikker på at du vil slette mappen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fil slettet",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> er blevet ændret på disken.<br /><br />Ønsker du at gemme filen og overskrive disse ændringer?",

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Wollen Sie die Änderungen in dem Dokument <span class='dialog-filename'>{0}</span> speichern?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Wollen Sie Ihre Änderungen in den folgenden Dateien speichern?",
     "EXT_MODIFIED_TITLE"                : "Externe Änderungen",
-    "CONFIRM_DELETE_TITLE"       : "Löschen bestätigen",
+    "CONFIRM_DELETE_TITLE"              : "Löschen bestätigen",
     "CONFIRM_FOLDER_DELETE"             : "Sind Sie sich sicher, dass Sie den Ordner <span class='dialog-filename'>{0}</span> löschen wollen?",
     "FILE_DELETED_TITLE"                : "Datei gelöscht",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> wurde außerhalb von {APP_NAME} geändert.<br /><br />Wollen Sie die Datei speichern und die externen Änderungen ersetzen?",

--- a/src/nls/de/strings.js
+++ b/src/nls/de/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Wollen Sie die Änderungen in dem Dokument <span class='dialog-filename'>{0}</span> speichern?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Wollen Sie Ihre Änderungen in den folgenden Dateien speichern?",
     "EXT_MODIFIED_TITLE"                : "Externe Änderungen",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Löschen bestätigen",
+    "CONFIRM_DELETE_TITLE"       : "Löschen bestätigen",
     "CONFIRM_FOLDER_DELETE"             : "Sind Sie sich sicher, dass Sie den Ordner <span class='dialog-filename'>{0}</span> löschen wollen?",
     "FILE_DELETED_TITLE"                : "Datei gelöscht",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> wurde außerhalb von {APP_NAME} geändert.<br /><br />Wollen Sie die Datei speichern und die externen Änderungen ersetzen?",

--- a/src/nls/el/strings.js
+++ b/src/nls/el/strings.js
@@ -100,7 +100,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Θέλετε να αποθηκεύσετε τις αλλαγές που κάνατε στο έγγραφο <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Θέλετε να αποθηκεύσετε τις αλλαγές σας στα παρακάτω αρχεία;",
     "EXT_MODIFIED_TITLE"                : "Εξωτερικές Αλλαγές",
-    "CONFIRM_DELETE_TITLE"       : "Επιβεβαίωση Διαγραφής",
+    "CONFIRM_DELETE_TITLE"              : "Επιβεβαίωση Διαγραφής",
     "CONFIRM_FOLDER_DELETE"             : "Είστε σίγουρος ότι θέλετε να διαγράψετε τον φάκελο <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Το Αρχείο Διαγράφηκε",
     "EXT_MODIFIED_MESSAGE"              : "Το <span class='dialog-filename'>{0}</span> έχει τροποποιηθεί στο δίσκο, αλλά υπάρχουν και μη αποθηκευμένες αλλαγές στο {APP_NAME}.<br /><br />Ποια έκδοση θέλετε να κρατήσετε;",

--- a/src/nls/el/strings.js
+++ b/src/nls/el/strings.js
@@ -100,7 +100,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Θέλετε να αποθηκεύσετε τις αλλαγές που κάνατε στο έγγραφο <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Θέλετε να αποθηκεύσετε τις αλλαγές σας στα παρακάτω αρχεία;",
     "EXT_MODIFIED_TITLE"                : "Εξωτερικές Αλλαγές",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Επιβεβαίωση Διαγραφής",
+    "CONFIRM_DELETE_TITLE"       : "Επιβεβαίωση Διαγραφής",
     "CONFIRM_FOLDER_DELETE"             : "Είστε σίγουρος ότι θέλετε να διαγράψετε τον φάκελο <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Το Αρχείο Διαγράφηκε",
     "EXT_MODIFIED_MESSAGE"              : "Το <span class='dialog-filename'>{0}</span> έχει τροποποιηθεί στο δίσκο, αλλά υπάρχουν και μη αποθηκευμένες αλλαγές στο {APP_NAME}.<br /><br />Ποια έκδοση θέλετε να κρατήσετε;",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "¿Quieres guardar los cambios existentes en el documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "¿Quieres guardar tus cambios en los siguientes documentos?",
     "EXT_MODIFIED_TITLE"                : "Cambios externos",
-    "CONFIRM_DELETE_TITLE"       : "Confirmar eliminación",
+    "CONFIRM_DELETE_TITLE"              : "Confirmar eliminación",
     "CONFIRM_FOLDER_DELETE"             : "¿Estás seguro que deseas eliminar el directorio <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Archivo eliminado",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> ha sido modificado en el disco fuera de {APP_NAME}.<br><br>¿Deseas guardar el archivo y sobrescribir esos cambios?",

--- a/src/nls/es/strings.js
+++ b/src/nls/es/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "¿Quieres guardar los cambios existentes en el documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "¿Quieres guardar tus cambios en los siguientes documentos?",
     "EXT_MODIFIED_TITLE"                : "Cambios externos",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Confirmar eliminación",
+    "CONFIRM_DELETE_TITLE"       : "Confirmar eliminación",
     "CONFIRM_FOLDER_DELETE"             : "¿Estás seguro que deseas eliminar el directorio <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Archivo eliminado",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> ha sido modificado en el disco fuera de {APP_NAME}.<br><br>¿Deseas guardar el archivo y sobrescribir esos cambios?",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                    : "آیا مایلید تغییرات داده شده در سند ذخیره گردند <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"              : "آیا مایلید تغییرات داده شده در پرونده های زیر، ذخیره گردند?    ",
     "EXT_MODIFIED_TITLE"                    : "تغییرات خارجی",
-    "CONFIRM_DELETE_TITLE"           : "تایید حذف",
+    "CONFIRM_DELETE_TITLE"                  : "تایید حذف",
     "CONFIRM_FOLDER_DELETE"                 : "آیا مطمئنید می خواهید این پوشه حذف گردد <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                    : "پرونده حذف گردید",
     "EXT_MODIFIED_WARNING"                  : "<span class='dialog-filename'>{0}</span> خارج از براکتس ویرایش شده.<br /><br />آیا می خواهید پرونده را ذخیره و تغییراتی را که داده اید دوباره بر روی پرونده ویرایش شده اعمال نمایید؟",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                    : "آیا مایلید تغییرات داده شده در سند ذخیره گردند <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"              : "آیا مایلید تغییرات داده شده در پرونده های زیر، ذخیره گردند?    ",
     "EXT_MODIFIED_TITLE"                    : "تغییرات خارجی",
-    "CONFIRM_FOLDER_DELETE_TITLE"           : "تایید حذف",
+    "CONFIRM_DELETE_TITLE"           : "تایید حذف",
     "CONFIRM_FOLDER_DELETE"                 : "آیا مطمئنید می خواهید این پوشه حذف گردد <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                    : "پرونده حذف گردید",
     "EXT_MODIFIED_WARNING"                  : "<span class='dialog-filename'>{0}</span> خارج از براکتس ویرایش شده.<br /><br />آیا می خواهید پرونده را ذخیره و تغییراتی را که داده اید دوباره بر روی پرونده ویرایش شده اعمال نمایید؟",

--- a/src/nls/fi/strings.js
+++ b/src/nls/fi/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Haluatko tallentaa tekemäsi muutokset dokumenttiin <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Haluatko tallentaa muutokset seuraaviin tiedostoihin?",
     "EXT_MODIFIED_TITLE"                : "Ulkoiset muutokset",
-    "CONFIRM_DELETE_TITLE"       : "Vahvista poisto",
+    "CONFIRM_DELETE_TITLE"              : "Vahvista poisto",
     "CONFIRM_FOLDER_DELETE"             : "Haluatko varmasti poistaa kansion <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Tiedosto poistettu",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> on muuttunut levyllä {APP_NAME}in ulkopuolella.<br /><br />Haluatko tallentaa tiedoston ja korvata kyseiset muutokset?",

--- a/src/nls/fi/strings.js
+++ b/src/nls/fi/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Haluatko tallentaa tekemäsi muutokset dokumenttiin <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Haluatko tallentaa muutokset seuraaviin tiedostoihin?",
     "EXT_MODIFIED_TITLE"                : "Ulkoiset muutokset",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Vahvista poisto",
+    "CONFIRM_DELETE_TITLE"       : "Vahvista poisto",
     "CONFIRM_FOLDER_DELETE"             : "Haluatko varmasti poistaa kansion <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Tiedosto poistettu",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> on muuttunut levyllä {APP_NAME}in ulkopuolella.<br /><br />Haluatko tallentaa tiedoston ja korvata kyseiset muutokset?",

--- a/src/nls/fr/strings.js
+++ b/src/nls/fr/strings.js
@@ -128,7 +128,7 @@ define({
 	"SAVE_CLOSE_MESSAGE": "Souhaitez-vous enregistrer les modifications apportées au document <span class='dialog-filename'>{0}</span> ?",
 	"SAVE_CLOSE_MULTI_MESSAGE": "Souhaitez-vous enregistrer les modifications apportées aux fichiers suivants ?",
 	"EXT_MODIFIED_TITLE": "Modifications externes",
-	"CONFIRM_FOLDER_DELETE_TITLE": "Confirmer la suppression",
+	"CONFIRM_DELETE_TITLE": "Confirmer la suppression",
 	"CONFIRM_FOLDER_DELETE": "Voulez-vous vraiment supprimer le dossier <span class='dialog-filename'>{0}</span> ?",
 	"FILE_DELETED_TITLE": "Fichier supprimé",
 	"EXT_MODIFIED_WARNING": "<span class='dialog-filename'>{0}</span> a été modifié sur le disque, dans une application autre que {APP_NAME}.<br /><br />Voulez-vous enregistrer le fichier et remplacer ces modifications ?",

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -115,7 +115,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "¿Queres gardar os cambios existentes no documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "¿Queres gardar os teus cambios nos seguintes documentos?",
     "EXT_MODIFIED_TITLE"                : "Cambios externos",
-    "CONFIRM_DELETE_TITLE"       : "Confirmar eliminación",
+    "CONFIRM_DELETE_TITLE"              : "Confirmar eliminación",
     "CONFIRM_FOLDER_DELETE"             : "¿Está seguro de que desexa eliminar o directorio <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Arquivo eliminado",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> foi modificado no disco.<br /><br />¿Desexa gardar o arquivo e sobrescribir eses cambios?",

--- a/src/nls/gl/strings.js
+++ b/src/nls/gl/strings.js
@@ -115,7 +115,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "¿Queres gardar os cambios existentes no documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "¿Queres gardar os teus cambios nos seguintes documentos?",
     "EXT_MODIFIED_TITLE"                : "Cambios externos",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Confirmar eliminación",
+    "CONFIRM_DELETE_TITLE"       : "Confirmar eliminación",
     "CONFIRM_FOLDER_DELETE"             : "¿Está seguro de que desexa eliminar o directorio <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Arquivo eliminado",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> foi modificado no disco.<br /><br />¿Desexa gardar o arquivo e sobrescribir eses cambios?",

--- a/src/nls/hr/strings.js
+++ b/src/nls/hr/strings.js
@@ -105,7 +105,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Želite li sačuvati izmjene koje ste napravili u dokumentu <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Želite li sačuvati izmjene sljedećih datoteka?",
     "EXT_MODIFIED_TITLE"                : "Vanjske izmjene",
-    "CONFIRM_DELETE_TITLE"       : "Potvrdi brisanje",
+    "CONFIRM_DELETE_TITLE"              : "Potvrdi brisanje",
     "CONFIRM_FOLDER_DELETE"             : "Da li ste sigurni da želite obrisati mapu <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Datoteka Obrisana",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> je bio izmjenjen na disku.<br /><br />Da li želite sačuvati datoteku i spremiti preko tih izmjena?",

--- a/src/nls/hr/strings.js
+++ b/src/nls/hr/strings.js
@@ -105,7 +105,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Želite li sačuvati izmjene koje ste napravili u dokumentu <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Želite li sačuvati izmjene sljedećih datoteka?",
     "EXT_MODIFIED_TITLE"                : "Vanjske izmjene",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Potvrdi brisanje",
+    "CONFIRM_DELETE_TITLE"       : "Potvrdi brisanje",
     "CONFIRM_FOLDER_DELETE"             : "Da li ste sigurni da želite obrisati mapu <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Datoteka Obrisana",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> je bio izmjenjen na disku.<br /><br />Da li želite sačuvati datoteku i spremiti preko tih izmjena?",

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Apakah Anda ingin menyimpan perubahan yang Anda buat di dokumen <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Apakah Anda ingin menyimpan perubahan pada file berikut?",
     "EXT_MODIFIED_TITLE"                : "Perubahan Eksternal",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Konfirmasi Hapus",
+    "CONFIRM_DELETE_TITLE"       : "Konfirmasi Hapus",
     "CONFIRM_FOLDER_DELETE"             : "Apakah Anda yakin ingin menghapus folder <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "File Dihapus",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> telah dimodifikasi di disk.<br /><br />Apakah Anda ingin menyimpan file dan menimpa perubahan tersebut?",

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Apakah Anda ingin menyimpan perubahan yang Anda buat di dokumen <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Apakah Anda ingin menyimpan perubahan pada file berikut?",
     "EXT_MODIFIED_TITLE"                : "Perubahan Eksternal",
-    "CONFIRM_DELETE_TITLE"       : "Konfirmasi Hapus",
+    "CONFIRM_DELETE_TITLE"              : "Konfirmasi Hapus",
     "CONFIRM_FOLDER_DELETE"             : "Apakah Anda yakin ingin menghapus folder <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "File Dihapus",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> telah dimodifikasi di disk.<br /><br />Apakah Anda ingin menyimpan file dan menimpa perubahan tersebut?",

--- a/src/nls/it/strings.js
+++ b/src/nls/it/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vuoi cambiare le modifiche apportate al file <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vuoi cambiare le modifiche apportate ai seguenti file?",
     "EXT_MODIFIED_TITLE"                : "Modifiche esterne",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Confermi l'eliminazione?",
+    "CONFIRM_DELETE_TITLE"       : "Confermi l'eliminazione?",
     "CONFIRM_FOLDER_DELETE"             : "Sei sicuro di eliminare la cartella <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "File Eliminato",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> è stato modificato sul disco.<br /><br />Vuoi salvare il file e sovrascrivere le modifiche?",

--- a/src/nls/it/strings.js
+++ b/src/nls/it/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vuoi cambiare le modifiche apportate al file <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vuoi cambiare le modifiche apportate ai seguenti file?",
     "EXT_MODIFIED_TITLE"                : "Modifiche esterne",
-    "CONFIRM_DELETE_TITLE"       : "Confermi l'eliminazione?",
+    "CONFIRM_DELETE_TITLE"              : "Confermi l'eliminazione?",
     "CONFIRM_FOLDER_DELETE"             : "Sei sicuro di eliminare la cartella <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "File Eliminato",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> è stato modificato sul disco.<br /><br />Vuoi salvare il file e sovrascrivere le modifiche?",

--- a/src/nls/ja/strings.js
+++ b/src/nls/ja/strings.js
@@ -128,7 +128,7 @@ define({
 	"SAVE_CLOSE_MESSAGE": "文書 <span class='dialog-filename'>{0}</span> に加えた変更を保存しますか？",
 	"SAVE_CLOSE_MULTI_MESSAGE": "以下のファイルに対する変更を保存しますか？",
 	"EXT_MODIFIED_TITLE": "外部で変更されました。",
-	"CONFIRM_FOLDER_DELETE_TITLE": "削除の確認",
+	"CONFIRM_DELETE_TITLE": "削除の確認",
 	"CONFIRM_FOLDER_DELETE": "<span class='dialog-filename'>{0}</span> フォルダーを削除してもよろしいですか？",
 	"FILE_DELETED_TITLE": "ファイルは削除されました",
 	"EXT_MODIFIED_WARNING": "<span class='dialog-filename'>{0}</span> は {APP_NAME} 外のディスク上で変更されています。<br /><br />ファイルを保存し、これらの変更を上書きしますか？",

--- a/src/nls/ko/strings.js
+++ b/src/nls/ko/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE": "문서 <span class='dialog-filename'>{0}</span> 변경 내용을 저장 하시겠습니까?",
     "SAVE_CLOSE_MULTI_MESSAGE": "다음 파일에 대한 변경 사항을 저장 하시겠습니까?",
     "EXT_MODIFIED_TITLE": "외부 변경 감지",
-    "CONFIRM_FOLDER_DELETE_TITLE": "삭제 확인",
+    "CONFIRM_DELETE_TITLE": "삭제 확인",
     "CONFIRM_FOLDER_DELETE": "<span class='dialog-filename'>{0}</span> 폴더를 삭제 하시겠습니까?",
     "FILE_DELETED_TITLE": "파일이 삭제되었습니다",
     "EXT_MODIFIED_WARNING": "<span class='dialog-filename'>{0}</span>파일이 변경되었습니다.<br /><br />파일을 저장하여 이 변경 사항을 덮어씌우겠습니까?",

--- a/src/nls/lv/strings.js
+++ b/src/nls/lv/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vai vēlaties saglabāt veiktās izmaiņas dokumentā <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vai vēlaties saglabāt izmaiņas šajās datnēs?",
     "EXT_MODIFIED_TITLE"                : "Ārējas izmaiņas",
-    "CONFIRM_DELETE_TITLE"       : "Apstiprināt dzēšanu",
+    "CONFIRM_DELETE_TITLE"              : "Apstiprināt dzēšanu",
     "CONFIRM_FOLDER_DELETE"             : "Vai tiešām vēlaties izdzēst mapi <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Datne izdzēsta",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> ir pārveidots diskā ārpus {APP_NAME}.<br /><br />Vai vēlaties saglabāt datni un pārrakstīt šīs izmaiņas?",

--- a/src/nls/lv/strings.js
+++ b/src/nls/lv/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vai vēlaties saglabāt veiktās izmaiņas dokumentā <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vai vēlaties saglabāt izmaiņas šajās datnēs?",
     "EXT_MODIFIED_TITLE"                : "Ārējas izmaiņas",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Apstiprināt dzēšanu",
+    "CONFIRM_DELETE_TITLE"       : "Apstiprināt dzēšanu",
     "CONFIRM_FOLDER_DELETE"             : "Vai tiešām vēlaties izdzēst mapi <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Datne izdzēsta",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> ir pārveidots diskā ārpus {APP_NAME}.<br /><br />Vai vēlaties saglabāt datni un pārrakstīt šīs izmaiņas?",

--- a/src/nls/nb/strings.js
+++ b/src/nls/nb/strings.js
@@ -112,7 +112,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Ønsker du å lagre enderinger i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Ønsker du å lagre enderinger i følgende filer?",
     "EXT_MODIFIED_TITLE"                : "Eksterne endringer",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Bekreft sletting",
+    "CONFIRM_DELETE_TITLE"       : "Bekreft sletting",
     "CONFIRM_FOLDER_DELETE"             : "Er du sikker på at du vil slette katalogen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fil slettet",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> har blitt modifisert på disk.<br /><br />Vil du lagre filen og overskrive de endringene?",

--- a/src/nls/nb/strings.js
+++ b/src/nls/nb/strings.js
@@ -112,7 +112,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Ønsker du å lagre enderinger i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Ønsker du å lagre enderinger i følgende filer?",
     "EXT_MODIFIED_TITLE"                : "Eksterne endringer",
-    "CONFIRM_DELETE_TITLE"       : "Bekreft sletting",
+    "CONFIRM_DELETE_TITLE"              : "Bekreft sletting",
     "CONFIRM_FOLDER_DELETE"             : "Er du sikker på at du vil slette katalogen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fil slettet",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> har blitt modifisert på disk.<br /><br />Vil du lagre filen og overskrive de endringene?",

--- a/src/nls/nl/strings.js
+++ b/src/nls/nl/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Wil je de wijzigingen opslaan die je maakte in het document <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Wil je je wijzigingen van de volgende bestanden opslaan?",
     "EXT_MODIFIED_TITLE"                : "Externe wijzigingen",
-    "CONFIRM_DELETE_TITLE"       : "Bevestig verwijderen",
+    "CONFIRM_DELETE_TITLE"              : "Bevestig verwijderen",
     "CONFIRM_FOLDER_DELETE"             : "Ben je zeker dat je de map <span class='dialog-filename'>{0}</span> wil verwijderen?",
     "FILE_DELETED_TITLE"                : "Bestand verwijderd",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> is gewijzigd op de schijf buiten {APP_NAME}.<br /><br />Wil je het bestand overschrijven evenals de wijzigingen buiten {APP_NAME} om?",

--- a/src/nls/nl/strings.js
+++ b/src/nls/nl/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Wil je de wijzigingen opslaan die je maakte in het document <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Wil je je wijzigingen van de volgende bestanden opslaan?",
     "EXT_MODIFIED_TITLE"                : "Externe wijzigingen",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Bevestig verwijderen",
+    "CONFIRM_DELETE_TITLE"       : "Bevestig verwijderen",
     "CONFIRM_FOLDER_DELETE"             : "Ben je zeker dat je de map <span class='dialog-filename'>{0}</span> wil verwijderen?",
     "FILE_DELETED_TITLE"                : "Bestand verwijderd",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> is gewijzigd op de schijf buiten {APP_NAME}.<br /><br />Wil je het bestand overschrijven evenals de wijzigingen buiten {APP_NAME} om?",

--- a/src/nls/pl/strings.js
+++ b/src/nls/pl/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Czy chcesz zapisać zmiany w dokumencie <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Czy chcesz zapisać zmiany w następujących plikach?",
     "EXT_MODIFIED_TITLE"                : "Zmiany zewnętrzne",
-    "CONFIRM_DELETE_TITLE"       : "Potwierdź usunięcie",
+    "CONFIRM_DELETE_TITLE"              : "Potwierdź usunięcie",
     "CONFIRM_FOLDER_DELETE"             : "Czy na pewno chcesz usunąć folder <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Plik został usunięty",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> został zmodyfikowany na dysku, poza {APP_NAME}.<br /><br />Czy chcesz zapisać plik i nadpisać te zmiany?",

--- a/src/nls/pl/strings.js
+++ b/src/nls/pl/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Czy chcesz zapisać zmiany w dokumencie <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Czy chcesz zapisać zmiany w następujących plikach?",
     "EXT_MODIFIED_TITLE"                : "Zmiany zewnętrzne",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Potwierdź usunięcie",
+    "CONFIRM_DELETE_TITLE"       : "Potwierdź usunięcie",
     "CONFIRM_FOLDER_DELETE"             : "Czy na pewno chcesz usunąć folder <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Plik został usunięty",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> został zmodyfikowany na dysku, poza {APP_NAME}.<br /><br />Czy chcesz zapisać plik i nadpisać te zmiany?",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Você quer salvar as alterações feitas no documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Você quer salvar as alterações feitas aos seguintes arquivos?",
     "EXT_MODIFIED_TITLE"                : "Alterações externas",
-    "CONFIRM_DELETE_TITLE"       : "Confirmar exclusão",
+    "CONFIRM_DELETE_TITLE"              : "Confirmar exclusão",
     "CONFIRM_FOLDER_DELETE"             : "Tem certeza que deseja excluir a pasta <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Arquivo excluído",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> foi modificado no disco.<br /><br />Deseja salvar o arquivo e sobrescrever essas alterações?",

--- a/src/nls/pt-br/strings.js
+++ b/src/nls/pt-br/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Você quer salvar as alterações feitas no documento <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Você quer salvar as alterações feitas aos seguintes arquivos?",
     "EXT_MODIFIED_TITLE"                : "Alterações externas",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Confirmar exclusão",
+    "CONFIRM_DELETE_TITLE"       : "Confirmar exclusão",
     "CONFIRM_FOLDER_DELETE"             : "Tem certeza que deseja excluir a pasta <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Arquivo excluído",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> foi modificado no disco.<br /><br />Deseja salvar o arquivo e sobrescrever essas alterações?",

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Doriți să salvați modificările făcute în documentul <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Doriți să salvați modificările din următoarele fișiere?",
     "EXT_MODIFIED_TITLE"                : "Modificări externe",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Confirmare ștergere dosar",
+    "CONFIRM_DELETE_TITLE"       : "Confirmare ștergere dosar",
     "CONFIRM_FOLDER_DELETE"             : "Sunteți sigur că doriți să ștergeți dosarul <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fișier șters",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> a fost modificat pe disc.<br /><br />Doriți să salvați fișierul și să suprascrieți aceste modificări?",

--- a/src/nls/ro/strings.js
+++ b/src/nls/ro/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Doriți să salvați modificările făcute în documentul <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Doriți să salvați modificările din următoarele fișiere?",
     "EXT_MODIFIED_TITLE"                : "Modificări externe",
-    "CONFIRM_DELETE_TITLE"       : "Confirmare ștergere dosar",
+    "CONFIRM_DELETE_TITLE"              : "Confirmare ștergere dosar",
     "CONFIRM_FOLDER_DELETE"             : "Sunteți sigur că doriți să ștergeți dosarul <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Fișier șters",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> a fost modificat pe disc.<br /><br />Doriți să salvați fișierul și să suprascrieți aceste modificări?",

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -111,7 +111,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Вы хотите сохранить изменения, которые вы сделали в документе <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Вы хотите сохранить изменения для следующих файлов?",
     "EXT_MODIFIED_TITLE"                : "Внешние изменения",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Подтвердить удаление",
+    "CONFIRM_DELETE_TITLE"       : "Подтвердить удаление",
     "CONFIRM_FOLDER_DELETE"             : "Вы уверены, что хотите удалить директорию <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Файл удален",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> был изменен на диске.<br /><br />Вы хотите сохранить ваши изменения и перезаписать внешние?",

--- a/src/nls/ru/strings.js
+++ b/src/nls/ru/strings.js
@@ -111,7 +111,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Вы хотите сохранить изменения, которые вы сделали в документе <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Вы хотите сохранить изменения для следующих файлов?",
     "EXT_MODIFIED_TITLE"                : "Внешние изменения",
-    "CONFIRM_DELETE_TITLE"       : "Подтвердить удаление",
+    "CONFIRM_DELETE_TITLE"              : "Подтвердить удаление",
     "CONFIRM_FOLDER_DELETE"             : "Вы уверены, что хотите удалить директорию <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Файл удален",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> был изменен на диске.<br /><br />Вы хотите сохранить ваши изменения и перезаписать внешние?",

--- a/src/nls/sk/strings.js
+++ b/src/nls/sk/strings.js
@@ -99,7 +99,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Chcete uložiť zmeny, ktoré ste spravili v dokumente <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Chcete uložiť zmeny v následujúcich súboroch?",
     "EXT_MODIFIED_TITLE"                : "Externé zmeny",
-    "CONFIRM_DELETE_TITLE"       : "Potvrdte odstránenie",
+    "CONFIRM_DELETE_TITLE"              : "Potvrdte odstránenie",
     "CONFIRM_FOLDER_DELETE"             : "Ste si istý zmazaním priečinku <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Súbor odstránený",
     "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> bol upravený na disku, ale tiež ma neuložené zmeny in {APP_NAME}.<br /><br />Ktorú verziu chcete ponechať?",

--- a/src/nls/sk/strings.js
+++ b/src/nls/sk/strings.js
@@ -99,7 +99,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Chcete uložiť zmeny, ktoré ste spravili v dokumente <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Chcete uložiť zmeny v následujúcich súboroch?",
     "EXT_MODIFIED_TITLE"                : "Externé zmeny",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Potvrdte odstránenie",
+    "CONFIRM_DELETE_TITLE"       : "Potvrdte odstránenie",
     "CONFIRM_FOLDER_DELETE"             : "Ste si istý zmazaním priečinku <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Súbor odstránený",
     "EXT_MODIFIED_MESSAGE"              : "<span class='dialog-filename'>{0}</span> bol upravený na disku, ale tiež ma neuložené zmeny in {APP_NAME}.<br /><br />Ktorú verziu chcete ponechať?",

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Да ли желите да сачувате измене које сте направили у документу <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Да ли желите да сачувате Ваше измене над следећим датотекама?",
     "EXT_MODIFIED_TITLE"                : "Екстерне измене",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Потврди брисање",
+    "CONFIRM_DELETE_TITLE"       : "Потврди брисање",
     "CONFIRM_FOLDER_DELETE"             : "Да ли сте сигурни да желите обрисати директоријум <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Датотека обрисана",
     "EXT_MODIFIED_WARNING"              : "Датотека <span class='dialog-filename'>{0}</span> је измењена на диску.<br /><br />Да ли желите да сачувате датотеку и преснимите те измене?",

--- a/src/nls/sr/strings.js
+++ b/src/nls/sr/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Да ли желите да сачувате измене које сте направили у документу <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Да ли желите да сачувате Ваше измене над следећим датотекама?",
     "EXT_MODIFIED_TITLE"                : "Екстерне измене",
-    "CONFIRM_DELETE_TITLE"       : "Потврди брисање",
+    "CONFIRM_DELETE_TITLE"              : "Потврди брисање",
     "CONFIRM_FOLDER_DELETE"             : "Да ли сте сигурни да желите обрисати директоријум <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Датотека обрисана",
     "EXT_MODIFIED_WARNING"              : "Датотека <span class='dialog-filename'>{0}</span> је измењена на диску.<br /><br />Да ли желите да сачувате датотеку и преснимите те измене?",

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vill du spara de ändringar i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vill du spara ändringarna du gjort följande filer?",
     "EXT_MODIFIED_TITLE"                : "Externa ändringar",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "Bekräfta borttagning",
+    "CONFIRM_DELETE_TITLE"       : "Bekräfta borttagning",
     "CONFIRM_FOLDER_DELETE"             : "Är du säker att du vill radera mappen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Filen raderades",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> har ändrats.<br /><br />Vill du spara filen och skriva över dessa ändringar?",

--- a/src/nls/sv/strings.js
+++ b/src/nls/sv/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "Vill du spara de ändringar i dokumentet <span class='dialog-filename'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "Vill du spara ändringarna du gjort följande filer?",
     "EXT_MODIFIED_TITLE"                : "Externa ändringar",
-    "CONFIRM_DELETE_TITLE"       : "Bekräfta borttagning",
+    "CONFIRM_DELETE_TITLE"              : "Bekräfta borttagning",
     "CONFIRM_FOLDER_DELETE"             : "Är du säker att du vill radera mappen <span class='dialog-filename'>{0}</span>?",
     "FILE_DELETED_TITLE"                : "Filen raderades",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> har ändrats.<br /><br />Vill du spara filen och skriva över dessa ändringar?",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                        : "Чи бажаєте ви зберегти зміни внесені у файл <span class=\'dialog-filename\'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"                  : "Чи бажаєте ви зберегти зміни до наступних файлів?",
     "EXT_MODIFIED_TITLE"                        : "Зовнішні зміни",
-    "CONFIRM_DELETE_TITLE"               : "Підтвердження видалення",
+    "CONFIRM_DELETE_TITLE"                      : "Підтвердження видалення",
     "CONFIRM_FOLDER_DELETE"                     : "Ви дійсно хочете видалити теку <span class=\'dialog-filename\'>{0}</span>?",
     "FILE_DELETED_TITLE"                        : "Файл видалено",
     "EXT_MODIFIED_WARNING"                      : "<span class=\'dialog-filename\'>{0}</span> змінено на диску.<br /><br />Чи ви хочете зберегти файл і перезаписати ці зміни?",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -126,7 +126,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                        : "Чи бажаєте ви зберегти зміни внесені у файл <span class=\'dialog-filename\'>{0}</span>?",
     "SAVE_CLOSE_MULTI_MESSAGE"                  : "Чи бажаєте ви зберегти зміни до наступних файлів?",
     "EXT_MODIFIED_TITLE"                        : "Зовнішні зміни",
-    "CONFIRM_FOLDER_DELETE_TITLE"               : "Підтвердження видалення",
+    "CONFIRM_DELETE_TITLE"               : "Підтвердження видалення",
     "CONFIRM_FOLDER_DELETE"                     : "Ви дійсно хочете видалити теку <span class=\'dialog-filename\'>{0}</span>?",
     "FILE_DELETED_TITLE"                        : "Файл видалено",
     "EXT_MODIFIED_WARNING"                      : "<span class=\'dialog-filename\'>{0}</span> змінено на диску.<br /><br />Чи ви хочете зберегти файл і перезаписати ці зміни?",

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "保存 <span class='dialog-filename'>{0}</span> 文件中所做的修改？",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "是否保存以下文件的修改？",
     "EXT_MODIFIED_TITLE"                : "外部文件发生变化",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "删除确认",
+    "CONFIRM_DELETE_TITLE"       : "删除确认",
     "CONFIRM_FOLDER_DELETE"             : "确认要删除目录 <span class='dialog-filename'>{0}</span>？",
     "FILE_DELETED_TITLE"                : "文件已删除",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> 已产生了外部修改，<br /><br />是否保存并覆盖外部修改？",

--- a/src/nls/zh-cn/strings.js
+++ b/src/nls/zh-cn/strings.js
@@ -128,7 +128,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "保存 <span class='dialog-filename'>{0}</span> 文件中所做的修改？",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "是否保存以下文件的修改？",
     "EXT_MODIFIED_TITLE"                : "外部文件发生变化",
-    "CONFIRM_DELETE_TITLE"       : "删除确认",
+    "CONFIRM_DELETE_TITLE"              : "删除确认",
     "CONFIRM_FOLDER_DELETE"             : "确认要删除目录 <span class='dialog-filename'>{0}</span>？",
     "FILE_DELETED_TITLE"                : "文件已删除",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> 已产生了外部修改，<br /><br />是否保存并覆盖外部修改？",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "您想要儲存 <span class='dialog-filename'>{0}</span> 檔案的變更嗎?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "您想要儲存下列檔案的變更嗎?",
     "EXT_MODIFIED_TITLE"                : "外部變更",
-    "CONFIRM_FOLDER_DELETE_TITLE"       : "確定刪除",
+    "CONFIRM_DELETE_TITLE"       : "確定刪除",
     "CONFIRM_FOLDER_DELETE"             : "您確定要刪除 <span class='dialog-filename'>{0}</span> 資料夾嗎?",
     "FILE_DELETED_TITLE"                : "檔案已刪除",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> 在 {APP_NAME} 外被修改過了。<br /><br />您想要儲存檔案並覆寫蓋掉外部的變更嗎?",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -127,7 +127,7 @@ define({
     "SAVE_CLOSE_MESSAGE"                : "您想要儲存 <span class='dialog-filename'>{0}</span> 檔案的變更嗎?",
     "SAVE_CLOSE_MULTI_MESSAGE"          : "您想要儲存下列檔案的變更嗎?",
     "EXT_MODIFIED_TITLE"                : "外部變更",
-    "CONFIRM_DELETE_TITLE"       : "確定刪除",
+    "CONFIRM_DELETE_TITLE"              : "確定刪除",
     "CONFIRM_FOLDER_DELETE"             : "您確定要刪除 <span class='dialog-filename'>{0}</span> 資料夾嗎?",
     "FILE_DELETED_TITLE"                : "檔案已刪除",
     "EXT_MODIFIED_WARNING"              : "<span class='dialog-filename'>{0}</span> 在 {APP_NAME} 外被修改過了。<br /><br />您想要儲存檔案並覆寫蓋掉外部的變更嗎?",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -250,10 +250,10 @@ module.exports = function (grunt) {
         var done = this.async(),
             PATH = "src/nls",
             ROOT_LANG = "root",
+            encounteredErrors = false,
             rootDefinitions = {},
             definitions,
-            unknownKeys,
-            encounteredErrors;
+            unknownKeys;
 
         function getDefinitions(abspath) {
             var fileContent,
@@ -292,7 +292,7 @@ module.exports = function (grunt) {
             }
         });
 
-        done(encounteredErrors);
+        done(!encounteredErrors);
     });
 
     build.getGitInfo = getGitInfo;


### PR DESCRIPTION
This PR actually consists of two parts:
- Renaming `CONFIRM_FOLDER_DELETE_TITLE` to `CONFIRM_DELETE_TITLE`, which I forgot about in #10258 where I changed it
- Make the `nls-check` task actually fail when we encounter such an issue
