### PR TITLE
Upgrade brackets-eslint to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "SHA": ""
     },
     "defaultExtensions": {
-        "brackets-eslint": "3.0.5"
+        "brackets-eslint": "3.2.0"
     },
     "dependencies": {
         "anymatch": "1.3.0",

--- a/src/config.json
+++ b/src/config.json
@@ -36,7 +36,7 @@
         "SHA": ""
     },
     "defaultExtensions": {
-        "brackets-eslint": "3.0.5"
+        "brackets-eslint": "3.2.0"
     },
     "dependencies": {
         "anymatch": "1.3.0",


### PR DESCRIPTION
I think it is safe to merge this directly in release branch.
I want this because it adds support for `.vue` files.
@zaggino is the change of the version the only change needed?