### PR TITLE
Graphics File Associate workflow should get triggered after UUID is generated

### DIFF
--- a/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
+++ b/src/extensions/default/OpenWithExternalApplication/GraphicsFile.js
@@ -72,6 +72,13 @@ define(function (require, exports, module) {
             return;
         }
 
+        var userUuid = PreferencesManager.getViewState("UUID"),
+            olderUuid = PreferencesManager.getViewState("OlderUUID");
+
+        if(!(userUuid || olderUuid)) {
+            return;
+        }
+
         _nodeDomain.exec("checkFileTypesInFolder", {
             extensions: _graphicsFileTypes.join(),
             folder: ProjectManager.getProjectRoot().fullPath,


### PR DESCRIPTION
in this PR Added a check that Associate Graphics File workflow will be triggered only if UUID is available.

@jha-g  @narayani28 please review