### PR TITLE
jsRefactor Rename Relative Path issue fixed

### DIFF
--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
         Session              = brackets.getModule("JSUtils/Session"),
         MessageIds           = brackets.getModule("JSUtils/MessageIds"),
         TokenUtils           = brackets.getModule("utils/TokenUtils"),
-        Strings              = brackets.getModule("strings");
+        Strings              = brackets.getModule("strings"),
+        ProjectManager      = brackets.getModule("project/ProjectManager");
 
     var session             = null,  // object that encapsulates the current session state
         keywords = ["define", "alert", "exports", "require", "module", "arguments"];
@@ -98,7 +99,17 @@ define(function (require, exports, module) {
 
         function isInSameFile(obj, refsResp) {
             // In case of unsaved files, After renameing once Tern is returning filename without forward slash
-            return (obj && (obj.file === refsResp.file || obj.file === refsResp.file.slice(1, refsResp.file.length)));
+            var projectDir = ProjectManager.getProjectRoot().fullPath,
+                fileName = "";
+
+            // get the relative path of File as Tern can also return
+            // references with file name as a relative path wrt projectRoot
+            // so refernce file will be compared with both relative and Absolute path ti check if it is same file
+            if (projectDir && refsResp && refsResp.file && refsResp.file.indexOf(projectDir) === 0) {
+                fileName = refsResp.file.slice(projectDir.length);
+            }
+            return (obj && (obj.file === refsResp.file || obj.file === fileName
+                            || obj.file === refsResp.file.slice(1, refsResp.file.length)));
         }
 
         /**

--- a/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
+++ b/src/extensions/default/JavaScriptRefactoring/RenameIdentifier.js
@@ -98,16 +98,20 @@ define(function (require, exports, module) {
         var result = new $.Deferred();
 
         function isInSameFile(obj, refsResp) {
-            // In case of unsaved files, After renameing once Tern is returning filename without forward slash
-            var projectDir = ProjectManager.getProjectRoot().fullPath,
+            var projectRoot = ProjectManager.getProjectRoot(),
+                projectDir,
                 fileName = "";
+            if (projectRoot) {
+                projectDir = projectRoot.fullPath;
+            }
 
             // get the relative path of File as Tern can also return
             // references with file name as a relative path wrt projectRoot
-            // so refernce file will be compared with both relative and Absolute path ti check if it is same file
+            // so refernce file name will be compared with both relative and absolute path to check if it is same file
             if (projectDir && refsResp && refsResp.file && refsResp.file.indexOf(projectDir) === 0) {
                 fileName = refsResp.file.slice(projectDir.length);
             }
+            // In case of unsaved files, After renameing once Tern is returning filename without forward slash
             return (obj && (obj.file === refsResp.file || obj.file === fileName
                             || obj.file === refsResp.file.slice(1, refsResp.file.length)));
         }


### PR DESCRIPTION
Rename doesn't work if TernNodeDomain return Refs with path relative to project Root.
So added check it will compare both Absolute path and Relative path so if either of these is true Refs will be considered in same file.

@boopeshmahendran @navch  please review  