### PR TITLE
In case unsaved file, Tern is returning filename without forward slash

### DIFF
--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -88,7 +88,8 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
 
         function isInSameFile(obj, refsResp) {
-            return (obj && obj.file === refsResp.file);
+            // In case of unsaved files, After renameing once Tern is returning filename without forward slash
+            return (obj && (obj.file === refsResp.file || (obj.file === refsResp.file.slice(1, refsResp.file.length))));
         }
 
         /**

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
 
         function isInSameFile(obj, refsResp) {
             // In case of unsaved files, After renameing once Tern is returning filename without forward slash
-            return (obj && (obj.file === refsResp.file || (obj.file === refsResp.file.slice(1, refsResp.file.length))));
+            return (obj && (obj.file === refsResp.file || obj.file === refsResp.file.slice(1, refsResp.file.length)));
         }
 
         /**


### PR DESCRIPTION
Fixing issue https://github.com/adobe/brackets/issues/14053

Please review @swmitra @nethip @boopeshmahendran 