### PR TITLE
fixes 3 failing find-in-files tests

### DIFF
--- a/src/search/SearchModel.js
+++ b/src/search/SearchModel.js
@@ -111,6 +111,7 @@ define(function (require, exports, module) {
      * Clears out the model to an empty state.
      */
     SearchModel.prototype.clear = function () {
+        var numMatchesBefore = this.numMatches;
         this.results = {};
         this.queryInfo = null;
         this.queryExpr = null;
@@ -120,7 +121,9 @@ define(function (require, exports, module) {
         this.numMatches = 0;
         this.foundMaximum = false;
         this.exceedsMaximum = false;
-        this.fireChanged();
+        if (numMatchesBefore !== 0) {
+            this.fireChanged();
+        }
     };
 
     /**

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -785,7 +785,8 @@ define(function (require, exports, module) {
                 gotChange = false;
                 oldResults = null;
                 wasQuickChange = false;
-                FindInFiles.searchModel.clear();
+
+                FindInFiles.clearSearch(); // calls FindInFiles.searchModel.clear internally
                 FindInFiles.searchModel.on("change.FindInFilesTest", function (event, quickChange) {
                     gotChange = true;
                     wasQuickChange = quickChange;

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -785,6 +785,7 @@ define(function (require, exports, module) {
                 gotChange = false;
                 oldResults = null;
                 wasQuickChange = false;
+                FindInFiles.searchModel.clear();
                 FindInFiles.searchModel.on("change.FindInFilesTest", function (event, quickChange) {
                     gotChange = true;
                     wasQuickChange = quickChange;


### PR DESCRIPTION
this PR fixes:
```
should add matches for a new file
should remove matches for a deleted file
should remove matches for a deleted folder
```
on my windows machine
ref: https://github.com/adobe/brackets/pull/12951