### PR TITLE
Fix #13274 - make Brackets margin/padding remoteHighlight work like Chrome one

### DIFF
--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -98,9 +98,7 @@ define(function main(require, exports, module) {
         "marginStyling": {
             "background-color": "rgba(21, 165, 255, 0.58)"
         },
-        "stylesToSet": {
-            "border-width": "1px"
-        },
+        "borderColor": "rgba(21, 165, 255, 0.85)",
         "showPaddingMargin": true
     }, {
         description: "LivePreview highlight settings"


### PR DESCRIPTION
Added support for `transform-origin` and fixed the way of showing `border` in highlight div.

This contains a little bit more of changes than the previous one and probably will need a bit of refactor, but it should work. Please mention me if it isn't working for some sets of properties and provide the piece of code that does not look correct.

I've tested/developed it on OSX Sierra 10.12.4, Chrome 57.0.2987.133 (64-bit)