### PR TITLE
Enable opening of remote(http|https) files in Brackets

### DIFF
--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -323,10 +323,11 @@ define(function (require, exports, module) {
      * If all you need is the Document's getText() value, use the faster getDocumentText() instead.
      *
      * @param {!string} fullPath
+     * @param {!object} fileObj actual File|RemoteFile or some other protocol adapter handle
      * @return {$.Promise} A promise object that will be resolved with the Document, or rejected
      *      with a FileSystemError if the file is not yet open and can't be read from disk.
      */
-    function getDocumentForPath(fullPath) {
+    function getDocumentForPath(fullPath, fileObj) {
         var doc = getOpenDocumentForPath(fullPath);
 
         if (doc) {
@@ -342,7 +343,7 @@ define(function (require, exports, module) {
                 return promise;
             }
 
-            var file            = FileSystem.getFileForPath(fullPath),
+            var file            = fileObj || FileSystem.getFileForPath(fullPath),
                 pendingPromise  = getDocumentForPath._pendingDocumentPromises[file.id];
 
             if (pendingPromise) {

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
      */
     function ImageView(file, $container) {
         this.file = file;
-        this.$el = $(Mustache.render(ImageViewTemplate, {fullPath: FileUtils.encodeFilePath(file.fullPath),
+        this.$el = $(Mustache.render(ImageViewTemplate, {fullPath: file.encodedPath || 'file:///' + FileUtils.encodeFilePath(file.fullPath),
                                                          now: new Date().valueOf()}));
 
         $container.append(this.$el);

--- a/src/extensions/default/RemoteFileAdapter/RemoteFile.js
+++ b/src/extensions/default/RemoteFileAdapter/RemoteFile.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
      * @param {!string} fullPath The full path for this File.
      * @param {!FileSystem} fileSystem The file system associated with this File.
      */
-    function RemoteFile(fullPath, fileSystem) {
+    function RemoteFile(protocol, fullPath, fileSystem) {
         this._isFile = true;
         this._isDirectory = false;
         this._path = fullPath;
@@ -65,6 +65,8 @@ define(function (require, exports, module) {
         this._name = fullPath.split('/').pop();
         this._fileSystem = fileSystem;
         this.donotWatch = true;
+        this.protocol = protocol;
+        this.encodedPath = fullPath;
     }
 
     // Add "fullPath", "name", "parent", "id", "isFile" and "isDirectory" getters
@@ -103,7 +105,21 @@ define(function (require, exports, module) {
      * Helpful toString for debugging and equality check purposes
      */
     RemoteFile.prototype.toString = function () {
-        return "[" + (this._isDirectory ? "Directory " : "RemoteFile ") + this._path + "]";
+        return "[RemoteFile " + this._path + "]";
+    };
+
+    /**
+     * Returns the stats for the remote entry.
+     *
+     * @param {function (?string, FileSystemStats=)} callback Callback with a
+     *      FileSystemError string or FileSystemStats object.
+     */
+    RemoteFile.prototype.stat = function (callback) {
+        if (this._stat) {
+            callback(null, this._stat);
+        } else {
+            callback(FileSystemError.NOT_FOUND);
+        }
     };
 
     RemoteFile.prototype.constructor = RemoteFile;

--- a/src/extensions/default/RemoteFileAdapter/RemoteFile.js
+++ b/src/extensions/default/RemoteFileAdapter/RemoteFile.js
@@ -99,15 +99,11 @@ define(function (require, exports, module) {
         }
     });
 
-    RemoteFile.prototype.exists = function (callback) {
-        callback(null, true);
-    };
-
     /**
      * Helpful toString for debugging and equality check purposes
      */
     RemoteFile.prototype.toString = function () {
-        return "[" + (this._isDirectory ? "Directory " : "File ") + this._path + "]";
+        return "[" + (this._isDirectory ? "Directory " : "RemoteFile ") + this._path + "]";
     };
 
     RemoteFile.prototype.constructor = RemoteFile;
@@ -189,7 +185,7 @@ define(function (require, exports, module) {
     };
 
     RemoteFile.prototype.exists = function (callback) {
-        callback(null, false);
+        callback(null, true);
     };
 
     RemoteFile.prototype.unlink = function (callback) {

--- a/src/extensions/default/RemoteFileAdapter/RemoteFile.js
+++ b/src/extensions/default/RemoteFileAdapter/RemoteFile.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
 
     var SESSION_START_TIME = new Date();
 
-    /*
+    /**
      * Create a new file stat. See the FileSystemStats class for more details.
      *
      * @param {!string} fullPath The full path for this File.
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         });
     }
 
-    /*
+    /**
      * Model for a RemoteFile.
      *
      * This class should *not* be instantiated directly. Use FileSystem.getFileForPath

--- a/src/extensions/default/RemoteFileAdapter/RemoteFile.js
+++ b/src/extensions/default/RemoteFileAdapter/RemoteFile.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2018 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var FileSystemError = brackets.getModule("filesystem/FileSystemError"),
+        FileSystemStats = brackets.getModule("filesystem/FileSystemStats");
+
+    var SESSION_START_TIME = new Date();
+
+    /*
+     * Create a new file stat. See the FileSystemStats class for more details.
+     *
+     * @param {!string} fullPath The full path for this File.
+     * @return {FileSystemStats} stats.
+     */
+    function _getStats(uri) {
+        return new FileSystemStats({
+            isFile: true,
+            mtime: SESSION_START_TIME.toISOString(),
+            size: 0,
+            realPath: uri,
+            hash: uri
+        });
+    }
+
+    /*
+     * Model for a RemoteFile.
+     *
+     * This class should *not* be instantiated directly. Use FileSystem.getFileForPath
+     *
+     * See the FileSystem class for more details.
+     *
+     * @constructor
+     * @param {!string} fullPath The full path for this File.
+     * @param {!FileSystem} fileSystem The file system associated with this File.
+     */
+    function RemoteFile(fullPath, fileSystem) {
+        this._isFile = true;
+        this._isDirectory = false;
+        this._path = fullPath;
+        this._stat = _getStats(fullPath);
+        this._id = fullPath;
+        this._name = fullPath.split('/').pop();
+        this._fileSystem = fileSystem;
+        this.donotWatch = true;
+    }
+
+    // Add "fullPath", "name", "parent", "id", "isFile" and "isDirectory" getters
+    Object.defineProperties(RemoteFile.prototype, {
+        "fullPath": {
+            get: function () { return this._path; },
+            set: function () { throw new Error("Cannot set fullPath"); }
+        },
+        "name": {
+            get: function () { return this._name; },
+            set: function () { throw new Error("Cannot set name"); }
+        },
+        "parentPath": {
+            get: function () { return this._parentPath; },
+            set: function () { throw new Error("Cannot set parentPath"); }
+        },
+        "id": {
+            get: function () { return this._id; },
+            set: function () { throw new Error("Cannot set id"); }
+        },
+        "isFile": {
+            get: function () { return this._isFile; },
+            set: function () { throw new Error("Cannot set isFile"); }
+        },
+        "isDirectory": {
+            get: function () { return this._isDirectory; },
+            set: function () { throw new Error("Cannot set isDirectory"); }
+        },
+        "_impl": {
+            get: function () { return this._fileSystem._impl; },
+            set: function () { throw new Error("Cannot set _impl"); }
+        }
+    });
+
+    RemoteFile.prototype.exists = function (callback) {
+        callback(null, true);
+    };
+
+    /**
+     * Helpful toString for debugging and equality check purposes
+     */
+    RemoteFile.prototype.toString = function () {
+        return "[" + (this._isDirectory ? "Directory " : "File ") + this._path + "]";
+    };
+
+    RemoteFile.prototype.constructor = RemoteFile;
+
+    /**
+     * Cached contents of this file. This value is nullable but should NOT be undefined.
+     * @private
+     * @type {?string}
+     */
+    RemoteFile.prototype._contents = null;
+
+
+    /**
+     * @private
+     * @type {?string}
+     */
+    RemoteFile.prototype._encoding = "utf8";
+
+    /**
+     * @private
+     * @type {?bool}
+     */
+    RemoteFile.prototype._preserveBOM = false;
+
+
+    /**
+     * Clear any cached data for this file. Note that this explicitly does NOT
+     * clear the file's hash.
+     * @private
+     */
+    RemoteFile.prototype._clearCachedData = function () {
+        // no-op
+    };
+
+    /**
+     * Reads a remote file.
+     *
+     * @param {Object=} options Currently unused.
+     * @param {function (?string, string=, FileSystemStats=)} callback Callback that is passed the
+     *              FileSystemError string or the file's contents and its stats.
+     */
+    RemoteFile.prototype.read = function (options, callback) {
+        if (typeof (options) === "function") {
+            callback = options;
+        }
+        this._encoding = "utf8";
+
+        if (this._contents !== null && this._stat) {
+            callback(null, this._contents, this._encoding, this._stat);
+            return;
+        }
+
+        var self = this;
+        $.ajax({
+            url: this.fullPath
+        })
+        .done(function (data) {
+            self._contents = data;
+            callback(null, data, self._encoding, self._stat);
+        })
+        .fail(function (e) {
+            callback(FileSystemError.NOT_FOUND);
+        });
+    };
+
+    /**
+     * Write a file.
+     *
+     * @param {string} data Data to write.
+     * @param {object=} options Currently unused.
+     * @param {function (?string, FileSystemStats=)=} callback Callback that is passed the
+     *              FileSystemError string or the file's new stats.
+     */
+    RemoteFile.prototype.write = function (data, encoding, callback) {
+        if (typeof (encoding) === "function") {
+            callback = encoding;
+        }
+        callback(FileSystemError.NOT_FOUND);
+    };
+
+    RemoteFile.prototype.exists = function (callback) {
+        callback(null, false);
+    };
+
+    RemoteFile.prototype.unlink = function (callback) {
+        callback(FileSystemError.NOT_FOUND);
+    };
+
+    RemoteFile.prototype.rename = function (newName, callback) {
+        callback(FileSystemError.NOT_FOUND);
+    };
+
+    RemoteFile.prototype.moveToTrash = function (callback) {
+        callback(FileSystemError.NOT_FOUND);
+    };
+
+    // Export this class
+    module.exports = RemoteFile;
+});

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -56,10 +56,8 @@ define(function (require, exports, module) {
                     return [HTTP_PROTOCOL, HTTPS_PROTOCOL].indexOf(protocol) !== -1;
                 },
                 itemFocus: function (query) {
-                    console.log(" in focus" + arguments);
                 }, // no op
                 itemSelect: function () {
-                    console.log(arguments);
                     CommandManager.execute(Commands.FILE_OPEN, {fullPath: arguments[0]});
                 }
             }

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -44,6 +44,11 @@ define(function (require, exports, module) {
             }
         };
 
+        // Register the custom object as HTTP and HTTPS protocol adapter
+        FileSystem.registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
+        FileSystem.registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
+
+        // Register as quick open plugin for file URI's having HTTP:|HTTPS: protocol
         QuickOpen.addQuickOpenPlugin(
             {
                 name: "Remote file URI input",
@@ -62,9 +67,6 @@ define(function (require, exports, module) {
                 }
             }
         );
-
-        FileSystem.registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
-        FileSystem.registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
     });
 
 });

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var AppInit     = brackets.getModule("utils/AppInit"),
+        FileSystem  = brackets.getModule("filesystem/FileSystem"),
+        RemoteFile  = require("RemoteFile");
+
+    var HTTP_PROTOCOL = "http:",
+        HTTPS_PROTOCOL = "https:";
+
+    AppInit.htmlReady(function() {
+
+        var protocolAdapter = {
+            priority: 0, // Default priority
+            fileImpl: RemoteFile,
+            canRead: function (filePath) {
+                return true; // Always claim true, we are the default adpaters
+            }
+        };
+
+        FileSystem.registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
+        FileSystem.registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
+    });
+
+});

--- a/src/extensions/default/RemoteFileAdapter/unittests.js
+++ b/src/extensions/default/RemoteFileAdapter/unittests.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, spyOn */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
+        FileUtils		= brackets.getModule("file/FileUtils"),
+        CommandManager,
+        Commands,
+        Dialogs,
+        EditorManager,
+        DocumentManager,
+        MainViewManager,
+        FileSystem;
+
+    var REMOTE_FILE_PATH = "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
+        INVALID_REMOTE_FILE_PATH = "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/invalid.min.css";
+
+
+
+    describe("RemoteFileAdapter", function () {
+        var testWindow,
+            $,
+            brackets;
+
+        function createRemoteFile(filePath) {
+            return CommandManager.execute(Commands.FILE_OPEN, {fullPath: filePath});
+        }
+
+        function deleteCurrentRemoteFile() {
+            CommandManager.execute(Commands.FILE_DELETE);
+        }
+
+        function saveRemoteFile() {
+            CommandManager.execute(Commands.FILE_SAVE);
+        }
+
+        function renameRemoteFile(filePath) {
+            CommandManager.execute(Commands.FILE_RENAME);
+        }
+
+        function closeRemoteFile(filePath) {
+            CommandManager.execute(Commands.FILE_CLOSE, {fullPath: filePath});
+        }
+
+        beforeEach(function () {
+            runs(function () {
+                SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
+                    testWindow = w;
+                    $ = testWindow.$;
+                    brackets		= testWindow.brackets;
+                    DocumentManager = testWindow.brackets.test.DocumentManager;
+                    MainViewManager = testWindow.brackets.test.MainViewManager;
+                    CommandManager  = testWindow.brackets.test.CommandManager;
+                    EditorManager   = testWindow.brackets.test.EditorManager;
+                    Dialogs			= testWindow.brackets.test.Dialogs;
+                    Commands        = testWindow.brackets.test.Commands;
+                    FileSystem      = testWindow.brackets.test.FileSystem;
+                });
+            });
+        });
+
+        afterEach(function () {
+            testWindow    = null;
+            $             = null;
+            brackets      = null;
+            EditorManager = null;
+            SpecRunnerUtils.closeTestWindow();
+        });
+
+
+        it("Open/close remote https file", function () {
+            createRemoteFile(REMOTE_FILE_PATH).done(function () {
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(1);
+                closeRemoteFile(REMOTE_FILE_PATH).done(function () {
+                    expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(0);
+                });
+            });
+        });
+
+        it("Open invalid remote file", function () {
+            spyOn(Dialogs, 'showModalDialog').andCallFake(function (dlgClass, title, message, buttons) {
+                console.warn(title, message);
+                return {done: function (callback) { callback(Dialogs.DIALOG_BTN_OK); } };
+            });
+            createRemoteFile(INVALID_REMOTE_FILE_PATH).always(function () {
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(0);
+                expect(Dialogs.showModalDialog).toHaveBeenCalled();
+                expect(Dialogs.showModalDialog.callCount).toBe(1);
+            });
+        });
+
+        it("Save remote file", function () {
+            createRemoteFile(REMOTE_FILE_PATH).done(function () {
+                spyOn(Dialogs, 'showModalDialog').andCallFake(function (dlgClass, title, message, buttons) {
+                    console.warn(title, message);
+                    return {done: function (callback) { callback(Dialogs.DIALOG_BTN_OK); } };
+                });
+                saveRemoteFile();
+                expect(Dialogs.showModalDialog).toHaveBeenCalled();
+                expect(Dialogs.showModalDialog.callCount).toBe(1);
+                closeRemoteFile(REMOTE_FILE_PATH).done(function () {
+                    expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(0);
+                });
+            });
+        });
+
+        it("Delete remote file", function () {
+            createRemoteFile(REMOTE_FILE_PATH).done(function () {
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(1);
+                spyOn(Dialogs, 'showModalDialog').andCallFake(function (dlgClass, title, message, buttons) {
+                    console.warn(title, message);
+                    return {done: function (callback) { callback(Dialogs.DIALOG_BTN_OK); } };
+                });
+                deleteCurrentRemoteFile();
+                expect(Dialogs.showModalDialog).toHaveBeenCalled();
+                expect(Dialogs.showModalDialog.callCount).toBe(1);
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(1);
+                closeRemoteFile(REMOTE_FILE_PATH).done(function () {
+                    expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(0);
+                });
+            });
+        });
+
+        it("Rename remote file", function () {
+            createRemoteFile(REMOTE_FILE_PATH).done(function () {
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(1);
+                spyOn(Dialogs, 'showModalDialog').andCallFake(function (dlgClass, title, message, buttons) {
+                    console.warn(title, message);
+                    return {done: function (callback) { callback(Dialogs.DIALOG_BTN_OK); } };
+                });
+                renameRemoteFile();
+                expect(Dialogs.showModalDialog).toHaveBeenCalled();
+                expect(Dialogs.showModalDialog.callCount).toBe(1);
+                expect(MainViewManager.getWorkingSet(MainViewManager.ACTIVE_PANE).length).toEqual(1);
+            });
+        });
+    });
+});

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -103,9 +103,17 @@ define(function (require, exports, module) {
     var _fileProtocolPlugins = {};
 
     /**
+     * Typical signature of a file protocol adapter.
+     * @typedef {Object} FileProtocol~Adapter
+     * @property {Number} priority - Indicates the priority.
+     * @property {Object} fileImpl - Handle for the custom file implementation prototype.
+     * @property {function} canRead - To check if this impl can read a file for a given path.
+     */
+
+    /**
      * FileSystem hook to register file protocol adapter
      * @param {string} protocol ex: "https:"|"http:"|"ftp:"|"file:"
-     * @param {object} adapter adapter wrapper over file implementation
+     * @param {...FileProtocol~Adapter} adapter wrapper over file implementation
      */
     function registerProtocolAdapter(protocol, adapter) {
         var adapters;

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -632,7 +632,7 @@ define(function (require, exports, module) {
             protocolAdapter = _getProtocolAdapter(protocol);
 
         if (protocolAdapter && protocolAdapter.fileImpl) {
-            return new protocolAdapter.fileImpl(path, this);
+            return new protocolAdapter.fileImpl(protocol, path, this);
         } else {
             return this._getEntryForPath(File, path);
         }

--- a/src/htmlContent/image-view.html
+++ b/src/htmlContent/image-view.html
@@ -6,7 +6,7 @@
         </div>
         <div class="image">
             <div class="image-scale"></div>
-            <img class="image-preview" src="file:///{{fullPath}}?ver={{now}}">
+            <img class="image-preview" src="{{fullPath}}?ver={{now}}">
             <div class="image-tip">
                 <table class="tip-container">
                     <tr>

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -111,6 +111,8 @@ define(function (require, exports, module) {
 
             if (doc.isUntitled()) {
                 result.resolve();
+            } else if (doc.file.donotWatch) { // Some file might not like to be watched!
+                result.resolve();
             } else {
                 doc.file.stat(function (err, stat) {
                     if (!err) {

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -343,9 +343,7 @@ define(function (require, exports, module) {
         if (!_traversingFileList) {
             pane.makeViewMostRecent(file);
 
-            index = _.findIndex(_mruList, function (record) {
-                return (record.file === file && record.paneId === pane.id);
-            });
+            index = _findFileInMRUList(pane.id, file);
 
             entry = _makeMRUListEntry(file, pane.id);
 
@@ -1288,9 +1286,9 @@ define(function (require, exports, module) {
                 });
         }
 
-        result.done(function () {
-            _makeFileMostRecent(paneId, file);
-        });
+       result.done(function () {
+           _makeFileMostRecent(paneId, file);
+       });
 
         return result;
     }

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1271,7 +1271,7 @@ define(function (require, exports, module) {
                 }
             });
         } else {
-            DocumentManager.getDocumentForPath(file.fullPath)
+            DocumentManager.getDocumentForPath(file.fullPath, file)
                 .done(function (doc) {
                     if (doc) {
                         _edit(paneId, doc, $.extend({}, options, {


### PR DESCRIPTION
This PR adds File protocol adoption model to support various file protocols which mainly differs in read and write mechanism. With this PR we are adding a reference implementation for this protocol adapter model by enabling `HTTP|HTTPS` protocols. We are introducing a new protocol adapter registration hook in `FileSystem` module as `function registerProtocolAdapter(protocol, adapter)` where `protocol` can be any valid file protocol string like 

> HTTP: | HTTPS: | FTP: | SFTP: 

 for which we want to add support. `adapter` is the the actual protocol adapter object which should expose `canRead(filePath)` function handle and `fileImpl` which is the `File` interface implementation prototype handle, this will be be used by `FileSystem` to instantiate this new type of `File` if the protocol adapter is selected based on the `filePath`. 

This change list also adds a plugin in `QuickOpen`, enabling user to input remote file path (`HTTP | HTTPS `) in QuickOpen file search dialog to open a file. 

TODO
------

- [x] Unit tests
- [x] Ux workflow
- [x] List remote files in Quick open file search list
