### PR TITLE
Create config.json based on task run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Thumbs.db
 # ignore .disabled file for default extensions
 /src/extensions/default/*/.disabled
 
+# generate through grunt
+/src/config.json
+
 #OSX .DS_Store files
 .DS_Store
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -341,7 +341,7 @@ module.exports = function (grunt) {
     });
 
     // task: install
-    grunt.registerTask('install', ['write-config', 'less', 'npm-install-source']);
+    grunt.registerTask('install', ['write-config:dev', 'less', 'npm-install-source']);
 
     // task: test
     grunt.registerTask('test', ['eslint', 'jasmine', 'nls-check']);
@@ -349,10 +349,11 @@ module.exports = function (grunt) {
 
     // task: set-release
     // Update version number in package.json and rewrite src/config.json
-    grunt.registerTask('set-release', ['update-release-number', 'write-config']);
+    grunt.registerTask('set-release', ['update-release-number', 'write-config:dev']);
 
     // task: build
     grunt.registerTask('build', [
+        'write-config:dist',
         'eslint:src',
         'jasmine',
         'clean',

--- a/src/brackets.config.dev.json
+++ b/src/brackets.config.dev.json
@@ -1,0 +1,3 @@
+{
+    "healthDataServerURL"        : "https://healthdev.brackets.io/healthDataLog"
+}

--- a/src/brackets.config.dist.json
+++ b/src/brackets.config.dist.json
@@ -1,0 +1,3 @@
+{
+    "healthDataServerURL"        : "https://health.brackets.io/healthDataLog"
+}

--- a/src/brackets.config.json
+++ b/src/brackets.config.json
@@ -20,7 +20,6 @@
         "extension_registry"         : "https://s3.amazonaws.com/extend.brackets/registry.json",
         "extension_url"              : "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default" : true,
-        "build_timestamp"            : "",
-        "healthDataServerURL"        : "https://health.brackets.io/healthDataLog"
+        "build_timestamp"            : ""
     }
 }

--- a/tasks/write-config.js
+++ b/tasks/write-config.js
@@ -31,9 +31,21 @@ module.exports = function (grunt) {
 
     // task: write-config
     grunt.registerTask("write-config", "Merge package.json and src/brackets.config.json into src/config.json", function () {
-        var packageJSON = grunt.file.readJSON("package.json"),
-            appConfigJSON = grunt.file.readJSON("src/brackets.config.json");
+        var name = "dev";
+        if (this.flags.dist === true) {
+            name = "dist";
+        }
 
+        var appConfigJSON = grunt.file.readJSON("src/brackets.config.json"),
+            appConfigEnvJSON = grunt.file.readJSON("src/brackets.config." + name + ".json"),
+            key;
+        for (key in appConfigEnvJSON) {
+            if (appConfigEnvJSON.hasOwnProperty(key)) {
+                appConfigJSON.config[key] = appConfigEnvJSON[key];
+            }
+        }
+
+        var packageJSON = grunt.file.readJSON("package.json");
         Object.keys(packageJSON).forEach(function (key) {
             if (appConfigJSON[key] === undefined) {
                 appConfigJSON[key] = packageJSON[key];


### PR DESCRIPTION
This is a possibly fix for https://github.com/adobe/brackets/issues/12771 which rely on grunt names.
This works under the assumption that `grunt build` is always run after `grunt install` and `grunt set-release`. So if you want to try the installer locally you end up with the production file, unfortunately.
So maybe we really need an environment variable on the build machines.
