### PR TITLE
set eslints max-len to 120

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,8 @@
         "valid-typeof": 2,
 
         "no-trailing-spaces": 0,
-        "eol-last": 0
+        "eol-last": 0,
+        "max-len": [1, 120]
     },
     "globals": {
         "brackets": false,


### PR DESCRIPTION
while 80 might be too narrow in some cases, anything over 120 means you have to scroll horizontally when reviewing pull requests on GH which is a real pain

cc @ficristo @petetnt
