### PR TITLE
Fixed Code/Parameter Hints Issue for large file

### DIFF
--- a/src/extensions/default/PhpTooling/CodeHintsProvider.js
+++ b/src/extensions/default/PhpTooling/CodeHintsProvider.js
@@ -90,10 +90,14 @@ define(function (require, exports, module) {
             self = this.defaultCodeHintProviders,
             client = this.defaultCodeHintProviders.client;
 
-        setTimeout(function(){
-            client.requestHints({
-                filePath: docPath,
-                cursorPos: pos
+        //Make sure the document is in sync with the server
+        client.notifyTextDocumentChanged({
+            filePath: docPath,
+            fileContent: editor.document.getText()
+        });
+        client.requestHints({
+            filePath: docPath,
+            cursorPos: pos
         }).done(function (msgObj) {
             var context = TokenUtils.getInitialContext(editor._codeMirror, pos),
                 hints = [];
@@ -159,7 +163,6 @@ define(function (require, exports, module) {
         }).fail(function () {
             $deferredHints.reject();
         });
-        }, 0);
 
         return $deferredHints;
     };

--- a/src/extensions/default/PhpTooling/CodeHintsProvider.js
+++ b/src/extensions/default/PhpTooling/CodeHintsProvider.js
@@ -87,11 +87,13 @@ define(function (require, exports, module) {
             pos = editor.getCursorPos(),
             docPath = editor.document.file._path,
             $deferredHints = $.Deferred(),
-            self = this.defaultCodeHintProviders;
+            self = this.defaultCodeHintProviders,
+            client = this.defaultCodeHintProviders.client;
 
-        this.defaultCodeHintProviders.client.requestHints({
-            filePath: docPath,
-            cursorPos: pos
+        setTimeout(function(){
+            client.requestHints({
+                filePath: docPath,
+                cursorPos: pos
         }).done(function (msgObj) {
             var context = TokenUtils.getInitialContext(editor._codeMirror, pos),
                 hints = [];
@@ -157,6 +159,7 @@ define(function (require, exports, module) {
         }).fail(function () {
             $deferredHints.reject();
         });
+        }, 0);
 
         return $deferredHints;
     };

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -109,51 +109,49 @@ define(function (require, exports, module) {
             $deferredHints = $.Deferred(),
             self = this;
 
-        setTimeout(function(){
-            self.client.requestHints({
-                filePath: docPath,
-                cursorPos: pos
-            }).done(function (msgObj) {
-                var context = TokenUtils.getInitialContext(editor._codeMirror, pos),
-                    hints = [];
+        this.client.requestHints({
+            filePath: docPath,
+            cursorPos: pos
+        }).done(function (msgObj) {
+            var context = TokenUtils.getInitialContext(editor._codeMirror, pos),
+                hints = [];
 
-                self.query = context.token.string.slice(0, context.pos.ch - context.token.start);
-                if (msgObj) {
-                    var res = msgObj.items,
-                        filteredHints = filterWithQueryAndMatcher(res, self.query);
+            self.query = context.token.string.slice(0, context.pos.ch - context.token.start);
+            if (msgObj) {
+                var res = msgObj.items,
+                    filteredHints = filterWithQueryAndMatcher(res, self.query);
 
-                    StringMatch.basicMatchSort(filteredHints);
-                    filteredHints.forEach(function (element) {
-                        var $fHint = $("<span>")
-                            .addClass("brackets-hints");
+                StringMatch.basicMatchSort(filteredHints);
+                filteredHints.forEach(function (element) {
+                    var $fHint = $("<span>")
+                        .addClass("brackets-hints");
 
-                        if (element.stringRanges) {
-                            element.stringRanges.forEach(function (item) {
-                                if (item.matched) {
-                                    $fHint.append($("<span>")
-                                        .append(_.escape(item.text))
-                                        .addClass("matched-hint"));
-                                } else {
-                                    $fHint.append(_.escape(item.text));
-                                }
-                            });
-                        } else {
-                            $fHint.text(element.label);
-                        }
+                    if (element.stringRanges) {
+                        element.stringRanges.forEach(function (item) {
+                            if (item.matched) {
+                                $fHint.append($("<span>")
+                                    .append(_.escape(item.text))
+                                    .addClass("matched-hint"));
+                            } else {
+                                $fHint.append(_.escape(item.text));
+                            }
+                        });
+                    } else {
+                        $fHint.text(element.label);
+                    }
 
-                        $fHint.data("token", element);
-                        formatTypeDataForToken($fHint, element);
-                        hints.push($fHint);
-                    });
-                }
-
-                $deferredHints.resolve({
-                    "hints": hints
+                    $fHint.data("token", element);
+                    formatTypeDataForToken($fHint, element);
+                    hints.push($fHint);
                 });
-            }).fail(function () {
-                $deferredHints.reject();
+            }
+
+            $deferredHints.resolve({
+                "hints": hints
             });
-        }, 0);
+        }).fail(function () {
+            $deferredHints.reject();
+        });
 
         return $deferredHints;
     };
@@ -223,45 +221,43 @@ define(function (require, exports, module) {
             $deferredHints = $.Deferred(),
             client = this.client;
 
-        setTimeout(function(){
-            client.requestParameterHints({
-                filePath: docPath,
-                cursorPos: pos
-            }).done(function (msgObj) {
-                let paramList = [];
-                let label;
-                let activeParameter;
-                if (msgObj) {
-                    let res;
-                    res = msgObj.signatures;
-                    activeParameter = msgObj.activeParameter;
-                    if (res && res.length) {
-                        res.forEach(function (element) {
-                            label = element.documentation;
-                            let param = element.parameters;
-                            param.forEach(ele => {
-                                paramList.push({
-                                    label: ele.label,
-                                    documentation: ele.documentation
-                                });
+        client.requestParameterHints({
+            filePath: docPath,
+            cursorPos: pos
+        }).done(function (msgObj) {
+            let paramList = [];
+            let label;
+            let activeParameter;
+            if (msgObj) {
+                let res;
+                res = msgObj.signatures;
+                activeParameter = msgObj.activeParameter;
+                if (res && res.length) {
+                    res.forEach(function (element) {
+                        label = element.documentation;
+                        let param = element.parameters;
+                        param.forEach(ele => {
+                            paramList.push({
+                                label: ele.label,
+                                documentation: ele.documentation
                             });
                         });
+                    });
 
-                        $deferredHints.resolve({
-                            parameters: paramList,
-                            currentIndex: activeParameter,
-                            functionDocumentation: label
-                        });
-                    } else {
-                        $deferredHints.reject();
-                    }
+                    $deferredHints.resolve({
+                        parameters: paramList,
+                        currentIndex: activeParameter,
+                        functionDocumentation: label
+                    });
                 } else {
                     $deferredHints.reject();
                 }
-            }).fail(function () {
+            } else {
                 $deferredHints.reject();
-            });
-        }, 0);
+            }
+        }).fail(function () {
+            $deferredHints.reject();
+        });
         return $deferredHints;
     };
 

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -218,10 +218,9 @@ define(function (require, exports, module) {
         var editor = EditorManager.getActiveEditor(),
             pos = editor.getCursorPos(),
             docPath = editor.document.file._path,
-            $deferredHints = $.Deferred(),
-            client = this.client;
+            $deferredHints = $.Deferred();
 
-        client.requestParameterHints({
+        this.client.requestParameterHints({
             filePath: docPath,
             cursorPos: pos
         }).done(function (msgObj) {
@@ -258,6 +257,7 @@ define(function (require, exports, module) {
         }).fail(function () {
             $deferredHints.reject();
         });
+
         return $deferredHints;
     };
 


### PR DESCRIPTION
on editorChange event we have multiple listeners, each does one specific Task. 
regarding LSP on editor change , textSynchronization(didChange) notification is sent to lsp server and simultaneously requestHints/ParameterHints request are sent to server. 
For large file we observed that requestHints/ParameterHints reqests are sent before the textSynchronization notification message as all these listeners work parallel. this behaviour is observed for some smallersize file also.

since we would want requestHints/ParameterHints request to be sent at the end. so I have made change in this PR that requestHints/ParameterHints request will be called from callback in setTimeout function with 0 second delay. reason 0 second delay is chosen because we just want all the queued task to be finished and then call the callback function.
https://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
I refered the this webpage for this solution.

@shubhsnov  @narayani28 @swmitra  please review