### PR TITLE
Don't prompt before unload while in SpecRunner

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1718,19 +1718,23 @@ define(function (require, exports, module) {
 
     /** Reload Without Extensions commnad handler **/
     var handleReloadWithoutExts = _.partial(handleReload, true);
-    
-    /** 
-     * Attach a beforeunload handler to notify user about unsaved changes and URL redirection in CEF. 
+
+    /**
+     * Attach a beforeunload handler to notify user about unsaved changes and URL redirection in CEF.
      * Prevents data loss in scenario reported under #13708
     **/
     window.onbeforeunload = function(e) {
+        if (window.location.pathname.indexOf('SpecRunner') > -1) {
+            return;
+        }
+
         var openDocs = DocumentManager.getAllOpenDocuments();
-        
+
         // Detect any unsaved changes
         openDocs = openDocs.filter(function(doc) {
             return doc && doc.isDirty;
         });
-        
+
         // Ensure we are not in normal app-quit or reload workflow
         if (!_isReloading && !_windowGoingAway) {
             if (openDocs.length > 0) {
@@ -1740,7 +1744,7 @@ define(function (require, exports, module) {
             }
         }
     };
- 
+
     /** Do some initialization when the DOM is ready **/
     AppInit.htmlReady(function () {
         // If in Reload Without User Extensions mode, update UI and log console message


### PR DESCRIPTION
Fixes #13963

Tested manually by:

- Opening test runner and navigating between the tabs and confirming that the prompts do not pop up anymore.

- Opening dev tools and trying `window.location.pathname = 'https://google.com'` to see that the prompt still pops up

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>