### PR TITLE
 undefined value (hope)

### DIFF
--- a/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file3.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file3.js
@@ -55,8 +55,7 @@ function getMonthName(mo) {
 
 function callOtherMethods() {
     testTryCatch();
-    
-}
+    }
 function testTryCatch() {
     "use strict";
     try {


### PR DESCRIPTION
Variable 'hope' has an undefined value because it is uninitialized. But its property is accessed at this point. 
 src/extensions/default/JavaScriptCodeHints/unittest-files/basic-test-files/file3.js
(line-29)

hope["frenchçProp"] = "";