### PR TITLE
Moving command line error message to infobar

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -257,12 +257,19 @@ define(function (require, exports, module) {
             );
         }
 
-        brackets.app.getRemoteDebuggingPort(function (err, remote_debugging_port){
-            if (remote_debugging_port && remote_debugging_port > 0) {
-                var InfoBar = require('widgets/infobar');
+        brackets.app.getRemoteDebuggingPort(function (err, remote_debugging_port, remote_debugging_port_arg){
+            var InfoBar = require('widgets/infobar'),
+                StringUtils = require("utils/StringUtils");
+            if ((!err) && remote_debugging_port && remote_debugging_port > 0) {
                 InfoBar.showInfoBar({
                     type: "warning",
                     title: `${Strings.REMOTE_DEBUGGING_ENABLED}${remote_debugging_port}`,
+                    description: ""
+                });
+            } else if (err) {
+                InfoBar.showInfoBar({
+                    type: "error",
+                    title: StringUtils.format(Strings.REMOTE_DEBUGGING_PORT_INVALID, remote_debugging_port_arg, 1025, 65534),
                     description: ""
                 });
             }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1643,7 +1643,7 @@ define(function (require, exports, module) {
             result.resolve();
         } else {
             brackets.app.getRemoteDebuggingPort(function (err, port){
-                if (port && port > 0) {
+                if ((!err) && port && port > 0) {
                     Inspector.getDebuggableWindows("127.0.0.1", port)
                         .fail(result.reject)
                         .done(function (response) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -900,5 +900,8 @@ define({
     "CMD_FIND_PROJECT_SYMBOLS"                       : "Find Project Symbols",
 
    // Remote debugging enabled
-    "REMOTE_DEBUGGING_ENABLED"                       : "Remote debugging enabled on localhost:"
+    "REMOTE_DEBUGGING_ENABLED"                       : "Remote debugging enabled on localhost:",
+
+   // Remote debugging port argument is invalid
+    "REMOTE_DEBUGGING_PORT_INVALID"                  : "Cannot enable remote debugging on port {0}. Port numbers should be between {1} and {2}."
 });


### PR DESCRIPTION
Moving command line port validation error messages to infobar.

Also CEF version used for Brackets, lack proper port validation logic(It is fixed from 3202), CEF relies on Operating System to block opening reserved ports:
This allows Brackets to open any positive number port less than 65535 on Windows, so for Win port range is [1,65534].
Mac and Linux do throw error while calling `bind()` on reserved port, so for Mac and Linux port range is [1024,65534].

Despite issues with Windows port range, we should continue showing valid port range to be [1024,65535] on info-bar.