### PR TITLE
undo history not working, when line-endings change after save

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1048,7 +1048,11 @@ define(function (require, exports, module) {
      */
     Editor.prototype._resetText = function (text) {
         var currentText = this._codeMirror.getValue();
-        if (text === currentText) {
+
+        // compare with ignoring line-endings, issue #11826
+        var textLF = text ? text.replace(/(\r\n|\r|\n)/g, "\n") : null;
+        var currentTextLF = currentText ? currentText.replace(/(\r\n|\r|\n)/g, "\n") : null;
+        if (textLF === currentTextLF) {
             // there's nothing to reset
             return;
         }

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -418,6 +418,24 @@ define(function (require, exports, module) {
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
                 });
             });
+
+            it("should not clean history when reset is called with the same text with different line-endings", function () {
+                runs(function () {
+                    promise = CommandManager.execute(Commands.FILE_OPEN, {fullPath: JS_FILE});
+                    waitsForDone(promise, "Open file");
+                });
+                runs(function () {
+                    var doc = DocumentManager.getOpenDocumentForPath(JS_FILE);
+
+                    // Put some text into editor
+                    doc.setText("a\r\nb\r\nc");
+                    expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
+
+                    // Reset text with the same value, expect history not to change
+                    doc.refreshText("a\nb\nc", Date.now());
+                    expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
+                });
+            });
         });
 
         describe("Refresh and change events", function () {

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -426,13 +426,19 @@ define(function (require, exports, module) {
                 });
                 runs(function () {
                     var doc = DocumentManager.getOpenDocumentForPath(JS_FILE);
+                    var crlf = "a\r\nb\r\nc";
+                    var lf = "a\nb\nc";
 
                     // Put some text into editor
-                    doc.setText("a\r\nb\r\nc");
+                    doc.setText(crlf);
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
 
                     // Reset text with the same value, expect history not to change
-                    doc.refreshText("a\nb\nc", Date.now());
+                    doc.refreshText(lf, Date.now());
+                    expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
+
+                    // Reset text with the same value, expect history not to change
+                    doc.refreshText(crlf, Date.now());
                     expect(doc._masterEditor._codeMirror.historySize().undo).toBe(1);
                 });
             });


### PR DESCRIPTION
For a bug identified in https://github.com/adobe/brackets/issues/11826#issuecomment-257429242

credits to @vahid-sanati for identifying this, put up a PR so we can have it merged asap

cc @petetnt @ficristo 