### PR TITLE
Correct typo (it run -> it runs)

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -124,7 +124,7 @@
     TODO (issue #324): We'll still have problems if editors can be nested more than one level deep,
     or if any other descendant-selector-driven CM styles can differ between inner & outer editors
     (potential problem areas include line wrap and coloring theme: basically, anything in codemirror.css
-    that uses a descandant selector where the CSS class name to the left of the space is something
+    that uses a descendant selector where the CSS class name to the left of the space is something
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {

--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -124,7 +124,7 @@
     TODO (issue #324): We'll still have problems if editors can be nested more than one level deep,
     or if any other descendant-selector-driven CM styles can differ between inner & outer editors
     (potential problem areas include line wrap and coloring theme: basically, anything in codemirror.css
-    that uses a descendant selector where the CSS class name to the left of the space is something
+    that uses a descandant selector where the CSS class name to the left of the space is something
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {

--- a/src/utils/Async.js
+++ b/src/utils/Async.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     //    so that we don't leave UI-blocking overlays up forever, etc. But this is hard: we'd have
     //    wrap every async callback (including low-level native ones that don't use [Super]Deferred)
     //    to catch exceptions, and then understand which Deferred(s) the code *would* have resolved/
-    //    rejected had it run to completion.
+    //    rejected had it runs to completion.
 
 
     /**


### PR DESCRIPTION
it run -> it runs (41 line)
(/src/utils/Async.js)