### PR TITLE
add font-display property

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -95,6 +95,7 @@
     "flow-into":                   {"values": ["none"], "type": "named-flow"},
     "flow-from":                   {"values": ["none", "inherit"], "type": "named-flow"},
     "font":                        {"values": []},
+    "font-display":                {"values": ["auto", "block", "swap", "fallback", "optional"]},
     "font-family":                 {"values": ["cursive", "fantasy", "inherit", "monospace", "sans-serif", "serif"]},
     "font-feature-settings":       {"values": ["normal"]},
     "font-kerning":                {"values": ["auto", "none", "normal"]},


### PR DESCRIPTION
Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display

*****\* Values **********
auto
The font display strategy is defined by the user agent.
block
Gives the font face a short block period and an infinite swap period.
swap
Gives the font face no block period and an infinite swap period.
fallback
Gives the font face an extremely small block period and a short swap period.
optional
gives the font face an extremely small block period and no swap period.
