### PR TITLE
add support for universal (language independent) code inspector

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -157,16 +157,13 @@ define(function (require, exports, module) {
     function getProvidersForPath(filePath) {
         var language            = LanguageManager.getLanguageForPath(filePath).getId(),
             context             = PreferencesManager._buildContext(filePath, language),
-            installedProviders  = _providers[language],
+            installedProviders  = getProvidersForLanguageId(language),
             preferredProviders,
 
             prefPreferredProviderNames  = prefs.get(PREF_PREFER_PROVIDERS, context),
             prefPreferredOnly           = prefs.get(PREF_PREFERRED_ONLY, context),
 
             providers;
-
-        // ensure there is an instance and that a copy is returned, always
-        installedProviders = (installedProviders && installedProviders.slice(0)) || [];
 
         if (prefPreferredProviderNames && prefPreferredProviderNames.length) {
             if (typeof prefPreferredProviderNames === "string") {
@@ -507,6 +504,20 @@ define(function (require, exports, module) {
         _providers[languageId].push(provider);
 
         run();  // in case a file of this type is open currently
+    }
+
+    /**
+     * Returns a list of providers registered for given languageId through register function
+     */
+    function getProvidersForLanguageId(languageId) {
+        var result = [];
+        if (_providers[languageId]) {
+            result = result.concat(_providers[languageId]);
+        }
+        if (_providers['*']) {
+            result = result.concat(_providers['*']);
+        }
+        return result;
     }
 
     /**

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -490,6 +490,30 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should support universal providers", function () {
+                var codeInspector1 = createCodeInspector("javascript linter", successfulLintResult());
+                var codeInspector2 = createCodeInspector("css linter", successfulLintResult());
+                var codeInspector3 = createCodeInspector("universal linter", successfulLintResult());
+
+                CodeInspection.register("javascript", codeInspector1);
+                CodeInspection.register("css", codeInspector2);
+                CodeInspection.register("*", codeInspector3);
+
+                var providers = CodeInspection.getProvidersForPath("test.js");
+                expect(providers.length).toBe(2);
+                expect(providers[0]).toBe(codeInspector1);
+                expect(providers[1]).toBe(codeInspector3);
+
+                providers = CodeInspection.getProvidersForPath("test.css");
+                expect(providers.length).toBe(2);
+                expect(providers[0]).toBe(codeInspector2);
+                expect(providers[1]).toBe(codeInspector3);
+
+                providers = CodeInspection.getProvidersForPath("test.other");
+                expect(providers.length).toBe(1);
+                expect(providers[0]).toBe(codeInspector3);
+            });
+
         });
 
         describe("Code Inspection UI", function () {


### PR DESCRIPTION
Hi guys, need this for https://github.com/zaggino/brackets-eslint/issues/54

Basically, eslint can be configured to lint any file extension through plugins (`.vue` in this case) and there're methods to check if a file path is lintable with the current eslint configuration, but to get there I need to be able to register the linter as language independent one which would be invoked for all potential files.

The change to Brackets is I believe quite trivial, also added a test-case.