### PR TITLE
CSS code hints in 'style' attribute value context

### DIFF
--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -624,7 +624,7 @@ define(function (require, exports, module) {
         // and in attribute value state of a tag with attribute name style
         if (ctx.token.state.htmlState && (!ctx.token.state.localMode || ctx.token.state.localMode.name !== "css")) {
 
-                // tagInfo is required to aquire the style attr value
+            // tagInfo is required to aquire the style attr value
             var tagInfo = HTMLUtils.getTagInfo(editor, pos, true),
                 // To be used as relative character position
                 offset = tagInfo.position.offset;
@@ -635,7 +635,7 @@ define(function (require, exports, module) {
              * a no-op display function to run CM without a DOM head.
              */
             var _contextCM = new CodeMirror(function () {}, {
-                value: "{" + tagInfo.attr.value + "}",
+                value: "{" + tagInfo.attr.value.replace(/(^")|("$)/g, ""),
                 mode:  "css"
             });
 

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -90,8 +90,13 @@ define(function (require, exports, module) {
             return null;
         }
         var state = ctx.token.state.localState || ctx.token.state;
-        if (!state.context && ctx.token.state.html && ctx.token.state.html.localState) {
-            state = ctx.token.state.html.localState;
+        // if state contains a valid html inner state use that first
+        if (state.htmlState) {
+            state = ctx.token.state.htmlState;
+        } else {
+            if (!state.context && ctx.token.state.html && ctx.token.state.html.localState) {
+                state = ctx.token.state.html.localState;
+            }
         }
         return state;
     }
@@ -435,11 +440,13 @@ define(function (require, exports, module) {
      *           range: {start: {line: number, ch: number},
      *                   end: {line: number, ch: number}}}} A CSS context info object.
      */
-    function _getRuleInfoStartingFromPropValue(ctx, editor) {
-        var propNamePos = $.extend({}, ctx.pos),
+    function _getRuleInfoStartingFromPropValue(ctx, editorParam) {
+        var editor      = editorParam._codeMirror || editorParam,
+            contextDoc  = editor.document || editor.doc,
+            propNamePos = $.extend({}, ctx.pos),
             backwardPos = $.extend({}, ctx.pos),
             forwardPos  = $.extend({}, ctx.pos),
-            propNameCtx = TokenUtils.getInitialContext(editor._codeMirror, propNamePos),
+            propNameCtx = TokenUtils.getInitialContext(editor, propNamePos),
             backwardCtx,
             forwardCtx,
             lastValue = "",
@@ -448,7 +455,7 @@ define(function (require, exports, module) {
             offset = TokenUtils.offsetInToken(ctx),
             canAddNewOne = false,
             testPos = {ch: ctx.pos.ch + 1, line: ctx.pos.line},
-            testToken = editor._codeMirror.getTokenAt(testPos, true),
+            testToken = editor.getTokenAt(testPos, true),
             propName,
             range;
 
@@ -460,7 +467,7 @@ define(function (require, exports, module) {
         }
 
         // Scan backward to collect all preceding property values
-        backwardCtx = TokenUtils.getInitialContext(editor._codeMirror, backwardPos);
+        backwardCtx = TokenUtils.getInitialContext(editor, backwardPos);
         propValues = _getPrecedingPropValues(backwardCtx);
 
         lastValue = "";
@@ -492,14 +499,14 @@ define(function (require, exports, module) {
             offset = 0;
 
             // If pos is at EOL, then there's implied whitespace (newline).
-            if (editor.document.getLine(ctx.pos.line).length > ctx.pos.ch  &&
+            if (contextDoc.getLine(ctx.pos.line).length > ctx.pos.ch  &&
                     (testToken.string.length === 0 || testToken.string.match(/\S/))) {
                 canAddNewOne = false;
             }
         }
 
         // Scan forward to collect all succeeding property values and append to all propValues.
-        forwardCtx = TokenUtils.getInitialContext(editor._codeMirror, forwardPos);
+        forwardCtx = TokenUtils.getInitialContext(editor, forwardPos);
         propValues = propValues.concat(_getSucceedingPropValues(forwardCtx, lastValue));
 
         if (propValues.length) {
@@ -613,16 +620,34 @@ define(function (require, exports, module) {
             return createInfo();
         }
 
+        // Context from the current editor will have htmlState if we are in css mode
+        // and in attribute value state of a tag with attribute name style
+        if (ctx.token.state.htmlState && (!ctx.token.state.localMode || ctx.token.state.localMode.name !== "css")) {
+
+                // tagInfo is required to aquire the style attr value
+            var tagInfo = HTMLUtils.getTagInfo(editor, pos, true),
+                // To be used as relative character position
+                offset = tagInfo.position.offset;
+
+            /**
+             * We will use this CM to cook css context in case of style attribute value
+             * as CM in htmlmixed mode doesn't yet identify this as css context. We provide
+             * a no-op display function to run CM without a DOM head.
+             */
+            var _contextCM = new CodeMirror(function () {}, {
+                value: "{" + tagInfo.attr.value + "}",
+                mode:  "css"
+            });
+
+            ctx = TokenUtils.getInitialContext(_contextCM, {line: 0, ch: offset + 1});
+        }
+        
         if (_isInPropName(ctx)) {
-            return _getPropNameInfo(ctx, editor);
+            return _getPropNameInfo(ctx, ctx.editor);
         }
-
+        
         if (_isInPropValue(ctx)) {
-            return _getRuleInfoStartingFromPropValue(ctx, editor);
-        }
-
-        if (_isInAtRule(ctx)) {
-            return _getImportUrlInfo(ctx, editor);
+            return _getRuleInfoStartingFromPropValue(ctx, ctx.editor);
         }
 
         return createInfo();

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -299,13 +299,14 @@ define(function (require, exports, module) {
      *      className:tag       string:"></span>"
      * @param {Editor} editor An instance of a Brackets editor
      * @param {{ch: number, line: number}} constPos  A CM pos (likely from editor.getCursorPos())
+     * @param {isHtmlMode:boolean} let the module know we are in html mode
      * @return {{tagName:string,
      *           attr:{name:string, value:string, valueAssigned:boolean, quoteChar:string, hasEndQuote:boolean},
      *           position:{tokenType:string, offset:number}
      *         }}
      *         A tagInfo object with some context about the current tag hint.
      */
-    function getTagInfo(editor, constPos) {
+    function getTagInfo(editor, constPos, isHtmlMode) {
         // We're going to be changing pos a lot, but we don't want to mess up
         // the pos the caller passed in so we use extend to make a safe copy of it.
         var pos = $.extend({}, constPos),
@@ -314,8 +315,8 @@ define(function (require, exports, module) {
             tagInfo,
             tokenType;
 
-        // Check if this is inside a style block.
-        if (editor.getModeForSelection() !== "html") {
+        // Check if this is not known to be in html mode and inside a style block.
+        if (!isHtmlMode && editor.getModeForSelection() !== "html") {
             return createTagInfo();
         }
 

--- a/src/language/HTMLUtils.js
+++ b/src/language/HTMLUtils.js
@@ -226,6 +226,18 @@ define(function (require, exports, module) {
                 return createTagInfo();
             }
         }
+        
+        //Skip all the 'string' tokens backwards. Required to reach to the first line 
+        //of multiline HTML attribute value.
+        while (TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, ctx)) {
+            if (ctx.token.type !== "string") {
+                break;
+            }
+        }
+
+        //As we have skipped all the string tokens, make a forward navigation to move to the
+        //first 'string token so that in next backward navigation we can find '='.
+        TokenUtils.moveSkippingWhitespace(TokenUtils.moveNextToken, ctx);
 
         //Move to the prev token, and check if it's "="
         if (!TokenUtils.moveSkippingWhitespace(TokenUtils.movePrevToken, ctx) || ctx.token.string !== "=") {


### PR DESCRIPTION
This PR enables Brackets to provide CSS code hints property-value code hints while editing 'style' attribute value in 'html' mode. The implementation contains minor tweaks to the CSSUtils module to recognize this as 'css' context as CodeMirror doesn't understand the 'style' attribute value as 'css' context. 

Adding @ingorichter @petetnt @zaggino and @ficristo for review, but others can also join 👍 