### PR TITLE
Add GitHub Brackets OAuth token to romove CLA pull request limit

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -149,7 +149,7 @@ module.exports = function (grunt) {
         }
 
         options.host    = "api.github.com";
-        options.path    = "/repos/adobe/brackets/issues/" + pull + "access_token=" + process.env.BRACKETS_REPO_OAUTH_TOKEN;
+        options.path    = "/repos/adobe/brackets/issues/" + pull + "?access_token=" + process.env.BRACKETS_REPO_OAUTH_TOKEN;
         options.method  = "GET";
         options.headers = {
             "User-Agent" : "Node.js"

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -149,7 +149,7 @@ module.exports = function (grunt) {
         }
 
         options.host    = "api.github.com";
-        options.path    = "/repos/adobe/brackets/issues/" + pull;
+        options.path    = "/repos/adobe/brackets/issues/" + pull + "access_token=" + process.env.BRACKETS_REPO_OAUTH_TOKEN;
         options.method  = "GET";
         options.headers = {
             "User-Agent" : "Node.js"


### PR DESCRIPTION
This PR adds an OAuth token to remove the CLS pull check limit. The corresponding environment variable has been added to travis environment already.
![oauth](https://cloud.githubusercontent.com/assets/12087205/24650593/4c546cd0-1948-11e7-993f-e55c2bb0d8b4.png)

![image](https://cloud.githubusercontent.com/assets/12087205/24651794/bae150c4-194c-11e7-95dc-b4635dbe6411.png)


@petetnt @ficristo Need your urgent review to merge 😄 