### PR TITLE
Disabling JS code insertion due JSRefactoring into PHP document or in any non-js scope

### DIFF
--- a/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
@@ -271,7 +271,7 @@ define(function(require, exports, module) {
             result.resolve(Strings.ERROR_EXTRACTTO_FUNCTION_MULTICURSORS);
             return;
         }
-        if (!editor || editor.getModeForSelection() !== "javascript") {
+        if (editor.getModeForSelection() !== "javascript") {
             editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_FUNCTION_NOT_VALID);
             return;
         }

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
@@ -272,7 +272,7 @@ define(function(require, exports, module) {
             return;
         }
         if (!editor || editor.getModeForSelection() !== "javascript") {
-            editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_NOT_VALID);
+            editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_FUNCTION_NOT_VALID);
             return;
         }
         initializeSession(editor);

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
@@ -272,6 +272,7 @@ define(function(require, exports, module) {
             return;
         }
         if (!editor || editor.getModeForSelection() !== "javascript") {
+            editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_NOT_VALID);
             return;
         }
         initializeSession(editor);

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToFunction.js
@@ -271,6 +271,9 @@ define(function(require, exports, module) {
             result.resolve(Strings.ERROR_EXTRACTTO_FUNCTION_MULTICURSORS);
             return;
         }
+        if (!editor || editor.getModeForSelection() !== "javascript") {
+            return;
+        }
         initializeSession(editor);
 
         var selection = editor.getSelection(),

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -225,6 +225,9 @@ define(function(require, exports, module) {
             editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_MULTICURSORS);
             return;
         }
+        if (!editor || editor.getModeForSelection() !== "javascript") {
+            return;
+        }
 
         initializeSession(editor);
 

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -225,7 +225,7 @@ define(function(require, exports, module) {
             editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_MULTICURSORS);
             return;
         }
-        if (!editor || editor.getModeForSelection() !== "javascript") {
+        if (editor.getModeForSelection() !== "javascript") {
             editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_NOT_VALID);
             return;
         }

--- a/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
+++ b/src/extensions/default/JavaScriptRefactoring/ExtractToVariable.js
@@ -226,6 +226,7 @@ define(function(require, exports, module) {
             return;
         }
         if (!editor || editor.getModeForSelection() !== "javascript") {
+            editor.displayErrorMessageAtCursor(Strings.ERROR_EXTRACTTO_VARIABLE_NOT_VALID);
             return;
         }
 

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -56,12 +56,11 @@ define(function (require, exports, module) {
      */
     function _wrapSelectedStatements (wrapperName, err) {
         var editor = EditorManager.getActiveEditor();
-        if (!editor || editor.getModeForSelection() !== "javascript") {
+        if (editor.getModeForSelection() !== "javascript") {
             if(wrapperName === TRY_CATCH) {
-                 editor.displayErrorMessageAtCursor(Strings.ERROR_TRY_CATCH);
-            }
-            else if(wrapperName === WRAP_IN_CONDITION) {
-                 editor.displayErrorMessageAtCursor(Strings.ERROR_WRAP_IN_CONDITION);
+                editor.displayErrorMessageAtCursor(Strings.ERROR_TRY_CATCH);
+            }else if(wrapperName === WRAP_IN_CONDITION) {
+                editor.displayErrorMessageAtCursor(Strings.ERROR_WRAP_IN_CONDITION);
             }
             return;
         }

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -57,6 +57,12 @@ define(function (require, exports, module) {
     function _wrapSelectedStatements (wrapperName, err) {
         var editor = EditorManager.getActiveEditor();
         if (!editor || editor.getModeForSelection() !== "javascript") {
+            if(wrapperName === TRY_CATCH) {
+                 editor.displayErrorMessageAtCursor(Strings.ERROR_TRY_CATCH);
+            }
+            else if(wrapperName === WRAP_IN_CONDITION) {
+                 editor.displayErrorMessageAtCursor(Strings.ERROR_WRAP_IN_CONDITION);
+            }
             return;
         }
         initializeRefactoringSession(editor);

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -57,11 +57,7 @@ define(function (require, exports, module) {
     function _wrapSelectedStatements (wrapperName, err) {
         var editor = EditorManager.getActiveEditor();
         if (editor.getModeForSelection() !== "javascript") {
-            if(wrapperName === TRY_CATCH) {
-                editor.displayErrorMessageAtCursor(Strings.ERROR_TRY_CATCH);
-            }else if(wrapperName === WRAP_IN_CONDITION) {
-                editor.displayErrorMessageAtCursor(Strings.ERROR_WRAP_IN_CONDITION);
-            }
+            editor.displayErrorMessageAtCursor(err);
             return;
         }
         initializeRefactoringSession(editor);

--- a/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
+++ b/src/extensions/default/JavaScriptRefactoring/WrapSelection.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
      */
     function _wrapSelectedStatements (wrapperName, err) {
         var editor = EditorManager.getActiveEditor();
-        if (!editor) {
+        if (!editor || editor.getModeForSelection() !== "javascript") {
             return;
         }
         initializeRefactoringSession(editor);


### PR DESCRIPTION
JSRefactoring was inserting JS code into PHP document while using option wrap in condition/try-catch.

![js-refactoring_in_php](https://user-images.githubusercontent.com/1094605/49232653-5e1bb000-f41a-11e8-883a-c1a0d4c3d697.PNG)

Added check to make wrap in condition/try-catch in non-js context as no-op. 