### PR TITLE
Fixed Find References Issue in release build

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -141,7 +141,6 @@ define(function (require, exports, module) {
     //load language features
     require("features/ParameterHintsManager");
     require("features/JumpToDefManager");
-    require("features/FindReferencesManager");
 
     // Load modules that self-register and just need to get included in the main project
     require("command/DefaultMenus");
@@ -155,6 +154,9 @@ define(function (require, exports, module) {
     require("help/HelpCommandHandlers");
     require("search/FindInFilesUI");
     require("search/FindReplace");
+
+    //Load find References Feature Manager
+    require("features/FindReferencesManager");
 
     //Load common JS module
     require("JSUtils/Session");

--- a/src/extensions/default/PhpTooling/main.js
+++ b/src/extensions/default/PhpTooling/main.js
@@ -116,6 +116,7 @@ define(function (require, exports, module) {
         CodeHintManager.registerHintProvider(chProvider, ["php"], 0);
         ParameterHintManager.registerHintProvider(phProvider, ["php"], 0);
         FindReferencesManager.registerFindReferencesProvider(refProvider, ["php"], 0);
+        FindReferencesManager.setMenuItemStateForLanguage();
         CodeInspection.register(["php"], {
             name: "",
             scanFileAsync: lProvider.getInspectionResultsAsync.bind(lProvider)

--- a/src/features/FindReferencesManager.js
+++ b/src/features/FindReferencesManager.js
@@ -26,6 +26,9 @@ define(function (require, exports, module) {
 
     var AppInit                     = require("utils/AppInit"),
         CommandManager              = require("command/CommandManager"),
+        MainViewManager             = require("view/MainViewManager"),
+        LanguageManager             = require("language/LanguageManager"),
+        DocumentManager     = require("document/DocumentManager"),
         Commands                    = require("command/Commands"),
         EditorManager               = require("editor/EditorManager"),
         ProjectManager              = require("project/ProjectManager"),
@@ -118,6 +121,58 @@ define(function (require, exports, module) {
         searchModel.clear();
     }
 
+    function setMenuItemStateForLanguage(languageId) {
+        if(!languageId) {
+            var editor = EditorManager.getActiveEditor();
+            if(editor) {
+                languageId = LanguageManager.getLanguageForPath(editor.document.file._path).getId();
+            }
+        }
+        var enabledProviders = _providerRegistrationHandler.getProvidersForLanguageId(languageId),
+            referencesProvider;
+
+        enabledProviders.some(function (item, index) {
+            if (item.provider.hasReferences()) {
+                referencesProvider = item.provider;
+                return true;
+            }
+        });
+        CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
+        if(referencesProvider) {
+            CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(true);
+        }
+
+    }
+
+    MainViewManager.on("currentFileChange", function (event, newFile, newPaneId, oldFile, oldPaneId) {
+        if (!newFile) {
+            CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
+            return;
+        }
+
+        var newFilePath = newFile.fullPath,
+            newLanguageId = LanguageManager.getLanguageForPath(newFilePath).getId();
+        setMenuItemStateForLanguage(newLanguageId);
+
+        DocumentManager.getDocumentForPath(newFilePath)
+            .done(function (newDoc) {
+                newDoc.on("languageChanged.reference-in-files", function () {
+                    var changedLanguageId = LanguageManager.getLanguageForPath(newDoc.file.fullPath).getId();
+                    setMenuItemStateForLanguage(changedLanguageId);
+                });
+            });
+
+        if (!oldFile) {
+            return;
+        }
+
+        var oldFilePath = oldFile.fullPath;
+        DocumentManager.getDocumentForPath(oldFilePath)
+            .done(function (oldDoc) {
+                oldDoc.off("languageChanged.reference-in-files");
+            });
+    });
+
     AppInit.appReady(function () {
         _resultsView = new SearchResultsView(
             searchModel,
@@ -147,7 +202,9 @@ define(function (require, exports, module) {
     ProjectManager.on("beforeProjectClose", function () { if (_resultsView) { _resultsView.close(); } });
 
     CommandManager.register(Strings.FIND_ALL_REFERENCES, Commands.CMD_FIND_ALL_REFERENCES, _openReferencesPanel);
+    CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
 
     exports.registerFindReferencesProvider    = registerFindReferencesProvider;
     exports.removeFindReferencesProvider      = removeFindReferencesProvider;
+    exports.setMenuItemStateForLanguage      = setMenuItemStateForLanguage;
 });

--- a/src/features/FindReferencesManager.js
+++ b/src/features/FindReferencesManager.js
@@ -122,9 +122,10 @@ define(function (require, exports, module) {
     }
 
     function setMenuItemStateForLanguage(languageId) {
-        if(!languageId) {
+        CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
+        if (!languageId) {
             var editor = EditorManager.getActiveEditor();
-            if(editor) {
+            if (editor) {
                 languageId = LanguageManager.getLanguageForPath(editor.document.file._path).getId();
             }
         }
@@ -137,8 +138,7 @@ define(function (require, exports, module) {
                 return true;
             }
         });
-        CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
-        if(referencesProvider) {
+        if (referencesProvider) {
             CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(true);
         }
 
@@ -173,7 +173,7 @@ define(function (require, exports, module) {
             });
     });
 
-    AppInit.appReady(function () {
+    AppInit.htmlReady(function () {
         _resultsView = new SearchResultsView(
             searchModel,
             "reference-in-files-results",

--- a/src/features/FindReferencesManager.js
+++ b/src/features/FindReferencesManager.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         CommandManager              = require("command/CommandManager"),
         MainViewManager             = require("view/MainViewManager"),
         LanguageManager             = require("language/LanguageManager"),
-        DocumentManager     = require("document/DocumentManager"),
+        DocumentManager             = require("document/DocumentManager"),
         Commands                    = require("command/Commands"),
         EditorManager               = require("editor/EditorManager"),
         ProjectManager              = require("project/ProjectManager"),
@@ -206,5 +206,5 @@ define(function (require, exports, module) {
 
     exports.registerFindReferencesProvider    = registerFindReferencesProvider;
     exports.removeFindReferencesProvider      = removeFindReferencesProvider;
-    exports.setMenuItemStateForLanguage      = setMenuItemStateForLanguage;
+    exports.setMenuItemStateForLanguage       = setMenuItemStateForLanguage;
 });

--- a/src/features/FindReferencesManager.js
+++ b/src/features/FindReferencesManager.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
         CommandManager              = require("command/CommandManager"),
         Commands                    = require("command/Commands"),
         EditorManager               = require("editor/EditorManager"),
+        ProjectManager              = require("project/ProjectManager"),
         ProviderRegistrationHandler = require("features/PriorityBasedRegistration").RegistrationHandler,
         SearchResultsView           = require("search/SearchResultsView").SearchResultsView,
         SearchModel                 = require("search/SearchModel").SearchModel,
@@ -117,7 +118,7 @@ define(function (require, exports, module) {
         searchModel.clear();
     }
 
-    AppInit.htmlReady(function () {
+    AppInit.appReady(function () {
         _resultsView = new SearchResultsView(
             searchModel,
             "reference-in-files-results",
@@ -141,6 +142,10 @@ define(function (require, exports, module) {
                 });
         }
     });
+
+    // Initialize: register listeners
+    ProjectManager.on("beforeProjectClose", function () { if (_resultsView) { _resultsView.close(); } });
+
     CommandManager.register(Strings.FIND_ALL_REFERENCES, Commands.CMD_FIND_ALL_REFERENCES, _openReferencesPanel);
 
     exports.registerFindReferencesProvider    = registerFindReferencesProvider;


### PR DESCRIPTION
This PR fixes two issues:

- Makes the Find References menu contextual (Active only when we have a provider for the file type)
- Correct the order in which DOM is created for FindReference Bottom panel (After status bar has been inserted, since a bottom panel is prepended to it)

@shubhsnov @narayani28 @swmitra  Please review