### PR TITLE
Fix box model regression (transform)

### DIFF
--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -431,19 +431,37 @@ function RemoteFunctions(config, remoteWSPort) {
             highlight.className = HIGHLIGHT_CLASSNAME;
 
             var offset = _screenOffset(element);
+            		
+            var el = element,		
+            offsetLeft = 0,		
+            offsetTop  = 0;		
+             		
+            // Probably the easiest way to get elements position without including transform		
+            do {		
+               offsetLeft += el.offsetLeft;		
+               offsetTop  += el.offsetTop;		
+               el = el.offsetParent;		
+            } while(el);
 
             var stylesToSet = {
-                "left": offset.left + "px",
-                "top": offset.top + "px",
-                "width": elementBounds.width + "px",
-                "height": elementBounds.height + "px",
+                "left": offsetLeft + "px",
+                "top": offsetTop + "px",
+                "width": innerWidth + "px",
+                "height": innerHeight + "px",
                 "z-index": 2000000,
                 "margin": 0,
                 "padding": 0,
                 "position": "absolute",
                 "pointer-events": "none",
                 "box-shadow": "0 0 1px #fff",
-                "box-sizing": "border-box"
+                "box-sizing": elementStyling.getPropertyValue('box-sizing'),		
+                "border-right": elementStyling.getPropertyValue('border-right'),		
+                "border-left": elementStyling.getPropertyValue('border-left'),		
+                "border-top": elementStyling.getPropertyValue('border-top'),		
+                "border-bottom": elementStyling.getPropertyValue('border-bottom'),		
+                "transform": elementStyling.getPropertyValue('transform'),		
+                "transform-origin": elementStyling.getPropertyValue('transform-origin'),		
+                "border-color": config.remoteHighlight.borderColor
             };
             
             var mergedStyles = Object.assign({}, stylesToSet,  config.remoteHighlight.stylesToSet);


### PR DESCRIPTION
Hi. In my recent commit https://github.com/adobe/brackets/commit/ad915c721ffe379d47e95335eaf2ddd1f6838a6f for whatever reason I've removed a piece of code that made showing the box-model of transformed elements appear OK. I must have discarded the wrong hunk and did not refresh Brackets afterwards, so I didn't see it was broken. I'm very sorry for that.

This PR fixes this regression. However, we should consider visual testing to this feature to prevent such cases #13356 .

For now, could you ensure that it looks good for transformed elements, too (with or without borders, etc). I have tested it, but as you can see you can never be too cautios. 