### PR TITLE
JavaScript Refactoring - Rename Identifier, Wrap selection, Convert to arrow function, Create Getters & Setters

### DIFF
--- a/src/JSUtils/MessageIds.js
+++ b/src/JSUtils/MessageIds.js
@@ -37,6 +37,7 @@ define(function (require, exports, module) {
         TERN_INFERENCE_TIMEDOUT     = "InferenceTimedOut",
         SET_CONFIG                  = "SetConfig",
         TERN_UPDATE_DIRTY_FILE      = "UpdateDirtyFileEntry",
+        TERN_REFS                   = "getRefs",
         TERN_CLEAR_DIRTY_FILES_LIST = "ClearDirtyFilesList";
 
     // Message parameter constants
@@ -62,6 +63,7 @@ define(function (require, exports, module) {
     exports.SET_CONFIG                  = SET_CONFIG;
     exports.TERN_UPDATE_DIRTY_FILE      = TERN_UPDATE_DIRTY_FILE;
     exports.TERN_CLEAR_DIRTY_FILES_LIST = TERN_CLEAR_DIRTY_FILES_LIST;
+    exports.TERN_REFS = TERN_REFS;
 });
 
 

--- a/src/JSUtils/ScopeManager.js
+++ b/src/JSUtils/ScopeManager.js
@@ -377,7 +377,23 @@ define(function (require, exports, module) {
         return text;
     }
 
+    /**
+     * Handle the response from the tern node domain when
+     * it responds with the references
+     *
+     * @param response - the response from the node domain
+     */
+    function handleRename(response) {
 
+        var file = response.file,
+            offset = response.offset;
+
+        var $deferredFindRefs = getPendingRequest(file, offset, MessageIds.TERN_REFS);
+
+        if ($deferredFindRefs) {
+            $deferredFindRefs.resolveWith(null, [response]);
+        }
+    }
 
     /**
      * Request Jump-To-Definition from Tern.
@@ -390,10 +406,12 @@ define(function (require, exports, module) {
      */
     function requestJumptoDef(session, document, offset) {
         var path    = document.file.fullPath,
-            fileInfo = {type: MessageIds.TERN_FILE_INFO_TYPE_FULL,
+            fileInfo = {
+                type: MessageIds.TERN_FILE_INFO_TYPE_FULL,
                 name: path,
                 offsetLines: 0,
-                text: filterText(session.getJavascriptText())};
+                text: filterText(session.getJavascriptText())
+            };
 
         var ternPromise = getJumptoDef(fileInfo, offset);
 
@@ -1091,6 +1109,8 @@ define(function (require, exports, module) {
                         handleTernGetFile(response);
                     } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
                         handleJumptoDef(response);
+                    } else if (type === MessageIds.TERN_REFS) {
+                        handleRename(response);
                     } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {
                         handlePrimePumpCompletion(response);
                     } else if (type === MessageIds.TERN_GET_GUESSES_MSG) {
@@ -1557,5 +1577,8 @@ define(function (require, exports, module) {
     exports.handleProjectClose = handleProjectClose;
     exports.handleProjectOpen = handleProjectOpen;
     exports._readyPromise = _readyPromise;
+    exports.filterText = filterText;
+    exports.postMessage = postMessage;
+    exports.addPendingRequest = addPendingRequest;
 
 });

--- a/src/JSUtils/ScopeManager.js
+++ b/src/JSUtils/ScopeManager.js
@@ -385,6 +385,11 @@ define(function (require, exports, module) {
      */
     function handleRename(response) {
 
+        if (response.error) {
+            EditorManager.getActiveEditor().displayErrorMessageAtCursor(response.error);
+            return;
+        }
+
         var file = response.file,
             offset = response.offset;
 

--- a/src/JSUtils/node/TernNodeDomain.js
+++ b/src/JSUtils/node/TernNodeDomain.js
@@ -154,7 +154,7 @@ function initTernServer(env, files) {
         defs: env,
         async: true,
         getFile: getFile,
-        plugins: {requirejs: {}, doc_comment: true, angular: true}
+        plugins: {requirejs: {}, commonjs: true, doc_comment: true, angular: true}
     };
 
     // If a server is already created just reset the analysis data before marking it for GC
@@ -252,7 +252,12 @@ function buildRequest(fileInfo, query, offset) {
     try {
         ternServer.request(request, function (error, data) {
             if (error) {
-                _log("Error returned from Tern 'definition' request: " + error);
+                _log("Error returned from Tern 'refs' request: " + error);
+                var response = {
+                    type: MessageIds.TERN_REFS,
+                    error: error.message
+                };
+                self.postMessage(response);
                 return;
             }
             var response = {

--- a/src/JSUtils/node/TernNodeDomain.js
+++ b/src/JSUtils/node/TernNodeDomain.js
@@ -259,7 +259,7 @@ function buildRequest(fileInfo, query, offset) {
                 type: MessageIds.TERN_REFS,
                 file: fileInfo.name,
                 offset: offset,
-                refs: data
+                references: data
             };
             // Post a message back to the main thread with the results
             self.postMessage(response);

--- a/src/JSUtils/node/TernNodeDomain.js
+++ b/src/JSUtils/node/TernNodeDomain.js
@@ -236,6 +236,39 @@ function buildRequest(fileInfo, query, offset) {
     return request;
 }
 
+
+/**
+ * Get all References location
+ * @param {{type: string, name: string, offsetLines: number, text: string}} fileInfo
+ * - type of update, name of file, and the text of the update.
+ * For "full" updates, the whole text of the file is present. For "part" updates,
+ * the changed portion of the text. For "empty" updates, the file has not been modified
+ * and the text is empty.
+ * @param {{line: number, ch: number}} offset - the offset into the
+ * file for cursor
+ */
+ function getRefs(fileInfo, offset) {
+    var request = buildRequest(fileInfo, "refs", offset);
+    try {
+        ternServer.request(request, function (error, data) {
+            if (error) {
+                _log("Error returned from Tern 'definition' request: " + error);
+                return;
+            }
+            var response = {
+                type: MessageIds.TERN_REFS,
+                file: fileInfo.name,
+                offset: offset,
+                refs: data
+            };
+            // Post a message back to the main thread with the results
+            self.postMessage(response);
+        });
+    } catch (e) {
+        _reportError(e, fileInfo.name);
+    }
+}
+
 /**
  * Get definition location
  * @param {{type: string, name: string, offsetLines: number, text: string}} fileInfo
@@ -745,6 +778,9 @@ function _requestTernServer(commandConfig) {
     } else if (type === MessageIds.TERN_JUMPTODEF_MSG) {
         offset  = request.offset;
         getJumptoDef(request.fileInfo, offset);
+    } else if (type === MessageIds.TERN_REFS) {
+        offset  = request.offset;
+        getRefs(request.fileInfo, offset);
     } else if (type === MessageIds.TERN_ADD_FILES_MSG) {
         handleAddFiles(request.files);
     } else if (type === MessageIds.TERN_PRIME_PUMP_MSG) {

--- a/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
+++ b/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
@@ -32,14 +32,13 @@ define(function (require, exports, module) {
     var templates = JSON.parse(require("text!Templates.json"));
 
     /**
-     * Note - Don't use this if you are in a batch operation and you already made some changes
-     * like set selection or replace range. I you want to use this then reinitialize this after every
-     * setSelection or replaceRange, but
-     * You can use member function of RefactoringSession as those are using up to date va;ues of selection or text
-     *
+     * Note - To use these state defined in Refactoring Session,
+     * Please reinitialize this RefactoringSession after performing any of the below operations
+     * (i.e. replaceRange, setSelection or indentLine) 
+     * 
      * RefactoringSession objects encapsulate state associated with a refactoring session
      * and This will help finding information around documents, selection,
-     * Position details, ast, and queries around AST nodes
+     * position, ast, and queries around AST nodes
      *
      * @constructor
      * @param {Editor} editor - the editor context for the session

--- a/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
+++ b/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var _ = brackets.getModule("thirdparty/lodash");
+
+    var AcornLoose           = brackets.getModule("thirdparty/acorn/dist/acorn_loose"),
+        ASTWalker            = brackets.getModule("thirdparty/acorn/dist/walk");
+
+    var templates = JSON.parse(require("text!Templates.json"));
+
+    /**
+     * Note - Don't use this if you are in a batch operation and you already made some changes
+     * like set selection or replace range. I you want to use this then reinitialize this after every
+     * setSelection or replaceRange, but
+     * You can use member function of RefactoringSession as those are using up to date va;ues of selection or text
+     *
+     * RefactoringSession objects encapsulate state associated with a refactoring session
+     * and This will help finding information around documents, selection,
+     * Position details, ast, and queries around AST nodes
+     *
+     * @constructor
+     * @param {Editor} editor - the editor context for the session
+     */
+    function RefactoringSession(editor) {
+        this.editor = editor;
+        this.document = editor.document;
+        this.selection = editor.getSelection();
+        this.text = this.document.getText();
+        this.selectedText = editor.getSelectedText();
+        this.cm = editor._codeMirror;
+        this.startIndex = editor.indexFromPos(this.selection.start);
+        this.endIndex = editor.indexFromPos(this.selection.end);
+        this.startPos = this.selection.start;
+        this.endPos = this.selection.end;
+        this.ast = this.createAstOfCurrentDoc();
+    }
+
+    /**
+     * Get the end position of given line
+     *
+     * @param {number} line - line number
+     * @return {{line: number, ch: number}} - line end position
+     */
+    RefactoringSession.prototype.lineEndPosition = function (line) {
+        var lineText = this.document.getLine(line);
+
+        return {
+            line: line,
+            ch: lineText.length
+        };
+    };
+
+    /**
+     * Get the ast of current opened document in focused editor
+     *
+     * @return {Object} - Ast of current opened doc
+     */
+    RefactoringSession.prototype.createAstOfCurrentDoc = function () {
+        return AcornLoose.parse_dammit(this.document.getText());
+    };
+
+    /**
+     * This will add template at given position/selection
+     *
+     * @param {string} template - name of templated defined in templates.json
+     * @param {Array} args- Check all arguments that exist in defined templated pass all that args as array
+     * @param {{line: number, ch: number}} rangeToReplace - Range which we want to rreplace
+     * @param {string} subTemplate - If template written under some category
+     */
+    RefactoringSession.prototype.replaceTextFromTemplate = function (template, args, rangeToReplace, subTemplate) {
+        var templateText = templates[template];
+
+        if (subTemplate) {
+            templateText = templateText[subTemplate];
+        }
+
+        var compiled = _.template(templateText),
+            formattedText = compiled(args);
+
+        if (!rangeToReplace) {
+            rangeToReplace = this.editor.getSelection();
+        }
+
+        this.document.replaceRange(formattedText, rangeToReplace.start, rangeToReplace.end);
+
+        var startLine = rangeToReplace.start.line,
+            endLine = startLine + formattedText.split("\n").length;
+
+        for (var i = startLine + 1; i < endLine; i++) {
+            this.cm.indentLine(i);
+        }
+    };
+
+
+    /*
+     * Finds the surrounding ast node of the given expression of any of the given types
+     * @param {!ASTNode} ast
+     * @param {!{start: number, end: number}} expn - contains start and end offsets of expn
+     * @param {!Array.<string>} types
+     * @return {?ASTNode}
+     */
+    RefactoringSession.prototype.findSurroundASTNode = function (ast, expn, types) {
+        var foundNode = ASTWalker.findNodeAround(ast, expn.start, function (nodeType, node) {
+            if (expn.end) {
+                return types.includes(nodeType) && node.end >= expn.end;
+            }
+            return types.includes(nodeType);
+        });
+        return foundNode && foundNode.node;
+    };
+
+    /*
+     * Checks whether the text between start and end offsets form a valid set of statements
+     * @param {!ASTNode} ast - the ast of the complete file
+     * @param {!number} start - the start offset
+     * @param {!number} end - the end offset
+     * @param {!string} fileText - selected text
+     * @return {boolean}
+     */
+    RefactoringSession.prototype.checkStatement = function (ast, start, end, selectedText, id) {
+        // Do not allow function or class nodes
+        var notStatement = false;
+        ASTWalker.simple(AcornLoose.parse_dammit(selectedText), {
+            Function: function (node) {
+                if (node.type === "FunctionDeclaration") {
+                    notStatement = true;
+                }
+            },
+            Class: function (node) {
+                notStatement = true;
+            }
+        });
+
+        if (notStatement) {
+            return false;
+        }
+
+        var startStatement = this.findSurroundASTNode(ast, {start: start}, ["Statement"]);
+        var endStatement   = this.findSurroundASTNode(ast, {start: end}, ["Statement"]);
+
+        return startStatement && endStatement && startStatement.start === start &&
+            startStatement.end <= end && endStatement.start >= start &&
+            endStatement.end === end;
+    };
+
+    /**
+     * Get Params of selected function
+     *
+     * @param {number} start- start offset
+     * @param {number} end - end offset
+     * @param {string} selectedText - Create ast for only selected node
+     * @return {Array} param - Array of all parameters in function
+     */
+    RefactoringSession.prototype.getParamsOfFunction = function getParamsOfFunction(start, end, selectedText) {
+        var param = [];
+        ASTWalker.simple(AcornLoose.parse_dammit(selectedText), {
+            Function: function (node) {
+                if (node.type === "FunctionDeclaration") {
+                    node.params.forEach(function (item) {
+                        param.push(item.name);
+                    });
+                }
+            }
+        });
+
+        return param;
+    };
+
+    /**
+     * Get the Parent node
+     *
+     * @param {Object} ast - ast of full document
+     * @param {number} start - start Offset
+     * @return {Object} node - Returns the parent node of node which is at offset start
+     */
+    RefactoringSession.prototype.getParentNode = function (ast, start) {
+        var foundNode = ASTWalker.findNodeAround(ast, start, function(nodeType, node) {
+            return (nodeType === "ObjectExpression");
+        });
+        return foundNode && foundNode.node;
+    };
+
+    /**
+     * Checks weather the node at start is last in that scope or not
+     *
+     * @param {Object} ast - ast of full document
+     * @param {number} start - start Offset
+     * @return {boolean} - is last node in that scope
+     */
+    RefactoringSession.prototype.isLastNodeInScope = function (ast, start) {
+        var parentNode = this.getParentNode(ast, start),
+            currentNodeStart;
+
+        ASTWalker.simple(parentNode, {
+            Property: function (node) {
+                currentNodeStart = node.start;
+            }
+        });
+
+        return start >= currentNodeStart;
+    };
+
+    /**
+    * Normalize text by removing leading and trailing whitespace characters
+    * and moves the start and end offset to reflect the new offset
+    * @param {!string} text - selected text
+    * @param {!number} start - the start offset of the text
+    * @param {!number} end - the end offset of the text
+    * @return {!{text: string, start: number, end: number}}
+    */
+    RefactoringSession.prototype.normalizeText = function normalizeText(text, start, end) {
+        var trimmedText;
+
+        // Remove leading spaces
+        trimmedText = _.trimLeft(text);
+
+        if (trimmedText.length < text.length) {
+            start += (text.length - trimmedText.length);
+        }
+
+        text = trimmedText;
+
+        // Remove trailing spaces
+        trimmedText = _.trimRight(text);
+
+        if (trimmedText.length < text.length) {
+            end -= (text.length - trimmedText.length);
+        }
+
+        text = trimmedText;
+
+
+        return {
+            text: trimmedText,
+            start: start,
+            end: end
+        };
+    };
+
+    module.exports = RefactoringSession;
+});

--- a/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
+++ b/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
@@ -84,9 +84,9 @@ define(function (require, exports, module) {
     /**
      * This will add template at given position/selection
      *
-     * @param {string} template - name of templated defined in templates.json
+     * @param {string} template - name of the template defined in templates.json
      * @param {Array} args- Check all arguments that exist in defined templated pass all that args as array
-     * @param {{line: number, ch: number}} rangeToReplace - Range which we want to rreplace
+     * @param {{line: number, ch: number}} rangeToReplace - Range which we want to replace
      * @param {string} subTemplate - If template written under some category
      */
     RefactoringSession.prototype.replaceTextFromTemplate = function (template, args, rangeToReplace, subTemplate) {

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var EditorManager        = brackets.getModule("editor/EditorManager"),
+        ScopeManager         = brackets.getModule("JSUtils/ScopeManager"),
+        Session              = brackets.getModule("JSUtils/Session"),
+        MessageIds           = brackets.getModule("JSUtils/MessageIds");
+    
+    
+    var session             = null,  // object that encapsulates the current session state
+        refactorRename      = "javascript.renamereference",
+        editor;
+
+    function initializeSession(editor) {
+        session = new Session(editor);
+    }
+
+    function getRefs(fileInfo, offset) {
+        ScopeManager.postMessage({
+            type: "getRefs",
+            fileInfo: fileInfo,
+            offset: offset
+        });
+
+        return ScopeManager.addPendingRequest(fileInfo.name, offset, MessageIds.TERN_REFS);
+    }
+
+    
+    function requestFindRefs(session, document, offset) {
+        var path    = document.file.fullPath,
+            fileInfo = {
+                type: MessageIds.TERN_FILE_INFO_TYPE_FULL,
+                name: path,
+                offsetLines: 0,
+                text: ScopeManager.filterText(session.getJavascriptText())
+            };
+
+        var ternPromise = getRefs(fileInfo, offset);
+
+        return {promise: ternPromise};
+    }
+    
+    function doRename(response) {
+
+        var file = response.file,
+            offset = response.offset;
+
+        var $deferredFindRefs = ScopeManager.getPendingRequest(file, offset, MessageIds.TERN_REFS);
+
+        if ($deferredFindRefs) {
+            $deferredFindRefs.resolveWith(null, [response]);
+        }
+    }
+        
+    function handleRename() {
+        if (!editor) {
+            editor = EditorManager.getActiveEditor();
+        }
+        var offset, handleFindRefs;
+        initializeSession(editor);
+
+
+        if (editor.getModeForSelection() !== "javascript") {
+            return;
+        }
+
+        var result = new $.Deferred();
+
+        /**
+         * Make a find ref request.
+         * @param {Session} session - the session
+         * @param {number} offset - the offset of where to jump from
+         */
+        function requestFindReferences(session, offset) {
+            var response = requestFindRefs(session, session.editor.document, offset);
+
+            if (response.hasOwnProperty("promise")) {
+                response.promise.done(handleFindRefs).fail(function () {
+                    result.reject();
+                });
+            }
+        }
+
+        /**
+         * Check if references are in this file only
+         * If yes then select all references
+         */
+        handleFindRefs = function (refsResp) {
+            function isInSameFile(obj) {
+                if (obj && obj.file === refsResp.file) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            
+            if (refsResp && refsResp.refs && refsResp.refs.refs) {
+                if (refsResp.refs.type === "local") {
+                    EditorManager.getActiveEditor().setSelections(refsResp.refs.refs.filter(isInSameFile));
+                } else {
+                    var isInSameFile = refsResp.refs.refs.filter(isInSameFile).length === refsResp.refs.refs.length;
+                    if (isInSameFile) {
+                        EditorManager.getActiveEditor().setSelections(refsResp.refs.refs);
+                    } else {
+                        //TODO- Rename across Project
+                    }
+                    
+                }
+            }
+        };
+
+        offset = session.getOffset();
+        requestFindReferences(session, offset);
+
+        return result.promise();
+    }
+    
+    exports.handleRename = handleRename;
+});

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
         initializeSession(editor);
 
 
-        if (editor.getModeForSelection() !== "javascript") {
+        if (!editor || editor.getModeForSelection() !== "javascript") {
             return;
         }
 
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
         function requestFindReferences(session, offset) {
             var response = requestFindRefs(session, session.editor.document, offset);
 
-            if (response.hasOwnProperty("promise")) {
+            if (response || response.hasOwnProperty("promise")) {
                 response.promise.done(handleFindRefs).fail(function () {
                     result.reject();
                 });
@@ -107,20 +107,16 @@ define(function (require, exports, module) {
          */
         handleFindRefs = function (refsResp) {
             function isInSameFile(obj) {
-                if (obj && obj.file === refsResp.file) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return (obj && obj.file === refsResp.file);
             }
             
-            if (refsResp && refsResp.refs && refsResp.refs.refs) {
-                if (refsResp.refs.type === "local") {
-                    EditorManager.getActiveEditor().setSelections(refsResp.refs.refs.filter(isInSameFile));
+            if (refsResp && refsResp.references && refsResp.references.refs) {
+                if (refsResp.references.type === "local") {
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(isInSameFile));
                 } else {
-                    var isInSameFile = refsResp.refs.refs.filter(isInSameFile).length === refsResp.refs.refs.length;
+                    var isInSameFile = refsResp.references.refs.filter(isInSameFile).length === refsResp.references.refs.length;
                     if (isInSameFile) {
-                        EditorManager.getActiveEditor().setSelections(refsResp.refs.refs);
+                        EditorManager.getActiveEditor().setSelections(refsResp.references.refs);
                     } else {
                         //TODO- Rename across Project
                     }

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
 
         var result = new $.Deferred();
 
-        function isInSameFile(obj) {
+        function isInSameFile(obj, refsResp) {
             return (obj && obj.file === refsResp.file);
         }
 
@@ -102,9 +102,11 @@ define(function (require, exports, module) {
         function handleFindRefs (refsResp) {
             if (refsResp && refsResp.references && refsResp.references.refs) {
                 if (refsResp.references.type === "local") {
-                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs, false, {scroll: false});
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs)
                 } else {
-                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(isInSameFile));
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(function(element) {
+                        return isInSameFile(element, refsResp);
+                    }));
                 }
             }
         }

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -30,8 +30,7 @@ define(function (require, exports, module) {
         MessageIds           = brackets.getModule("JSUtils/MessageIds");
     
     
-    var session             = null,  // object that encapsulates the current session state
-        refactorRename      = "javascript.renamereference";
+    var session             = null;  // object that encapsulates the current session state
 
     function initializeSession(editor) {
         session = new Session(editor);

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -79,6 +79,7 @@ define(function (require, exports, module) {
 
         if (editor.getSelections().length > 1) {
             editor.displayErrorMessageAtCursor("Rename doesn't work in case of multicursor");
+            return;
         }
         initializeSession(editor);
 

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -75,7 +75,11 @@ define(function (require, exports, module) {
         
     function handleRename() {
         var editor = EditorManager.getActiveEditor(),
-        offset, handleFindRefs;
+            offset, handleFindRefs;
+
+        if (editor.getSelections().length > 1) {
+            editor.displayErrorMessageAtCursor("Rename doesn't work in case of multicursor");
+        }
         initializeSession(editor);
 
 
@@ -117,7 +121,7 @@ define(function (require, exports, module) {
                     if (isInSameFile) {
                         EditorManager.getActiveEditor().setSelections(refsResp.references.refs);
                     } else {
-                        //TODO- Rename across Project
+                        editor.displayErrorMessageAtCursor("As of now Rename doesn't work across project");
                     }
                     
                 }

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -31,8 +31,7 @@ define(function (require, exports, module) {
     
     
     var session             = null,  // object that encapsulates the current session state
-        refactorRename      = "javascript.renamereference",
-        editor;
+        refactorRename      = "javascript.renamereference";
 
     function initializeSession(editor) {
         session = new Session(editor);
@@ -76,10 +75,8 @@ define(function (require, exports, module) {
     }
         
     function handleRename() {
-        if (!editor) {
-            editor = EditorManager.getActiveEditor();
-        }
-        var offset, handleFindRefs;
+        var editor = EditorManager.getActiveEditor(),
+        offset, handleFindRefs;
         initializeSession(editor);
 
 

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -102,7 +102,7 @@ define(function (require, exports, module) {
         function handleFindRefs (refsResp) {
             if (refsResp && refsResp.references && refsResp.references.refs) {
                 if (refsResp.references.type === "local") {
-                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs)
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs);
                 } else {
                     EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(function(element) {
                         return isInSameFile(element, refsResp);

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
             offset, handleFindRefs;
 
         if (editor.getSelections().length > 1) {
-            editor.displayErrorMessageAtCursor("Rename doesn't work in case of multicursor");
+            editor.displayErrorMessageAtCursor(Strings.ERROR_RENAME_MULTICURSOR);
             return;
         }
         initializeSession(editor);
@@ -111,14 +111,9 @@ define(function (require, exports, module) {
 
             if (refsResp && refsResp.references && refsResp.references.refs) {
                 if (refsResp.references.type === "local") {
-                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(isInSameFile));
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs);
                 } else {
-                    var isInSameFile = refsResp.references.refs.filter(isInSameFile).length === refsResp.references.refs.length;
-                    if (isInSameFile) {
-                        EditorManager.getActiveEditor().setSelections(refsResp.references.refs);
-                    } else {
-                        editor.displayErrorMessageAtCursor("As of now Rename doesn't work across project");
-                    }
+                    EditorManager.getActiveEditor().setSelections(refsResp.references.refs.filter(isInSameFile));
                 }
             }
         };

--- a/src/extensions/default/JavaScriptRefactoring/Templates.json
+++ b/src/extensions/default/JavaScriptRefactoring/Templates.json
@@ -1,5 +1,5 @@
 {
-    "wrapCondition": "if () {\n${body}\n}\n",
+    "wrapCondition": "if (x) {\n${body}\n}",
 
     "arrowFunction": {
         "oneParamOneStament": "${params} => ${statement}",
@@ -8,7 +8,7 @@
         "manyParamManyStament": "(${params}) => "
     },
 
-    "tryCatch": "try {\n${body}\n} catch (e) {\nconsole.log(e.message);\n}\n",
+    "tryCatch": "try {\n${body}\n} catch (e) {\nconsole.log(e.message);\n}",
 
     "gettersSetters": "\nget ${getName}() {\nreturn this.${tokenName};\n},\n\nset ${setName}(val) {\nthis.${tokenName} = val;\n}"
 }

--- a/src/extensions/default/JavaScriptRefactoring/Templates.json
+++ b/src/extensions/default/JavaScriptRefactoring/Templates.json
@@ -1,0 +1,14 @@
+{
+    "wrapCondition": "if () {\n${body}\n}\n",
+
+    "arrowFunction": {
+        "oneParamOneStament": "${params} => ${statement}",
+        "oneParamManyStament": "${params} => ",
+        "manyParamOneStament": "(${params}) => ${statement}",
+        "manyParamManyStament": "(${params}) => "
+    },
+
+    "tryCatch": "try {\n${body}\n} catch (e) {\nconsole.log(e.message);\n}\n",
+
+    "gettersSetters": "\nget ${getName}() {\nreturn this.${tokenName};\n},\n\nset ${setName}(val) {\nthis.${tokenName} = val;\n}"
+}

--- a/src/extensions/default/JavaScriptRefactoring/Templates.json
+++ b/src/extensions/default/JavaScriptRefactoring/Templates.json
@@ -1,5 +1,5 @@
 {
-    "wrapCondition": "if (x) {\n${body}\n}",
+    "wrapCondition": "if (Condition) {\n${body}\n}",
 
     "arrowFunction": {
         "oneParamOneStament": "${params} => ${statement}",
@@ -8,7 +8,7 @@
         "manyParamManyStament": "(${params}) => "
     },
 
-    "tryCatch": "try {\n${body}\n} catch (e) {\nconsole.log(e.message);\n}",
+    "tryCatch": "try {\n${body}\n} catch (e) {\n\/\/Catch Statement\n}",
 
     "gettersSetters": "\nget ${getName}() {\nreturn this.${tokenName};\n},\n\nset ${setName}(val) {\nthis.${tokenName} = val;\n}"
 }

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
      */
     Current.prototype.createAstOfCurrentDoc = function () {
         return AcornLoose.parse_dammit(this.document.getText());
-    }
+    };
 
     /**
      * Initialize session 
@@ -170,7 +170,9 @@ define(function (require, exports, module) {
             }
         });
 
-        if (notStatement) return false;
+        if (notStatement) {
+            return false;
+        }
 
         var startStatement = findSurroundASTNode(ast, {start: start}, ["Statement"]);
         var endStatement   = findSurroundASTNode(ast, {start: end}, ["Statement"]);
@@ -240,7 +242,7 @@ define(function (require, exports, module) {
         this.document.batchOperation(function() {
             replaceTextFromTemplate(wrapperName, {body: selectedText}, pos);
         });
-    }
+    };
 
 
      //Wrap selected statements in try catch block   
@@ -259,7 +261,7 @@ define(function (require, exports, module) {
     function convertToArrowFunction() {
         initializeRefactoringSession();
         //Handle when there is no selected line
-        var funcExprNode = findSurroundASTNode(current.ast, {start: current.startIndex}, ["FunctionExpression"])
+        var funcExprNode = findSurroundASTNode(current.ast, {start: current.startIndex}, ["FunctionExpression"]);
 
         if (!funcExprNode || funcExprNode.type !== "FunctionExpression" || funcExprNode.id) {
             current.editor.displayErrorMessageAtCursor("Cursor is not inside function expression");

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -94,19 +94,25 @@ define(function (require, exports, module) {
         current.document.batchOperation(function() {
             current.replaceTextFromTemplate(wrapperName, {body: selectedText}, pos);
         });
+
+        if (wrapperName === TRY_CATCH) {
+            current.editor.setSelection({"line": pos.start.line, "ch": pos.start.ch + 5});
+        } else if (wrapperName === WRAP_IN_CONDITION) {
+            current.editor.setSelection({"line": pos.start.line, "ch": pos.start.ch + 4}, {"line": pos.start.line, "ch": pos.start.ch + 5});
+        }
     }
 
 
      //Wrap selected statements in try catch block
     function wrapInTryCatch() {
         initializeRefactoringSession();
-        _wrapSelectedStatements(TRY_CATCH, "Please select valid statements to wrap them in try catch block");
+        _wrapSelectedStatements(TRY_CATCH, Strings.ERROR_TRY_CATCH);
     }
 
     //Wrap selected statements in try condition
     function wrapInCondition() {
         initializeRefactoringSession();
-        _wrapSelectedStatements(WRAP_IN_CONDITION, "Please select valid statements to wrap them in condition");
+        _wrapSelectedStatements(WRAP_IN_CONDITION, Strings.ERROR_WRAP_IN_CONDITION);
     }
 
     //Convert function to arrow function
@@ -116,7 +122,7 @@ define(function (require, exports, module) {
         var funcExprNode = current.findSurroundASTNode(current.ast, {start: current.startIndex}, ["FunctionExpression"]);
 
         if (!funcExprNode || funcExprNode.type !== "FunctionExpression" || funcExprNode.id) {
-            current.editor.displayErrorMessageAtCursor("Cursor is not inside function expression");
+            current.editor.displayErrorMessageAtCursor(Strings.ERROR_ARROW_FUNCTION);
             return;
         }
         var noOfStatements = funcExprNode.body.body.length,
@@ -192,13 +198,13 @@ define(function (require, exports, module) {
 
         //Create getters and setters only if selected reference is a property
         if (token.type !== "property") {
-            current.editor.displayErrorMessageAtCursor("Cursor is not at property.");
+            current.editor.displayErrorMessageAtCursor(Strings.ERROR_GETTERS_SETTERS);
             return;
         }
 
         // Check if selected propery is child of a object expression
         if (!current.getParentNode(current.ast, endIndex)) {
-            current.editor.displayErrorMessageAtCursor("This property is not part of object expression");
+            current.editor.displayErrorMessageAtCursor(Strings.ERROR_GETTERS_SETTERS);
             return;
         }
 
@@ -237,8 +243,8 @@ define(function (require, exports, module) {
     function addCommands() {
         CommandManager.register(Strings.CMD_REFACTORING_TRY_CATCH, refactorWrapInTryCatch, wrapInTryCatch);
         CommandManager.register(Strings.CMD_REFACTORING_CONDITION, refactorWrapInCondition, wrapInCondition);
-        CommandManager.register(Strings.CMD_REFACTORING_GETTERS_SETTERS, refactorConvertToArrowFn, convertToArrowFunction);
-        CommandManager.register(Strings.CMD_REFACTORING_ARROW_FUNCTION, refactorCreateGetSet, createGettersAndSetters);
+        CommandManager.register(Strings.CMD_REFACTORING_ARROW_FUNCTION, refactorConvertToArrowFn, convertToArrowFunction);
+        CommandManager.register(Strings.CMD_REFACTORING_GETTERS_SETTERS, refactorCreateGetSet, createGettersAndSetters);
 
         var menuLocation = Menus.AppMenuBar.EDIT_MENU,
             editorCmenu = Menus.getContextMenu(Menus.ContextMenuIds.EDITOR_MENU);

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -327,7 +327,7 @@ define(function (require, exports, module) {
         var currentNodeStart;
         var node = _findParentNode (ast, start);
         var childNode = ASTWalker.simple(node, {
-            Property(node) {
+            Property: function (node) {
                 currentNodeStart = node.start;
             }
         });

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -24,88 +24,371 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var EditorManager        = brackets.getModule("editor/EditorManager");
+    var _ = brackets.getModule("thirdparty/lodash");
 
-    function _getPositionOfSelectedText() {
-        var editor = EditorManager.getActiveEditor(),
-            selection   = editor.getSelection();
-          
-        if (editor.getSelections().length > 1) {
-            editor.displayErrorMessageAtCursor("Wrap Selection doesn't work in case of multicursor");
-            return;
-        }
+    var EditorManager        = brackets.getModule("editor/EditorManager"),
+        TokenUtils           = brackets.getModule("utils/TokenUtils"),
+        StringUtils          = brackets.getModule("utils/StringUtils"),
+        AcornLoose           = brackets.getModule("thirdparty/acorn/dist/acorn_loose"),
+        ASTWalker            = brackets.getModule("thirdparty/acorn/dist/walk");
 
-        var start = editor.indexFromPos(selection.start),
-            end = editor.indexFromPos(selection.end),
-            startPos = editor._codeMirror.posFromIndex(start),
-            endPos = editor._codeMirror.posFromIndex(end);
+    var templates = JSON.parse(require("text!Templates.json"));
+
+    var WRAP_IN_CONDITION       = "wrapCondition",
+        ARROW_FUNCTION          = "arrowFunction",
+        GETTERS_SETTERS         = "gettersSetters",
+        TRY_CATCH               = "tryCatch";
+
+
+    var current = null;
+    
+    /**
+     * Current objects encapsulate state associated with a refactoring session
+     * and This will help finding information around documents, selection,
+     * Position details, ast, and queries around AST nodes
+     *
+     * @constructor
+     * @param {Editor} editor - the editor context for the session
+     */
+    function Current(editor) {
+        this.editor = editor;
+        this.document = editor.document;
+        this.selection = editor.getSelection();
+        this.text = this.document.getText();
+        this.selectedText = editor.getSelectedText();
+        this.cm = editor._codeMirror;
+        this.startIndex = editor.indexFromPos(this.selection.start);
+        this.endIndex = editor.indexFromPos(this.selection.end);
+        this.startPos = this.selection.start;
+        this.endPos = this.selection.end;
+        this.ast = this.createAstOfCurrentDoc();
+    }
+
+    /**
+     * Get the end position of given line
+     *
+     * @param {number} line - line number
+     * @return {{line: number, ch: number}} - line end position
+     */
+    Current.prototype.lineEndPosition = function (line) {
+        var lineText = this.document.getLine(line);
 
         return {
-            start: startPos,
-            end: endPos
+            line: line,
+            ch: lineText.length
         };
+    };
+
+    /**
+     * Get the ast of current opened document in focused editor
+     *
+     * @return {Object} - Ast of current opened doc
+     */
+    Current.prototype.createAstOfCurrentDoc = function () {
+        return AcornLoose.parse_dammit(this.document.getText());
+    }
+
+    /**
+     * Initialize session 
+     */
+    function initializeRefactoringSession() {
+        current = new Current(EditorManager.getActiveEditor());
     }
     
-    function _getTextWrapedInTryCatch(text) {
-        var trytext = "try {\n",
-            catchText = "\n} catch (e) {\nconsole.log(e.message);\n}",
-            formattedText = trytext + text + catchText;
-
-        return formattedText;
-    }
+    /**
+     * This will add template at given position/selection
+     *
+     * @param {string} template - name of templated defined in templates.json
+     * @param {Array} args- Check all arguments that exist in defined templated pass all that args as array
+     * @param {{line: number, ch: number}} rangeToReplace - Range which we want to rreplace
+     * @param {string} subTemplate - If template written under some category
+     */
+    function replaceTextFromTemplate(template, args, rangeToReplace, subTemplate) {
+        var editor = EditorManager.getActiveEditor();
         
+        var templateText = templates[template];
+
+        if (subTemplate) {
+            templateText = templateText[subTemplate];
+        }
+
+        var compiled = _.template(templateText);
+        var formattedText = compiled(args);
+
+        if (!rangeToReplace) {
+            rangeToReplace = editor.getSelection();
+        }
+        
+        editor.document.replaceRange(formattedText, rangeToReplace.start, rangeToReplace.end);
+
+        var startLine = rangeToReplace.start.line,
+        endLine = startLine + formattedText.split("\n").length;
+
+        for (var i = startLine + 1; i < endLine; i++) {
+            editor._codeMirror.indentLine(i);
+        }
+    }
+
+    
+    /*
+     * Finds the surrounding ast node of the given expression of any of the given types
+     * @param {!ASTNode} ast
+     * @param {!{start: number, end: number}} expn - contains start and end offsets of expn
+     * @param {!Array.<string>} types
+     * @return {?ASTNode} 
+     */
+    function findSurroundASTNode(ast, expn, types) {
+        var foundNode = ASTWalker.findNodeAround(ast, expn.start, function (nodeType, node) {
+            if (expn.end) {
+                return types.includes(nodeType) && node.end >= expn.end;
+            } else {
+                return types.includes(nodeType);
+            }
+        });
+        return foundNode && foundNode.node;
+    }
+
+    /*
+     * Checks whether the text between start and end offsets form a valid set of statements
+     * @param {!ASTNode} ast - the ast of the complete file
+     * @param {!number} start - the start offset
+     * @param {!number} end - the end offset
+     * @param {!string} fileText - selected text
+     * @return {boolean}
+     */
+    function checkStatement(ast, start, end, selectedText, id) {
+        // Do not allow function or class nodes
+        var notStatement = false;
+        ASTWalker.simple(AcornLoose.parse_dammit(selectedText), {
+            Function: function (node) {
+                if (node.type === "FunctionDeclaration") {
+                    notStatement = true;
+                }
+            },
+            Class: function (node) {
+                notStatement = true;
+            }
+        });
+
+        if (notStatement) return false;
+
+        var startStatement = findSurroundASTNode(ast, {start: start}, ["Statement"]);
+        var endStatement   = findSurroundASTNode(ast, {start: end}, ["Statement"]);
+
+        return startStatement && endStatement && startStatement.start === start &&
+            startStatement.end <= end && endStatement.start >= start &&
+            endStatement.end === end;
+    }
+
+    /**
+     * Get Params of selected function
+     *
+     * @param {Object} ast - ast of whole file
+     * @param {number} start- start offset
+     * @param {number} end - end offset
+     * @param {string} selectedText - Create ast for only selected node
+     * @return {Array} param - Array of all parameters in function
+     */
+    function getParamsOfFunction(ast, start, end, selectedText) {
+        var param = [];
+        ASTWalker.simple(AcornLoose.parse_dammit(selectedText), {
+            Function: function (node) {
+                if (node.type === "FunctionDeclaration") {
+                    node.params.forEach(function (item) {
+                        param.push(item.name);
+                    });
+                }
+            }
+        });
+
+        return param;
+    }
+
+    /**
+     * Wrap selected statements 
+     *
+     * @param {string} wrapperName - template name where we want wrap selected statements
+     * @param {string} err- error message
+     */
+    Current.prototype.wrapSelectedStatements =  function (wrapperName, err) {
+        initializeRefactoringSession();
+        var selectedText;
+
+        var startIndex,
+            endIndex,
+            statementNode,
+            isStatements,
+            pos;
+
+        if (this.selectedText.length === 0) {
+            statementNode = findSurroundASTNode(this.ast, {start: this.startIndex}, ["Statement"]);
+            selectedText = this.text.substr(statementNode.start, statementNode.end - statementNode.start);
+            startIndex = statementNode.start;
+            endIndex = statementNode.end;
+        }
+
+        if (!checkStatement(this.ast, startIndex, endIndex, selectedText)) {
+            this.editor.displayErrorMessageAtCursor(err);
+            return;
+        }
+
+        pos = {
+            "start": this.cm.posFromIndex(startIndex),
+            "end": this.cm.posFromIndex(endIndex)
+        };
+
+        this.document.batchOperation(function() {
+            replaceTextFromTemplate(wrapperName, {body: selectedText}, pos);
+        });
+    }
+
+
+     //Wrap selected statements in try catch block   
     function wrapInTryCatch() {
-
-        var editor = EditorManager.getActiveEditor(),
-            newText = _getTextWrapedInTryCatch(editor.getSelectedText().trim()),
-            pos = _getPositionOfSelectedText();
-        
-        if (!pos) {
-            return;
-        }
-
-        editor.document.replaceRange(newText, pos.start, pos.end);
-        
-        var startLine = pos.start.line,
-            endLine = startLine + newText.split("\n").length;
-
-        for (var i = startLine + 1; i < endLine; i++) {
-            editor._codeMirror.indentLine(i);
-        }
-
-        //Place cursor or selection
+        initializeRefactoringSession();
+        current.wrapSelectedStatements(TRY_CATCH, "Please select valid statements to wrap them in try catch block");
     }
 
-    function _getTextWrapedInCondition(text) {
-        var ifText = "if () {\n",
-            closeIf = "\n}",
-            formattedText = ifText + text + closeIf;
-
-        return formattedText;
-    }
-
-
+    //Wrap selected statements in try condition  
     function wrapInCondition() {
+        initializeRefactoringSession();
+        current.wrapSelectedStatements(WRAP_IN_CONDITION, "Please select valid statements to wrap them in condition");
+    }
 
-        var editor = EditorManager.getActiveEditor(),
-            newText = _getTextWrapedInCondition(editor.getSelectedText().trim()),
-            pos = _getPositionOfSelectedText();
+    //Convert function to arrow function
+    function convertToArrowFunction() {
+        initializeRefactoringSession();
+        //Handle when there is no selected line
+        var funcExprNode = findSurroundASTNode(current.ast, {start: current.startIndex}, ["FunctionExpression"])
 
-        if (!pos) {
+        if (!funcExprNode || funcExprNode.type !== "FunctionExpression" || funcExprNode.id) {
+            current.editor.displayErrorMessageAtCursor("Cursor is not inside function expression");
+            return;
+        }
+        var noOfStatements = funcExprNode.body.body.length,
+            selectedText = current.text.substr(funcExprNode.start, funcExprNode.end - funcExprNode.start),
+            param = getParamsOfFunction(current.ast, funcExprNode.start, funcExprNode.end, selectedText),
+            loc = {
+                "fullFunctionScope" : {
+                    start: funcExprNode.start,
+                    end: funcExprNode.end
+                },
+                "functionsDeclOnly": {
+                    start: funcExprNode.start,
+                    end: funcExprNode.body.start
+                }
+            },
+            locPos = {
+                "fullFunctionScope": {
+                    "start": current.cm.posFromIndex(loc.fullFunctionScope.start),
+                    "end": current.cm.posFromIndex(loc.fullFunctionScope.end)
+                },
+                "functionsDeclOnly": {
+                    "start": current.cm.posFromIndex(loc.functionsDeclOnly.start),
+                    "end": current.cm.posFromIndex(loc.functionsDeclOnly.end)
+                }
+            },
+            isReturnStatement = funcExprNode.body.body[0].type === "ReturnStatement",
+            bodyStatements = funcExprNode.body.body[0],
+            params = {
+                "params": param.join(", "),
+                "statement": _.trimRight(current.text.substr(bodyStatements.start, bodyStatements.end - bodyStatements.start), ";")
+            };
+
+        if (isReturnStatement) {
+            params.statement = params.statement.substr(7).trim();
+        }
+
+        if (noOfStatements === 1) {
+            current.document.batchOperation(function() {
+                funcExprNode.params.length === 1 ?  replaceTextFromTemplate(ARROW_FUNCTION, params, locPos.fullFunctionScope, "oneParamOneStament") :
+                replaceTextFromTemplate(ARROW_FUNCTION, params, locPos.fullFunctionScope, "manyParamOneStament");
+
+            });
+        } else {
+            current.document.batchOperation(function() {
+                funcExprNode.params.length === 1 ?  replaceTextFromTemplate(ARROW_FUNCTION, {params: param},
+                locPos.functionsDeclOnly, "oneParamManyStament") :
+                replaceTextFromTemplate(ARROW_FUNCTION, {params: param.join(", ")}, locPos.functionsDeclOnly, "manyParamManyStament");
+            });
+        }
+
+        current.editor.setCursorPos(locPos.functionsDeclOnly.end.line, locPos.functionsDeclOnly.end.ch, false);
+    }
+
+    function _findParentNode(ast, start) {
+        var foundNode = ASTWalker.findNodeAround(ast, start, function(nodeType, node) {
+            return (nodeType === "ObjectExpression");
+        });
+        return foundNode && foundNode.node;
+    }
+
+    function _isLastNodeInScope(ast, start) {
+        var currentNodeStart;
+        var node = _findParentNode (ast, start);
+        var childNode = ASTWalker.simple(node, {
+            Property(node) {
+                currentNodeStart = node.start;
+            }
+        });
+
+        return start >= currentNodeStart;
+    }
+
+    //Create gtteres and setters for a property
+    function createGettersAndSetters() {
+        initializeRefactoringSession();
+            
+        var token = TokenUtils.getTokenAt(current.cm, current.cm.getCursor()),
+            isLastNode,
+            lineEndPos,
+            templateParams;
+
+        //Create getters and setters only if selected reference is a property
+        if (token.type !== "property") {
+            current.editor.displayErrorMessageAtCursor("Cursor is not at property.");
+            return;
+        }
+   
+        if (!_findParentNode (current.ast, current.startIndex)) {
+            current.editor.displayErrorMessageAtCursor("This property is not part of object expression");
             return;
         }
 
-        editor.document.replaceRange(newText, pos.start, pos.end);
-        
-        var startLine = pos.start.line,
-        endLine = startLine + newText.split("\n").length;
-        for (var i = startLine + 1; i < endLine; i++) {
-            editor._codeMirror.indentLine(i);
-        }
+        //We have to add ',' so we need to find position of current property selected
+        isLastNode = _isLastNodeInScope(current.ast, current.startIndex);
+        lineEndPos = current.lineEndPosition(current.startPos.line);
+        templateParams = {
+            "getName": "get" + token.string,
+            "setName": "set" + token.string,
+            "tokenName": token.string
+        };
 
-        //Place cursor at if
+        // Replace, setSelection, IndentLine
+        // We need this as indentLine don't have option to add origin as like replaceRange
+        current.editor.document.batchOperation(function() {
+            if (isLastNode) {
+                //Add ',' in the end of current line
+                current.editor.document.replaceRange(",", lineEndPos, lineEndPos);
+
+                // We can use getLineEnding defined in FileUtils but i feel this better, If we will do that way then we need to call indent code manually
+                // Sometime that doesn't work properly
+                lineEndPos.ch++;
+            }
+
+            current.editor.setSelection(lineEndPos); //Selection on line end
+
+            //Add getters and setters for given token using template at current cursor position
+            replaceTextFromTemplate(GETTERS_SETTERS, templateParams);
+
+            if (!isLastNode) {
+                current.editor.document.replaceRange(",", current.editor.getSelection().start, current.editor.getSelection().start);
+            }
+        });
     }
     
     exports.wrapInTryCatch = wrapInTryCatch;
     exports.wrapInCondition = wrapInCondition;
+    exports.convertToArrowFunction = convertToArrowFunction;
+    exports.createGettersAndSetters = createGettersAndSetters;
 });

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var EditorManager        = brackets.getModule("editor/EditorManager"),
+        ScopeManager         = brackets.getModule("JSUtils/ScopeManager"),
+        Session              = brackets.getModule("JSUtils/Session"),
+        MessageIds           = brackets.getModule("JSUtils/MessageIds");
+    
+    
+    var session             = null;  // object that encapsulates the current session state
+
+    // Removes the leading and trailing spaces from selection and the trailing semicolons
+    function normalizeSelection() {
+        var selection   = this.editor.getSelection(),
+            text        = this.editor.getSelectedText(),
+            trimmedText;
+
+        // Remove leading spaces
+        trimmedText = text.trim();
+
+
+    };
+    
+    function getTextWrapedInTryCatch(text) {
+        var trytext = "try {\n \t",
+            catchText = "}\ catch (e) {\n \t console.log(e) }";
+        var formattedText = trytext + text + catchText;
+        return formattedText;
+    }
+        
+    function wrapInTryCatch() {
+        var editor = EditorManager.getActiveEditor(),
+            selection   = editor.getSelection(),
+            text        = editor.getSelectedText();
+        
+        var newText = getTextWrapedInTryCatch(text);
+    }
+    
+    exports.wrapInTryCatch = wrapInTryCatch;
+});

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -212,8 +212,8 @@ define(function (require, exports, module) {
         isLastNode = current.isLastNodeInScope(current.ast, endIndex);
         lineEndPos = current.lineEndPosition(current.startPos.line);
         templateParams = {
-            "getName": "get" + token.string,
-            "setName": "set" + token.string,
+            "getName": token.string,
+            "setName": token.string,
             "tokenName": token.string
         };
 

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -45,8 +45,8 @@ define(function (require, exports, module) {
     };
     
     function getTextWrapedInTryCatch(text) {
-        var trytext = "try {\n \t",
-            catchText = "}\ catch (e) {\n \t console.log(e) }";
+        var trytext = "try {\n",
+            catchText = "\n} catch (e) {\nconsole.log(e);\n}";
         var formattedText = trytext + text + catchText;
         return formattedText;
     }
@@ -55,9 +55,61 @@ define(function (require, exports, module) {
         var editor = EditorManager.getActiveEditor(),
             selection   = editor.getSelection(),
             text        = editor.getSelectedText();
+
+            
+        if (editor.getSelections().length > 1) {
+            editor.displayErrorMessageAtCursor("Wrap in try catch doesn't work in case of multicursor");
+        }
+
+        var newText = getTextWrapedInTryCatch(text.trim()),
+            doc = editor.document,
+            start = editor.indexFromPos(selection.start),
+            end = editor.indexFromPos(selection.end),
+            startPos = editor._codeMirror.posFromIndex(start),
+            endPos = editor._codeMirror.posFromIndex(end);
+
+        doc.replaceRange(newText, startPos, endPos);
         
-        var newText = getTextWrapedInTryCatch(text);
+        var startLine = startPos.line,
+        endLine = startLine + newText.split("\n").length;
+        for (var i = startLine + 1; i < endLine; i++) {
+            editor._codeMirror.indentLine(i);
+        }
+    }
+
+    function getTextWrapedInCondition(text) {
+        var ifText = "if () {\n",
+            closeIf = "\n}";
+        var formattedText = ifText + text + closeIf;
+        return formattedText;
+    }
+
+
+    function wrapInCondition() {
+        var editor = EditorManager.getActiveEditor(),
+            selection   = editor.getSelection(),
+            text        = editor.getSelectedText();
+
+        if (editor.getSelections().length > 1) {
+            editor.displayErrorMessageAtCursor("Wrap in condition doesn't work in case of multicursor");
+        }
+
+        var newText = getTextWrapedInCondition(text.trim()),
+            doc = editor.document,
+            start = editor.indexFromPos(selection.start),
+            end = editor.indexFromPos(selection.end),
+            startPos = editor._codeMirror.posFromIndex(start),
+            endPos = editor._codeMirror.posFromIndex(end);
+
+        doc.replaceRange(newText, startPos, endPos);
+        
+        var startLine = startPos.line,
+        endLine = startLine + newText.split("\n").length;
+        for (var i = startLine + 1; i < endLine; i++) {
+            editor._codeMirror.indentLine(i);
+        }
     }
     
     exports.wrapInTryCatch = wrapInTryCatch;
+    exports.wrapInCondition = wrapInCondition;
 });

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
 
     // This preference controls whether to create a session and process all JS files or not.
     PreferencesManager.definePreference("refactoring.JSRefactoring", "boolean", true, {
-        description: Strings.DESCRIPTION_CODE_REFACTORIG
+        description: Strings.DESCRIPTION_CODE_REFACTORING
     });
 
 

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
 
     var AppInit              = brackets.getModule("utils/AppInit"),
         PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
+        Strings              = brackets.getModule("strings"),
         RenameIdentifier     = require("RenameIdentifier"),
         WrapSelection        = require("WrapSelection");
 
@@ -34,7 +35,7 @@ define(function (require, exports, module) {
 
     // This preference controls whether to create a session and process all JS files or not.
     PreferencesManager.definePreference("refactoring.JSRefactoring", "boolean", true, {
-        description: "Enable JavaScript code refactoring"
+        description: Strings.DESCRIPTION_CODE_REFACTORIG
     });
 
 

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -31,14 +31,21 @@ define(function (require, exports, module) {
         
 
     var MessageIds           = brackets.getModule("JSUtils/MessageIds"),
-        RenameIdentifier     = require("RenameIdentifier");
+        RenameIdentifier     = require("RenameIdentifier"),
+        WrapSelection        = require("WrapSelection");
     
     
     var refactorRename          = "javascript.renamereference",
+        refactorWrapInTryCatch  = "refactoring.wrapintrycatch",
+        refactorWrapInCondition = "refactoring.wrapincondition",
         editor;
 
 
     CommandManager.register("Rename", refactorRename, RenameIdentifier.handleRename);
+
+    CommandManager.register("Wrap in Try Catch", refactorWrapInTryCatch, WrapSelection.wrapInTryCatch);
+
+    CommandManager.register("Wrap in Condition", refactorWrapInCondition, WrapSelection.wrapInCondition);
     
     var menuLocation = Menus.AppMenuBar.NAVIGATE_MENU;
     
@@ -55,6 +62,12 @@ define(function (require, exports, module) {
             editor = EditorManager.getActiveEditor();
             var cm = editor._codeMirror,
             tokenType = TokenUtils.getTokenAt(cm, cm.getCursor()).type;
+
+            var sel = editor.getSelection();
+            if ((editor.getModeForSelection() === "javascript") && (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch)) {
+                editorCmenu.addMenuItem(refactorWrapInTryCatch);
+                editorCmenu.addMenuItem(refactorWrapInCondition);
+            }
             
             if (editor.getModeForSelection() === "javascript" && (tokenType === "variable-2" ||
                 tokenType === "variable" || tokenType === "property" || tokenType === "def")) {
@@ -65,4 +78,6 @@ define(function (require, exports, module) {
 
     Menus.getMenu(menuLocation).addMenuDivider();
     Menus.getMenu(menuLocation).addMenuItem(refactorRename, keysRename);
+    Menus.getMenu(menuLocation).addMenuItem(refactorWrapInTryCatch);
+    Menus.getMenu(menuLocation).addMenuItem(refactorWrapInCondition);
 });

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var EditorManager        = brackets.getModule("editor/EditorManager"),
+        CommandManager       = brackets.getModule("command/CommandManager"),
+        TokenUtils           = brackets.getModule("utils/TokenUtils"),
+        Menus                = brackets.getModule("command/Menus");
+        
+
+    var MessageIds           = brackets.getModule("JSUtils/MessageIds"),
+        RenameIdentifier     = require("RenameIdentifier");
+    
+    
+    var refactorRename = "javascript.renamereference",
+        editor;
+
+
+    CommandManager.register("Rename", refactorRename, RenameIdentifier.handleRename);
+    
+    var menuLocation = Menus.AppMenuBar.NAVIGATE_MENU;
+    
+    var keys = [
+        {key: "Ctrl-R", platform:"mac"}, // don't translate to Cmd-R on mac
+        {key: "Ctrl-R", platform:"win"},
+        {key: "Ctrl-R", platform:"linux"}
+    ];
+
+    var editorCmenu = Menus.getContextMenu(Menus.ContextMenuIds.EDITOR_MENU);
+    if (editorCmenu) {
+        editorCmenu.on("beforeContextMenuOpen", function (e) {
+            
+            editor = EditorManager.getActiveEditor();
+            var cm = editor._codeMirror,
+            tokenType = TokenUtils.getTokenAt(cm, cm.getCursor()).type,
+            renameInJSFile = CommandManager.get(refactorRename);
+            
+            if (editor.getModeForSelection() === "javascript" && (tokenType === "variable-2" || tokenType === "variable" || tokenType === "property" || tokenType === "def")) {
+                editorCmenu.addMenuItem(refactorRename);
+            } else {
+                editorCmenu.removeMenuItem(refactorRename);
+            }
+        });
+    }
+    
+    Menus.getMenu(menuLocation).addMenuItem(refactorRename, keys);
+});

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -31,18 +31,14 @@ define(function (require, exports, module) {
         
 
     var MessageIds           = brackets.getModule("JSUtils/MessageIds"),
-        RenameIdentifier     = require("RenameIdentifier"),
-        WrapSelection        = require("WrapSelection");
+        RenameIdentifier     = require("RenameIdentifier");
     
     
     var refactorRename          = "javascript.renamereference",
-        refactorWrapInTryCatch  = "refactoring.wrapintrycatch",
         editor;
 
 
     CommandManager.register("Rename", refactorRename, RenameIdentifier.handleRename);
-
-    CommandManager.register("Wrap in Try Catch", refactorWrapInTryCatch, WrapSelection.wrapInTryCatch)
     
     var menuLocation = Menus.AppMenuBar.NAVIGATE_MENU;
     
@@ -58,31 +54,15 @@ define(function (require, exports, module) {
             
             editor = EditorManager.getActiveEditor();
             var cm = editor._codeMirror,
-            tokenType = TokenUtils.getTokenAt(cm, cm.getCursor()).type,
-            renameInJSFile = CommandManager.get(refactorRename);
-
-            if (editor.getSelections().length > 1) {
-                editorCmenu.removeMenuItem(refactorRename);
-                editorCmenu.removeMenuItem(refactorWrapInTryCatch);
-            }
-
-            var sel = editor.getSelection();
-            if ((editor.getModeForSelection() === "javascript") && (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch)) {
-                editorCmenu.addMenuItem(refactorWrapInTryCatch);
-            } else {
-                editorCmenu.removeMenuItem(refactorWrapInTryCatch);
-            }
+            tokenType = TokenUtils.getTokenAt(cm, cm.getCursor()).type;
             
-            if (editor.getModeForSelection() === "javascript" && (tokenType === "variable-2" || tokenType === "variable" || tokenType === "property" || tokenType === "def")) {
+            if (editor.getModeForSelection() === "javascript" && (tokenType === "variable-2" ||
+                tokenType === "variable" || tokenType === "property" || tokenType === "def")) {
                 editorCmenu.addMenuItem(refactorRename);
-            } else {
-                editorCmenu.removeMenuItem(refactorRename);
-                
             }
         });
     }
 
-    
+    Menus.getMenu(menuLocation).addMenuDivider();
     Menus.getMenu(menuLocation).addMenuItem(refactorRename, keysRename);
-    Menus.getMenu(menuLocation).addMenuItem(refactorWrapInTryCatch);
 });

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -38,6 +38,8 @@ define(function (require, exports, module) {
     var refactorRename          = "javascript.renamereference",
         refactorWrapInTryCatch  = "refactoring.wrapintrycatch",
         refactorWrapInCondition = "refactoring.wrapincondition",
+        refactorConvertToArrowFn = "refactoring.converttoarrowfunction",
+        refactorCreateGetSet = "refactoring.creategettersandsetters",
         editor;
 
 
@@ -46,6 +48,10 @@ define(function (require, exports, module) {
     CommandManager.register("Wrap in Try Catch", refactorWrapInTryCatch, WrapSelection.wrapInTryCatch);
 
     CommandManager.register("Wrap in Condition", refactorWrapInCondition, WrapSelection.wrapInCondition);
+
+    CommandManager.register("Convert to Arrow Function", refactorConvertToArrowFn, WrapSelection.convertToArrowFunction);
+
+    CommandManager.register("Create Getters Setters", refactorCreateGetSet, WrapSelection.createGettersAndSetters);
     
     var menuLocation = Menus.AppMenuBar.EDIT_MENU;
     
@@ -63,16 +69,16 @@ define(function (require, exports, module) {
             var cm = editor._codeMirror,
             tokenType = TokenUtils.getTokenAt(cm, cm.getCursor()).type;
 
-            var sel = editor.getSelection();
-            if ((editor.getModeForSelection() === "javascript") && (sel.start.line !== sel.end.line || sel.start.ch !== sel.end.ch)) {
-                editorCmenu.addMenuItem(refactorWrapInTryCatch);
-                editorCmenu.addMenuItem(refactorWrapInCondition);
-            }
+            editorCmenu.addMenuItem(refactorWrapInTryCatch);
+            editorCmenu.addMenuItem(refactorWrapInCondition);
             
             if (editor.getModeForSelection() === "javascript" && (tokenType === "variable-2" ||
                 tokenType === "variable" || tokenType === "property" || tokenType === "def")) {
                 editorCmenu.addMenuItem(refactorRename);
             }
+
+            editorCmenu.addMenuItem(refactorConvertToArrowFn);
+            editorCmenu.addMenuItem(refactorCreateGetSet);
         });
     }
 
@@ -80,4 +86,6 @@ define(function (require, exports, module) {
     Menus.getMenu(menuLocation).addMenuItem(refactorRename, keysRename);
     Menus.getMenu(menuLocation).addMenuItem(refactorWrapInTryCatch);
     Menus.getMenu(menuLocation).addMenuItem(refactorWrapInCondition);
+    Menus.getMenu(menuLocation).addMenuItem(refactorConvertToArrowFn);
+    Menus.getMenu(menuLocation).addMenuItem(refactorCreateGetSet);
 });

--- a/src/extensions/default/JavaScriptRefactoring/main.js
+++ b/src/extensions/default/JavaScriptRefactoring/main.js
@@ -47,7 +47,7 @@ define(function (require, exports, module) {
 
     CommandManager.register("Wrap in Condition", refactorWrapInCondition, WrapSelection.wrapInCondition);
     
-    var menuLocation = Menus.AppMenuBar.NAVIGATE_MENU;
+    var menuLocation = Menus.AppMenuBar.EDIT_MENU;
     
     var keysRename = [
         {key: "Ctrl-R", platform:"mac"}, // don't translate to Cmd-R on mac

--- a/src/extensions/default/JavaScriptRefactoring/package.json
+++ b/src/extensions/default/JavaScriptRefactoring/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "brackets-javascript-code-refactoring",
-  "dependencies": {
-    "acorn": "3.3.0"
-  }
-}

--- a/src/extensions/default/JavaScriptRefactoring/package.json
+++ b/src/extensions/default/JavaScriptRefactoring/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "brackets-javascript-code-refactoring",
+  "dependencies": {
+    "acorn": "3.3.0"
+  }
+}

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -681,7 +681,7 @@ define({
     "CMD_REFACTORING_CONDITION"                 : "Wrap in Condition",
     "CMD_REFACTORING_GETTERS_SETTERS"           : "Create Getters Setters",
     "CMD_REFACTORING_ARROW_FUNCTION"            : "Convert to Arrow Function",
-    "DESCRIPTION_CODE_REFACTORIG"               : "Enable/disable JavaScript Code Refactoring",
+    "DESCRIPTION_CODE_REFACTORING"               : "Enable/disable JavaScript Code Refactoring",
     "ERROR_TRY_CATCH"                           : "Select valid code to wrap in a Try-catch block",
     "ERROR_WRAP_IN_CONDITION"                   : "Select valid code to wrap in a Condition block",
     "ERROR_ARROW_FUNCTION"                      : "Place the cursor inside a function expression",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -681,6 +681,12 @@ define({
     "CMD_REFACTORING_CONDITION"                 : "Wrap in Condition",
     "CMD_REFACTORING_GETTERS_SETTERS"           : "Create Getters Setters",
     "CMD_REFACTORING_ARROW_FUNCTION"            : "Convert to Arrow Function",
+    "DESCRIPTION_CODE_REFACTORIG"               : "Enable/disable JavaScript Code Refactoring",
+    "ERROR_TRY_CATCH"                           : "Select valid code to wrap in a Try-catch block",
+    "ERROR_WRAP_IN_CONDITION"                   : "Select valid code to wrap in a Condition block",
+    "ERROR_ARROW_FUNCTION"                      : "Place the cursor inside a function expression",
+    "ERROR_GETTERS_SETTERS"                     : "Place the cursor at a member of an object expression",
+    "ERROR_RENAME_MULTICURSOR"                  : "Cannot rename when using multi-cursors",
 
     // extensions/default/JSLint
     "JSLINT_NAME"                               : "JSLint",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -674,6 +674,14 @@ define({
     "DETECTED_EXCLUSION_TITLE"                  : "JavaScript File Inference Problem",
     "DETECTED_EXCLUSION_INFO"                   : "{APP_NAME} ran into trouble processing <span class='dialog-filename'>{0}</span>.<br><br>This file will no longer be processed for code hints, Jump to Definition or Quick Edit. To re-enable this file, open <code>.brackets.json</code> in your project and edit <code>jscodehints.detectedExclusions</code>.<br><br>This is likely a {APP_NAME} bug. If you can provide a copy of this file, please <a href='https://github.com/adobe/brackets/wiki/How-to-Report-an-Issue'>file a bug</a> with a link to the file named here.",
 
+
+    // extensions/default/JavaScriptRefactoring
+    "CMD_REFACTORING_RENAME"                    : "Rename",
+    "CMD_REFACTORING_TRY_CATCH"                 : "Wrap in Try Catch",
+    "CMD_REFACTORING_CONDITION"                 : "Wrap in Condition",
+    "CMD_REFACTORING_GETTERS_SETTERS"           : "Create Getters Setters",
+    "CMD_REFACTORING_ARROW_FUNCTION"            : "Convert to Arrow Function",
+
     // extensions/default/JSLint
     "JSLINT_NAME"                               : "JSLint",
 


### PR DESCRIPTION
This PR implements "rename" functionality in JS mode to enable intelligent rename feature by using Tern's scope analysis and inference functions. Renaming across multiple files has been intentionally blocked for the time being as we are not analyzing all the JS files in current project root right now.

The rename function works by selecting a variable def/ref or placing cursor in and using Ctrl+R.

This code is written by @swmitra and already reviewed by @petetnt ([PR 13047](https://github.com/adobe/brackets/pull/13047))

I just restructured this code and created new extension called JavascriptCodeRefactoring.

**Known issues:-**

In a particular case Tern inference engine is picking up wrong hit. For example :-
```javascript
function fn1(error) {
    error.a = "abc";
    var a = "test";
    console.log(a);
}
```
If we try to rename a in line 3 or 4 , Tern picks up fake ref from line 2 as well.

#Issue reported in tern [950](https://github.com/ternjs/tern/issues/950), [951](https://github.com/ternjs/tern/issues/951)
[951](https://github.com/ternjs/tern/issues/951) is already fixed.


**Wrap Selection in Try Catch/Condition** 
1) Select code/Just put cursor anywhere
2) Edit -> wrap in try catch/condition Or find this in submenu
3) If you just placed cursor it will find surrounding statements around cursor position
 else if you selected code then it will check weather these are statements or not
5) If statements -> It will wrap that code in TryCatch/Condition
 else error (Please select valid statements)

`AppInit.appReady(function () {
            brackets.test.doneLoading = true;
        });`

Select whole code or just place cursor on 3rd line it will wrap whole code in try catch block/Condition block

`try {
            AppInit.appReady(function () {
                brackets.test.doneLoading = true;
            });
        } catch (e) {
            console.log(e.message);
        }`
Put selection on 2nd line and do wrap in try catch/condition it will wrap that line only.

Know Issue:- Some time indention goes wrong in case of wrap in condition

**Convert to arrow function**
1) Put cursor anywhere in anonymous function and click convert to arrow function
If one param structure will be `param => {statements}`
If zero or more than one param `(param1, param2) => {statements}` 
In case of one statement, it will remove "{, }" and ";"as well

**Create Setters and Getters for given property**
1) Put cursor on property
2) Create getter/setter
`get getTest() {
 return this.test;
},
set setTest(val) {
this.test = val;
}`

Please review @nethip @boopeshmahendran @petetnt @swmitra @ficristo @saurabh95 