### PR TITLE
Revert "Ensures fold-gutter is always inserted after the line-number gutter (if it exists)"

### DIFF
--- a/.brackets.json
+++ b/.brackets.json
@@ -20,7 +20,6 @@
             "clearTimeout",
 
             "ArrayBuffer",
-            "MutationObserver",
             "XMLHttpRequest",
             "Uint32Array",
             "WebSocket"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,6 @@
         "clearTimeout": false,
 
         "ArrayBuffer": false,
-        "MutationObserver": false,
         "XMLHttpRequest": false,
         "Uint32Array": false,
         "WebSocket": false

--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -49,24 +49,6 @@
     padding-right: 5px;
 }
 
-// If line numbers are not shown and codefolding is enabled we remove the left padding.
- // We add the same padding below to the fold gutter
- .show-line-padding {
-     .folding-enabled.linenumber-disabled pre {
-         padding-left: 0;
-     }
- }
- 
- .CodeMirror.linenumber-disabled {
-     // When there are no line numbers, .show-line-padding class adds 15px left padding to line numbers.
-     // Here we compensate for that gap by adding the same padding to the folding gutter.
-     .CodeMirror-foldgutter,
-     .CodeMirror-foldgutter-open,
-     .CodeMirror-foldgutter-folded,
-     .CodeMirror-foldgutter-blank {
-         padding-left: 15px;
-     }
- }
 
 .CodeMirror-foldmarker {
     // Re-enabling the pointer events for the fold marker. As pointer events are disabled for "CodeMirror-lines"


### PR DESCRIPTION
Reverts adobe/brackets#12673

The PR had some issues regarding scroll states in some cases which I didn't catch/that didn't occur to myself.

Let's revert the PR and think of nicer API instead.

Reopen #11577 #10864 and #12725 when this gets merged. 

/cc @zaggino 
