### PR TITLE
Added Extension Sorting capability according to downloads and last published date

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -108,6 +108,9 @@ define(function (require, exports, module) {
         _idsToDisable = {};
 
     PreferencesManager.stateManager.definePreference(FOLDER_AUTOINSTALL, "object", undefined);
+    PreferencesManager.definePreference("extensions.sort", "string", "publishedDate", {
+        description: Strings.SORT_EXTENSION_METHOD
+    });
 
     /**
      * @private

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
         KeyEvent                    = require("utils/KeyEvent"),
         ExtensionManager            = require("extensibility/ExtensionManager"),
         ExtensionManagerView        = require("extensibility/ExtensionManagerView").ExtensionManagerView,
-        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel");
+        ExtensionManagerViewModel   = require("extensibility/ExtensionManagerViewModel"),
+        PreferencesManager          = require("preferences/PreferencesManager");
 
     var dialogTemplate    = require("text!htmlContent/extension-manager-dialog.html");
 
@@ -372,6 +373,11 @@ define(function (require, exports, module) {
             if (models[_activeTabIndex]) {
                 $modalDlg.scrollTop(models[_activeTabIndex].scrollPos || 0);
                 clearSearch();
+                if (_activeTabIndex === 2) {
+                    $(".ext-sort-group").hide();
+                } else {
+                    $(".ext-sort-group").show();
+                }
             }
         }
 
@@ -460,6 +466,18 @@ define(function (require, exports, module) {
                     $modalDlg.scrollTop(0);
                 });
             }).on("click", ".search-clear", clearSearch);
+            
+            // Sort the extension list based on the current selected sorting criteria
+            $dlg.on("change", ".sort-extensions", function (e) {
+                var sortBy = $(this).val();
+                PreferencesManager.set("extensions.sort", sortBy);
+                models.forEach(function (model, index) {
+                    if (index <= 1) {
+                        model._setSortedExtensionList(ExtensionManager.extensions, index === 1);
+                        views[index].filter($(".search").val());
+                    }
+                });
+            });
 
             // Disable the search field when there are no items in the model
             models.forEach(function (model, index) {

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -498,6 +498,11 @@ define(function (require, exports, module) {
             } else { // Otherwise show the first tab
                 $dlg.find(".nav-tabs a:first").tab("show");
             }
+            if ($activeTab.hasClass("installed")) {
+                $(".ext-sort-group").hide();
+            } else {
+                $(".ext-sort-group").show();
+            }
         });
 
         // Handle the 'Install from URL' button.

--- a/src/extensibility/ExtensionManagerView.js
+++ b/src/extensibility/ExtensionManagerView.js
@@ -36,7 +36,8 @@ define(function (require, exports, module) {
         LanguageManager           = require("language/LanguageManager"),
         Mustache                  = require("thirdparty/mustache/mustache"),
         PathUtils                 = require("thirdparty/path-utils/path-utils"),
-        itemTemplate              = require("text!htmlContent/extension-manager-view-item.html");
+        itemTemplate              = require("text!htmlContent/extension-manager-view-item.html"),
+        PreferencesManager        = require("preferences/PreferencesManager");
         
 
     /**
@@ -71,6 +72,7 @@ define(function (require, exports, module) {
         this._$infoMessage = $("<div class='info-message'/>")
             .appendTo(this.$el).html(this.model.infoMessage);
         this._$table = $("<table class='table'/>").appendTo(this.$el);
+        $(".sort-extensions").val(PreferencesManager.get("extensions.sort"));
 
         this.model.initialize().done(function () {
             self._setupEventHandlers();
@@ -248,6 +250,7 @@ define(function (require, exports, module) {
                 var installWarningBase = context.requiresNewer ? Strings.EXTENSION_LATEST_INCOMPATIBLE_NEWER : Strings.EXTENSION_LATEST_INCOMPATIBLE_OLDER;
                 context.installWarning = StringUtils.format(installWarningBase, entry.registryInfo.versions[entry.registryInfo.versions.length - 1].version, latestVerCompatInfo.compatibleVersion);
             }
+            context.downloadCount = entry.registryInfo.totalDownloads;
         } else {
             // We should only get here when viewing the Installed tab and some extensions don't exist in the registry
             // (or registry is offline). These flags *should* always be ignored in that scenario, but just in case...

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -28,10 +28,11 @@ define(function (require, exports, module) {
 
     var _ = require("thirdparty/lodash");
 
-    var ExtensionManager = require("extensibility/ExtensionManager"),
-        registry_utils   = require("extensibility/registry_utils"),
-        EventDispatcher  = require("utils/EventDispatcher"),
-        Strings          = require("strings");
+    var ExtensionManager    = require("extensibility/ExtensionManager"),
+        registry_utils      = require("extensibility/registry_utils"),
+        EventDispatcher     = require("utils/EventDispatcher"),
+        Strings             = require("strings"),
+        PreferencesManager  = require("preferences/PreferencesManager");
 
     /**
      * @private
@@ -293,12 +294,12 @@ define(function (require, exports, module) {
     };
 
     ExtensionManagerViewModel.prototype._setSortedExtensionList = function (extensions, isTheme) {
-        this.filterSet = this.sortedFullSet = registry_utils.sortRegistry(extensions, "registryInfo")
+        this.filterSet = this.sortedFullSet = registry_utils.sortRegistry(extensions, "registryInfo", PreferencesManager.get("extensions.sort"))
             .filter(function (entry) {
                 if (!isTheme) {
-                    return entry.registryInfo !== undefined && !isTheme && entry.registryInfo.metadata.theme === undefined;
+                    return entry.registryInfo && !entry.registryInfo.metadata.theme;
                 } else {
-                    return entry.registryInfo !== undefined && entry.registryInfo.metadata.theme;
+                    return entry.registryInfo && entry.registryInfo.metadata.theme;
                 }
             })
             .map(function (entry) {

--- a/src/extensibility/ExtensionManagerViewModel.js
+++ b/src/extensibility/ExtensionManagerViewModel.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
 
     var ExtensionManager = require("extensibility/ExtensionManager"),
         registry_utils   = require("extensibility/registry_utils"),
-        EventDispatcher = require("utils/EventDispatcher"),
+        EventDispatcher  = require("utils/EventDispatcher"),
         Strings          = require("strings");
 
     /**
@@ -292,6 +292,20 @@ define(function (require, exports, module) {
             });
     };
 
+    ExtensionManagerViewModel.prototype._setSortedExtensionList = function (extensions, isTheme) {
+        this.filterSet = this.sortedFullSet = registry_utils.sortRegistry(extensions, "registryInfo")
+            .filter(function (entry) {
+                if (!isTheme) {
+                    return entry.registryInfo !== undefined && !isTheme && entry.registryInfo.metadata.theme === undefined;
+                } else {
+                    return entry.registryInfo !== undefined && entry.registryInfo.metadata.theme;
+                }
+            })
+            .map(function (entry) {
+                return entry.registryInfo.metadata.name;
+            });
+    };
+
     /**
      * The model for the ExtensionManagerView that is responsible for handling registry-based extensions.
      * This extends ExtensionManagerViewModel.
@@ -329,13 +343,7 @@ define(function (require, exports, module) {
                 self.extensions = ExtensionManager.extensions;
 
                 // Sort the registry by last published date and store the sorted list of IDs.
-                self.sortedFullSet = registry_utils.sortRegistry(self.extensions, "registryInfo")
-                    .filter(function (entry) {
-                        return entry.registryInfo !== undefined && entry.registryInfo.metadata.theme === undefined;
-                    })
-                    .map(function (entry) {
-                        return entry.registryInfo.metadata.name;
-                    });
+                self._setSortedExtensionList(ExtensionManager.extensions, false);
                 self._setInitialFilter();
             })
             .fail(function () {
@@ -536,13 +544,7 @@ define(function (require, exports, module) {
                 self.extensions = ExtensionManager.extensions;
 
                 // Sort the registry by last published date and store the sorted list of IDs.
-                self.sortedFullSet = registry_utils.sortRegistry(self.extensions, "registryInfo")
-                    .filter(function (entry) {
-                        return entry.registryInfo !== undefined && entry.registryInfo.metadata.theme;
-                    })
-                    .map(function (entry) {
-                        return entry.registryInfo.metadata.name;
-                    });
+                self._setSortedExtensionList(ExtensionManager.extensions, true);
                 self._setInitialFilter();
             })
             .fail(function () {

--- a/src/extensibility/registry_utils.js
+++ b/src/extensibility/registry_utils.js
@@ -31,8 +31,6 @@
 
 define(function (require, exports, module) {
     "use strict";
-    
-    var PreferencesManager  = require("preferences/PreferencesManager");
 
     // From Brackets StringUtils
     function htmlEscape(str) {
@@ -122,7 +120,7 @@ define(function (require, exports, module) {
      *     we should look at the top level of the object.
      * @return {Array} Sorted array of registry entries.
      */
-    exports.sortRegistry = function (registry, subkey) {
+    exports.sortRegistry = function (registry, subkey, sortBy) {
         function getPublishTime(entry) {
             if (entry.versions) {
                 return new Date(entry.versions[entry.versions.length - 1].published).getTime();
@@ -138,7 +136,7 @@ define(function (require, exports, module) {
             sortedEntries.push(registry[key]);
         });
         sortedEntries.sort(function (entry1, entry2) {
-            if (PreferencesManager.get("extensions.sort") !== "publishedDate") {
+            if (sortBy !== "publishedDate") {
                 if (entry1.registryInfo && entry2.registryInfo) {
                     return entry2.registryInfo.totalDownloads - entry1.registryInfo.totalDownloads;
                 } else {

--- a/src/extensibility/registry_utils.js
+++ b/src/extensibility/registry_utils.js
@@ -31,6 +31,8 @@
 
 define(function (require, exports, module) {
     "use strict";
+    
+    var PreferencesManager  = require("preferences/PreferencesManager");
 
     // From Brackets StringUtils
     function htmlEscape(str) {
@@ -136,8 +138,16 @@ define(function (require, exports, module) {
             sortedEntries.push(registry[key]);
         });
         sortedEntries.sort(function (entry1, entry2) {
-            return getPublishTime((subkey && entry2[subkey]) || entry2) -
-                getPublishTime((subkey && entry1[subkey]) || entry1);
+            if (PreferencesManager.get("extensions.sort") !== "publishedDate") {
+                if (entry1.registryInfo && entry2.registryInfo) {
+                    return entry2.registryInfo.totalDownloads - entry1.registryInfo.totalDownloads;
+                } else {
+                    return Number.NEGATIVE_INFINITY;
+                }
+            } else {
+                return getPublishTime((subkey && entry2[subkey]) || entry2) -
+                    getPublishTime((subkey && entry1[subkey]) || entry1);
+            }
         });
 
         return sortedEntries;

--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -9,6 +9,11 @@
             <li><a href="#installed" class="installed" data-toggle="tab"><span class="notification"></span><img src="styles/images/extension-manager-installed.svg"/><br/>{{Strings.EXTENSIONS_INSTALLED_TITLE}}</a></li>
         </ul>
         <div>
+            <span class="sort-extensions-title ext-sort-group">{{Strings.EXTENSIONS_SORT_BY}}</span>
+            <select class="sort-extensions ext-sort-group">
+                <option value="publishedDate">{{Strings.EXTENSIONS_LAST_UPDATED}}</option>
+                <option value="downloadCount">{{Strings.EXTENSIONS_DOWNLOADS}}</option>
+            </select>
             <button class="search-clear">&times;</button>
             <input class="search" type="text" placeholder="{{EXTENSION_SEARCH_PLACEHOLDER}}">
         </div>

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -9,7 +9,7 @@
             <span class="muted ext-date"> &mdash; {{lastVersionDate}}</span>
         {{/hasVersionInfo}}
         {{#downloadCount}}
-            <p title="{{downloadCount}} {{Strings.EXTENSIONS_DOWNLOADS}}">&#x21F2; {{downloadCount}}</p>
+            <p title="{{downloadCount}} {{Strings.EXTENSIONS_DOWNLOADS}}"><img src="styles/images/download-icon.svg"/> {{downloadCount}}</p>
         {{/downloadCount}}
     </td>
     <td class="ext-desc">

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -8,6 +8,7 @@
         {{#hasVersionInfo}}
             <span class="muted ext-date"> &mdash; {{lastVersionDate}}</span>
         {{/hasVersionInfo}}
+        <p title="{{downloadCount}} {{Strings.EXTENSIONS_DOWNLOADS}}">&#x21F2; {{downloadCount}}</p>
     </td>
     <td class="ext-desc">
         {{#showInstallButton}}

--- a/src/htmlContent/extension-manager-view-item.html
+++ b/src/htmlContent/extension-manager-view-item.html
@@ -8,7 +8,9 @@
         {{#hasVersionInfo}}
             <span class="muted ext-date"> &mdash; {{lastVersionDate}}</span>
         {{/hasVersionInfo}}
-        <p title="{{downloadCount}} {{Strings.EXTENSIONS_DOWNLOADS}}">&#x21F2; {{downloadCount}}</p>
+        {{#downloadCount}}
+            <p title="{{downloadCount}} {{Strings.EXTENSIONS_DOWNLOADS}}">&#x21F2; {{downloadCount}}</p>
+        {{/downloadCount}}
     </td>
     <td class="ext-desc">
         {{#showInstallButton}}

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -503,6 +503,7 @@ define({
     "INSTALL_CANCELED"                     : "Installation canceled.",
     "VIEW_COMPLETE_DESCRIPTION"            : "View complete description",
     "VIEW_TRUNCATED_DESCRIPTION"           : "View truncated description",
+    "SORT_EXTENSION_METHOD"                : "Sort Extensions using downloadCount or publishedDate",
     // These must match the error codes in ExtensionsDomain.Errors.* :
     "INVALID_ZIP_FILE"                     : "The downloaded content is not a valid zip file.",
     "MISSING_PACKAGE_JSON"                 : "The package has no package.json file.",
@@ -579,6 +580,9 @@ define({
     "EXTENSIONS_AVAILABLE_TITLE"           : "Available",
     "EXTENSIONS_THEMES_TITLE"              : "Themes",
     "EXTENSIONS_UPDATES_TITLE"             : "Updates",
+    "EXTENSIONS_SORT_BY"                   : "Sort By",
+    "EXTENSIONS_LAST_UPDATED"              : "Last Updated",
+    "EXTENSIONS_DOWNLOADS"                 : "Downloads",
 
     "INLINE_EDITOR_NO_MATCHES"             : "No matches available.",
     "INLINE_EDITOR_HIDDEN_MATCHES"         : "All matches are collapsed. Expand the files listed at right to view matches.",

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1183,6 +1183,17 @@ a[href^="http"] {
                 opacity: 0.3;
             }
         }
+        .sort-extensions-title {
+            float: left;
+            margin-right: 5px;
+            margin-top: 5px;
+        }
+        .sort-extensions {
+            float: left;
+            margin-right: 10px;
+            width: auto;
+            padding-right: 18px;
+        }
     }
     .modal-body {
         height: 400px;

--- a/src/styles/images/download-icon.svg
+++ b/src/styles/images/download-icon.svg
@@ -1,0 +1,19 @@
+<svg id="S_Download_18_N" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 18 18">
+  <defs>
+    <style>
+      .cls-1, .cls-2 {
+        fill: #707070;
+      }
+
+      .cls-2 {
+        fill-rule: evenodd;
+      }
+
+      
+    </style>
+  </defs>
+  <title>S_Download_18_N</title>
+  <path class="cls-1" d="M8.25,1h1.5a0.25,0.25,0,0,1,.25.25V10a0,0,0,0,1,0,0H8a0,0,0,0,1,0,0V1.25A0.25,0.25,0,0,1,8.25,1Z"/>
+  <path class="cls-2" d="M9,14L5.427,10.427A0.25,0.25,0,0,1,5.6,10H12.4a0.25,0.25,0,0,1,.177.427Z" transform="translate(0 0)"/>
+  <path class="cls-2" d="M15,13.25V15H3V13.25A0.25,0.25,0,0,0,2.75,13H1.25a0.25,0.25,0,0,0-.25.25V16.5a0.5,0.5,0,0,0,.5.5h15a0.5,0.5,0,0,0,.5-0.5V13.25A0.25,0.25,0,0,0,16.75,13h-1.5A0.25,0.25,0,0,0,15,13.25Z" transform="translate(0 0)"/>
+  </svg>

--- a/test/spec/ExtensionManager-test-files/mockRegistry.json
+++ b/test/spec/ExtensionManager-test-files/mockRegistry.json
@@ -20,7 +20,8 @@
         "published": "2013-04-10T18:21:27.058Z",
         "brackets": ">0.20.0"
       }
-    ]
+    ],
+    "totalDownloads": 10
   },
   "long-desc-extension": {
     "metadata": {
@@ -42,7 +43,8 @@
         "version": "1.0.0",
         "published": "2013-04-10T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 184
   },
   "mock-extension-1": {
     "metadata": {
@@ -65,7 +67,8 @@
         "version": "1.0.0",
         "published": "2013-04-11T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 190
   },
   "mock-extension-2": {
     "metadata": {
@@ -79,7 +82,8 @@
         "version": "1.0.0",
         "published": "2013-04-11T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 88
   },
   "mock-extension-3": {
     "metadata": {
@@ -93,7 +97,8 @@
         "version": "1.0.0",
         "published": "2013-04-11T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 34
   },
   "mock-extension-4": {
     "metadata": {
@@ -107,7 +112,8 @@
         "version": "1.0.0",
         "published": "2013-04-11T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 20
   },
   "malicious-script-extension": {
     "metadata": {
@@ -122,7 +128,8 @@
         "version": "1.0.0",
         "published": "2013-04-10T18:26:24.956Z"
       }
-    ]
+    ],
+    "totalDownloads": 781
   },
   "select-parent": {
     "metadata": {
@@ -147,7 +154,8 @@
         "published": "2013-04-10T18:26:47.580Z",
         "brackets": ">0.22.0"
       }
-    ]
+    ],
+    "totalDownloads": 101
   },
   "basic-valid-extension": {
     "metadata": {
@@ -165,7 +173,8 @@
         "version": "3.0.0",
         "published": "2013-04-10T18:29:11.907Z"
       }
-    ]
+    ],
+    "totalDownloads": 130
   },
   "everyscrub": {
     "metadata": {
@@ -179,6 +188,7 @@
         "version": "0.23.0",
         "published": "2013-04-11T17:22:38.033Z"
       }
-    ]
+    ],
+    "totalDownloads": 101
   }
 }

--- a/test/spec/ExtensionManager-test-files/mockRegistryForSearch.json
+++ b/test/spec/ExtensionManager-test-files/mockRegistryForSearch.json
@@ -19,7 +19,8 @@
         "published": "2013-04-10T18:21:27.058Z",
         "brackets": ">0.20.0"
       }
-    ]
+    ],
+    "totalDownloads": 10
   },
   "item-2": {
     "metadata": {
@@ -36,7 +37,8 @@
         "version": "1.0.0",
         "published": "2013-04-10T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 5
   },
   "item-3": {
     "metadata": {
@@ -53,7 +55,8 @@
         "version": "1.0.0",
         "published": "2013-04-10T13:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 11
   },
   "item-4": {
     "metadata": {
@@ -71,7 +74,8 @@
         "version": "1.0.0",
         "published": "2013-04-10T15:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 12
   },
   "item-5": {
     "metadata": {
@@ -89,7 +93,8 @@
         "version": "1.0.0",
         "published": "2013-04-16T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 2
   },
   "item-6": {
     "metadata": {
@@ -111,6 +116,7 @@
         "version": "1.0.0",
         "published": "2013-04-15T18:26:20.553Z"
       }
-    ]
+    ],
+    "totalDownloads": 100
   }
 }

--- a/test/spec/ExtensionManager-test-files/mockRegistryThemes.json
+++ b/test/spec/ExtensionManager-test-files/mockRegistryThemes.json
@@ -188,7 +188,8 @@
         "version": "0.0.1",
         "published": "2014-08-31T04:05:47.778Z"
       }
-    ]
+    ],
+    "totalDownloads": 80
   },
   "theme-2": {
     "metadata": {
@@ -205,6 +206,7 @@
         "version": "1.0.1",
         "published": "2014-07-31T04:05:47.778Z"
       }
-    ]
+    ],
+    "totalDownloads": 99
   }
 }

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -48,6 +48,7 @@ define(function (require, exports, module) {
         Strings                   = require("strings"),
         StringUtils               = require("utils/StringUtils"),
         LocalizationUtils         = require("utils/LocalizationUtils"),
+        PreferencesManager        = require("preferences/PreferencesManager"),
         mockRegistryText          = require("text!spec/ExtensionManager-test-files/mockRegistry.json"),
         mockRegistryThemesText    = require("text!spec/ExtensionManager-test-files/mockRegistryThemes.json"),
         mockRegistryForSearch     = require("text!spec/ExtensionManager-test-files/mockRegistryForSearch.json"),
@@ -734,7 +735,15 @@ define(function (require, exports, module) {
                     expect(model.extensions).toEqual(ExtensionManager.extensions);
                 });
 
+                it("should start with the full set sorted in reverse download count order", function () {
+                    PreferencesManager.set("extensions.sort", "downloadCount");
+                    model._setSortedExtensionList(ExtensionManager.extensions, false);
+                    expect(model.filterSet).toEqual(["item-6", "item-4", "item-3", "find-uniq1-in-name", "item-2", "item-5"]);
+                });
+                
                 it("should start with the full set sorted in reverse publish date order", function () {
+                    PreferencesManager.set("extensions.sort", "publishedDate");
+                    model._setSortedExtensionList(ExtensionManager.extensions, false);
                     expect(model.filterSet).toEqual(["item-5", "item-6", "item-2", "find-uniq1-in-name", "item-4", "item-3"]);
                 });
 
@@ -828,6 +837,12 @@ define(function (require, exports, module) {
 
                 it("should start with the full set sorted in reverse publish date order", function () {
                     expect(model.filterSet).toEqual(["theme-1", "theme-2"]);
+                });
+                
+                it("should start with the full set sorted in reverse download count order", function () {
+                    PreferencesManager.set("extensions.sort", "downloadCount");
+                    model._setSortedExtensionList(ExtensionManager.extensions, true);
+                    expect(model.filterSet).toEqual(["theme-2", "theme-1"]);
                 });
             });
 

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -1297,7 +1297,8 @@ define(function (require, exports, module) {
 
                             // Simple fields
                             [item.metadata.version,
-                                item.metadata.author && item.metadata.author.name]
+                                item.metadata.author && item.metadata.author.name,
+                                item.totalDownloads]
                                 .forEach(function (value) {
                                     if (value) {
                                         expect(view).toHaveText(value);


### PR DESCRIPTION
Now on opening the Extension Manager, a drop-down is shown on the left side of the search bar, which indicates the sorting of extensions according to the selected criteria(currently sort methods available are  Last Updated and Download Count), on change of the selection we store the the changed selection in the preferences and if the Extension Manager is invoked again, then we use the same sorting criteria which was selected by user earlier. The sorting is available for Available and Theme Extensions.
I have attached a snapshot of the feature in use where the sort order and the download count has been highlighted for illustration. 

![downloadcount](https://cloud.githubusercontent.com/assets/5630113/22639343/937ad5d8-ec73-11e6-89aa-99ba11475ab1.png)
