### PR TITLE
Now reverse inspect can be disabled by setting the 'livedev.enableReverseInspect' pref to false 

### DIFF
--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -201,6 +201,10 @@ define(function LiveDevelopment(require, exports, module) {
     PreferencesManager.definePreference("livedev.wsPort", "number", 8125, {
         description: Strings.DESCRIPTION_LIVEDEV_WEBSOCKET_PORT
     });
+    
+    PreferencesManager.definePreference("livedev.enableReverseInspect", "boolean", true, {
+        description: Strings.DESCRIPTION_LIVEDEV_ENABLE_REVERSE_INSPECT
+    });
 
     function _isPromisePending(promise) {
         return promise && promise.state() === "pending";
@@ -1369,8 +1373,10 @@ define(function LiveDevelopment(require, exports, module) {
             // wait for server (StaticServer, Base URL or file:)
             prepareServerPromise
                 .done(function () {
-                    var wsPort = PreferencesManager.get("livedev.wsPort");
-                    if (wsPort) {
+                    var reverseInspectPref = PreferencesManager.get("livedev.enableReverseInspect"),
+                        wsPort             = PreferencesManager.get("livedev.wsPort");
+                        
+                    if (wsPort && reverseInspectPref) {
                         WebSocketTransport.createWebSocketServer(wsPort);
                     }
                     _doLaunchAfterServerReady(doc);

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -1369,7 +1369,10 @@ define(function LiveDevelopment(require, exports, module) {
             // wait for server (StaticServer, Base URL or file:)
             prepareServerPromise
                 .done(function () {
-                    WebSocketTransport.createWebSocketServer(PreferencesManager.get("livedev.wsPort"));
+                    var wsPort = PreferencesManager.get("livedev.wsPort");
+                    if (wsPort) {
+                        WebSocketTransport.createWebSocketServer(wsPort);
+                    }
                     _doLaunchAfterServerReady(doc);
                 })
                 .fail(function () {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -807,5 +807,6 @@ define({
     "DESCRIPTION_INDENT_LINE_COMMENT"                : "true to enable indenting of line comments",
     "DESCRIPTION_RECENT_FILES_NAV"                   : "Enable/disable navigation in recent files",
     "DESCRIPTION_LIVEDEV_WEBSOCKET_PORT"             : "Port on which WebSocket Server runs for Live Preview",
-    "DESCRIPTION_LIVE_DEV_HIGHLIGHT_SETTINGS"        : "Live Preview Highlight settings"
+    "DESCRIPTION_LIVE_DEV_HIGHLIGHT_SETTINGS"        : "Live Preview Highlight settings",
+    "DESCRIPTION_LIVEDEV_ENABLE_REVERSE_INSPECT"     : "false to disable live preview reverse inpsect"
 });


### PR DESCRIPTION
Fixes: https://github.com/adobe/brackets/issues/13307