### PR TITLE
Correcting file name if file path ends with forward slash

### DIFF
--- a/src/extensions/default/RemoteFileAdapter/RemoteFile.js
+++ b/src/extensions/default/RemoteFileAdapter/RemoteFile.js
@@ -44,6 +44,17 @@ define(function (require, exports, module) {
             hash: uri
         });
     }
+    
+    function _getFileName(filePath) {
+        var fileName = filePath.split('/').pop();
+        
+        if (!fileName.trim()) {
+            fileName = filePath.trim().slice(0, -1);
+            fileName = fileName.split('/').pop();
+        }
+        
+        return fileName;
+    }
 
     /**
      * Model for a RemoteFile.
@@ -62,7 +73,7 @@ define(function (require, exports, module) {
         this._path = fullPath;
         this._stat = _getStats(fullPath);
         this._id = fullPath;
-        this._name = fullPath.split('/').pop();
+        this._name = _getFileName(fullPath);
         this._fileSystem = fileSystem;
         this.donotWatch = true;
         this.protocol = protocol;


### PR DESCRIPTION
Issue : - When we copy a homepage URL of any website then we get URL ending with forwarding slash i.e. http://brackets.io/ and when we try to open any such URL in brackets then we get file name as "".
