### PR TITLE
upgrading lodash node module to 4.17.15 from 4.17.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1946,9 +1946,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.4",
-      "from": "lodash@4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      "version": "4.17.15",
+      "from": "lodash@4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz"
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "chokidar": "1.6.1",
         "decompress-zip": "0.3.0",
         "fs-extra": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.15",
         "npm": "3.10.10",
         "opn": "4.0.2",
         "request": "2.79.0",

--- a/src/config.json
+++ b/src/config.json
@@ -47,7 +47,7 @@
         "chokidar": "1.6.1",
         "decompress-zip": "0.3.0",
         "fs-extra": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.15",
         "npm": "3.10.10",
         "opn": "4.0.2",
         "request": "2.79.0",


### PR DESCRIPTION
to address reported security vulnerability, Upgrading lodash node module version  to 4.17.15 from 4.17.4.

@jha-g  @narayani28  please review