### PR TITLE
Update Codemirror to version 5.25.2

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -59,7 +59,7 @@
         "phantomjs": "1.9.18",
         "grunt-lib-phantomjs": "0.3.0",
         "grunt-eslint": "19.0.0",
-        "grunt-contrib-watch": "0.4.3",
+        "grunt-contrib-watch": "1.0.0",
         "grunt-contrib-jasmine": "0.4.2",
         "grunt-template-jasmine-requirejs": "0.1.0",
         "grunt-contrib-cssmin": "0.6.0",

--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -72,9 +72,9 @@
       "optional": true
     },
     "codemirror": {
-      "version": "5.24.2",
-      "from": "codemirror@5.24.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.24.2.tgz"
+      "version": "5.25.2",
+      "from": "codemirror@5.25.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.25.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brackets-src",
   "dependencies": {
-    "codemirror": "5.24.2",
+    "codemirror": "5.25.2",
     "less": "2.7.2"
   }
 }


### PR DESCRIPTION
Updating CM to 5.25.2 to get the SCSS mode fix done @https://github.com/codemirror/CodeMirror/commit/2c46d1b45af0baba87804f451c566de256c8d390.
This is required for PR #13295.

//Ping @ficristo @petetnt @zaggino for review. 