### PR TITLE
Browser issue

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.9.0-0",

--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.9.0-0",

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -72,9 +72,13 @@ define(function (require, exports, module) {
     function stopURIListPropagation(files, event) {
         var types = event.dataTransfer.types;
             
-        if ((!files || !files.length) && types) {// stop default behavior if a url is dragged in so the browser does not takeove
+        if ((!files || !files.length) && types) { // We only want to check if a string of text was dragged into the editor
             types.forEach(function (value) {
-                if (value === "text/uri-list") { //plain text just has text/html
+                //Draging text externally (dragging text from another file): types has "text/plain" and "text/html"
+                //Draging text internally (dragging text to another line): types has just "text/plain"
+                //Draging a file: types has "Files"
+                //Draging a url: types has "text/plain" and "text/uri-list" <-what we are interested in
+                if (value === "text/uri-list") { 
                     event.stopPropagation();
                     event.preventDefault();
                     return;

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -156,6 +156,18 @@ define(function (require, exports, module) {
             event = event.originalEvent || event;
 
             var files = event.dataTransfer.files;
+
+            var types = event.dataTransfer.types;
+            if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
+                types.forEach(function (value){
+                    if(value == "text/uri-list"){ //plain text just has text/html
+                        event.stopPropagation();
+                        event.preventDefault();
+                        return;
+                    }
+                });
+            }
+
             if (files && files.length) {
                 event.stopPropagation();
                 event.preventDefault();
@@ -174,6 +186,18 @@ define(function (require, exports, module) {
             event = event.originalEvent || event;
 
             var files = event.dataTransfer.files;
+
+            var types = event.dataTransfer.types;
+            if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
+                types.forEach(function (value){
+                    if(value == "text/uri-list"){ //plain text just has text/html
+                        event.stopPropagation();
+                        event.preventDefault();
+                        return;
+                    }
+                });
+            }
+
             if (files && files.length) {
                 event.stopPropagation();
                 event.preventDefault();

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -160,7 +160,7 @@ define(function (require, exports, module) {
             var types = event.dataTransfer.types;
             if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
                 types.forEach(function (value){
-                    if(value == "text/uri-list"){ //plain text just has text/html
+                    if(value === "text/uri-list"){ //plain text just has text/html
                         event.stopPropagation();
                         event.preventDefault();
                         return;
@@ -190,7 +190,7 @@ define(function (require, exports, module) {
             var types = event.dataTransfer.types;
             if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
                 types.forEach(function (value){
-                    if(value == "text/uri-list"){ //plain text just has text/html
+                    if(value === "text/uri-list"){ //plain text just has text/html
                         event.stopPropagation();
                         event.preventDefault();
                         return;

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -70,17 +70,17 @@ define(function (require, exports, module) {
      * @param {event} event The event datastucture containing datatransfer information about the drag/drop event. Contains a type list which may or may not hold a URI-list depending on what was dragged/dropped. Interested if it does.
      */
     function stopURIListPropagation(files, event) {
-
         var types = event.dataTransfer.types;
-            if((!files || !files.length) && types){// stop default behavior if a url is dragged in so the browser does not takeove
-                types.forEach(function (value){
-                    if(value === "text/uri-list"){ //plain text just has text/html
-                        event.stopPropagation();
-                        event.preventDefault();
-                        return;
-                    }
-                });
-            }
+            
+        if ((!files || !files.length) && types) {// stop default behavior if a url is dragged in so the browser does not takeove
+            types.forEach(function (value) {
+                if (value === "text/uri-list") { //plain text just has text/html
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+            });
+        }
     }
 
     /**

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -61,6 +61,27 @@ define(function (require, exports, module) {
         // No valid entries found
         return false;
     }
+    
+    /**
+     * Determines if the event contains a type list that has a URI-list.
+     * If it does and contains an empty file list, then what is being dropped is a URL.
+     * If that is true then we stop the event propagation and default behavior to save Brackets editor from the browser taking over.
+     * @param {Array.<File>} files Array of File objects from the event datastructure. URLs are the only drop item that would contain a URI-list.
+     * @param {event} event The event datastucture containing datatransfer information about the drag/drop event. Contains a type list which may or may not hold a URI-list depending on what was dragged/dropped. Interested if it does.
+     */
+    function stopURIListPropagation(files, event) {
+
+        var types = event.dataTransfer.types;
+            if((!files || !files.length) && types){// stop default behavior if a url is dragged in so the browser does not takeove
+                types.forEach(function (value){
+                    if(value === "text/uri-list"){ //plain text just has text/html
+                        event.stopPropagation();
+                        event.preventDefault();
+                        return;
+                    }
+                });
+            }
+    }
 
     /**
      * Open dropped files
@@ -157,16 +178,7 @@ define(function (require, exports, module) {
 
             var files = event.dataTransfer.files;
 
-            var types = event.dataTransfer.types;
-            if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
-                types.forEach(function (value){
-                    if(value === "text/uri-list"){ //plain text just has text/html
-                        event.stopPropagation();
-                        event.preventDefault();
-                        return;
-                    }
-                });
-            }
+            stopURIListPropagation(files, event);
 
             if (files && files.length) {
                 event.stopPropagation();
@@ -187,16 +199,7 @@ define(function (require, exports, module) {
 
             var files = event.dataTransfer.files;
 
-            var types = event.dataTransfer.types;
-            if(!files.length){// stop default behavior if a url is dragged in so the browser does not takeove
-                types.forEach(function (value){
-                    if(value === "text/uri-list"){ //plain text just has text/html
-                        event.stopPropagation();
-                        event.preventDefault();
-                        return;
-                    }
-                });
-            }
+            stopURIListPropagation(files, event);
 
             if (files && files.length) {
                 event.stopPropagation();


### PR DESCRIPTION
The solution code is in the commit: Browser issue fix

This is a bug fix for issue:(Brackets turns into a web browser #12441). 

Description: Filters out drag/drop events from text strings being dropped into Brackets that will actually change the DOM structure of the Brackets layout. It looks for a “text/url-list” type in the types list and stops the event propagation if there are any.

All unit tests and smoke tests were performed and passed.

Here is a test that verifies that the solution works: 
Settings should be as they are in a smoke test

1. Create an empty folder externally.
2. Open the folder with Brackets.
3. Enable "dragDropText" in Brackets preferences.
4. Drag a text or HTML file into Brackets.
5. The file should be open and focused in the workspace.
6. Open up a browser.
7. Type in any valid URL (a webpage with text) and go there in the browser.
8. Add a few lines to the test file that was opened in Brackets.
9. Highlight some text from the webpage and copy it to a line in the test file.
10. Verify that the text in Brackets can be highlighted and dragged to any other line.
11. Drag the URL from the Browser’s URL field into Brackets. Do this several times over all areas of the Brackets editor.
12. Verify that the URL did not drop into Brackets, or Brackets refuses the URL, and that Brackets remains an editor and not a browsable webpage. Failed test: If Brackets does become a webpage restart Brackets and perform steps 1 through 5.

13. Set the view to Vertical Split.
14. Open another test file and verify steps 1 through 5 in the other non-used split view.
15. There should be two test files open, one in each view. Perform steps 6 through 12 for both split editors.

16. Perform steps 13 through 15 for a Horizontal Split view

My repo: https://github.com/jamran7/brackets

This is on behalf of ChainsawFist