### PR TITLE
Correct typo (ommitted -> omitted)

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -124,7 +124,7 @@
     TODO (issue #324): We'll still have problems if editors can be nested more than one level deep,
     or if any other descendant-selector-driven CM styles can differ between inner & outer editors
     (potential problem areas include line wrap and coloring theme: basically, anything in codemirror.css
-    that uses a descandant selector where the CSS class name to the left of the space is something
+    that uses a descendant selector where the CSS class name to the left of the space is something
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {

--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -124,7 +124,7 @@
     TODO (issue #324): We'll still have problems if editors can be nested more than one level deep,
     or if any other descendant-selector-driven CM styles can differ between inner & outer editors
     (potential problem areas include line wrap and coloring theme: basically, anything in codemirror.css
-    that uses a descendant selector where the CSS class name to the left of the space is something
+    that uses a descandant selector where the CSS class name to the left of the space is something
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {

--- a/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/jshint.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/jshint.js
@@ -279,7 +279,7 @@ var JSHINT = (function () {
             immed       : true, // if immediate invocations must be wrapped in parens
             iterator    : true, // if the `__iterator__` property should be allowed
             jquery      : true, // if jQuery globals should be predefined
-            lastsemic   : true, // if semicolons may be ommitted for the trailing
+            lastsemic   : true, // if semicolons may be omitted for the trailing
                                 // statements inside of a one-line blocks.
             latedef     : true, // if the use before definition should not be tolerated
             laxbreak    : true, // if line breaks should not be checked


### PR DESCRIPTION
(/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/external/jshint.js) (282line)

ommitted -> omitted