### PR TITLE
Add autocompletion for justify-items and justify-self

### DIFF
--- a/src/extensions/default/CSSCodeHints/CSSProperties.json
+++ b/src/extensions/default/CSSCodeHints/CSSProperties.json
@@ -140,6 +140,8 @@
     "image-resolution":            {"values": ["from-image", "snap"]},
     "isolation":                   {"values": ["auto", "isolate"]},
     "justify-content":             {"values": ["center", "flex-end", "flex-start", "space-around", "space-between"]},
+    "justify-items":               {"values": ["auto", "normal", "stretch", "center", "start", "end", "flex-start", "flex-end", "self-start", "self-end", "left", "right", "baseline", "first", "last", "safe", "unsafe", "inherit", "initial", "unset"]},
+    "justity-self":                {"values": ["auto", "normal", "stretch", "center", "start", "end", "flex-start", "flex-end", "self-start", "self-end", "left", "right", "baseline", "first", "last", "safe", "unsafe", "inherit", "initial", "unset"]},
     "left":                        {"values": ["auto", "inherit"]},
     "letter-spacing":              {"values": ["normal", "inherit"]},
     "line-height":                 {"values": ["normal", "inherit"]},


### PR DESCRIPTION
This PR adds autocompletion for the CSS `justify-items` and `justify-self` properties.