### PR TITLE
Remove space between localhost: and port in infobar message

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
                 var InfoBar = require('widgets/infobar');
                 InfoBar.showInfoBar({
                     type: "warning",
-                    title: `${Strings.REMOTE_DEBUGGING_ENABLED} ${remote_debugging_port}`,
+                    title: `${Strings.REMOTE_DEBUGGING_ENABLED}${remote_debugging_port}`,
                     description: ""
                 });
             }


### PR DESCRIPTION
Remove space between localhost: and port in infobar message.
This was pending from https://github.com/adobe/brackets/pull/14956