### PR TITLE
Fix issue 14298

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -991,6 +991,7 @@ define(function (require, exports, module) {
             viewModel.renameItem(oldProjectPath, self.makeProjectRelativeIfPossible(newPath));
             if (self._selections.selected && self._selections.selected.indexOf(oldPath) === 0) {
                 self._selections.selected = newPath + self._selections.selected.slice(oldPath.length);
+                self.setCurrentFile(newPath);
             }
         }
 


### PR DESCRIPTION
Fixes #14298 
If the selected file is renamed(or moved), keep track of it in the `_currentPath` variable