### PR TITLE
Fix the bug where errors during installation of a local .zip file wer…

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
                     // new install or an update.
                     Package.validate(path, { requirePackageJSON: true }).done(function (info) {
                         if (info.errors.length) {
-                            result.reject(Package.formatError(info.errors));
+                            result.reject(Package.formatError(info.errors[0]));
                             return;
                         }
 

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
                     // new install or an update.
                     Package.validate(path, { requirePackageJSON: true }).done(function (info) {
                         if (info.errors.length) {
-                            result.reject(Package.formatError(info.errors[0]));
+                            result.reject(info.errors.map(Package.formatError).join(" "));
                             return;
                         }
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -503,6 +503,7 @@ define({
     "VIEW_TRUNCATED_DESCRIPTION"           : "View truncated description",
     // These must match the error codes in ExtensionsDomain.Errors.* :
     "INVALID_ZIP_FILE"                     : "The downloaded content is not a valid zip file.",
+    "MISSING_PACKAGE_JSON"                 : "The package has no package.json file.",
     "INVALID_PACKAGE_JSON"                 : "The package.json file is not valid (error was: {0}).",
     "MISSING_PACKAGE_NAME"                 : "The package.json file doesn't specify a package name.",
     "BAD_PACKAGE_NAME"                     : "{0} is an invalid package name.",


### PR DESCRIPTION
…e always shown as "Unknown internal error"

Fixes #8498.

`info.errors` is an array in the format `[error1, error2]`, where every error is another array in the format `[errorCode, additionalInfo1, additionalInfo2]`, so overall, `info.errors` could look like `[["MISSING_PACKAGE_NAME", "C:/ext.zip"], ["INVALID_VERSION_NUMBER", "invalidver", "C/ext.zip"]]`. `Package.formatError`, though, can only handle formatting one error.
That's why I decided we only handle the first error in the array (we can only output one error per file), so we don't always get "Unknown internal error" when attempting to install an invalid local .zip file.
