### PR TITLE
Issue 1715

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "anymatch": "1.3.0",
         "chokidar": "1.6.0",
         "lodash": "4.15.0",
-        "nunjucks": "^2.4.3",
+        "nunjucks": "2.4.3",
         "ws": "~0.4.31"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "anymatch": "1.3.0",
         "chokidar": "1.6.0",
         "lodash": "4.15.0",
+        "nunjucks": "^2.4.3",
         "ws": "~0.4.31"
     },
     "devDependencies": {


### PR DESCRIPTION
Hi,

I am trying to solve the issue: https://github.com/mozilla/thimble.mozilla.org/issues/1715
It asked for nunjucks 2.4.3 to be added to both Brackets and Thimble.
It was already present in Thimble, but I didn't see it in Brackets.

I added it into the dependencies list, yet I'm unsure if that was a wise thing to do. Please consider using the
code and let me know if it works or not, and where to make changes elsewhere.