### PR TITLE
Fix MacOS folder icon handling. Fixes #12789

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
      *    https://github.com/adobe/brackets/issues/6781
      * @type {RegExp}
      */
-    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.hgtags$|^\.idea$|^\.c9revisions$|^\.SyncArchive$|^\.SyncID$|^\.SyncIgnore$|\~$/;
+    var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Icon\r|^Thumbs\.db$|^\.hg$|^CVS$|^\.hgtags$|^\.idea$|^\.c9revisions$|^\.SyncArchive$|^\.SyncID$|^\.SyncIgnore$|\~$/;
 
     /**
      * Glob definition of files and folders that should be excluded directly


### PR DESCRIPTION
This PR handles an rare edge case where MacOS folder icon breaks down the whole FileTreeView. For repro steps see #12789

Background from [superuser.com](http://superuser.com/questions/298785/icon-file-on-os-x-desktop):

> ### What is it?
> 
> It's name is actually Icon\r, with \r being the carriage return 0x0D. If letting the shell autocomplete the path in Terminal, it yields Icon^M, ^M being \r.
> 
> Icon^M is a file existing in all directories that have a custom icon in Finder. If you change a directory's icon e.g. in its Get Info dialog by pasting an image into the icon in the upper left corner, the Icon^M file is created.

This PR checks for the existence of an file called `Icon\r`, and bails out of rendering the said `fileNode` if it's name matches it. This is relatively safe, because you shouldn't be able to create filenames with such special characters yourself.

There's an side effect of failing to create a file called "Icon" if `Icon\r` already exists in the same folder, but the behaviour matches MacOS Finder, which also fails (silently).

The PR includes adds `Icon\r` to the default exclusion list
