### PR TITLE
MainViewManager shows right currently viewed file after left split closes

### DIFF
--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1306,6 +1306,9 @@ define(function (require, exports, module) {
                 secondPane = _panes[SECOND_PANE],
                 fileList = secondPane.getViewList(),
                 lastViewed = getCurrentlyViewedFile();
+            if(firstPane.getCurrentlyViewedFile() == null && secondPane.getCurrentlyViewedFile != null){
+                lastViewed = secondPane.getCurrentlyViewedFile();
+            }
 
             Resizer.removeSizable(firstPane.$el);
             firstPane.mergeFrom(secondPane);


### PR DESCRIPTION
Fixed MainViewManager so that if you close the left split (firstPane) and open files exist in the right split (secondPane), then the file shown in secondPane will be shown in firstPane.
Before it was only done one-sidedly.

My first pull request for Brackets, hope I did ok!

Issue: #14533 