### PR TITLE
Fix the typo in ExtensionManagerDomain.js

### DIFF
--- a/src/extensibility/node/ExtensionManagerDomain.js
+++ b/src/extensibility/node/ExtensionManagerDomain.js
@@ -623,7 +623,7 @@ function init(domainManager) {
         [{
             name: "downloadId",
             type: "string",
-            description: "Unique identifier for this download 'session', previously pased to downloadFile"
+            description: "Unique identifier for this download 'session', previously passed to downloadFile"
         }],
         {
             type: "boolean",


### PR DESCRIPTION
fix typo(pased->passed)