### PR TITLE
Update README.md to remove 'debian/ubuntu' #10255

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ How to install and run Brackets
 -------------------------------
 #### Download
 
-Installers for the latest stable build for Mac, Windows and Linux (Debian/Ubuntu) can be [downloaded here](http://brackets.io/).
+Installers for the latest stable build for Mac, Windows and Linux can be [downloaded here](http://brackets.io/).
 
 The Linux version has most of the features of the Mac and Windows versions, but
 is still missing a few things. See the [Linux wiki page](https://github.com/adobe/brackets/wiki/Linux-Version)


### PR DESCRIPTION
Changing Linux(Debian/Ubuntu) to just Linux as Debian based Linux flavors no longer install and won't continue based on comments by ficristo here https://github.com/adobe/brackets/issues/10255#issuecomment-243854796

Ultimately this has a work around but I don't see how to edit the wiki pages on adobe/brackets.  I'll be opening an issue with that as the ask which is to change the wiki pages to make it clear you can install on Debian.

I'm unsure what version of CEF is used for brackets here, but it does appear maintained if it's this one;
https://bitbucket.org/chromiumembedded/cef/

With that being said, they have a similar issue and have it as "WONTFIX"
https://bitbucket.org/chromiumembedded/cef/issues?q=libgcrypt

So pretty much unless someone finds and fixes there issue for them either the .deb will no longer work on debian os's that dont come packed with libgcrypt11 so all of them.