### PR TITLE
Update ISSUE_TEMPLATE.md to cover platform differences

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Prerequisites
 
-* [ ] Can you reproduce the problem with `Debug \ Reload Without Extensions`?
+* [ ] Can you reproduce the problem with `Debug -> Reload Without Extensions`?
 * [ ] Did you perform a cursory search to see if your bug or enhancement is already reported?
 * [ ] Did you read the [Troubleshooting guide](https://github.com/adobe/brackets/wiki/Troubleshooting)?
 
@@ -24,4 +24,4 @@ For more information on how to contribute read [here](https://github.com/adobe/b
 ### Versions
 
 Please include the OS and what version of the OS you're running.
-Please include the version of Brackets. You can find it under `Help \ About Brackets`
+Please include the version of Brackets. You can find it under `Help -> About Brackets` (Windows and Linux) or `Brackets -> About Brackets` (macOS)


### PR DESCRIPTION
There are small differences between the platforms, as evident in https://github.com/adobe/brackets/issues/12864. This PR fixes that.

Could someone check that the Linux version has the menu under Help, as I don't have a GUI machine at hand.