### PR TITLE
Add new comments preference. Support indent block comments on line co…

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2713,7 +2713,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Returns true if blockCommentIndent is enabled for the specified or current file
+     * Sets indentBlockComment option.
      * Affects any editors that share the same preference location.
      * @param {boolean} value
      * @param {string=} fullPath Path to file to get preference for

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -81,25 +81,24 @@ define(function (require, exports, module) {
 
     /** Editor preferences */
 
-    var CLOSE_BRACKETS       = "closeBrackets",
-        CLOSE_TAGS           = "closeTags",
-        DRAG_DROP            = "dragDropText",
-        HIGHLIGHT_MATCHES    = "highlightMatches",
-        LINEWISE_COPY_CUT    = "lineWiseCopyCut",
-        SCROLL_PAST_END      = "scrollPastEnd",
-        SHOW_CURSOR_SELECT   = "showCursorWhenSelecting",
-        SHOW_LINE_NUMBERS    = "showLineNumbers",
-        SMART_INDENT         = "smartIndent",
-        SOFT_TABS            = "softTabs",
-        SPACE_UNITS          = "spaceUnits",
-        STYLE_ACTIVE_LINE    = "styleActiveLine",
-        TAB_SIZE             = "tabSize",
-        UPPERCASE_COLORS     = "uppercaseColors",
-        USE_TAB_CHAR         = "useTabChar",
-        WORD_WRAP            = "wordWrap",
-        INDENT_LINE_COMMENT  = "indentLineComment",
-        INDENT_BLOCK_COMMENT = "indentBlockComment",
-        INPUT_STYLE          = "inputStyle";
+    var CLOSE_BRACKETS      = "closeBrackets",
+        CLOSE_TAGS          = "closeTags",
+        DRAG_DROP           = "dragDropText",
+        HIGHLIGHT_MATCHES   = "highlightMatches",
+        LINEWISE_COPY_CUT   = "lineWiseCopyCut",
+        SCROLL_PAST_END     = "scrollPastEnd",
+        SHOW_CURSOR_SELECT  = "showCursorWhenSelecting",
+        SHOW_LINE_NUMBERS   = "showLineNumbers",
+        SMART_INDENT        = "smartIndent",
+        SOFT_TABS           = "softTabs",
+        SPACE_UNITS         = "spaceUnits",
+        STYLE_ACTIVE_LINE   = "styleActiveLine",
+        TAB_SIZE            = "tabSize",
+        UPPERCASE_COLORS    = "uppercaseColors",
+        USE_TAB_CHAR        = "useTabChar",
+        WORD_WRAP           = "wordWrap",
+        INDENT_LINE_COMMENT = "indentLineComment",
+        INPUT_STYLE         = "inputStyle";
 
 
     /**
@@ -230,9 +229,6 @@ define(function (require, exports, module) {
     });
     PreferencesManager.definePreference(INDENT_LINE_COMMENT,  "boolean", false, {
         description: Strings.DESCRIPTION_INDENT_LINE_COMMENT
-    });
-    PreferencesManager.definePreference(INDENT_BLOCK_COMMENT,  "boolean", false, {
-        description: Strings.DESCRIPTION_INDENT_BLOCK_COMMENT
     });
     PreferencesManager.definePreference(INPUT_STYLE,  "string", "textarea", {
         description: Strings.DESCRIPTION_INPUT_STYLE
@@ -2710,27 +2706,6 @@ define(function (require, exports, module) {
      */
     Editor.getIndentLineComment = function (fullPath) {
         return PreferencesManager.get(INDENT_LINE_COMMENT, _buildPreferencesContext(fullPath));
-    };
-
-    /**
-     * Sets indentBlockComment option.
-     * Affects any editors that share the same preference location.
-     * @param {boolean} value
-     * @param {string=} fullPath Path to file to get preference for
-     * @return {boolean} true if value was valid
-     */
-    Editor.setIndentBlockComment = function (value, fullPath) {
-        var options = fullPath && {context: fullPath};
-        return PreferencesManager.set(INDENT_BLOCK_COMMENT, value, options);
-    };
-
-    /**
-     * Returns true if indentBlockComment is enabled for the specified or current file
-     * @param {string=} fullPath Path to file to get preference for
-     * @return {boolean}
-     */
-    Editor.getIndentBlockComment = function (fullPath) {
-        return PreferencesManager.get(INDENT_BLOCK_COMMENT, _buildPreferencesContext(fullPath));
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -80,24 +80,27 @@ define(function (require, exports, module) {
         _                  = require("thirdparty/lodash");
 
     /** Editor preferences */
-    var CLOSE_BRACKETS      = "closeBrackets",
-        CLOSE_TAGS          = "closeTags",
-        DRAG_DROP           = "dragDropText",
-        HIGHLIGHT_MATCHES   = "highlightMatches",
-        LINEWISE_COPY_CUT   = "lineWiseCopyCut",
-        SCROLL_PAST_END     = "scrollPastEnd",
-        SHOW_CURSOR_SELECT  = "showCursorWhenSelecting",
-        SHOW_LINE_NUMBERS   = "showLineNumbers",
-        SMART_INDENT        = "smartIndent",
-        SOFT_TABS           = "softTabs",
-        SPACE_UNITS         = "spaceUnits",
-        STYLE_ACTIVE_LINE   = "styleActiveLine",
-        TAB_SIZE            = "tabSize",
-        UPPERCASE_COLORS    = "uppercaseColors",
-        USE_TAB_CHAR        = "useTabChar",
-        WORD_WRAP           = "wordWrap",
-        INDENT_LINE_COMMENT = "indentLineComment",
-        INPUT_STYLE         = "inputStyle";
+
+    var CLOSE_BRACKETS       = "closeBrackets",
+        CLOSE_TAGS           = "closeTags",
+        DRAG_DROP            = "dragDropText",
+        HIGHLIGHT_MATCHES    = "highlightMatches",
+        LINEWISE_COPY_CUT    = "lineWiseCopyCut",
+        SCROLL_PAST_END      = "scrollPastEnd",
+        SHOW_CURSOR_SELECT   = "showCursorWhenSelecting",
+        SHOW_LINE_NUMBERS    = "showLineNumbers",
+        SMART_INDENT         = "smartIndent",
+        SOFT_TABS            = "softTabs",
+        SPACE_UNITS          = "spaceUnits",
+        STYLE_ACTIVE_LINE    = "styleActiveLine",
+        TAB_SIZE             = "tabSize",
+        UPPERCASE_COLORS     = "uppercaseColors",
+        USE_TAB_CHAR         = "useTabChar",
+        WORD_WRAP            = "wordWrap",
+        INDENT_LINE_COMMENT  = "indentLineComment",
+        INDENT_BLOCK_COMMENT = "indentBlockComment",
+        INPUT_STYLE          = "inputStyle";
+
 
     /**
       * A list of gutter name and priorities currently registered for editors.
@@ -225,11 +228,12 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference(WORD_WRAP,          "boolean", true, {
         description: Strings.DESCRIPTION_WORD_WRAP
     });
-
     PreferencesManager.definePreference(INDENT_LINE_COMMENT,  "boolean", false, {
         description: Strings.DESCRIPTION_INDENT_LINE_COMMENT
     });
-
+    PreferencesManager.definePreference(INDENT_BLOCK_COMMENT,  "boolean", false, {
+        description: Strings.DESCRIPTION_INDENT_BLOCK_COMMENT
+    });
     PreferencesManager.definePreference(INPUT_STYLE,  "string", "textarea", {
         description: Strings.DESCRIPTION_INPUT_STYLE
     });
@@ -2688,8 +2692,8 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Sets lineCommentIndent option.
-     *
+     * Sets indentLineComment option.
+     * Affects any editors that share the same preference location.
      * @param {boolean} value
      * @param {string=} fullPath Path to file to get preference for
      * @return {boolean} true if value was valid
@@ -2700,12 +2704,33 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Returns true if word wrap is enabled for the specified or current file
+     * Returns true if indentLineComment is enabled for the specified or current file
      * @param {string=} fullPath Path to file to get preference for
      * @return {boolean}
      */
     Editor.getIndentLineComment = function (fullPath) {
         return PreferencesManager.get(INDENT_LINE_COMMENT, _buildPreferencesContext(fullPath));
+    };
+
+    /**
+     * Returns true if blockCommentIndent is enabled for the specified or current file
+     * Affects any editors that share the same preference location.
+     * @param {boolean} value
+     * @param {string=} fullPath Path to file to get preference for
+     * @return {boolean} true if value was valid
+     */
+    Editor.setIndentBlockComment = function (value, fullPath) {
+        var options = fullPath && {context: fullPath};
+        return PreferencesManager.set(INDENT_BLOCK_COMMENT, value, options);
+    };
+
+    /**
+     * Returns true if indentBlockComment is enabled for the specified or current file
+     * @param {string=} fullPath Path to file to get preference for
+     * @return {boolean}
+     */
+    Editor.getIndentBlockComment = function (fullPath) {
+        return PreferencesManager.get(INDENT_BLOCK_COMMENT, _buildPreferencesContext(fullPath));
     };
 
     /**

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -308,7 +308,7 @@ define(function (require, exports, module) {
     function _firstNotWs(doc, lineNum) {
         var text = doc.getLine(lineNum);
         if (text === null || text === undefined) {
-            return null;
+            return 0;
         }
 
         return text.search(/\S|$/);

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -489,12 +489,14 @@ define(function (require, exports, module) {
                 if (completeLineSel) {
                     if (indentBlockComment) {
                         var endCh = _firstNotWs(doc, sel.end.line - 1);
+                        var useTabChar = Editor.getUseTabChar(editor.document.file.fullPath);
+                        var indentChar = useTabChar ? "\t" : " ";
                         editGroup.push({
-                            text: _.repeat(" ", endCh) + suffix + "\n",
+                            text: _.repeat(indentChar, endCh) + suffix + "\n",
                             start: {line: sel.end.line, ch: 0}
                         });
                         editGroup.push({
-                            text: prefix + "\n" + _.repeat(" ", startCh),
+                            text: prefix + "\n" + _.repeat(indentChar, startCh),
                             start: {line: sel.start.line, ch: startCh}
                         });
                     } else {

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -361,7 +361,7 @@ define(function (require, exports, module) {
 
         var searchCtx, atSuffix, suffixEnd, initialPos, endLine;
 
-        var indentBlockComment = Editor.getIndentBlockComment();
+        var indentLineComment = Editor.getIndentLineComment();
 
         if (!selectionsToTrack) {
             // Track the original selection.
@@ -487,7 +487,7 @@ define(function (require, exports, module) {
                 var completeLineSel = sel.start.ch === 0 && sel.end.ch === 0 && sel.start.line < sel.end.line;
                 var startCh = _firstNotWs(doc, sel.start.line);
                 if (completeLineSel) {
-                    if (indentBlockComment) {
+                    if (indentLineComment) {
                         var endCh = _firstNotWs(doc, sel.end.line - 1);
                         var useTabChar = Editor.getUseTabChar(editor.document.file.fullPath);
                         var indentChar = useTabChar ? "\t" : " ";
@@ -505,7 +505,7 @@ define(function (require, exports, module) {
                     }
                 } else {
                     editGroup.push({text: suffix, start: sel.end});
-                    if (indentBlockComment) {
+                    if (indentLineComment) {
                         editGroup.push({text: prefix, start: { line: sel.start.line, ch: startCh }});
                     } else {
                         editGroup.push({text: prefix, start: sel.start});
@@ -534,7 +534,7 @@ define(function (require, exports, module) {
                             if (completeLineSel) {
                                 // Just move the line down.
                                 pos.line++;
-                            } else if (!indentBlockComment && pos.line === sel.start.line) {
+                            } else if (!indentLineComment && pos.line === sel.start.line) {
                                 pos.ch += prefix.length;
                             }
                         }
@@ -550,14 +550,14 @@ define(function (require, exports, module) {
                 // If both are found we assume that a complete line selection comment added new lines, so we remove them.
                 var line          = doc.getLine(prefixPos.line).trim(),
                     prefixAtStart = prefixPos.ch === 0 && prefix.length === line.length,
-                    prefixIndented = indentBlockComment && prefix.length === line.length,
+                    prefixIndented = indentLineComment && prefix.length === line.length,
                     suffixAtStart = false,
                     suffixIndented = false;
 
                 if (suffixPos) {
                     line = doc.getLine(suffixPos.line).trim();
                     suffixAtStart = suffixPos.ch === 0 && suffix.length === line.length;
-                    suffixIndented = indentBlockComment && suffix.length === line.length;
+                    suffixIndented = indentLineComment && suffix.length === line.length;
                 }
 
                 // Remove the suffix if there is one

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -797,6 +797,7 @@ define({
     "DEFAULT_PREFERENCES_JSON_DEFAULT"               : "Default",
     "DESCRIPTION_PURE_CODING_SURFACE"                : "true to enable code only mode and hide all other UI elements in {APP_NAME}",
     "DESCRIPTION_INDENT_LINE_COMMENT"                : "true to enable indenting of line comments",
+    "DESCRIPTION_INDENT_BLOCK_COMMENT"               : "true to enable indenting of block comments",
     "DESCRIPTION_RECENT_FILES_NAV"                   : "Enable/disable navigation in recent files",
     "DESCRIPTION_LIVEDEV_WEBSOCKET_PORT"             : "Port on which WebSocket Server runs for Live Preview"
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -797,7 +797,6 @@ define({
     "DEFAULT_PREFERENCES_JSON_DEFAULT"               : "Default",
     "DESCRIPTION_PURE_CODING_SURFACE"                : "true to enable code only mode and hide all other UI elements in {APP_NAME}",
     "DESCRIPTION_INDENT_LINE_COMMENT"                : "true to enable indenting of line comments",
-    "DESCRIPTION_INDENT_BLOCK_COMMENT"               : "true to enable indenting of block comments",
     "DESCRIPTION_RECENT_FILES_NAV"                   : "Enable/disable navigation in recent files",
     "DESCRIPTION_LIVEDEV_WEBSOCKET_PORT"             : "Port on which WebSocket Server runs for Live Preview"
 });

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -1093,6 +1093,58 @@ define(function (require, exports, module) {
             });
         });
 
+        // The "block comment" command should be unaffected by indentLineComment preference.
+        describe("Block comment/uncomment in languages with only block comments and with indentLineComment enabled", function () {
+            var htmlContent = "<html>\n" +
+                              "    <body>\n" +
+                              "        <p>Hello</p>\n" +
+                              "    </body>\n" +
+                              "</html>";
+
+            beforeEach(function () {
+                setupFullEditor(htmlContent, "html");
+                PreferencesManager.set("indentLineComment", true);
+            });
+
+            afterEach(function () {
+                PreferencesManager.set("indentLineComment", shouldIndentLineComment);
+            });
+
+            it("should comment/uncomment a single line, cursor at start", function () {
+                myEditor.setCursorPos(2, 0);
+
+                var lines = htmlContent.split("\n");
+                lines[2] = "<!---->        <p>Hello</p>";
+                var expectedText = lines.join("\n");
+
+                testToggleBlock(expectedText, {line: 2, ch: 0});
+            });
+
+            it("should comment/uncomment a single line, cursor at end", function () {
+                myEditor.setCursorPos(2, 20);
+
+                var lines = htmlContent.split("\n");
+                lines[2] = "        <p>Hello</p><!---->";
+                var expectedText = lines.join("\n");
+
+                testToggleBlock(expectedText, {line: 2, ch: 24});
+            });
+
+            it("should comment/uncomment a block", function () {
+                myEditor.setSelection({line: 1, ch: 4}, {line: 3, ch: 11});
+
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+
+                var expectedText = "<html>\n" +
+                                   "    <!--<body>\n" +
+                                   "        <p>Hello</p>\n" +
+                                   "    </body>-->\n" +
+                                   "</html>";
+
+                testToggleBlock(expectedText, {start: {line: 1, ch: 8}, end: {line: 3, ch: 11}});
+            });
+        });
+
         describe("Line comment in languages with mutiple line comment prefixes", function () {
             // Define a special version of JavaScript for testing purposes
             LanguageManager.defineLanguage("javascript2", {

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -1133,8 +1133,6 @@ define(function (require, exports, module) {
             it("should comment/uncomment a block", function () {
                 myEditor.setSelection({line: 1, ch: 4}, {line: 3, ch: 11});
 
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-
                 var expectedText = "<html>\n" +
                                    "    <!--<body>\n" +
                                    "        <p>Hello</p>\n" +

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -959,12 +959,13 @@ define(function (require, exports, module) {
                 var expectedText = lines.join("\n");
 
                 testToggleLine(expectedText, {line: 2, ch: 0});
+
+                // Uncomment
+                testToggleLine(htmlContent, {line: 2, ch: 0});
             });
 
             it("should comment/uncomment a block", function () {
                 myEditor.setSelection({line: 1, ch: 7}, {line: 3, ch: 7});
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
 
                 var expectedText = "<html>\n" +
                                    "    <!--\n" +
@@ -974,14 +975,14 @@ define(function (require, exports, module) {
                                    "    -->\n" +
                                    "</html>";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 2, ch: 7}, end: {line: 4, ch: 7}});
+                testToggleLine(expectedText, {start: {line: 2, ch: 7}, end: {line: 4, ch: 7}});
+
+                // Uncomment
+                testToggleLine(htmlContent, {start: {line: 1, ch: 7}, end: {line: 3, ch: 7}});
             });
 
             it("should comment/uncomment a block with not closing tag ", function () {
                 myEditor.setSelection({line: 1, ch: 7}, {line: 2, ch: 7});
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
 
                 var expectedText = "<html>\n" +
                                    "    <!--\n" +
@@ -991,14 +992,14 @@ define(function (require, exports, module) {
                                    "    </body>\n" +
                                    "</html>";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 2, ch: 7}, end: {line: 3, ch: 7}});
+                testToggleLine(expectedText, {start: {line: 2, ch: 7}, end: {line: 3, ch: 7}});
+
+                // Uncomment
+                testToggleLine(htmlContent, {start: {line: 1, ch: 7}, end: {line: 2, ch: 7}});
             });
 
             it("should comment/uncomment a block with not closing tag at end of file", function () {
                 myEditor.setSelection({line: 3, ch: 9}, {line: 4, ch: 5});
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
 
                 var expectedText = "<html>\n" +
                                    "    <body>\n" +
@@ -1007,8 +1008,10 @@ define(function (require, exports, module) {
                                    "    </body>\n" +
                                    "</html>-->\n";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 4, ch: 9}, end: {line: 5, ch: 5}});
+                testToggleLine(expectedText, {start: {line: 4, ch: 9}, end: {line: 5, ch: 5}});
+
+                // Uncomment
+                testToggleLine(htmlContent + "\n", {start: {line: 3, ch: 9}, end: {line: 4, ch: 5}});
             });
         });
 
@@ -1045,8 +1048,6 @@ define(function (require, exports, module) {
             it("should comment/uncomment a block", function () {
                 myEditor.setSelection({line: 1, ch: 4}, {line: 3, ch: 4});
 
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-
                 var expectedText = "<html>\n" +
                                    "\t<!--\n" +
                                    "\t<body>\n" +
@@ -1055,14 +1056,14 @@ define(function (require, exports, module) {
                                    "\t-->\n" +
                                    "</html>";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 2, ch: 4}, end: {line: 4, ch: 4}});
+                testToggleLine(expectedText, {start: {line: 2, ch: 4}, end: {line: 4, ch: 4}});
+
+                // Uncomment
+                testToggleLine(htmlContent, {start: {line: 1, ch: 4}, end: {line: 3, ch: 4}});
             });
 
             it("should comment/uncomment a block with not closing tag ", function () {
                 myEditor.setSelection({line: 1, ch: 4}, {line: 2, ch: 7});
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
 
                 var expectedText = "<html>\n" +
                                    "\t<!--\n" +
@@ -1072,14 +1073,14 @@ define(function (require, exports, module) {
                                    "\t</body>\n" +
                                    "</html>";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 2, ch: 4}, end: {line: 3, ch: 7}});
+                testToggleLine(expectedText, {start: {line: 2, ch: 4}, end: {line: 3, ch: 7}});
+
+                // Uncomment
+                testToggleLine(htmlContent, {start: {line: 1, ch: 4}, end: {line: 2, ch: 7}});
             });
 
             it("should comment/uncomment a block with not closing tag at end of file", function () {
                 myEditor.setSelection({line: 3, ch: 6}, {line: 4, ch: 2});
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
 
                 var expectedText = "<html>\n" +
                                    "\t<body>\n" +
@@ -1088,8 +1089,10 @@ define(function (require, exports, module) {
                                    "\t</body>\n" +
                                    "</html>-->\n";
 
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelection({start: {line: 4, ch: 6}, end: {line: 5, ch: 2}});
+                testToggleLine(expectedText, {start: {line: 4, ch: 6}, end: {line: 5, ch: 2}});
+
+                // Uncomment
+                testToggleLine(htmlContent + "\n", {start: {line: 3, ch: 6}, end: {line: 4, ch: 2}});
             });
         });
 
@@ -1117,7 +1120,7 @@ define(function (require, exports, module) {
                 lines[2] = "<!---->        <p>Hello</p>";
                 var expectedText = lines.join("\n");
 
-                testToggleBlock(expectedText, {line: 2, ch: 0});
+                testToggleBlock(expectedText, {line: 2, ch: 4});
             });
 
             it("should comment/uncomment a single line, cursor at end", function () {

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -37,8 +37,7 @@ define(function (require, exports, module) {
 
     require("editor/EditorCommandHandlers");
 
-    var shouldIndentLineComment = Editor.getIndentLineComment(),
-        shouldIndentBlockComment = Editor.getIndentBlockComment();
+    var shouldIndentLineComment = Editor.getIndentLineComment();
 
     describe("EditorCommandHandlers", function () {
 
@@ -936,7 +935,7 @@ define(function (require, exports, module) {
             });
         });
 
-        describe("Line comment/uncomment in languages with only block comments and with indentBlockComment enabled", function () {
+        describe("Line comment/uncomment in languages with only block comments and with indentLineComment enabled", function () {
             var htmlContent = "<html>\n" +
                               "    <body>\n" +
                               "        <p>Hello</p>\n" +
@@ -945,11 +944,11 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor(htmlContent, "html");
-                PreferencesManager.set("indentBlockComment", true);
+                PreferencesManager.set("indentLineComment", true);
             });
 
             afterEach(function () {
-                PreferencesManager.set("indentBlockComment", shouldIndentBlockComment);
+                PreferencesManager.set("indentLineComment", shouldIndentLineComment);
             });
 
             it("should comment/uncomment a single line, cursor at start", function () {
@@ -1013,7 +1012,7 @@ define(function (require, exports, module) {
             });
         });
 
-        describe("Line comment/uncomment in languages with only block comments and with indentBlockComment enabled and use of Tabs", function () {
+        describe("Line comment/uncomment in languages with only block comments and with indentLineComment enabled and use of Tabs", function () {
             var htmlContent = "<html>\n" +
                               "\t<body>\n" +
                               "\t\t<p>Hello</p>\n" +
@@ -1024,12 +1023,12 @@ define(function (require, exports, module) {
 
             beforeEach(function () {
                 setupFullEditor(htmlContent, "html");
-                PreferencesManager.set("indentBlockComment", true);
+                PreferencesManager.set("indentLineComment", true);
                 PreferencesManager.set("useTabChar", true);
             });
 
             afterEach(function () {
-                PreferencesManager.set("indentBlockComment", shouldIndentBlockComment);
+                PreferencesManager.set("indentLineComment", shouldIndentLineComment);
                 PreferencesManager.set("useTabChar", shouldUseTabChar);
             });
 
@@ -1091,104 +1090,6 @@ define(function (require, exports, module) {
 
                 expect(myDocument.getText()).toEqual(expectedText);
                 expectSelection({start: {line: 4, ch: 6}, end: {line: 5, ch: 2}});
-            });
-        });
-
-        describe("Comment/uncomment with mixed syntax modes with indentLineComment and indentBlockComment enabled", function () {
-            var htmlContent = "<html>\n" +
-                              "    <head>\n" +
-                              "        <style type='text/css'>\n" +
-                              "            body {\n" +
-                              "                font-size: 15px;\n" +
-                              "            }\n" +
-                              "        </style>\n" +
-                              "        <script type='text/javascript'>\n" +
-                              "            function foo() {\n" +
-                              "                function bar() {\n" +
-                              "                    a();\n" +
-                              "                }\n" +
-                              "            }\n" +
-                              "        </script>\n" +
-                              "    </head>\n" +
-                              "    <body>\n" +
-                              "        <p>Hello</p>\n" +
-                              "        <p>World</p>\n" +
-                              "    </body>\n" +
-                              "</html>";
-
-            beforeEach(function () {
-                setupFullEditor(htmlContent, "html");
-                PreferencesManager.set("indentLineComment", true);
-                PreferencesManager.set("indentBlockComment", true);
-            });
-
-            afterEach(function () {
-                PreferencesManager.set("indentLineComment", shouldIndentLineComment);
-                PreferencesManager.set("indentBlockComment", shouldIndentBlockComment);
-            });
-
-            it("should line comment/uncomment generic JS, CSS and HTML code with multiple cursors at start of line", function () {
-                myEditor.setSelections([
-                    {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}},
-                    {start: {line: 10, ch: 0}, end: {line: 10, ch: 0}},
-                    {start: {line: 16, ch: 0}, end: {line: 16, ch: 0}}
-                ]);
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-
-                var lines = htmlContent.split("\n");
-                lines[4] = "                /*font-size: 15px;*/";
-                lines[10] = "                    //a();";
-                lines[16] = "        <!--<p>Hello</p>-->";
-                var expectedText = lines.join("\n");
-
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelections([
-                    {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
-                    {start: {line: 10, ch: 0}, end: {line: 10, ch: 0}, reversed: false, primary: false},
-                    {start: {line: 16, ch: 0}, end: {line: 16, ch: 0}, reversed: false, primary: true}
-                ]);
-
-                // Uncomment
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-                expect(myDocument.getText()).toEqual(htmlContent);
-                expectSelections([
-                    {start: {line: 4, ch: 0}, end: {line: 4, ch: 0}, reversed: false, primary: false},
-                    {start: {line: 10, ch: 0}, end: {line: 10, ch: 0}, reversed: false, primary: false},
-                    {start: {line: 16, ch: 0}, end: {line: 16, ch: 0}, reversed: false, primary: true}
-                ]);
-            });
-
-            it("should line comment/uncomment generic JS, CSS and HTML code with multiple cursors at end of line", function () {
-                myEditor.setSelections([
-                    {start: {line: 4, ch: 32}, end: {line: 4, ch: 32}},
-                    {start: {line: 10, ch: 24}, end: {line: 10, ch: 24}},
-                    {start: {line: 16, ch: 20}, end: {line: 16, ch: 20}}
-                ]);
-
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-
-                var lines = htmlContent.split("\n");
-                lines[4] = "                /*font-size: 15px;*/";
-                lines[10] = "                    //a();";
-                lines[16] = "        <!--<p>Hello</p>-->";
-                var expectedText = lines.join("\n");
-
-                expect(myDocument.getText()).toEqual(expectedText);
-                expectSelections([
-                    {start: {line: 4, ch: 32}, end: {line: 4, ch: 32}, reversed: false, primary: false},
-                    {start: {line: 10, ch: 26}, end: {line: 10, ch: 26}, reversed: false, primary: false},
-                    {start: {line: 16, ch: 20}, end: {line: 16, ch: 20}, reversed: false, primary: true}
-                ]);
-
-                // Uncomment
-                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
-                expect(myDocument.getText()).toEqual(htmlContent);
-                expectSelections([
-                    {start: {line: 4, ch: 30}, end: {line: 4, ch: 30}, reversed: false, primary: false},
-                    {start: {line: 10, ch: 24}, end: {line: 10, ch: 24}, reversed: false, primary: false},
-                    {start: {line: 16, ch: 16}, end: {line: 16, ch: 16}, reversed: false, primary: true}
-                ]);
             });
         });
 
@@ -2604,7 +2505,6 @@ define(function (require, exports, module) {
             });
 
             it("should line comment/uncomment generic JS code", function () {
-                
                 myEditor.setCursorPos(10, 0);
 
                 CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
@@ -2620,11 +2520,27 @@ define(function (require, exports, module) {
                 CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
                 expect(myDocument.getText()).toEqual(htmlContent);
                 expectCursorAt({line: 10, ch: 0});
-             
+            });
+
+            it("should line comment/uncomment and indent HTML code", function () {
+                myEditor.setCursorPos(16, 8);
+
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+
+                var lines = htmlContent.split("\n");
+                lines[16] = "        <!--<p>Hello</p>-->";
+                var expectedText = lines.join("\n");
+
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectCursorAt({line: 16, ch: 12});
+
+                // Uncomment
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+                expect(myDocument.getText()).toEqual(htmlContent);
+                expectCursorAt({line: 16, ch: 8});
             });
 
             describe("with multiple selections", function () {
-                
                 beforeEach(function () {
                     PreferencesManager.set("indentLineComment", true);
                 });
@@ -2632,26 +2548,22 @@ define(function (require, exports, module) {
                 afterEach(function () {
                     PreferencesManager.set("indentLineComment", shouldIndentLineComment);
                 });
-                
 
                 it("should handle multiple selections in different regions, toggling line selection (but falling back to block selection in HTML/CSS)", function () {
-                    
                     myEditor.setSelections([{start: {line: 1, ch: 4}, end: {line: 1, ch: 10}},
                                         {start: {line: 4, ch: 16}, end: {line: 4, ch: 32}},
                                         {start: {line: 10, ch: 0}, end: {line: 10, ch: 0}}]);
 
                     var lines = htmlContent.split("\n");
-                    lines[1] = "<!--    <head>-->";
-                    lines[4] = "/*                font-size: 15px;*/";
+                    lines[1] = "    <!--<head>-->";
+                    lines[4] = "                /*font-size: 15px;*/";
                     lines[10] = "                    //a();";
 
                     testToggleLine(lines.join("\n"), [{start: {line: 1, ch: 8 }, end: {line: 1, ch: 14 }, reversed: false, primary: false},
                                                       {start: {line: 4, ch: 18 }, end: {line: 4, ch: 34 }, reversed: false, primary: false},
                                                       {start: {line: 10, ch: 0 }, end: {line: 10, ch: 0 }, reversed: false, primary: true}]);
-                    
                 });
             });
-
         });
 
 

--- a/test/spec/EditorCommandHandlers-test.js
+++ b/test/spec/EditorCommandHandlers-test.js
@@ -1013,6 +1013,87 @@ define(function (require, exports, module) {
             });
         });
 
+        describe("Line comment/uncomment in languages with only block comments and with indentBlockComment enabled and use of Tabs", function () {
+            var htmlContent = "<html>\n" +
+                              "\t<body>\n" +
+                              "\t\t<p>Hello</p>\n" +
+                              "\t</body>\n" +
+                              "</html>";
+
+            var shouldUseTabChar = Editor.getUseTabChar();
+
+            beforeEach(function () {
+                setupFullEditor(htmlContent, "html");
+                PreferencesManager.set("indentBlockComment", true);
+                PreferencesManager.set("useTabChar", true);
+            });
+
+            afterEach(function () {
+                PreferencesManager.set("indentBlockComment", shouldIndentBlockComment);
+                PreferencesManager.set("useTabChar", shouldUseTabChar);
+            });
+
+            it("should comment/uncomment a single line, cursor at start", function () {
+                myEditor.setCursorPos(2, 0);
+
+                var lines = htmlContent.split("\n");
+                lines[2] = "\t\t<!--<p>Hello</p>-->";
+                var expectedText = lines.join("\n");
+
+                testToggleLine(expectedText, {line: 2, ch: 0});
+            });
+
+            it("should comment/uncomment a block", function () {
+                myEditor.setSelection({line: 1, ch: 4}, {line: 3, ch: 4});
+
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+
+                var expectedText = "<html>\n" +
+                                   "\t<!--\n" +
+                                   "\t<body>\n" +
+                                   "\t\t<p>Hello</p>\n" +
+                                   "\t</body>\n" +
+                                   "\t-->\n" +
+                                   "</html>";
+
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 2, ch: 4}, end: {line: 4, ch: 4}});
+            });
+
+            it("should comment/uncomment a block with not closing tag ", function () {
+                myEditor.setSelection({line: 1, ch: 4}, {line: 2, ch: 7});
+
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+
+                var expectedText = "<html>\n" +
+                                   "\t<!--\n" +
+                                   "\t<body>\n" +
+                                   "\t\t<p>Hello</p>\n" +
+                                   "\t\t-->\n" +
+                                   "\t</body>\n" +
+                                   "</html>";
+
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 2, ch: 4}, end: {line: 3, ch: 7}});
+            });
+
+            it("should comment/uncomment a block with not closing tag at end of file", function () {
+                myEditor.setSelection({line: 3, ch: 6}, {line: 4, ch: 2});
+
+                CommandManager.execute(Commands.EDIT_LINE_COMMENT, myEditor);
+
+                var expectedText = "<html>\n" +
+                                   "\t<body>\n" +
+                                   "\t\t<p>Hello</p>\n" +
+                                   "\t<!--\n" +
+                                   "\t</body>\n" +
+                                   "</html>-->\n";
+
+                expect(myDocument.getText()).toEqual(expectedText);
+                expectSelection({start: {line: 4, ch: 6}, end: {line: 5, ch: 2}});
+            });
+        });
+
         describe("Comment/uncomment with mixed syntax modes with indentLineComment and indentBlockComment enabled", function () {
             var htmlContent = "<html>\n" +
                               "    <head>\n" +


### PR DESCRIPTION
…mment command

Fixes https://github.com/adobe/brackets/issues/13169

I created a new `comments` preference with an indent option with the idea of deprecate the `indentLineComment` preference. Is there a way to deprecate a preference?
I used a new object with the idea to add also a `padding` option in the future (like the CodeMirror addon), but maybe is better to simply create a new `indentBlockComment` preference without deprecate anything.
Any thought?