### PR TITLE
Detect Graphics file in project and associate it with OS default application

### DIFF
--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
             if(response.id !== _requestID) {
                 return;
             }
-            _graphicsFilePresentInProject(response.present)
+            _graphicsFilePresentInProject(response.present);
         });
 
         ProjectManager.on("projectOpen", function () {
@@ -99,15 +99,16 @@ define(function (require, exports, module) {
             ]
         ).done(function (id) {
             
-            if(id !== Dialogs.DIALOG_BTN_OK)
+            if(id !== Dialogs.DIALOG_BTN_OK) {
                 return;
+            }
 
             brackets.app.getSystemDefaultApp(_graphicsFileTypes.join(), function (err, out) {
                 var associateApp = out.split(','),
                     fileTypeToAppMap = {};
 
                 associateApp.forEach(function(item) {
-                    fileTypeToAppMap[item.split(':')[0]] = item.split(':')[1]
+                    fileTypeToAppMap[item.split(':')[0]] = item.split(':')[1];
                 });
                 Dialogs.showModalDialog(
                     DefaultDialogs.DIALOG_ID_INFO,
@@ -121,7 +122,7 @@ define(function (require, exports, module) {
                             text: Strings.BUTTON_YES
                         }
                     ]
-                )
+                );
             });
         });
         PreferencesManager.setViewState("AssociateGraphicsFileDialogShown", true);

--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -119,7 +119,11 @@ define(function (require, exports, module) {
                 for (var key in fileTypeToAppMap) {
                     if (fileTypeToAppMap.hasOwnProperty(key)) {
                         if(key && !prefs[key]) {
-                            prefs[key] = "default";
+                            prefs[key] = fileTypeToAppMap[key];
+                            if(brackets.platform === "win" && !fileTypeToAppMap[key].endsWith('.exe') &&
+                                !fileTypeToAppMap[key].endsWith('.EXE')) {
+                                prefs[key] = "default";
+                            }
                         }
                     }
                 }

--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
         _initialized = false;
 
     var _graphicsFileTypes = ["jpg", "jpeg", "png", "svg", "xd", "psd", "ai"];
-    //var _graphicsFileTypes = [ "psd"];
 
     var _nodeDomain;
 
@@ -104,12 +103,29 @@ define(function (require, exports, module) {
             }
 
             brackets.app.getSystemDefaultApp(_graphicsFileTypes.join(), function (err, out) {
+
+                if(err) {
+                    return;
+                }
                 var associateApp = out.split(','),
                     fileTypeToAppMap = {};
 
                 associateApp.forEach(function(item) {
-                    fileTypeToAppMap[item.split(':')[0]] = item.split(':')[1];
+                    fileTypeToAppMap[item.split('##')[0]] = item.split('##')[1];
                 });
+
+                var prefs = PreferencesManager.get('externalApplications');
+
+                for (var key in fileTypeToAppMap) {
+                    if (fileTypeToAppMap.hasOwnProperty(key)) {
+                        if(key && !prefs[key]) {
+                            prefs[key] = "default";
+                        }
+                    }
+                }
+
+                PreferencesManager.set('externalApplications', prefs);
+
                 Dialogs.showModalDialog(
                     DefaultDialogs.DIALOG_ID_INFO,
                     Strings.ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_TITLE,

--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+define(function (require, exports, module) {
+    "use strict";
+
+
+    var PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
+        Strings              = brackets.getModule("strings"),
+        ProjectManager       = brackets.getModule("project/ProjectManager");
+
+
+    var _requestID = 0,
+        _initialized = false;
+
+    var _graphicsFileTypes = ["jpg", "jpeg", "png", "svg", "xd", "psd", "ai"];
+
+    var _nodeDomain;
+
+    function init(nodeDomain) {
+
+        if(_initialized) {
+            return;
+        }
+        _initialized = true;
+
+        _nodeDomain = nodeDomain;
+
+        _nodeDomain.on('checkFileTypesInFolderResponse', function (event, response) {
+            if(response.id !== _requestID) {
+                return;
+            }
+            _graphicsFilePresentInProject(response.present)
+        });
+
+        ProjectManager.on("projectOpen", function () {
+            _checkForGraphicsFileInPrjct();
+        });
+
+        _checkForGraphicsFileInPrjct();
+
+    }
+
+
+    function _checkForGraphicsFileInPrjct() {
+
+        _nodeDomain.exec("checkFileTypesInFolder", {
+            extensions: _graphicsFileTypes.join(),
+            folder: ProjectManager.getProjectRoot().fullPath,
+            reqId: ++_requestID
+        });
+
+    }
+
+    function _graphicsFilePresentInProject(isPresent) {
+
+        console.log("Graphics File present in project", isPresent);
+
+    }
+
+    exports.init = init;
+
+});

--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -137,15 +137,16 @@ define(function (require, exports, module) {
                     }
 
                     if (filetype === "xd") {
-                        if (app.toLowerCase() !== "adobe xd" && app !== "adobe.cc.xd") {
+                        if (app.toLowerCase() !== "adobe xd" && app.toLowerCase() !== "adobe.cc.xd") {
                             return;
                         }
+                        
                         app = "Adobe XD";
                     }
                     fileTypeToAppMap[filetype] = app;
 
-                    if (brackets.platform === "win" && !app.toLowerCase().endsWith('.exe')) {
-                        app = app.substring(app.lastIndexOf('//') + 2, app.length - 4);
+                    if (brackets.platform === "win" && app.toLowerCase().endsWith('.exe')) {
+                        app = app.substring(app.lastIndexOf('\\') + 1, app.length - 4);
                     }
                     if (AppToFileTypeMap[app]) {
                         AppToFileTypeMap[app].push(filetype);

--- a/src/extensions/default/OpenWithExternalApplication/main.js
+++ b/src/extensions/default/OpenWithExternalApplication/main.js
@@ -49,8 +49,6 @@ define(function (require, exports, module) {
 
     var extensionToExtApplicationMap = {};
 
-    var graphicsFileTypes = [".jpg", ".jpeg", ".png", ".svg", ".xd", ".psd", ".ai"];
-
     function _openWithExternalApplication(event, path) {
         _nodeDomain.exec("open", {
             path: path,

--- a/src/extensions/default/OpenWithExternalApplication/main.js
+++ b/src/extensions/default/OpenWithExternalApplication/main.js
@@ -29,9 +29,11 @@ define(function (require, exports, module) {
         PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
         Strings              = brackets.getModule("strings"),
         FileViewController   = brackets.getModule("project/FileViewController"),
+        ProjectManager       = brackets.getModule("project/ProjectManager"),
         ExtensionUtils       = brackets.getModule("utils/ExtensionUtils"),
         NodeDomain           = brackets.getModule("utils/NodeDomain"),
-        FileUtils            = brackets.getModule("file/FileUtils");
+        FileUtils            = brackets.getModule("file/FileUtils"),
+        GraphicsFile         = require("GraphicsFile");
 
     /**
      * @private
@@ -46,6 +48,8 @@ define(function (require, exports, module) {
     var _nodeDomain = new NodeDomain("OpenWithExternalApplication", _domainPath);
 
     var extensionToExtApplicationMap = {};
+
+    var graphicsFileTypes = [".jpg", ".jpeg", ".png", ".svg", ".xd", ".psd", ".ai"];
 
     function _openWithExternalApplication(event, path) {
         _nodeDomain.exec("open", {
@@ -66,6 +70,8 @@ define(function (require, exports, module) {
     FileViewController.on("openWithExternalApplication", _openWithExternalApplication);
 
     AppInit.appReady(function () {
+        
+        GraphicsFile.init(_nodeDomain);
         extensionToExtApplicationMap = PreferencesManager.get("externalApplications");
         FileUtils.addExtensionToExternalAppList(Object.keys(extensionToExtApplicationMap));
     });

--- a/src/extensions/default/OpenWithExternalApplication/main.js
+++ b/src/extensions/default/OpenWithExternalApplication/main.js
@@ -29,7 +29,6 @@ define(function (require, exports, module) {
         PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
         Strings              = brackets.getModule("strings"),
         FileViewController   = brackets.getModule("project/FileViewController"),
-        ProjectManager       = brackets.getModule("project/ProjectManager"),
         ExtensionUtils       = brackets.getModule("utils/ExtensionUtils"),
         NodeDomain           = brackets.getModule("utils/NodeDomain"),
         FileUtils            = brackets.getModule("file/FileUtils"),

--- a/src/extensions/default/OpenWithExternalApplication/node/OpenWithExternalApplicationDomain.js
+++ b/src/extensions/default/OpenWithExternalApplication/node/OpenWithExternalApplicationDomain.js
@@ -58,7 +58,7 @@ function _checkFileTypesInFolder(params) {
         var respObj = {
             id: params.reqId,
             present: matches.length > 0 ? true : false
-        }
+        };
         _domainManager.emitEvent('OpenWithExternalApplication', 'checkFileTypesInFolderResponse', [respObj]);
     });
 
@@ -67,7 +67,7 @@ function _checkFileTypesInFolder(params) {
         var respObj = {
             id: params.reqId,
             present: true
-        }
+        };
         _domainManager.emitEvent('OpenWithExternalApplication', 'checkFileTypesInFolderResponse', [respObj]);
     });
 

--- a/src/extensions/default/OpenWithExternalApplication/node/OpenWithExternalApplicationDomain.js
+++ b/src/extensions/default/OpenWithExternalApplication/node/OpenWithExternalApplicationDomain.js
@@ -51,10 +51,9 @@ function _checkFileTypesInFolder(params) {
     var extList = params.extensions,
         dirPath = path.normalize(params.folder),
 
-        pattern = dirPath + "/**/*.+(" + extList.replace(",", "|") + ")";
-        //pattern = dirPath + "/**/*.jpg";
+        pattern = dirPath + "/**/*.+(" + extList.replace(/,/g, "|") + ")";
 
-    var mg = new Glob(pattern, function (err, matches) {
+    var globMgr = new Glob(pattern, function (err, matches) {
 
         var respObj = {
             id: params.reqId,
@@ -63,13 +62,13 @@ function _checkFileTypesInFolder(params) {
         _domainManager.emitEvent('OpenWithExternalApplication', 'checkFileTypesInFolderResponse', [respObj]);
     });
 
-    mg.on("match", function() {
-        //mg.abort();
+    globMgr.on("match", function() {
+        globMgr.abort();
         var respObj = {
             id: params.reqId,
             present: true
         }
-        //_domainManager.emitEvent('OpenWithExternalApplication', 'checkFileTypesInFolderResponse', [respObj]);
+        _domainManager.emitEvent('OpenWithExternalApplication', 'checkFileTypesInFolderResponse', [respObj]);
     });
 
 }

--- a/src/extensions/default/OpenWithExternalApplication/node/package.json
+++ b/src/extensions/default/OpenWithExternalApplication/node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "brackets-open-external_application",
   "dependencies": {
-    "open": "0.0.5"
+    "open": "0.0.5",
+    "glob": "7.1.1"
   }
 }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -906,5 +906,10 @@ define({
     "REMOTE_DEBUGGING_PORT_INVALID"                  : "Cannot enable remote debugging on port {0}. Port numbers should be between {1} and {2}.",
     
     //Associate File Type to External App
-    "DESCRIPTION_EXTERNAL_APPLICATION_ASSOCIATE"     : "Add File type association to external App here"
+    "DESCRIPTION_EXTERNAL_APPLICATION_ASSOCIATE"     : "Add File type association to external App here",
+
+    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_TITLE"   : "Open Graphics Files in external editors?",
+    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_MSG"     : "Click Yes to associate the graphic files with its appropriate external editors."
+
+
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -906,10 +906,11 @@ define({
     "REMOTE_DEBUGGING_PORT_INVALID"                  : "Cannot enable remote debugging on port {0}. Port numbers should be between {1} and {2}.",
     
     //Associate File Type to External App
-    "DESCRIPTION_EXTERNAL_APPLICATION_ASSOCIATE"     : "Add File type association to external App here",
+    "DESCRIPTION_EXTERNAL_APPLICATION_ASSOCIATE"     : "Associate File type to external App settings. e.g { \"<file_type>\": \"<app_name>\" } app_name is OS dependant, for example \"google chrome\" on macOS and \"chrome\" on Windows. app_name can also be given as \"default\" for OS default application.",
 
-    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_TITLE"   : "Open Graphics Files in external editors?",
-    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_MSG"     : "Click Yes to associate the graphic files with its appropriate external editors."
+    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_TITLE"   : "Open Graphic Files in External Editors.",
+    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_MSG"     : "Your current folder has graphic file types which are not supported by Brackets.<br/>You can now associate specific file types with external editors. Once associated, you can open graphic files like .xd, .psd, .jpg, .png, .ai, .svg in their default applications by double clicking on the files in File Tree.<br/><br/>Please click on ‘Ok’ button to associate the graphic file types with their respective default applications.",
+    "ASSOCIATE_GRAPHICS_FILE_TO_DEFAULT_APP_CNF_MSG" : "Following file types have been successfully associated with default applications.<br/>{0} You can further add new file type associations or customize in brackets.json by going to “Debug->Open Preferences File” menu."
 
 
 });


### PR DESCRIPTION
in this PR Graphics File with type ["jpg", "jpeg", "png", "svg", "xd", "psd", "ai"] are checked in project , if files are present , a dialog is shown to user if user would like to associate these graphics file type to os default app. If user click yes, Brackets check OS Default app for each type mentioned above and associate it.

@jha-g @shubhsnov @sobisht @swmitra @narayani28 please review