### PR TITLE
Git ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ Thumbs.db
 # ignore jenkins build info
 /build.prop
 
+# package-lock.json
+package-lock.json
+
 # ignore node_modules created by grunt, but not more deeply-nested node_modules
 /node_modules
 /npm-debug.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
We already use npm-shrinkwrap, so it will be ignored anyway.