### PR TITLE
Adding null check for encoding preference

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -334,7 +334,7 @@ define(function (require, exports, module) {
                         }
                     };
                 var encoding = PreferencesManager.getViewState("encoding", context);
-                if (encoding[fullPath]) {
+                if (encoding && encoding[fullPath]) {
                     file._encoding = encoding[fullPath];
                 }
             }


### PR DESCRIPTION
This PR is a fix for #13656.
For some strange reason, in the reported scenario encoding preference fetched is undefined which causes the code to break while checking for encoding cache with the given file path. This check is good to have even without the reported issue. 

@saurabh95 @nethip @petetnt  Can you please have a look at this PR?  