### PR TITLE
Disabling certain working set context menu items for remote files

### DIFF
--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
         Commands        = brackets.getModule("command/Commands"),
         Menus           = brackets.getModule("command/Menus"),
         MainViewManager = brackets.getModule("view/MainViewManager"),
+        WorkingSetView  = brackets.getModule("project/WorkingSetView"),
         RemoteFile      = require("RemoteFile");
 
     var HTTP_PROTOCOL = "http:",
@@ -41,7 +42,7 @@ define(function (require, exports, module) {
      * Disable context menus which are not useful for remote file
      */
     function _setMenuItemsVisible() {
-        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
+        var file = WorkingSetView.getContext(),
             cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS];
         
         if (file.constructor.name === "RemoteFile") {

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -31,7 +31,6 @@ define(function (require, exports, module) {
         CommandManager  = brackets.getModule("command/CommandManager"),
         Commands        = brackets.getModule("command/Commands"),
         Menus           = brackets.getModule("command/Menus"),
-        MainViewManager = brackets.getModule("view/MainViewManager"),
         WorkingSetView  = brackets.getModule("project/WorkingSetView"),
         RemoteFile      = require("RemoteFile");
 

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -42,15 +42,15 @@ define(function (require, exports, module) {
      */
     function _setMenuItemsVisible() {
         var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
-            cMenusFile = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS];
+            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS];
         
-        if (file.toString().indexOf("[RemoteFile") === 0) {
-            cMenusFile.forEach(function (menu) {
-                CommandManager.get(menu).setEnabled(false);
+        if (file.constructor.name === "RemoteFile") {
+            cMenuItems.forEach(function (item) {
+                CommandManager.get(item).setEnabled(false);
             });
         } else {
-            //Explicitly handeling save other commands are handeled by DefaultMenus
-            CommandManager.get(cMenusFile[0]).setEnabled(true);
+            //Explicitly enabling save, other commands are handled by DefaultMenus.js
+            CommandManager.get(Commands.FILE_SAVE).setEnabled(true);
         }
     }
 

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -30,12 +30,34 @@ define(function (require, exports, module) {
         PathUtils       = brackets.getModule("thirdparty/path-utils/path-utils"),
         CommandManager  = brackets.getModule("command/CommandManager"),
         Commands        = brackets.getModule("command/Commands"),
+        Menus           = brackets.getModule("command/Menus"),
+        MainViewManager = brackets.getModule("view/MainViewManager"),
         RemoteFile      = require("RemoteFile");
 
     var HTTP_PROTOCOL = "http:",
         HTTPS_PROTOCOL = "https:";
+    
+    /**
+     * Disable context menus which are not useful for remote file
+     */
+    function _setMenuItemsVisible() {
+        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
+            cMenusFile = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS];
+        
+        if (file.toString().indexOf("[RemoteFile") === 0) {
+            cMenusFile.forEach(function (menu) {
+                CommandManager.get(menu).setEnabled(false);
+            });
+        } else {
+            //Explicitly handeling save other commands are handeled by DefaultMenus
+            CommandManager.get(cMenusFile[0]).setEnabled(true);
+        }
+    }
 
     AppInit.htmlReady(function () {
+        
+        Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU).on("beforeContextMenuOpen", _setMenuItemsVisible);
+        
         var protocolAdapter = {
             priority: 0, // Default priority
             fileImpl: RemoteFile,

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -60,6 +60,13 @@ define(function (require, exports, module) {
     var _iconProviders = [];
 
     /**
+     * The file/folder object of the current context
+     * @type {FileSystemEntry}
+     * @private
+     */
+    var _contextEntry;
+
+    /**
      * Class Providers
      * @see {@link #addClassProvider}
      * @private
@@ -78,7 +85,8 @@ define(function (require, exports, module) {
      * @enum {number}
      */
     var LEFT_BUTTON = 1,
-        MIDDLE_BUTTON = 2;
+        MIDDLE_BUTTON = 2,
+        RIGHT_BUTTON = 3;
 
     /**
      * Each list item in the working set stores a references to the related document in the list item's data.
@@ -773,6 +781,11 @@ define(function (require, exports, module) {
                                 .always(function () {
                                     postDropCleanup();
                                 });
+
+                            // Set the context entry if the click is a right click
+                            if (e.which === RIGHT_BUTTON) {
+                                _contextEntry = sourceFile;
+                            }
                         }
                     } else {
                         // no need to refresh
@@ -1489,6 +1502,13 @@ define(function (require, exports, module) {
             $element.addClass(provider(data));
         });
     }
+
+    /**
+     * Gets the filesystem object for the current context in the working set.
+     */
+    function getContext() {
+        return _contextEntry;
+    }
     
     // Public API
     exports.createWorkingSetViewForPane   = createWorkingSetViewForPane;
@@ -1496,6 +1516,7 @@ define(function (require, exports, module) {
     exports.addIconProvider               = addIconProvider;
     exports.addClassProvider              = addClassProvider;
     exports.syncSelectionIndicator        = syncSelectionIndicator;
+    exports.getContext                    = getContext;
     
     // API to be used only by default extensions
     exports.useIconProviders              = useIconProviders;


### PR DESCRIPTION
Issue Fixed : - Disabling four commands Save, Show in Explorer, Show in the file tree, Rename.