### PR TITLE
Changed url to access Japanese translated page

### DIFF
--- a/src/nls/ja/urls.js
+++ b/src/nls/ja/urls.js
@@ -25,5 +25,5 @@ define({
     // Relative to the samples folder
     "GETTING_STARTED"           : "ja/Getting Started",
     "ADOBE_THIRD_PARTY"         : "http://www.adobe.com/go/thirdparty_jp/",
-    "WEB_PLATFORM_DOCS_LICENSE" : "http://creativecommons.org/licenses/by/3.0/"
+    "WEB_PLATFORM_DOCS_LICENSE" : "http://creativecommons.org/licenses/by/3.0/deed.ja"
 });


### PR DESCRIPTION
This PR is to fix issue #11814 

The issue was regarding the **Help -> About Brackets** when using the Japanese language. The 'CC-BY 3.0 Unported' link was set to the default. I got the link for the Japanese page and changed the urls.js in order to reflect that change. 

This solves the issue and I think its safe to close it.