### PR TITLE
Added UI for search History

### DIFF
--- a/src/htmlContent/findreplace-bar.html
+++ b/src/htmlContent/findreplace-bar.html
@@ -1,6 +1,6 @@
 <div class="find-input-group">
     <div id="find-group"><!--
-        --><div class="search-input-container"><input type="text" id="find-what" placeholder="{{queryPlaceholder}}" value="{{initialQuery}}" /><div class="error"></div><span id="find-counter"></span></div><!--
+        --><div class="search-input-container"><input type="text" id="find-what" placeholder="{{queryPlaceholder}}" value="{{initialQuery}}" /><div class="dropdown-icon"></div><div class="error"></div><span id="find-counter"></span></div><!--
         --><button id="find-case-sensitive" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_CASESENSITIVE_HINT}}"><div class="button-icon"></div></button><!--
         --><button id="find-regexp" class="btn no-focus" tabindex="-1" title="{{Strings.BUTTON_REGEXP_HINT}}"><div class="button-icon"></div></button><!--
         {{^multifile}}

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -408,6 +408,10 @@ define(function (require, exports, module) {
         this.focusQuery();
     };
 
+    /**
+     * @private
+     * Shows the search History in dropdown.
+     */
     FindBar.prototype.showSearchHints = function () {
         var self = this;
         this.$searchField = $("input#find-what");

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -491,8 +491,8 @@ define(function (require, exports, module) {
                 //self.trigger("queryChange");
                 self.searchField.destroy();
             },
-            onHighlight: function (selectedItem, query, explicit) {}
-            //verticalAdjust: 44
+            onHighlight: function (selectedItem, query, explicit) {},
+            highlightZeroIndex: false
         });
         this.searchField.setText($("#find-what").val());
     };

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
                 if (e.keyCode === KeyEvent.DOM_VK_RETURN) {
                     e.preventDefault();
                     e.stopPropagation();
-                    var searchVal = self.$("#find-what").val()
+                    var searchVal = self.$("#find-what").val();
                     var searchQueryIndex = searchHistory.indexOf(searchVal);
                     if (searchQueryIndex !== -1) {
                         searchHistory.splice(searchQueryIndex, 1);

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -495,7 +495,7 @@ define(function (require, exports, module) {
             //verticalAdjust: 44
         });
         this.searchField.setText($("#find-what").val());
-    }
+    };
 
     /**
      * Closes this Find bar. If already closed, does nothing.

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -434,11 +434,7 @@ define(function (require, exports, module) {
             maxResults: 20,
             resultProvider: function (query) {
                 var asyncResult = new $.Deferred();
-                var searchHistory = PreferencesManager.getViewState("searchHistory");
-                var filteredResults = _.filter(searchHistory, function (s) {
-                    return s.indexOf(query) !== -1;
-                });
-                asyncResult.resolve(filteredResults);
+                asyncResult.resolve(PreferencesManager.getViewState("searchHistory"));
                 return asyncResult.promise();
             },
             formatter: function (item, query) {

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -40,7 +40,6 @@ define(function (require, exports, module) {
         ViewUtils          = require("utils/ViewUtils"),
         FindUtils          = require("search/FindUtils"),
         QuickSearchField   = require("search/QuickSearchField").QuickSearchField,
-        StringUtils        = require("utils/StringUtils"),
         HealthLogger       = require("utils/HealthLogger");
 
     /**
@@ -228,55 +227,12 @@ define(function (require, exports, module) {
             $elem.attr("title", oldTitle + "(" + KeyBindingManager.formatKeyDescriptor(replaceShortcut.displayKey) + ")");
         }
     };
-    
-    function highlightMatch(item, matchClass, rangeFilter) {
-        var label = item.label || item;
-        matchClass = matchClass || "quicksearch-namematch";
-
-        var stringRanges = item.stringRanges;
-        if (!stringRanges) {
-            // If result didn't come from stringMatch(), highlight nothing
-            stringRanges = [{
-                text: label,
-                matched: false,
-                includesLastSegment: true
-            }];
-        }
-
-        var displayName = "";
-        if (item.scoreDebug) {
-            var sd = item.scoreDebug;
-            displayName += '<span title="sp:' + sd.special + ', m:' + sd.match +
-                ', ls:' + sd.lastSegment + ', b:' + sd.beginning +
-                ', ld:' + sd.lengthDeduction + ', c:' + sd.consecutive + ', nsos: ' +
-                sd.notStartingOnSpecial + ', upper: ' + sd.upper + '">(' + item.matchGoodness + ') </span>';
-        }
-
-        // Put the path pieces together, highlighting the matched parts
-        stringRanges.forEach(function (range) {
-            if (range.matched) {
-                displayName += "<span class='" + matchClass + "'>";
-            }
-
-            var rangeText = rangeFilter ? rangeFilter(range.includesLastSegment, range.text) : range.text;
-            displayName += StringUtils.breakableUrl(rangeText);
-
-            if (range.matched) {
-                displayName += "</span>";
-            }
-        });
-        return displayName;
-    }
 
     /**
      * Opens the Find bar, closing any other existing Find bars.
      */
     FindBar.prototype.open = function () {
         var self = this;
-        
-        //var searchBarHTML = "<div align='right'><input type='text' autocomplete='off' id='' placeholder='" + Strings.CMD_FIND + "\u2026' style='width: 30em'><span class=''></span></div>";
-        //this.modalBar = new ModalBar(searchBarHTML, true);
-        var searchHistory = PreferencesManager.getViewState("searchHistory");
 
         // Normally, creating a new Find bar will simply cause the old one to close
         // automatically. This can cause timing issues because the focus change might
@@ -307,7 +263,9 @@ define(function (require, exports, module) {
             FindBar._removeFindBar(self);
             MainViewManager.focusActivePane();
             self.trigger("close");
-            self.searchField.destroy();
+            if (self.searchField) {
+                self.searchField.destroy();
+            }
         });
 
         FindBar._addFindBar(this);
@@ -357,7 +315,7 @@ define(function (require, exports, module) {
                 if (intervalId === 0) {
                     intervalId = window.setInterval(executeSearchIfNeeded, 50);
                 }
-                
+                var searchHistory = PreferencesManager.getViewState("searchHistory");
                 var maxCount = PreferencesManager.get("maxSearchHistory");
                 if (e.keyCode === KeyEvent.DOM_VK_RETURN) {
                     e.preventDefault();
@@ -395,15 +353,11 @@ define(function (require, exports, module) {
                         self.trigger("doFind", e.shiftKey);
                     }
                     historyIndex = 0;
-                }/* else if (e.keyCode === KeyEvent.DOM_VK_DOWN || e.keyCode === KeyEvent.DOM_VK_UP) {
-                    if (e.keyCode === KeyEvent.DOM_VK_DOWN) {
-                        historyIndex = (historyIndex - 1 + searchHistory.length) % searchHistory.length;
-                    } else {
-                        historyIndex = (historyIndex + 1 + searchHistory.length) % searchHistory.length;
+                } else if (e.keyCode === KeyEvent.DOM_VK_DOWN || e.keyCode === KeyEvent.DOM_VK_UP) {
+                    if (!self.searchField) {
+                        self.showSearchHints();
                     }
-                    $("#find-what").val(searchHistory[historyIndex]);
-                    self.trigger("queryChange");
-                }*/
+                }
             });
 
         if (!this._options.multifile) {
@@ -449,17 +403,12 @@ define(function (require, exports, module) {
             this.showIndexingSpinner();
         }
 
-        //this.$searchField.focus();
-
         // Set up the initial UI state.
         this._updateSearchBarFromPrefs();
         this.focusQuery();
-        //setTimeout(function() {
-        self.showSearchHints(searchHistory);
-        //},0);
     };
 
-    FindBar.prototype.showSearchHints = function (searchHistory) {
+    FindBar.prototype.showSearchHints = function () {
         var self = this;
         this.$searchField = $("input#find-what");
         this.$searchField = $(this.$searchField[this.$searchField.length - 1]);
@@ -468,18 +417,16 @@ define(function (require, exports, module) {
             maxResults: 20,
             resultProvider: function (query) {
                 var asyncResult = new $.Deferred();
-                var filteredResults = _.filter(searchHistory,
-                    function (s) { return s.indexOf(query) !== -1; }
-                                              );
+                var searchHistory = PreferencesManager.getViewState("searchHistory");
+                var filteredResults = _.filter(searchHistory, function (s) {
+                    return s.indexOf(query) !== -1;
+                });
                 asyncResult.resolve(filteredResults);
                 return asyncResult.promise();
-            },  //this._filterCallback,
+            },
             formatter: function (item, query) {
-                //query = query.slice(query.indexOf("@") + 1, query.length);
-
-                var displayName = highlightMatch(item);
-                return "<li>" + displayName + "</li>";
-            },  //this._resultsFormatterCallback,
+                return "<li>" + item + "</li>";
+            },
             onCommit: function (selectedItem, query) {
                 if (selectedItem) {
                     $("#find-what").val(selectedItem);
@@ -488,11 +435,9 @@ define(function (require, exports, module) {
                     self.searchField.setText(query);
                 }
                 self.$("#find-what").focus();
-                //self.trigger("queryChange");
                 self.searchField.destroy();
             },
             onHighlight: function (selectedItem, query, explicit) {}
-            //verticalAdjust: 44
         });
         this.searchField.setText($("#find-what").val());
     };
@@ -505,7 +450,6 @@ define(function (require, exports, module) {
         if (this._modalBar) {
             // 1st arg = restore scroll pos; 2nd arg = no animation, since getting replaced immediately
             this._modalBar.close(true, !suppressAnimation);
-            //this.searchField.destroy();
         }
     };
 

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -286,13 +286,14 @@ define(function (require, exports, module) {
                 }
             })
             .on("click", ".dropdown-icon", function (e) {
+                var quickSearchContainer = $(".quick-search-container");
                 if (!self.searchField) {
                     self.showSearchHints();
-                } else if ($(".quick-search-container").is(':visible')) {
-                    $(".quick-search-container").hide();
-                } else if (!$(".quick-search-container").is(':visible')) {
-                    self.searchField.setText($("#find-what").val());
-                    $(".quick-search-container").show();
+                } else if (quickSearchContainer.is(':visible')) {
+                    quickSearchContainer.hide();
+                } else {
+                    self.searchField.setText(self.$("#find-what").val());
+                    quickSearchContainer.show();
                 }
                 self.$("#find-what").focus();
             })
@@ -331,7 +332,8 @@ define(function (require, exports, module) {
                 if (e.keyCode === KeyEvent.DOM_VK_RETURN) {
                     e.preventDefault();
                     e.stopPropagation();
-                    var searchQueryIndex = searchHistory.indexOf($('#find-what').val());
+                    var searchVal = self.$("#find-what").val()
+                    var searchQueryIndex = searchHistory.indexOf(searchVal);
                     if (searchQueryIndex !== -1) {
                         searchHistory.splice(searchQueryIndex, 1);
                     } else {
@@ -339,8 +341,8 @@ define(function (require, exports, module) {
                             searchHistory.pop();
                         }
                     }
-                    if ($('#find-what').val()) {
-                        searchHistory.unshift($('#find-what').val());
+                    if (searchVal) {
+                        searchHistory.unshift(searchVal);
                     }
                     PreferencesManager.setViewState("searchHistory", searchHistory);
                     lastQueriedText = self.getQueryInfo().query;
@@ -365,10 +367,11 @@ define(function (require, exports, module) {
                     }
                     historyIndex = 0;
                 } else if (e.keyCode === KeyEvent.DOM_VK_DOWN || e.keyCode === KeyEvent.DOM_VK_UP) {
+                    var quickSearchContainer = $(".quick-search-container");
                     if (!self.searchField) {
                         self.showSearchHints();
-                    } else if (!$(".quick-search-container").is(':visible')) {
-                        $(".quick-search-container").show();
+                    } else if (!quickSearchContainer.is(':visible')) {
+                        quickSearchContainer.show();
                     }
                 }
             });
@@ -427,10 +430,9 @@ define(function (require, exports, module) {
      */
     FindBar.prototype.showSearchHints = function () {
         var self = this;
-        this.$searchField = $("input#find-what");
-        this.$searchField = $(this.$searchField[this.$searchField.length - 1]);
-        this.searchField = new QuickSearchField(this.$searchField, {
-            verticalAdjust: this.$searchField.offset().top > 0 ? 0 : this._modalBar.getRoot().outerHeight(),
+        var searchFieldInput = self.$("#find-what");
+        this.searchField = new QuickSearchField(searchFieldInput, {
+            verticalAdjust: searchFieldInput.offset().top > 0 ? 0 : this._modalBar.getRoot().outerHeight(),
             maxResults: 20,
             resultProvider: function (query) {
                 var asyncResult = new $.Deferred();
@@ -442,7 +444,7 @@ define(function (require, exports, module) {
             },
             onCommit: function (selectedItem, query) {
                 if (selectedItem) {
-                    $("#find-what").val(selectedItem);
+                    self.$("#find-what").val(selectedItem);
                     self.trigger("queryChange");
                 } else if (query.length) {
                     self.searchField.setText(query);
@@ -453,7 +455,7 @@ define(function (require, exports, module) {
             onHighlight: function (selectedItem, query, explicit) {},
             highlightZeroResults: false
         });
-        this.searchField.setText($("#find-what").val());
+        this.searchField.setText(searchFieldInput.val());
     };
 
     /**

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -285,6 +285,17 @@ define(function (require, exports, module) {
                     self.trigger("doFind");
                 }
             })
+            .on("click", ".dropdown-icon", function (e) {
+                if (!self.searchField) {
+                    self.showSearchHints();
+                } else if ($(".quick-search-container").is(':visible')) {
+                    $(".quick-search-container").hide();
+                } else if (!$(".quick-search-container").is(':visible')) {
+                    self.searchField.setText($("#find-what").val());
+                    $(".quick-search-container").show();
+                }
+                self.$("#find-what").focus();
+            })
             .on("keydown", "#find-what, #replace-with", function (e) {
                 lastTypedTime = new Date().getTime();
                 lastKeyCode = e.keyCode;
@@ -356,6 +367,8 @@ define(function (require, exports, module) {
                 } else if (e.keyCode === KeyEvent.DOM_VK_DOWN || e.keyCode === KeyEvent.DOM_VK_UP) {
                     if (!self.searchField) {
                         self.showSearchHints();
+                    } else if (!$(".quick-search-container").is(':visible')) {
+                        $(".quick-search-container").show();
                     }
                 }
             });
@@ -439,7 +452,7 @@ define(function (require, exports, module) {
                     self.searchField.setText(query);
                 }
                 self.$("#find-what").focus();
-                self.searchField.destroy();
+                $(".quick-search-container").hide();
             },
             onHighlight: function (selectedItem, query, explicit) {},
             highlightZeroResults: false

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -455,23 +455,24 @@ define(function (require, exports, module) {
         this._updateSearchBarFromPrefs();
         this.focusQuery();
         //setTimeout(function() {
-            self.showSearchHints(searchHistory);
+        self.showSearchHints(searchHistory);
         //},0);
     };
 
     FindBar.prototype.showSearchHints = function (searchHistory) {
         var self = this;
         this.$searchField = $("input#find-what");
+        this.$searchField = $(this.$searchField[this.$searchField.length - 1]);
         this.searchField = new QuickSearchField(this.$searchField, {
             verticalAdjust: this.$searchField.offset().top > 0 ? 0 : this._modalBar.getRoot().outerHeight(),
             maxResults: 20,
             resultProvider: function (query) {
                 var asyncResult = new $.Deferred();
                 var filteredResults = _.filter(searchHistory,
-                    function(s) { return s.indexOf(query) !== -1; }
-                );
+                    function (s) { return s.indexOf(query) !== -1; }
+                                              );
                 asyncResult.resolve(filteredResults);
-                return asyncResult.promise(); 
+                return asyncResult.promise();
             },  //this._filterCallback,
             formatter: function (item, query) {
                 //query = query.slice(query.indexOf("@") + 1, query.length);
@@ -480,14 +481,13 @@ define(function (require, exports, module) {
                 return "<li>" + displayName + "</li>";
             },  //this._resultsFormatterCallback,
             onCommit: function (selectedItem, query) {
-                console.log(selectedItem);
-                console.log(query);
                 if (selectedItem) {
                     $("#find-what").val(selectedItem);
                     self.trigger("queryChange");
                 } else if (query.length) {
                     self.searchField.setText(query);
                 }
+                self.$("#find-what").focus();
                 //self.trigger("queryChange");
                 self.searchField.destroy();
             },

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -172,9 +172,9 @@ define(function (require, exports, module) {
     QuickSearchField.prototype._doCommit = function (index) {
         var item;
         if (this._displayedResults && this._displayedResults.length) {
-            if (index !== null && index !== undefined) {
+            if (index >= 0) {
                 item = this._displayedResults[index];
-            } else if (this._highlightIndex !== null) {
+            } else if (this._highlightIndex >= 0) {
                 item = this._displayedResults[this._highlightIndex];
             }
         }

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -171,20 +171,26 @@ define(function (require, exports, module) {
     /** Call onCommit() immediately */
     QuickSearchField.prototype._doCommit = function (index) {
         var item;
-        if (this._displayedResults && this._displayedResults.length && this._highlightIndex>=0) {
-            item = this._displayedResults[this._highlightIndex];
+        if (this._displayedResults && this._displayedResults.length) {
+            if (index !== null && index !== undefined) {
+                item = this._displayedResults[index];
+            } else if (this._highlightIndex !== null) {
+                item = this._displayedResults[this._highlightIndex];
+            }
         }
         this.options.onCommit(item, this._displayedQuery);
     };
 
     /** Update display to reflect value of _highlightIndex, & call onHighlight() */
     QuickSearchField.prototype._updateHighlight = function (explicit) {
-        var $items = this._$dropdown.find("li");
-        $items.removeClass("highlight");
-        if (this._highlightIndex !== null) {
-            $items.eq(this._highlightIndex).addClass("highlight");
+        if (this._$dropdown) {
+            var $items = this._$dropdown.find("li");
+            $items.removeClass("highlight");
+            if (this._highlightIndex !== null) {
+                $items.eq(this._highlightIndex).addClass("highlight");
 
-            this.options.onHighlight(this._displayedResults[this._highlightIndex], this.$input.val(), explicit);
+                this.options.onHighlight(this._displayedResults[this._highlightIndex], this.$input.val(), explicit);
+            }
         }
     };
 
@@ -208,12 +214,14 @@ define(function (require, exports, module) {
                     this._pending = null;
                 }
             });
-            this._pending.fail(function () {
-                if (self._pending === results) {
-                    self._render([], query);
-                    this._pending = null;
-                }
-            });
+            if (this._pending) {
+                this._pending.fail(function () {
+                    if (self._pending === results) {
+                        self._render([], query);
+                        this._pending = null;
+                    }
+                });
+            }
         } else {
             // Synchronous result - render immediately
             this._render(results, query);

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -83,6 +83,12 @@ define(function (require, exports, module) {
         this._handleInput   = this._handleInput.bind(this);
         this._handleKeyDown = this._handleKeyDown.bind(this);
 
+        if (options.highlightZeroIndex !== null) {
+            this._highlightZeroIndex = options.highlightZeroIndex;
+        } else {
+            this._highlightZeroIndex = true;
+        }
+
         $input.on("input", this._handleInput);
         $input.on("keydown", this._handleKeyDown);
 
@@ -171,7 +177,7 @@ define(function (require, exports, module) {
     /** Call onCommit() immediately */
     QuickSearchField.prototype._doCommit = function (index) {
         var item;
-        if (this._displayedResults && this._displayedResults.length && this._highlightIndex>=0) {
+        if (this._displayedResults && this._displayedResults.length && this._highlightIndex >= 0) {
             item = this._displayedResults[this._highlightIndex];
         }
         this.options.onCommit(item, this._displayedQuery);
@@ -268,7 +274,9 @@ define(function (require, exports, module) {
 
         if (results.error || results.length === 0) {
             this._closeDropdown();
-            this.$input.addClass("no-results");
+            if (this._highlightZeroIndex) {
+                this.$input.addClass("no-results");
+            }
         } else if (results.hasOwnProperty("error")) {
             // Error present but falsy - no results to show, but don't decorate with error style
             this._closeDropdown();

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -171,9 +171,8 @@ define(function (require, exports, module) {
     /** Call onCommit() immediately */
     QuickSearchField.prototype._doCommit = function (index) {
         var item;
-        if (this._displayedResults && this._displayedResults.length) {
-            var committedIndex = index !== undefined ? index : (this._highlightIndex || 0);
-            item = this._displayedResults[committedIndex];
+        if (this._displayedResults && this._displayedResults.length && this._highlightIndex>=0) {
+            item = this._displayedResults[this._highlightIndex];
         }
         this.options.onCommit(item, this._displayedQuery);
     };
@@ -264,7 +263,7 @@ define(function (require, exports, module) {
     QuickSearchField.prototype._render = function (results, query) {
         this._displayedQuery = query;
         this._displayedResults = results;
-        this._highlightIndex = 0;
+        this._highlightIndex = null;
         // TODO: fixup to match prev value's item if possible?
 
         if (results.error || results.length === 0) {

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -83,7 +83,7 @@ define(function (require, exports, module) {
         this._handleInput   = this._handleInput.bind(this);
         this._handleKeyDown = this._handleKeyDown.bind(this);
 
-        if (options.highlightZeroResults !== null) {
+        if (options.highlightZeroResults !== undefined) {
             this._highlightZeroResults = options.highlightZeroResults;
         } else {
             this._highlightZeroResults = true;

--- a/src/search/QuickSearchField.js
+++ b/src/search/QuickSearchField.js
@@ -288,9 +288,13 @@ define(function (require, exports, module) {
         } else if (results.hasOwnProperty("error")) {
             // Error present but falsy - no results to show, but don't decorate with error style
             this._closeDropdown();
-            this.$input.removeClass("no-results");
+            if (this._highlightZeroResults) {
+                this.$input.removeClass("no-results");
+            }
         } else {
-            this.$input.removeClass("no-results");
+            if (this._highlightZeroResults) {
+                this.$input.removeClass("no-results");
+            }
 
             var count = Math.min(results.length, this.options.maxResults),
                 html = "",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1578,10 +1578,18 @@ a, img {
         }
 
         #find-what {
-            padding-right: 62px;  // room for #find-counter overlay
+            padding-right: 78px;  // room for #find-counter overlay
             width: 295px - (62px - 6px);  // maintain width, accounting for differing padding
         }
-        #find-counter {
+
+        .dropdown-icon {
+            background: url(images/dropdown-icon.svg) no-repeat scroll 15px 15px;
+            background-position: center right;
+            width: 20px;
+            height: 20px;
+        }
+
+        #find-counter, .dropdown-icon {
             position: absolute;
             color: @bc-text-thin-quiet;
             top: 1px;
@@ -1822,6 +1830,7 @@ textarea.exclusions-editor {
 #find-counter {
     font-weight: @font-weight-semibold;
     padding: 0 5px;
+    margin-right: 17px;
 }
 
 .tickmark-track {

--- a/src/styles/images/dropdown-icon.svg
+++ b/src/styles/images/dropdown-icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="9859.26 444.26 31.48 31.481" width="20" height="20">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #878787;
+      }
+
+      .cls-2 {
+        fill: none;
+      }
+    </style>
+  </defs>
+  <g id="ic_arrow_drop_down_black_24px" transform="translate(9859.26 444.26)">
+    <path id="Path_23" data-name="Path 23" class="cls-1" d="M7,10l8.549,8.549L24.1,10Z" transform="translate(0.192 2.122)"/>
+    <path id="Path_24" data-name="Path 24" class="cls-2" d="M0,0H31.481V31.481H0Z"/>
+  </g>
+</svg>

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -427,7 +427,7 @@ define(function (require, exports, module) {
                 });
             });
             
-            it("should traverse through search history using up and down arrow keys", function () {
+            it("should traverse through search history using arrow down key", function () {
                 var fileEntry = FileSystem.getFileForPath(testPath + "/foo.js");
                 openSearchBar(fileEntry);
                 executeSearch("foo1");
@@ -439,11 +439,32 @@ define(function (require, exports, module) {
                 runs(function () {
                     var searchHistory = PreferencesManager.getViewState("searchHistory");
                     var $searchField = $("#find-what");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_UP, "keydown", $searchField[0]);
-                    expect($("#find-what").val()).toBe("foo4");
+
+                    $("#find-what").val("");
                     SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $searchField[0]);
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $searchField[0]);
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $searchField[0]);
                     expect($("#find-what").val()).toBe("foo5");
-                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $searchField[0]);
+                });
+            });
+            
+            it("should traverse through search history using arrow up key", function () {
+                var fileEntry = FileSystem.getFileForPath(testPath + "/foo.js");
+                openSearchBar(fileEntry);
+                executeSearch("foo1");
+                executeSearch("foo2");
+                executeSearch("foo3");
+                executeSearch("foo4");
+                executeSearch("foo5");
+
+                runs(function () {
+                    var searchHistory = PreferencesManager.getViewState("searchHistory");
+                    var $searchField = $("#find-what");
+
+                    $("#find-what").val("");
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_UP, "keydown", $searchField[0]);
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_UP, "keydown", $searchField[0]);
+                    SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $searchField[0]);
                     expect($("#find-what").val()).toBe("foo1");
                 });
             });


### PR DESCRIPTION
The UI is inspired from https://trello.com/c/IzACddEv/344-s-find-recent-search-history with minor tweaks.

Dark Theme

![image](https://cloud.githubusercontent.com/assets/5630113/25003498/4c3bf4e4-206d-11e7-92d2-2e760cf8cb84.png)

Light Theme

![image](https://cloud.githubusercontent.com/assets/5630113/25003514/60bbbf94-206d-11e7-8c33-a5e7e400e12b.png)

The UI can be invoked using arrow up and down keys or clicking on the down arrow on the right of the search input.
The UI is reused from QuickSearchField.js which is also used by Quick Open.