### PR TITLE
Set the context entry on context menu event

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -85,8 +85,7 @@ define(function (require, exports, module) {
      * @enum {number}
      */
     var LEFT_BUTTON = 1,
-        MIDDLE_BUTTON = 2,
-        RIGHT_BUTTON = 3;
+        MIDDLE_BUTTON = 2;
 
     /**
      * Each list item in the working set stores a references to the related document in the list item's data.

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -781,11 +781,6 @@ define(function (require, exports, module) {
                                 .always(function () {
                                     postDropCleanup();
                                 });
-
-                            // Set the context entry if the click is a right click
-                            if (e.which === RIGHT_BUTTON) {
-                                _contextEntry = sourceFile;
-                            }
                         }
                     } else {
                         // no need to refresh
@@ -1397,6 +1392,7 @@ define(function (require, exports, module) {
         this.$openFilesContainer.css("overflow-x", "hidden");
 
         this.$openFilesContainer.on("contextmenu.workingSetView", function (e) {
+            _contextEntry = $(e.target).closest("li").data(_FILE_KEY);
             Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU).open(e);
         });
 


### PR DESCRIPTION
Fixes #14334 

The issue was that I was explicitly checking right-click for context-menu on my [PR](https://github.com/adobe/brackets/pull/14326). It seems that there are other key combinations also that trigger contextmenu. So I have changed the implementation to use `contextmenu` event.