### PR TITLE
Removing the old Brackets CLA check

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "scripts": {
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
-        "test": "grunt test cla-check-pull",
+        //"test": "grunt test cla-check-pull",
         "eslint": "grunt eslint"
     },
     "licenses": [

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
         //"test": "grunt test cla-check-pull",
+        "test": "grunt test",
         "eslint": "grunt eslint"
     },
     "licenses": [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "scripts": {
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
-        //"test": "grunt test cla-check-pull",
         "test": "grunt test",
         "eslint": "grunt eslint"
     },

--- a/src/config.json
+++ b/src/config.json
@@ -90,7 +90,6 @@
     "scripts": {
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
-        //"test": "grunt test cla-check-pull",
         "test": "grunt test",
         "eslint": "grunt eslint"
     },

--- a/src/config.json
+++ b/src/config.json
@@ -90,7 +90,7 @@
     "scripts": {
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
-        "test": "grunt test cla-check-pull",
+        //"test": "grunt test cla-check-pull",
         "eslint": "grunt eslint"
     },
     "licenses": [

--- a/src/config.json
+++ b/src/config.json
@@ -91,6 +91,7 @@
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
         //"test": "grunt test cla-check-pull",
+        "test": "grunt test",
         "eslint": "grunt eslint"
     },
     "licenses": [


### PR DESCRIPTION
Brackets has integrated Adobe CLA check by default now, so we don't need the old check anymore. This task can be updated if we ever have to create a custom Adobe CLA bot integration.
ping @swmitra for review