### PR TITLE
Do not initialize dontCloseTags

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -141,7 +141,10 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference(CLOSE_BRACKETS,     "boolean", true, {
         description: Strings.DESCRIPTION_CLOSE_BRACKETS
     });
-    PreferencesManager.definePreference(CLOSE_TAGS,         "object", { whenOpening: true, whenClosing: true, indentTags: [], dontCloseTags: [] }, {
+
+    // CodeMirror, html mode, set some tags do not close automatically.
+    // We do not initialize "dontCloseTags" because otherwise we would overwrite the default behavior of CodeMirror.
+    PreferencesManager.definePreference(CLOSE_TAGS,         "object", { whenOpening: true, whenClosing: true, indentTags: [] }, {
         description: Strings.DESCRIPTION_CLOSE_TAGS,
         keys: {
             dontCloseTags: {


### PR DESCRIPTION
I think this fixes https://github.com/adobe/brackets/issues/13161
@johnroper100 could you give a try?

Regression of https://github.com/adobe/brackets/pull/13132