### PR TITLE
Move CodeMirror on node_modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/thirdparty/CodeMirror"]
-	path = src/thirdparty/CodeMirror
-	url = https://github.com/adobe/CodeMirror2.git
 [submodule "src/thirdparty/path-utils"]
 	path = src/thirdparty/path-utils
 	url = https://github.com/jblas/path-utils.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,11 +278,6 @@ module.exports = function (grunt) {
                 vendor : [
                     'test/polyfills.js', /* For reference to why this polyfill is needed see Issue #7951. The need for this should go away once the version of phantomjs gets upgraded to 2.0 */
                     'src/thirdparty/jquery-2.1.3.min.js',
-                    'src/thirdparty/CodeMirror/lib/codemirror.js',
-                    'src/thirdparty/CodeMirror/lib/util/dialog.js',
-                    'src/thirdparty/CodeMirror/lib/util/searchcursor.js',
-                    'src/thirdparty/CodeMirror/addon/edit/closetag.js',
-                    'src/thirdparty/CodeMirror/addon/selection/active-line.js',
                     'src/thirdparty/less-2.5.1.min.js'
                 ],
                 helpers : [
@@ -298,7 +293,19 @@ module.exports = function (grunt) {
                             'spec' : '../test/spec',
                             'text' : 'thirdparty/text/text',
                             'i18n' : 'thirdparty/i18n/i18n'
-                        }
+                        },
+                        map: {
+                            "*": {
+                                "thirdparty/CodeMirror2": "thirdparty/CodeMirror"
+                            }
+                        },
+                        packages: [
+                            {
+                                name: "thirdparty/CodeMirror",
+                                location: "../node_modules/codemirror",
+                                main: "lib/codemirror"
+                            }
+                        ]
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "anymatch": "1.3.0",
         "chokidar": "1.6.0",
+        "codemirror": "5.21.0",
         "lodash": "4.15.0"
     },
     "devDependencies": {

--- a/src/config.json
+++ b/src/config.json
@@ -38,6 +38,7 @@
     "dependencies": {
         "anymatch": "1.3.0",
         "chokidar": "1.6.0",
+        "codemirror": "5.21.0",
         "lodash": "4.15.0"
     },
     "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
     <!-- Warn about failed cross origin requests in Chrome -->
     <script type="application/javascript" src="xorigin.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
+    <link rel="stylesheet" type="text/css" href="../node_modules/CodeMirror/lib/codemirror.css">
     <!--(if target dev)><!-->
     <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">
     <!--<!(endif)-->

--- a/src/main.js
+++ b/src/main.js
@@ -38,9 +38,16 @@ require.config({
     map: {
         "*": {
             "thirdparty/CodeMirror2": "thirdparty/CodeMirror",
-            "thirdparty/react":	"react"
+            "thirdparty/react":       "react"
         }
-    }
+    },
+    packages: [
+        {
+            name: "thirdparty/CodeMirror",
+            location: "../node_modules/codemirror",
+            main: "lib/codemirror"
+        }
+    ]
 });
 
 if (window.location.search.indexOf("testEnvironment") > -1) {


### PR DESCRIPTION
What I had in mind was something like this.
I think this will NOT work on distribution since the node_modules would be in a different location.
Also I find worrisome I had to change the css link.

Ref #12940