### PR TITLE
Fix issue where file extension is outputted twice when saving…

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -955,8 +955,10 @@ define(function (require, exports, module) {
             defaultName = FileUtils.getBaseName(origPath);
             var file = FileSystem.getFileForPath(origPath);
             if (file instanceof InMemoryFile) {
-                var language = LanguageManager.getLanguageForPath(origPath);
-                if (language) {
+                var language = LanguageManager.getLanguageForPath(origPath),
+                    hasExtension = (FileUtils.getFileExtension(origPath).length > 0);
+
+                if (language && !hasExtension) {
                     var fileExtensions = language.getFileExtensions();
                     if (fileExtensions && fileExtensions.length > 0) {
                         defaultName += "." + fileExtensions[0];


### PR DESCRIPTION
…a file created using DocumentManager.createUntitledDocument

Brackets v1.9.0 added support for creating untitled files with extensions (along with the ability to change language types in untitled files). See Brackets 13086. When using DocumentManager.createUntitledDocument(count, ext);, everything works as expected until you save. The bug is that when you save an untitled file with an extension, the filename outputted into the save-as dialog treats the untitled documents extension as part of its filename and appends the extension again. In other words, the save-as dialogs filename has the extension twice.

See: https://github.com/adobe/brackets/issues/13381