### PR TITLE
add: flow-root as value for display

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -81,7 +81,7 @@
     "counter-reset":               {"values": ["none", "inherit"]},
     "cursor":                      {"values": ["alias", "all-scroll", "auto", "cell", "col-resize", "context-menu", "copy", "crosshair", "default", "e-resize", "ew-resize", "grab", "grabbing", "help", "inherit", "move", "n-resize", "ne-resize", "nesw-resize", "no-drop", "none", "not-allowed", "ns-resize", "nw-resize", "nwse-resize", "pointer", "progress", "row-resize", "s-resize", "se-resize", "sw-resize", "text", "vertical-text", "w-resize", "wait", "zoom-in", "zoom-out"]},
     "direction":                   {"values": ["ltr", "rtl", "inherit"]},
-    "display":                     {"values": ["block", "flex", "grid", "inline", "inline-block", "inline-flex", "inline-grid", "inline-table", "list-item", "none", "run-in", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group", "table-row", "table-row-group", "inherit"]},
+    "display":                     {"values": ["block", "flex", "flow-root", "grid", "inline", "inline-block", "inline-flex", "inline-grid", "inline-table", "list-item", "none", "run-in", "table", "table-caption", "table-cell", "table-column", "table-column-group", "table-footer-group", "table-header-group", "table-row", "table-row-group", "inherit"]},
     "empty-cells":                 {"values": ["hide", "show", "inherit"]},
     "filter":                      {"values": ["blur()", "brightness()", "contrast()", "custom()", "drop-shadow()", "grayscale()", "hue-rotate()", "invert()", "none", "opacity()", "sepia()", "saturate()", "url()"]},
     "flex":                        {"values": ["auto", "initial", "none"]},


### PR DESCRIPTION
`display` now has a new value `flow-root` which is also getting browser support. Both Chrome and Firefox support it. Should be handy to have as an autocompletion value.