### PR TITLE
Update Brackets-Linux-Guide link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Linux version has most of the features of the Mac and Windows versions, but
 is still missing a few things. See the [Linux wiki page](https://github.com/adobe/brackets/wiki/Linux-Version)
 for a list of known issues and to find out how you can help.
 
-Additionally, for a list of common Linux installation issues and workarounds you can [visit this guide](https://nathanjplummer.github.io/Brackets/).
+Additionally, for a list of common Linux installation issues and workarounds you can [visit this guide](https://github.com/adobe/brackets/wiki/Brackets-Linux-Guide).
 
 
 #### Usage


### PR DESCRIPTION
This PR updates the Brackets Linux guide link to point to the Wiki, which contains all the material in the other link plus additional debugging help.