### PR TITLE
Fix for "GetItNow" action behaviour

### DIFF
--- a/src/extensions/default/AutoUpdate/main.js
+++ b/src/extensions/default/AutoUpdate/main.js
@@ -483,6 +483,9 @@ define(function (require, exports, module) {
 
             //Initiate the auto update, with update params
             initiateAutoUpdate(updateParams);
+	    
+	    //Send a truthy value to ensure caller is informed about successful initialization of auto-update
+	    return true;
     }
 
 

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -522,8 +522,8 @@ define(function (require, exports, module) {
      */
     function handleUpdateProcess(updates) {
         var handler = _updateProcessHandler || _defaultUpdateProcessHandler;
-        var success = handler(updates);
-        if (_updateProcessHandler && !success) {
+        var initSuccess = handler(updates);
+        if (_updateProcessHandler && !initSuccess) {
             // Give a chance to default handler in case
             // the auot update mechanism has failed.
             _defaultUpdateProcessHandler(updates);


### PR DESCRIPTION
When user clicks on "GetItNow" it should perform one of these actions 

- Either initialises Auto-Update process after all the conditions verified. 
- Or if Auto-Update can't be initialised, then take the user to brackets.io.

However, we shouldn't perform both the actions. 

This PR fixes the faulty behaviour and ensures, we don't open brackets.io if we are able to start auto-update successfully. 

@shubhsnov @narayani28 Please review. 