### PR TITLE
Don't let ESC key bubble in CodeHintList. Fixes #12799

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -392,14 +392,17 @@ define(function (require, exports, module) {
         if (event.type === "keydown" && this.isHandlingKeyCode(event)) {
             keyCode = event.keyCode;
 
-            if (event.keyCode === KeyEvent.DOM_VK_ESCAPE || 
-                  (event.shiftKey &&
+            if (event.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+                event.stopImmediatePropagation();
+                this.handleClose();
+
+                return false;
+            } else if (event.shiftKey &&
                     (event.keyCode === KeyEvent.DOM_VK_UP ||
                      event.keyCode === KeyEvent.DOM_VK_DOWN ||
                      event.keyCode === KeyEvent.DOM_VK_PAGE_UP ||
-                     event.keyCode === KeyEvent.DOM_VK_PAGE_DOWN))) {
+                     event.keyCode === KeyEvent.DOM_VK_PAGE_DOWN)) {
                 this.handleClose();
-
                 // Let the event bubble.
                 return false;
             } else if (keyCode === KeyEvent.DOM_VK_UP) {


### PR DESCRIPTION
This PR fixes #12799 by handling ESC key presses differently from other actions that close the CodeHintList popup. `event.stopImmediatePropagation` is used to prevent the stop event from bubbling up.

cc @adityapaturi  who reported the original issue.

Signed-off-by: petetnt pete.a.nykanen@gmail.com
