### PR TITLE
Update notification - based on current platform

### DIFF
--- a/src/extensions/default/AutoUpdate/main.js
+++ b/src/extensions/default/AutoUpdate/main.js
@@ -329,27 +329,6 @@ define(function (require, exports, module) {
     }
 
 
-     /**
-     * Generates the extension for installer file, based on platform
-     * @returns {string} - OS - current OS }
-     */
-    function getPlatformInfo() {
-        var OS = "";
-
-        if (/Windows|Win32|WOW64|Win64/.test(window.navigator.userAgent)) {
-            OS = "WIN";
-        } else if (/Mac/.test(window.navigator.userAgent)) {
-            OS = "OSX";
-        } else if (/Linux|X11/.test(window.navigator.userAgent)) {
-            OS = "LINUX32";
-            if (/x86_64/.test(window.navigator.appVersion + window.navigator.userAgent)) {
-                OS = "LINUX64";
-            }
-        }
-
-        return OS;
-    }
-
     /**
      * Initializes the state for AutoUpdate process
      * @returns {$.Deferred} - a jquery promise,
@@ -466,7 +445,7 @@ define(function (require, exports, module) {
                 console.warn("AutoUpdate : updates information not available.");
                 return;
             }
-            var OS = getPlatformInfo(),
+            var OS = brackets.getPlatformInfo(),
                 checksum,
                 downloadURL,
                 installerName,

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -99,7 +99,7 @@ define(function (require, exports, module) {
         }
 
         return OS;
-    }
+    };
 
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
 

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -83,6 +83,24 @@ define(function (require, exports, module) {
         global.brackets.platform = "win";
     }
 
+    // Expose platform info for build applicability consumption
+    global.brackets.getPlatformInfo = function () {
+        var OS = "";
+
+        if (/Windows|Win32|WOW64|Win64/.test(window.navigator.userAgent)) {
+            OS = "WIN";
+        } else if (/Mac/.test(window.navigator.userAgent)) {
+            OS = "OSX";
+        } else if (/Linux|X11/.test(window.navigator.userAgent)) {
+            OS = "LINUX32";
+            if (/x86_64/.test(window.navigator.appVersion + window.navigator.userAgent)) {
+                OS = "LINUX64";
+            }
+        }
+
+        return OS;
+    }
+
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
 
     // Are we in a desktop shell with a native menu bar?

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -278,21 +278,22 @@ define(function (require, exports, module) {
         var lastIndex = 0;
         var len = versionInfo.length;
         var versionEntry;
+        var validBuildEntries;
 
         while (lastIndex < len) {
             versionEntry = versionInfo[lastIndex];
-            if (versionEntry.buildNumber <= buildNumber && _checkBuildApplicability(versionEntry)) {
+            if (versionEntry.buildNumber <= buildNumber) {
                 break;
             }
             lastIndex++;
         }
 
         if (lastIndex > 0) {
-            return versionInfo.slice(0, lastIndex);
+            // Filter recent update entries based on applicability to current platform
+            validBuildEntries = versionInfo.slice(0, lastIndex).filter(_checkBuildApplicability);
         }
 
-        // No new version info
-        return null;
+        return validBuildEntries;
     }
 
     /**
@@ -455,7 +456,7 @@ define(function (require, exports, module) {
                     return;
                 }
 
-                if (allUpdates) {
+                if (allUpdates && allUpdates.length > 0) {
                     // Always show the "update available" icon if any updates are available
                     var $updateNotification = $("#update-notification");
 

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -262,6 +262,13 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Checks whether a build is applicable to the current platform.
+     */
+    function _checkBuildApplicability(buildInfo) {
+        return !buildInfo.platforms || buildInfo.platforms[brackets.getPlatformInfo()];
+    }
+
+    /**
      * Return a new array of version information that is newer than "buildNumber".
      * Returns null if there is no new version information.
      */
@@ -270,9 +277,11 @@ define(function (require, exports, module) {
         // should get through the search quickly.
         var lastIndex = 0;
         var len = versionInfo.length;
+        var versionEntry;
 
         while (lastIndex < len) {
-            if (versionInfo[lastIndex].buildNumber <= buildNumber) {
+            versionEntry = versionInfo[lastIndex];
+            if (versionEntry.buildNumber <= buildNumber && _checkBuildApplicability(versionEntry)) {
                 break;
             }
             lastIndex++;


### PR DESCRIPTION
Handle platform entries from updates.json. This PR adds capability to identify OS specific releases and offer update notification accordingly. In new update entry format, builds available for specific platforms is being listed under that platform key. If an entry doesn't contains the current platform, we assume the build is not applicable to the current platform.

This is how the new Update entries look like - 

```json
{
        "buildNumber": 17696,
        "versionString": "Release 1.13",
        "dateString": "06-18-2018",
        "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-1.13",
        "downloadURL": "http://brackets.io",
        "newFeatures": [
            {
                "name": "Organize Files/Folders in File Tree",
                "description": "You can now manipulate folder structure from within Brackets. Move a file/folder from one folder to another with a simple drag and drop."
            },
            {
                "name": "Open Remote Files",
                "description": "You can now open a remotely hosted web-page from within Brackets. Use Ctrl/Cmd-Shift-O shortcut and supply a URL to quickly open the file and review the code within Brackets."
            },
            {
                "name": "Auto-Update",
                "description": "You can now automatically update Brackets, without leaving the code editor. "
            }
        ],
        "platforms" : {
            "WIN": {
                "checksum": "a1020f55d4ec92c824ed6e5a3db941eaae6ffeb2334a77fa3465fe2736304a86",
                "downloadURL": "https://github.com/adobe/brackets/releases/download/release-1.13/Brackets.Release.1.13.msi"
            },
            "OSX": {
                "checksum": "34d8960d78e7301febcc6b68b85970d119b7a904cdb9a0ecfc445348de1e4bd4",
                "downloadURL": "https://github.com/adobe/brackets/releases/download/release-1.13/Brackets.Release.1.13.dmg"
            },
            "LINUX32" : {
                "checksum": "3a83332e4e54fa3721dfa7e67a9d143c0b2658aec9de9b0c1042435f5f496624",
                "downloadURL" : "https://github.com/adobe/brackets/releases/download/release-1.13/Brackets.Release.1.13.32-bit.deb"
            },
            "LINUX64" : {
                "checksum" : "5c489a51d14b66d696f1b167018dae598f9a27c1bd08a4026334e300f7dc93cf",
                "downloadURL" : "https://github.com/adobe/brackets/releases/download/release-1.13/Brackets.Release.1.13.64-bit.deb"
            }
        },
        "prerelease" : "false"
    }
```
Ping @narayani28 @vickramdhawal for review. 