### PR TITLE
Addressed performance problems when navigating between large code folded files

### DIFF
--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -38,6 +38,7 @@ define(function (require, exports, module) {
         EditorManager           = brackets.getModule("editor/EditorManager"),
         ProjectManager          = brackets.getModule("project/ProjectManager"),
         ViewStateManager        = brackets.getModule("view/ViewStateManager"),
+        MainViewManager         = brackets.getModule("view/MainViewManager"),
         KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
         Menus                   = brackets.getModule("command/Menus"),
@@ -329,14 +330,14 @@ define(function (require, exports, module) {
     }
 
     /**
-      * When a brand new editor is seen, initialise fold-gutter and restore line folds in it. Save line folds in
-      * departing editor in case it's getting closed.
+      * When a brand new editor is seen, initialise fold-gutter and restore line folds in it. 
+      * Save line folds in departing editor in case it's getting closed.
       * @param {object} event the event object
       * @param {Editor} current the current editor
       * @param {Editor} previous the previous editor
       */
     function onActiveEditorChanged(event, current, previous) {
-        if (current) {
+        if (current && !current._codeMirror._lineFolds) {
             enableFoldingInEditor(current);
         }
         if (previous) {

--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -38,7 +38,6 @@ define(function (require, exports, module) {
         EditorManager           = brackets.getModule("editor/EditorManager"),
         ProjectManager          = brackets.getModule("project/ProjectManager"),
         ViewStateManager        = brackets.getModule("view/ViewStateManager"),
-        MainViewManager         = brackets.getModule("view/MainViewManager"),
         KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
         Menus                   = brackets.getModule("command/Menus"),


### PR DESCRIPTION
Addresses #13282 by preventing reinitialisation of the fold gutter for editors whose fold gutters have already been initialised.

cc @lkcampbell 