### PR TITLE
Move initialization of Brackets object from appshell_extensions.js to Global.js

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.12.0-0",

--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
         "extension_url": "https://s3.amazonaws.com/extend.brackets/{0}/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "healthDataServerURL": "https://health.brackets.io/healthDataLog"
+        "healthDataServerURL": "https://healthdev.brackets.io/healthDataLog"
     },
     "name": "Brackets",
     "version": "1.12.0-0",

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -42,11 +42,10 @@ define(function (require, exports, module) {
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
 
-        // Earlier this initialization was happening inside appshell_extensions.js. But
-        // since the newer CEF versions have stronger JS checks render process was crashing
-        // citing JS eval error. So moved the initialization from
-        // https://github.com/adobe/brackets-shell/blob/908ed1503995c1b5ae013473c4b181a9aa64fd22/appshell/appshell_extensions.js#L945
-        // to here.
+        // Earlier brackets object was initialized at 
+        // https://github.com/adobe/brackets-shell/blob/908ed1503995c1b5ae013473c4b181a9aa64fd22/appshell/appshell_extensions.js#L945.
+        // With the newer versions of CEF, the initialization was crashing the render process, citing
+        // JS eval error. So moved the brackets object initialization from appshell_extensions.js to here.
         if (global.appshell) {
             global.brackets = global.appshell;
         } else {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -21,7 +21,6 @@
  *
  */
 
- /*global appshell */
 
 /**
  * Initializes the global "brackets" variable and it's properties.
@@ -43,11 +42,14 @@ define(function (require, exports, module) {
     // inside Node for CI testing) we use this trick to get the global object.
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
+
         // Earlier this initialization was happening inside appshell_extensions.js. But
         // since the newer CEF versions have stronger JS checks render process was crashing
-        // siting JS eval error. So moved the initialization to here.
-        if (appshell) {
-            global.brackets = appshell;
+        // siting JS eval error. So moved the initialization from
+        // https://github.com/adobe/brackets-shell/blob/908ed1503995c1b5ae013473c4b181a9aa64fd22/appshell/appshell_extensions.js#L945
+        // to here.
+        if (global.appshell) {
+            global.brackets = global.appshell;
         } else {
             global.brackets = {};
         }

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -41,7 +41,14 @@ define(function (require, exports, module) {
     // inside Node for CI testing) we use this trick to get the global object.
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
-        global.brackets = {};
+        // Earlier this initialization was happening inside appshell_extensions.js. But
+        // since the newer CEF versions have stronger JS checks render process was crashing 
+        // siting JS eval error. So moved the initialization to here.
+        if (appshell) {
+            global.brackets = appshell;
+        } else {
+            global.brackets = {};
+        }
     }
 
     // Parse URL params

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -21,7 +21,6 @@
  *
  */
 
-
 /**
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
@@ -45,7 +44,7 @@ define(function (require, exports, module) {
 
         // Earlier this initialization was happening inside appshell_extensions.js. But
         // since the newer CEF versions have stronger JS checks render process was crashing
-        // siting JS eval error. So moved the initialization from
+        // citing JS eval error. So moved the initialization from
         // https://github.com/adobe/brackets-shell/blob/908ed1503995c1b5ae013473c4b181a9aa64fd22/appshell/appshell_extensions.js#L945
         // to here.
         if (global.appshell) {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -21,6 +21,8 @@
  *
  */
 
+ /*global appshell */
+
 /**
  * Initializes the global "brackets" variable and it's properties.
  * Modules should not access the global.brackets object until either
@@ -42,7 +44,7 @@ define(function (require, exports, module) {
     var Fn = Function, global = (new Fn("return this"))();
     if (!global.brackets) {
         // Earlier this initialization was happening inside appshell_extensions.js. But
-        // since the newer CEF versions have stronger JS checks render process was crashing 
+        // since the newer CEF versions have stronger JS checks render process was crashing
         // siting JS eval error. So moved the initialization to here.
         if (appshell) {
             global.brackets = appshell;


### PR DESCRIPTION
With newer versions of CEF, brackets object initialization inside `appshell_extensions.js` is causing a crash in the app. So moved the initialization to Brackets side where Brackets variable is defined. This was required as we are moving to a later version of CEF, 2785 on Linux only.

@abhijitapte @boopeshmahendran Could you please review this PR?