### PR TITLE
add husky to prevent pushing failing code

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "fs-extra": "0.5.0",
         "glob": "7.0.6",
         "grunt": "0.4.5",
+        "husky": "0.13.2",
         "jasmine-node": "1.11.0",
         "grunt-jasmine-node": "0.1.0",
         "grunt-cli": "0.1.9",
@@ -50,6 +51,7 @@
         "grunt-cleanempty": "1.0.3"
     },
     "scripts": {
+        "prepush": "npm run eslint",
         "postinstall": "grunt install",
         "test": "grunt test cla-check-pull",
         "eslint": "grunt eslint"


### PR DESCRIPTION
this is just two lines, but it makes a significant change, consider it a proposal

basically, when you do `git push`, husky runs `prepush` script and if it fails, it won't allow you to push unless you override it with a command line parameter

advantages are clear, people won't push any code that doesn't fit our settings, while disadvantage is that it slows down the push (but how often you push anyway?)