### PR TITLE
Fixing issue 14163, F&R replaces all content of file when replacing new line

### DIFF
--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -148,7 +148,7 @@ define(function (require, exports, module) {
         while ((match = queryExpr.exec(contents)) !== null) {
             lineNum          = StringUtils.offsetToLineNum(lines, match.index);
             line             = lines[lineNum];
-            ch               = match.index - contents.lastIndexOf("\n", match.index) - 1;  // 0-based index
+            ch               = match.index - contents.lastIndexOf("\n", match.index - 1) - 1;  // 0-based index
             matchedLines     = match[0].split("\n");
             numMatchedLines  = matchedLines.length;
             totalMatchLength = match[0].length;


### PR DESCRIPTION
Edge case for "\n". In this case, the value of ch was -1 because of match.index value and value returned by lastIndexOf is same.

Issue https://github.com/adobe/brackets/issues/14163

Please review @swmitra @nethip