### PR TITLE
Executing default update process handler, in case auto-update fails.

### DIFF
--- a/src/extensions/default/AutoUpdate/main.js
+++ b/src/extensions/default/AutoUpdate/main.js
@@ -486,12 +486,12 @@ define(function (require, exports, module) {
 
             } else {
                 // Update not present for current platform
-                return;
+                return false;
             }
 
             if (!checksum || !downloadURL || !installerName) {
                 console.warn("AutoUpdate : asset information incorrect for the update");
-                return;
+                return false;
             }
 
             var updateParams = {

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -512,7 +512,12 @@ define(function (require, exports, module) {
      */
     function handleUpdateProcess(updates) {
         var handler = _updateProcessHandler || _defaultUpdateProcessHandler;
-        handler(updates);
+        var success = handler(updates);
+        if (_updateProcessHandler && !success) {
+            // Give a chance to default handler in case
+            // the auot update mechanism has failed.
+            _defaultUpdateProcessHandler(updates);
+        }
     }
 
     /**


### PR DESCRIPTION
Added error checks to the auto update mechanism. So in case the auto update mechansim fails, we will now give chance to the default update process Handler to handle the update mechanism (Which is essentially taking the user to brackets.io).

@swmitra Could you please review this?