### PR TITLE
Feature/add meta viewport tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,7 @@
 <html spellcheck="false">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title></title>
 
     <!-- CSS/LESS -->


### PR DESCRIPTION
This PR allows Brackets to be more responsive when being moved from different screen sizes. I use an external monitor with my mac and when I move brackets from my mac screen to my external monitor, it doesn't size properly so it becomes an annoyance. The meta viewport tag should allow for it to be responsive when moving brackets between different screen sizes.

https://www.w3schools.com/css/css_rwd_viewport.asp