### PR TITLE
de-captilized "T"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ see the [extensions wiki page](https://github.com/adobe/brackets/wiki/Brackets-E
 #### Need help?
 
 Having problems starting Brackets the first time, or not sure how to use Brackets?  Please 
-review [Troubleshooting](https://github.com/adobe/brackets/wiki/Troubleshooting), which helps 
+review [troubleshooting](https://github.com/adobe/brackets/wiki/Troubleshooting), which helps 
 you to fix common problems and find extra help if needed.
 
 Helping Brackets


### PR DESCRIPTION
Makes more sense to have to not have a "T" in a middle of a sentence even if it is a link. :)