### PR TITLE
Sync code hint font size with code view font size

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
+++ b/src/extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css
@@ -149,7 +149,6 @@ span.brackets-js-hints-with-type-details {
     color: #d4d4d4;
     word-wrap: break-word;	
     white-space: normal;
-    width:300px;
     box-sizing: border-box;
 }
 
@@ -163,12 +162,15 @@ span.brackets-js-hints-with-type-details {
     color: grey;
     word-wrap: break-word;
     white-space: normal;
-    width: 300px;
     box-sizing: border-box;
     float: left;
     clear: left;
-    max-height: 3em;
+    max-height: 2em;
     overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1em;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
 
 .dark .jshint-jsdoc {
@@ -219,7 +221,7 @@ span.brackets-js-hints-with-type-details {
 }
 
 .highlight .jshint-jsdoc {
-    display: block;
+    display: -webkit-box;
 }
 
 .dark .brackets-js-hints-type-details {

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -21,6 +21,8 @@
  *
  */
 
+/*global less */
+
 /**
  * The ViewCommandHandlers object dispatches the following event(s):
  *    - fontSizeChange -- Triggered when the font size is changed via the

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -72,6 +72,12 @@ define(function (require, exports, module) {
      * @type {string}
      */
     var DYNAMIC_CODEHINT_FONT_STYLE_ID = "codehint-dynamic-fonts";
+    
+    /**
+     * @const
+     * @type {string}
+     */
+    var DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID = "codehint-with-type-dynamic-width";
 
     /**
      * @const
@@ -110,6 +116,14 @@ define(function (require, exports, module) {
      * @type {string}
      */
     var DEFAULT_FONT_FAMILY = "'SourceCodePro-Medium', ＭＳ ゴシック, 'MS Gothic', monospace";
+    
+    /**
+     * @const
+     * @private
+     * The default hint span width for hints with annotated type details
+     * @type {number}
+     */
+    var DEFAULT_TYPED_HINT_SPAN_WIDTH = 300;
 
     /**
      * @private
@@ -119,19 +133,22 @@ define(function (require, exports, module) {
     function _removeDynamicProperty(propertyID) {
         $("#" + propertyID).remove();
     }
-
+    
     /**
      * @private
      * Add the style property to the DOM
      * @param {string} propertyID Is the property ID to be added
-     * @param {string} name Is the name of the style property
-     * @param {string} value Is the value of the style
-     * @param {boolean} important Is a flag to make the style property !important
+     * @param {object} ruleCfg Is the CSS Rule configuration object
+     * @param {string} ruleCfg.propName Is the name of the style property
+     * @param {string} ruleCfg.propValue Is the value of the style property
+     * @param {boolean} ruleCfg.priorityFlag Is a flag to make the style property !important
+     * @param {string} ruleCfg.ruleName Optional Selctor name to be used for the rule
+     * @param {string} ruleCfg.ruleText Optional selector definition text
      */
-    function _addDynamicProperty(propertyID, name, value, important, cssRule, cssText) {
-        cssRule = cssRule || ".CodeMirror";
+    function _addDynamicProperty(propertyID, ruleCfg) {
+        var cssRule = ruleCfg.ruleName || ".CodeMirror";
         var $style   = $("<style type='text/css'></style>").attr("id", propertyID);
-        var styleStr = cssText || StringUtils.format("{0}: {1} {2}", name, value, important ? " !important" : "");
+        var styleStr = ruleCfg.ruleText || StringUtils.format("{0}: {1} {2}", ruleCfg.propName, ruleCfg.propValue, ruleCfg.priorityFlag ? "!important" : "");
         $style.html(cssRule + "{ " + styleStr + " }");
 
         // Let's make sure we remove the already existing item from the DOM.
@@ -146,6 +163,7 @@ define(function (require, exports, module) {
     function _removeDynamicFontSize() {
         _removeDynamicProperty(DYNAMIC_FONT_STYLE_ID);
         _removeDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID);
+        _removeDynamicProperty(DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID);
     }
 
     /**
@@ -156,7 +174,22 @@ define(function (require, exports, module) {
         var styleStr = "";
         styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "font-size", fontSize, " !important");
         styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "line-height", (parseInt(fontSize, 10) + 2) + fontSize.replace(parseInt(fontSize, 10), ""), " !important");
-        _addDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID, "font-size", fontSize, true, ".codehint-menu .dropdown-menu li a", styleStr);
+        
+        _addDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID, {
+            propName: "font-size",
+            propValue: fontSize,
+            priorityFlag: true,
+            ruleName: ".codehint-menu .dropdown-menu li a",
+            ruleText: styleStr
+        });
+
+        _addDynamicProperty(DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID, {
+            propName: "width",
+            propValue: DEFAULT_TYPED_HINT_SPAN_WIDTH * (parseInt(fontSize, 10) / DEFAULT_FONT_SIZE) + "px",
+            priorityFlag: true,
+            ruleName: "span.brackets-js-hints-with-type-details",
+            ruleText: ""
+        });
     }
 
     /**
@@ -165,7 +198,11 @@ define(function (require, exports, module) {
      * @param {string} fontSize  A string with the font size and the size unit
      */
     function _addDynamicFontSize(fontSize) {
-        _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, "font-size", fontSize, true);
+        _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, {
+            propName: "font-size",
+            propValue: fontSize,
+            priorityFlag: true
+        });
 
         // Sync code-hint font size
         _addDynamicFontSizeForCodeHints(fontSize);
@@ -185,7 +222,10 @@ define(function (require, exports, module) {
      * @param {string} fontFamily  A string with the font family
      */
     function _addDynamicFontFamily(fontFamily) {
-        _addDynamicProperty(DYNAMIC_FONT_FAMILY_ID, "font-family", fontFamily);
+        _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, {
+            propName: "font-family",
+            propValue: fontFamily
+        });
     }
 
     /**

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -78,6 +78,12 @@ define(function (require, exports, module) {
      * @type {string}
      */
     var DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID = "codehint-with-type-dynamic-width";
+    
+    /**
+     * @const
+     * @type {string}
+     */
+    var DYNAMIC_CODEHINT_HEIGHT_STYLE_ID = "codehint-dynamic-height";
 
     /**
      * @const
@@ -124,6 +130,30 @@ define(function (require, exports, module) {
      * @type {number}
      */
     var DEFAULT_TYPED_HINT_SPAN_WIDTH = 300;
+    
+    /**
+     * @const
+     * @private
+     * The default hint menu max-height
+     * @type {number}
+     */
+    var DEFAULT_HINT_MENU_HEIGHT = 160;
+    
+    /**
+     * @const
+     * @private
+     * The default hint menu item line height offset
+     * @type {number}
+     */
+    var DEFAULT_HINT_MENU_LINE_HEIGHT_OFFSET = 7;
+    
+    /**
+     * @const
+     * @private
+     * The default number of visible menu items
+     * @type {number}
+     */
+    var DEFAULT_VISIBLE_HINT_MENU_ITEMS_COUNT = 8;
 
     /**
      * @private
@@ -155,7 +185,7 @@ define(function (require, exports, module) {
         _removeDynamicProperty(propertyID);
         $("head").append($style);
     }
-
+    
     /**
      * @private
      * Removes the styles used to update the font size
@@ -164,16 +194,18 @@ define(function (require, exports, module) {
         _removeDynamicProperty(DYNAMIC_FONT_STYLE_ID);
         _removeDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID);
         _removeDynamicProperty(DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID);
+        _removeDynamicProperty(DYNAMIC_CODEHINT_HEIGHT_STYLE_ID);
     }
 
     /**
      * @private
      * Adds a new embeded style top sync code-hint font size with codeview font size
+     * @param {string} fontSize  A string with the font size and the size unit
      */
     function _addDynamicFontSizeForCodeHints(fontSize) {
         var styleStr = "";
         styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "font-size", fontSize, " !important");
-        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "line-height", (parseInt(fontSize, 10) + 2) + fontSize.replace(parseInt(fontSize, 10), ""), " !important");
+        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "line-height", (parseInt(fontSize, 10) + 5) + fontSize.replace(parseInt(fontSize, 10), ""), " !important");
         
         _addDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID, {
             propName: "font-size",
@@ -188,6 +220,14 @@ define(function (require, exports, module) {
             propValue: DEFAULT_TYPED_HINT_SPAN_WIDTH * (parseInt(fontSize, 10) / DEFAULT_FONT_SIZE) + "px",
             priorityFlag: true,
             ruleName: "span.brackets-js-hints-with-type-details",
+            ruleText: ""
+        });
+        
+        _addDynamicProperty(DYNAMIC_CODEHINT_HEIGHT_STYLE_ID, {
+            propName: "max-height",
+            propValue: DEFAULT_VISIBLE_HINT_MENU_ITEMS_COUNT * (parseInt(fontSize, 10) + DEFAULT_HINT_MENU_LINE_HEIGHT_OFFSET) + "px",
+            priorityFlag: true,
+            ruleName: ".codehint-menu .dropdown-menu",
             ruleText: ""
         });
     }

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -66,6 +66,12 @@ define(function (require, exports, module) {
      * @type {string}
      */
     var DYNAMIC_FONT_STYLE_ID = "codemirror-dynamic-fonts";
+    
+    /**
+     * @const
+     * @type {string}
+     */
+    var DYNAMIC_CODEHINT_FONT_STYLE_ID = "codehint-dynamic-fonts";
 
     /**
      * @const
@@ -122,10 +128,10 @@ define(function (require, exports, module) {
      * @param {string} value Is the value of the style
      * @param {boolean} important Is a flag to make the style property !important
      */
-    function _addDynamicProperty(propertyID, name, value, important, cssRule) {
+    function _addDynamicProperty(propertyID, name, value, important, cssRule, cssText) {
         cssRule = cssRule || ".CodeMirror";
         var $style   = $("<style type='text/css'></style>").attr("id", propertyID);
-        var styleStr = StringUtils.format("{0}: {1}{2}", name, value, important ? " !important" : "");
+        var styleStr = cssText || StringUtils.format("{0}: {1} {2}", name, value, important ? " !important" : "");
         $style.html(cssRule + "{ " + styleStr + " }");
 
         // Let's make sure we remove the already existing item from the DOM.
@@ -139,6 +145,18 @@ define(function (require, exports, module) {
      */
     function _removeDynamicFontSize() {
         _removeDynamicProperty(DYNAMIC_FONT_STYLE_ID);
+        _removeDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID);
+    }
+
+    /**
+     * @private
+     * Adds a new embeded style top sync code-hint font size with codeview font size
+     */
+    function _addDynamicFontSizeForCodeHints(fontSize) {
+        var styleStr = "";
+        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "font-size", fontSize, " !important");
+        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "line-height", (parseInt(fontSize, 10) + 2) + fontSize.replace(parseInt(fontSize, 10), ""), " !important");
+        _addDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID, "font-size", fontSize, true, ".codehint-menu .dropdown-menu li a", styleStr);
     }
 
     /**
@@ -148,6 +166,9 @@ define(function (require, exports, module) {
      */
     function _addDynamicFontSize(fontSize) {
         _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, "font-size", fontSize, true);
+
+        // Sync code-hint font size
+        _addDynamicFontSizeForCodeHints(fontSize);
     }
 
     /**

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -42,7 +42,8 @@ define(function (require, exports, module) {
         ThemeSettings       = require("view/ThemeSettings"),
         MainViewManager     = require("view/MainViewManager"),
         AppInit             = require("utils/AppInit"),
-        _                   = require("thirdparty/lodash");
+        _                   = require("thirdparty/lodash"),
+        FontRuleTemplate    = require("text!view/fontrules/font-based-rules.less");
 
     var prefs = PreferencesManager.getExtensionPrefs("fonts");
 
@@ -66,24 +67,6 @@ define(function (require, exports, module) {
      * @type {string}
      */
     var DYNAMIC_FONT_STYLE_ID = "codemirror-dynamic-fonts";
-    
-    /**
-     * @const
-     * @type {string}
-     */
-    var DYNAMIC_CODEHINT_FONT_STYLE_ID = "codehint-dynamic-fonts";
-    
-    /**
-     * @const
-     * @type {string}
-     */
-    var DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID = "codehint-with-type-dynamic-width";
-    
-    /**
-     * @const
-     * @type {string}
-     */
-    var DYNAMIC_CODEHINT_HEIGHT_STYLE_ID = "codehint-dynamic-height";
 
     /**
      * @const
@@ -124,38 +107,6 @@ define(function (require, exports, module) {
     var DEFAULT_FONT_FAMILY = "'SourceCodePro-Medium', ＭＳ ゴシック, 'MS Gothic', monospace";
     
     /**
-     * @const
-     * @private
-     * The default hint span width for hints with annotated type details
-     * @type {number}
-     */
-    var DEFAULT_TYPED_HINT_SPAN_WIDTH = 300;
-    
-    /**
-     * @const
-     * @private
-     * The default hint menu max-height
-     * @type {number}
-     */
-    var DEFAULT_HINT_MENU_HEIGHT = 160;
-    
-    /**
-     * @const
-     * @private
-     * The default hint menu item line height offset
-     * @type {number}
-     */
-    var DEFAULT_HINT_MENU_LINE_HEIGHT_OFFSET = 7;
-    
-    /**
-     * @const
-     * @private
-     * The default number of visible menu items
-     * @type {number}
-     */
-    var DEFAULT_VISIBLE_HINT_MENU_ITEMS_COUNT = 8;
-
-    /**
      * @private
      * Removes style property from the DOM
      * @param {string} propertyID is the id of the property to be removed
@@ -176,10 +127,14 @@ define(function (require, exports, module) {
      * @param {string} ruleCfg.ruleText Optional selector definition text
      */
     function _addDynamicProperty(propertyID, ruleCfg) {
-        var cssRule = ruleCfg.ruleName || ".CodeMirror";
         var $style   = $("<style type='text/css'></style>").attr("id", propertyID);
-        var styleStr = ruleCfg.ruleText || StringUtils.format("{0}: {1} {2}", ruleCfg.propName, ruleCfg.propValue, ruleCfg.priorityFlag ? "!important" : "");
-        $style.html(cssRule + "{ " + styleStr + " }");
+        if (ruleCfg.ruleText) {
+            $style.html(ruleCfg.ruleText);
+        } else {
+            var cssRule = ruleCfg.ruleName || ".CodeMirror";
+            var styleStr = ruleCfg.ruleText || StringUtils.format("{0}: {1} {2}", ruleCfg.propName, ruleCfg.propValue, ruleCfg.priorityFlag ? "!important" : "");
+            $style.html(cssRule + "{ " + styleStr + " }");
+        }
 
         // Let's make sure we remove the already existing item from the DOM.
         _removeDynamicProperty(propertyID);
@@ -192,44 +147,6 @@ define(function (require, exports, module) {
      */
     function _removeDynamicFontSize() {
         _removeDynamicProperty(DYNAMIC_FONT_STYLE_ID);
-        _removeDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID);
-        _removeDynamicProperty(DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID);
-        _removeDynamicProperty(DYNAMIC_CODEHINT_HEIGHT_STYLE_ID);
-    }
-
-    /**
-     * @private
-     * Adds a new embeded style top sync code-hint font size with codeview font size
-     * @param {string} fontSize  A string with the font size and the size unit
-     */
-    function _addDynamicFontSizeForCodeHints(fontSize) {
-        var styleStr = "";
-        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "font-size", fontSize, " !important");
-        styleStr = styleStr + StringUtils.format("{0}: {1} {2};", "line-height", (parseInt(fontSize, 10) + 5) + fontSize.replace(parseInt(fontSize, 10), ""), " !important");
-        
-        _addDynamicProperty(DYNAMIC_CODEHINT_FONT_STYLE_ID, {
-            propName: "font-size",
-            propValue: fontSize,
-            priorityFlag: true,
-            ruleName: ".codehint-menu .dropdown-menu li a",
-            ruleText: styleStr
-        });
-
-        _addDynamicProperty(DYNAMIC_CODEHINT_WITH_TYPE_STYLE_ID, {
-            propName: "width",
-            propValue: DEFAULT_TYPED_HINT_SPAN_WIDTH * (parseInt(fontSize, 10) / DEFAULT_FONT_SIZE) + "px",
-            priorityFlag: true,
-            ruleName: "span.brackets-js-hints-with-type-details",
-            ruleText: ""
-        });
-        
-        _addDynamicProperty(DYNAMIC_CODEHINT_HEIGHT_STYLE_ID, {
-            propName: "max-height",
-            propValue: DEFAULT_VISIBLE_HINT_MENU_ITEMS_COUNT * (parseInt(fontSize, 10) + DEFAULT_HINT_MENU_LINE_HEIGHT_OFFSET) + "px",
-            priorityFlag: true,
-            ruleName: ".codehint-menu .dropdown-menu",
-            ruleText: ""
-        });
     }
 
     /**
@@ -238,14 +155,16 @@ define(function (require, exports, module) {
      * @param {string} fontSize  A string with the font size and the size unit
      */
     function _addDynamicFontSize(fontSize) {
-        _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, {
-            propName: "font-size",
-            propValue: fontSize,
-            priorityFlag: true
+        var template = FontRuleTemplate.split("{font-size-param}").join(fontSize);
+        less.render(template, null, function onParse(err, tree) {
+            if (err) {
+                console.error(err);
+            } else {
+                _addDynamicProperty(DYNAMIC_FONT_STYLE_ID, {
+                    ruleText: tree.css
+                });
+            }
         });
-
-        // Sync code-hint font size
-        _addDynamicFontSizeForCodeHints(fontSize);
     }
 
     /**

--- a/src/view/fontrules/font-based-rules.less
+++ b/src/view/fontrules/font-based-rules.less
@@ -1,24 +1,41 @@
+@basefontsize: 16;
+
+/* mixin for converting EM to PX */
+.emtoPx( @emvalue ) when (isem( @emvalue)) {
+    @return: (unit(@emvalue) * @basefontsize) + 0px;
+}
+
+/* mixin for passthrough other units */
+.emtoPx( @emvalue ) when (isem(@emvalue) = false) {
+    @return: @emvalue;
+}
+
+@fontsizeparam : {font-size-param};
+
+@value: return;
+.emtoPx(@fontsizeparam);
+@fontsize: @@value;
+
 @defaultfontsize : 12px;
 @maxvisibleitems: 8;
-@lineheightoffset: 7px;
-@defaultmenuwidth: 300px;
+@lineheightoffset: 5px/@defaultfontsize;
+@defaultmenuwidth: 300px/@defaultfontsize;
 
-@fontsize : {font-size-param};
-@lineheight: @fontsize + @lineheightoffset; 
+@lineheight: @fontsize +  @fontsize * @lineheightoffset;
 
-.CodeMirror { 
-    font-size: @fontsize !important 
-}
-
-.codehint-menu .dropdown-menu li a { 
+.CodeMirror {
     font-size: @fontsize !important;
-    line-height: @lineheight  !important; 
 }
 
-span.brackets-js-hints-with-type-details { 
-    width: @defaultmenuwidth * (@fontsize / @defaultfontsize) !important; 
+.codehint-menu .dropdown-menu li a {
+    font-size: @fontsize !important;
+    line-height: @lineheight  !important;
 }
 
-.codehint-menu .dropdown-menu { 
-    max-height: @maxvisibleitems * @lineheight !important; 
+span.brackets-js-hints-with-type-details {
+    width: @defaultmenuwidth * @fontsize !important;
+}
+
+.codehint-menu .dropdown-menu {
+    max-height: @maxvisibleitems * @lineheight !important;
 }

--- a/src/view/fontrules/font-based-rules.less
+++ b/src/view/fontrules/font-based-rules.less
@@ -1,0 +1,24 @@
+@defaultfontsize : 12px;
+@maxvisibleitems: 8;
+@lineheightoffset: 7px;
+@defaultmenuwidth: 300px;
+
+@fontsize : {font-size-param};
+@lineheight: @fontsize + @lineheightoffset; 
+
+.CodeMirror { 
+    font-size: @fontsize !important 
+}
+
+.codehint-menu .dropdown-menu li a { 
+    font-size: @fontsize !important;
+    line-height: @lineheight  !important; 
+}
+
+span.brackets-js-hints-with-type-details { 
+    width: @defaultmenuwidth * (@fontsize / @defaultfontsize) !important; 
+}
+
+.codehint-menu .dropdown-menu { 
+    max-height: @maxvisibleitems * @lineheight !important; 
+}


### PR DESCRIPTION
This PR enhances Brackets user experience by syncing the code hint font-size with code view font size. This was a problem in high dpi monitors ( WQHD and above ), where code hints were not readable with the current font-size. With this PR , when user changes code view font size, code hint font size also gets changed accordingly.

Without this PR, code hints are rendered as - 

![hdpihint](https://cloud.githubusercontent.com/assets/12087205/22820152/8d0f6684-ef9b-11e6-9a55-4b98f95d2aef.png)

With the changes in PR - 

![hdpihintfix](https://cloud.githubusercontent.com/assets/12087205/22820165/9b657dae-ef9b-11e6-83a2-b6d139140c6b.png)

