### PR TITLE
Introducing a buildtype to config

### DIFF
--- a/src/brackets.config.dev.json
+++ b/src/brackets.config.dev.json
@@ -3,5 +3,6 @@
     "analyticsDataServerURL"     : "https://cc-api-data-stage.adobe.io/ingest",
     "serviceKey"                 : "brackets-service",
     "environment"                : "stage",
-    "update_info_url"            : "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json"
+    "update_info_url"            : "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json",
+    "buildtype"                  : "dev"
 }

--- a/src/brackets.config.dist.json
+++ b/src/brackets.config.dist.json
@@ -3,5 +3,6 @@
     "analyticsDataServerURL"  : "https://cc-api-data.adobe.io/ingest",
     "serviceKey"              : "brackets-service",
     "environment"             : "production",
-    "update_info_url"         : "https://getupdates.brackets.io/getupdates/"
+    "update_info_url"         : "https://getupdates.brackets.io/getupdates/",
+    "buildtype"               : "production"
 }

--- a/src/brackets.config.prerelease.json
+++ b/src/brackets.config.prerelease.json
@@ -2,7 +2,7 @@
     "healthDataServerURL"     : "https://health.brackets.io/healthDataLog",
     "analyticsDataServerURL"  : "https://cc-api-data.adobe.io/ingest",
     "serviceKey"              : "brackets-service",
-    "environment"             : "prerelease",
+    "environment"             : "production",
     "update_info_url"         : "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json",
     "buildtype"               : "prerelease"
 }

--- a/src/brackets.config.prerelease.json
+++ b/src/brackets.config.prerelease.json
@@ -3,5 +3,6 @@
     "analyticsDataServerURL"  : "https://cc-api-data.adobe.io/ingest",
     "serviceKey"              : "brackets-service",
     "environment"             : "prerelease",
-    "update_info_url"         : "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json"
+    "update_info_url"         : "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json",
+    "buildtype"               : "prerelease"
 }

--- a/src/strings.js
+++ b/src/strings.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
     if (isDevBuild) {
         additionalGlobals.BUILD_TYPE = strings.DEVELOPMENT_BUILD;
     } else {
-        if (brackets.config.environment === 'production') {
+        if (brackets.config.buildtype === 'production') {
             additionalGlobals.BUILD_TYPE = strings.RELEASE_BUILD;
         } else {
             additionalGlobals.BUILD_TYPE = strings.PRERELEASE_BUILD;


### PR DESCRIPTION
Introducing a build type key to the config file. Switching the environment back production as the analytics server expects that