### PR TITLE
Adding a unit test which will use the production url rather than local files

### DIFF
--- a/test/spec/UpdateNotification-test.js
+++ b/test/spec/UpdateNotification-test.js
@@ -59,6 +59,22 @@ define(function (require, exports, module) {
                 // always pretend to run with en locale
                 spyOn(testWindow.brackets, "getLocale").andReturn("en");
             });
+            
+            it("should be able to parse the JSON returned by actual URL (all the other unit-tests use local files)", function () {
+                var updateInfo = {
+                    _buildNumber: 1,
+                    lastNotifiedBuildNumber: 0
+                };
+
+                runs(function () {
+                    var promise = UpdateNotification.checkForUpdate(false, updateInfo);
+                    waitsForDone(promise, "Check for updates", 10000);
+                });
+
+                runs(function () {
+                    expect($(testWindow.document).find(".update-dialog.instance").length).toBe(1);
+                });
+            });
 
             it("should show a notification if an update is available", function () {
                 var updateInfo = {


### PR DESCRIPTION
Current unit tests for Update Notification use local files. There is no unit test which uses the original URL. If someone modifies the schema returned by the original URL, then the current set of unit tests cannot catch it. Adding a unit test to address this scenario. 
@swmitra @nethip @petetnt @mbhavi