### PR TITLE
On Windows force a 32 bit build until nodejs 64 bit is supported

### DIFF
--- a/src/extensibility/node/npm-installer.js
+++ b/src/extensibility/node/npm-installer.js
@@ -37,22 +37,13 @@ var Errors = {
  * Private function to run "npm install --production" command in the extension directory.
  *
  * @param {string} installDirectory Directory to remove
+ * @param {array} npmOptions can contain additional options like `--production` or `--proxy http://127.0.0.1:8888`
  * @param {function} callback NodeJS style callback to call after finish
  */
 function _performNpmInstall(installDirectory, npmOptions, callback) {
     var npmPath = path.resolve(path.dirname(require.resolve("npm")), "..", "bin", "npm-cli.js");
-    var args = [npmPath, "install"];
-    
-    // npmOptions can contain additional args like { "production": true, "proxy": "http://127.0.0.1:8888" }
-    Object.keys(npmOptions).forEach(function (key) {
-        var value = npmOptions[key];
-        if (value === true) {
-            args.push("--" + key);
-        } else if (typeof value === "string" && value.length > 0) {
-            args.push("--" + key, value);
-        }
-    });
-    
+    var args = [npmPath, "install"].concat(npmOptions);
+
     console.log("running npm " + args.slice(1).join(" ") + " in " + installDirectory);
 
     var child = spawn(process.execPath, args, { cwd: installDirectory });

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -295,10 +295,20 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
                     errors.push([Errors.MISSING_MAIN, zipPath, mainJS]);
                 }
 
-                performNpmInstallIfRequired({
-                    production: true,
-                    proxy: options.proxy
-                }, {
+                var npmOptions = ['--production'];
+
+                if (options.proxy) {
+                    npmOptions.push('--proxy ' + options.proxy);
+                }
+
+                if (process.platform.startsWith('win')) {
+                    // On Windows force a 32 bit build until nodejs 64 bit is supported.
+                    npmOptions.push('--arch=ia32');
+                    npmOptions.push('--npm_config_arch=ia32');
+                    npmOptions.push('--npm_config_target_arch=ia32');
+                }
+
+                performNpmInstallIfRequired(npmOptions, {
                     errors: errors,
                     metadata: metadata,
                     commonPrefix: commonPrefix,


### PR DESCRIPTION
Since Brackets doesn't support nodejs 64 bit, I needed to force to compile my [extension](https://github.com/ficristo/brackets-terminal-x) to 32 bit by adding a .npmrc file with the right flags.
But with that, users on unix platform cannot install the extension from the extension manager anymore.
Adding those flags directly in Brackets should let me remove the .npmrc file.
