### PR TITLE
Public methods for closing Search Results and References bottom panel

### DIFF
--- a/src/features/FindReferencesManager.js
+++ b/src/features/FindReferencesManager.js
@@ -121,6 +121,16 @@ define(function (require, exports, module) {
         searchModel.clear();
     }
 
+    /**
+     * @public
+     * Closes the references panel
+     */
+    function closeReferencesPanel() {
+        if (_resultsView) {
+            _resultsView.close();
+        }
+    }
+    
     function setMenuItemStateForLanguage(languageId) {
         CommandManager.get(Commands.CMD_FIND_ALL_REFERENCES).setEnabled(false);
         if (!languageId) {
@@ -207,4 +217,5 @@ define(function (require, exports, module) {
     exports.registerFindReferencesProvider    = registerFindReferencesProvider;
     exports.removeFindReferencesProvider      = removeFindReferencesProvider;
     exports.setMenuItemStateForLanguage       = setMenuItemStateForLanguage;
+    exports.closeReferencesPanel              = closeReferencesPanel;
 });

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -450,6 +450,15 @@ define(function (require, exports, module) {
         }
     }
 
+    /**
+    * @public
+    * Closes the search results panel
+    */
+    function closeResultsPanel() {
+        _resultsView.close();
+        _closeFindBar();
+	}
+
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         var model = FindInFiles.searchModel;
@@ -495,6 +504,7 @@ define(function (require, exports, module) {
     // Public exports
     exports.searchAndShowResults = searchAndShowResults;
     exports.searchAndReplaceResults = searchAndReplaceResults;
+    exports.closeResultsPanel = closeResultsPanel;
 
     // For unit testing
     exports._showFindBar  = _showFindBar;


### PR DESCRIPTION
The bottom panels 'Search Results' and 'References' can only be closed by mouse clicking at the close button. Somehow this always bothers me: I can start a search with Ctrl-Shift-F, I can close the search bar with ESC, but I can't close the search results panel with a keyboard shortcut...

Public methods for closing them enables extensions to attach a keyboard shortcut to this action. As I did already in my custom build ;-)