### PR TITLE
Add 'onHighlight' optional event callback mechanism for better extensibility features in hint providers

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -150,6 +150,10 @@ define(function (require, exports, module) {
 
             $item.find("a").addClass("highlight");
             ViewUtils.scrollElementIntoView($view, $item, false);
+
+            if (this.handleHighlight) {
+                this.handleHighlight($item.find("a"));
+            }
         }
     };
 
@@ -542,6 +546,15 @@ define(function (require, exports, module) {
      */
     CodeHintList.prototype.onSelect = function (callback) {
         this.handleSelect = callback;
+    };
+
+    /**
+      * Set the hint list highlight callback function
+      *
+      * @param {Function} callback
+      */
+    CodeHintList.prototype.onHighlight = function (callback) {
+        this.handleHighlight = callback;
     };
 
     /**

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -507,6 +507,12 @@ define(function (require, exports, module) {
 
             sessionEditor = editor;
             hintList = new CodeHintList(sessionEditor, insertHintOnTab, maxCodeHints);
+            hintList.onHighlight(function ($hint) {
+                // If the current hint provider listening for hint item highlight change
+                if (sessionProvider.onHighlight) {
+                    sessionProvider.onHighlight($hint);
+                }
+            });
             hintList.onSelect(function (hint) {
                 var restart = sessionProvider.insertHint(hint),
                     previousEditor = sessionEditor;


### PR DESCRIPTION
This PR is targeted to add an optional `onHighlight` hook handling for Code hint providers. This will help extension developers to add interactive workflows when a user crawls over hint items in hint popup. 

@nethip @petetnt All yours now, please have a look at the change set.  