### PR TITLE
If user cancels save as dialog after changing the encoding of dirty f…

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -486,6 +486,8 @@ define(function (require, exports, module) {
                     } else {
                         document.file._encoding = originalEncoding;
                     }
+                }).fail(function () {
+                    document.file._encoding = originalEncoding;
                 });
             } else if (document.file instanceof InMemoryFile) {
                 encodingSelect.$button.text(encoding);


### PR DESCRIPTION
…ile, then encoding should not be changed in the file data structure