### PR TITLE
New File and New Folder execute in project root if there's no selection

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -627,7 +627,7 @@ define(function (require, exports, module) {
         // If a directory is currently selected in the tree, put it in it.
         // If an Untitled document is selected or nothing is selected in the tree, put it at the root of the project.
         var baseDirEntry,
-            selected = ProjectManager.getSelectedFileTreeItem();
+            selected = ProjectManager.getFileTreeContext();
         if ((!selected) || (selected instanceof InMemoryFile)) {
             selected = ProjectManager.getProjectRoot();
         }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -626,10 +626,8 @@ define(function (require, exports, module) {
         // If a file is currently selected in the tree, put it next to it.
         // If a directory is currently selected in the tree, put it in it.
         // If an Untitled document is selected or nothing is selected in the tree, put it at the root of the project.
-        // (Note: 'selected' may be an item that's selected in the workingset and not the tree; but in that case
-        // ProjectManager.createNewItem() ignores the baseDir we give it and falls back to the project root on its own)
         var baseDirEntry,
-            selected = ProjectManager.getSelectedItem(false);
+            selected = ProjectManager.getSelectedFileTreeItem();
         if ((!selected) || (selected instanceof InMemoryFile)) {
             selected = ProjectManager.getProjectRoot();
         }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -629,7 +629,7 @@ define(function (require, exports, module) {
         // (Note: 'selected' may be an item that's selected in the workingset and not the tree; but in that case
         // ProjectManager.createNewItem() ignores the baseDir we give it and falls back to the project root on its own)
         var baseDirEntry,
-            selected = ProjectManager.getSelectedItem();
+            selected = ProjectManager.getSelectedItem(false);
         if ((!selected) || (selected instanceof InMemoryFile)) {
             selected = ProjectManager.getProjectRoot();
         }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -388,15 +388,20 @@ define(function (require, exports, module) {
      * the file tree OR in the working set; or null if no item is selected anywhere in the sidebar.
      * May NOT be identical to the current Document - a folder may be selected in the sidebar, or the sidebar may not
      * have the current document visible in the tree & working set.
+     * @param {boolean=} includeWorkingSet If true, fall back to the working set item that is selected if there's
+     *      no selected file tree item (default behaviour)
      * @return {?(File|Directory)}
      */
-    function getSelectedItem() {
+    function getSelectedItem(includeWorkingSet) {
+        if (includeWorkingSet === undefined) {
+            includeWorkingSet = true;
+        }
         // Prefer file tree context, then selection, else use working set
         var selectedEntry = model.getContext();
         if (!selectedEntry) {
             selectedEntry = model.getSelected();
         }
-        if (!selectedEntry) {
+        if (!selectedEntry && includeWorkingSet) {
             selectedEntry = MainViewManager.getCurrentlyViewedFile();
         }
         return selectedEntry;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -382,26 +382,33 @@ define(function (require, exports, module) {
      * Singleton actionCreator that is used for dispatching changes to the ProjectModel.
      */
     var actionCreator = new ActionCreator(model);
+    
+    /**
+     * Returns the File or Directory corresponding to the item selected in the file tree; or null if no
+     * file tree item is selected.
+     * MAY NOT be identical to the current Document - a folder may be selected in the file tree.
+     * @return {?(File|Directory)}
+     */
+    function getSelectedFileTreeItem() {
+        // Prefer file tree context, else use file tree selection
+        var selectedEntry = model.getContext();
+        if (!selectedEntry) {
+            selectedEntry = model.getSelected();
+        }
+        return selectedEntry;
+    }
 
     /**
      * Returns the File or Directory corresponding to the item selected in the sidebar panel, whether in
      * the file tree OR in the working set; or null if no item is selected anywhere in the sidebar.
      * May NOT be identical to the current Document - a folder may be selected in the sidebar, or the sidebar may not
      * have the current document visible in the tree & working set.
-     * @param {boolean=} includeWorkingSet If true, fall back to the working set item that is selected if there's
-     *      no selected file tree item (default behaviour)
      * @return {?(File|Directory)}
      */
-    function getSelectedItem(includeWorkingSet) {
-        if (includeWorkingSet === undefined) {
-            includeWorkingSet = true;
-        }
-        // Prefer file tree context, then selection, else use working set
-        var selectedEntry = model.getContext();
+    function getSelectedItem() {
+        // Prefer file tree, else use working set
+        var selectedEntry = getSelectedFileTreeItem();
         if (!selectedEntry) {
-            selectedEntry = model.getSelected();
-        }
-        if (!selectedEntry && includeWorkingSet) {
             selectedEntry = MainViewManager.getCurrentlyViewedFile();
         }
         return selectedEntry;
@@ -1401,6 +1408,7 @@ define(function (require, exports, module) {
     exports.makeProjectRelativeIfPossible = makeProjectRelativeIfPossible;
     exports.shouldShow                    = ProjectModel.shouldShow;
     exports.openProject                   = openProject;
+    exports.getSelectedFileTreeItem       = getSelectedFileTreeItem;
     exports.getSelectedItem               = getSelectedItem;
     exports.getContext                    = getContext;
     exports.getInitialProjectPath         = getInitialProjectPath;

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -384,17 +384,11 @@ define(function (require, exports, module) {
     var actionCreator = new ActionCreator(model);
     
     /**
-     * Returns the File or Directory corresponding to the item selected in the file tree; or null if no
-     * file tree item is selected.
-     * MAY NOT be identical to the current Document - a folder may be selected in the file tree.
+     * Returns the File or Directory corresponding to the item that was right-clicked on in the file tree menu.
      * @return {?(File|Directory)}
      */
-    function getSelectedFileTreeItem() {
-        // Prefer file tree context, else use file tree selection
+    function getFileTreeContext() {
         var selectedEntry = model.getContext();
-        if (!selectedEntry) {
-            selectedEntry = model.getSelected();
-        }
         return selectedEntry;
     }
 
@@ -406,8 +400,11 @@ define(function (require, exports, module) {
      * @return {?(File|Directory)}
      */
     function getSelectedItem() {
-        // Prefer file tree, else use working set
-        var selectedEntry = getSelectedFileTreeItem();
+        // Prefer file tree context, then file tree selection, else use working set
+        var selectedEntry = getFileTreeContext();
+        if (!selectedEntry) {
+            selectedEntry = model.getSelected();
+        }
         if (!selectedEntry) {
             selectedEntry = MainViewManager.getCurrentlyViewedFile();
         }
@@ -1408,7 +1405,7 @@ define(function (require, exports, module) {
     exports.makeProjectRelativeIfPossible = makeProjectRelativeIfPossible;
     exports.shouldShow                    = ProjectModel.shouldShow;
     exports.openProject                   = openProject;
-    exports.getSelectedFileTreeItem       = getSelectedFileTreeItem;
+    exports.getFileTreeContext            = getFileTreeContext;
     exports.getSelectedItem               = getSelectedItem;
     exports.getContext                    = getContext;
     exports.getInitialProjectPath         = getInitialProjectPath;


### PR DESCRIPTION
Fixes #9341 and #11472.

@dangoor's comments in #9341 are interesting, but I think he over-thought this.

The solution is actually as simple as providing an additional param to `ProjectManager.getSelectedItem()`, which is only false for this one call to the function, so it's not an API change.
