### PR TITLE
improvements to file system events processing for search

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -830,8 +830,6 @@ define(function (require, exports, module) {
 
         var addPromise;
         if (entry.isDirectory) {
-            added = added || [];
-            removed = removed || [];
             if (added.length === 0 && removed.length === 0) {
                 // If the added or removed sets are null, must redo the search for the entire subtree - we
                 // don't know which child files/folders may have been added or removed.
@@ -872,12 +870,9 @@ define(function (require, exports, module) {
         // we need to reduce _cachedFileSystemEvents not to contain duplicates!
         _cachedFileSystemEvents = _cachedFileSystemEvents.reduce(function (result, obj) {
             var fullPath = obj.entry ? obj.entry.fullPath : null;
-            // merge added
-            if (result[fullPath] && obj.added) {
+            // merge added & removed
+            if (result[fullPath] && obj.isDirectory) {
                 obj.added = obj.added.concat(result[fullPath].added);
-            }
-            // merge removed
-            if (result[fullPath] && obj.removed) {
                 obj.removed = obj.removed.concat(result[fullPath].removed);
             }
             // use the latest event as base
@@ -895,9 +890,17 @@ define(function (require, exports, module) {
      * putting them to cache and executing a debounced function
      */
     _debouncedFileSystemChangeHandler = function (event, entry, added, removed) {
+        // normalize this here so we don't need to handle null later
+        var isDirectory = false;
+        if (entry && entry.isDirectory) {
+            isDirectory = true;
+            added = added || [];
+            removed = removed || [];
+        }
         _cachedFileSystemEvents.push({
             event: event,
             entry: entry,
+            isDirectory: isDirectory,
             added: added,
             removed: removed
         });

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -744,7 +744,7 @@ define(function (require, exports, module) {
 
         /*
          * Remove existing search results that match the given entry's path
-         * @param {(File|Directory)} entry
+         * @param {Array.<(File|Directory)>} entries
          */
         function _removeSearchResultsForEntries(entries) {
             var fullPaths = [];
@@ -766,8 +766,8 @@ define(function (require, exports, module) {
         }
 
         /*
-         * Add new search results for this entry and all of its children
-         * @param {(File|Directory)} entry
+         * Add new search results for these entries and all of its children
+         * @param {Array.<(File|Directory)>} entries
          * @return {jQuery.Promise} Resolves when the results have been added
          */
         function _addSearchResultsForEntries(entries) {
@@ -859,8 +859,15 @@ define(function (require, exports, module) {
         });
     };
     
+    /**
+     * This stores file system events emitted by watchers that were not yet processed
+     */
     var _cachedFileSystemEvents = [];
     
+    /**
+     * Debounced function to process emitted file system events
+     * for cases when there's a lot of fs events emitted in a very short period of time
+     */
     _processCachedFileSystemEvents = _.debounce(function () {
         // we need to reduce _cachedFileSystemEvents not to contain duplicates!
         _cachedFileSystemEvents = _cachedFileSystemEvents.reduce(function (result, obj) {
@@ -883,6 +890,10 @@ define(function (require, exports, module) {
         _cachedFileSystemEvents = [];
     }, FILE_SYSTEM_EVENT_DEBOUNCE_TIME);
     
+    /**
+     * Wrapper function for _fileSystemChangeHandler which handles all incoming fs events
+     * putting them to cache and executing a debounced function
+     */
     _debouncedFileSystemChangeHandler = function (event, entry, added, removed) {
         _cachedFileSystemEvents.push({
             event: event,

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -80,8 +80,12 @@ define(function (require, exports, module) {
         _fileNameChangeHandler,
         clearSearch;
     
-    /* Waits for FS changes to stack up until processing them (scripts like npm install can do a lot of movements on the disk) */
-    var FILE_SYSTEM_EVENT_DEBOUNCE_TIME = 1000;
+    /**
+     * Waits for FS changes to stack up until processing them
+     * (scripts like npm install can do a lot of movements on the disk)
+     * @const
+     */
+    var FILE_SYSTEM_EVENT_DEBOUNCE_TIME = 100;
 
     /** Remove the listeners that were tracking potential search result changes */
     function _removeListeners() {
@@ -665,7 +669,7 @@ define(function (require, exports, module) {
      * Inform node that the list of files has changed.
      * @param {array} fileList The list of files that changed.
      */
-    function filesChanged(fileList) {        
+    function filesChanged(fileList) {
         if (FindUtils.isNodeSearchDisabled() || !fileList || fileList.length === 0) {
             return;
         }
@@ -859,29 +863,33 @@ define(function (require, exports, module) {
     
     _processCachedFileSystemEvents = _.debounce(function () {
         // we need to reduce _cachedFileSystemEvents not to contain duplicates!
-        _cachedFileSystemEvents = _cachedFileSystemEvents.reduce(function (result, arr) {
-            var fsEntry = arr[1];
-            var fullPath = fsEntry ? fsEntry.fullPath : null;            
+        _cachedFileSystemEvents = _cachedFileSystemEvents.reduce(function (result, obj) {
+            var fullPath = obj.entry ? obj.entry.fullPath : null;
             // merge added
-            if (result[fullPath] && arr[2]) {
-                arr[2] = arr[2].concat(result[fullPath][2]);
+            if (result[fullPath] && obj.added) {
+                obj.added = obj.added.concat(result[fullPath].added);
             }
             // merge removed
-            if (result[fullPath] && arr[3]) {
-                arr[3] = arr[3].concat(result[fullPath][3]);
+            if (result[fullPath] && obj.removed) {
+                obj.removed = obj.removed.concat(result[fullPath].removed);
             }
             // use the latest event as base
-            result[fullPath] = arr;
+            result[fullPath] = obj;
             return result;
         }, {});
-        _.forEach(_cachedFileSystemEvents, function (arr) {
-            _fileSystemChangeHandler.apply(null, arr);
+        _.forEach(_cachedFileSystemEvents, function (obj) {
+            _fileSystemChangeHandler(obj.event, obj.entry, obj.added, obj.removed);
         });
         _cachedFileSystemEvents = [];
     }, FILE_SYSTEM_EVENT_DEBOUNCE_TIME);
     
     _debouncedFileSystemChangeHandler = function (event, entry, added, removed) {
-        _cachedFileSystemEvents.push([ event, entry, added, removed ]);
+        _cachedFileSystemEvents.push({
+            event: event,
+            entry: entry,
+            added: added,
+            removed: removed
+        });
         _processCachedFileSystemEvents();
     };
 


### PR DESCRIPTION
Hi guys, I've reported elsewhere that my db dump script crashes both brackets (white-screen) and also brackets-electron. This is the work done to fix that (and I can confirm that with this fix there's no crash when running my script anymore) - it's not final and I'd like to have it reviewed before working on little things as docs and similar.

There're two main things, first aggregate duplicate events and debounce for a short while before processing. My script quickly deletes and creates back a lot of stuff, before this change some of the directories were removed and added back to search multiple times. With debouncing it's only once after script is done.

Second, no less important thing is fixing calls to `filesChanged` and `filesRemoved` functions. In case of my script these two were called about 1000 times with an array of size 1 which cause a lot of trouble for IPC connection in electron and socket connection in regular brackets. With the fix these are now properly called.

Marking this as high-priority because it fixes brackets completely crashing in some cases.