### PR TITLE
test (eslint) should be run before cla-check-pull

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "scripts": {
         "postinstall": "grunt install",
-        "test": "grunt cla-check-pull test"
+        "test": "grunt test cla-check-pull"
     },
     "licenses": [
         {


### PR DESCRIPTION
Reasoning: I merged https://github.com/adobe/brackets/pull/13143 which didn't pass CLA check (I verified manually, but it didn't occur to me to run grunt test manually) leading to direct commit to master https://github.com/adobe/brackets/commit/26cea37ce5731c93a39b9898637afd8e874277cb