### PR TITLE
Fixed #11291 - Added a delay of 200ms when searching for extensions and now we are updating the current view only instead of updating all 3 views

### DIFF
--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -459,11 +459,11 @@ define(function (require, exports, module) {
             });
 
             // Filter the views when the user types in the search field.
-            var searchTimeOut = 0;
+            var searchTimeoutID;
             $dlg.on("input", ".search", function (e) {
-                clearTimeout(searchTimeOut);
+                clearTimeout(searchTimeoutID);
                 var query = $(this).val();
-                searchTimeOut = setTimeout(function () {
+                searchTimeoutID = setTimeout(function () {
                     views[_activeTabIndex].filter(query);
                     $modalDlg.scrollTop(0);
                 }, 200);

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -459,12 +459,14 @@ define(function (require, exports, module) {
             });
 
             // Filter the views when the user types in the search field.
+            var searchTimeOut = 0;
             $dlg.on("input", ".search", function (e) {
+                clearTimeout(searchTimeOut);
                 var query = $(this).val();
-                views.forEach(function (view) {
-                    view.filter(query);
+                searchTimeOut = setTimeout(function () {
+                    views[_activeTabIndex].filter(query);
                     $modalDlg.scrollTop(0);
-                });
+                }, 200);
             }).on("click", ".search-clear", clearSearch);
             
             // Sort the extension list based on the current selected sorting criteria


### PR DESCRIPTION
Now we are updating the current view only instead of updating all 3 views as when we switch between views, then we call clear search(.filter("") is called) so there is no need of updating the other views on key-up.