### PR TITLE
Fix for CodeHint Description CSS Issue

### DIFF
--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -266,16 +266,12 @@ define(function (require, exports, module) {
             // attach to DOM
             $parent.append($ul);
 
-//            $parent.find(".hint-list-offset").remove();
-//            $("<div class='hint-list-offset'></div>").appendTo($parent);
-
             // If a a description field requested attach one
             if (this.enableDescription) {
                 // Remove the desc element first to ensure DOM order
                 $parent.find("#codehint-desc").remove();
                 $parent.append("<div id='codehint-desc' class='dropdown-menu quiet-scrollbars'></div>");
                 $ul.addClass("withDesc");
-                //$parent.find(".hint-list-offset").addClass("withDesc");
             }
             this._setSelectedIndex(selectInitial ? 0 : -1);
         }

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -266,8 +266,8 @@ define(function (require, exports, module) {
             // attach to DOM
             $parent.append($ul);
 
-            $parent.find(".hint-list-offset").remove();
-            $("<div class='hint-list-offset'></div>").appendTo($parent);
+//            $parent.find(".hint-list-offset").remove();
+//            $("<div class='hint-list-offset'></div>").appendTo($parent);
 
             // If a a description field requested attach one
             if (this.enableDescription) {
@@ -275,7 +275,7 @@ define(function (require, exports, module) {
                 $parent.find("#codehint-desc").remove();
                 $parent.append("<div id='codehint-desc' class='dropdown-menu quiet-scrollbars'></div>");
                 $ul.addClass("withDesc");
-                $parent.find(".hint-list-offset").addClass("withDesc");
+                //$parent.find(".hint-list-offset").addClass("withDesc");
             }
             this._setSelectedIndex(selectInitial ? 0 : -1);
         }
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
         if (descOffset === 0) {
             descOffset = menuHeight - descOverhang;
         }
-        this.$hintMenu.find(".hint-list-offset").css("height", descOffset - 1);
+        this.$hintMenu.find("#codehint-desc").css("margin-top", descOffset - 1);
 
         return {left: posLeft, top: posTop, width: availableWidth};
     };

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -586,11 +586,10 @@ a:focus {
 
 #codehint-desc {
 	background: @bc-codehint-desc;
-	position: relative;
+	position: absolute;
 	width: 100%;
 	box-sizing: border-box;
 	float: left;
-	top: 34px;
 	border-radius: 1px !important;
 	border-top-left-radius: 0px !important;
 	border-top-right-radius: 0px !important;


### PR DESCRIPTION
To calculate the offset for the code hint description I was using a dummy div earlier. This was causing the parent element (anchor for the codehint menu) to inherit the height of the dummy div and overlap with certain area of the editor outside of the codehint list. Due to this we were not able to put cursor on the overlapped area.

Solution: Fixing this issue by using a modified approach which doesn't require a dummy div. Instead, we rely on absolute positioning and adjust the top margin on the description box according to codehint menu height.

ping @swmitra @narayani28 @niteskum for review.