### PR TITLE
In writeJSON (grunt), use CRLF on Windows

### DIFF
--- a/tasks/lib/common.js
+++ b/tasks/lib/common.js
@@ -30,10 +30,6 @@ module.exports = function (grunt) {
         path        = require("path"),
         _platform;
 
-    function writeJSON(grunt, path, obj) {
-        grunt.file.write(path, JSON.stringify(obj, null, "    "));
-    }
-
     function resolve(relPath) {
         return path.resolve(process.cwd(), relPath);
     }
@@ -50,6 +46,14 @@ module.exports = function (grunt) {
         }
 
         return _platform;
+    }
+    
+    function writeJSON(grunt, path, obj) {
+        var content = JSON.stringify(obj, null, "    ");
+        if (platform() === "win") {
+            content = content.split("\n").join("\r\n");
+        }
+        grunt.file.write(path, content);
     }
 
     common.writeJSON    = writeJSON;


### PR DESCRIPTION
On current master and Windows, `grunt write-config` still adds changes to my `git status`, even though the diff is only "warning: LF will be replaced by CRLF in src/config.json."

![image](https://user-images.githubusercontent.com/2641501/27256334-b9b0046c-53b1-11e7-8cb2-9808057a3c93.png)

This now fixes it by making the grunt method `common.writeJSON` use CRLF line endings on Windows only.
I couldn't test this on Linux or Mac, but it should only affect Windows.

Also, the other times `common.writeJSON` is used are as follows:
* In task `build-config` writing to `dist/config.json`
* In task `npm-install` writing to `dist/npm-shrinkwrap.json` and `dist/package.json`
* In task `update-release-number` writing to `package.json`
I don't think the difference of CRLF and LF (used before) matters in these cases, but I'm not 100% sure either and don't know how to test.

cc @ficristo @zaggino 
#12771 would be fully fixed with this.