### PR TITLE
JSUtils modification to handle es6 constructs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,14 @@ module.exports = function (grunt) {
                         src: [
                             'less/dist/less.min.js'
                         ]
+                    },
+                    {
+                        expand: true,
+                        dest: 'src/thirdparty/acorn',
+                        cwd: 'src/node_modules/acorn',
+                        src: [
+                            'dist/{,*/}*'
+                        ]
                     }
                 ]
             }

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -65,9 +65,7 @@ define(function (require, exports, module) {
         var lines = docText.split("\n");
         var functions = JSUtils.findAllMatchingFunctionsInText(docText, "*");
         functions.forEach(function (funcEntry) {
-            var chFrom = funcEntry.columnStart;
-            var chTo = funcEntry.columnEnd;
-            functionList.push(new FileLocation(null, funcEntry.nameLineStart, chFrom, chTo, funcEntry.label || funcEntry.name));
+            functionList.push(new FileLocation(null, funcEntry.nameLineStart, funcEntry.columnStart, funcEntry.columnEnd, funcEntry.label || funcEntry.name));
         });
         return functionList;
     }

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -65,9 +65,9 @@ define(function (require, exports, module) {
         var lines = docText.split("\n");
         var functions = JSUtils.findAllMatchingFunctionsInText(docText, "*");
         functions.forEach(function (funcEntry) {
-            var chFrom = lines[funcEntry.lineStart].indexOf(funcEntry.name);
-            var chTo = chFrom + funcEntry.name.length;
-            functionList.push(new FileLocation(null, funcEntry.lineStart, chFrom, chTo, funcEntry.name));
+            var chFrom = funcEntry.columnStart;
+            var chTo = funcEntry.columnEnd;
+            functionList.push(new FileLocation(null, funcEntry.nameLineStart, chFrom, chTo, funcEntry.label || funcEntry.name));
         });
         return functionList;
     }

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -27,9 +27,9 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var _ = require("thirdparty/lodash");
-    var Acorn_Loose = require("node_modules/acorn/dist/acorn_loose");
-    var AST_Walker  = require("node_modules/acorn/dist/walk");
+    var _          = require("thirdparty/lodash"),
+        AcornLoose = require("node_modules/acorn/dist/acorn_loose"),
+        ASTWalker  = require("node_modules/acorn/dist/walk");
 
     // Load brackets modules
     var CodeMirror              = require("thirdparty/CodeMirror/lib/codemirror"),
@@ -60,10 +60,10 @@ define(function (require, exports, module) {
             resultNode,
             memberPrefix,
             match;
-            
+   
         PerfUtils.markStart(PerfUtils.JSUTILS_REGEXP);
         
-        var AST = Acorn_Loose.parse_dammit(text, {locations: true});
+        var AST = AcornLoose.parse_dammit(text, {locations: true});
         
         function _addResult(node, offset, prefix) {
             memberPrefix = prefix ? prefix + " - " : "";
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
             );
         }
         
-        AST_Walker.simple(AST, {
+        ASTWalker.simple(AST, {
             /*
                 function <functionName> () {}
             */
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
             */
             ClassDeclaration: function (node) {
                 _addResult(node);
-                AST_Walker.simple(node, {
+                ASTWalker.simple(node, {
                     /*
                         class <className> () {
                             <methodName> () {
@@ -152,7 +152,7 @@ define(function (require, exports, module) {
         });
 
         PerfUtils.addMeasurement(PerfUtils.JSUTILS_REGEXP);
-        
+
         return results;
     }
 

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -21,8 +21,6 @@
  *
  */
 
-/*jslint regexp: true */
-
 /**
  * Set of utilities for simple parsing of JS text.
  */
@@ -30,6 +28,8 @@ define(function (require, exports, module) {
     "use strict";
 
     var _ = require("thirdparty/lodash");
+    var Acorn_Loose = require("node_modules/acorn/dist/acorn_loose");
+    var AST_Walker  = require("node_modules/acorn/dist/walk");
 
     // Load brackets modules
     var CodeMirror              = require("thirdparty/CodeMirror/lib/codemirror"),
@@ -48,17 +48,6 @@ define(function (require, exports, module) {
     var _changedDocumentTracker = new ChangedDocumentTracker();
 
     /**
-     * Function matching regular expression. Recognizes the forms:
-     * "function functionName()", "functionName = function()", and
-     * "functionName: function()".
-     *
-     * Note: JavaScript identifier matching is not strictly to spec. This
-     * RegExp matches any sequence of characters that is not whitespace.
-     * @type {RegExp}
-     */
-    var _functionRegExp = /(function\s+([$_A-Za-z\u007F-\uFFFF][$_A-Za-z0-9\u007F-\uFFFF]*)\s*(\([^)]*\)))|(([$_A-Za-z\u007F-\uFFFF][$_A-Za-z0-9\u007F-\uFFFF]*)\s*[:=]\s*function\s*(\([^)]*\)))/g;
-
-    /**
      * @private
      * Return an object mapping function name to offset info for all functions in the specified text.
      * Offset info is an array, since multiple functions of the same name can exist.
@@ -68,22 +57,102 @@ define(function (require, exports, module) {
     function _findAllFunctionsInText(text) {
         var results = {},
             functionName,
+            resultNode,
+            memberPrefix,
             match;
-
+            
         PerfUtils.markStart(PerfUtils.JSUTILS_REGEXP);
-
-        while ((match = _functionRegExp.exec(text)) !== null) {
-            functionName = (match[2] || match[5]).trim();
-
+        
+        var AST = Acorn_Loose.parse_dammit(text, {locations: true});
+        
+        function _addResult(node, offset, prefix) {
+            memberPrefix = prefix ? prefix + " - " : "";
+            resultNode = node.id || node.key || node;
+            functionName = resultNode.name;
             if (!Array.isArray(results[functionName])) {
                 results[functionName] = [];
             }
 
-            results[functionName].push({offsetStart: match.index});
+            results[functionName].push(
+                {
+                    offsetStart: offset || node.start,
+                    label: memberPrefix ? memberPrefix + functionName : null,
+                    location: resultNode.loc
+                }
+            );
         }
+        
+        AST_Walker.simple(AST, {
+            /*
+                function <functionName> () {}
+            */
+            FunctionDeclaration: function (node) {
+                if (node.id.name !== '✖') { // A hack to reject anonymous declarations 
+                    _addResult(node);
+                }
+            },
+            /*
+                class <className> () {}
+            */
+            ClassDeclaration: function (node) {
+                _addResult(node);
+                AST_Walker.simple(node, {
+                    /*
+                        class <className> () {
+                            <methodName> () {
+                            
+                            }
+                        }
+                    */
+                    MethodDefinition: function (methodNode) {
+                        _addResult(methodNode, methodNode.key.start, node.id.name);
+                    }
+                });
+            },
+            /*
+                var <functionName> = function () {}
+            */
+            VariableDeclarator: function (node) {
+                if (node.init && node.init.type === "FunctionExpression") {
+                    _addResult(node);
+                }
+            },
+            /*
+                SomeFunction.prototype.<functionName> = function () {}
+            */
+            AssignmentExpression: function (node) {
+                if (node.right && node.right.type === "FunctionExpression") {
+                    if (node.left && node.left.type === "MemberExpression" && node.left.property) {
+                        _addResult(node.left.property);
+                    }
+                }
+            },
+            /*
+                {
+                    <functionName>: function() {}
+                }
+            */
+            Property: function (node) {
+                if (node.value && node.value.type === "FunctionExpression") {
+                    if (node.key && node.key.type === "Identifier") {
+                        _addResult(node.key);
+                    }
+                }
+            },
+            /*
+                <functionName>: function() {}
+            */
+            LabeledStatement: function (node) {
+                if (node.body && node.body.type === "FunctionDeclaration") {
+                    if (node.label) {
+                        _addResult(node.label);
+                    }
+                }
+            }
+        });
 
         PerfUtils.addMeasurement(PerfUtils.JSUTILS_REGEXP);
-
+        
         return results;
     }
 
@@ -415,8 +484,13 @@ define(function (require, exports, module) {
                     var endOffset = _getFunctionEndOffset(text, funcEntry.offsetStart);
                     result.push({
                         name: functionName,
+                        label: funcEntry.label,
                         lineStart: StringUtils.offsetToLineNum(lines, funcEntry.offsetStart),
-                        lineEnd: StringUtils.offsetToLineNum(lines, endOffset)
+                        lineEnd: StringUtils.offsetToLineNum(lines, endOffset),
+                        nameLineStart: funcEntry.location.start.line - 1,
+                        nameLineEnd: funcEntry.location.end.line - 1,
+                        columnStart: funcEntry.location.start.column,
+                        columnEnd: funcEntry.location.end.column
                     });
                 });
             }

--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -1,6 +1,12 @@
 {
   "name": "brackets-src",
   "dependencies": {
+    "acorn": {
+      "version": "5.1.1",
+      "from": "acorn@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "from": "ansi-regex@>=2.0.0 <3.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,7 @@
 {
   "name": "brackets-src",
   "dependencies": {
+    "acorn": "5.1.1",
     "codemirror": "5.28.0",
     "less": "2.7.2"
   }

--- a/test/spec/JSUtils-test-files/es6-async-arrow.js
+++ b/test/spec/JSUtils-test-files/es6-async-arrow.js
@@ -1,0 +1,4 @@
+// Async fn def
+var foo = { async bar() {} };
+// ArrowExpression usage to define function
+var fooAgain = () => {};

--- a/test/spec/JSUtils-test-files/es6-classes.js
+++ b/test/spec/JSUtils-test-files/es6-classes.js
@@ -1,0 +1,10 @@
+class Shape {
+    constructor (id, x, y) {
+        this.id = id
+        this.move(x, y)
+    }
+    move (x, y) {
+        this.x = x
+        this.y = y
+    }
+}

--- a/test/spec/JSUtils-test-files/es6-getter-setter.js
+++ b/test/spec/JSUtils-test-files/es6-getter-setter.js
@@ -1,0 +1,11 @@
+class Rectangle {
+    constructor (width, height) {
+        this._width  = width
+        this._height = height
+    }
+    set width  (width)  { this._width = width               }
+    get width  ()       { return this._width                }
+    set height (height) { this._height = height             }
+    get height ()       { return this._height               }
+    get area   ()       { return this._width * this._height }
+}

--- a/test/spec/JSUtils-test-files/es6-inheritance.js
+++ b/test/spec/JSUtils-test-files/es6-inheritance.js
@@ -1,0 +1,13 @@
+class Rectangle extends Shape {
+    constructor (id, x, y, width, height) {
+        super(id, x, y)
+        this.width  = width
+        this.height = height
+    }
+}
+class Circle extends Shape {
+    constructor (id, x, y, radius) {
+        super(id, x, y)
+        this.radius = radius
+    }
+}

--- a/test/spec/JSUtils-test-files/es6-static-methods.js
+++ b/test/spec/JSUtils-test-files/es6-static-methods.js
@@ -1,0 +1,5 @@
+class Rectangle extends Shape {
+    static defaultRectangle () {
+        return new Rectangle("default", 0, 0, 100, 100)
+    }
+}

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -45,13 +45,17 @@ define(function (require, exports, module) {
         return this.actual.functionName.trim() === expected;
     };
 
-    var simpleJsFileEntry   = FileSystem.getFileForPath(testPath + "/simple.js");
-    var trickyJsFileEntry   = FileSystem.getFileForPath(testPath + "/tricky.js");
-    var invalidJsFileEntry  = FileSystem.getFileForPath(testPath + "/invalid.js");
-    var jQueryJsFileEntry   = FileSystem.getFileForPath(testPath + "/jquery-1.7.js");
-    var braceEndJsFileEntry = FileSystem.getFileForPath(testPath + "/braceEnd.js");
-    var eofJsFileEntry      = FileSystem.getFileForPath(testPath + "/eof.js");
-    var eof2JsFileEntry     = FileSystem.getFileForPath(testPath + "/eof2.js");
+    var simpleJsFileEntry           = FileSystem.getFileForPath(testPath + "/simple.js");
+    var trickyJsFileEntry           = FileSystem.getFileForPath(testPath + "/tricky.js");
+    var invalidJsFileEntry          = FileSystem.getFileForPath(testPath + "/invalid.js");
+    var jQueryJsFileEntry           = FileSystem.getFileForPath(testPath + "/jquery-1.7.js");
+    var braceEndJsFileEntry         = FileSystem.getFileForPath(testPath + "/braceEnd.js");
+    var eofJsFileEntry              = FileSystem.getFileForPath(testPath + "/eof.js");
+    var eof2JsFileEntry             = FileSystem.getFileForPath(testPath + "/eof2.js");
+    var es6ClassesFileEntry         = FileSystem.getFileForPath(testPath + "/es6-classes.js");
+    var es6StaticsFileEntry         = FileSystem.getFileForPath(testPath + "/es6-static-methods.js");
+    var es6InheritanceFileEntry     = FileSystem.getFileForPath(testPath + "/es6-inheritance.js");
+    var es6GetterSetterFileEntry    = FileSystem.getFileForPath(testPath + "/es6-getter-setter.js");
 
     function init(spec, fileEntry) {
         if (fileEntry) {
@@ -110,6 +114,63 @@ define(function (require, exports, module) {
                 var result = JSUtils.findAllMatchingFunctionsInText(jsCode, functionName);
                 expect(result.length).toBe(0);
             }
+            
+            it("should return correct start and end line numbers for es6 class definitions and methods", function () {
+                runs(function () {
+                    doneLoading = false;
+                    init(this, es6ClassesFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "Shape", [ {start:  0, end:  9} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "constructor", [ {start:  1, end:  4} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "move", [ {start: 5, end: 8} ]);
+                });
+            });
+            
+            it("should return correct start and end line numbers for es6 static class methods", function () {
+                runs(function () {
+                    doneLoading = false;
+                    init(this, es6StaticsFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "Rectangle", [ {start:  0, end:  4} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "defaultRectangle", [ {start:  1, end:  3} ]);
+                });
+            });
+            
+            it("should return correct start and end line numbers for es6 class inheritance", function () {
+                runs(function () {
+                    doneLoading = false;
+                    init(this, es6InheritanceFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "Rectangle", [ {start:  0, end:  6} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "Circle", [ {start:  7, end:  12} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "constructor", [ {start:  1, end:  5}, {start:  8, end:  11} ]);
+                });
+            });
+            
+            it("should return correct start and end line numbers for es6 class members getters/setters", function () {
+                runs(function () {
+                    doneLoading = false;
+                    init(this, es6GetterSetterFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "Rectangle", [ {start:  0, end:  10} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "constructor", [ {start:  1, end:  4} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "width", [ {start:  5, end:  5}, {start:  6, end:  6} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "height", [ {start:  7, end:  7}, {start:  8, end:  8} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "area", [ {start:  9, end:  9} ]);
+                });
+            });
 
             it("should return correct start and end line numbers for simple functions", function () {
                 runs(function () {
@@ -178,25 +239,6 @@ define(function (require, exports, module) {
                     //expectFunctionRanges(this, this.fileJsContent, "functionX",   [ {start: 53, end: 55} ]);
                     expectFunctionRanges(this, this.fileJsContent, "my_function", [ {start: 56, end: 57} ]);
                     expectFunctionRanges(this, this.fileJsContent, "function3",   [ {start: 58, end: 60} ]);
-                });
-            });
-
-            it("should ignore identifiers with whitespace", function () {
-                runs(function () {
-                    doneLoading = false;
-                    init(this, simpleJsFileEntry);
-                });
-                waitsFor(function () { return doneLoading; }, 1000);
-
-                runs(function () {
-                    var negativeTests = ["invalid", "identifier", "invalid identifier"],
-                        result,
-                        content = this.fileJsContent;
-
-                    negativeTests.forEach(function (name) {
-                        result = JSUtils.findAllMatchingFunctionsInText(content, name);
-                        expect(result.length).toBe(0);
-                    });
                 });
             });
 

--- a/test/spec/JSUtils-test.js
+++ b/test/spec/JSUtils-test.js
@@ -56,6 +56,7 @@ define(function (require, exports, module) {
     var es6StaticsFileEntry         = FileSystem.getFileForPath(testPath + "/es6-static-methods.js");
     var es6InheritanceFileEntry     = FileSystem.getFileForPath(testPath + "/es6-inheritance.js");
     var es6GetterSetterFileEntry    = FileSystem.getFileForPath(testPath + "/es6-getter-setter.js");
+    var es6AsyncAndArrowFileEntry   = FileSystem.getFileForPath(testPath + "/es6-async-arrow.js");
 
     function init(spec, fileEntry) {
         if (fileEntry) {
@@ -169,6 +170,19 @@ define(function (require, exports, module) {
                     expectFunctionRanges(this, this.fileJsContent, "width", [ {start:  5, end:  5}, {start:  6, end:  6} ]);
                     expectFunctionRanges(this, this.fileJsContent, "height", [ {start:  7, end:  7}, {start:  8, end:  8} ]);
                     expectFunctionRanges(this, this.fileJsContent, "area", [ {start:  9, end:  9} ]);
+                });
+            });
+            
+            it("should return correct start and end line numbers for es6 async and arrow function expressions", function () {
+                runs(function () {
+                    doneLoading = false;
+                    init(this, es6AsyncAndArrowFileEntry);
+                });
+                waitsFor(function () { return doneLoading; }, 1000);
+
+                runs(function () {
+                    expectFunctionRanges(this, this.fileJsContent, "bar", [ {start:  1, end:  1} ]);
+                    expectFunctionRanges(this, this.fileJsContent, "fooAgain", [ {start:  3, end:  3} ]);
                 });
             });
 


### PR DESCRIPTION
This PR will replace the existing regex based function def extraction with Acorn and also adds the capability to identify classes and methods (es6). Our current implementations is having some limitations and issues. One issue which is noticed during my dev test is wrong location information for function definition. Consider the following snippet - 
``` javascript 
Handsome.prototype.some = function () {
}
```
From the function/type list when we select `some`, instead of highlighting the member "some" , "some" from `Handsome` gets highlighted. With the new implementation, this issue is resolved as we get location information from the AST generated by Acorn. 

Couple of other observations which are actually open questions to all reviewers, there are some odd syntax which is considered valid in our current regex based implementation. Consider the following snippets - 
``` javascript 
something: function () {
}
```
``` javascript 
function hello() {
     something: function () {
     }
}   
```
It has been handled in the new implementation to let the existing tests pass, should we consider this to be valid?

Second observation is regarding a broken syntax for which we have a negative test case(this single test fails in the new implementation), but in the new implementation, Acorn parses it successfully. The snippet in consideration is - 
``` javascript
function invalid name () {
}
```
How do we handle this case?

@zaggino @petetnt @ficristo @MarcelGerber Can you please have a look at this PR? 