### PR TITLE
Fix Grammar adverb location

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -1432,7 +1432,7 @@ define(function (require, exports, module) {
          * (the first one which is pending or loaded that is before the failed
          * scope). There's always the lowest-priority "default" scope which is
          * loaded and added, it guarantees that a successfully loaded scope will
-         * always be added.
+         * be always added.
          *
          * Adding a Scope "before" another Scope means that the new Scope's
          * preferences will take priority over the "before" Scope's preferences.


### PR DESCRIPTION
The adverb 'always' is usually put after the verb 'be'.
So, always be -> be always