### PR TITLE
Fixes wrong function call in ProjectManager.js

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1072,7 +1072,10 @@ define(function (require, exports, module) {
         baseDir = model.getDirectoryInProject(baseDir);
 
         if (skipRename) {
-            return model.createAtPath(baseDir + initialName, isFolder);
+            if(isFolder) {
+                return model.createAtPath(baseDir + initialName + "/");
+            }
+            return model.createAtPath(baseDir + initialName);
         }
         return actionCreator.startCreating(baseDir, initialName, isFolder);
     }


### PR DESCRIPTION
The createNewItem function in ProjectManager.js calls the createAtPath in Projectmodel.js.

The function call expects a single parameter, which is the path at which the file must be created.
And it expects a "/" in the end of the path in case it is a folder.

However, right now 2 parameters are being passed. One of them being the isFolder variable.