### PR TITLE
Reverting version bump for patch release, will redo version bump once release is complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Brackets",
-    "version": "1.15.0-0",
-    "apiVersion": "1.15.0",
+    "version": "1.14.0-0",
+    "apiVersion": "1.14.0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets/issues"

--- a/src/config.json
+++ b/src/config.json
@@ -26,8 +26,8 @@
         "update_info_url": "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json"
     },
     "name": "Brackets",
-    "version": "1.15.0-0",
-    "apiVersion": "1.15.0",
+    "version": "1.14.0-0",
+    "apiVersion": "1.14.0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets/issues"


### PR DESCRIPTION
 Reverting version bump for patch release "Merge pull request #14733 from adobe/shubham/updateReleaseto1.15"

This reverts commit d5d00d43602c438266d32b8eda8f8a3ca937b524, reversing
changes made to ee01b79490cbb8a04d6454c5ad0f8beab654808f.

Old PR: https://github.com/adobe/brackets/pull/14965