### PR TITLE
Fixed search from overstepping bounds

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1155,19 +1155,21 @@ a[href^="http"] {
         }
 
         .search-container {
-            float: right;
+            float: right; 
             .flex-item(1);
         }
 
         .search {
             @media (max-width: (@extension-manager-min-width - 1px)) {
-                width: calc(~'100% - 27px - 20px'); // 100% minus padding etc.
+                width: calc(~'100% - 27px - 20px'); // 100% minus padding etc. 
             }
 
             background: @bc-input-bg url("images/topcoat-search-20.svg") 2px 2px no-repeat;
             margin: 0;
             padding-left: 27px;
             padding-right: 20px;
+
+            width:auto;
 
             .dark & {
                 background: @dark-bc-input-bg url("images/topcoat-search-20.svg") 2px 2px no-repeat;
@@ -1188,7 +1190,7 @@ a[href^="http"] {
             height: 16px;
             z-index: 1;
             border: 0;
-
+           
             &:disabled {
                 opacity: 0.3;
                 cursor: default;


### PR DESCRIPTION
Changed css file regarding Extension Manager header, preventing the search bar from overlapping default tab in French present in issue [#13433](https://github.com/adobe/brackets/issues/13433).

Before the fix:
![Before](https://user-images.githubusercontent.com/22790704/33480952-567aa256-d68a-11e7-8a0b-412e39a71b32.png)

After the fix:
![After](https://user-images.githubusercontent.com/22790704/33481001-81bfabaa-d68a-11e7-9080-e26e4de15511.png)

This has been tested on other languages, and the correction still worked.

