### PR TITLE
Adds Filter Exclusion Name character limit & related UI

### DIFF
--- a/src/htmlContent/edit-filter-dialog.html
+++ b/src/htmlContent/edit-filter-dialog.html
@@ -7,6 +7,7 @@
             {{{instruction}}}
             <textarea class="exclusions-editor"></textarea>
             <input type="text" class="exclusions-name" placeholder="{{Strings.FILTER_NAME_PLACEHOLDER}}">
+            <div class="exclusions-name-characters-remaining"></div>
             <div class="exclusions-filecount">{{Strings.FILTER_COUNTING_FILES}}</div>
         </div>
     </div>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -210,6 +210,7 @@ define({
     "FILE_FILTER_DIALOG"                : "Edit Exclusion Set",
     "FILE_FILTER_INSTRUCTIONS"          : "Exclude files and folders matching any of the following strings / substrings or <a href='{0}' title='{0}'>wildcards</a>. Enter each string on a new line.",
     "FILTER_NAME_PLACEHOLDER"           : "Name this exclusion set (optional)",
+    "FILTER_NAME_REMAINING"             : "{0} characters remaining",
     "FILE_FILTER_CLIPPED_SUFFIX"        : "and {0} more",
     "FILTER_COUNTING_FILES"             : "Counting files\u2026",
     "FILTER_FILE_COUNT"                 : "Allows {0} of {1} files {2}",

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -355,7 +355,7 @@ define(function (require, exports, module) {
         dialog.done(function (buttonId) {
             if (buttonId === Dialogs.DIALOG_BTN_OK) {
                 // Update saved filter preference
-                setActiveFilter({ name: $nameField.val(), patterns: getValue() }, index);
+                setActiveFilter({ name: $nameField.val().substr(0, 10), patterns: getValue() }, index);
                 _updatePicker();
                 _doPopulate();
             }

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -363,12 +363,13 @@ define(function (require, exports, module) {
             else {
                 $remainingField.hide();
             }
+            updatePrimaryButton();
         });
 
         dialog.done(function (buttonId) {
             if (buttonId === Dialogs.DIALOG_BTN_OK) {
                 // Update saved filter preference
-                setActiveFilter({ name: $nameField.val().substr(0, FILTER_NAME_CHARACTER_MAX), patterns: getValue() }, index);
+                setActiveFilter({ name: $nameField.val(), patterns: getValue() }, index);
                 _updatePicker();
                 _doPopulate();
             }
@@ -395,8 +396,9 @@ define(function (require, exports, module) {
 
         function updatePrimaryButton() {
             var trimmedValue = $editField.val().trim();
+            var exclusionNameLength = $nameField.val().length;
 
-            $primaryBtn.prop("disabled", !trimmedValue.length);
+            $primaryBtn.prop("disabled", !trimmedValue.length || (exclusionNameLength > FILTER_NAME_CHARACTER_MAX));
         }
 
         $editField.on("input", updatePrimaryButton);

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -341,7 +341,7 @@ define(function (require, exports, module) {
         $nameField.bind('input', function () {
             var remainingCharacters = 10 - $(this).val().length;
             $remainingField.text(StringUtils.format(
-                "{0} characters remaining",
+                Strings.FILTER_NAME_REMAINING,
                 remainingCharacters
             ));
 

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -46,6 +46,12 @@ define(function (require, exports, module) {
     var FIRST_FILTER_INDEX = 3;
 
     /**
+     * Constant: max number of characters for the filter name
+     * @type {number}
+     */
+    var FILTER_NAME_CHARACTER_MAX = 20;
+
+    /**
      * Context Info on which files the filter will be applied to.
      * It will be initialized when createFilterPicker is called and if specified, editing UI will
      * indicate how many files are excluded by the filter. Label should be of the form "in ..."
@@ -339,7 +345,7 @@ define(function (require, exports, module) {
         }
 
         $nameField.bind('input', function () {
-            var remainingCharacters = 10 - $(this).val().length;
+            var remainingCharacters = FILTER_NAME_CHARACTER_MAX - $(this).val().length;
             $remainingField.text(StringUtils.format(
                 Strings.FILTER_NAME_REMAINING,
                 remainingCharacters
@@ -355,7 +361,7 @@ define(function (require, exports, module) {
         dialog.done(function (buttonId) {
             if (buttonId === Dialogs.DIALOG_BTN_OK) {
                 // Update saved filter preference
-                setActiveFilter({ name: $nameField.val().substr(0, 10), patterns: getValue() }, index);
+                setActiveFilter({ name: $nameField.val().substr(0, FILTER_NAME_CHARACTER_MAX), patterns: getValue() }, index);
                 _updatePicker();
                 _doPopulate();
             }

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -346,15 +346,22 @@ define(function (require, exports, module) {
 
         $nameField.bind('input', function () {
             var remainingCharacters = FILTER_NAME_CHARACTER_MAX - $(this).val().length;
-            $remainingField.text(StringUtils.format(
-                Strings.FILTER_NAME_REMAINING,
-                remainingCharacters
-            ));
+            if (remainingCharacters < 0.25*FILTER_NAME_CHARACTER_MAX) {
+                $remainingField.show();
 
-            if (remainingCharacters < 0) {
-               $remainingField.addClass("exclusions-name-characters-limit-reached");
-            } else {
-               $remainingField.removeClass("exclusions-name-characters-limit-reached");
+                $remainingField.text(StringUtils.format(
+                    Strings.FILTER_NAME_REMAINING,
+                    remainingCharacters
+                ));
+
+                if (remainingCharacters < 0) {
+                    $remainingField.addClass("exclusions-name-characters-limit-reached");
+                } else {
+                    $remainingField.removeClass("exclusions-name-characters-limit-reached");
+                }
+            }
+            else {
+                $remainingField.hide();
             }
         });
 

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -339,15 +339,16 @@ define(function (require, exports, module) {
         }
 
         $nameField.bind('input', function () {
-            var textLength = $(this).val().length;
+            var remainingCharacters = 10 - $(this).val().length;
             $remainingField.text(StringUtils.format(
-              "Characters Remaining: {0}",
-              30-textLength
+                "{0} characters remaining",
+                remainingCharacters
             ));
 
-            Mustache.render(EditFilterTemplate, {charactersRemaining: 30 - textLength})
-            if ($(this).val().length > 30) {
-              console.log("Too long!");
+            if (remainingCharacters < 0) {
+               $remainingField.addClass("exclusions-name-characters-limit-reached");
+            } else {
+               $remainingField.removeClass("exclusions-name-characters-limit-reached");
             }
         });
 

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -337,6 +337,12 @@ define(function (require, exports, module) {
             });
         }
 
+        $nameField.bind('input', function () {
+            if ($(this).val().length > 30) {
+              console.log("Too long!");
+            }
+        });
+
         dialog.done(function (buttonId) {
             if (buttonId === Dialogs.DIALOG_BTN_OK) {
                 // Update saved filter preference

--- a/src/search/FileFilters.js
+++ b/src/search/FileFilters.js
@@ -323,7 +323,8 @@ define(function (require, exports, module) {
             };
         var dialog = Dialogs.showModalDialogUsingTemplate(Mustache.render(EditFilterTemplate, templateVars)),
             $nameField = dialog.getElement().find(".exclusions-name"),
-            $editField = dialog.getElement().find(".exclusions-editor");
+            $editField = dialog.getElement().find(".exclusions-editor"),
+            $remainingField = dialog.getElement().find(".exclusions-name-characters-remaining");
 
         $nameField.val(filter.name);
         $editField.val(filter.patterns.join("\n")).focus();
@@ -338,6 +339,13 @@ define(function (require, exports, module) {
         }
 
         $nameField.bind('input', function () {
+            var textLength = $(this).val().length;
+            $remainingField.text(StringUtils.format(
+              "Characters Remaining: {0}",
+              30-textLength
+            ));
+
+            Mustache.render(EditFilterTemplate, {charactersRemaining: 30 - textLength})
             if ($(this).val().length > 30) {
               console.log("Too long!");
             }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1782,6 +1782,9 @@ textarea.exclusions-editor {
     text-align: right;
     padding-top: 4px;
 }
+.exclusions-name-characters-limit-reached {
+    color: red;
+}
 .exclusions-filecount {
     margin: 12px 0 -14px 0;
     padding: 4px 8px;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -120,7 +120,7 @@ a, img {
         left: @sidebar-width;  // changed dynamically via Resizer
         right: @main-toolbar-width;
     }
-    
+
     .force-right-zero {
         right: 0;
     }
@@ -133,7 +133,7 @@ a, img {
     // Make sure the bottom box-shadow goes above the editor (position: relative needed to start a new stacking group)
     position: relative;
     z-index: @z-index-brackets-toolbar;
-    
+
     .dark & {
         border-bottom: 1px solid @dark-bc-shadow;
         box-shadow: 0 1px 3px @dark-bc-shadow-small;
@@ -183,7 +183,7 @@ a, img {
 
 #status-file {
     color: @bc-text-quiet;
-    
+
     .dark & {
         color: @dark-bc-text-quiet;
     }
@@ -205,7 +205,7 @@ a, img {
     > div {
         &:not(.spinner) {
             border-left: 1px solid @bc-panel-border;
-            
+
             .dark & {
                 border-left: 1px solid @dark-bc-panel-separator;
             }
@@ -222,12 +222,12 @@ a, img {
         border-right: 1px solid @bc-panel-border;
         padding: 0;
         margin: 0;
-        
+
         .dark & {
             border-right: 1px solid @dark-bc-panel-separator;
         }
     }
-    
+
     /* dropdown button styling */
     .btn-status-bar {
         border: 0;
@@ -244,7 +244,7 @@ a, img {
         border-radius: 0;
         box-shadow: none;
         text-shadow: none;
-        
+
         &:focus {
             outline: 0;
         }
@@ -258,7 +258,7 @@ a, img {
             right: 8px;
         }
     }
-    
+
 }
 
 #status-indent > * {
@@ -292,7 +292,7 @@ a, img {
     top: -1px;
     width: 6px;
     transition: 0.1s linear all;
-    
+
     .dark & {
         color: @dark-bc-text;
     }
@@ -312,7 +312,7 @@ a, img {
     background-color: rgba(255, 255, 255, 0);
     color: @bc-text;
     cursor: pointer;
-    
+
     .dark & {
         color: @dark-bc-text;
     }
@@ -409,7 +409,7 @@ a, img {
         }
 
         .image-guide,
-        .image-tip, 
+        .image-tip,
         .image-scale {
             pointer-events: none;
         }
@@ -527,7 +527,7 @@ a, img {
             &.flipview-icon-top {
                 background-position: center 1px;
             }
-            
+
             &.flipview-icon-right {
                 background-position: center -18px;
             }
@@ -580,7 +580,7 @@ a, img {
     }
 
     .active-pane {
-        
+
         .pane-header {
             opacity: 1;
             color: @bc-menu-text;
@@ -643,10 +643,10 @@ a, img {
     display: none;
     height: 200px;
     border-top: 1px solid @bc-panel-border;
-    
+
     .dark & {
         background-color: @dark-bc-panel-bg;
-        border-top: 1px solid @dark-bc-panel-border;        
+        border-top: 1px solid @dark-bc-panel-border;
     }
 
     .check-all {
@@ -661,18 +661,18 @@ a, img {
         padding-bottom: (@base-padding / 2);
         z-index: @z-index-brackets-results-panel;
         box-shadow: inset 0 1px 0 @bc-highlight-hard, 0 -1px 3px @bc-shadow-small;
-        
+
         .dark & {
             background-color: @dark-bc-panel-bg-promoted;
             border-bottom: @dark-bc-panel-separator;
-            box-shadow: inset 0 1px 0 @dark-bc-highlight, 0 -1px 3px @dark-bc-shadow-small;            
+            box-shadow: inset 0 1px 0 @dark-bc-highlight, 0 -1px 3px @dark-bc-shadow-small;
         }
-        
+
         .title {
             color: @bc-text;
             font-size: @label-font-size;
             font-weight: @font-weight-semibold;
-            
+
             .dark & {
                 color: @dark-bc-text;
             }
@@ -694,7 +694,7 @@ a, img {
         .highlight {
             background: @bc-panel-bg-text-highlight;
             border-radius: 2px;
-            
+
             .dark & {
                 background: @dark-bc-panel-bg-text-highlight;
             }
@@ -703,7 +703,7 @@ a, img {
         tr.selected td {
             background-color: @bc-panel-bg-selected;
             color: @bc-text-thin;
-            
+
             .dark & {
                 background-color: @dark-bc-panel-bg-selected;
                 color: @dark-bc-text-thin;
@@ -732,7 +732,7 @@ a, img {
         text-align: right;
         white-space: nowrap;
         width: 5px;
-        
+
         .dark & {
             color: @dark-bc-text-thin-quiet;
         }
@@ -792,8 +792,8 @@ a, img {
 
 #working-set-list-container {
     background: @bc-sidebar-bg;
-    
-    > div:last-child ul { 
+
+    > div:last-child ul {
         padding-bottom: 21px; // Adds working set bottom padding to the last UL.
     }
 }
@@ -806,13 +806,13 @@ a, img {
     color: @project-panel-text-2;
     text-shadow: none;
     overflow: hidden;
-    
+
     > span {
         background: @bc-sidebar-bg;
         position: relative;
         z-index: 9;
     }
-    
+
     > div {
         background-color: @dark-bc-sidebar-bg;
         opacity: 1;
@@ -863,7 +863,7 @@ a, img {
         .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
         margin: 0 5px 0 -1px;
         vertical-align: -2px;
-        
+
         .dark & {
             .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons-dark.svg");
         }
@@ -894,13 +894,13 @@ a, img {
     font-size: 13px;
     color: @project-panel-text-2;
     overflow: hidden;
-    
+
     .btn-alt-quiet {
         background-color: #47484b;
-        
+
         // relative positioning plus z-index make sure that the splitview button flows under the left aligned buttons in the project pane when there are no working set files
         position: relative;
-        z-index: 9; 
+        z-index: 9;
     }
 }
 
@@ -922,7 +922,7 @@ a, img {
         min-height: 18px;
         vertical-align: baseline;
         white-space: nowrap;
-        
+
         &.selected a {
             color: @open-working-file-name-highlight;
         }
@@ -1049,7 +1049,7 @@ a, img {
     vertical-align: middle;
     width: @jstree-sprite-size;
     height: @jstree-sprite-size;
-    
+
     .dark & {
         background-image: @dark-jstree-sprite;
     }
@@ -1065,7 +1065,7 @@ a, img {
     transition: transform 190ms cubic-bezier(.01, .91, 0, .99);
     -webkit-filter: drop-shadow(1px 0 1px @bc-shadow);
     filter: drop-shadow(1px 0 1px @bc-shadow);
-    
+
     .dark & {
         -webkit-filter: drop-shadow(1px 0 1px @dark-bc-shadow);
         filter: drop-shadow(1px 0 1px @dark-bc-shadow);
@@ -1080,7 +1080,7 @@ a, img {
     transition: transform 90ms cubic-bezier(.01, .91, 0, .99);
     -webkit-filter: drop-shadow(1px 0 1px @bc-shadow);
     filter: drop-shadow(1px 0 1px @bc-shadow);
-    
+
     .dark & {
         -webkit-filter: drop-shadow(1px 0 1px @dark-bc-shadow);
         filter: drop-shadow(1px 0 1px @dark-bc-shadow);
@@ -1109,17 +1109,17 @@ a, img {
         .unicode-icon-container;
         color: rgba(255, 255, 255, 0.5);
     }
-    
+
     &.dirty:before {
         content: "\2022";
         line-height: 1em;
     }
-    
+
     &.can-close:before {
         content: "\00D7";
         line-height: 1.1em;
     }
-    
+
     &.can-close:hover:before {
         color: rgba(255, 255, 255, 0.7);
     }
@@ -1145,7 +1145,7 @@ a, img {
     cursor: default;
 
     .dark & {
-        background-color: @dark-bc-bg-inline-widget; 
+        background-color: @dark-bc-bg-inline-widget;
     }
 
     &.animating {
@@ -1189,7 +1189,7 @@ a, img {
                 overflow: hidden;
                 position: relative;
                 top: 1px;
-                
+
                 .dark & {
                     color: @dark-bc-text-quiet;
                 }
@@ -1226,7 +1226,7 @@ a, img {
 
         .CodeMirror-linenumbers {
             background-color: @bc-bg-inline-widget;
-            
+
             .dark & {
                 background-color: @dark-bc-bg-inline-widget;
             }
@@ -1297,7 +1297,7 @@ a, img {
         margin-top: -@inline-triangle-size;
         top: 50%;
         .scale-x(0.9, left, top);
-        
+
         .dark & {
             border-left: @inline-triangle-size solid @dark-bc-bg-inline-widget;
         }
@@ -1327,7 +1327,7 @@ a, img {
             .dark & {
                 color: @dark-bc-text-emphasized;
             }
-            
+
             &.section-header {
                 padding-left: 0;
                 padding-bottom: 0;
@@ -1342,7 +1342,7 @@ a, img {
             .related-file {
                 color: @bc-text-thin-quiet;
                 padding-left: 3px;
-                
+
                 .dark & {
                     color: @dark-bc-text-thin-quiet;
                 }
@@ -1352,7 +1352,7 @@ a, img {
         .selected {
             color: @bc-text-thin;
             transition: color 0.1s ease-out .15s;
-            
+
             .dark & {
                 color: @dark-bc-text-thin;
             }
@@ -1367,7 +1367,7 @@ a, img {
     line-height: 17px;
     height: 20px;
     padding: 10px 0 40px 50px;
-    
+
     .dark & {
         color: @dark-bc-text-thin-quiet;
     }
@@ -1422,11 +1422,11 @@ a, img {
     }
     .pagination-col > span:active {
         background-color: @bc-shadow;
-        
+
         .dark & {
             background-color: @dark-bc-shadow;
         }
-    } 
+    }
     .replace-col {
         .flex-item(1, 0);
         min-width: 120px;
@@ -1510,7 +1510,7 @@ a, img {
     body:not(.has-appshell-menus) & {
         // Separator line between us and the HTML menu/titlebar above
         border-top: 1px solid @bc-panel-border;
-        
+
         .dark & {
             border-top: 1px solid @dark-bc-panel-border;
         }
@@ -1540,7 +1540,7 @@ a, img {
         &.no-results {
             border: 1px solid  @bc-btn-border-error;
             box-shadow: inset 0 1px 0 @bc-shadow-small, 0 0 0 1px @bc-btn-border-error-glow;
-            
+
             .dark & {
                 border: 1px solid  @dark-bc-btn-border-error;
                 box-shadow: inset 0 1px 0 @dark-bc-shadow-small, 0 0 0 1px @dark-bc-btn-border-error-glow;
@@ -1569,7 +1569,7 @@ a, img {
             padding: 3px 8px;
             border-radius: 0 0 3px 3px;
             box-shadow: 0 1px 3px @bc-shadow-small;
-            
+
             .dark & {
                 background-color: @dark-bc-error;
                 color: @dark-bc-text-alt;
@@ -1587,7 +1587,7 @@ a, img {
             top: 1px;
             right: 2px;
             font-size: 12px;
-            
+
             .dark & {
                 color: @dark-bc-text-thin-quiet;
             }
@@ -1605,7 +1605,7 @@ a, img {
         // If scope controls are showing, force the replace controls to a second line.
         display: block;
     }
-    
+
     .scope-group {
         display: inline-block;
         margin-left: 10px;
@@ -1651,7 +1651,7 @@ a, img {
     #find-case-sensitive.active,
     #find-case-sensitive:active { // Make the toggle buttons' down states the same color as 'on' state to prevent a flash of different color.
         background-color: @bc-bg-highlight;
-        
+
         .dark & {
             background-color: @dark-bc-bg-highlight;
         }
@@ -1750,7 +1750,7 @@ li:hover .filter-edit-icon {
 .recent-filter-patterns {
     color: @bc-text-thin-quiet;
     padding-right: 52px;
-    
+
     .dark & {
         color: @dark-bc-text-thin-quiet;
     }
@@ -1778,12 +1778,16 @@ textarea.exclusions-editor {
     margin-bottom: 0;
     .code-font();
 }
+.exclusions-name-characters-remaining {
+    text-align: right;
+    padding-top: 4px;
+}
 .exclusions-filecount {
     margin: 12px 0 -14px 0;
     padding: 4px 8px;
     background-color: @bc-bg-highlight;
     border-radius: @bc-border-radius;
-    
+
     .dark & {
         background-color: @dark-bc-bg-highlight;
     }
@@ -1795,11 +1799,11 @@ textarea.exclusions-editor {
     background-color: @cm-match-highlight;
     box-shadow: 0 1px 3px @bc-shadow-small;
     color: @match-text !important;
-    
+
     .dark & {
         box-shadow: 0 1px 3px @dark-bc-shadow-small;
     }
-    
+
     &.searching-current-match {
         background-color: @cm-current-match-highlight;
     }
@@ -1854,7 +1858,7 @@ textarea.exclusions-editor {
     text-align: right;
     top: 12px;
     z-index: 9999;
-    
+
     .dark & {
         background: @dark-bc-input-bg;
         color: @dark-bc-text-quiet;
@@ -1868,7 +1872,7 @@ textarea.exclusions-editor {
     border-radius: 0 0 4px 4px;
     box-shadow: 0 5px 10px @bc-shadow;
     opacity: 0;
-    
+
     .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99));
     -webkit-animation-fill-mode: forwards;
     animation-fill-mode: forwards;
@@ -1877,7 +1881,7 @@ textarea.exclusions-editor {
 
     padding: 0;
     margin: 9px 0 0;
-    
+
     z-index: @z-index-brackets-context-menu-base;
 
     .dark & {
@@ -1891,7 +1895,7 @@ textarea.exclusions-editor {
         font-size: 11px;
         letter-spacing: 0.04em;
         line-height: 11px;
-        
+
         .dark & {
             color: @dark-bc-text-medium;
         }
@@ -1910,7 +1914,7 @@ textarea.exclusions-editor {
 
         &:nth-child(odd) {
             background-color: @bc-panel-bg-alt;
-            
+
             .dark & {
                 background-color: @dark-bc-panel-bg-alt;
             }
@@ -1921,7 +1925,7 @@ textarea.exclusions-editor {
 
         &:hover {
             background-color: @bc-panel-bg-hover;
-            
+
             .dark & {
                 background-color: @dark-bc-panel-bg-hover;
             }
@@ -1930,7 +1934,7 @@ textarea.exclusions-editor {
         &.highlight {
             background-color: @bc-bg-highlight;
             color: @bc-menu-text;
-            
+
             .dark & {
                 background-color: @dark-bc-bg-highlight;
                 color: @dark-bc-menu-text;
@@ -1955,7 +1959,7 @@ textarea.exclusions-editor {
 
 .quicksearch-pathmatch {
     color: @bc-text-medium;
-    
+
     .dark & {
         color: @dark-bc-text-medium;
     }
@@ -2033,7 +2037,7 @@ textarea.exclusions-editor {
             }
         }
     }
-    
+
     &.inline {
         margin-left: 8px;
         position: relative;
@@ -2060,7 +2064,7 @@ textarea.exclusions-editor {
     border: none;
     cursor: default;
     width: 13px;
-    
+
     &.inspection-errors {
         cursor: pointer;
     }
@@ -2102,7 +2106,7 @@ textarea.exclusions-editor {
         width: 100%;
         padding-left: 10px;
     }
-    
+
     .inspector-section > td {
         padding-left: 5px;
     }
@@ -2140,12 +2144,12 @@ label input {
         color: @bc-text-alt;
         box-shadow: 0 3px 9px @bc-shadow;
         white-space: nowrap;
-        
+
         .dark & {
             background-color: @dark-bc-error;
             border-radius: 3px;
             color: @dark-bc-text-alt;
-            box-shadow: 0 3px 9px @dark-bc-shadow;            
+            box-shadow: 0 3px 9px @dark-bc-shadow;
         }
     }
     .arrowAbove {
@@ -2154,7 +2158,7 @@ label input {
         border-width: 0 10px 10px 10px;
         border-color: transparent transparent @bc-error transparent;
         border-style: solid;
-        
+
         .dark & {
             border-color: transparent transparent @dark-bc-error transparent;
         }
@@ -2165,7 +2169,7 @@ label input {
         border-width: 10px 10px 0 10px;
         border-color: @bc-error transparent transparent transparent;
         border-style: solid;
-        
+
         .dark & {
             border-color: @dark-bc-error transparent transparent transparent;
         }
@@ -2216,12 +2220,12 @@ label input {
     position: absolute;
     top: -1px;
     left: -1px;
-    
+
     padding: 1px;
     width: 100%;
     height: 100%;
     display: none;
-    
+
     cursor: copy;
 }
 
@@ -2236,11 +2240,11 @@ label input {
     border: 1px solid @bc-primary-btn-bg;
     color: @bc-text-alt;
     text-shadow: none;
-    
+
     .dark & {
         background: @dark-bc-primary-btn-bg;
         border: 1px solid @dark-bc-primary-btn-bg;
-        color: @dark-bc-text-alt;        
+        color: @dark-bc-text-alt;
     }
 }
 


### PR DESCRIPTION
This PR address issue #13140 by doing the following:
1) Truncates exclusion names over 20 characters.
2) Adds text underneath the input bar to note the remaining characters.

<img width="1429" alt="screen shot 2017-03-06 at 8 09 04 pm" src="https://cloud.githubusercontent.com/assets/6589909/23638694/c58b348c-02a8-11e7-953f-9b50ed1fe0fa.png">

Note: This has one string (for the "characters remaining" text) that is externalized in nls/root.

#### Questions: 
I'm having trouble unit testing this, which I've left out of this PR for now. This is my first time working on the project, and I believe I'm making a mistake causing my unit tests to not be considered when I try to run them from the testing interface. None of the `console.log` statements I've added to my unit test pass through. My process has been: 
1) Add a unit test in FileFilters-test.js
2) Reload Brackets
3) Test the FileFilters unit test section.



