### PR TITLE
Fixed Project Manager failing tests

### DIFF
--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
 
             // copy files to temp directory
             runs(function () {
-                waitsForDone(SpecRunnerUtils.copy(testPath, tempDir), "copy temp files");
+                waitsForDone(SpecRunnerUtils.copyPath(testPath, tempDir), "copy temp files");
             });
 
             runs(function () {


### PR DESCRIPTION
There are some issues in `copy` api, I am trying to fix that. Until then we can use `copyPath` to run tests. Please note that `copyPath` cannot copy binary files, so we can't use the same API in `LowLevelFileIO` and `FindInFiles` Tests which are also failing as they use test files involving some images.
Once copy API is fixed, then we can fix the failing tests in `LowLevelFileIO` and `FindInFiles` as well.