### PR TITLE
Don't allow find/replace if read only (#13774)

### DIFF
--- a/src/search/FindReplace.js
+++ b/src/search/FindReplace.js
@@ -672,6 +672,11 @@ define(function (require, exports, module) {
             state = getSearchState(cm),
             replaceText = findBar.getReplaceText();
 
+        // Do not replace if editor is set to read only
+        if (cm.options.readOnly) {
+            return;
+        }
+
         if (all === null) {
             findBar.close();
             FindInFilesUI.searchAndReplaceResults(state.queryInfo, editor.document.file, null, replaceText);

--- a/test/spec/FindReplace-test.js
+++ b/test/spec/FindReplace-test.js
@@ -1371,6 +1371,28 @@ define(function (require, exports, module) {
                 });
             });
 
+            it("should not replace string if document is read only", function () {
+                runs(function () {
+                    myEditor._codeMirror.options.readOnly = true;
+                    twCommandManager.execute(Commands.CMD_REPLACE);
+                    enterSearchText("foo");
+
+                    expectSelection(fooExpectedMatches[0]);
+                    expectMatchIndex(0, 4);
+                    expect(/foo/i.test(myEditor.getSelectedText())).toBe(true);
+                    expect(tw$("#replace-yes").is(":enabled")).toBe(true);
+
+                    enterReplaceText("bar");
+
+                    tw$("#replace-yes").click();
+                    expectSelection(fooExpectedMatches[0]);
+                    expectMatchIndex(0, 4);
+
+                    myEditor.setSelection(fooExpectedMatches[0].start, fooExpectedMatches[0].end);
+                    expect(/bar/i.test(myEditor.getSelectedText())).toBe(false);
+                });
+            });
+
             it("should use replace keyboard shortcut for single Replace while search bar open", function () {
                 runs(function () {
                     twCommandManager.execute(Commands.CMD_REPLACE);
@@ -1567,7 +1589,7 @@ define(function (require, exports, module) {
                 twFindInFiles._searchDone = false;
                 twFindInFiles._replaceDone = false;
             });
-            
+
             it("should find and replace all using replace all button", function () {
                 var searchText  = "require",
                     replaceText = "brackets.getModule";


### PR DESCRIPTION
Adds check in doReplace function to prevent Find/Replace in read only document ([issue #13774](https://github.com/adobe/brackets/issues/13774))

/cc @kenstuddy