### PR TITLE
Fix #11416: Enter key behaviour on Extension Manager Search Box

### DIFF
--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
             stopEvent();
             if (e.target.tagName === "BUTTON") {
                 this.find(e.target).click();
-            } else if (e.target.tagName != "INPUT") {
+            } else if (e.target.tagName !== "INPUT") {
                 // If the target element is not BUTTON or INPUT, click the primary button
                 // We're making an exception for INPUT element because of this issue: GH-11416
                 $primaryBtn.click();

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -166,7 +166,9 @@ define(function (require, exports, module) {
             stopEvent();
             if (e.target.tagName === "BUTTON") {
                 this.find(e.target).click();
-            } else {
+            } else if (e.target.tagName != "INPUT") {
+                // If the target element is not BUTTON or INPUT, click the primary button
+                // We're making an exception for INPUT element because of this issue: GH-11416
                 $primaryBtn.click();
             }
         } else if (e.which === KeyEvent.DOM_VK_SPACE) {


### PR DESCRIPTION
Fixes #11416
Made an exception for INPUT element in Dialogs.js so that we don't click
the primary button (in this case ESCAPE) when it's an INPUT.
