### PR TITLE
Fix NavigationProvider throwing errors when doc.file is missing

### DIFF
--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -535,7 +535,9 @@ define(function (require, exports, module) {
             _reinstateMarkers(editor, jumpForwardStack);
         });
         FileSystem.on("change", function (event, entry) {
-            _handleExternalChange(event, {file: entry});
+            if (entry) {
+                _handleExternalChange(event, {file: entry});
+            }
         });
         Document.on("_documentRefreshed", function (event, doc) {
             _handleExternalChange(event, {file: doc.file});


### PR DESCRIPTION
Fixes #13491

~Need to investigate _why_ `doc.file` can be missing though.~

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>