### PR TITLE
Makes the content of script and style tags collapsible

### DIFF
--- a/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldcode.js
@@ -139,7 +139,7 @@ define(function (require, exports, module) {
                 keys.forEach(function (lineNumber) {
                     lineNumber = +lineNumber;
                     if (lineNumber >= cm.firstLine() && lineNumber <= cm.lastLine()) {
-                        range = rf(cm, CodeMirror.Pos(lineNumber));
+                        range = rf(cm, CodeMirror.Pos(lineNumber, 0));
                         cachedRange = folds[lineNumber];
                         if (range && cachedRange && range.from.line === cachedRange.from.line &&
                                 range.to.line === cachedRange.to.line) {

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
             var sr = _isCurrentlyFolded(i), // surrounding range for the current line if one exists
                 range;
             var mark = marker("CodeMirror-foldgutter-blank");
-            var pos = CodeMirror.Pos(i),
+            var pos = CodeMirror.Pos(i, 0),
                 func = opts.rangeFinder || CodeMirror.fold.auto;
             // don't look inside collapsed ranges
             if (sr) {
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
      * @returns {TextMarker} A CodeMirror TextMarker object
      */
     function getFoldOnLine(cm, line) {
-        var pos = CodeMirror.Pos(line);
+        var pos = CodeMirror.Pos(line, 0);
         var folds = cm.findMarksAt(pos) || [];
         folds = folds.filter(isFold);
         return folds.length ? folds[0] : undefined;
@@ -220,7 +220,7 @@ define(function (require, exports, module) {
 
         if (linesDiff === 0) {
             if (foldedLines.indexOf(from) >= 0) {
-                newRange = rf(cm, CodeMirror.Pos(from));
+                newRange = rf(cm, CodeMirror.Pos(from, 0));
                 if (newRange && newRange.to.line - newRange.from.line >= minFoldSize) {
                     cm._lineFolds[from] = newRange;
                 } else {

--- a/src/extensions/default/CodeFolding/unittest-files/test.html
+++ b/src/extensions/default/CodeFolding/unittest-files/test.html
@@ -1,9 +1,17 @@
 <html>
     <head>
-    
+        <style>      
+            .test {
+                /* this should be collapsible */
+            }
+        </style>
+        <script>
+            function () {
+                /* this should be collapsible */
+            }
+        </script>
     </head>
     <body>
-   
         <form action="#" method="post">
             <div>
                  <label for="name">Text Input:</label>
@@ -12,7 +20,9 @@
             <table>
                 <thead>
                     <tr>
-                        <th></th>
+                        <th>
+                           {{handlebars}}
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/extensions/default/CodeFolding/unittests.js
+++ b/src/extensions/default/CodeFolding/unittests.js
@@ -37,10 +37,10 @@ define(function (require, exports, module) {
                 },
                 html: {
                     filePath: testDocumentDirectory + "test.html",
-                    foldableLines: [1, 2, 5, 7, 8, 12, 13, 14, 18, 19, 24, 27],
-                    sameLevelFoldableLines: [8, 24],
-                    firstSelection: {start: {line: 3, ch: 0}, end: {line: 10, ch: 0}},
-                    secondSelection: {start: {line: 6, ch: 0}, end: {line: 17, ch: 4}}
+                    foldableLines: [1, 2, 3, 4, 8, 9, 14, 15, 16, 20, 21, 22, 23, 28, 29, 34, 37],
+                    sameLevelFoldableLines: [3, 8],
+                    firstSelection: {start: {line: 38, ch: 0}, end: {line: 41, ch: 0}},
+                    secondSelection: {start: {line: 42, ch: 0}, end: {line: 45, ch: 4}}
                 },
                 hbs: {
                     filePath: testDocumentDirectory + "test.hbs",
@@ -382,7 +382,7 @@ define(function (require, exports, module) {
                         });
                     });
 
-                    it("can be disable persistence of fold states", function () {
+                    it("can disable persistence of fold states", function () {
                         setPreference("saveFoldStates", false);
                         runs(function () {
                             foldCodeOnLine(foldableLines[0]);


### PR DESCRIPTION
Addresses issue #13165 where style and script tags (and their contents) did not appear as collapsible in html mixed mode.