### PR TITLE
Reinitiate tooling service on Node process crash

### DIFF
--- a/src/extensions/default/PhpTooling/CodeHintsProvider.js
+++ b/src/extensions/default/PhpTooling/CodeHintsProvider.js
@@ -54,6 +54,10 @@ define(function (require, exports, module) {
         this.defaultCodeHintProviders = new DefaultProviders.CodeHintsProvider(client);
     }
 
+    CodeHintsProvider.prototype.setClient = function (client) {
+        this.defaultCodeHintProviders.setClient(client);
+    };
+
     function setStyleAndCacheToken($hintObj, token) {
         $hintObj.addClass('brackets-hints-with-type-details');
         $hintObj.data('completionItem', token);

--- a/src/extensions/default/PhpTooling/PHPSymbolProviders.js
+++ b/src/extensions/default/PhpTooling/PHPSymbolProviders.js
@@ -22,7 +22,7 @@
  */
 
 /*jslint regexp: true */
-
+/*eslint no-invalid-this: 0, max-len: 0*/
 define(function (require, exports, module) {
     "use strict";
 
@@ -33,6 +33,12 @@ define(function (require, exports, module) {
         PathConverters = brackets.getModule("languageTools/PathConverters");
 
     var SymbolKind = QuickOpen.SymbolKind;
+
+    function setClient(client) {
+        if (client) {
+            this.client = client;
+        }
+    }
 
     function convertRangePosToEditorPos(rangePos) {
         return {
@@ -112,6 +118,8 @@ define(function (require, exports, module) {
         this.client = client;
     }
 
+    DocumentSymbolsProvider.prototype.setClient = setClient;
+
     DocumentSymbolsProvider.prototype.match = function (query) {
         return query.startsWith("@");
     };
@@ -170,6 +178,8 @@ define(function (require, exports, module) {
     function ProjectSymbolsProvider(client) {
         this.client = client;
     }
+
+    ProjectSymbolsProvider.prototype.setClient = setClient;
 
     ProjectSymbolsProvider.prototype.match = function (query) {
         return query.startsWith("#");

--- a/src/extensions/default/PhpTooling/main.js
+++ b/src/extensions/default/PhpTooling/main.js
@@ -28,8 +28,8 @@ define(function (require, exports, module) {
         AppInit = brackets.getModule("utils/AppInit"),
         ExtensionUtils = brackets.getModule("utils/ExtensionUtils"),
         ProjectManager = brackets.getModule("project/ProjectManager"),
-        EditorManager = brackets.getModule("editor/EditorManager"),
-        LanguageManager = brackets.getModule("language/LanguageManager"),
+        EditorManager =  brackets.getModule("editor/EditorManager"),
+        LanguageManager =  brackets.getModule("language/LanguageManager"),
         CodeHintManager = brackets.getModule("editor/CodeHintManager"),
         QuickOpen = brackets.getModule("search/QuickOpen"),
         ParameterHintManager = brackets.getModule("features/ParameterHintsManager"),
@@ -40,13 +40,13 @@ define(function (require, exports, module) {
         CodeHintsProvider = require("CodeHintsProvider").CodeHintsProvider,
         SymbolProviders = require("PHPSymbolProviders").SymbolProviders,
         DefaultEventHandlers = brackets.getModule("languageTools/DefaultEventHandlers"),
-        PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
-        Strings = brackets.getModule("strings"),
-        Dialogs = brackets.getModule("widgets/Dialogs"),
-        DefaultDialogs = brackets.getModule("widgets/DefaultDialogs"),
-        Commands = brackets.getModule("command/Commands"),
-        CommandManager = brackets.getModule("command/CommandManager"),
-        StringUtils = brackets.getModule("utils/StringUtils");
+        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        Strings             = brackets.getModule("strings"),
+        Dialogs             = brackets.getModule("widgets/Dialogs"),
+        DefaultDialogs      = brackets.getModule("widgets/DefaultDialogs"),
+        Commands               = brackets.getModule("command/Commands"),
+        CommandManager         = brackets.getModule("command/CommandManager"),
+        StringUtils             = brackets.getModule("utils/StringUtils");
 
     var clientFilePath = ExtensionUtils.getModulePath(module, "client.js"),
         clientName = "PhpClient",
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
             memoryLimit: "4095M",
             validateOnType: "false"
         },
-        DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW = "debug.openPrefsInSplitView",
+        DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW  = "debug.openPrefsInSplitView",
         phpServerRunning = false,
         serverCapabilities,
         currentRootPath,
@@ -81,8 +81,8 @@ define(function (require, exports, module) {
         if (lProvider && newPhpConfig["validateOnType"] !== phpConfig["validateOnType"]) {
             lProvider._validateOnType = !(newPhpConfig["validateOnType"] === "false");
         }
-        if ((newPhpConfig["executablePath"] !== phpConfig["executablePath"]) ||
-            (newPhpConfig["enablePhpTooling"] !== phpConfig["enablePhpTooling"])) {
+        if ((newPhpConfig["executablePath"] !== phpConfig["executablePath"])
+                || (newPhpConfig["enablePhpTooling"] !== phpConfig["enablePhpTooling"])) {
             phpConfig = newPhpConfig;
             runPhpServer();
             return;
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
 
     var handleProjectOpen = function (event, directory) {
         lProvider.clearExistingResults();
-        if (serverCapabilities["workspace"] && serverCapabilities["workspace"]["workspaceFolders"]) {
+        if(serverCapabilities["workspace"] && serverCapabilities["workspace"]["workspaceFolders"]) {
             _client.notifyProjectRootsChanged({
                 foldersAdded: [directory.fullPath],
                 foldersRemoved: [currentRootPath]
@@ -192,7 +192,7 @@ define(function (require, exports, module) {
     }
 
     function showErrorPopUp(err) {
-        if (!err) {
+        if(!err) {
             return;
         }
         var localizedErrStr = "";
@@ -201,21 +201,15 @@ define(function (require, exports, module) {
         } else {
             localizedErrStr = StringUtils.format(Strings[err[0]], err[1]);
         }
-        if (!localizedErrStr) {
+        if(!localizedErrStr) {
             console.error("Php Tooling Error: " + err);
             return;
         }
         var Buttons = [
-            {
-                className: Dialogs.DIALOG_BTN_CLASS_NORMAL,
-                id: Dialogs.DIALOG_BTN_CANCEL,
-                text: Strings.CANCEL
-            },
-            {
-                className: Dialogs.DIALOG_BTN_CLASS_PRIMARY,
-                id: Dialogs.DIALOG_BTN_DOWNLOAD,
-                text: Strings.OPEN_PREFERENNCES
-            }
+            { className: Dialogs.DIALOG_BTN_CLASS_NORMAL, id: Dialogs.DIALOG_BTN_CANCEL,
+                text: Strings.CANCEL },
+            { className: Dialogs.DIALOG_BTN_CLASS_PRIMARY, id: Dialogs.DIALOG_BTN_DOWNLOAD,
+                text: Strings.OPEN_PREFERENNCES}
         ];
         Dialogs.showModalDialog(
             DefaultDialogs.DIALOG_ID_ERROR,
@@ -290,7 +284,7 @@ define(function (require, exports, module) {
         }
     }
 
-    function initiateService(onAppReady) {
+    function initiateService(evt, onAppReady) {
         if (onAppReady) {
             console.log("Php tooling: Starting the service");
         } else {
@@ -311,12 +305,10 @@ define(function (require, exports, module) {
     }
 
     AppInit.appReady(function () {
-        initiateService(true);
+        initiateService(null, true);
         ClientLoader.on("languageClientModuleInitialized", initiateService);
     });
 
     //Only for Unit testing
-    exports.getClient = function () {
-        return _client;
-    };
+    exports.getClient = function() { return _client; };
 });

--- a/src/extensions/default/PhpTooling/main.js
+++ b/src/extensions/default/PhpTooling/main.js
@@ -109,11 +109,12 @@ define(function (require, exports, module) {
         var logErr = "PhpTooling: Can't reset client for : ";
         chProvider ? chProvider.setClient(_client) : console.log(logErr, "CodeHintsProvider");
         phProvider ? phProvider.setClient(_client) : console.log(logErr, "ParameterHintsProvider");
-        lProvider ? lProvider.setClient(_client) : console.log(logErr, "LintingProvider");
         jdProvider ? jdProvider.setClient(_client) : console.log(logErr, "JumpToDefProvider");
         dSymProvider ? dSymProvider.setClient(_client) : console.log(logErr, "DocumentSymbolsProvider");
         pSymProvider ? pSymProvider.setClient(_client) : console.log(logErr, "ProjectSymbolsProvider");
         refProvider ? refProvider.setClient(_client) : console.log(logErr, "FindReferencesProvider");
+        lProvider ? lProvider.setClient(_client) : console.log(logErr, "LintingProvider");
+        _client.addOnCodeInspection(lProvider.setInspectionResults.bind(lProvider));
     }
 
     function registerToolingProviders() {
@@ -266,13 +267,7 @@ define(function (require, exports, module) {
                         serverCapabilities = result.capabilities;
                         handlePostPhpServerStart();
                     });
-                }).fail(function (err) {
-                    showErrorPopUp(err);
-                    //Retry on next active editor change
-                    EditorManager.on("activeEditorChange.php", activeEditorChangeHandler);
-                    LanguageManager.on("languageModified.php", languageModifiedHandler);
-                    activeEditorChangeHandler(null, EditorManager.getActiveEditor());
-                });
+                }).fail(showErrorPopUp);
         }
     }
 

--- a/src/extensions/default/PhpTooling/main.js
+++ b/src/extensions/default/PhpTooling/main.js
@@ -276,18 +276,18 @@ define(function (require, exports, module) {
     }
 
     function initiateService() {
-        if (!phpServerRunning) {
-            LanguageTools.initiateToolingService(clientName, clientFilePath, ['php']).done(function (client) {
-                _client = client;
-                //Attach only once
-                EditorManager.off("activeEditorChange.php");
-                EditorManager.on("activeEditorChange.php", activeEditorChangeHandler);
-                //Attach only once
-                LanguageManager.off("languageModified.php");
-                LanguageManager.on("languageModified.php", languageModifiedHandler);
-                activeEditorChangeHandler(null, EditorManager.getActiveEditor());
-            });
-        }
+        console.log("Php tooling: Starting the service");
+        phpServerRunning = false;
+        LanguageTools.initiateToolingService(clientName, clientFilePath, ['php']).done(function (client) {
+            _client = client;
+            //Attach only once
+            EditorManager.off("activeEditorChange.php");
+            EditorManager.on("activeEditorChange.php", activeEditorChangeHandler);
+            //Attach only once
+            LanguageManager.off("languageModified.php");
+            LanguageManager.on("languageModified.php", languageModifiedHandler);
+            activeEditorChangeHandler(null, EditorManager.getActiveEditor());
+        });
     }
 
     AppInit.appReady(function () {

--- a/src/languageTools/ClientLoader.js
+++ b/src/languageTools/ClientLoader.js
@@ -45,9 +45,7 @@ define(function (require, exports, module) {
         clientInfoLoadedPromise = null,
         //Clients that have to be loaded once the LanguageClient info is successfully loaded on the
         //node side.
-        pendingClientsToBeLoaded = [],
-        //list of the client which have to be loaded
-        clientMap = {};
+        pendingClientsToBeLoaded = [];
 
     function syncPrefsWithDomain(languageToolsPrefs) {
         if (clientInfoDomain) {
@@ -104,7 +102,6 @@ define(function (require, exports, module) {
     function initiateLanguageClient(clientName, clientFilePath) {
         var result = $.Deferred();
 
-        clientMap[clientName] = clientFilePath;
         //Only load clients after the LanguageClient Info has been initialized
         if (!clientInfoLoadedPromise || clientInfoLoadedPromise.state() === "pending") {
             var pendingClient = {
@@ -129,14 +126,7 @@ define(function (require, exports, module) {
                     pendingClient.load();
                 });
             } else {
-                //the node process might have restarted, so try loading all the clients again
-//                console.log("Reloading clients due to Node process crash...");
-//                var clients = Object.keys(clientMap);
-//                clients.forEach(function (client) {
-//                    var clientPromise = $.Deferred();
-//                    _clientLoader(client, clientMap[client], clientPromise);
-//                });
-                exports.trigger("clientsReloaded");
+                exports.trigger("languageClientModuleInitialized");
             }
             pendingClientsToBeLoaded = null;
         }, function () {

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -23,7 +23,7 @@
 
 /*global Map*/
 /* eslint-disable indent */
-/* eslint max-len: ["error", { "code": 200 }]*/
+/* eslint max-len: ["error", { "code": 200 }], no-invalid-this: 0*/
 define(function (require, exports, module) {
     "use strict";
 
@@ -44,11 +44,19 @@ define(function (require, exports, module) {
 
     ExtensionUtils.loadStyleSheet(module, "styles/default_provider_style.css");
 
+    function setClient(client) {
+        if (client) {
+            this.client = client;
+        }
+    }
+
     function CodeHintsProvider(client) {
         this.client = client;
         this.query = "";
         this.ignoreQuery = ["-", "->", ">", ":", "::", "(", "()", ")", "[", "[]", "]", "{", "{}", "}"];
     }
+
+    CodeHintsProvider.prototype.setClient = setClient;
 
     function formatTypeDataForToken($hintObj, token) {
         $hintObj.addClass('brackets-hints-with-type-details');
@@ -197,6 +205,8 @@ define(function (require, exports, module) {
         this.client = client;
     }
 
+    ParameterHintsProvider.prototype.setClient = setClient;
+
     ParameterHintsProvider.prototype.hasParameterHints = function (editor, implicitChar) {
         if (!this.client) {
             return false;
@@ -273,6 +283,8 @@ define(function (require, exports, module) {
         this.client = client;
     }
 
+    JumpToDefProvider.prototype.setClient = setClient;
+
     JumpToDefProvider.prototype.canJumpToDef = function (editor, implicitChar) {
         if (!this.client) {
             return false;
@@ -341,6 +353,8 @@ define(function (require, exports, module) {
         this._promiseMap = new Map();
         this._validateOnType = false;
     }
+
+    LintingProvider.prototype.setClient = setClient;
 
     LintingProvider.prototype.clearExistingResults = function (filePath) {
         var filePathProvided = !!filePath;
@@ -450,6 +464,8 @@ define(function (require, exports, module) {
     function ReferencesProvider(client) {
         this.client = client;
     }
+
+    ReferencesProvider.prototype.setClient = setClient;
 
     ReferencesProvider.prototype.hasReferences = function() {
         if (!this.client) {

--- a/src/languageTools/node/RegisterLanguageClientInfo.js
+++ b/src/languageTools/node/RegisterLanguageClientInfo.js
@@ -285,18 +285,18 @@ function init(domainManager) {
         ],
         []
     );
-    
+
     domainManager.registerEvent(
         domainName,
         "requestLanguageClientInfo",
-        []
+        [] //no parameters
     );
-    
+
     function requestInfo() {
         domainManager.emitEvent(domainName, "requestLanguageClientInfo", []);
     }
     //Allow the handler enough time to get registered on Brackets side.
-    setTimeout(requestInfo, 500); 
+    setTimeout(requestInfo, 250);
 }
 
 exports.init = init;

--- a/src/languageTools/node/RegisterLanguageClientInfo.js
+++ b/src/languageTools/node/RegisterLanguageClientInfo.js
@@ -296,7 +296,7 @@ function init(domainManager) {
         domainManager.emitEvent(domainName, "requestLanguageClientInfo", []);
     }
     //Allow the handler enough time to get registered on Brackets side.
-    setTimeout(requestInfo, 250);
+    setTimeout(requestInfo, 500);
 }
 
 exports.init = init;

--- a/src/languageTools/node/RegisterLanguageClientInfo.js
+++ b/src/languageTools/node/RegisterLanguageClientInfo.js
@@ -229,7 +229,11 @@ function syncPreferences(prefs) {
     global.LanguageClientInfo.preferences = prefs || global.LanguageClientInfo.preferences || {};
 }
 
-function initialize(bracketsSourcePath, toolingInfo) {
+function initialize(bracketsSourcePath, toolingInfo, resolve) {
+    if (!bracketsSourcePath || !toolingInfo) {
+        resolve(true, null); //resolve with err param
+    }
+    
     var normalizedBracketsSourcePath = bracketsSourcePath.split(BACKWARD_SLASH).join(FORWARD_SLASH),
         bracketsSourcePathArray = normalizedBracketsSourcePath.split(FORWARD_SLASH),
         languageClientAbsolutePath = bracketsSourcePathArray.concat(LANGUAGE_CLIENT_RELATIVE_PATH_ARRAY).join(FORWARD_SLASH);
@@ -239,6 +243,8 @@ function initialize(bracketsSourcePath, toolingInfo) {
     global.LanguageClientInfo.defaultBracketsCapabilities = defaultBracketsCapabilities;
     global.LanguageClientInfo.toolingInfo = toolingInfo;
     global.LanguageClientInfo.preferences = {};
+    
+    resolve(null, true); //resolve with boolean denoting success
 }
 
 function init(domainManager) {
@@ -253,7 +259,7 @@ function init(domainManager) {
         domainName,
         "initialize",
         initialize,
-        false,
+        true,
         "Initialize node environment for Language Client Module",
         [
             {
@@ -285,18 +291,6 @@ function init(domainManager) {
         ],
         []
     );
-
-    domainManager.registerEvent(
-        domainName,
-        "requestLanguageClientInfo",
-        [] //no parameters
-    );
-
-    function requestInfo() {
-        domainManager.emitEvent(domainName, "requestLanguageClientInfo", []);
-    }
-    //Allow the handler enough time to get registered on Brackets side.
-    setTimeout(requestInfo, 500);
 }
 
 exports.init = init;

--- a/src/languageTools/node/RegisterLanguageClientInfo.js
+++ b/src/languageTools/node/RegisterLanguageClientInfo.js
@@ -285,6 +285,18 @@ function init(domainManager) {
         ],
         []
     );
+    
+    domainManager.registerEvent(
+        domainName,
+        "requestLanguageClientInfo",
+        []
+    );
+    
+    function requestInfo() {
+        domainManager.emitEvent(domainName, "requestLanguageClientInfo", []);
+    }
+    //Allow the handler enough time to get registered on Brackets side.
+    setTimeout(requestInfo, 500); 
 }
 
 exports.init = init;


### PR DESCRIPTION
All tooling extensions dependent on LanguageClient module in Brackets must only initiate tooling service post the initialization of the module on Node side. On cold launch, we were waiting for the initialization and only then loading the respective client domain. However, when the node process crashes due to any issue, both the language server, as well as the initialized state in the node process are lost. The client then becomes useless.

Solution: Broadcasting an event in the Brackets context to inform the client to reinitiate tooling service once the node process is back up and initialized with LanguageClient module information.

Adding reference handling of the event in the PhpTooling extension.

ping @narayani28 @swmitra @niteskum for review.