### PR TITLE
Fix layout on narrow extension manager

### DIFF
--- a/src/htmlContent/extension-manager-dialog.html
+++ b/src/htmlContent/extension-manager-dialog.html
@@ -16,8 +16,10 @@
                    <option value="downloadCount">{{Strings.EXTENSIONS_DOWNLOADS}}</option>
                </select>
             </div>
-            <button class="search-clear">&times;</button>
-            <input class="search" type="text" placeholder="{{Strings.EXTENSION_SEARCH_PLACEHOLDER}}">
+            <div class="search-container">
+                <button class="search-clear">&times;</button>
+                <input class="search" type="text" placeholder="{{Strings.EXTENSION_SEARCH_PLACEHOLDER}}">
+            </div>
         </div>
     </div>
     <div class="modal-body no-padding table-striped tab-content">

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1141,7 +1141,7 @@ a[href^="http"] {
 
         /* Search box */
         > :nth-child(2) {
-            @media (max-width: @extension-manager-min-width) {
+            @media (max-width: (@extension-manager-min-width - 1px)) {
                 overflow: hidden;
                 padding: 8px 1em;
             }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1155,9 +1155,8 @@ a[href^="http"] {
         }
 
         .search-container {
-          float: right;
-          // flex-grow: 1;
-          .flex-item(1);
+            float: right;
+            .flex-item(1);
         }
 
         .search {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1142,6 +1142,7 @@ a[href^="http"] {
         /* Search box */
         > :nth-child(2) {
             @media (max-width: (@extension-manager-min-width - 1px)) {
+                display: flex;
                 overflow: hidden;
                 padding: 8px 1em;
             }
@@ -1153,9 +1154,15 @@ a[href^="http"] {
             }
         }
 
+        .search-container {
+          float: right;
+          // flex-grow: 1;
+          .flex-item(1);
+        }
+
         .search {
             background: @bc-input-bg url("images/topcoat-search-20.svg") 2px 2px no-repeat;
-            float: right;
+            width: calc(~'100% - 27px - 20px'); // 100% minus padding etc.
             margin: 0;
             padding-left: 27px;
             padding-right: 20px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -45,7 +45,7 @@ a {
 a:hover {
     color: @bc-text-link;
     text-decoration: underline;
-    
+
     .dark & {
         color: @dark-bc-text-link;
     }
@@ -89,7 +89,7 @@ a:focus {
     background-color: transparent;
 
     text-shadow: 0 1px 2px @bc-shadow-large;
-    
+
     .dark & {
         text-shadow: 0 1px 2px @dark-bc-shadow-large;
     }
@@ -368,7 +368,7 @@ a:focus {
         // Offset for better alignment with button
         top: 34px;
         margin-top: 0;
-        
+
         // Fix for #4593: don't let narrow parent (menubar item) cause text wrap at the float boundary between
         // the menu item label and keyboard shortcut. This takes away the "gotta get narrower" pressure.
         // This technique won't work on all browsers; see comments in #4593 for alternative options.
@@ -596,7 +596,7 @@ a:focus {
     &.dropdown-menu:focus {
         outline: none;
     }
-    
+
     &.dropdown-menu {
         border: none;
         border-radius: @bc-border-radius;
@@ -614,11 +614,11 @@ a:focus {
             box-shadow: 0 3px 9px @dark-bc-shadow;
         }
     }
-    
+
     &.dropdown-menu li a {
         padding: 1px 15px 1px 15px;
         color: @bc-menu-text;
-        
+
         .dark & {
             color: @dark-bc-menu-text;
         }
@@ -631,11 +631,11 @@ a:focus {
             }
         }
     }
-    
+
     &.dropdown-menu .stylesheet-link {
         display: block;
     }
-    
+
     &.dropdown-menu a.selected {
         background: @bc-bg-highlight;
         color: @bc-menu-text !important;
@@ -659,7 +659,7 @@ a:focus {
             display: inline-block;
         }
     }
-    
+
     &.dropdown-menu a:hover {
         /* toggle checkmark visibility */
         &.checked::before {
@@ -683,12 +683,12 @@ a:focus {
     transform-origin: 0 100%;
     height: auto;
     max-height: 80%;
-    
+
     // Improve how bottom of the dropdown joins with top of status bar button
     margin-top: -6px;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    
+
     li a .default-language {
         font-style: italic;
         color: @bc-text-quiet;
@@ -716,7 +716,7 @@ a:focus {
     .stylesheet-link, .stylesheet-name {
         white-space: nowrap;
     }
-    
+
     .stylesheet-name {
         color: @bc-text;
 
@@ -724,7 +724,7 @@ a:focus {
             color: @dark-bc-text;
         }
     }
-    
+
     .stylesheet-dir {
         color: @bc-text-quiet;
 
@@ -981,15 +981,15 @@ a[href^="http"] {
             // Enable text selection
             cursor: auto;
             .user-select(text);
-            
+
             h3 {
                 font-weight: normal;
                 margin: 0 0 10px;
             }
-            
+
             ul {
                 margin-bottom: 0 0 20px;
-                
+
                 > li {
                     margin-bottom: 10px;
                 }
@@ -1027,7 +1027,7 @@ a[href^="http"] {
 .extension-manager-dialog {
     background-color: @bc-panel-bg-promoted;
     width: 760px;
-    
+
     .dark & {
         background-color: @dark-bc-panel-bg-promoted;
     }
@@ -1035,7 +1035,7 @@ a[href^="http"] {
     .modal-header {
         border-bottom: none;
         padding: 0;
-        
+
         .nav-tabs {
             margin: 0;
             border-color: @bc-panel-separator;
@@ -1107,7 +1107,7 @@ a[href^="http"] {
                     border-color: @dark-bc-btn-border @dark-bc-btn-border transparent @dark-bc-btn-border;
                 }
             }
-            
+
             > .active > a:focus {
                 background-color: @bc-panel-bg;
                 border-color: @bc-btn-border-focused @bc-btn-border-focused transparent @bc-btn-border-focused;
@@ -1141,10 +1141,18 @@ a[href^="http"] {
 
         /* Search box */
         > :nth-child(2) {
-            position: absolute;
-            top: 15px;
-            right: 15px;
+            @media (max-width: @extension-manager-min-width) {
+                overflow: hidden;
+                padding: 0 15px;
+            }
+
+            @media (min-width: @extension-manager-min-width) {
+                position: absolute;
+                top: 15px;
+                right: 15px;
+            }
         }
+
         .search {
             background: @bc-input-bg url("images/topcoat-search-20.svg") 2px 2px no-repeat;
             float: right;
@@ -1217,7 +1225,7 @@ a[href^="http"] {
         overflow-y: scroll;
         background-color: @bc-panel-bg;
         padding: 0;
-        
+
         .dark & {
             background-color: @dark-bc-panel-bg;
         }
@@ -1482,7 +1490,7 @@ input[type="color"],
     &.top .tooltip-arrow {
         border-top-color: @bc-menu-bg;
         left: 50%;
-        
+
         .dark & {
             border-top-color: @dark-bc-menu-bg;
         }
@@ -1490,7 +1498,7 @@ input[type="color"],
     &.right .tooltip-arrow {
         border-right-color: @bc-menu-bg;
         top: 15px;
-        
+
         .dark & {
             border-right-color: @dark-bc-menu-bg;
         }
@@ -1498,7 +1506,7 @@ input[type="color"],
     &.left .tooltip-arrow {
         border-left-color: @bc-menu-bg;
         top: 15px;
-        
+
         .dark & {
             border-left-color: @dark-bc-menu-bg;
         }
@@ -1506,7 +1514,7 @@ input[type="color"],
     &.bottom .tooltip-arrow {
         border-bottom-color: @bc-menu-bg;
         left: 50%;
-        
+
         .dark & {
             border-bottom-color: @dark-bc-menu-bg;
         }
@@ -1610,7 +1618,7 @@ input[type="color"],
             color: @dark-bc-text-alt;
         }
     }
-    
+
     &:active:not([disabled]) {
         background-image: none;
         background-color: @bc-btn-bg-down;
@@ -1673,7 +1681,7 @@ input[type="color"],
             }
         }
     }
-    
+
     // Update Button Type
     &.update {
         background-color: @bc-secondary-btn-bg;
@@ -1682,7 +1690,7 @@ input[type="color"],
         color: @bc-text-alt;
         font-weight: @font-weight-semibold;
         text-shadow: 0 -1px 0 @bc-shadow-small;
-        
+
         .dark & {
             background-color: @dark-bc-secondary-btn-bg;
             border-color: @dark-bc-secondary-btn-border;
@@ -1923,13 +1931,13 @@ select {
     &:active {
         background-color: @bc-btn-bg-down;
         box-shadow: inset 0 1px 0 @bc-shadow-small;
-        
+
         .dark & {
             background-color: @dark-bc-btn-bg-down;
             box-shadow: inset 0 1px 0 @dark-bc-shadow-small;
         }
     }
-    
+
     > option { // Windows (but not Mac) lets you style the dropdown items
         background-color: @bc-menu-bg;
         color: @bc-menu-text;
@@ -1992,7 +2000,7 @@ code {
 .dropdown-menu {
     background-color: @bc-menu-bg;
     color: @bc-menu-text;
-    
+
     .dark & {
         background-color: @dark-bc-menu-bg;
         color: @dark-bc-menu-text;
@@ -2011,7 +2019,7 @@ code {
 .form-horizontal {
     .controls {
         margin-left: 170px;
-        
+
         input[type='checkbox'] {
              margin-top: 8px;
         }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1143,7 +1143,7 @@ a[href^="http"] {
         > :nth-child(2) {
             @media (max-width: @extension-manager-min-width) {
                 overflow: hidden;
-                padding: 0 1em;
+                padding: 8px 1em;
             }
 
             @media (min-width: @extension-manager-min-width) {
@@ -1194,6 +1194,7 @@ a[href^="http"] {
         .sort-extensions {
             float: left;
             margin-right: 10px;
+            margin-bottom: 0;
             width: auto;
             padding-right: 18px;
             border-bottom-left-radius: 0px;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1143,7 +1143,7 @@ a[href^="http"] {
         > :nth-child(2) {
             @media (max-width: @extension-manager-min-width) {
                 overflow: hidden;
-                padding: 0 15px;
+                padding: 0 1em;
             }
 
             @media (min-width: @extension-manager-min-width) {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1160,8 +1160,11 @@ a[href^="http"] {
         }
 
         .search {
+            @media (max-width: (@extension-manager-min-width - 1px)) {
+                width: calc(~'100% - 27px - 20px'); // 100% minus padding etc.
+            }
+
             background: @bc-input-bg url("images/topcoat-search-20.svg") 2px 2px no-repeat;
-            width: calc(~'100% - 27px - 20px'); // 100% minus padding etc.
             margin: 0;
             padding-left: 27px;
             padding-right: 20px;

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -1,21 +1,21 @@
 // Copyright (c) 2012 - present Adobe Systems Incorporated. All rights reserved.
-//  
+//
 // Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-//  
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-//  
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 
@@ -35,6 +35,9 @@
 /* Main layout */
 @sidebar-width: 200px;  // user resizable, however
 @main-toolbar-width: 30px;
+
+/* Extension Manager */
+@extension-manager-min-width: 680px; // Used for responsive styling
 
 /* z-index */
 @z-index-cm-dialog-override: 11;


### PR DESCRIPTION
I've added queries to stop the search and filter drop-down from overlapping the tabs when the window becomes too small, and from there, the search bar element will adjust in size

Ref issue: #13209 