### PR TITLE
Fix for Title bar text and Save button issue for empty active pane

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -158,8 +158,8 @@ define(function (require, exports, module) {
         var currentDoc          = DocumentManager.getCurrentDocument(),
             windowTitle         = brackets.config.app_title,
             currentlyViewedFile = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
-            currentlyViewedPath = currentlyViewedFile.fullPath,
-            readOnlyString      = currentlyViewedFile.readOnly ? "[Read Only] - " : "";
+            currentlyViewedPath = currentlyViewedFile && currentlyViewedFile.fullPath,
+            readOnlyString      = (currentlyViewedFile && currentlyViewedFile.readOnly) ? "[Read Only] - " : "";
 
         if (!brackets.nativeMenus) {
             if (currentlyViewedPath) {

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
     function _setMenuItemsVisible() {
         var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
             cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
-            enable = (file.constructor.name !== "RemoteFile");
+            enable = (file && file.constructor.name !== "RemoteFile");
         
             // Enable or disable commands based on whether the file is a remoteFile or not.
             cMenuItems.forEach(function (item) {

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -57,14 +57,18 @@ define(function (require, exports, module) {
      * Disable context menus which are not useful for remote file
      */
     function _setMenuItemsVisible() {
-        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
-            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
-            enable = (file && file.constructor.name !== "RemoteFile");
+        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE);
+        
+        // Set Menu items visibility if a file is present in active pane
+        if (file) {
+            var cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
+                enable = (file.constructor.name !== "RemoteFile");
         
             // Enable or disable commands based on whether the file is a remoteFile or not.
             cMenuItems.forEach(function (item) {
                 CommandManager.get(item).setEnabled(enable);
             });
+        }
     }
 
     AppInit.htmlReady(function () {

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -57,18 +57,15 @@ define(function (require, exports, module) {
      * Disable context menus which are not useful for remote file
      */
     function _setMenuItemsVisible() {
-        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE);
-        
-        // Set Menu items visibility if a file is present in active pane
-        if (file) {
-            var cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
-                enable = (file.constructor.name !== "RemoteFile");
+        var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
+            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
+            // Enable menu options when no file is present in active pane
+            enable = !file || (file.constructor.name !== "RemoteFile");
         
             // Enable or disable commands based on whether the file is a remoteFile or not.
             cMenuItems.forEach(function (item) {
                 CommandManager.get(item).setEnabled(enable);
             });
-        }
     }
 
     AppInit.htmlReady(function () {


### PR DESCRIPTION
- _updateTitle() failed when there is no file opened in active pane. Causing the title bar retaining the text of last opened document as title. Added a null check for that.
- _setMenuItemsVisible() failed when there is no file opened in active pane. Causing the state of file menu options same as for previous file. Added a check to enable menu options if no file is present in active pane.