### PR TITLE
Upgraded codemirror version to 5.30.0

### DIFF
--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -72,9 +72,9 @@
       "optional": true
     },
     "codemirror": {
-      "version": "5.28.0",
-      "from": "codemirror@5.28.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz"
+      "version": "5.30.0",
+      "from": "codemirror@5.30.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.30.0.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "brackets-src",
   "dependencies": {
     "acorn": "5.1.1",
-    "codemirror": "5.28.0",
+    "codemirror": "5.30.0",
     "less": "2.7.2",
     "preact": "8.2.1",
     "preact-test-utils": "0.1.3",


### PR DESCRIPTION
Ran Unit tests, not seeing any new failure.
Steps to upgrade:
- Inside `src` folder delete `npm-shrinkwrap.json`
- Update the codemirror version in `src/package.json`
- Run `npm install` inside `src` folder (Make sure to use the node version as mentioned in `.travis.yml`) 
- Run `npm shrinkwrap` (This will update the `npm-shrinkwrap.json`)