### PR TITLE
Correct typo (gurantee -> guarantee)

### DIFF
--- a/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/qunit.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/qunit.js
@@ -333,7 +333,7 @@ QUnit = {
 		test.queue();
 	},
 
-	// Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
+	// Specify the number of expected assertions to guarantee that failed test (no assertions are run at all) don't slip through.
 	expect: function( asserts ) {
 		config.current.expected = asserts;
 	},


### PR DESCRIPTION
gurantee -> guarantee
(/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/qunit.js)