### PR TITLE
Move npm dependencies inside src and add CodeMirror to them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ Thumbs.db
 /node_modules
 /npm-debug.log
 
+# ignore node_modules inside src
+/src/node_modules
+
 # ignore compiled files
 /dist
 /src/.index.html

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/thirdparty/CodeMirror"]
-	path = src/thirdparty/CodeMirror
-	url = https://github.com/adobe/CodeMirror2.git
 [submodule "src/thirdparty/path-utils"]
 	path = src/thirdparty/path-utils
 	url = https://github.com/jblas/path-utils.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,8 @@ module.exports = function (grunt) {
                         cwd: 'src/',
                         src: [
                             'nls/{,*/}*.js',
+                            'package.json',
+                            'npm-shrinkwrap.json',
                             'xorigin.js',
                             'dependencies.js',
                             'thirdparty/requirejs/require.js',
@@ -278,11 +280,6 @@ module.exports = function (grunt) {
                 vendor : [
                     'test/polyfills.js', /* For reference to why this polyfill is needed see Issue #7951. The need for this should go away once the version of phantomjs gets upgraded to 2.0 */
                     'src/thirdparty/jquery-2.1.3.min.js',
-                    'src/thirdparty/CodeMirror/lib/codemirror.js',
-                    'src/thirdparty/CodeMirror/lib/util/dialog.js',
-                    'src/thirdparty/CodeMirror/lib/util/searchcursor.js',
-                    'src/thirdparty/CodeMirror/addon/edit/closetag.js',
-                    'src/thirdparty/CodeMirror/addon/selection/active-line.js',
                     'src/thirdparty/less-2.5.1.min.js'
                 ],
                 helpers : [
@@ -298,7 +295,19 @@ module.exports = function (grunt) {
                             'spec' : '../test/spec',
                             'text' : 'thirdparty/text/text',
                             'i18n' : 'thirdparty/i18n/i18n'
-                        }
+                        },
+                        map: {
+                            "*": {
+                                "thirdparty/CodeMirror2": "thirdparty/CodeMirror"
+                            }
+                        },
+                        packages: [
+                            {
+                                name: "thirdparty/CodeMirror",
+                                location: "node_modules/codemirror",
+                                main: "lib/codemirror"
+                            }
+                        ]
                     }
                 }
             }
@@ -323,7 +332,7 @@ module.exports = function (grunt) {
     });
 
     // task: install
-    grunt.registerTask('install', ['write-config', 'less', 'npm-install-extensions']);
+    grunt.registerTask('install', ['write-config', 'less', 'npm-install-source']);
 
     // task: test
     grunt.registerTask('test', ['eslint', 'jasmine', 'nls-check']);

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
         "branch": "",
         "SHA": ""
     },
-    "dependencies": {
-        "anymatch": "1.3.0",
-        "chokidar": "1.6.0",
-        "lodash": "4.15.0"
-    },
     "devDependencies": {
         "glob": "7.0.6",
         "grunt": "0.4.5",

--- a/src/config.json
+++ b/src/config.json
@@ -35,11 +35,6 @@
         "branch": "",
         "SHA": ""
     },
-    "dependencies": {
-        "anymatch": "1.3.0",
-        "chokidar": "1.6.0",
-        "lodash": "4.15.0"
-    },
     "devDependencies": {
         "glob": "7.0.6",
         "grunt": "0.4.5",

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
     <!-- Warn about failed cross origin requests in Chrome -->
     <script type="application/javascript" src="xorigin.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
+    <link rel="stylesheet" type="text/css" href="node_modules/codemirror/lib/codemirror.css">
     <!--(if target dev)><!-->
     <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">
     <!--<!(endif)-->

--- a/src/main.js
+++ b/src/main.js
@@ -38,9 +38,16 @@ require.config({
     map: {
         "*": {
             "thirdparty/CodeMirror2": "thirdparty/CodeMirror",
-            "thirdparty/react":	"react"
+            "thirdparty/react":       "react"
         }
-    }
+    },
+    packages: [
+        {
+            name: "thirdparty/CodeMirror",
+            location: "node_modules/codemirror",
+            main: "lib/codemirror"
+        }
+    ]
 });
 
 if (window.location.search.indexOf("testEnvironment") > -1) {

--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -1,6 +1,5 @@
 {
-  "name": "Brackets",
-  "version": "1.8.0-0",
+  "name": "brackets-src",
   "dependencies": {
     "anymatch": {
       "version": "1.3.0",
@@ -38,9 +37,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "binary-extensions": {
-      "version": "1.5.0",
+      "version": "1.8.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
     },
     "brace-expansion": {
       "version": "1.1.6",
@@ -61,6 +60,11 @@
       "version": "1.6.0",
       "from": "chokidar@1.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz"
+    },
+    "codemirror": {
+      "version": "5.21.0",
+      "from": "codemirror@5.21.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.21.0.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -98,13 +102,13 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "for-in": {
-      "version": "0.1.5",
+      "version": "0.1.6",
       "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
     },
     "for-own": {
       "version": "0.1.4",
-      "from": "for-own@>=0.1.3 <0.2.0",
+      "from": "for-own@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "glob-base": {
@@ -118,14 +122,14 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "graceful-fs": {
-      "version": "4.1.6",
+      "version": "4.1.11",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "inherits": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "from": "inherits@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -188,9 +192,9 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
     },
     "kind-of": {
-      "version": "3.0.4",
+      "version": "3.1.0",
       "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
     },
     "lodash": {
       "version": "4.15.0",
@@ -213,9 +217,9 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "object.omit": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -223,9 +227,9 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "path-is-absolute": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "preserve": {
       "version": "0.2.0",
@@ -238,14 +242,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "randomatic": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
     },
     "readable-stream": {
-      "version": "2.1.5",
+      "version": "2.2.2",
       "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
     },
     "readdirp": {
       "version": "2.1.0",
@@ -263,9 +267,9 @@
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
-      "version": "1.5.4",
+      "version": "1.6.1",
       "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "brackets-src",
+  "dependencies": {
+    "anymatch": "1.3.0",
+    "chokidar": "1.6.0",
+    "codemirror": "5.21.0",
+    "lodash": "4.15.0"
+  }
+}

--- a/tasks/npm-install.js
+++ b/tasks/npm-install.js
@@ -47,16 +47,15 @@ module.exports = function (grunt) {
     }
 
     grunt.registerTask("npm-install", "Install node_modules to the dist folder so it gets bundled with release", function () {
-        var npmShrinkwrapJSON = grunt.file.readJSON("npm-shrinkwrap.json");
-        common.writeJSON(grunt, "dist/npm-shrinkwrap.json", npmShrinkwrapJSON);
-
-        var packageJSON = grunt.file.readJSON("package.json");
-        delete packageJSON.devDependencies;
-        delete packageJSON.scripts; // we don't want to run post-install scripts in dist folder
-        common.writeJSON(grunt, "dist/package.json", packageJSON);
-
         var done = this.async();
         runNpmInstall("dist", function (err) {
+            return err ? done(false) : done();
+        });
+    });
+
+    grunt.registerTask("npm-install-src", "Install node_modules to the src folder", function () {
+        var done = this.async();
+        runNpmInstall("src", function (err) {
             return err ? done(false) : done();
         });
     });
@@ -79,5 +78,11 @@ module.exports = function (grunt) {
             });
         });
     });
+
+    grunt.registerTask(
+        "npm-install-source",
+        "Install node_modules for src folder and default extensions which have package.json defined",
+        ["npm-install-src", "npm-install-extensions"]
+    );
 
 };

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -38,9 +38,17 @@ require.config({
     },
     map: {
         "*": {
-            "thirdparty/react":	"react"
+            "thirdparty/CodeMirror2": "thirdparty/CodeMirror",
+            "thirdparty/react":       "react"
         }
-    }
+    },
+    packages: [
+        {
+            name: "thirdparty/CodeMirror",
+            location: "node_modules/codemirror",
+            main: "lib/codemirror"
+        }
+    ]
 });
 
 define(function (require, exports, module) {


### PR DESCRIPTION
Alternative to #12963
I was wondering if, instead of this approach, we could use some other tool to copy `node_modules` like using browserify, webpack or others.

Ref #12940