### PR TITLE
Fix for #12997: Live preview breaks on reload w/out editor

### DIFF
--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -102,6 +102,8 @@ define(function HTMLDocumentModule(require, exports, module) {
         var body;
         if (this._instrumentationEnabled && this.editor) {
             body = HTMLInstrumentation.generateInstrumentedHTML(this.editor);
+        } else if (this._instrumentationEnabled && this.doc._masterEditor) {
+            body = HTMLInstrumentation.generateInstrumentedHTML(this.doc._masterEditor);
         }
 
         return {

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -100,10 +100,13 @@ define(function HTMLDocumentModule(require, exports, module) {
      */
     HTMLDocument.prototype.getResponseData = function getResponseData(enabled) {
         var body;
-        if (this._instrumentationEnabled && this.editor) {
-            body = HTMLInstrumentation.generateInstrumentedHTML(this.editor);
-        } else if (this._instrumentationEnabled && this.doc._masterEditor) {
-            body = HTMLInstrumentation.generateInstrumentedHTML(this.doc._masterEditor);
+        if(this._instrumentationEnabled) {
+            if(this.editor) {
+                body = HTMLInstrumentation.generateInstrumentedHTML(this.editor);
+            } else {
+                this.doc._ensureMasterEditor();
+                body = HTMLInstrumentation.generateInstrumentedHTML(this.doc._masterEditor);
+            }
         }
 
         return {

--- a/src/LiveDevelopment/Documents/HTMLDocument.js
+++ b/src/LiveDevelopment/Documents/HTMLDocument.js
@@ -100,8 +100,8 @@ define(function HTMLDocumentModule(require, exports, module) {
      */
     HTMLDocument.prototype.getResponseData = function getResponseData(enabled) {
         var body;
-        if(this._instrumentationEnabled) {
-            if(this.editor) {
+        if (this._instrumentationEnabled) {
+            if (this.editor) {
                 body = HTMLInstrumentation.generateInstrumentedHTML(this.editor);
             } else {
                 this.doc._ensureMasterEditor();

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -1103,7 +1103,9 @@ define(function (require, exports, module) {
             it("should reload the page when editing a non-live document", function () {
                 var promise,
                     jsdoc,
-                    loadEventPromise;
+                    loadEventPromise,
+                    liveDoc,
+                    liveResponse;
 
                 runs(function () {
                     // Setup reload spy
@@ -1157,6 +1159,17 @@ define(function (require, exports, module) {
 
                 runs(function () {
                     expect(Inspector.Page.reload.callCount).toEqual(2);
+                });
+
+                waitForLiveDoc(tempDir + "/simple1.html", function (doc) {
+                    liveDoc = doc;
+                    liveResponse = doc.getResponseData();
+                });
+
+                runs(function () {
+                    // Make sure a reload without an editor still sends back instrumented HTML
+                    expect(liveDoc.editor).toBe(null);
+                    expect(liveResponse.body.indexOf("data-brackets-id")).not.toBe(-1);
                 });
             });
 


### PR DESCRIPTION
This should fix #12997  by making sure an editor is present when sending instrumented HTML back to the browser.

Updated an existing unit test to account for this bug (creating a new one seemed unnecessary)