### PR TITLE
Fix for: `Reload With(out) Extensions` not working

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1665,6 +1665,8 @@ define(function (require, exports, module) {
                             // In case of an error
                             _socket.onerror = result.reject;
                         });
+                } else {
+                    result.reject();
                 }
             });
         }


### PR DESCRIPTION
In Brackets 1.14.1 a browser reload fails (menu items Debug | Reload With(out) Extensions will do completely nothing at the moment).
Rejecting the `_disableCache()` promise when no remote debugging port is found, will fix this.