### PR TITLE
FIX: Creating a resizable panel using an HTML code fragment starting …

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1455,6 +1455,7 @@ define(function (require, exports, module) {
     exports.getKeyBindings = getKeyBindings;
     exports.addGlobalKeydownHook = addGlobalKeydownHook;
     exports.removeGlobalKeydownHook = removeGlobalKeydownHook;
+    exports.normalizeKeyDescriptorString = normalizeKeyDescriptorString;
 
     /**
      * Use windows-specific bindings if no other are found (e.g. Linux).

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -166,6 +166,8 @@ define(function (require, exports, module) {
      */
     function Panel($panel, minSize) {
         this.$panel = $panel;
+        // Since the panel source code may start with a html comment, 
+        // the 'root' DOM node must be targeted explicitly using a filter removing all comments.
         var $rootNodeWithID = $panel.filter("*")[0];
         Resizer.makeResizable($rootNodeWithID, Resizer.DIRECTION_VERTICAL, Resizer.POSITION_TOP, minSize, false, undefined, true);
         listenToResize($panel);

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -166,8 +166,8 @@ define(function (require, exports, module) {
      */
     function Panel($panel, minSize) {
         this.$panel = $panel;
-
-        Resizer.makeResizable($panel[0], Resizer.DIRECTION_VERTICAL, Resizer.POSITION_TOP, minSize, false, undefined, true);
+        var $rootNodeWithID = $panel.filter("*")[0];
+        Resizer.makeResizable($rootNodeWithID, Resizer.DIRECTION_VERTICAL, Resizer.POSITION_TOP, minSize, false, undefined, true);
         listenToResize($panel);
     }
 


### PR DESCRIPTION
…with a comment will break

As mentioned in #6252, the original error msg isn't really helpful. 
The modified msg could be improved as well, though:
Since the content of the panel may be a **HTML fragment** (usually starting with a DIV node), mentioning that ```the first (root) DOM node must have an ID that will be used as a pref key``` would help.

Nevertheless, the mangled code in WorkspaceManager.js isn't reliable since it will _break_ when the panel content **starts with a html comment**. Such a comment may be necessary when  a plugin like HTMLhint is used. On a "panel" code fragment, this plugin attests an error due to a missing doctype. To disable this error, one may put a comment at the top of the html code: ```<!--htmlhint doctype-first: false-->```. WorkspaceManager.js will fail creating the panel, then. The proposed modification fixes such an issue.

**sample test code for a resizable panel**
```
<!--htmlhint doctype-first: false-->
<!--This comment is of no use but for testing purpose-->
<div id="my-very-special-testing-panel"><span style="color: red">Elvis</span> was here!</div>
```