### PR TITLE
fix invalid filename 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 
 # unit test working directory
 /test/results
+/test/temp
 
 # Netbeans
 /nbproject

--- a/test/spec/CodeHint-test.js
+++ b/test/spec/CodeHint-test.js
@@ -144,7 +144,7 @@ define(function (require, exports, module) {
 
                 // Place cursor inside a sample regular expression
                 // Note: line for pos is 0-based and editor lines numbers are 1-based
-                initCodeHintTest("testRegexp.js", pos);
+                initCodeHintTest("testRegExp.js", pos);
 
                 runs(function () {
                     editor = EditorManager.getCurrentFullEditor();


### PR DESCRIPTION
mentioned here https://github.com/adobe/brackets/pull/11569

(passes on windows due to fs being case insensitive)

file here: https://github.com/adobe/brackets/blob/master/test/spec/CodeHint-test-files/testRegExp.js

cc @MarcelGerber @ficristo 
