### PR TITLE
Enable DOMAgent in live preview

### DIFF
--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -231,11 +231,20 @@ define(function CSSAgent(require, exports, module) {
         return _styleSheetDetails[styleSheetId] && _styleSheetDetails[styleSheetId].canonicalizedURL;
     }
 
+    /**
+     * Returns styleSheetDetails object
+     */
+
+    function getStyleSheetDetails() {
+        return _styleSheetDetails;
+    }
+
     EventDispatcher.makeEventDispatcher(exports);
 
     // Export public functions
     exports.enable = enable;
     exports.styleForURL = styleForURL;
+    exports.getStyleSheetDetails = getStyleSheetDetails;
     exports.getURLForStyleSheetId = getURLForStyleSheetId;
     exports.reloadCSSForDocument = reloadCSSForDocument;
     exports.clearCSSForDocument = clearCSSForDocument;

--- a/src/LiveDevelopment/Agents/CSSAgent.js
+++ b/src/LiveDevelopment/Agents/CSSAgent.js
@@ -234,7 +234,6 @@ define(function CSSAgent(require, exports, module) {
     /**
      * Returns styleSheetDetails object
      */
-
     function getStyleSheetDetails() {
         return _styleSheetDetails;
     }

--- a/src/LiveDevelopment/Agents/DOMAgent.js
+++ b/src/LiveDevelopment/Agents/DOMAgent.js
@@ -184,6 +184,7 @@ define(function DOMAgent(require, exports, module) {
     function _onLoadEventFired(event, res) {
         // res = {timestamp}
         Inspector.DOM.getDocument(function onGetDocument(res) {
+            exports.document = res;
             exports.trigger("getDocument", res);
             // res = {root}
             _idToNode = {};
@@ -318,6 +319,10 @@ define(function DOMAgent(require, exports, module) {
         Inspector.DOM.off(".DOMAgent");
     }
 
+    /** Return id to DOM Node mapping object */
+    function getIdToNodeMap() {
+        return _idToNode;
+    }
 
     EventDispatcher.makeEventDispatcher(exports);
 
@@ -334,4 +339,5 @@ define(function DOMAgent(require, exports, module) {
     exports.applyChange = applyChange;
     exports.load = load;
     exports.unload = unload;
+    exports.getIdToNodeMap = getIdToNodeMap;
 });

--- a/src/LiveDevelopment/Agents/DOMNode.js
+++ b/src/LiveDevelopment/Agents/DOMNode.js
@@ -146,6 +146,8 @@ define(function DOMNodeModule(require, exports, module) {
         } else if (payload.childNodeCount) {
             this.agent.requestChildNodes(this);
         }
+
+        this._setPseudoElements(payload.pseudoElements);
     };
 
     /** Create child nodes from the given payload
@@ -158,6 +160,28 @@ define(function DOMNodeModule(require, exports, module) {
             node = new DOMNode(this.agent, payload);
             this.appendChild(node);
         }
+    };
+
+    /** Create pseudoElements child nodes from the given payload
+     * @param [[DOM.Node]] payload of pseudoElements
+     */
+    DOMNode.prototype._setPseudoElements = function _setPseudoElements(pseudoElementsPayload) {
+        this._pseudoElements = {};
+        if (!pseudoElementsPayload) {
+            return;
+        }
+        var i, payload, node;
+        for (i in pseudoElementsPayload) {
+            payload = pseudoElementsPayload[i];
+            node = new DOMNode(this.agent, payload);
+            node.parent = this;
+            this._pseudoElements[payload.pseudoType] = node;
+        }
+    };
+
+    /** Get pseudo elements of a node */
+    DOMNode.prototype.pseudoElements = function pseudoElements() {
+        return this._pseudoElements;
     };
 
     /** Construct the payload for this node */

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -151,6 +151,7 @@ define(function LiveDevelopment(require, exports, module) {
         "remote"    : true,
         "network"   : true,
         "css"       : true,
+        "dom"       : true,
         "highlight" : true
     };
 


### PR DESCRIPTION
This PR enables DOM Agent in live preview and adds getter methods for idToNode and styleSheetDetails objects