### PR TITLE
Fix : Error occurs when dismissing QuickOpen dialog when no document is open

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -367,10 +367,10 @@ define(function (require, exports, module) {
             // completes) since ModalBar has already resized the editor and done its own scroll adjustment before
             // this event fired - so anything we set here will override the pos that was (re)set by ModalBar.
             var editor = EditorManager.getCurrentFullEditor();
-            if (this._origSelections) {
+            if (editor && this._origSelections) {
                 editor.setSelections(this._origSelections);
             }
-            if (this._origScrollPos) {
+            if (editor && this._origScrollPos) {
                 editor.setScrollPos(this._origScrollPos.x, this._origScrollPos.y);
             }
         }


### PR DESCRIPTION
Add null checks for the same.
ping @niteskum @narayani28 for review.