### PR TITLE
Fix to avoid window location change confirmation dialog while running tests - onbeforeunload conditional registration

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1728,10 +1728,6 @@ define(function (require, exports, module) {
     var isTestWindow = (new window.URLSearchParams(window.location.search || "")).get("testEnvironment");
     if (!isTestWindow) {
         window.onbeforeunload = function(e) {
-            if (window.location.pathname.indexOf('SpecRunner') > -1) {
-                return;
-            }
-
             var openDocs = DocumentManager.getAllOpenDocuments();
 
             // Detect any unsaved changes

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1722,28 +1722,33 @@ define(function (require, exports, module) {
     /**
      * Attach a beforeunload handler to notify user about unsaved changes and URL redirection in CEF.
      * Prevents data loss in scenario reported under #13708
+     * Make sure we don't attach this handler if the current window is actually a test window
     **/
-    window.onbeforeunload = function(e) {
-        if (window.location.pathname.indexOf('SpecRunner') > -1) {
-            return;
-        }
 
-        var openDocs = DocumentManager.getAllOpenDocuments();
-
-        // Detect any unsaved changes
-        openDocs = openDocs.filter(function(doc) {
-            return doc && doc.isDirty;
-        });
-
-        // Ensure we are not in normal app-quit or reload workflow
-        if (!_isReloading && !_windowGoingAway) {
-            if (openDocs.length > 0) {
-                return Strings.WINDOW_UNLOAD_WARNING_WITH_UNSAVED_CHANGES;
-            } else {
-                return Strings.WINDOW_UNLOAD_WARNING;
+    var isTestWindow = (new window.URLSearchParams(window.location.search || "")).get("testEnvironment");
+    if (!isTestWindow) {
+        window.onbeforeunload = function(e) {
+            if (window.location.pathname.indexOf('SpecRunner') > -1) {
+                return;
             }
-        }
-    };
+
+            var openDocs = DocumentManager.getAllOpenDocuments();
+
+            // Detect any unsaved changes
+            openDocs = openDocs.filter(function(doc) {
+                return doc && doc.isDirty;
+            });
+
+            // Ensure we are not in normal app-quit or reload workflow
+            if (!_isReloading && !_windowGoingAway) {
+                if (openDocs.length > 0) {
+                    return Strings.WINDOW_UNLOAD_WARNING_WITH_UNSAVED_CHANGES;
+                } else {
+                    return Strings.WINDOW_UNLOAD_WARNING;
+                }
+            }
+        };
+    }
 
     /** Do some initialization when the DOM is ready **/
     AppInit.htmlReady(function () {


### PR DESCRIPTION
This PR adds `testEnvironment` search param validation to skip `onbeforeunload` registration if the current brackets window is a test window.

@nethip @petetnt Please review.

@vickramdhawal You can use this patch to run tests 😄 