### PR TITLE
Moving command line port validation errors to info bar

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -258,11 +258,18 @@ define(function (require, exports, module) {
         }
 
         brackets.app.getRemoteDebuggingPort(function (err, remote_debugging_port){
-            if (remote_debugging_port && remote_debugging_port > 0) {
-                var InfoBar = require('widgets/infobar');
+            var InfoBar = require('widgets/infobar'),
+                StringUtils = require("utils/StringUtils");
+            if ((!err) && remote_debugging_port && remote_debugging_port > 0) {
                 InfoBar.showInfoBar({
                     type: "warning",
                     title: `${Strings.REMOTE_DEBUGGING_ENABLED}${remote_debugging_port}`,
+                    description: ""
+                });
+            } else if (err) {
+                InfoBar.showInfoBar({
+                    type: "error",
+                    title: StringUtils.format(Strings.REMOTE_DEBUGGING_PORT_INVALID, err, 1024, 65534),
                     description: ""
                 });
             }

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1643,7 +1643,7 @@ define(function (require, exports, module) {
             result.resolve();
         } else {
             brackets.app.getRemoteDebuggingPort(function (err, port){
-                if (port && port > 0) {
+                if ((!err) && port && port > 0) {
                     Inspector.getDebuggableWindows("127.0.0.1", port)
                         .fail(result.reject)
                         .done(function (response) {


### PR DESCRIPTION
Moving command line port validation errors to info bar

![Screen Shot 2019-11-20 at 7 03 14 PM](https://user-images.githubusercontent.com/1094605/69243139-6ee3a980-0bc8-11ea-92f8-2bde80740064.png)
