### PR TITLE
Add inputStyle preference

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -96,7 +96,8 @@ define(function (require, exports, module) {
         UPPERCASE_COLORS    = "uppercaseColors",
         USE_TAB_CHAR        = "useTabChar",
         WORD_WRAP           = "wordWrap",
-        INDENT_LINE_COMMENT   = "indentLineComment";
+        INDENT_LINE_COMMENT = "indentLineComment",
+        INPUT_STYLE         = "inputStyle";
 
     /**
       * A list of gutter name and priorities currently registered for editors.
@@ -137,6 +138,7 @@ define(function (require, exports, module) {
     cmOptions[TAB_SIZE]           = "tabSize";
     cmOptions[USE_TAB_CHAR]       = "indentWithTabs";
     cmOptions[WORD_WRAP]          = "lineWrapping";
+    cmOptions[INPUT_STYLE]        = "inputStyle";
 
     PreferencesManager.definePreference(CLOSE_BRACKETS,     "boolean", true, {
         description: Strings.DESCRIPTION_CLOSE_BRACKETS
@@ -226,6 +228,10 @@ define(function (require, exports, module) {
 
     PreferencesManager.definePreference(INDENT_LINE_COMMENT,  "boolean", false, {
         description: Strings.DESCRIPTION_INDENT_LINE_COMMENT
+    });
+
+    PreferencesManager.definePreference(INPUT_STYLE,  "string", "textarea", {
+        description: Strings.DESCRIPTION_INPUT_STYLE
     });
 
     var editorOptions = Object.keys(cmOptions);
@@ -413,7 +419,7 @@ define(function (require, exports, module) {
             highlightSelectionMatches   : currentOptions[HIGHLIGHT_MATCHES],
             indentUnit                  : currentOptions[USE_TAB_CHAR] ? currentOptions[TAB_SIZE] : currentOptions[SPACE_UNITS],
             indentWithTabs              : currentOptions[USE_TAB_CHAR],
-            inputStyle                  : "textarea", // the "contenteditable" mode used on mobiles could cause issues
+            inputStyle                  : currentOptions[INPUT_STYLE],
             lineNumbers                 : currentOptions[SHOW_LINE_NUMBERS],
             lineWiseCopyCut             : currentOptions[LINEWISE_COPY_CUT],
             lineWrapping                : currentOptions[WORD_WRAP],

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -752,6 +752,7 @@ define({
     "DESCRIPTION_LANGUAGE_FILE_EXTENSIONS"           : "Additional mappings from file extension to language name",
     "DESCRIPTION_LANGUAGE_FILE_NAMES"                : "Additional mappings from file name to language name",
     "DESCRIPTION_LINEWISE_COPY_CUT"                  : "Doing copy and cut when there's no selection will copy or cut the whole lines that have cursors in them",
+    "DESCRIPTION_INPUT_STYLE"                        : "Selects the way CodeMirror handles input and focus. It cans be textarea, which is the default, or contenteditable which is better for screen readers (unstable)",
     "DESCRIPTION_LINTING_ENABLED"                    : "true to enable Code Inspection",
     "DESCRIPTION_ASYNC_TIMEOUT"                      : "The time in milliseconds after which asynchronous linters time out",
     "DESCRIPTION_LINTING_PREFER"                     : "Array of linters to run first",


### PR DESCRIPTION
Looking around it seems that setting `inputStyle` to `contenteditable` could improve the situation for screen readers but from what I understood is not stable enough.
After setting it I had some problems with the usage of the context menu so is not stable for Brackets.
I'm not sure what is the policy is in this case for adding new preferences,
but I think it could be useful to at least do some tests.