### PR TITLE
Possible Fix Issue #7855

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -18,7 +18,13 @@
         "Ctrl-S"
     ],
     "file.saveAll":  [
-        "Ctrl-Alt-S"
+        {
+           "key": "Ctrl-Alt-S"
+        },
+        {
+           "key":"Shift-Alt-S",
+           "platform": "linux"
+        }
     ],
     "file.saveAs":  [
         "Ctrl-Shift-S"
@@ -235,6 +241,7 @@
             "key": "Ctrl-+"
         }
     ],
+   
     "view.decreaseFontSize":  [
         {
             "key": "Ctrl--",


### PR DESCRIPTION
Added alternative key binding for "Save All" only for Linux.
Ctrl-Alt-S is a default key binding for Linux, so I created an alternative only for Linux, Shift-Alt-S.