### PR TITLE
Add error strings for drag and drop in filetreeview

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -66,6 +66,8 @@ define({
     "ERROR_RENAMING_FILE_TITLE"         : "Error Renaming {0}",
     "ERROR_RENAMING_FILE"               : "An error occurred when trying to rename the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "ERROR_RENAMING_NOT_IN_PROJECT"     : "The file or directory is not part of the currently opened project. Unfortunately, only project files can be renamed at this point.",
+    "ERROR_MOVING_FILE_TITLE"           : "Error Moving {0}",
+    "ERROR_MOVING_FILE"                 : "An error occurred when trying to move the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "ERROR_DELETING_FILE_TITLE"         : "Error Deleting {0}",
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid {0}",


### PR DESCRIPTION
This PR adds the error strings that will be used [here](https://github.com/adobe/brackets/pull/13546/commits/f416c6552fde82fbd4310fd94d5aa1bb5ed21fcc) 