### PR TITLE
Fixed ExtractToVariable Menu Close Issue due to scrolling

### DIFF
--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -265,6 +265,11 @@ define(function(require, exports, module) {
                 inlineMenu = new InlineMenu(session.editor, Strings.EXTRACTTO_VARIABLE_SELECT_EXPRESSION);
 
                 inlineMenu.onHover(function (expnId) {
+                    editor.off("scroll.inlinemenu");
+                    editor.on("scroll.inlinemenu", function() {
+                        editor.off("scroll.inlinemenu");
+                        inlineMenu.openRemovedMenu();
+                    });
                     editor.setSelection(editor.posFromIndex(expns[expnId].start), editor.posFromIndex(expns[expnId].end));
                 });
 

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -267,6 +267,8 @@ define(function(require, exports, module) {
                 inlineMenu.onHover(function (expnId) {
                     // Remove the scroll Handlers If already Attached.
                     editor.off("scroll.inlinemenu");
+                    // Add a scroll handler If Selection Range is not View.
+                    // This is Added for a Bug, where Menu used not to open for the irst Time
                     if(!editor.isLineVisible(editor.posFromIndex(expns[expnId].end).line)) {
                         editor.on("scroll.inlinemenu", function() {
                             // Remove the Handlers so that If scroll event is triggerd again by any other operation

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -265,8 +265,12 @@ define(function(require, exports, module) {
                 inlineMenu = new InlineMenu(session.editor, Strings.EXTRACTTO_VARIABLE_SELECT_EXPRESSION);
 
                 inlineMenu.onHover(function (expnId) {
+                    // Remove the scroll Handlers If already Attached.
                     editor.off("scroll.inlinemenu");
                     editor.on("scroll.inlinemenu", function() {
+                        // Remove the Handlers so that If scroll event is triggerd again by any other operation
+                        // Menu should not be reopened.
+                        // Menu Should be reopened only if Scroll event is triggered by onHover.
                         editor.off("scroll.inlinemenu");
                         inlineMenu.openRemovedMenu();
                     });

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -268,7 +268,7 @@ define(function(require, exports, module) {
                     // Remove the scroll Handlers If already Attached.
                     editor.off("scroll.inlinemenu");
                     // Add a scroll handler If Selection Range is not View.
-                    // This is Added for a Bug, where Menu used not to open for the irst Time
+                    // This is Added for a Bug, where Menu used not to open for the first Time
                     if(!editor.isLineVisible(editor.posFromIndex(expns[expnId].end).line)) {
                         editor.on("scroll.inlinemenu", function() {
                             // Remove the Handlers so that If scroll event is triggerd again by any other operation

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -267,13 +267,15 @@ define(function(require, exports, module) {
                 inlineMenu.onHover(function (expnId) {
                     // Remove the scroll Handlers If already Attached.
                     editor.off("scroll.inlinemenu");
-                    editor.on("scroll.inlinemenu", function() {
-                        // Remove the Handlers so that If scroll event is triggerd again by any other operation
-                        // Menu should not be reopened.
-                        // Menu Should be reopened only if Scroll event is triggered by onHover.
-                        editor.off("scroll.inlinemenu");
-                        inlineMenu.openRemovedMenu();
-                    });
+                    if(!editor.isLineVisible(editor.posFromIndex(expns[expnId].end).line)) {
+                        editor.on("scroll.inlinemenu", function() {
+                            // Remove the Handlers so that If scroll event is triggerd again by any other operation
+                            // Menu should not be reopened.
+                            // Menu Should be reopened only if Scroll event is triggered by onHover.
+                            editor.off("scroll.inlinemenu");
+                            inlineMenu.openRemovedMenu();
+                        });
+                    }
                     editor.setSelection(editor.posFromIndex(expns[expnId].start), editor.posFromIndex(expns[expnId].end));
                 });
 

--- a/src/widgets/InlineMenu.js
+++ b/src/widgets/InlineMenu.js
@@ -414,6 +414,19 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Displays the last menu which was closed due to Scrolling
+     */
+    InlineMenu.prototype.openRemovedMenu = function () {
+        if (this.opened === true) {
+            if (this.$menu && !this.$menu.hasClass("open")) {
+                var menuPos = this._calcMenuLocation();
+                this.$menu.addClass("open")
+                    .css({"left": menuPos.left, "top": menuPos.top, "width": menuPos.width + "px"});
+            }
+        }
+    };
+
+    /**
      * Closes the menu
      */
     InlineMenu.prototype.close = function () {


### PR DESCRIPTION
ping @boopeshmahendran  for review

For ExtractToVariable If selection range is not in view It scrolls to bring selected text in view, and It triggers scroll event , and scroll event handler closes all dropdown menu.

so to fix this issue. in Mouse Hover listener of Inline Menu, attached a handler to scroll Event, that reopen the inline Menu. If it has been closed due to scrolling triggered Inline Menu Itself. 