### PR TITLE
Fix for #11801: "Font Size" field on themes settings dialog could accept any characters

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -301,6 +301,7 @@ define(function (require, exports, module) {
 
         // Make sure that the font size is expressed in terms we can handle (px or em). If not, simply bail.
         if (fsStyle.search(validFont) === -1) {
+        	prefs.set("fontSize", DEFAULT_FONT_SIZE + "px");
             return false;
         }
 


### PR DESCRIPTION
When the input field for font is not valid set the preferences in the default font size.
