### PR TITLE
Change in UUID fetching for first launches

### DIFF
--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -83,7 +83,6 @@ define(function (require, exports, module) {
                                 if (err) {
                                     userUuid = uuid.v4();
                                 } else {
-                                    console.log(macHash);
                                     userUuid = macHash;
                                 }
 
@@ -92,8 +91,7 @@ define(function (require, exports, module) {
                                 oneTimeHealthData.uuid = userUuid;
                                 return result.resolve(oneTimeHealthData);
                             });
-                            
-                            
+
                         } else {
                             oneTimeHealthData.uuid = userUuid;
                             return result.resolve(oneTimeHealthData);


### PR DESCRIPTION
With this PR, UUID is now mapped to a system hash instead of relying on unique identifiers. This will make sure the user id is captured uniquely and not logged as two users in situations like launching Brackets after clearing preferences.

Also fixed linter errors in this file.

[This](https://github.com/adobe/brackets-shell/pull/603) relevant PR on Brackets-shell side needs to be merged too. The PR on the shell side introduces new shell API by name `getMachineHash`

Pending: Need to unit test on Linux.