### PR TITLE
 Updated default dark-theme to hightlight errors

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -59,7 +59,7 @@
         color: #fff;
     }
     .inline-widget .CodeMirror-gutter-elt {
-        color: #767676;    
+        color: #767676;
     }
 }
 
@@ -68,11 +68,12 @@
 .cm-def, .cm-property {color: #b77fdb;}
 .cm-variable, .cm-variable-2, .cm-variable-3, .cm-operator, .cm-meta, .cm-bracket {color: @foreground;}
 .cm-comment {color: #767676;}
-.cm-error, .cm-minus {color: #dc322f;}
+.cm-minus {color: #dc322f;}
 .cm-header {color: #d85896;}
 .cm-link {color: #b77fdb; text-decoration: none;}
 .cm-rangeinfo {color: #6c71c4;}
 .cm-keyword, .cm-qualifier, .cm-builtin, .cm-tag, .cm-quote {color: #6c9ef8;}
+.cm-error {color: #dc322f;}
 
 /* Extra CSS */
 


### PR DESCRIPTION
Updated the default dark theme to ensure that .cm-error gets applied
last.


Before:
<img width="1003" alt="screen shot 2017-01-26 at 4 17 08 pm" src="https://cloud.githubusercontent.com/assets/179895/22356160/22716b1e-e3e4-11e6-87cf-870c626c986e.png">


After: 
<img width="997" alt="screen shot 2017-01-26 at 4 17 49 pm" src="https://cloud.githubusercontent.com/assets/179895/22356163/2752cda8-e3e4-11e6-8440-8f4fb5ac696f.png">

This pull request fixes issue https://github.com/adobe/brackets/issues/13057

