### PR TITLE
Fix for #12970: Non-default languages and user preferences bug

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.9.0-0",

--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.9.0-0",

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -997,6 +997,12 @@ define(function (require, exports, module) {
                 delete _pendingLanguages[id];
             });
         }
+        
+        // Non-default languages should update prefs to fix any invalid mappings
+        if(_defaultLanguagesJSON[id] === undefined) {
+            _updateFromPrefs(_EXTENSION_MAP_PREF);
+            _updateFromPrefs(_NAME_MAP_PREF);
+        }
 
         return result.promise();
     }

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1005,6 +1005,7 @@ define(function (require, exports, module) {
                 delete _pendingLanguages[id];
             });
         }
+
         return result.promise();
     }
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -963,11 +963,9 @@ define(function (require, exports, module) {
             _languages[language.getId()] = language;
 
             // restore any preferences for non-default languages
-            if(!_defaultLanguagesJSON[language.getId()]) {
-                if(PreferencesManager) {
-                    _updateFromPrefs(_EXTENSION_MAP_PREF);
-                    _updateFromPrefs(_NAME_MAP_PREF);
-                }
+            if(PreferencesManager) {
+                _updateFromPrefs(_EXTENSION_MAP_PREF);
+                _updateFromPrefs(_NAME_MAP_PREF);
             }
         }
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -666,6 +666,11 @@ define(function (require, exports, module) {
             }
 
             this._wasModified();
+        } else if(!_fileExtensionToLanguageMap[extension]) {
+            
+            // Language should be in the extension map but isn't
+            _fileExtensionToLanguageMap[extension] = this;
+            this._wasModified();
         }
     };
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1084,6 +1084,33 @@ define(function (require, exports, module) {
                 _restoreOverriddenDefault(name, state);
             }
         });
+
+        // Look for invalid mappings and correct/restore them
+        newNames.forEach(function(name) {
+            var prefsLanguage = getLanguage(newMapping[name]),
+                currentLanguage = exports[state.get](name);
+
+            if(prefsLanguage) {
+                // If the current language doesn't match the prefs language, update it
+                if(currentLanguage && currentLanguage.getId() !== prefsLanguage.getId()) {
+                    currentLanguage[state.remove](name);
+                    if(!overridden[name]) {
+                        overridden[name] = currentLanguage.getId();
+                    }
+                    prefsLanguage[state.add](name);
+                }
+
+                // If the current language is undefined, use the language in prefs
+                if(!currentLanguage) {
+                    prefsLanguage[state.add](name);
+                }
+            } else {
+                // If the language in prefs doesn't exist and is overriding a default, restore it
+                if(overridden[name]) {
+                    _restoreOverriddenDefault(name, state);
+                }
+            }
+        });
         state.last = newMapping;
     }
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1084,33 +1084,6 @@ define(function (require, exports, module) {
                 _restoreOverriddenDefault(name, state);
             }
         });
-
-        // Look for invalid mappings and correct/restore them
-        newNames.forEach(function(name) {
-            var prefsLanguage = getLanguage(newMapping[name]),
-                currentLanguage = exports[state.get](name);
-
-            if(prefsLanguage) {
-                // If the current language doesn't match the prefs language, update it
-                if(currentLanguage && currentLanguage.getId() !== prefsLanguage.getId()) {
-                    currentLanguage[state.remove](name);
-                    if(!overridden[name]) {
-                        overridden[name] = currentLanguage.getId();
-                    }
-                    prefsLanguage[state.add](name);
-                }
-
-                // If the current language is undefined, use the language in prefs
-                if(!currentLanguage) {
-                    prefsLanguage[state.add](name);
-                }
-            } else {
-                // If the language in prefs doesn't exist and is overriding a default, restore it
-                if(overridden[name]) {
-                    _restoreOverriddenDefault(name, state);
-                }
-            }
-        });
         state.last = newMapping;
     }
 

--- a/src/language/LanguageManager.js
+++ b/src/language/LanguageManager.js
@@ -1082,6 +1082,15 @@ define(function (require, exports, module) {
                     language[state.add](name);
                 }
             }
+            if(!getLanguage(newMapping[name])) {
+                
+                // If the language doesn't exist, restore any overrides and remove it
+                // from the state.
+                if(overridden[name]) {
+                    _restoreOverriddenDefault(name, state);
+                }
+                delete newMapping[name];
+            }
         });
 
         // Look for removed names (extensions or filenames)
@@ -1090,17 +1099,6 @@ define(function (require, exports, module) {
             if (language) {
                 language[state.remove](name);
                 _restoreOverriddenDefault(name, state);
-            }
-        });
-
-        // Look for invalid mappings and remove them
-        newNames.forEach(function(name) {
-            var language = getLanguage(newMapping[name]);
-            if(!language) {
-                if(overridden[name]) {
-                    _restoreOverriddenDefault(name, state);
-                }
-                delete newMapping[name];
             }
         });
         state.last = newMapping;

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -849,6 +849,22 @@ define(function (require, exports, module) {
                 language = LanguageManager.getLanguageForPath("Gemfile");
                 expect(language.getId()).toBe("ruby");
             });
+
+            it("should manage preferences for non-default languages", function() {
+                var language,
+                    def = { id: "test", name: "Test", mode: ["null", "text/plain"] };
+                PreferencesManager.set(LanguageManager._EXTENSION_MAP_PREF, {
+                    extension: "test"
+                });
+                PreferencesManager.set(LanguageManager._NAME_MAP_PREF, {
+                    filename: "test"
+                });
+                defineLanguage(def);
+                language = LanguageManager.getLanguageForExtension("extension");
+                expect(language.getId()).toBe("test");
+                language = LanguageManager.getLanguageForPath("filename");
+                expect(language.getId()).toBe("test");
+            });
         });
 
         describe("isBinary", function () {


### PR DESCRIPTION
This fixes #12970 by removing invalid mappings from the preference state, occurring when a language has not been loaded yet. When the language is eventually loaded, an `_updateFromPrefs` call restores the preferences.