### PR TITLE
Added a check of Untitled doc in _getNormalizedFilename and _getDenormalizedFilename

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
+++ b/src/extensions/default/JavaScriptCodeHints/ScopeManager.js
@@ -927,10 +927,11 @@ define(function (require, exports, module) {
          * @param {string} path - full path of file
          * @return {jQuery.Promise} - the promise for the request
          */
-        function primePump(path) {
+        function primePump(path, isUntitledDoc) {
             _postMessageByPass({
-                type        : MessageIds.TERN_PRIME_PUMP_MSG,
-                path        : path
+                type            : MessageIds.TERN_PRIME_PUMP_MSG,
+                path            : path,
+                isUntitledDoc   : isUntitledDoc
             });
 
             return addPendingRequest(path, OFFSET_ZERO, MessageIds.TERN_PRIME_PUMP_MSG);
@@ -1152,7 +1153,7 @@ define(function (require, exports, module) {
                 if (isDocumentDirty && previousDocument) {
                     var updateFilePromise = updateTernFile(previousDocument);
                     updateFilePromise.done(function () {
-                        primePump(path);
+                        primePump(path, document.isUntitled());
                         addFilesDeferred.resolveWith(null, [_ternWorker]);
                     });
                 } else {
@@ -1171,7 +1172,7 @@ define(function (require, exports, module) {
             deferredPreferences.done(function () {
                 if (file instanceof InMemoryFile) {
                     initTernServer(pr, []);
-                    var hintsPromise = primePump(path);
+                    var hintsPromise = primePump(path, true);
                     hintsPromise.done(function () {
                         addFilesDeferred.resolveWith(null, [_ternWorker]);
                     });
@@ -1202,7 +1203,7 @@ define(function (require, exports, module) {
 
                         initTernServer(dir, files);
 
-                        var hintsPromise = primePump(path);
+                        var hintsPromise = primePump(path, false);
                         hintsPromise.done(function () {
                             if (!usingModules()) {
                                 // Read the subdirectories of the new file's directory.
@@ -1217,7 +1218,7 @@ define(function (require, exports, module) {
                                         addAllFilesAndSubdirectories(projectRoot, function () {
                                             // prime the pump again but this time don't wait
                                             // for completion.
-                                            primePump(path);
+                                            primePump(path, false);
 
                                             addFilesDeferred.resolveWith(null, [_ternWorker]);
                                         });

--- a/src/extensions/default/JavaScriptCodeHints/tern-worker.js
+++ b/src/extensions/default/JavaScriptCodeHints/tern-worker.js
@@ -41,7 +41,8 @@ var config = {};
             Infer = infer;
 
             var ternServer  = null,
-                inferenceTimeout;
+                inferenceTimeout,
+                isUntitledDoc = false;
 
             // Save the tern callbacks for when we get the contents of the file
             var fileCallBacks = {};
@@ -107,14 +108,14 @@ var config = {};
             }
 
             function _getNormalizedFilename(fileName) {
-                if (ternServer.projectDir && fileName.indexOf(ternServer.projectDir) === -1) {
+                if (!isUntitledDoc && ternServer.projectDir && fileName.indexOf(ternServer.projectDir) === -1) {
                     fileName = ternServer.projectDir + fileName;
                 }
                 return fileName;
             }
 
             function _getDenormalizedFilename(fileName) {
-                if (ternServer.projectDir && fileName.indexOf(ternServer.projectDir) === 0) {
+                if (!isUntitledDoc && ternServer.projectDir && fileName.indexOf(ternServer.projectDir) === 0) {
                     fileName = fileName.slice(ternServer.projectDir.length);
                 }
                 return fileName;
@@ -659,6 +660,7 @@ var config = {};
                 } else if (type === MessageIds.TERN_ADD_FILES_MSG) {
                     handleAddFiles(request.files);
                 } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
+                    isUntitledDoc = request.isUntitledDoc;
                     handlePrimePump(request.path);
                 } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
                     offset  = request.offset;


### PR DESCRIPTION
Actually in the normalize path earlier there was no check of Untitled doc and it was appending the project dir to the Untitled path, so I added a check for Untitled doc before appending the project root.
Due to this JS codehints were not working for Untitled documents on changing the mode to JS.

All JavaScriptCodeHints tests are passing