### PR TITLE
bugfix : double click to crash SearchResultsView

### DIFF
--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -181,7 +181,7 @@ define(function (require, exports, module) {
                 HealthLogger.searchDone(HealthLogger.SEARCH_PREV_PAGE);
             })
             // The link to go to the next page
-            .on("click.searchResults", ".next-page:not(.disabled)", function (e) {
+            .on("click.searchResults", ".next-page:not(.disabled)", function () {
                 self.trigger('getNextPage');
                 HealthLogger.searchDone(HealthLogger.SEARCH_NEXT_PAGE);
             })

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -201,6 +201,7 @@ define(function (require, exports, module) {
             .on("click.searchResults .table-container", function (e) {
                 var $row = $(e.target).closest("tr");
 
+            
                 if ($row.length) {
                     if (self._$selectedRow) {
                         self._$selectedRow.removeClass("selected");

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -151,6 +151,17 @@ define(function (require, exports, module) {
         var self = this;
         this._panel.$panel
             .off(".searchResults")  // Remove the old events
+            // MiddleClick on the toolbar closes the panel
+            .on('click', ".toolbar",function(e) {
+                if( e.which === 2 ) {
+                    self.close();
+                }
+            })          
+            // Keep the doubleClick event to propagate when clicking 
+            // buttons rapidly (which closes the panel)
+            .on("dblclick.searchResults", ".pagination-col", function(e){
+                e.stopPropagation();
+            })
             .on("dblclick.searchResults", ".toolbar", function() {
                 self.close();
             })
@@ -170,7 +181,7 @@ define(function (require, exports, module) {
                 HealthLogger.searchDone(HealthLogger.SEARCH_PREV_PAGE);
             })
             // The link to go to the next page
-            .on("click.searchResults", ".next-page:not(.disabled)", function () {
+            .on("click.searchResults", ".next-page:not(.disabled)", function (e) {
                 self.trigger('getNextPage');
                 HealthLogger.searchDone(HealthLogger.SEARCH_NEXT_PAGE);
             })

--- a/src/search/SearchResultsView.js
+++ b/src/search/SearchResultsView.js
@@ -200,8 +200,6 @@ define(function (require, exports, module) {
             // Add the click event listener directly on the table parent
             .on("click.searchResults .table-container", function (e) {
                 var $row = $(e.target).closest("tr");
-
-            
                 if ($row.length) {
                     if (self._$selectedRow) {
                         self._$selectedRow.removeClass("selected");

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -826,9 +826,130 @@ define(function (require, exports, module) {
 
                     $("#find-in-files-results .first-page").click();
                     expectPageDisplay(expectedPages[0]);
+
                 });
             });
+            
+            it("should close the view when double clicking toolbar", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
 
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .toolbar").dblclick();
+                    expect($searchResults.is(":visible")).toBeFalsy();
+                });
+            });
+            
+            it("should keep the view open when double clicking the next page button", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+                
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    $("#find-in-files-results .first-page").dblclick();
+                    expect($searchResults.is(":visible")).toBeTruthy();
+                });
+            });
+            
+            it("should keep the view open when double clicking the first-page button", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .first-page").dblclick();
+                    expect($searchResults.is(":visible")).toBeTruthy();
+                });
+            });
+            
+            it("should keep the view open when double clicking the last-page button", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .last-page").dblclick();
+                    expect($searchResults.is(":visible")).toBeTruthy();
+                });
+            });
+            
+            it("should keep the view open when double clicking the prev-page button", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .prev-page").dblclick();
+                    expect($searchResults.is(":visible")).toBeTruthy();
+                });
+            });
+            
+            it("should keep the view open when double clicking the first-page button", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .first-page").dblclick();
+                    expect($searchResults.is(":visible")).toBeTruthy();
+                });
+            });
+            
+            it("should close the view when double clicking on the title div", function () {
+                openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
+                openSearchBar();
+
+                // This search will find 500 hits in 2 files. Since there are 100 hits per page, there should
+                // be five pages, and the third page should have 50 results from the first file and 50 results
+                // from the second file.
+                executeSearch("find this");
+
+                runs(function () {
+                    var $searchResults = $("#find-in-files-results");
+                    
+                    $("#find-in-files-results .title").dblclick();
+                    expect($searchResults.is(":visible")).toBeFalsy();
+                });
+            });
+            
+            
+            
             it("should jump to last page, then page backward, displaying correct contents at each step", function () {
                 openProject(SpecRunnerUtils.getTestPath("/spec/FindReplace-test-files-manyhits"));
 


### PR DESCRIPTION
-added : added an event listener to the pagination-col class with a event.stopPropagation to prevent the dblclick event to propagate to the toolbar, which caused the SearchResultsView to crash when clicking rapidly the next/previous button. First this will avoid the view to crash, second it will prevent users to accidentally close the panel.

-added: new event listener on mouse 3 when clicking the toolbar, which allows a better internal consistency (middle click to close is used to close the files in the working set), and a better external consistency (middle clicks are often used to close tabs on web browsers for example)

-added: tests to ensure that the event listeners I've added are working as expected

This pull request fix the #13768 issue