### PR TITLE
Fixing update notification locale issue, update notification was shown in English for all locales

### DIFF
--- a/src/brackets.config.dist.json
+++ b/src/brackets.config.dist.json
@@ -3,7 +3,7 @@
     "analyticsDataServerURL"  : "https://cc-api-data.adobe.io/ingest",
     "serviceKey"              : "brackets-service",
     "environment"             : "production",
-    "update_info_url"         : "https://getupdates.brackets.io/getupdates/",
+    "update_info_url"         : "https://getupdates.brackets.io/getupdates?locale=<locale>",
     "notification_info_url"   : "https://getupdates.brackets.io/getnotifications?locale=<locale>",
     "buildtype"               : "production"
 }

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -115,32 +115,6 @@ define(function (require, exports, module) {
             locale = locale.substring(0, 2);
         }
 
-        //AUTOUPDATE_PRERELEASE_BEGIN
-        // The following code is needed for supporting Auto Update in prerelease,
-        //and will be removed eventually for stable releases
-        {
-            if (locale) {
-                if(locale.length > 2) {
-                    locale = locale.substring(0, 2);
-                }
-                switch(locale)  {
-                case "de":
-                    break;
-                case "es":
-                    break;
-                case "fr":
-                    break;
-                case "ja":
-                    break;
-                case "en":
-                default:
-                    locale = "en";
-                }
-                return brackets.config.update_info_url.replace("<locale>", locale);
-            }
-        }
-        //AUTOUPDATE_PRERELEASE_END
-
         return brackets.config.update_info_url + '?locale=' + locale;
     }
 

--- a/src/utils/UpdateNotification.js
+++ b/src/utils/UpdateNotification.js
@@ -115,7 +115,7 @@ define(function (require, exports, module) {
             locale = locale.substring(0, 2);
         }
 
-        return brackets.config.update_info_url + '?locale=' + locale;
+        return brackets.config.update_info_url.replace('<locale>', locale || 'en');
     }
 
     /**


### PR DESCRIPTION
Removing pre-release specific code from release code, as it is causing update notification to be shown in English for all locales.
This will fix https://github.com/adobe/brackets/issues/14994