### PR TITLE
Live-Vorschau in anderen Browsern

### DIFF
--- a/samples/de/Erste Schritte/index.html
+++ b/samples/de/Erste Schritte/index.html
@@ -137,8 +137,7 @@
             Derzeit unterstützt Brackets die Live-Vorschau nur für HTML und CSS. Allerdings werden in der aktuellen
             Version Änderungen an JavaScript-Dateien automatisch neu geladen, wenn Sie diese speichern. Wir arbeiten
             momentan an der Unterstützung der Live-Vorschau für JavaScript.
-            Die Live-Vorschau ist außerdem nur mit Google Chrome möglich, doch wir hoffen, diese Funktionalität
-            zukünftig zu allen wichtigen Browsern hinzuzufügen.
+            Die Live-Vorschau ist standartmäßig mit Google Chrome möglich, Sie können sie aber über die Experimentelle Live-Vorschau auch mit anderen Browsern verwenden.
         </p>
 
         <h3>Schnelle Farbansicht</h3>


### PR DESCRIPTION
Die Live-Vorschau ist auch in anderen Browsern, als Google Chrome möglich, z.B. in Opera, Vivaldi oder Ms Edge Chromium