### PR TITLE
Sequential navigation in edit history

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1017,6 +1017,9 @@ define(function (require, exports, module) {
         this._codeMirror.on("cursorActivity", function (instance) {
             self.trigger("cursorActivity", self);
         });
+        this._codeMirror.on("beforeSelectionChange", function (instance, selectionObj) {
+            self.trigger("beforeSelectionChange", selectionObj);
+        });
         this._codeMirror.on("scroll", function (instance) {
             // If this editor is visible, close all dropdowns on scroll.
             // (We don't want to do this if we're just scrolling in a non-visible editor

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -113,7 +113,7 @@ define(function (require, exports, module) {
                 } else {
                     deferred.reject();
                 }
-	    	});
+			});
 		}
 
         return deferred.promise();
@@ -158,7 +158,7 @@ define(function (require, exports, module) {
     
    /**
     * Function to create CM TextMarkers for the navigated positions/selections.
-    * This logic is required to ensure that the captured navaigation positions 
+    * This logic is required to ensure that the captured navigation positions 
     * stay valid and contextual even when the actual document text mutates.
     * The mutations which are handled here :
     * -> Addition/Deletion of lines before the captured position
@@ -166,8 +166,8 @@ define(function (require, exports, module) {
     */
     NavigationFrame.prototype._createMarkers = function (ranges) {
         var range,
-	    	index,
-	    	bookMark;
+			index,
+			bookMark;
 
         this.bookMarkIds = [];
         for (index in ranges) {
@@ -325,14 +325,14 @@ define(function (require, exports, module) {
                 CommandManager.execute(NAVIGATION_JUMP_BACK);
             }).always(function () {
 				_validateNavigationCmds();
-	    	});
+			});
         }
     }
     
    /**
     * Command handler to navigate forward
     */
-    function _navigateFwd() {
+    function _navigateForward() {
         var navFrame = jumpedPosStack.pop();
 		
 		// Check if the poped frame is the current active frame
@@ -375,7 +375,7 @@ define(function (require, exports, module) {
     */
     function _initNavigationCommands() {
         CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
-        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateFwd);
+        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
         commandJumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
         commandJumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
         commandJumpBack.setEnabled(false);

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -27,119 +27,119 @@
  * persisted to file system when a project is being closed.
  */
 define(function (require, exports, module) {
-    "use strict";
+	"use strict";
 
-    var Strings                 = brackets.getModule("strings"),
-        MainViewManager         = brackets.getModule("view/MainViewManager"),
-        DocumentManager         = brackets.getModule("document/DocumentManager"),
-        DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
-        EditorManager           = brackets.getModule("editor/EditorManager"),
-        Editor                  = brackets.getModule("editor/Editor"),
-        ProjectManager          = brackets.getModule("project/ProjectManager"),
-        CommandManager          = brackets.getModule("command/CommandManager"),
-        Commands                = brackets.getModule("command/Commands"),
-        Menus                   = brackets.getModule("command/Menus"),
-        KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
-        FileSystem              = brackets.getModule("filesystem/FileSystem");
+	var Strings                 = brackets.getModule("strings"),
+		MainViewManager         = brackets.getModule("view/MainViewManager"),
+		DocumentManager         = brackets.getModule("document/DocumentManager"),
+		DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
+		EditorManager           = brackets.getModule("editor/EditorManager"),
+		Editor                  = brackets.getModule("editor/Editor"),
+		ProjectManager          = brackets.getModule("project/ProjectManager"),
+		CommandManager          = brackets.getModule("command/CommandManager"),
+		Commands                = brackets.getModule("command/Commands"),
+		Menus                   = brackets.getModule("command/Menus"),
+		KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
+		FileSystem              = brackets.getModule("filesystem/FileSystem");
 
-    var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
-    
-    // Command constants for navigation history
-    var NAVIGATION_JUMP_BACK      = "navigation.jump.back",
-        NAVIGATION_JUMP_FWD       = "navigation.jump.fwd";
-    
-    // The latency time to capture an explicit cursor movement as a navigation frame
-    var NAV_FRAME_CAPTURE_LATENCY = 2000,
+	var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
+	
+	// Command constants for navigation history
+	var NAVIGATION_JUMP_BACK      = "navigation.jump.back",
+		NAVIGATION_JUMP_FWD       = "navigation.jump.fwd";
+	
+	// The latency time to capture an explicit cursor movement as a navigation frame
+	var NAV_FRAME_CAPTURE_LATENCY = 2000,
 		MAX_NAV_FRAMES_COUNT = 50;
-    
+	
    /**
-    * Contains list of most recently known cursor positions.
-    * @private
-    * @type {Array.<Object>}
-    */
-    var jumpToPosStack = [];
-    
+	* Contains list of most recently known cursor positions.
+	* @private
+	* @type {Array.<Object>}
+	*/
+	var jumpToPosStack = [];
+	
    /**
-    * Contains list of most recently traversed cursor positions using NAVIGATION_JUMP_BACK command.
-    * @private
-    * @type {Array.<Object>}
-    */
-    var jumpedPosStack = [],
-        activePosNotSynced = false,
-        captureTimer,
+	* Contains list of most recently traversed cursor positions using NAVIGATION_JUMP_BACK command.
+	* @private
+	* @type {Array.<Object>}
+	*/
+	var jumpedPosStack = [],
+		activePosNotSynced = false,
+		captureTimer,
 		currentEditPos,
-        jumpInProgress,
-        commandJumpBack,
-        commandJumpFwd;
+		jumpInProgress,
+		commandJumpBack,
+		commandJumpFwd;
 		
    /**
-    * Function to check if there are any navigatable frame backward.
-    * @private
-    */
-    function _hasNavBackFrames() {
+	* Function to check if there are any navigatable frame backward.
+	* @private
+	*/
+	function _hasNavBackFrames() {
 		return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
 			|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
-    }
-     
+	}
+	 
    /**
-    * Function to enable/disable navigation command based on cursor positions availability.
-    * @private
-    */
-    function _validateNavigationCmds() {
-        commandJumpBack.setEnabled(_hasNavBackFrames());
-        commandJumpFwd.setEnabled(jumpedPosStack.length > 0);
-    }
-    
+	* Function to enable/disable navigation command based on cursor positions availability.
+	* @private
+	*/
+	function _validateNavigationCmds() {
+		commandJumpBack.setEnabled(_hasNavBackFrames());
+		commandJumpFwd.setEnabled(jumpedPosStack.length > 0);
+	}
+	
    /**
-    * Function to check existence of a file entry
-    * @private
-    */
-    function _checkIfExist(entry) {
-        var deferred = new $.Deferred(),
-            fileEntry = FileSystem.getFileForPath(entry.file);
+	* Function to check existence of a file entry
+	* @private
+	*/
+	function _checkIfExist(entry) {
+		var deferred = new $.Deferred(),
+			fileEntry = FileSystem.getFileForPath(entry.file);
 
-        if (entry.inMem) {
-            var indexInWS = MainViewManager.findInWorkingSet(entry.paneId, entry.file);
-            // Remove entry if InMemoryFile is not found in Working set
-            if (indexInWS === -1) {
-                deferred.reject();
-            } else {
-                deferred.resolve();
-            }
-        } else {
-            fileEntry.exists(function (err, exists) {
-                if (!err && exists) {
-                    deferred.resolve();
-                } else {
-                    deferred.reject();
-                }
+		if (entry.inMem) {
+			var indexInWS = MainViewManager.findInWorkingSet(entry.paneId, entry.file);
+			// Remove entry if InMemoryFile is not found in Working set
+			if (indexInWS === -1) {
+				deferred.reject();
+			} else {
+				deferred.resolve();
+			}
+		} else {
+			fileEntry.exists(function (err, exists) {
+				if (!err && exists) {
+					deferred.resolve();
+				} else {
+					deferred.reject();
+				}
 			});
 		}
 
-        return deferred.promise();
-    }
-        
+		return deferred.promise();
+	}
+		
    /**
-    * Prototype to capture a navigation frame and it's various data/functional attributues
-    */
-    function NavigationFrame(editor, selectionObj) {
-        this.cm = editor._codeMirror;
-        this.file = editor.document.file._path;
-        this.inMem = editor.document.file.constructor.name === "InMemoryFile";
-        this.paneId = editor._paneId;
-        this.uId = (new Date()).getTime();
-        this.selections = [];
-        this.bookMarkIds = [];
-        this._createMarkers(selectionObj.ranges);
-        this._bindEditor(editor);
-    }
-    
+	* Prototype to capture a navigation frame and it's various data/functional attributues
+	*/
+	function NavigationFrame(editor, selectionObj) {
+		this.cm = editor._codeMirror;
+		this.file = editor.document.file._path;
+		this.inMem = editor.document.file.constructor.name === "InMemoryFile";
+		this.paneId = editor._paneId;
+		this.uId = (new Date()).getTime();
+		this.selections = [];
+		this.bookMarkIds = [];
+		this._createMarkers(selectionObj.ranges);
+		this._bindEditor(editor);
+	}
+	
    /**
-    * Binds the lifecycle event listener of the editor for which this frame is captured
-    */
-    NavigationFrame.prototype._bindEditor = function (editor) {
-        var self = this;
-        editor.on("beforeDestroy", function () {
+	* Binds the lifecycle event listener of the editor for which this frame is captured
+	*/
+	NavigationFrame.prototype._bindEditor = function (editor) {
+		var self = this;
+		editor.on("beforeDestroy", function () {
 			var updateCurrentPos;
 
 			// Check if this frame is actually the current frame
@@ -153,49 +153,49 @@ define(function (require, exports, module) {
 			if (updateCurrentPos) {
 				currentEditPos = self;
 			}
-        });
-    };
-    
+		});
+	};
+	
    /**
-    * Function to create CM TextMarkers for the navigated positions/selections.
-    * This logic is required to ensure that the captured navigation positions 
-    * stay valid and contextual even when the actual document text mutates.
-    * The mutations which are handled here :
-    * -> Addition/Deletion of lines before the captured position
-    * -> Addition/Updation of characters in the captured selection
-    */
-    NavigationFrame.prototype._createMarkers = function (ranges) {
-        var range,
+	* Function to create CM TextMarkers for the navigated positions/selections.
+	* This logic is required to ensure that the captured navigation positions 
+	* stay valid and contextual even when the actual document text mutates.
+	* The mutations which are handled here :
+	* -> Addition/Deletion of lines before the captured position
+	* -> Addition/Updation of characters in the captured selection
+	*/
+	NavigationFrame.prototype._createMarkers = function (ranges) {
+		var range,
 			index,
 			bookMark;
 
-        this.bookMarkIds = [];
-        for (index in ranges) {
-            range = ranges[index];
-            // 'markText' has to used for a non-zero length position, if current selection is 
-            // of zero length use bookmark instead.
-            if (range.anchor.line === range.head.line && range.anchor.ch === range.head.ch) {
-                bookMark = this.cm.setBookmark(range.anchor, range.head);
-                this.bookMarkIds.push(bookMark.id);
-            } else {
-                this.cm.markText(range.anchor, range.head, {className: (this.uId)});
-            }
-        }
-    };
-    
+		this.bookMarkIds = [];
+		for (index in ranges) {
+			range = ranges[index];
+			// 'markText' has to used for a non-zero length position, if current selection is 
+			// of zero length use bookmark instead.
+			if (range.anchor.line === range.head.line && range.anchor.ch === range.head.ch) {
+				bookMark = this.cm.setBookmark(range.anchor, range.head);
+				this.bookMarkIds.push(bookMark.id);
+			} else {
+				this.cm.markText(range.anchor, range.head, {className: (this.uId)});
+			}
+		}
+	};
+	
    /**
-    * Function to actually convert the CM markers to CM positions which can be used to 
-    * set selections or cursor positions in Editor.
-    */
-    NavigationFrame.prototype._backupSelectionRanges = function () {
-        if (!this.cm) {
-            return;
-        }
+	* Function to actually convert the CM markers to CM positions which can be used to 
+	* set selections or cursor positions in Editor.
+	*/
+	NavigationFrame.prototype._backupSelectionRanges = function () {
+		if (!this.cm) {
+			return;
+		}
 		
 		var marker,
 			selection,
 			index;
-        
+		
 		// Reset selections first.
 		this.selections = [];
 		var self = this;
@@ -208,74 +208,74 @@ define(function (require, exports, module) {
 		});
 
 		// Iterate over CM textmarkers and collate the updated(if?) positions
-        for (index in markers) {
-            marker = markers[index];
-            selection = marker.find();
-            if (marker.type === "bookmark") {
-                this.selections.push({start: selection, end: selection});
-            } else {
-                this.selections.push({start: selection.from, end: selection.to});
-            }
-        }
-    };
+		for (index in markers) {
+			marker = markers[index];
+			selection = marker.find();
+			if (marker.type === "bookmark") {
+				this.selections.push({start: selection, end: selection});
+			} else {
+				this.selections.push({start: selection.from, end: selection.to});
+			}
+		}
+	};
 	
    /**
-    * Function to clean up the markers in cm
-    */
-    NavigationFrame.prototype._clearMarkers = function () {
-        if (!this.cm) {
-            return;
-        }
-        var self = this;
+	* Function to clean up the markers in cm
+	*/
+	NavigationFrame.prototype._clearMarkers = function () {
+		if (!this.cm) {
+			return;
+		}
+		var self = this;
 		
 		// clear only the markers we used to mark selections/cursors
-        this.cm.getAllMarks().filter(function (entry) {
-            if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
-                entry.clear();
-            }
-        });
-    };
+		this.cm.getAllMarks().filter(function (entry) {
+			if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
+				entry.clear();
+			}
+		});
+	};
 
    /**
-    * Function to actually navigate to the position(file,selections) captured in this frame
-    */
-    NavigationFrame.prototype.goTo = function () {
-        var self = this;
-        this._backupSelectionRanges();
-        jumpInProgress = true;
-        CommandManager.execute(Commands.FILE_OPEN, {fullPath: this.file, paneId: this.paneId}).done(function () {
-            EditorManager.getCurrentFullEditor().setSelections(self.selections, true);
-            _validateNavigationCmds();
-        }).always(function () {
-            jumpInProgress = false;
-        });
-    };
-    
-    
+	* Function to actually navigate to the position(file,selections) captured in this frame
+	*/
+	NavigationFrame.prototype.goTo = function () {
+		var self = this;
+		this._backupSelectionRanges();
+		jumpInProgress = true;
+		CommandManager.execute(Commands.FILE_OPEN, {fullPath: this.file, paneId: this.paneId}).done(function () {
+			EditorManager.getCurrentFullEditor().setSelections(self.selections, true);
+			_validateNavigationCmds();
+		}).always(function () {
+			jumpInProgress = false;
+		});
+	};
+	
+	
    /**
-    * Function to capture a non-zero set of selections as a navigation frame.
-    * The assumptions behind capturing a frame as a navigation frame are :
-    *
-    * -> If it's set by user explicitly (using mouse click or jump to definition)
-    * -> By clicking on search results
-    * -> Change of cursor by keyboard navigation keys or actual edits are not captured.
-    *
-    * @private
-    */
-    function _recordJumpDef(event, selectionObj) {
-        if (jumpInProgress) {
-            return;
-        }
-        // Reset forward navigation stack if we are capturing a new event
-        jumpedPosStack = [];
-        if (captureTimer) {
-            window.clearTimeout(captureTimer);
-            captureTimer = null;
-        }
+	* Function to capture a non-zero set of selections as a navigation frame.
+	* The assumptions behind capturing a frame as a navigation frame are :
+	*
+	* -> If it's set by user explicitly (using mouse click or jump to definition)
+	* -> By clicking on search results
+	* -> Change of cursor by keyboard navigation keys or actual edits are not captured.
+	*
+	* @private
+	*/
+	function _recordJumpDef(event, selectionObj) {
+		if (jumpInProgress) {
+			return;
+		}
+		// Reset forward navigation stack if we are capturing a new event
+		jumpedPosStack = [];
+		if (captureTimer) {
+			window.clearTimeout(captureTimer);
+			captureTimer = null;
+		}
 		
-        // Ensure cursor activity has not happened because of arrow keys or edit
-        if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
-            captureTimer = window.setTimeout(function () {
+		// Ensure cursor activity has not happened because of arrow keys or edit
+		if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
+			captureTimer = window.setTimeout(function () {
 				// Check if we have reached MAX_NAV_FRAMES_COUNT
 				// If yes, control overflow
 				if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
@@ -287,24 +287,24 @@ define(function (require, exports, module) {
 				jumpToPosStack.push(currentEditPos);
 				_validateNavigationCmds();
 				activePosNotSynced = false;
-            }, NAV_FRAME_CAPTURE_LATENCY);
-        } else {
-            activePosNotSynced = true;
-        }
-    }
-    
+			}, NAV_FRAME_CAPTURE_LATENCY);
+		} else {
+			activePosNotSynced = true;
+		}
+	}
+	
    /**
-    * Command handler to navigate backward
-    */
-    function _navigateBack() {
-        if (!jumpedPosStack.length) {
-            if (activePosNotSynced) {
+	* Command handler to navigate backward
+	*/
+	function _navigateBack() {
+		if (!jumpedPosStack.length) {
+			if (activePosNotSynced) {
 				currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
-                jumpedPosStack.push(currentEditPos);
-            }
-        }
+				jumpedPosStack.push(currentEditPos);
+			}
+		}
 		
-        var navFrame = jumpToPosStack.pop();
+		var navFrame = jumpToPosStack.pop();
 		
 		// Check if the poped frame is the current active frame
 		// if true, jump again
@@ -314,26 +314,26 @@ define(function (require, exports, module) {
 			return;
 		}
 		
-        if (navFrame) {
-            // We will check for the file existence now, if it doesn't exist we will jump back again
-            // but discard the popped frame as invalid.
-            _checkIfExist(navFrame).done(function () {
-                jumpedPosStack.push(navFrame);
-                navFrame.goTo();
+		if (navFrame) {
+			// We will check for the file existence now, if it doesn't exist we will jump back again
+			// but discard the popped frame as invalid.
+			_checkIfExist(navFrame).done(function () {
+				jumpedPosStack.push(navFrame);
+				navFrame.goTo();
 				currentEditPos = navFrame;
-            }).fail(function () {
-                CommandManager.execute(NAVIGATION_JUMP_BACK);
-            }).always(function () {
+			}).fail(function () {
+				CommandManager.execute(NAVIGATION_JUMP_BACK);
+			}).always(function () {
 				_validateNavigationCmds();
 			});
-        }
-    }
-    
+		}
+	}
+	
    /**
-    * Command handler to navigate forward
-    */
-    function _navigateForward() {
-        var navFrame = jumpedPosStack.pop();
+	* Command handler to navigate forward
+	*/
+	function _navigateForward() {
+		var navFrame = jumpedPosStack.pop();
 		
 		// Check if the poped frame is the current active frame
 		// if true, jump again
@@ -343,90 +343,90 @@ define(function (require, exports, module) {
 			return;
 		}
 		
-        if (navFrame) {
-            // We will check for the file existence now, if it doesn't exist we will jump back again
-            // but discard the popped frame as invalid.
-            _checkIfExist(navFrame).done(function () {
-                jumpToPosStack.push(navFrame);
-                navFrame.goTo();
+		if (navFrame) {
+			// We will check for the file existence now, if it doesn't exist we will jump back again
+			// but discard the popped frame as invalid.
+			_checkIfExist(navFrame).done(function () {
+				jumpToPosStack.push(navFrame);
+				navFrame.goTo();
 				currentEditPos = navFrame;
-            }).fail(function () {
-                _validateNavigationCmds();
-                CommandManager.execute(NAVIGATION_JUMP_FWD);
-            }).always(function () {
+			}).fail(function () {
+				_validateNavigationCmds();
+				CommandManager.execute(NAVIGATION_JUMP_FWD);
+			}).always(function () {
 				_validateNavigationCmds();
 			});
-        }
-    }
-    
+		}
+	}
+	
    /**
-    * Function to initialize navigation menu items.
-    * @private
-    */
-    function _initNavigationMenuItems() {
-        var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
-        menu.addMenuItem(NAVIGATION_JUMP_BACK, "", Menus.AFTER, Commands.NAVIGATE_PREV_DOC);
-        menu.addMenuItem(NAVIGATION_JUMP_FWD, "", Menus.AFTER, NAVIGATION_JUMP_BACK);
-    }
-    
+	* Function to initialize navigation menu items.
+	* @private
+	*/
+	function _initNavigationMenuItems() {
+		var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
+		menu.addMenuItem(NAVIGATION_JUMP_BACK, "", Menus.AFTER, Commands.NAVIGATE_PREV_DOC);
+		menu.addMenuItem(NAVIGATION_JUMP_FWD, "", Menus.AFTER, NAVIGATION_JUMP_BACK);
+	}
+	
    /**
-    * Function to initialize navigation commands and it's keyboard shortcuts.
-    * @private
-    */
-    function _initNavigationCommands() {
-        CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
-        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
-        commandJumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
-        commandJumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
-        commandJumpBack.setEnabled(false);
-        commandJumpFwd.setEnabled(false);
-        KeyBindingManager.addBinding(NAVIGATION_JUMP_BACK, KeyboardPrefs[NAVIGATION_JUMP_BACK]);
-        KeyBindingManager.addBinding(NAVIGATION_JUMP_FWD, KeyboardPrefs[NAVIGATION_JUMP_FWD]);
-        _initNavigationMenuItems();
-    }
-    
+	* Function to initialize navigation commands and it's keyboard shortcuts.
+	* @private
+	*/
+	function _initNavigationCommands() {
+		CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
+		CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
+		commandJumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
+		commandJumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
+		commandJumpBack.setEnabled(false);
+		commandJumpFwd.setEnabled(false);
+		KeyBindingManager.addBinding(NAVIGATION_JUMP_BACK, KeyboardPrefs[NAVIGATION_JUMP_BACK]);
+		KeyBindingManager.addBinding(NAVIGATION_JUMP_FWD, KeyboardPrefs[NAVIGATION_JUMP_FWD]);
+		_initNavigationMenuItems();
+	}
+	
    /**
-    * Function to request a navigation frame creation explicitly.
-    * @private
-    */
-    function _captureFrame(editor) {
-        // Capture the active position now if it was not captured earlier
-        if ((activePosNotSynced || !jumpToPosStack.length) && !jumpInProgress) {
-            jumpToPosStack.push(new NavigationFrame(editor, {ranges: editor._codeMirror.listSelections()}));
-        }
-    }
-    
-    /**
-     * Handle Active Editor change to update navigation information
-     * @private
-     */
-    function _handleActiveEditorChange(event, current, previous) {
-        if (previous && previous._paneId) { // Handle only full editors
-            previous.off("beforeSelectionChange", _recordJumpDef);
-            _captureFrame(previous);
-            _validateNavigationCmds();
-        }
-        
-        if (current && current._paneId) { // Handle only full editors
-            activePosNotSynced = true;
-            current.on("beforeSelectionChange", _recordJumpDef);
-        }
-    }
-    
-    function _handleProjectOpen() {
-        jumpToPosStack = [];
-        jumpedPosStack = [];
-    }
-    
-    function _initHandlers() {
-        EditorManager.on("activeEditorChange", _handleActiveEditorChange);
-        ProjectManager.on("projectOpen", _handleProjectOpen);
-    }
+	* Function to request a navigation frame creation explicitly.
+	* @private
+	*/
+	function _captureFrame(editor) {
+		// Capture the active position now if it was not captured earlier
+		if ((activePosNotSynced || !jumpToPosStack.length) && !jumpInProgress) {
+			jumpToPosStack.push(new NavigationFrame(editor, {ranges: editor._codeMirror.listSelections()}));
+		}
+	}
+	
+	/**
+	 * Handle Active Editor change to update navigation information
+	 * @private
+	 */
+	function _handleActiveEditorChange(event, current, previous) {
+		if (previous && previous._paneId) { // Handle only full editors
+			previous.off("beforeSelectionChange", _recordJumpDef);
+			_captureFrame(previous);
+			_validateNavigationCmds();
+		}
+		
+		if (current && current._paneId) { // Handle only full editors
+			activePosNotSynced = true;
+			current.on("beforeSelectionChange", _recordJumpDef);
+		}
+	}
+	
+	function _handleProjectOpen() {
+		jumpToPosStack = [];
+		jumpedPosStack = [];
+	}
+	
+	function _initHandlers() {
+		EditorManager.on("activeEditorChange", _handleActiveEditorChange);
+		ProjectManager.on("projectOpen", _handleProjectOpen);
+	}
 
-    function init() {
-        _initNavigationCommands();
-        _initHandlers();
-    }
-    
-    exports.init = init;
+	function init() {
+		_initNavigationCommands();
+		_initHandlers();
+	}
+	
+	exports.init = init;
 });

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -66,9 +66,9 @@ define(function (require, exports, module) {
     */
     var jumpedPosStack = [],
         activePosNotSynced = false,
-        captureTimer,
-        currentEditPos,
-        jumpInProgress,
+        captureTimer = null,
+        currentEditPos = null,
+        jumpInProgress = false,
         commandJumpBack,
         commandJumpFwd;
         

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -27,406 +27,406 @@
  * persisted to file system when a project is being closed.
  */
 define(function (require, exports, module) {
-	"use strict";
+    "use strict";
 
-	var Strings                 = brackets.getModule("strings"),
-		MainViewManager         = brackets.getModule("view/MainViewManager"),
-		DocumentManager         = brackets.getModule("document/DocumentManager"),
-		DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
-		EditorManager           = brackets.getModule("editor/EditorManager"),
-		Editor                  = brackets.getModule("editor/Editor"),
-		ProjectManager          = brackets.getModule("project/ProjectManager"),
-		CommandManager          = brackets.getModule("command/CommandManager"),
-		Commands                = brackets.getModule("command/Commands"),
-		Menus                   = brackets.getModule("command/Menus"),
-		KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
-		FileSystem              = brackets.getModule("filesystem/FileSystem");
+    var Strings                 = brackets.getModule("strings"),
+        MainViewManager         = brackets.getModule("view/MainViewManager"),
+        DocumentManager         = brackets.getModule("document/DocumentManager"),
+        DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
+        EditorManager           = brackets.getModule("editor/EditorManager"),
+        Editor                  = brackets.getModule("editor/Editor"),
+        ProjectManager          = brackets.getModule("project/ProjectManager"),
+        CommandManager          = brackets.getModule("command/CommandManager"),
+        Commands                = brackets.getModule("command/Commands"),
+        Menus                   = brackets.getModule("command/Menus"),
+        KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
+        FileSystem              = brackets.getModule("filesystem/FileSystem");
 
-	var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
-	
-	// Command constants for navigation history
-	var NAVIGATION_JUMP_BACK      = "navigation.jump.back",
-		NAVIGATION_JUMP_FWD       = "navigation.jump.fwd";
-	
-	// The latency time to capture an explicit cursor movement as a navigation frame
-	var NAV_FRAME_CAPTURE_LATENCY = 2000,
-		MAX_NAV_FRAMES_COUNT = 50;
-	
+    var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
+    
+    // Command constants for navigation history
+    var NAVIGATION_JUMP_BACK      = "navigation.jump.back",
+        NAVIGATION_JUMP_FWD       = "navigation.jump.fwd";
+    
+    // The latency time to capture an explicit cursor movement as a navigation frame
+    var NAV_FRAME_CAPTURE_LATENCY = 2000,
+        MAX_NAV_FRAMES_COUNT = 50;
+    
    /**
-	* Contains list of most recently known cursor positions.
-	* @private
-	* @type {Array.<Object>}
-	*/
-	var jumpToPosStack = [];
-	
+    * Contains list of most recently known cursor positions.
+    * @private
+    * @type {Array.<Object>}
+    */
+    var jumpToPosStack = [];
+    
    /**
-	* Contains list of most recently traversed cursor positions using NAVIGATION_JUMP_BACK command.
-	* @private
-	* @type {Array.<Object>}
-	*/
-	var jumpedPosStack = [],
-		activePosNotSynced = false,
-		captureTimer,
-		currentEditPos,
-		jumpInProgress,
-		commandJumpBack,
-		commandJumpFwd;
-		
+    * Contains list of most recently traversed cursor positions using NAVIGATION_JUMP_BACK command.
+    * @private
+    * @type {Array.<Object>}
+    */
+    var jumpedPosStack = [],
+        activePosNotSynced = false,
+        captureTimer,
+        currentEditPos,
+        jumpInProgress,
+        commandJumpBack,
+        commandJumpFwd;
+        
    /**
-	* Function to check if there are any navigatable frame backward.
-	* @private
-	*/
-	function _hasNavBackFrames() {
-		return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
-			|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
-	}
-	 
+    * Function to check if there are any navigatable frame backward.
+    * @private
+    */
+    function _hasNavBackFrames() {
+        return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
+            || (!jumpedPosStack.length && jumpToPosStack.length > 1);
+    }
+     
    /**
-	* Function to enable/disable navigation command based on cursor positions availability.
-	* @private
-	*/
-	function _validateNavigationCmds() {
-		commandJumpBack.setEnabled(_hasNavBackFrames());
-		commandJumpFwd.setEnabled(jumpedPosStack.length > 0);
-	}
-	
+    * Function to enable/disable navigation command based on cursor positions availability.
+    * @private
+    */
+    function _validateNavigationCmds() {
+        commandJumpBack.setEnabled(_hasNavBackFrames());
+        commandJumpFwd.setEnabled(jumpedPosStack.length > 0);
+    }
+    
    /**
-	* Function to check existence of a file entry
-	* @private
-	*/
-	function _checkIfExist(entry) {
-		var deferred = new $.Deferred(),
-			fileEntry = FileSystem.getFileForPath(entry.file);
+    * Function to check existence of a file entry
+    * @private
+    */
+    function _checkIfExist(entry) {
+        var deferred = new $.Deferred(),
+            fileEntry = FileSystem.getFileForPath(entry.file);
 
-		if (entry.inMem) {
-			var indexInWS = MainViewManager.findInWorkingSet(entry.paneId, entry.file);
-			// Remove entry if InMemoryFile is not found in Working set
-			if (indexInWS === -1) {
-				deferred.reject();
-			} else {
-				deferred.resolve();
-			}
-		} else {
-			fileEntry.exists(function (err, exists) {
-				if (!err && exists) {
-					deferred.resolve();
-				} else {
-					deferred.reject();
-				}
-			});
-		}
+        if (entry.inMem) {
+            var indexInWS = MainViewManager.findInWorkingSet(entry.paneId, entry.file);
+            // Remove entry if InMemoryFile is not found in Working set
+            if (indexInWS === -1) {
+                deferred.reject();
+            } else {
+                deferred.resolve();
+            }
+        } else {
+            fileEntry.exists(function (err, exists) {
+                if (!err && exists) {
+                    deferred.resolve();
+                } else {
+                    deferred.reject();
+                }
+            });
+        }
 
-		return deferred.promise();
-	}
-		
+        return deferred.promise();
+    }
+        
    /**
-	* Prototype to capture a navigation frame and it's various data/functional attributues
-	*/
-	function NavigationFrame(editor, selectionObj) {
-		this.cm = editor._codeMirror;
-		this.file = editor.document.file._path;
-		this.inMem = editor.document.file.constructor.name === "InMemoryFile";
-		this.paneId = editor._paneId;
-		this.uId = (new Date()).getTime();
-		this.selections = [];
-		this.bookMarkIds = [];
-		this._createMarkers(selectionObj.ranges);
-		this._bindEditor(editor);
-	}
-	
+    * Prototype to capture a navigation frame and it's various data/functional attributues
+    */
+    function NavigationFrame(editor, selectionObj) {
+        this.cm = editor._codeMirror;
+        this.file = editor.document.file._path;
+        this.inMem = editor.document.file.constructor.name === "InMemoryFile";
+        this.paneId = editor._paneId;
+        this.uId = (new Date()).getTime();
+        this.selections = [];
+        this.bookMarkIds = [];
+        this._createMarkers(selectionObj.ranges);
+        this._bindEditor(editor);
+    }
+    
    /**
-	* Binds the lifecycle event listener of the editor for which this frame is captured
-	*/
-	NavigationFrame.prototype._bindEditor = function (editor) {
-		var self = this;
-		editor.on("beforeDestroy", function () {
-			var updateCurrentPos;
+    * Binds the lifecycle event listener of the editor for which this frame is captured
+    */
+    NavigationFrame.prototype._bindEditor = function (editor) {
+        var self = this;
+        editor.on("beforeDestroy", function () {
+            var updateCurrentPos;
 
-			// Check if this frame is actually the current frame
-			// if true then we will update the current frame with serialized positions from CM
-			if (self === currentEditPos) {
-				updateCurrentPos = true;
-			}
-			self._backupSelectionRanges();
-			self.cm = null;
-			self.bookMarkIds = null;
-			if (updateCurrentPos) {
-				currentEditPos = self;
-			}
-		});
-	};
-	
+            // Check if this frame is actually the current frame
+            // if true then we will update the current frame with serialized positions from CM
+            if (self === currentEditPos) {
+                updateCurrentPos = true;
+            }
+            self._backupSelectionRanges();
+            self.cm = null;
+            self.bookMarkIds = null;
+            if (updateCurrentPos) {
+                currentEditPos = self;
+            }
+        });
+    };
+    
    /**
-	* Function to create CM TextMarkers for the navigated positions/selections.
-	* This logic is required to ensure that the captured navigation positions 
-	* stay valid and contextual even when the actual document text mutates.
-	* The mutations which are handled here :
-	* -> Addition/Deletion of lines before the captured position
-	* -> Addition/Updation of characters in the captured selection
-	*/
-	NavigationFrame.prototype._createMarkers = function (ranges) {
-		var range,
-			index,
-			bookMark;
+    * Function to create CM TextMarkers for the navigated positions/selections.
+    * This logic is required to ensure that the captured navigation positions 
+    * stay valid and contextual even when the actual document text mutates.
+    * The mutations which are handled here :
+    * -> Addition/Deletion of lines before the captured position
+    * -> Addition/Updation of characters in the captured selection
+    */
+    NavigationFrame.prototype._createMarkers = function (ranges) {
+        var range,
+            index,
+            bookMark;
 
-		this.bookMarkIds = [];
-		for (index in ranges) {
-			range = ranges[index];
-			// 'markText' has to used for a non-zero length position, if current selection is 
-			// of zero length use bookmark instead.
-			if (range.anchor.line === range.head.line && range.anchor.ch === range.head.ch) {
-				bookMark = this.cm.setBookmark(range.anchor, range.head);
-				this.bookMarkIds.push(bookMark.id);
-			} else {
-				this.cm.markText(range.anchor, range.head, {className: (this.uId)});
-			}
-		}
-	};
-	
+        this.bookMarkIds = [];
+        for (index in ranges) {
+            range = ranges[index];
+            // 'markText' has to used for a non-zero length position, if current selection is 
+            // of zero length use bookmark instead.
+            if (range.anchor.line === range.head.line && range.anchor.ch === range.head.ch) {
+                bookMark = this.cm.setBookmark(range.anchor, range.head);
+                this.bookMarkIds.push(bookMark.id);
+            } else {
+                this.cm.markText(range.anchor, range.head, {className: (this.uId)});
+            }
+        }
+    };
+    
    /**
-	* Function to actually convert the CM markers to CM positions which can be used to 
-	* set selections or cursor positions in Editor.
-	*/
-	NavigationFrame.prototype._backupSelectionRanges = function () {
-		if (!this.cm) {
-			return;
-		}
-		
-		var marker,
-			selection,
-			index;
-		
-		// Reset selections first.
-		this.selections = [];
-		var self = this;
+    * Function to actually convert the CM markers to CM positions which can be used to 
+    * set selections or cursor positions in Editor.
+    */
+    NavigationFrame.prototype._backupSelectionRanges = function () {
+        if (!this.cm) {
+            return;
+        }
+        
+        var marker,
+            selection,
+            index;
+        
+        // Reset selections first.
+        this.selections = [];
+        var self = this;
 
-		// Collate only the markers we used to mark selections/cursors
-		var markers = this.cm.getAllMarks().filter(function (entry) {
-			if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
-				return entry;
-			}
-		});
+        // Collate only the markers we used to mark selections/cursors
+        var markers = this.cm.getAllMarks().filter(function (entry) {
+            if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
+                return entry;
+            }
+        });
 
-		// Iterate over CM textmarkers and collate the updated(if?) positions
-		for (index in markers) {
-			marker = markers[index];
-			selection = marker.find();
-			if (marker.type === "bookmark") {
-				this.selections.push({start: selection, end: selection});
-			} else {
-				this.selections.push({start: selection.from, end: selection.to});
-			}
-		}
-	};
-	
+        // Iterate over CM textmarkers and collate the updated(if?) positions
+        for (index in markers) {
+            marker = markers[index];
+            selection = marker.find();
+            if (marker.type === "bookmark") {
+                this.selections.push({start: selection, end: selection});
+            } else {
+                this.selections.push({start: selection.from, end: selection.to});
+            }
+        }
+    };
+    
    /**
-	* Function to clean up the markers in cm
-	*/
-	NavigationFrame.prototype._clearMarkers = function () {
-		if (!this.cm) {
-			return;
-		}
-		var self = this;
-		
-		// clear only the markers we used to mark selections/cursors
-		this.cm.getAllMarks().filter(function (entry) {
-			if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
-				entry.clear();
-			}
-		});
-	};
+    * Function to clean up the markers in cm
+    */
+    NavigationFrame.prototype._clearMarkers = function () {
+        if (!this.cm) {
+            return;
+        }
+        var self = this;
+        
+        // clear only the markers we used to mark selections/cursors
+        this.cm.getAllMarks().filter(function (entry) {
+            if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
+                entry.clear();
+            }
+        });
+    };
 
    /**
-	* Function to actually navigate to the position(file,selections) captured in this frame
-	*/
-	NavigationFrame.prototype.goTo = function () {
-		var self = this;
-		this._backupSelectionRanges();
-		jumpInProgress = true;
-		CommandManager.execute(Commands.FILE_OPEN, {fullPath: this.file, paneId: this.paneId}).done(function () {
-			EditorManager.getCurrentFullEditor().setSelections(self.selections, true);
-			_validateNavigationCmds();
-		}).always(function () {
-			jumpInProgress = false;
-		});
-	};
-	
-	
+    * Function to actually navigate to the position(file,selections) captured in this frame
+    */
+    NavigationFrame.prototype.goTo = function () {
+        var self = this;
+        this._backupSelectionRanges();
+        jumpInProgress = true;
+        CommandManager.execute(Commands.FILE_OPEN, {fullPath: this.file, paneId: this.paneId}).done(function () {
+            EditorManager.getCurrentFullEditor().setSelections(self.selections, true);
+            _validateNavigationCmds();
+        }).always(function () {
+            jumpInProgress = false;
+        });
+    };
+    
+    
    /**
-	* Function to capture a non-zero set of selections as a navigation frame.
-	* The assumptions behind capturing a frame as a navigation frame are :
-	*
-	* -> If it's set by user explicitly (using mouse click or jump to definition)
-	* -> By clicking on search results
-	* -> Change of cursor by keyboard navigation keys or actual edits are not captured.
-	*
-	* @private
-	*/
-	function _recordJumpDef(event, selectionObj) {
-		if (jumpInProgress) {
-			return;
-		}
-		// Reset forward navigation stack if we are capturing a new event
-		jumpedPosStack = [];
-		if (captureTimer) {
-			window.clearTimeout(captureTimer);
-			captureTimer = null;
-		}
-		
-		// Ensure cursor activity has not happened because of arrow keys or edit
-		if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
-			captureTimer = window.setTimeout(function () {
-				// Check if we have reached MAX_NAV_FRAMES_COUNT
-				// If yes, control overflow
-				if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
-					var navFrame = jumpToPosStack.splice(0, 1);
-					navFrame._clearMarkers();
-				}
+    * Function to capture a non-zero set of selections as a navigation frame.
+    * The assumptions behind capturing a frame as a navigation frame are :
+    *
+    * -> If it's set by user explicitly (using mouse click or jump to definition)
+    * -> By clicking on search results
+    * -> Change of cursor by keyboard navigation keys or actual edits are not captured.
+    *
+    * @private
+    */
+    function _recordJumpDef(event, selectionObj) {
+        if (jumpInProgress) {
+            return;
+        }
+        // Reset forward navigation stack if we are capturing a new event
+        jumpedPosStack = [];
+        if (captureTimer) {
+            window.clearTimeout(captureTimer);
+            captureTimer = null;
+        }
+        
+        // Ensure cursor activity has not happened because of arrow keys or edit
+        if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
+            captureTimer = window.setTimeout(function () {
+                // Check if we have reached MAX_NAV_FRAMES_COUNT
+                // If yes, control overflow
+                if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
+                    var navFrame = jumpToPosStack.splice(0, 1);
+                    navFrame._clearMarkers();
+                }
 
-				currentEditPos = new NavigationFrame(event.target, selectionObj);
-				jumpToPosStack.push(currentEditPos);
-				_validateNavigationCmds();
-				activePosNotSynced = false;
-			}, NAV_FRAME_CAPTURE_LATENCY);
-		} else {
-			activePosNotSynced = true;
-		}
-	}
-	
+                currentEditPos = new NavigationFrame(event.target, selectionObj);
+                jumpToPosStack.push(currentEditPos);
+                _validateNavigationCmds();
+                activePosNotSynced = false;
+            }, NAV_FRAME_CAPTURE_LATENCY);
+        } else {
+            activePosNotSynced = true;
+        }
+    }
+    
    /**
-	* Command handler to navigate backward
-	*/
-	function _navigateBack() {
-		if (!jumpedPosStack.length) {
-			if (activePosNotSynced) {
-				currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
-				jumpedPosStack.push(currentEditPos);
-			}
-		}
-		
-		var navFrame = jumpToPosStack.pop();
-		
-		// Check if the poped frame is the current active frame
-		// if true, jump again
-		if (navFrame === currentEditPos) {
-			jumpedPosStack.push(navFrame);
-			CommandManager.execute(NAVIGATION_JUMP_BACK);
-			return;
-		}
-		
-		if (navFrame) {
-			// We will check for the file existence now, if it doesn't exist we will jump back again
-			// but discard the popped frame as invalid.
-			_checkIfExist(navFrame).done(function () {
-				jumpedPosStack.push(navFrame);
-				navFrame.goTo();
-				currentEditPos = navFrame;
-			}).fail(function () {
-				CommandManager.execute(NAVIGATION_JUMP_BACK);
-			}).always(function () {
-				_validateNavigationCmds();
-			});
-		}
-	}
-	
+    * Command handler to navigate backward
+    */
+    function _navigateBack() {
+        if (!jumpedPosStack.length) {
+            if (activePosNotSynced) {
+                currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
+                jumpedPosStack.push(currentEditPos);
+            }
+        }
+        
+        var navFrame = jumpToPosStack.pop();
+        
+        // Check if the poped frame is the current active frame
+        // if true, jump again
+        if (navFrame === currentEditPos) {
+            jumpedPosStack.push(navFrame);
+            CommandManager.execute(NAVIGATION_JUMP_BACK);
+            return;
+        }
+        
+        if (navFrame) {
+            // We will check for the file existence now, if it doesn't exist we will jump back again
+            // but discard the popped frame as invalid.
+            _checkIfExist(navFrame).done(function () {
+                jumpedPosStack.push(navFrame);
+                navFrame.goTo();
+                currentEditPos = navFrame;
+            }).fail(function () {
+                CommandManager.execute(NAVIGATION_JUMP_BACK);
+            }).always(function () {
+                _validateNavigationCmds();
+            });
+        }
+    }
+    
    /**
-	* Command handler to navigate forward
-	*/
-	function _navigateForward() {
-		var navFrame = jumpedPosStack.pop();
-		
-		// Check if the poped frame is the current active frame
-		// if true, jump again
-		if (navFrame === currentEditPos) {
-			jumpToPosStack.push(navFrame);
-			CommandManager.execute(NAVIGATION_JUMP_FWD);
-			return;
-		}
-		
-		if (navFrame) {
-			// We will check for the file existence now, if it doesn't exist we will jump back again
-			// but discard the popped frame as invalid.
-			_checkIfExist(navFrame).done(function () {
-				jumpToPosStack.push(navFrame);
-				navFrame.goTo();
-				currentEditPos = navFrame;
-			}).fail(function () {
-				_validateNavigationCmds();
-				CommandManager.execute(NAVIGATION_JUMP_FWD);
-			}).always(function () {
-				_validateNavigationCmds();
-			});
-		}
-	}
-	
+    * Command handler to navigate forward
+    */
+    function _navigateForward() {
+        var navFrame = jumpedPosStack.pop();
+        
+        // Check if the poped frame is the current active frame
+        // if true, jump again
+        if (navFrame === currentEditPos) {
+            jumpToPosStack.push(navFrame);
+            CommandManager.execute(NAVIGATION_JUMP_FWD);
+            return;
+        }
+        
+        if (navFrame) {
+            // We will check for the file existence now, if it doesn't exist we will jump back again
+            // but discard the popped frame as invalid.
+            _checkIfExist(navFrame).done(function () {
+                jumpToPosStack.push(navFrame);
+                navFrame.goTo();
+                currentEditPos = navFrame;
+            }).fail(function () {
+                _validateNavigationCmds();
+                CommandManager.execute(NAVIGATION_JUMP_FWD);
+            }).always(function () {
+                _validateNavigationCmds();
+            });
+        }
+    }
+    
    /**
-	* Function to initialize navigation menu items.
-	* @private
-	*/
-	function _initNavigationMenuItems() {
-		var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
-		menu.addMenuItem(NAVIGATION_JUMP_BACK, "", Menus.AFTER, Commands.NAVIGATE_PREV_DOC);
-		menu.addMenuItem(NAVIGATION_JUMP_FWD, "", Menus.AFTER, NAVIGATION_JUMP_BACK);
-	}
-	
+    * Function to initialize navigation menu items.
+    * @private
+    */
+    function _initNavigationMenuItems() {
+        var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
+        menu.addMenuItem(NAVIGATION_JUMP_BACK, "", Menus.AFTER, Commands.NAVIGATE_PREV_DOC);
+        menu.addMenuItem(NAVIGATION_JUMP_FWD, "", Menus.AFTER, NAVIGATION_JUMP_BACK);
+    }
+    
    /**
-	* Function to initialize navigation commands and it's keyboard shortcuts.
-	* @private
-	*/
-	function _initNavigationCommands() {
-		CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
-		CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
-		commandJumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
-		commandJumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
-		commandJumpBack.setEnabled(false);
-		commandJumpFwd.setEnabled(false);
-		KeyBindingManager.addBinding(NAVIGATION_JUMP_BACK, KeyboardPrefs[NAVIGATION_JUMP_BACK]);
-		KeyBindingManager.addBinding(NAVIGATION_JUMP_FWD, KeyboardPrefs[NAVIGATION_JUMP_FWD]);
-		_initNavigationMenuItems();
-	}
-	
+    * Function to initialize navigation commands and it's keyboard shortcuts.
+    * @private
+    */
+    function _initNavigationCommands() {
+        CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
+        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
+        commandJumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
+        commandJumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
+        commandJumpBack.setEnabled(false);
+        commandJumpFwd.setEnabled(false);
+        KeyBindingManager.addBinding(NAVIGATION_JUMP_BACK, KeyboardPrefs[NAVIGATION_JUMP_BACK]);
+        KeyBindingManager.addBinding(NAVIGATION_JUMP_FWD, KeyboardPrefs[NAVIGATION_JUMP_FWD]);
+        _initNavigationMenuItems();
+    }
+    
    /**
-	* Function to request a navigation frame creation explicitly.
-	* @private
-	*/
-	function _captureFrame(editor) {
-		// Capture the active position now if it was not captured earlier
-		if ((activePosNotSynced || !jumpToPosStack.length) && !jumpInProgress) {
-			jumpToPosStack.push(new NavigationFrame(editor, {ranges: editor._codeMirror.listSelections()}));
-		}
-	}
-	
-	/**
-	 * Handle Active Editor change to update navigation information
-	 * @private
-	 */
-	function _handleActiveEditorChange(event, current, previous) {
-		if (previous && previous._paneId) { // Handle only full editors
-			previous.off("beforeSelectionChange", _recordJumpDef);
-			_captureFrame(previous);
-			_validateNavigationCmds();
-		}
-		
-		if (current && current._paneId) { // Handle only full editors
-			activePosNotSynced = true;
-			current.on("beforeSelectionChange", _recordJumpDef);
-		}
-	}
-	
-	function _handleProjectOpen() {
-		jumpToPosStack = [];
-		jumpedPosStack = [];
-	}
-	
-	function _initHandlers() {
-		EditorManager.on("activeEditorChange", _handleActiveEditorChange);
-		ProjectManager.on("projectOpen", _handleProjectOpen);
-	}
+    * Function to request a navigation frame creation explicitly.
+    * @private
+    */
+    function _captureFrame(editor) {
+        // Capture the active position now if it was not captured earlier
+        if ((activePosNotSynced || !jumpToPosStack.length) && !jumpInProgress) {
+            jumpToPosStack.push(new NavigationFrame(editor, {ranges: editor._codeMirror.listSelections()}));
+        }
+    }
+    
+    /**
+     * Handle Active Editor change to update navigation information
+     * @private
+     */
+    function _handleActiveEditorChange(event, current, previous) {
+        if (previous && previous._paneId) { // Handle only full editors
+            previous.off("beforeSelectionChange", _recordJumpDef);
+            _captureFrame(previous);
+            _validateNavigationCmds();
+        }
+        
+        if (current && current._paneId) { // Handle only full editors
+            activePosNotSynced = true;
+            current.on("beforeSelectionChange", _recordJumpDef);
+        }
+    }
+    
+    function _handleProjectOpen() {
+        jumpToPosStack = [];
+        jumpedPosStack = [];
+    }
+    
+    function _initHandlers() {
+        EditorManager.on("activeEditorChange", _handleActiveEditorChange);
+        ProjectManager.on("projectOpen", _handleProjectOpen);
+    }
 
-	function init() {
-		_initNavigationCommands();
-		_initHandlers();
-	}
-	
-	exports.init = init;
+    function init() {
+        _initNavigationCommands();
+        _initHandlers();
+    }
+    
+    exports.init = init;
 });

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
     
     // The latency time to capture an explicit cursor movement as a navigation frame
     var NAV_FRAME_CAPTURE_LATENCY = 2000,
-		MAX_NAV_FRAMES_COUNT = 50;
+	MAX_NAV_FRAMES_COUNT = 50;
     
     /*
     * Contains list of most recently known cursor positions.
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
     var jumpedPosStack = [],
         activePosNotSynced = false,
         captureTimer,
-		currentEditPos,
+	currentEditPos,
         jumpInProgress,
         commandJumpBack,
         commandJumpFwd;
@@ -76,10 +76,10 @@ define(function (require, exports, module) {
     * Function to check if there are any navigatable frame backward.
     * @private
     */
-	function _hasNavBackFrames() {
-		return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
-				|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
-	}
+    function _hasNavBackFrames() {
+	return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
+		|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
+    }
      
    /**
     * Function to enable/disable navigation command based on cursor positions availability.
@@ -113,8 +113,8 @@ define(function (require, exports, module) {
                 } else {
                     deferred.reject();
                 }
-			});
-	    }
+	    });
+	}
 
         return deferred.promise();
     }
@@ -140,20 +140,19 @@ define(function (require, exports, module) {
     NavigationFrame.prototype._bindEditor = function (editor) {
         var self = this;
         editor.on("beforeDestroy", function () {
-			var updateCurrentPos;
-			
-			// Check if this frame is actually the current frame
-			// if true then we will update the current frame with serialized positions from CM
-			if (self === currentEditPos) {
-				updateCurrentPos = true;
-			}
-            self._backupSelectionRanges();
-            self.cm = null;
-            self.bookMarkIds = null;
-			
-			if (updateCurrentPos) {
-				currentEditPos = self;
-			}
+		var updateCurrentPos;
+
+		// Check if this frame is actually the current frame
+		// if true then we will update the current frame with serialized positions from CM
+		if (self === currentEditPos) {
+			updateCurrentPos = true;
+		}
+		self._backupSelectionRanges();
+		self.cm = null;
+		self.bookMarkIds = null;
+		if (updateCurrentPos) {
+			currentEditPos = self;
+		}
         });
     };
     
@@ -167,8 +166,8 @@ define(function (require, exports, module) {
     */
     NavigationFrame.prototype._createMarkers = function (ranges) {
         var range,
-			index,
-			bookMark;
+	    index,
+	    bookMark;
 
         this.bookMarkIds = [];
         for (index in ranges) {
@@ -193,22 +192,22 @@ define(function (require, exports, module) {
             return;
         }
 		
-		var marker,
-			selection,
-			index;
+	var marker,
+	    selection,
+	    index;
         
-		// Reset selections first.
+	// Reset selections first.
         this.selections = [];
         var self = this;
 		
-		// Collate only the markers we used to mark selections/cursors
+	// Collate only the markers we used to mark selections/cursors
         var markers = this.cm.getAllMarks().filter(function (entry) {
             if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
                 return entry;
             }
         });
 		
-		// Iterate over CM textmarkers and collate the updated(if?) positions
+	// Iterate over CM textmarkers and collate the updated(if?) positions
         for (index in markers) {
             marker = markers[index];
             selection = marker.find();
@@ -220,7 +219,7 @@ define(function (require, exports, module) {
         }
     };
 	
-	/**
+    /**
     * Function to clean up the markers in cm
     */
     NavigationFrame.prototype._clearMarkers = function () {
@@ -229,7 +228,7 @@ define(function (require, exports, module) {
         }
         var self = this;
 		
-		// clear only the markers we used to mark selections/cursors
+	// clear only the markers we used to mark selections/cursors
         this.cm.getAllMarks().filter(function (entry) {
             if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
                 entry.clear();
@@ -277,15 +276,15 @@ define(function (require, exports, module) {
         // Ensure cursor activity has not happened because of arrow keys or edit
         if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
             captureTimer = window.setTimeout(function () {
-				// Check if we have reached MAX_NAV_FRAMES_COUNT
-				// If yes, control overflow
-				if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
-					var navFrame = jumpToPosStack.splice(0, 1);
-					navFrame._clearMarkers();
-				}
-				
-				currentEditPos = new NavigationFrame(event.target, selectionObj);
-				jumpToPosStack.push(currentEditPos);
+		// Check if we have reached MAX_NAV_FRAMES_COUNT
+		// If yes, control overflow
+		if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
+			var navFrame = jumpToPosStack.splice(0, 1);
+			navFrame._clearMarkers();
+		}
+
+		currentEditPos = new NavigationFrame(event.target, selectionObj);
+		jumpToPosStack.push(currentEditPos);
                 _validateNavigationCmds();
                 activePosNotSynced = false;
             }, NAV_FRAME_CAPTURE_LATENCY);
@@ -300,20 +299,20 @@ define(function (require, exports, module) {
     function _navigateBack() {
         if (!jumpedPosStack.length) {
             if (activePosNotSynced) {
-				currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
+		currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
                 jumpedPosStack.push(currentEditPos);
             }
         }
 		
         var navFrame = jumpToPosStack.pop();
 		
-		// Check if the poped frame is the current active frame
-		// if true, jump again
-		if (navFrame === currentEditPos) {
-			jumpedPosStack.push(navFrame);
-			CommandManager.execute(NAVIGATION_JUMP_BACK);
-			return;
-		}
+	// Check if the poped frame is the current active frame
+	// if true, jump again
+	if (navFrame === currentEditPos) {
+		jumpedPosStack.push(navFrame);
+		CommandManager.execute(NAVIGATION_JUMP_BACK);
+		return;
+	}
 		
         if (navFrame) {
             // We will check for the file existence now, if it doesn't exist we will jump back again
@@ -321,12 +320,12 @@ define(function (require, exports, module) {
             _checkIfExist(navFrame).done(function () {
                 jumpedPosStack.push(navFrame);
                 navFrame.goTo();
-				currentEditPos = navFrame;
+		currentEditPos = navFrame;
             }).fail(function () {
                 CommandManager.execute(NAVIGATION_JUMP_BACK);
             }).always(function () {
-				_validateNavigationCmds();
-			});
+		_validateNavigationCmds();
+	    });
         }
     }
     
@@ -336,13 +335,13 @@ define(function (require, exports, module) {
     function _navigateFwd() {
         var navFrame = jumpedPosStack.pop();
 		
-		// Check if the poped frame is the current active frame
-		// if true, jump again
-		if (navFrame === currentEditPos) {
-			jumpToPosStack.push(navFrame);
-			CommandManager.execute(NAVIGATION_JUMP_FWD);
-			return;
-		}
+	// Check if the poped frame is the current active frame
+	// if true, jump again
+	if (navFrame === currentEditPos) {
+		jumpToPosStack.push(navFrame);
+		CommandManager.execute(NAVIGATION_JUMP_FWD);
+		return;
+	}
 		
         if (navFrame) {
             // We will check for the file existence now, if it doesn't exist we will jump back again
@@ -350,13 +349,13 @@ define(function (require, exports, module) {
             _checkIfExist(navFrame).done(function () {
                 jumpToPosStack.push(navFrame);
                 navFrame.goTo();
-				currentEditPos = navFrame;
+		currentEditPos = navFrame;
             }).fail(function () {
                 _validateNavigationCmds();
                 CommandManager.execute(NAVIGATION_JUMP_FWD);
             }).always(function () {
-				_validateNavigationCmds();
-			});
+		_validateNavigationCmds();
+	    });
         }
     }
     

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -50,16 +50,16 @@ define(function (require, exports, module) {
     
     // The latency time to capture an explicit cursor movement as a navigation frame
     var NAV_FRAME_CAPTURE_LATENCY = 2000,
-	MAX_NAV_FRAMES_COUNT = 50;
+		MAX_NAV_FRAMES_COUNT = 50;
     
-    /*
+   /**
     * Contains list of most recently known cursor positions.
     * @private
     * @type {Array.<Object>}
     */
     var jumpToPosStack = [];
     
-    /*
+   /**
     * Contains list of most recently traversed cursor positions using NAVIGATION_JUMP_BACK command.
     * @private
     * @type {Array.<Object>}
@@ -67,18 +67,18 @@ define(function (require, exports, module) {
     var jumpedPosStack = [],
         activePosNotSynced = false,
         captureTimer,
-	currentEditPos,
+		currentEditPos,
         jumpInProgress,
         commandJumpBack,
         commandJumpFwd;
 		
-	/**
+   /**
     * Function to check if there are any navigatable frame backward.
     * @private
     */
     function _hasNavBackFrames() {
-	return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
-		|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
+		return (jumpedPosStack.length > 0 && jumpToPosStack.length > 0)
+			|| (!jumpedPosStack.length && jumpToPosStack.length > 1);
     }
      
    /**
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
         commandJumpFwd.setEnabled(jumpedPosStack.length > 0);
     }
     
-    /**
+   /**
     * Function to check existence of a file entry
     * @private
     */
@@ -113,8 +113,8 @@ define(function (require, exports, module) {
                 } else {
                     deferred.reject();
                 }
-	    });
-	}
+	    	});
+		}
 
         return deferred.promise();
     }
@@ -140,19 +140,19 @@ define(function (require, exports, module) {
     NavigationFrame.prototype._bindEditor = function (editor) {
         var self = this;
         editor.on("beforeDestroy", function () {
-		var updateCurrentPos;
+			var updateCurrentPos;
 
-		// Check if this frame is actually the current frame
-		// if true then we will update the current frame with serialized positions from CM
-		if (self === currentEditPos) {
-			updateCurrentPos = true;
-		}
-		self._backupSelectionRanges();
-		self.cm = null;
-		self.bookMarkIds = null;
-		if (updateCurrentPos) {
-			currentEditPos = self;
-		}
+			// Check if this frame is actually the current frame
+			// if true then we will update the current frame with serialized positions from CM
+			if (self === currentEditPos) {
+				updateCurrentPos = true;
+			}
+			self._backupSelectionRanges();
+			self.cm = null;
+			self.bookMarkIds = null;
+			if (updateCurrentPos) {
+				currentEditPos = self;
+			}
         });
     };
     
@@ -166,8 +166,8 @@ define(function (require, exports, module) {
     */
     NavigationFrame.prototype._createMarkers = function (ranges) {
         var range,
-	    index,
-	    bookMark;
+	    	index,
+	    	bookMark;
 
         this.bookMarkIds = [];
         for (index in ranges) {
@@ -192,22 +192,22 @@ define(function (require, exports, module) {
             return;
         }
 		
-	var marker,
-	    selection,
-	    index;
+		var marker,
+			selection,
+			index;
         
-	// Reset selections first.
-        this.selections = [];
-        var self = this;
-		
-	// Collate only the markers we used to mark selections/cursors
-        var markers = this.cm.getAllMarks().filter(function (entry) {
-            if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
-                return entry;
-            }
-        });
-		
-	// Iterate over CM textmarkers and collate the updated(if?) positions
+		// Reset selections first.
+		this.selections = [];
+		var self = this;
+
+		// Collate only the markers we used to mark selections/cursors
+		var markers = this.cm.getAllMarks().filter(function (entry) {
+			if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
+				return entry;
+			}
+		});
+
+		// Iterate over CM textmarkers and collate the updated(if?) positions
         for (index in markers) {
             marker = markers[index];
             selection = marker.find();
@@ -219,7 +219,7 @@ define(function (require, exports, module) {
         }
     };
 	
-    /**
+   /**
     * Function to clean up the markers in cm
     */
     NavigationFrame.prototype._clearMarkers = function () {
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
         }
         var self = this;
 		
-	// clear only the markers we used to mark selections/cursors
+		// clear only the markers we used to mark selections/cursors
         this.cm.getAllMarks().filter(function (entry) {
             if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
                 entry.clear();
@@ -276,17 +276,17 @@ define(function (require, exports, module) {
         // Ensure cursor activity has not happened because of arrow keys or edit
         if (selectionObj.origin !== "+move" && (!window.event || (window.event && window.event.type !== "input"))) {
             captureTimer = window.setTimeout(function () {
-		// Check if we have reached MAX_NAV_FRAMES_COUNT
-		// If yes, control overflow
-		if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
-			var navFrame = jumpToPosStack.splice(0, 1);
-			navFrame._clearMarkers();
-		}
+				// Check if we have reached MAX_NAV_FRAMES_COUNT
+				// If yes, control overflow
+				if (jumpToPosStack.length === MAX_NAV_FRAMES_COUNT) {
+					var navFrame = jumpToPosStack.splice(0, 1);
+					navFrame._clearMarkers();
+				}
 
-		currentEditPos = new NavigationFrame(event.target, selectionObj);
-		jumpToPosStack.push(currentEditPos);
-                _validateNavigationCmds();
-                activePosNotSynced = false;
+				currentEditPos = new NavigationFrame(event.target, selectionObj);
+				jumpToPosStack.push(currentEditPos);
+				_validateNavigationCmds();
+				activePosNotSynced = false;
             }, NAV_FRAME_CAPTURE_LATENCY);
         } else {
             activePosNotSynced = true;
@@ -299,20 +299,20 @@ define(function (require, exports, module) {
     function _navigateBack() {
         if (!jumpedPosStack.length) {
             if (activePosNotSynced) {
-		currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
+				currentEditPos = new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()});
                 jumpedPosStack.push(currentEditPos);
             }
         }
 		
         var navFrame = jumpToPosStack.pop();
 		
-	// Check if the poped frame is the current active frame
-	// if true, jump again
-	if (navFrame === currentEditPos) {
-		jumpedPosStack.push(navFrame);
-		CommandManager.execute(NAVIGATION_JUMP_BACK);
-		return;
-	}
+		// Check if the poped frame is the current active frame
+		// if true, jump again
+		if (navFrame === currentEditPos) {
+			jumpedPosStack.push(navFrame);
+			CommandManager.execute(NAVIGATION_JUMP_BACK);
+			return;
+		}
 		
         if (navFrame) {
             // We will check for the file existence now, if it doesn't exist we will jump back again
@@ -320,12 +320,12 @@ define(function (require, exports, module) {
             _checkIfExist(navFrame).done(function () {
                 jumpedPosStack.push(navFrame);
                 navFrame.goTo();
-		currentEditPos = navFrame;
+				currentEditPos = navFrame;
             }).fail(function () {
                 CommandManager.execute(NAVIGATION_JUMP_BACK);
             }).always(function () {
-		_validateNavigationCmds();
-	    });
+				_validateNavigationCmds();
+	    	});
         }
     }
     
@@ -335,13 +335,13 @@ define(function (require, exports, module) {
     function _navigateFwd() {
         var navFrame = jumpedPosStack.pop();
 		
-	// Check if the poped frame is the current active frame
-	// if true, jump again
-	if (navFrame === currentEditPos) {
-		jumpToPosStack.push(navFrame);
-		CommandManager.execute(NAVIGATION_JUMP_FWD);
-		return;
-	}
+		// Check if the poped frame is the current active frame
+		// if true, jump again
+		if (navFrame === currentEditPos) {
+			jumpToPosStack.push(navFrame);
+			CommandManager.execute(NAVIGATION_JUMP_FWD);
+			return;
+		}
 		
         if (navFrame) {
             // We will check for the file existence now, if it doesn't exist we will jump back again
@@ -349,17 +349,17 @@ define(function (require, exports, module) {
             _checkIfExist(navFrame).done(function () {
                 jumpToPosStack.push(navFrame);
                 navFrame.goTo();
-		currentEditPos = navFrame;
+				currentEditPos = navFrame;
             }).fail(function () {
                 _validateNavigationCmds();
                 CommandManager.execute(NAVIGATION_JUMP_FWD);
             }).always(function () {
-		_validateNavigationCmds();
-	    });
+				_validateNavigationCmds();
+			});
         }
     }
     
-    /**
+   /**
     * Function to initialize navigation menu items.
     * @private
     */

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
             self.cm = null;
             self.bookMarkIds = null;
         });
-    }
+    };
     
     NavigationFrame.prototype._createMarkers = function (ranges) {
         var range, index, bookMark;
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
             if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
                 return entry;
             }
-        })
+        });
         for (index in markers) {
             marker = markers[index];
             selection = marker.find();

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2016 - present Adobe Systems Incorporated. All rights reserved.
+ *  
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *  
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *  
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var Strings                 = brackets.getModule("strings"),
+        MainViewManager         = brackets.getModule("view/MainViewManager"),
+        DocumentManager         = brackets.getModule("document/DocumentManager"),
+        DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
+        EditorManager           = brackets.getModule("editor/EditorManager"),
+        Editor                  = brackets.getModule("editor/Editor"),
+        ProjectManager          = brackets.getModule("project/ProjectManager"),
+        CommandManager          = brackets.getModule("command/CommandManager"),
+        Commands                = brackets.getModule("command/Commands"),
+        Menus                   = brackets.getModule("command/Menus"),
+        KeyBindingManager       = brackets.getModule("command/KeyBindingManager");
+
+    var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
+    
+    // Command constants for navigation history
+    var NAVIGATION_JUMP_BACK      = "navigation.jump.back",
+        NAVIGATION_JUMP_FWD       = "navigation.jump.fwd";
+        
+    var NAV_FRAME_CAPTURE_LATENCY = 3000;
+        
+    
+    /*
+    * Contains list of most recently opened files and their last known cursor position
+    * @private
+    * @type {Array.<Object>}
+    */
+    var jumpToPosStack = [],
+        jumpedPosStack = [],
+        captureTimer,
+        activePosNotSynched = false,
+        jumpInProgress,
+        command_JumpBack,
+        command_JumpFwd,
+        cmMarkers = {};
+        
+    
+    function NavigationFrame(editor, selectionObj) {
+        this.cm = editor._codeMirror;
+        this.file = editor.document.file._path;
+        this.paneId = editor._paneId;
+        this.uId = (new Date()).getTime() + "";
+        this.selections = [];
+        this.bookMarkIds = [];
+        this._createMarkers(selectionObj.ranges);
+        this._bindEditor(editor);
+    }
+    
+    NavigationFrame.prototype._bindEditor = function (editor) {
+        var self = this;
+        editor.on("beforeDestroy", function () {
+            self._backupSelectionRanges();
+            self.cm = null;
+            self.bookMarkIds = null;
+        });
+    }
+    
+    NavigationFrame.prototype._createMarkers = function (ranges) {
+        var range, index, bookMark;
+        this.bookMarkIds = [];
+        for (index in ranges) {
+            range = ranges[index];
+            if (range.anchor.line === range.head.line && range.anchor.ch === range.head.ch) {
+                bookMark = this.cm.setBookmark(range.anchor, range.head);
+                this.bookMarkIds.push(bookMark.id);
+            } else {
+                this.cm.markText(range.anchor, range.head, {className: (this.uId + "")});
+            }
+        }
+    };
+    
+    NavigationFrame.prototype._backupSelectionRanges = function () {
+        if (!this.cm) {
+            return;
+        }
+        
+        this.selections = [];
+        var marker, selection, index;
+        var self = this;
+        var markers = this.cm.getAllMarks().filter(function (entry) {
+            if (entry.className === self.uId || self.bookMarkIds.indexOf(entry.id) !== -1) {
+                return entry;
+            }
+        })
+        for (index in markers) {
+            marker = markers[index];
+            selection = marker.find();
+            if (marker.type === "bookmark") {
+                this.selections.push({start: selection, end: selection});
+            } else {
+                this.selections.push({start: selection.from, end: selection.to});
+            }
+        }
+    };
+
+    NavigationFrame.prototype.goTo = function () {
+        var self = this;
+        this._backupSelectionRanges();
+        jumpInProgress = true;
+        CommandManager.execute(Commands.FILE_OPEN, {fullPath: this.file, paneId: this.paneId}).done(function () {
+            EditorManager.getCurrentFullEditor().setSelections(self.selections, true);
+            command_JumpFwd.setEnabled(true);
+        }).always(function () {
+            jumpInProgress = false;
+        });
+    };
+    
+    function _recordJumpDef(event, selectionObj) {
+        if (jumpInProgress) {
+            return;
+        }
+        jumpedPosStack = [];
+        if (selectionObj.origin !== "+move" && (window.event && window.event.type !== "input")) {
+            if (captureTimer) {
+                window.clearTimeout(captureTimer);
+                captureTimer = null;
+            }
+            captureTimer = window.setTimeout(function () {
+                jumpToPosStack.push(new NavigationFrame(event.target, selectionObj));
+                command_JumpFwd.setEnabled(false);
+                if (jumpToPosStack.length > 1) {
+                    command_JumpBack.setEnabled(true);
+                }
+                activePosNotSynched = false;
+            }, NAV_FRAME_CAPTURE_LATENCY);
+        } else {
+            activePosNotSynched = true;
+        }
+    }
+    
+    function _jumpToPosBack() {
+        if (!jumpedPosStack.length) {
+            if (activePosNotSynched) {
+                jumpToPosStack.push(new NavigationFrame(EditorManager.getCurrentFullEditor(), {ranges: EditorManager.getCurrentFullEditor()._codeMirror.listSelections()}));
+            } else {
+                jumpedPosStack.push(jumpToPosStack.pop());
+            }
+        }
+        var navFrame = jumpToPosStack.pop();
+        if (navFrame) {
+            jumpedPosStack.push(navFrame);
+            navFrame.goTo();
+        }
+    }
+    
+    function _jumpToPosFwd() {
+        var navFrame = jumpedPosStack.pop();
+        if (navFrame) {
+            jumpToPosStack.push(navFrame);
+            navFrame.goTo();
+        }
+    }
+    
+    /**
+     * Handle Active Editor change to update navigation information
+     * @private
+     */
+    function _handleActiveEditorChange(event, current, previous) {
+        if (current && current._paneId) { // Handle only full editors
+            current.on("beforeSelectionChange", _recordJumpDef);
+        }
+
+        if (previous && previous._paneId) { 
+            previous.off("beforeSelectionChange", _recordJumpDef);
+        }
+    }
+    
+    function _handleProjectOpen() {
+        jumpToPosStack = [];
+        jumpedPosStack = [];
+    }
+
+    function init() {
+        CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _jumpToPosBack);
+        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _jumpToPosFwd);
+        command_JumpBack = CommandManager.get(NAVIGATION_JUMP_BACK);
+        command_JumpFwd = CommandManager.get(NAVIGATION_JUMP_FWD);
+        command_JumpBack.setEnabled(false);
+        command_JumpFwd.setEnabled(false);
+        KeyBindingManager.addBinding(NAVIGATION_JUMP_BACK, KeyboardPrefs[NAVIGATION_JUMP_BACK]);
+        KeyBindingManager.addBinding(NAVIGATION_JUMP_FWD, KeyboardPrefs[NAVIGATION_JUMP_FWD]);
+        var menu = Menus.getMenu(Menus.AppMenuBar.NAVIGATE_MENU);
+        menu.addMenuItem(NAVIGATION_JUMP_BACK, "", Menus.AFTER, Commands.NAVIGATE_PREV_DOC);
+        menu.addMenuItem(NAVIGATION_JUMP_FWD, "", Menus.AFTER, NAVIGATION_JUMP_BACK);
+        EditorManager.on("activeEditorChange", _handleActiveEditorChange);
+        ProjectManager.on("projectOpen", _handleProjectOpen);
+    }
+    
+    exports.init = init;
+});

--- a/src/extensions/default/NavigationAndHistory/keyboard.json
+++ b/src/extensions/default/NavigationAndHistory/keyboard.json
@@ -27,5 +27,15 @@
             "key": "Cmd-Shift-[",
             "platform": "mac"
         }
+    ],
+    "navigation.jump.back":  [
+        {
+            "key": "Alt-I"
+        }
+    ],
+    "navigation.jump.fwd":  [
+        {
+            "key": "Alt-Shift-I"
+        }
     ]
 }

--- a/src/extensions/default/NavigationAndHistory/main.js
+++ b/src/extensions/default/NavigationAndHistory/main.js
@@ -646,6 +646,10 @@ define(function (require, exports, module) {
     
     function _initRecentFilesList() {
         _mrofList = PreferencesManager.getViewState(OPEN_FILES_VIEW_STATE, _getPrefsContext()) || [];
+        
+        _mrofList = _mrofList.filter(function (entry) {
+            return entry;
+        });
         // Have a check on the number of entries to fallback to working set if we detect corruption
         if (_mrofList.length < MainViewManager.getWorkingSetSize(MainViewManager.ALL_PANES)) {
             _mrofList = _createMROFList();

--- a/src/extensions/default/NavigationAndHistory/main.js
+++ b/src/extensions/default/NavigationAndHistory/main.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
         PreferencesManager      = brackets.getModule("preferences/PreferencesManager"),
         KeyBindingManager       = brackets.getModule("command/KeyBindingManager"),
         ExtensionUtils          = brackets.getModule("utils/ExtensionUtils"),
-        Mustache                = brackets.getModule("thirdparty/mustache/mustache");
+        Mustache                = brackets.getModule("thirdparty/mustache/mustache"),
+        NavigationProvider      = require("NavigationProvider");
 
     var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
     
@@ -829,5 +830,6 @@ define(function (require, exports, module) {
 
     AppInit.appReady(function () {
         ExtensionUtils.loadStyleSheet(module, "styles/recent-files.css");
+        NavigationProvider.init();
     });
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -415,6 +415,8 @@ define({
     "CMD_CSS_QUICK_EDIT_NEW_RULE"         : "New Rule",
     "CMD_NEXT_DOC"                        : "Next Document",
     "CMD_PREV_DOC"                        : "Previous Document",
+    "CMD_NAVIGATE_BACKWARD"               : "Navigate Backward",
+    "CMD_NAVIGATE_FORWARD"                : "Navigate Forward",
     "CMD_NEXT_DOC_LIST_ORDER"             : "Next Document in List",
     "CMD_PREV_DOC_LIST_ORDER"             : "Previous Document in List",
     "CMD_SHOW_IN_TREE"                    : "Show in File Tree",


### PR DESCRIPTION
This feature is something which I missed a lot! Remembering most recently used (interesting?) cursor positions and navigating there manually is really cumbersome. 

This module adds the feature of remembering  cursors/selections across full editors inside a project root and aids the user by providing 'Navigate Back'(Alt+I) and 'Navigate Fwd'(Alt+Shift+I) using the captured navigation frames.

Ping @petetnt @ficristo for review. 
