### PR TITLE
Monkeypatch ternServer.normalizeFilename so it doesn't break Mac/Linu…

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -122,6 +122,14 @@ var config = {};
                 };
                 ternServer = new Tern.Server(ternOptions);
 
+                // Since we don't specify projectDir, Tern will "normalize" file names by
+                // removing any leading "/" (the default projectDir, which cannot be changed to "").
+                // This is not a problem on Windows, but on Mac and Linux, it will break
+                // absolute paths ("/home/" to "home/", for example)
+                ternServer.normalizeFilename = function (name) {
+                    return name;
+                };
+
                 files.forEach(function (file) {
                     ternServer.addFile(file);
                 });


### PR DESCRIPTION
…x absolute paths

Fixes two issues:
- _All_ `Extensions/JavaScript Code Hinting` tests fail on Linux/Mac (reported by @ficristo in https://github.com/adobe/brackets/pull/11569#issuecomment-242835715)
- On Linux (probably also Mac), Code Hints are not shown immediately, but only after invoking them using `Ctrl+Space` (reported by @zaggino on Slack)

I could only test this on Linux.

The corresponding Tern "culprit" commit is ternjs/tern@24044a4781089b399f9bd4b98679c209ae8d86d0
