### PR TITLE
Default code coloring change to distinguish variables from other foreground tokens like braces, operators

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -67,7 +67,7 @@
 .cm-number, .cm-attribute, .cm-plus {color: #85a300;}
 .cm-def, .cm-property {color: #b77fdb;}
 .cm-operator, .cm-meta, .cm-bracket {color: @foreground;}
-.cm-variable, .cm-variable-2, .cm-variable-3 {color: #00b9c4;}
+.cm-variable, .cm-variable-2, .cm-variable-3 {color: #00c3b4;}
 .cm-comment {color: #767676;}
 .cm-minus {color: #dc322f;}
 .cm-header {color: #d85896;}

--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -66,7 +66,8 @@
 .cm-atom, .cm-string, .cm-string-2, .cm-hr {color: #d89333;}
 .cm-number, .cm-attribute, .cm-plus {color: #85a300;}
 .cm-def, .cm-property {color: #b77fdb;}
-.cm-variable, .cm-variable-2, .cm-variable-3, .cm-operator, .cm-meta, .cm-bracket {color: @foreground;}
+.cm-operator, .cm-meta, .cm-bracket {color: @foreground;}
+.cm-variable, .cm-variable-2, .cm-variable-3 {color: #00b9c4;}
 .cm-comment {color: #767676;}
 .cm-minus {color: #dc322f;}
 .cm-header {color: #d85896;}

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -50,13 +50,13 @@
 /* Code Styling */
 
 /* code accent colors */
-@accent-keyword: #446fbd;
+@accent-keyword: #0090e0;
 @accent-atom: #e88501;
 @accent-number: #6d8600;
 @accent-def: #8757ad;
-@accent-variable: #535353;
-@accent-variable-2: #535353;
-@accent-variable-3: #535353;
+@accent-variable: #0096ab;
+@accent-variable-2: #0096ab;
+@accent-variable-3: #0096ab;
 @accent-property: #8757ad;
 @accent-operator: #535353;
 @accent-comment: #949494;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -54,9 +54,9 @@
 @accent-atom: #e88501;
 @accent-number: #6d8600;
 @accent-def: #8757ad;
-@accent-variable: #0096ab;
-@accent-variable-2: #0096ab;
-@accent-variable-3: #0096ab;
+@accent-variable: #bf00bf;
+@accent-variable-2: #bf00bf;
+@accent-variable-3: #bf00bf;
 @accent-property: #8757ad;
 @accent-operator: #535353;
 @accent-comment: #949494;


### PR DESCRIPTION
With this PR, default code coloring in Brackets ( Default Light and Dark) being changed to distinguish between variables and other tokens colored as fore ground. Consider the following snippet - 
![image](https://user-images.githubusercontent.com/12087205/29505188-4e83c186-8662-11e7-96c2-01e9954f5147.png)
With this change set, the same snippet will be rendered as - 
![image](https://user-images.githubusercontent.com/12087205/29505118-bbe5ea66-8661-11e7-8a0a-f33a01b4ff5e.png)

Along with this change we might have to implement some more changes to distinguish between call expressions and simple variable access. As suggested by @marijnh in CM issue [4906](https://github.com/codemirror/CodeMirror/issues/4906), I am looking into extending our JavaScript mode with [google-modes](https://github.com/codemirror/google-modes)
