### PR TITLE
add syntax highlighting for pug (jade) templating language

### DIFF
--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -317,5 +317,13 @@
         "fileExtensions": ["go"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
+    },
+
+    "pug": {
+        "name": "Pug",
+        "mode": "pug",
+        "fileExtensions": ["pug", "jade"],
+        "lineComment": ["//"]
     }
+
 }


### PR DESCRIPTION
The extension available is not maintained (https://github.com/ForbesLindesay/jade-brackets) and it actually breaks Brackets (see https://github.com/ForbesLindesay/jade-brackets/issues/26) when used with JSX or TSX files. This actives syntax highlighting provided by latest version of CodeMirrors without side-effects of the extension.